### PR TITLE
Ensure table name length is consistent across CPUs

### DIFF
--- a/cmake/sample_defs/sample_mission_cfg.h
+++ b/cmake/sample_defs/sample_mission_cfg.h
@@ -300,7 +300,9 @@
 **
 **
 **  \par Limits
-**      Not Applicable
+**       This value should be kept as a multiple of 4, to maintain alignment of
+**       any possible neighboring fields without implicit padding.
+**
 */
 #define CFE_MISSION_ES_CDS_MAX_NAME_LENGTH         16
 
@@ -310,7 +312,7 @@
 **  \cfeevscfg Maximum Event Message Length
 **
 **  \par Description:
-**      Indicates the maximum length (in characers) of the formatted text
+**      Indicates the maximum length (in characters) of the formatted text
 **      string portion of an event message
 **
 **  \par Limits
@@ -349,7 +351,8 @@
 **      form: "ApplicationName.TblName"
 **
 **  \par Limits
-**      Not Applicable
+**       This value should be kept as a multiple of 4, to maintain alignment of
+**       any possible neighboring fields without implicit padding.
 */
 #define CFE_MISSION_TBL_MAX_NAME_LENGTH         16
 
@@ -500,6 +503,8 @@
 **       Note this affects the size of messages, so it must not cause any message
 **       to exceed the max length.
 **
+**       This value should be kept as a multiple of 4, to maintain alignment of
+**       any possible neighboring fields without implicit padding.
 */
 #define CFE_MISSION_ES_MAX_SHELL_CMD  64
 
@@ -521,6 +526,9 @@
 **       All CPUs within the same SB domain (mission) must share the same definition
 **       Note this affects the size of messages, so it must not cause any message
 **       to exceed the max length.
+**
+**       This value should be kept as a multiple of 4, to maintain alignment of
+**       any possible neighboring fields without implicit padding.
 **
 */
 #define CFE_MISSION_ES_MAX_SHELL_PKT    64
@@ -547,7 +555,8 @@
 **
 **  \par Description:
 **      Indicates the maximum length (in characters) of the entire table name
-**      within software bus messages
+**      within software bus messages, in "AppName.TableName" notation.
+**
 **      This affects the layout of command/telemetry messages but does not affect run
 **      time behavior or internal allocation.
 **
@@ -556,8 +565,10 @@
 **       Note this affects the size of messages, so it must not cause any message
 **       to exceed the max length.
 **
+**       This value should be kept as a multiple of 4, to maintain alignment of
+**       any possible neighboring fields without implicit padding.
 */
-#define CFE_MISSION_TBL_MAX_FULL_NAME_LEN         (CFE_MISSION_TBL_MAX_NAME_LENGTH + CFE_MISSION_MAX_API_LEN + 2)
+#define CFE_MISSION_TBL_MAX_FULL_NAME_LEN         (CFE_MISSION_TBL_MAX_NAME_LENGTH + CFE_MISSION_MAX_API_LEN + 4)
 
 /**
 **  \cfesbcfg Maximum Number of pipes that SB command/telemetry messages may hold
@@ -578,43 +589,76 @@
 
 
 /**
-**  \cfemissioncfg cFE Maximum length for filenames in messages
+**  \cfemissioncfg cFE Maximum length for pathnames within data exchange structures
 **
 **  \par Description:
-**       The value of this constant dictates the size of filenames within SB messages.
+**       The value of this constant dictates the size of pathnames within all structures
+**       used for external data exchange, such as Software bus messages and table definitions.
 **       This is typically the same as OS_MAX_PATH_LEN but that is OSAL dependent --
 **       and as such it definable on a per-processor/OS basis and hence may be different
-**       across multiple processors.  Since this defines a message format, it must be
-**       consistent across ALL processors exchanging SB messages.
+**       across multiple processors.  It is recommended to set this to the value of the
+**       largest OS_MAX_PATH_LEN in use on any CPU on the mission.
 **
-**       This affects the layout of command/telemetry messages but does not affect run
-**       time behavior or internal allocation.
+**       This affects only the layout of command/telemetry messages and table definitions;
+**       internal allocation may use the platform-specific OS_MAX_PATH_LEN value.
 **   
 **  \par Limits
-**       All CPUs within the same SB domain (mission) must share the same definition
+**       All CPUs within the same SB domain (mission) and ground tools must share the
+**       same definition.
 **       Note this affects the size of messages, so it must not cause any message
 **       to exceed the max length.
 **
+**       This value should be kept as a multiple of 4, to maintain alignment of
+**       any possible neighboring fields without implicit padding.
 */
 #define CFE_MISSION_MAX_PATH_LEN      64
 
 /**
-**  \cfemissioncfg cFE Maximum length for API names in messages
+**  \cfemissioncfg cFE Maximum length for filenames within data exchange structures
 **
 **  \par Description:
-**       The value of this constant dictates the size of API names within SB messages.
+**       The value of this constant dictates the size of filenames within all structures
+**       used for external data exchange, such as Software bus messages and table definitions.
+**       This is typically the same as OS_MAX_FILE_LEN but that is OSAL dependent --
+**       and as such it definable on a per-processor/OS basis and hence may be different
+**       across multiple processors.  It is recommended to set this to the value of the
+**       largest OS_MAX_FILE_LEN in use on any CPU on the mission.
+**
+**       This affects only the layout of command/telemetry messages and table definitions;
+**       internal allocation may use the platform-specific OS_MAX_FILE_LEN value.
+**
+**  \par Limits
+**       All CPUs within the same SB domain (mission) and ground tools must share the
+**       same definition.
+**       Note this affects the size of messages, so it must not cause any message
+**       to exceed the max length.
+**
+**       This value should be kept as a multiple of 4, to maintain alignment of
+**       any possible neighboring fields without implicit padding.
+*/
+#define CFE_MISSION_MAX_FILE_LEN      20
+
+/**
+**  \cfemissioncfg cFE Maximum length for API names within data exchange structures
+**
+**  \par Description:
+**       The value of this constant dictates the size of filenames within all structures
+**       used for external data exchange, such as Software bus messages and table definitions.
 **       This is typically the same as OS_MAX_API_LEN but that is OSAL dependent --
 **       and as such it definable on a per-processor/OS basis and hence may be different
-**       across multiple processors.
+**       across multiple processors.  It is recommended to set this to the value of the
+**       largest OS_MAX_API_LEN in use on any CPU on the mission.
 **
-**       This affects the layout of command/telemetry messages but does not affect run
-**       time behavior or internal allocation.
+**       This affects only the layout of command/telemetry messages and table definitions;
+**       internal allocation may use the platform-specific OS_MAX_API_LEN value.
 **
 **  \par Limits
 **       All CPUs within the same SB domain (mission) must share the same definition
 **       Note this affects the size of messages, so it must not cause any message
 **       to exceed the max length.
 **
+**       This value should be kept as a multiple of 4, to maintain alignment of
+**       any possible neighboring fields without implicit padding.
 */
 #define CFE_MISSION_MAX_API_LEN       20
 
@@ -632,8 +676,11 @@
 **       All CPUs within the same SB domain (mission) must share the same definition
 **       Note this affects the size of messages, so it must not cause any message
 **       to exceed the max length.
+**
+**       This value should be kept as a multiple of 4, to maintain alignment of
+**       any possible neighboring fields without implicit padding.
 */
-#define CFE_MISSION_ES_CDS_MAX_NAME_LEN       (CFE_MISSION_ES_CDS_MAX_NAME_LENGTH + CFE_MISSION_MAX_API_LEN + 2)
+#define CFE_MISSION_ES_CDS_MAX_NAME_LEN       (CFE_MISSION_ES_CDS_MAX_NAME_LENGTH + CFE_MISSION_MAX_API_LEN + 4)
 
 
 /*

--- a/fsw/cfe-core/src/es/cfe_es_verify.h
+++ b/fsw/cfe-core/src/es/cfe_es_verify.h
@@ -353,5 +353,29 @@
     #error CFE_PLATFORM_ES_START_TASK_STACK_SIZE must be greater than or equal to 2048
 #endif
 
+
+#if ((CFE_MISSION_MAX_API_LEN % 4) != 0)
+    #error CFE_MISSION_MAX_API_LEN must be a multiple of 4
+#endif
+#if ((CFE_MISSION_MAX_PATH_LEN % 4) != 0)
+    #error CFE_MISSION_MAX_PATH_LEN must be a multiple of 4
+#endif
+#if ((CFE_MISSION_MAX_FILE_LEN % 4) != 0)
+    #error CFE_MISSION_MAX_FILE_LEN must be a multiple of 4
+#endif
+#if ((CFE_MISSION_ES_MAX_SHELL_CMD % 4) != 0)
+    #error CFE_MISSION_ES_MAX_SHELL_CMD must be a multiple of 4
+#endif
+#if ((CFE_MISSION_ES_MAX_SHELL_PKT % 4) != 0)
+    #error CFE_MISSION_ES_MAX_SHELL_PKT must be a multiple of 4
+#endif
+#if ((CFE_MISSION_ES_CDS_MAX_NAME_LENGTH % 4) != 0)
+    #error CFE_MISSION_ES_CDS_MAX_NAME_LENGTH must be a multiple of 4
+#endif
+#if ((CFE_MISSION_ES_CDS_MAX_NAME_LEN % 4) != 0)
+    #error CFE_MISSION_ES_CDS_MAX_NAME_LEN must be a multiple of 4
+#endif
+
+
 #endif /* _cfe_es_verify_ */
 /*****************************************************************************/

--- a/fsw/cfe-core/src/inc/cfe_fs.h
+++ b/fsw/cfe-core/src/inc/cfe_fs.h
@@ -43,12 +43,6 @@
 
 
 
-/******************* Macro Definitions ***********************/
-#define CFE_FS_HDR_DESC_MAX_LEN 32 /**< \brief Max length of description field in a standard cFE File Header */
-
-#define CFE_FS_FILE_CONTENT_ID  0x63464531  /**< \brief Magic Number for cFE compliant files (= 'cFE1') */
-
-
 /*
  * To preserve source-code compatibility with existing code,
  * this allows the old enum names to still work.  This should
@@ -76,29 +70,6 @@
 
 
 #endif  /* CFE_OMIT_DEPRECATED_6_6 */
-
-
-/**
-** \brief Standard cFE File header structure definition
-*/
-typedef struct
-{
-    uint32  ContentType;           /**< \brief Identifies the content type (='cFE1'=0x63464531)*/
-    uint32  SubType;               /**< \brief Type of \c ContentType, if necessary */
-                                   /**< Standard SubType definitions can be found
-                                        \link #CFE_FS_SubType_ES_ERLOG here \endlink */
-    uint32  Length;                /**< \brief Length of primary header */
-    uint32  SpacecraftID;          /**< \brief Spacecraft that generated the file */
-    uint32  ProcessorID;           /**< \brief Processor that generated the file */
-    uint32  ApplicationID;         /**< \brief Application that generated the file */
-  
-    uint32  TimeSeconds;           /**< \brief File creation timestamp (seconds) */
-    uint32  TimeSubSeconds;        /**< \brief File creation timestamp (sub-seconds) */
-
-    char    Description[CFE_FS_HDR_DESC_MAX_LEN];       /**< \brief File description */
-
-} CFE_FS_Header_t;
-
 
 /*
 ** File header access functions...

--- a/fsw/cfe-core/src/inc/cfe_fs_extern_typedefs.h
+++ b/fsw/cfe-core/src/inc/cfe_fs_extern_typedefs.h
@@ -33,6 +33,21 @@
 
 #include "common_types.h"
 
+/******************* Macro Definitions ***********************/
+
+/*
+ * NOTE: the value of CFE_FS_HDR_DESC_MAX_LEN, if modified, should
+ * be constrained to multiples of 4, as it is used within a structure that
+ * also contains uint32 types.  This ensures that the entire structure
+ * remains 32-bit aligned without the need for implicit padding bytes.
+ */
+
+#define CFE_FS_HDR_DESC_MAX_LEN 32          /**< \brief Max length of description field in a standard cFE File Header */
+
+#define CFE_FS_FILE_CONTENT_ID  0x63464531  /**< \brief Magic Number for cFE compliant files (= 'cFE1') */
+
+
+
 /**
  * @brief Label definitions associated with CFE_FS_SubType_Enum_t
  */
@@ -200,6 +215,29 @@ enum CFE_FS_SubType
  * @sa enum CFE_FS_SubType
  */
 typedef uint32                                           CFE_FS_SubType_Enum_t;
+
+
+/**
+** \brief Standard cFE File header structure definition
+*/
+typedef struct
+{
+    uint32  ContentType;           /**< \brief Identifies the content type (='cFE1'=0x63464531)*/
+    uint32  SubType;               /**< \brief Type of \c ContentType, if necessary */
+                                   /**< Standard SubType definitions can be found
+                                        \link #CFE_FS_SubType_ES_ERLOG here \endlink */
+    uint32  Length;                /**< \brief Length of primary header */
+    uint32  SpacecraftID;          /**< \brief Spacecraft that generated the file */
+    uint32  ProcessorID;           /**< \brief Processor that generated the file */
+    uint32  ApplicationID;         /**< \brief Application that generated the file */
+
+    uint32  TimeSeconds;           /**< \brief File creation timestamp (seconds) */
+    uint32  TimeSubSeconds;        /**< \brief File creation timestamp (sub-seconds) */
+
+    char    Description[CFE_FS_HDR_DESC_MAX_LEN];       /**< \brief File description */
+
+} CFE_FS_Header_t;
+
 
 
 

--- a/fsw/cfe-core/src/inc/cfe_tbl.h
+++ b/fsw/cfe-core/src/inc/cfe_tbl.h
@@ -64,11 +64,12 @@
 
 #define CFE_TBL_OPT_DEFAULT      (CFE_TBL_OPT_SNGL_BUFFER | CFE_TBL_OPT_LOAD_DUMP)
 
-/** Computation for maximum length allowed for a table name. <BR>
-** NOTE: "+2" is for NULL Character and "." (i.e. - "AppName.TblName") */
-#define CFE_TBL_MAX_FULL_NAME_LEN_COMP (CFE_MISSION_TBL_MAX_NAME_LENGTH + OS_MAX_API_NAME + 2)
-/* Ensure the table name falls on a 4-byte boundary */
-#define CFE_TBL_MAX_FULL_NAME_LEN (((CFE_TBL_MAX_FULL_NAME_LEN_COMP + 3)/4)*4)
+/*
+ * The full length of table names is defined at the mission scope.
+ * This is defined here to support applications that depend on cfe_tbl.h
+ * providing this value.
+ */
+#define CFE_TBL_MAX_FULL_NAME_LEN (CFE_MISSION_TBL_MAX_FULL_NAME_LEN)
 
 #define CFE_TBL_BAD_TABLE_HANDLE  (CFE_TBL_Handle_t) 0xFFFF
 

--- a/fsw/cfe-core/src/inc/cfe_tbl_extern_typedefs.h
+++ b/fsw/cfe-core/src/inc/cfe_tbl_extern_typedefs.h
@@ -32,6 +32,7 @@
 /* Use the local definitions of these types */
 
 #include "common_types.h"
+#include <cfe_mission_cfg.h>  /* for CFE_MISSION_TBL_MAX_FULL_NAME_LEN */
 
 /**
  * @brief Label definitions associated with CFE_TBL_BufferSelect_Enum_t
@@ -57,6 +58,23 @@ enum CFE_TBL_BufferSelect
  * @sa enum CFE_TBL_BufferSelect
  */
 typedef uint16                                           CFE_TBL_BufferSelect_Enum_t;
+
+
+
+/**
+ * @brief The definition of the header fields that are included in CFE Table Data files.
+ *
+ * This header follows the CFE_FS header and precedes the the actual table data.
+ */
+typedef struct
+{
+    uint32                   Reserved;                             /**< Future Use: NumTblSegments in File?   */
+    uint32                   Offset;                               /**< Byte Offset at which load should commence */
+    uint32                   NumBytes;                             /**< Number of bytes to load into table */
+    char                     TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< Fully qualified name of table to load */
+} CFE_TBL_File_Hdr_t;
+
+
 
 
 #endif /* CFE_EDS_ENABLED_BUILD */

--- a/fsw/cfe-core/src/inc/cfe_tbl_filedef.h
+++ b/fsw/cfe-core/src/inc/cfe_tbl_filedef.h
@@ -49,41 +49,22 @@
 #ifndef _cfe_tbl_filedef_
 #define _cfe_tbl_filedef_
 
-#include "cfe.h"
+#include <cfe_mission_cfg.h>
+#include <common_types.h>
+#include "cfe_tbl_extern_typedefs.h"    /* for "CFE_TBL_FileHdr_t" definition */
+#include "cfe_fs_extern_typedefs.h"     /* for "CFE_FS_HDR_DESC_MAX_LEN" definition */
 
-/* CFE_TBL_MAX_FULL_NAME_LEN is defined in cfe_tbl.h and includes alignment bytes */
-#define CFE_TBL_FILDEF_MAX_NAME_LEN       (CFE_TBL_MAX_FULL_NAME_LEN)
-
-/* Compute number of additional bytes needed to make               */
-/* CFE_FS_HDR_DESC_MAX_LEN rounded up to nearest longword boundary */
-#define CFE_TBL_FILEDEF_FS_HDR_ALIGN32    (CFE_FS_HDR_DESC_MAX_LEN - ((CFE_FS_HDR_DESC_MAX_LEN/4)*4))
-
-/* Allocate enough space for maximum table description length plus alignment bytes */
-#define CFE_TBL_FILDEF_FS_HDR_LEN         (CFE_FS_HDR_DESC_MAX_LEN + CFE_TBL_FILEDEF_FS_HDR_ALIGN32)
-
-/* Compute number of additional bytes needed to make        */
-/* OS_MAX_FILE_NAME rounded up to nearest longword boundary */
-#define CFE_TBL_FILEDEF_OS_FILE_ALIGN32   (OS_MAX_FILE_NAME - ((OS_MAX_FILE_NAME/4)*4))
-
-/* Allocate enough space for maximum file name length plus alignment bytes */
-#define CFE_TBL_FILDEF_OS_FILE_LEN        (OS_MAX_FILE_NAME + CFE_TBL_FILEDEF_OS_FILE_ALIGN32)
-
+/*
+ * The definition of the file definition metadata that can be used by
+ * external tools (e.g. elf2cfetbl) to generate CFE table data files.
+ */
 typedef struct
 {
-    uint32                   Reserved;                             /**< Future Use: NumTblSegments in File?   */
-    uint32                   Offset;                               /**< Byte Offset at which load should commence */
-    uint32                   NumBytes;                             /**< Number of bytes to load into table */
-    char                     TableName[CFE_TBL_MAX_FULL_NAME_LEN]; /**< Fully qualified name of table to load */
-} CFE_TBL_File_Hdr_t;
-
-
-typedef struct
-{
-    char        ObjectName[64];                           /**< \brief Name of instantiated variable that contains desired table image */
-    char        TableName[CFE_TBL_FILDEF_MAX_NAME_LEN];   /**< \brief Name of Table as defined onboard */
-    char        Description[CFE_TBL_FILDEF_FS_HDR_LEN];   /**< \brief Description of table image that is included in cFE File Header */
-    char        TgtFilename[CFE_TBL_FILDEF_OS_FILE_LEN];  /**< \brief Default filename to be used for output of elf2cfetbl utility  */
-    uint32      ObjectSize;                               /**< \brief Size, in bytes, of instantiated object */
+    char        ObjectName[64];                             /**< \brief Name of instantiated variable that contains desired table image */
+    char        TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \brief Name of Table as defined onboard */
+    char        Description[CFE_FS_HDR_DESC_MAX_LEN];       /**< \brief Description of table image that is included in cFE File Header */
+    char        TgtFilename[CFE_MISSION_MAX_FILE_LEN];      /**< \brief Default filename to be used for output of elf2cfetbl utility  */
+    uint32      ObjectSize;                                 /**< \brief Size, in bytes, of instantiated object */
 } CFE_TBL_FileDef_t;
 
 /** The CFE_TBL_FILEDEF macro can be used to simplify the declaration of a table image when using the elf2cfetbl utility.

--- a/fsw/cfe-core/src/tbl/cfe_tbl_verify.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_verify.h
@@ -80,5 +80,16 @@
 #endif
 */
 
+/*
+ * For configuration values that should be multiples of 4
+ * as noted in the documentation, this confirms that they are.
+ */
+#if ((CFE_MISSION_TBL_MAX_NAME_LENGTH % 4) != 0)
+    #error CFE_MISSION_TBL_MAX_NAME_LENGTH must be a multiple of 4
+#endif
+#if ((CFE_MISSION_TBL_MAX_FULL_NAME_LEN % 4) != 0)
+    #error CFE_MISSION_TBL_MAX_FULL_NAME_LEN must be a multiple of 4
+#endif
+
 #endif /* _cfe_tbl_verify_ */
 /*****************************************************************************/


### PR DESCRIPTION
**Describe the contribution**
To ensure consistency in the size of the CFE_TBL_FileHdr_t struct, this should be constrained to use only mission-scope definitions.
    
Also simplifies the structure definitions by _NOT_ padding strings out to 32 bit multiples.  The default size of the strings are already 32 bit multiples so this is just unnecessary complexity.  There is also no major issue if not 32 bit aligned, as the compiler will add it automatically where needed.

Add a note in the related cfe_mission_cfg.h descriptions to affected values, that these should be kept as a multiple of 4 to maintain alignment.
    
Fixes #25

**Testing performed**
Built CFE using default/sample config
Verified no build issues, CFE and unit tests all run as expected (no change).

**Expected behavior changes**
No impact to behavior, but this may change the size of telemetry packets in some cases depending on the mission config.

**System(s) tested on:**
 Ubuntu 18.04 (64 bit)

**Contributor Info**
Full name and company/organization of all contributors (required for acceptance)

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
