### PR TITLE
Fix #298, fix infinite loop when gz file is truncated

### DIFF
--- a/fsw/cfe-core/src/fs/cfe_fs_decompress.c
+++ b/fsw/cfe-core/src/fs/cfe_fs_decompress.c
@@ -284,16 +284,14 @@ int16 FS_gz_fill_inbuf_Reentrant( CFE_FS_Decompress_State_t *State )
    {
 		len = OS_read( State->srcFile_fd, (int8*)State->inbuf + State->insize, INBUFSIZ - State->insize );
 		
-		if ( len == 0 || len == EOF || len == OS_FS_ERROR ) break;
+		if ( len <= 0 ) break;
 		
 		State->insize += len;
 		
 	} while ( State->insize < INBUFSIZ );
 
 
-	if ( State->insize == 0 ) return EOF;
-
-	if ( len == OS_FS_ERROR ) 
+	if ( State->insize == 0 || len < 0) 
    {
 		State->Error = CFE_FS_GZIP_READ_ERROR;
 		return EOF;


### PR DESCRIPTION
**Describe the contribution**
Fix issue #298, when cfe_fs_decompress goes into infinite loop when gz file is truncated. 

**Testing performed**
1. Build 
2. Pass in truncated file as parameter to cfe_fs_decompress.
[corgi2.jpg.gz](https://github.com/nasa/cFE/files/3698606/corgi2.jpg.gz)
3. Verify the return status:

```
STATUS CODE = -973078518
```

4. Gzip good file
![66239143-f6736880-e6ad-11e9-98ac-ce321d6d495a](https://user-images.githubusercontent.com/26749312/66332444-c1ac1f00-e902-11e9-8518-62dcbbad2736.jpg)

5. Pass as parameter and verify output. 

**System(s) tested on:**
 - Hardware
 - Ubuntu 18.04.03
 - cFE 6.7.0


**Contributor Info**
Anh Van, NASA Goddard

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
