### PR TITLE
Fix #374: CFE_ES_GetTaskInfo must be passed a task ID

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_shell.c
+++ b/fsw/cfe-core/src/es/cfe_es_shell.c
@@ -306,7 +306,7 @@ int32 CFE_ES_ListTasks(int32 fd)
                 /*
                 ** Populate the AppInfo entry 
                 */
-                Result = CFE_ES_GetTaskInfo(&TaskInfo,i);
+                Result = CFE_ES_GetTaskInfo(&TaskInfo,CFE_ES_Global.TaskTable[i].TaskId);
 
                 if ( Result == CFE_SUCCESS )
                 {

--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -390,8 +390,16 @@ int32 CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId,uint32 AppId)
 
     CFE_SB_UnlockSharedData(__func__,__LINE__);
 
+    /*
+     * Get the app name of the actual pipe owner for the event string
+     * as this may be different than the task doing the deletion.
+     *
+     * Note: If this fails (e.g. bad AppID, it returns an empty string
+     */
+    CFE_ES_GetAppName(FullName, Owner, sizeof(FullName));
+
     CFE_EVS_SendEventWithAppID(CFE_SB_PIPE_DELETED_EID,CFE_EVS_EventType_DEBUG,CFE_SB.AppId,
-          "Pipe Deleted:id %d,owner %s",(int)PipeId, CFE_SB_GetAppTskName(Owner,FullName));
+          "Pipe Deleted:id %d,owner %s",(int)PipeId, FullName);
 
     return CFE_SUCCESS;
 
@@ -460,8 +468,17 @@ int32 CFE_SB_SetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 Opts)
     CFE_SB.PipeTbl[PipeTblIdx].Opts = Opts;
 
     CFE_SB_UnlockSharedData(__func__,__LINE__);
+
+    /*
+     * Get the app name of the actual pipe owner for the event string
+     * as this may be different than the task doing the deletion.
+     *
+     * Note: If this fails (e.g. bad AppID, it returns an empty string
+     */
+    CFE_ES_GetAppName(FullName, Owner, sizeof(FullName));
+
     CFE_EVS_SendEventWithAppID(CFE_SB_SETPIPEOPTS_EID,CFE_EVS_EventType_DEBUG,CFE_SB.AppId,
-          "Pipe opts set:id %d,owner %s, opts=0x%02x",(int)PipeId, CFE_SB_GetAppTskName(Owner,FullName), (unsigned int)Opts);
+          "Pipe opts set:id %d,owner %s, opts=0x%02x",(int)PipeId, FullName, (unsigned int)Opts);
 
     return CFE_SUCCESS;
 }/* end CFE_SB_SetPipeOpts */


### PR DESCRIPTION
Fix 2 areas where the CFE_ES_GetTaskInfo() function could
have been passed an App ID rather than a task ID, which
would create an incorrect result and generate an error in the syslog

**Testing performed**
Steps taken to test the contribution:
- Set EVS default configuration to enable all events (including DEBUG) by default
- Built all for pc-linux from a clean slate
- Run CFE core and confirm all startup OK
- Externally Issue StopApp command for "SAMPLE_APP"
- Confirmed that all debug events are correct
- Confirmed that the original error is not generated
- Externally Issue Shell command for "ES_ListTasks"
- Confirmed that no bad task ID errors are shown
- Confirmed that the file output is correct

**Expected behavior changes**
The invalid task errors shown in the logs prior to this change are NOT generated after this change.

**System(s) tested on:**
Ubuntu 18.04.2 LTS  64-bit

**Contributor Info**
Joseph Hickey, Vantage Systems, Inc.

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
