### PR TITLE
Fix #381, Add VxWorks Example Toolchain

### DIFF
--- a/cmake/sample_defs/toolchain-ppc-vxworks6.9.cmake
+++ b/cmake/sample_defs/toolchain-ppc-vxworks6.9.cmake
@@ -1,0 +1,51 @@
+# This example toolchain file describes the cross compiler to use for
+# the target architecture indicated in the configuration file.
+
+# Basic cross system configuration
+set(CMAKE_SYSTEM_NAME VxWorks-CFE)
+set(CMAKE_SYSTEM_PROCESSOR ppc)
+set(CMAKE_SYSTEM_VERSION 6.9)
+set(VXWORKS_GCC_VERSION 4.3.3)
+set(VXWORKS_HOST_VERSION x86-linux2)
+set(WIND_HOME_DFL "$ENV{WIND_HOME}")
+if(NOT WIND_HOME_DFL)
+  set(WIND_HOME_DFL "/opt/WindRiver")
+endif(NOT WIND_HOME_DFL)
+set(WIND_HOME "${WIND_HOME_DFL}" CACHE PATH "Wind River installation directory")
+set(VXWORKS_TOOLS_PREFIX "${WIND_HOME}/gnu/${VXWORKS_GCC_VERSION}-vxworks-${CMAKE_SYSTEM_VERSION}/${VXWORKS_HOST_VERSION}")
+
+
+# specify the cross compiler - adjust accord to compiler installation
+# This uses the compiler-wrapper toolchain that buildroot produces
+SET(SDKHOSTBINDIR               "${VXWORKS_TOOLS_PREFIX}/bin")
+set(TARGETSUFFIX                "${CMAKE_SYSTEM_PROCESSOR}")
+#set(VXWORKS_BSP_C_FLAGS           "-march=i686 -mtune=i686 -fno-common")
+#set(VXWORKS_BSP_CXX_FLAGS         ${VXWORKS_BSP_C_FLAGS})
+
+SET(CMAKE_C_COMPILER            "${SDKHOSTBINDIR}/cc${TARGETSUFFIX}")
+SET(CMAKE_CXX_COMPILER          "${SDKHOSTBINDIR}/c++${TARGETSUFFIX}")
+SET(CMAKE_LINKER                "${SDKHOSTBINDIR}/ld${TARGETSUFFIX}")
+SET(CMAKE_ASM_COMPILER          "${SDKHOSTBINDIR}/as${TARGETSUFFIX}")
+SET(CMAKE_AR                    "${SDKHOSTBINDIR}/ar${TARGETSUFFIX}")
+SET(CMAKE_OBJDUMP               "${SDKHOSTBINDIR}/objdump${TARGETSUFFIX}")
+SET(CMAKE_RANLIB                "${SDKHOSTBINDIR}/ranlib${TARGETSUFFIX}")
+
+# Note that CEXP is not a shared library loader - it will not support code compiled with -fPIC
+# Also exception handling is very iffy.  These two options disable eh_frame creation.
+#set(CMAKE_C_COMPILE_OPTIONS_PIC -fno-exceptions -fno-asynchronous-unwind-tables)
+
+# search for programs in the build host directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM   NEVER)
+
+# for libraries and headers in the target directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY   ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE   ONLY)
+
+SET(CMAKE_PREFIX_PATH                   /)
+
+# these settings are specific to cFE/OSAL and determines which
+# abstraction layers are built when using this toolchain
+SET(CFE_SYSTEM_PSPNAME                  mcp750-vxworks)
+SET(OSAL_SYSTEM_BSPTYPE                 genppc-vxworks6.4)
+SET(OSAL_SYSTEM_OSTYPE                  vxworks)
+


### PR DESCRIPTION
**Describe the contribution**
Fixes #381, Add VxWorks sample toolchain

**Testing performed**
Steps taken to test the contribution:
1. Checked out cFS rc-6.7.0 bundle and standard setup per README
1. Added `SET(TGT1_SYSTEM ppc-vxworks6.9)` to targets.cmake
1. Set up vxworks build environment `/opt/WindRiver/wrenv.sh -pvxworks-6.9`
1. `make ENABLE_UNIT_TESTS=TRUE prep`
1. `make`
1. `make install`
1. Loaded test executable to target
1. Executed all test executables (all passed except sem-speed-test with exception at interrupt level, and 2 of the timer tests returned slightly out of tolerance values)

**Expected behavior changes**
Able to build for cFS lab vxworks setup

**System(s) tested on:**
 - Hardware Host: cFS dev server , Target: MCP750
 - OS Host: Ubuntu 16.04.6 LTS, Target: VxWorks 6.9
 - Versions rc-6.7.0 bundle

**Additional context**
None

**Contributor Info**
Jacob Hageman - NASA/GSFC

**Community contributors**
N/A