### PR TITLE
Fix #384, Unable to resolve link

### DIFF
--- a/docs/src/cfe_es.dox
+++ b/docs/src/cfe_es.dox
@@ -220,7 +220,7 @@
   cFE will also reset every application that is running at the time the command is received. 
 
   Also part of this service is the Exception and Reset (ER) Log, which has a command for 
-  \link #CFE_ES_WRITE_ERLOG_CC dumping \endlink or \link #CFE_ES_CLEAR_ERLOG_CC clearing \endlink
+  \link #CFE_ES_WRITE_ER_LOG_CC dumping \endlink or \link #CFE_ES_CLEAR_ER_LOG_CC clearing \endlink
   the log and telemetry to show the number of entries in the log.  In addition to the ER log,
    the user may find information about the most recent reset in the ES task housekeeping telemetry.
 
@@ -731,7 +731,7 @@
   allocates a section of the Critical Data Store memory for the application's use and
   assigns the Application specified name to the memory area.  The operator can find
   and learn the characteristics of these Critical Data Stores by using the
-  \link #CFE_ES_DUMP_CDS_REG_CC Dump CDS Registry Command. \endlink  This command will
+  \link #CFE_ES_DUMP_CDS_REGISTRY_CC Dump CDS Registry Command. \endlink  This command will
   dump the contents of the CDS Registry maintained by the Executive Services into a
   file that can be downlinked and examined by the operator.
   
@@ -856,7 +856,7 @@
   by mission requirements).
     
   An operator can obtain information about an Application's Memory Pool by using
-  the \link #CFE_ES_TLM_POOL_STATS_CC Telemeter Memory Pool Statistics Command.
+  the \link #CFE_ES_SEND_MEM_POOL_STATS_CC Telemeter Memory Pool Statistics Command.
   \endlink
   
   This command will cause Executive Services to extract pertinent statistics
@@ -878,7 +878,7 @@
   
   <UL>
     <LI> <B>Memory Pool Handle</B> - the handle, as provided by the operator in the
-         \link #CFE_ES_TLM_POOL_STATS_CC Telemeter Memory Pool Statistics Command. \endlink
+         \link #CFE_ES_SEND_MEM_POOL_STATS_CC Telemeter Memory Pool Statistics Command. \endlink
          This repeating of the handle in telemetry insures the operator knows which Memory
          Pool Statistics are being viewed <BR>
     <LI> <B>Pool Size</B> - The total size of the memory pool (in bytes)<BR>

--- a/docs/src/cfe_evs.dox
+++ b/docs/src/cfe_evs.dox
@@ -361,7 +361,7 @@
   however, these are only available for those events that are registered for filtering hence if you 
   have a message that is not registered for filtering and the message type (e.g. DEBUG) is disabled 
   then you won't know if the event was ever issued by an application.  These counters are available 
-  by sending a command to \link #CFE_EVS_FILE_WRITE_APP_DATA_CC write the EVS Application Data \endlink
+  by sending a command to \link #CFE_EVS_WRITE_APP_DATA_FILE_CC write the EVS Application Data \endlink
   and transferring the file to the ground. 
 
 
@@ -466,7 +466,7 @@
         <TR><TD COLSPAN=2 WIDTH="100%"> <B>(Q)
            How do I find out which events are registered for filtering?
         </B><TR><TD WIDTH="5%"> &nbsp; <TD WIDTH="95%">
-           EVS provides a command (\link #CFE_EVS_FILE_WRITE_APP_DATA_CC \EVS_WRITEAPPDATA2FILE \endlink)
+           EVS provides a command (\link #CFE_EVS_WRITE_APP_DATA_FILE_CC  \EVS_WRITEAPPDATA2FILE \endlink)
            which generates a file containing all of the applications that have registered with EVS and 
            all of the filters that are registered for each application.  Note that EVS merely generates 
            the file.  The file must be transferred to the ground in order to view it.

--- a/fsw/cfe-core/src/inc/cfe_es_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_es_msg.h
@@ -136,7 +136,7 @@
 **  \cfecmdmnemonic \ES_RESET
 **
 **  \par Command Structure
-**       #CFE_ES_RestartCmd_t
+**       #CFE_ES_RestartCmd_Payload_t
 **
 **  \par Command Verification
 **       Successful execution of this command (as a Processor Reset)  
@@ -152,7 +152,7 @@
 **  \par Error Conditions
 **       This command may fail for the following reason(s):
 **       - The command packet length is incorrect
-**       - The \link #CFE_ES_RestartCmd_t.RestartType Restart Type \endlink was
+**       - The \link #CFE_ES_RestartCmd_Payload_t Restart Type \endlink was
 **         not a recognized value. 
 **       
 **       Evidence of failure may be found in the following telemetry:

--- a/fsw/cfe-core/src/inc/cfe_evs_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_evs_msg.h
@@ -346,7 +346,7 @@
 **       - \b \c \EVS_CMDPC - command execution counter will 
 **       increment
 **       - The generation of #CFE_EVS_DISAPPENTTYPE_EID debug event message      
-**       - The clearing of the Active Flag in \link #CFE_EVS_AppDataFile_t::ActiveFlag The Active Flag in EVS App Data File \endlink
+**       - The clearing of the Event Type Active Flag in The Event Type Active Flag in EVS App Data File
 **
 **  \par Error Conditions
 **      This command may fail for the following reason(s):
@@ -386,7 +386,7 @@
 **       - \b \c \EVS_CMDPC - command execution counter will 
 **       increment
 **       - The generation of #CFE_EVS_ENAAPPEVT_EID debug event message 
-**       - The setting of the Active Flag in \link #CFE_EVS_AppDataFile_t::ActiveFlag The Active Flag in EVS App Data File \endlink
+**       - The setting of the Active Flag in The Active Flag in EVS App Data File
 **
 **  \par Error Conditions
 **      This command may fail for the following reason(s):


### PR DESCRIPTION
**Describe the contribution**
Fixed doxygen warning: Unable to resolve linke

**Testing performed**
Steps taken to test the contribution:
1. Make usersguide

2. cfe_es_msg.h:155:  Check cfe__es__msg_8h.html 
3.  cfe_evs_msg.h:349: - cfe__evs__msg_8h.html
4. cfe_evs_msg.h:389:  - cfe__evs__msg_8h.html
5. cfe_es.dox:223:  -  cfeesugswreset.html
6. cfe_es.dox:734:  cfeesugcdssrv.html
7. cfe_es.dox:859: - cfeesugmempoolsrv.html
8. cfe_es.dox:881: - cfeesugmempoolsrv.html
9. cfe_evs.dox:364: - cfeevsugcounters.html
10. cfe_evs.dox:469: - cfeevsugfaq.html

11. Verify warning.log that warning is longer there. 

**System(s) tested on:**
 - Hardware
 - Ubuntu 18.04
 - cFE 6.7.1, rc- 6.7.0

**Contributor Info**
Anh Van, NASA Goddard