### PR TITLE
Fix #392, cpp check warning

### DIFF
--- a/fsw/cfe-core/unit-test/ut_time_stubs.c
+++ b/fsw/cfe-core/unit-test/ut_time_stubs.c
@@ -133,7 +133,7 @@ void CFE_TIME_Print(char *PrintBuffer, CFE_TIME_SysTime_t TimeToPrint)
 CFE_TIME_SysTime_t CFE_TIME_GetTime(void)
 {
     static CFE_TIME_SysTime_t SimTime = { 0 };
-    CFE_TIME_SysTime_t Result;
+    CFE_TIME_SysTime_t Result = { 0 };
     int32 status;
 
     status = UT_DEFAULT_IMPL(CFE_TIME_GetTime);
@@ -193,7 +193,7 @@ CFE_TIME_Compare_t  CFE_TIME_Compare(CFE_TIME_SysTime_t TimeA, CFE_TIME_SysTime_
 CFE_TIME_SysTime_t  CFE_TIME_Add(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2)
 {
     static CFE_TIME_SysTime_t SimTime = { 0 };
-    CFE_TIME_SysTime_t Result;
+    CFE_TIME_SysTime_t Result = { 0 };
     int32 status;
 
     status = UT_DEFAULT_IMPL(CFE_TIME_Add);


### PR DESCRIPTION
**Describe the contribution**
Fix #392, resolve cpp check warning

**Testing performed**
Steps taken to test the contribution:
1. cppcheck --force . 
2. verify warning is gone

**System observed on:**
Hardware
1)  Ubuntu18.04
2) Cppcheck 1.82, cFE 6.7.1, osal 5.0.1

**Contributor Info**
Anh Van, NASA Goddard

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
