### PR TITLE
Fix #380: Exclude unit tests from lcov report

### DIFF
--- a/cmake/Makefile.sample
+++ b/cmake/Makefile.sample
@@ -127,12 +127,16 @@ clean:
 distclean:
 	rm -rf "$(O)"
 
+# Grab lcov baseline before running tests
 test:
+	lcov --capture --initial --directory $(O)/$(ARCH) --output-file $(O)/$(ARCH)/coverage_base.info
 	(cd $(O)/$(ARCH) && ctest -O ctest.log)
 
 lcov:
-	lcov --capture --directory $(O)/$(ARCH) --output-file $(O)/$(ARCH)/coverage.info
-	genhtml $(O)/$(ARCH)/coverage.info --output-directory $(O)/$(ARCH)/lcov
+	lcov --capture --directory $(O)/$(ARCH) --output-file $(O)/$(ARCH)/coverage_test.info
+	lcov --add-tracefile $(O)/$(ARCH)/coverage_base.info --add-tracefile $(O)/$(ARCH)/coverage_test.info --output-file $(O)/$(ARCH)/coverage_total.info
+	lcov --remove $(O)/$(ARCH)/coverage_total.info 'unit-test/*' --output-file $(O)/$(ARCH)/coverage_filtered.info
+	genhtml $(O)/$(ARCH)/coverage_filtered.info --output-directory $(O)/$(ARCH)/lcov
 	@/bin/echo -e "\n\nCoverage Report Link: file:$(CURDIR)/$(O)/$(ARCH)/lcov/index.html\n"
 
 doc:


### PR DESCRIPTION
**Describe the contribution**
Fixes #380, exclude unit-test files from lcov report

**Testing performed**
Steps taken to test the contribution:
1. Build/test/run lcov
```
make distclean
make ENABLE_UNIT_TESTS=TRUE SIMULATION=native prep
make
make install
make test
make lcov
```
1. Processed files no longer include unit test code, confirmed processed file list against repo
1. Coverage from 6.7.0 was
```
lines......: 92.6% (20233 of 21841 lines)
functions..: 95.9% (827 of 862 functions)
```
with unit test files included, now
```
  lines......: 98.6% (8195 of 8308 lines)
  functions..: 99.6% (471 of 473 functions)
```

**Expected behavior changes**
Valid coverage of flight code now reported

**System(s) tested on:**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 16.04
 - Versions: master bundle with this change

**Additional context**
None

**Contributor Info**
Jacob Hageman - NASA/GSFC