### PR TITLE
fix-288-remove_pipename changes

### DIFF
--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -1048,8 +1048,10 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId,CFE_SB_PipeId_t PipeId,
     if(!CFE_SB_IsValidRouteIdx(RouteIdx)){
         char    PipeName[OS_MAX_API_NAME] = {'\0'};
 
-        CFE_SB_GetPipeName(PipeId, PipeName);
         CFE_SB_UnlockSharedData(__func__,__LINE__);
+
+        CFE_SB_GetPipeName(PipeId, PipeName);
+
         CFE_EVS_SendEventWithAppID(CFE_SB_UNSUB_NO_SUBS_EID,CFE_EVS_EventType_INFORMATION,CFE_SB.AppId,
             "Unsubscribe Err:No subs for Msg 0x%x on %s,app %s",
             (unsigned int)MsgId,PipeName,CFE_SB_GetAppTskName(TskId,FullName));

--- a/fsw/cfe-core/src/sb/cfe_sb_init.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_init.c
@@ -194,7 +194,6 @@ void CFE_SB_InitPipeTbl(void){
         CFE_SB.PipeTbl[i].SysQueueId    = CFE_SB_UNUSED_QUEUE;
         CFE_SB.PipeTbl[i].PipeId        = CFE_SB_INVALID_PIPE;
         CFE_SB.PipeTbl[i].CurrentBuff   = NULL;
-        memset(&CFE_SB.PipeTbl[i].PipeName[0],0,OS_MAX_API_NAME);
     }/* end for */
 
 }/* end CFE_SB_InitPipeTbl */

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.c
@@ -514,7 +514,7 @@ int32 CFE_SB_GetPipeName(CFE_SB_PipeId_t PipeId, char *PipeNameBuf){
     }else{
         if (OS_QueueGetInfo(CFE_SB.PipeTbl[PipeId].SysQueueId, &queue_prop)
             == OS_SUCCESS){
-            strncpy(queue_prop.name, PipeNameBuf, OS_MAX_API_NAME-1);
+            strncpy(PipeNameBuf, queue_prop.name, OS_MAX_API_NAME-1);
         }
         else{
             Status = CFE_SB_FAILED;

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.c
@@ -497,24 +497,33 @@ CFE_SB_RouteEntry_t* CFE_SB_GetRoutePtrFromIdx(CFE_SB_MsgRouteIdx_t RouteIdx)
 **    Pipe ID.
 **
 **  Arguments:
-**    MsgId  : ID of the message
+**    MsgId       : ID of the message
+**    PipeNameBuf : Buffer to receive name, must be OS_MAX_API_NAME bytes long
 **
 **  Return:
-**    Will return a pointer to the PipeName array in the pipe table if the the pipeid
-**    is in range. Otherwise this function returns a pointer to the
-**    PipeName4ErrCase[0], which is initialized with a null terminator.
+**    Will return CFE_SUCCESS and populate PipeNameBuf with the name
+**    of the pipe on success, otherwise returns CFE_SB_FAILED on error.
 **
 */
-char *CFE_SB_GetPipeName(CFE_SB_PipeId_t PipeId){
-
-    static char PipeName4ErrCase[1] = {'\0'};
+int32 CFE_SB_GetPipeName(CFE_SB_PipeId_t PipeId, char *PipeNameBuf){
+    OS_queue_prop_t queue_prop;
+    int32 Status = CFE_SUCCESS;
 
     if(PipeId >= CFE_PLATFORM_SB_MAX_PIPES){
-        return &PipeName4ErrCase[0];
+        Status = CFE_SB_FAILED;
     }else{
-        return &CFE_SB.PipeTbl[PipeId].PipeName[0];
+        if (OS_QueueGetInfo(CFE_SB.PipeTbl[PipeId].SysQueueId, &queue_prop)
+            == OS_SUCCESS)
+        {
+            strcpy(queue_prop.name, PipeNameBuf);
+        }
+        else
+        {
+            Status = CFE_SB_FAILED;
+        }
     }/* end if */
 
+    return Status;
 }/* end CFE_SB_GetPipeName */
 
 

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.c
@@ -509,18 +509,16 @@ int32 CFE_SB_GetPipeName(CFE_SB_PipeId_t PipeId, char *PipeNameBuf){
     OS_queue_prop_t queue_prop;
     int32 Status = CFE_SUCCESS;
 
-    if(PipeId >= CFE_PLATFORM_SB_MAX_PIPES){
+    if(PipeNameBuf == NULL || PipeId >= CFE_PLATFORM_SB_MAX_PIPES){
         Status = CFE_SB_FAILED;
     }else{
         if (OS_QueueGetInfo(CFE_SB.PipeTbl[PipeId].SysQueueId, &queue_prop)
-            == OS_SUCCESS)
-        {
-            strcpy(queue_prop.name, PipeNameBuf);
+            == OS_SUCCESS){
+            strncpy(queue_prop.name, PipeNameBuf, OS_MAX_API_NAME-1);
         }
-        else
-        {
+        else{
             Status = CFE_SB_FAILED;
-        }
+        }/* end if */
     }/* end if */
 
     return Status;

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.h
@@ -249,7 +249,6 @@ typedef struct {
 typedef struct {
      uint8              InUse;
      CFE_SB_PipeId_t    PipeId;
-     char               PipeName[OS_MAX_API_NAME];
      char               AppName[OS_MAX_API_NAME];
      uint8              Opts;
      uint8              Spare;
@@ -363,7 +362,7 @@ int32  CFE_SB_DuplicateSubscribeCheck(CFE_SB_MsgKey_t MsgKey,CFE_SB_PipeId_t Pip
 void   CFE_SB_SetRoutingTblIdx(CFE_SB_MsgKey_t MsgKey, CFE_SB_MsgRouteIdx_t Value);
 CFE_SB_RouteEntry_t* CFE_SB_GetRoutePtrFromIdx(CFE_SB_MsgRouteIdx_t RouteIdx);
 void   CFE_SB_ResetCounters(void);
-char   *CFE_SB_GetPipeName(CFE_SB_PipeId_t PipeId);
+int32 CFE_SB_GetPipeName(CFE_SB_PipeId_t PipeId, char *PipeNameBuf);
 void   CFE_SB_SetMsgSeqCnt(CFE_SB_MsgPtr_t MsgPtr,uint32 Count);
 char   *CFE_SB_GetAppTskName(uint32 TaskId, char* FullName);
 CFE_SB_BufferD_t *CFE_SB_GetBufferFromPool(CFE_SB_MsgId_t MsgId, uint16 size);

--- a/fsw/cfe-core/src/sb/cfe_sb_task.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_task.c
@@ -898,7 +898,7 @@ int32 CFE_SB_SendRtgInfo(const char *Filename)
                  * the buffer, therefore the initialization above will protect for now 
                  */
                 CFE_ES_GetAppName(&Entry.AppName[0], pd->AppId, sizeof(Entry.AppName));
-                strncpy(&Entry.PipeName[0],CFE_SB_GetPipeName(Entry.PipeId),sizeof(Entry.PipeName));
+                CFE_SB_GetPipeName(Entry.PipeId, Entry.PipeName);
 
                 WriteStat = OS_write (fd, &Entry, sizeof(CFE_SB_RoutingFileEntry_t));
                 if(WriteStat != sizeof(CFE_SB_RoutingFileEntry_t)){

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -9613,7 +9613,7 @@ void Test_OS_MutSem_ErrLogic(void)
 void Test_GetPipeName_ErrLogic(void)
 {
     CFE_SB_PipeId_t PipeId;
-    char            *CharStar;
+    char            PipeNameBuf[OS_MAX_API_NAME] = {'\0'};
     uint16          PipeDepth = 50;
     int32           ExpRtn;
     int32           ActRtn;
@@ -9625,13 +9625,15 @@ void Test_GetPipeName_ErrLogic(void)
 
     SB_ResetUnitTest();
     CFE_SB_CreatePipe(&PipeId, PipeDepth, "TestPipe");
-    CharStar = CFE_SB_GetPipeName(CFE_PLATFORM_SB_MAX_PIPES);
 
-    if (*CharStar != '\0')
+    ActRtn = CFE_SB_GetPipeName(CFE_PLATFORM_SB_MAX_PIPES, PipeNameBuf);
+    ExpRtn = CFE_SB_FAILED;
+
+    if (ActRtn == CFE_SUCCESS || PipeNameBuf[0] != '\0')
     {
         snprintf(cMsg, UT_MAX_MESSAGE_LENGTH,
-                 "Unexpected rtn from CFE_SB_CreatePipe, exp=NULL, act=%s",
-                 CharStar);
+                 "Unexpected rtn from CFE_SB_CreatePipe, exp=%d, act=%d",
+                 ExpRtn, ActRtn);
         UT_Text(cMsg);
         TestStat = CFE_FAIL;
     }


### PR DESCRIPTION
**Describe the contribution**
Removes the PipeName field from the CFE_SB_PipeD_t struct.

**Testing performed**
make install
make test

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - API Change: internal change to CFE_SB_GetPipeName
 - Behavior Change: reduced memory impact of the CFE_SB_PipeD_t table

**System(s) tested on:**
 - Hardware: VM
 - OS: Linux
 - Versions: "master"

**Contributor Info**
Chris Knight, NASA Ames Research Center
