### PR TITLE
Fix #210, Add SB API to get pipe by name

### DIFF
--- a/fsw/cfe-core/src/inc/cfe_sb.h
+++ b/fsw/cfe-core/src/inc/cfe_sb.h
@@ -193,7 +193,7 @@ typedef struct {
 ** \retcode #CFE_SB_PIPE_CR_ERR    \retdesc \copydoc CFE_SB_PIPE_CR_ERR   \endcode
 ** \endreturns
 **
-** \sa #CFE_SB_DeletePipe #CFE_SB_GetPipeOpts #CFE_SB_SetPipeOpts
+** \sa #CFE_SB_DeletePipe #CFE_SB_GetPipeOpts #CFE_SB_SetPipeOpts #CFE_SB_GetPipeIdByName
 **/
 int32  CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr,
                          uint16  Depth,
@@ -225,7 +225,7 @@ int32  CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr,
 ** \retcode #CFE_SB_BAD_ARGUMENT   \retdesc  \copydoc CFE_SB_BAD_ARGUMENT \endcode
 ** \endreturns
 **
-** \sa #CFE_SB_CreatePipe #CFE_SB_GetPipeOpts #CFE_SB_SetPipeOpts
+** \sa #CFE_SB_CreatePipe #CFE_SB_GetPipeOpts #CFE_SB_SetPipeOpts #CFE_SB_GetPipeIdByName
 **/
 int32  CFE_SB_DeletePipe(CFE_SB_PipeId_t PipeId);
 
@@ -246,7 +246,7 @@ int32  CFE_SB_DeletePipe(CFE_SB_PipeId_t PipeId);
 ** \retcode #CFE_SB_BAD_ARGUMENT   \retdesc  \copydoc CFE_SB_BAD_ARGUMENT \endcode
 ** \endreturns
 **
-** \sa #CFE_SB_CreatePipe #CFE_SB_DeletePipe #CFE_SB_GetPipeOpts #CFE_SB_PIPEOPTS_IGNOREMINE
+** \sa #CFE_SB_CreatePipe #CFE_SB_DeletePipe #CFE_SB_GetPipeOpts #CFE_SB_GetPipeIdByName #CFE_SB_PIPEOPTS_IGNOREMINE
 **/
 int32  CFE_SB_SetPipeOpts(CFE_SB_PipeId_t     PipeId,
                           uint8               Opts);
@@ -267,10 +267,54 @@ int32  CFE_SB_SetPipeOpts(CFE_SB_PipeId_t     PipeId,
 ** \retcode #CFE_SB_BAD_ARGUMENT   \retdesc  \copydoc CFE_SB_BAD_ARGUMENT \endcode
 ** \endreturns
 **
-** \sa #CFE_SB_CreatePipe #CFE_SB_DeletePipe #CFE_SB_SetPipeOpts #CFE_SB_PIPEOPTS_IGNOREMINE
+** \sa #CFE_SB_CreatePipe #CFE_SB_DeletePipe #CFE_SB_SetPipeOpts #CFE_SB_GetPipeIdByName #CFE_SB_PIPEOPTS_IGNOREMINE
 **/
 int32  CFE_SB_GetPipeOpts(CFE_SB_PipeId_t     PipeId,
                           uint8               *OptPtr);
+
+/*****************************************************************************/
+/**
+** \brief Get the pipe name for a given id.
+**
+** \par Description
+**          This routine finds the pipe name for a pipe id.
+**
+** \param[out] PipeNameBuf  The buffer to receive the pipe name.
+**
+** \param[in] PipeNameSize  The size (in chars) of the PipeName buffer.
+**
+** \param[in] PipeId        The PipeId for that name.
+**
+** \returns
+** \retcode #CFE_SUCCESS           \retdesc  \copydoc CFE_SUCCESS         \endcode
+** \retcode #CFE_SB_BAD_ARGUMENT   \retdesc  \copydoc CFE_SB_BAD_ARGUMENT \endcode
+** \retcode #CFE_SB_INVALID_PIPE   \retdesc  \copydoc CFE_SB_INVALID_PIPE \endcode
+** \endreturns
+**
+** \sa #CFE_SB_CreatePipe #CFE_SB_DeletePipe #CFE_SB_SetPipeOpts #CFE_SB_GetPipeIdByName
+**/
+int32 CFE_SB_GetPipeName(char *PipeNameBuf, size_t PipeNameSize, CFE_SB_PipeId_t PipeId);
+
+/*****************************************************************************/
+/**
+** \brief Get pipe id by pipe name.
+**
+** \par Description
+**          This routine finds the pipe id for a pipe name.
+**
+** \param[in]  PipeName     The name of the pipe.
+**
+** \param[out] PipeIdPtr    The PipeId for that name.
+**
+** \returns
+** \retcode #CFE_SUCCESS           \retdesc  \copydoc CFE_SUCCESS         \endcode
+** \retcode #CFE_SB_BAD_ARGUMENT   \retdesc  \copydoc CFE_SB_BAD_ARGUMENT \endcode
+** \retcode #CFE_SB_INVALID_PIPE   \retdesc  \copydoc CFE_SB_INVALID_PIPE \endcode
+** \endreturns
+**
+** \sa #CFE_SB_CreatePipe #CFE_SB_DeletePipe #CFE_SB_SetPipeOpts #CFE_SB_PIPEOPTS_IGNOREMINE
+**/
+int32  CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *PipeName);
 
 /*****************************************************************************/
 /** 

--- a/fsw/cfe-core/src/inc/cfe_sb_events.h
+++ b/fsw/cfe-core/src/inc/cfe_sb_events.h
@@ -40,7 +40,7 @@
 ** and when you're done adding, set this to the highest EID you used. It may
 ** be worthwhile to, on occasion, re-number the EID's to put them back in order.
 */
-#define CFE_SB_MAX_EID                  61
+#define CFE_SB_MAX_EID                  67
 
 /*
 ** SB task event message ID's.
@@ -183,6 +183,73 @@
 **/
 #define CFE_SB_GETPIPEOPTS_EID        60
 
+/** \brief <tt> 'GetPipeName: Name retrieved. NameOut \%s,Id \%d, app \%s' </tt>
+** \event <tt> 'GetPipeName: Name retrieved. NameOut \%s,Id \%d, app \%s' </tt>
+**
+**  \par Type: DEBUG
+**
+**  \par Cause:
+**
+**  This debug event is generated when name is retrieved by id.
+**/
+#define CFE_SB_GETPIPENAME_EID        62
+
+/** \brief <tt> 'GetPipeName: Null ptr error. Id \%d, app \%s' </tt>
+** \event <tt> 'GetPipeName: Null ptr error. Id \%d, app \%s' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This debug event is generated when the name buffer ptr is null.
+**/
+#define CFE_SB_GETPIPENAME_NULL_PTR_EID        63
+
+/** \brief <tt> 'GetPipeName: Id error. NameOut \%s,Id \%d, app \%s' </tt>
+** \event <tt> 'GetPipeName: Id error. NameOut \%s,Id \%d, app \%s' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This debug event is generated when name is retrieved by id.
+**/
+#define CFE_SB_GETPIPENAME_ID_ERR_EID        64
+
+/** \brief <tt> 'GetPipeIdByName: ID retrieved. Name \%s,IdOut 0x\%x, app \%s' </tt>
+** \event <tt> 'GetPipeIdByName: ID retrieved. Name \%s,IdOut 0x\%x, app \%s' </tt>
+**
+**  \par Type: DEBUG
+**
+**  \par Cause:
+**
+**  This debug event is generated when id is retrieved by name.
+**/
+#define CFE_SB_GETPIPEIDBYNAME_EID        65
+
+/** \brief <tt> 'GetPipeIdByName Err:Bad input argument,Name 0x\%x,IdOut 0x%x,App \%s' </tt>
+**  \event <tt> 'GetPipeIdByName Err:Bad input argument,Name 0x\%x,IdOut 0x%x,App \%s' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This error event message is issued when the #CFE_SB_GetMsgIdByName API receives an
+**  invalid (possibly NULL) ptr as an argument.
+**/
+#define CFE_SB_GETPIPEIDBYNAME_NULL_ERR_EID         66
+
+/** \brief <tt> 'GetPipeIdByName Err:Name not found,Name \%s,IdOut 0x%x,App \%s' </tt>
+**  \event <tt> 'GetPipeIdByName Err:Name not found,Name \%s,IdOut 0x%x,App \%s' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This error event message is issued when the #CFE_SB_GetMsgIdByName API receives an
+**  invalid name.
+**/
+#define CFE_SB_GETPIPEIDBYNAME_NAME_ERR_EID         67
 
 /** \brief <tt> 'Subscribe Err:Bad Arg,MsgId 0x\%x,PipeId \%d,app \%s,scope \%d' </tt>
 **  \event <tt> 'Subscribe Err:Bad Arg,MsgId 0x\%x,PipeId \%d,app \%s,scope \%d' </tt>

--- a/fsw/cfe-core/src/inc/cfe_sb_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_sb_msg.h
@@ -561,7 +561,9 @@ typedef struct {
                                         \brief Count of errors in set/get pipe options API */
     uint8           DuplicateSubscriptionsCounter;/**< \cfetlmmnemonic \SB_DUPSUBCNT
                                              \brief Count of duplicate subscriptions */
-    uint8           Spare2Align[2];/**< \cfetlmmnemonic \SB_SPARE2ALIGN
+    uint8           GetPipeIdByNameErrorCounter; /**< \cfetlmmnemonic \SB_GETPIPEIDBYNAMEEC
+                                        \brief Count of errors in get pipe id by name API */
+    uint8           Spare2Align[1];/**< \cfetlmmnemonic \SB_SPARE2ALIGN
                                         \brief Spare bytes to ensure alignment */
 
     uint16          PipeOverflowErrorCounter;/**< \cfetlmmnemonic \SB_PIPEOVREC

--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -180,8 +180,6 @@ int32  CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16  Depth, const char *
     CFE_SB.PipeTbl[PipeTblIdx].CurrentBuff = NULL;
     CFE_SB.PipeTbl[PipeTblIdx].ToTrashBuff = NULL;
     strcpy(&CFE_SB.PipeTbl[PipeTblIdx].AppName[0],&AppName[0]);
-    strncpy(&CFE_SB.PipeTbl[PipeTblIdx].PipeName[0],PipeName,OS_MAX_API_NAME);
-    CFE_SB.PipeTbl[PipeTblIdx].PipeName[OS_MAX_API_NAME-1]='\0';
 
     /* Increment the Pipes in use ctr and if it's > the high water mark,*/
     /* adjust the high water mark */
@@ -207,8 +205,7 @@ int32  CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16  Depth, const char *
     /* send debug event */
     CFE_EVS_SendEventWithAppID(CFE_SB_PIPE_ADDED_EID,CFE_EVS_EventType_DEBUG,CFE_SB.AppId,
           "Pipe Created:name %s,id %d,app %s",
-          CFE_SB_GetPipeName(CFE_SB.PipeTbl[PipeTblIdx].PipeId),
-          (int)CFE_SB.PipeTbl[PipeTblIdx].PipeId,
+          PipeName, (int)CFE_SB.PipeTbl[PipeTblIdx].PipeId,
           CFE_SB_GetAppTskName(TskId,FullName));
 
     return CFE_SUCCESS;
@@ -375,7 +372,6 @@ int32 CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId,uint32 AppId)
     CFE_SB.PipeTbl[PipeTblIdx].SysQueueId    = CFE_SB_UNUSED_QUEUE;
     CFE_SB.PipeTbl[PipeTblIdx].PipeId        = CFE_SB_INVALID_PIPE;
     CFE_SB.PipeTbl[PipeTblIdx].CurrentBuff   = NULL;
-    memset(&CFE_SB.PipeTbl[PipeTblIdx].PipeName[0],0,OS_MAX_API_NAME);
 
     /* zero out the pipe depth stats */
     if (PipeTblIdx < CFE_SB_TLM_PIPEDEPTHSTATS_SIZE)
@@ -539,6 +535,171 @@ int32 CFE_SB_GetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 *OptsPtr)
           "Pipe opts set:id %d, opts=0x%02x",(int)PipeId, (unsigned int)*OptsPtr);
     return CFE_SUCCESS;
 }/* end CFE_SB_GetPipeOpts */
+
+/******************************************************************************
+**  Function:  CFE_SB_GetPipeName()
+**
+**  Purpose:
+**    SB internal function to get the string of the pipe name of the given
+**    Pipe ID.
+**
+**  Arguments:
+**    MsgId       : ID of the message
+**    PipeNameBuf : Buffer to receive name, must be OS_MAX_API_NAME bytes long
+**
+**  Return:
+**    Will return CFE_SUCCESS and populate PipeNameBuf with the name
+**    of the pipe on success, otherwise PipeNameBuf is filled with NULLs
+**    and this returns CFE_SB_BAD_ARGUMENT on error.
+**
+*/
+int32 CFE_SB_GetPipeName(char *PipeNameBuf, size_t PipeNameSize, CFE_SB_PipeId_t PipeId){
+    OS_queue_prop_t queue_prop;
+    int32 Status = CFE_SUCCESS;
+    uint32 TskId = 0;
+    char FullName[(OS_MAX_API_NAME * 2)];
+
+    if(PipeNameBuf == NULL || PipeNameSize == 0) {
+        CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPENAME_NULL_PTR_EID, CFE_EVS_EventType_ERROR,
+            CFE_SB.AppId, "Pipe Name Error:NullPtr,Requestor %s",
+            CFE_SB_GetAppTskName(TskId,FullName));
+
+        Status = CFE_SB_BAD_ARGUMENT;
+    } else if(PipeId >= CFE_PLATFORM_SB_MAX_PIPES){
+        CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPENAME_ID_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_SB.AppId, "Pipe Id Error:Bad Argument,Id=%d,Requestor %s",
+            PipeId,CFE_SB_GetAppTskName(TskId,FullName));
+
+        memset(PipeNameBuf, 0, PipeNameSize);
+
+        Status = CFE_SB_BAD_ARGUMENT;
+    }else{
+        if (OS_QueueGetInfo(CFE_SB.PipeTbl[PipeId].SysQueueId, &queue_prop)
+                == OS_SUCCESS){
+            strncpy(PipeNameBuf, queue_prop.name, PipeNameSize-1);
+
+            PipeNameBuf[PipeNameSize-1] = '\0'; 
+
+            CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPENAME_EID,
+                CFE_EVS_EventType_DEBUG,CFE_SB.AppId,
+                "GetPipeName name=%s id=%d",
+                PipeNameBuf, PipeId);
+        } else{
+            CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPENAME_ID_ERR_EID, CFE_EVS_EventType_ERROR,
+                CFE_SB.AppId, "Pipe Id Error:Bad Argument,Id=%d,Requestor %s",
+                PipeId,CFE_SB_GetAppTskName(TskId,FullName));
+
+            memset(PipeNameBuf, 0, PipeNameSize);
+
+            Status = CFE_SB_BAD_ARGUMENT;
+        }/* end if */
+    }/* end if */
+
+    return Status;
+}/* end CFE_SB_GetPipeName */
+
+/******************************************************************************
+**  Function:  CFE_SB_GetPipeIdByName()
+**
+**  Purpose:
+**  Gets the pipe id given its name.
+**
+**  Arguments:
+**    PipeIdPtr  - The ID of the pipe for the name.
+**    PipeName   - The name of the pipe.
+**
+**  Return:
+**    CFE_SUCCESS or cFE Error Code
+*/
+int32 CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *PipeName)
+{
+    uint8         PipeTblIdx = 0;
+    int32         Status = CFE_SUCCESS;
+    int32         RtnFromVal = 0;
+    uint32        TskId = 0;
+    uint32        QueueId = 0;
+    char          FullName[(OS_MAX_API_NAME * 2)];
+
+    if(PipeName == NULL || PipeIdPtr == NULL)
+    {
+        CFE_SB.HKTlmMsg.Payload.GetPipeIdByNameErrorCounter++;
+
+        CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPEIDBYNAME_NULL_ERR_EID, CFE_EVS_EventType_ERROR, CFE_SB.AppId,
+          "Pipe ID By Name Error:Bad Argument,Requestor %s",
+          CFE_SB_GetAppTskName(TskId,FullName));
+
+        Status = CFE_SB_BAD_ARGUMENT;
+    }
+    else
+    {
+        /* get TaskId of caller for events */
+        TskId = OS_TaskGetId();
+
+        RtnFromVal = OS_QueueGetIdByName(&QueueId, PipeName);
+
+        if(RtnFromVal == OS_SUCCESS)
+        {
+            /* take semaphore to prevent a task switch while iterating
+             * through the PipeTbl.
+             */
+            CFE_SB_LockSharedData(__func__,__LINE__);
+
+            for(PipeTblIdx = 0;
+                PipeTblIdx < CFE_PLATFORM_SB_MAX_PIPES;
+                PipeTblIdx++)
+            {
+                if(CFE_SB.PipeTbl[PipeTblIdx].InUse != 0
+                    && CFE_SB.PipeTbl[PipeTblIdx].SysQueueId == QueueId)
+                {
+                    /* grab the ID before we release the lock */
+                    *PipeIdPtr = CFE_SB.PipeTbl[PipeTblIdx].PipeId;
+
+                    break;
+                }/* end if */
+
+            }/* end for */
+
+            CFE_SB_UnlockSharedData(__func__,__LINE__);
+
+            if(PipeTblIdx == CFE_PLATFORM_SB_MAX_PIPES)
+            {
+                /* should never get here! */
+                CFE_SB.HKTlmMsg.Payload.GetPipeIdByNameErrorCounter++;
+
+                CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPEIDBYNAME_NAME_ERR_EID,
+                    CFE_EVS_EventType_ERROR, CFE_SB.AppId,
+                    "Pipe ID By Name Error:Bad Argument,Requestor %s",
+                    CFE_SB_GetAppTskName(TskId,FullName));
+
+                Status = CFE_SB_BAD_ARGUMENT;
+            }
+            else
+            {
+                CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPEIDBYNAME_EID,
+                    CFE_EVS_EventType_DEBUG,CFE_SB.AppId,
+                    "PipeIdByName name=%s id=%d",
+                    PipeName, *PipeIdPtr);
+
+                Status = CFE_SUCCESS;
+            }
+        }
+        else
+        {
+            CFE_SB.HKTlmMsg.Payload.GetPipeIdByNameErrorCounter++;
+
+            CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPEIDBYNAME_NAME_ERR_EID,
+                CFE_EVS_EventType_ERROR, CFE_SB.AppId,
+                "Pipe ID By Name Error:Bad Argument,Requestor %s",
+                CFE_SB_GetAppTskName(TskId,FullName));
+
+            Status = CFE_SB_BAD_ARGUMENT;
+        }/* end if */
+
+    }/* end if */
+
+    return Status;
+
+}/* end CFE_SB_GetPipeIdByName */
 
 
 /******************************************************************************
@@ -704,6 +865,9 @@ int32  CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
     uint8  PipeIdx;
     CFE_SB_DestinationD_t *DestBlkPtr = NULL;
     char   FullName[(OS_MAX_API_NAME * 2)];
+    char   PipeName[OS_MAX_API_NAME] = {'\0'};
+
+    CFE_SB_GetPipeName(PipeName, sizeof(PipeName), PipeId);
 
     /* take semaphore to prevent a task switch during this call */
     CFE_SB_LockSharedData(__func__,__LINE__);
@@ -755,7 +919,7 @@ int32  CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
         CFE_SB_UnlockSharedData(__func__,__LINE__);
         CFE_EVS_SendEventWithAppID(CFE_SB_DUP_SUBSCRIP_EID,CFE_EVS_EventType_INFORMATION,CFE_SB.AppId,
           "Duplicate Subscription,MsgId 0x%x on %s pipe,app %s",
-           (unsigned int)MsgId,CFE_SB_GetPipeName(PipeId),CFE_SB_GetAppTskName(TskId,FullName));
+           (unsigned int)MsgId,PipeName,CFE_SB_GetAppTskName(TskId,FullName));
         return CFE_SUCCESS;
     }/* end if */
 
@@ -790,7 +954,7 @@ int32  CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
             CFE_SB_UnlockSharedData(__func__,__LINE__);
             CFE_EVS_SendEventWithAppID(CFE_SB_MAX_MSGS_MET_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
               "Subscribe Err:Max Msgs(%d)In Use,MsgId 0x%x,pipe %s,app %s",
-              CFE_PLATFORM_SB_MAX_MSG_IDS,(unsigned int)MsgId,CFE_SB_GetPipeName(PipeId),CFE_SB_GetAppTskName(TskId,FullName));
+              CFE_PLATFORM_SB_MAX_MSG_IDS,(unsigned int)MsgId,PipeName,CFE_SB_GetAppTskName(TskId,FullName));
             return CFE_SB_MAX_MSGS_MET;
         }/* end if */
 
@@ -814,7 +978,7 @@ int32  CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
         CFE_SB_UnlockSharedData(__func__,__LINE__);
         CFE_EVS_SendEventWithAppID(CFE_SB_MAX_DESTS_MET_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
             "Subscribe Err:Max Dests(%d)In Use For Msg 0x%x,pipe %s,app %s",
-             CFE_PLATFORM_SB_MAX_DEST_PER_PKT,(unsigned int)MsgId,CFE_SB_GetPipeName(PipeId),
+             CFE_PLATFORM_SB_MAX_DEST_PER_PKT,(unsigned int)MsgId,PipeName,
              CFE_SB_GetAppTskName(TskId,FullName));
 
         return CFE_SB_MAX_DESTS_MET;
@@ -868,7 +1032,7 @@ int32  CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
 
     CFE_EVS_SendEventWithAppID(CFE_SB_SUBSCRIPTION_RCVD_EID,CFE_EVS_EventType_DEBUG,CFE_SB.AppId,
         "Subscription Rcvd:MsgId 0x%x on %s(%d),app %s",
-         (unsigned int)MsgId,CFE_SB_GetPipeName(PipeId),(int)PipeId,CFE_SB_GetAppTskName(TskId,FullName));
+         (unsigned int)MsgId,PipeName,(int)PipeId,CFE_SB_GetAppTskName(TskId,FullName));
 
     return CFE_SUCCESS;
 
@@ -1064,10 +1228,15 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId,CFE_SB_PipeId_t PipeId,
 
     /* if there are no subscriptions for this message id... */
     if(!CFE_SB_IsValidRouteIdx(RouteIdx)){
+        char    PipeName[OS_MAX_API_NAME] = {'\0'};
+
         CFE_SB_UnlockSharedData(__func__,__LINE__);
+
+        CFE_SB_GetPipeName(PipeName, sizeof(PipeName), PipeId);
+
         CFE_EVS_SendEventWithAppID(CFE_SB_UNSUB_NO_SUBS_EID,CFE_EVS_EventType_INFORMATION,CFE_SB.AppId,
             "Unsubscribe Err:No subs for Msg 0x%x on %s,app %s",
-            (unsigned int)MsgId,CFE_SB_GetPipeName(PipeId),CFE_SB_GetAppTskName(TskId,FullName));
+            (unsigned int)MsgId,PipeName,CFE_SB_GetAppTskName(TskId,FullName));
         return CFE_SUCCESS;
     }/* end if */
 
@@ -1247,6 +1416,7 @@ int32  CFE_SB_SendMsgFull(CFE_SB_Msg_t    *MsgPtr,
     uint16                  i;
     char                    FullName[(OS_MAX_API_NAME * 2)];
     CFE_SB_EventBuf_t       SBSndErr;
+    char                    PipeName[OS_MAX_API_NAME] = {'\0'};
 
     SBSndErr.EvtsToSnd = 0;
 
@@ -1490,16 +1660,18 @@ int32  CFE_SB_SendMsgFull(CFE_SB_Msg_t    *MsgPtr,
     {
         if(SBSndErr.EvtBuf[i].EventId == CFE_SB_MSGID_LIM_ERR_EID)
         {
+
             /* Determine if event can be sent without causing recursive event problem */
             if(CFE_SB_RequestToSendEvent(TskId,CFE_SB_MSGID_LIM_ERR_EID_BIT) == CFE_SB_GRANTED){
+
+              CFE_SB_GetPipeName(PipeName, sizeof(PipeName), SBSndErr.EvtBuf[i].PipeId);
 
               CFE_ES_PerfLogEntry(CFE_MISSION_SB_MSG_LIM_PERF_ID);
               CFE_ES_PerfLogExit(CFE_MISSION_SB_MSG_LIM_PERF_ID);
 
               CFE_EVS_SendEventWithAppID(CFE_SB_MSGID_LIM_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
                 "Msg Limit Err,MsgId 0x%x,pipe %s,sender %s",
-                (unsigned int)RtgTblPtr->MsgId,
-                CFE_SB_GetPipeName(SBSndErr.EvtBuf[i].PipeId),
+                (unsigned int)RtgTblPtr->MsgId, PipeName,
                 CFE_SB_GetAppTskName(TskId,FullName));
 
               /* clear the bit so the task may send this event again */
@@ -1511,13 +1683,14 @@ int32  CFE_SB_SendMsgFull(CFE_SB_Msg_t    *MsgPtr,
             /* Determine if event can be sent without causing recursive event problem */
             if(CFE_SB_RequestToSendEvent(TskId,CFE_SB_Q_FULL_ERR_EID_BIT) == CFE_SB_GRANTED){
 
+              CFE_SB_GetPipeName(PipeName, sizeof(PipeName), SBSndErr.EvtBuf[i].PipeId);
+
               CFE_ES_PerfLogEntry(CFE_MISSION_SB_PIPE_OFLOW_PERF_ID);
               CFE_ES_PerfLogExit(CFE_MISSION_SB_PIPE_OFLOW_PERF_ID);
 
               CFE_EVS_SendEventWithAppID(CFE_SB_Q_FULL_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
                   "Pipe Overflow,MsgId 0x%x,pipe %s,sender %s",
-                  (unsigned int)RtgTblPtr->MsgId,
-                  CFE_SB_GetPipeName(SBSndErr.EvtBuf[i].PipeId),
+                  (unsigned int)RtgTblPtr->MsgId, PipeName,
                   CFE_SB_GetAppTskName(TskId,FullName));
 
                /* clear the bit so the task may send this event again */
@@ -1529,10 +1702,11 @@ int32  CFE_SB_SendMsgFull(CFE_SB_Msg_t    *MsgPtr,
             /* Determine if event can be sent without causing recursive event problem */
             if(CFE_SB_RequestToSendEvent(TskId,CFE_SB_Q_WR_ERR_EID_BIT) == CFE_SB_GRANTED){
 
+              CFE_SB_GetPipeName(PipeName, sizeof(PipeName), SBSndErr.EvtBuf[i].PipeId);
+
               CFE_EVS_SendEventWithAppID(CFE_SB_Q_WR_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
                 "Pipe Write Err,MsgId 0x%x,pipe %s,sender %s,stat 0x%x",
-                (unsigned int)RtgTblPtr->MsgId,
-                CFE_SB_GetPipeName(SBSndErr.EvtBuf[i].PipeId),
+                (unsigned int)RtgTblPtr->MsgId, PipeName,
                 CFE_SB_GetAppTskName(TskId,FullName),
                 (unsigned int)SBSndErr.EvtBuf[i].ErrStat);
 
@@ -2112,6 +2286,7 @@ int32  CFE_SB_ReadQueue (CFE_SB_PipeD_t         *PipeDscPtr,
     int32              Status,TimeOut;
     uint32             Nbytes;
     char               FullName[(OS_MAX_API_NAME * 2)];
+    char               PipeName[OS_MAX_API_NAME] = {'\0'};
 
     /* translate the given Time_Out value */
     switch(Time_Out){
@@ -2157,9 +2332,10 @@ int32  CFE_SB_ReadQueue (CFE_SB_PipeD_t         *PipeDscPtr,
           CFE_SB.HKTlmMsg.Payload.InternalErrorCounter++;
           CFE_SB_UnlockSharedData(__func__,__LINE__);
           /* Unexpected error while reading the queue. */
+          CFE_SB_GetPipeName(PipeName, sizeof(PipeName), PipeDscPtr->PipeId);
           CFE_EVS_SendEventWithAppID(CFE_SB_Q_RD_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
               "Pipe Read Err,pipe %s,app %s,stat 0x%x",
-              CFE_SB_GetPipeName(PipeDscPtr->PipeId),CFE_SB_GetAppTskName(TskId,FullName),(unsigned int)Status);
+              PipeName,CFE_SB_GetAppTskName(TskId,FullName),(unsigned int)Status);
 
           Status = CFE_SB_PIPE_RD_ERR;
           break;

--- a/fsw/cfe-core/src/sb/cfe_sb_init.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_init.c
@@ -194,7 +194,6 @@ void CFE_SB_InitPipeTbl(void){
         CFE_SB.PipeTbl[i].SysQueueId    = CFE_SB_UNUSED_QUEUE;
         CFE_SB.PipeTbl[i].PipeId        = CFE_SB_INVALID_PIPE;
         CFE_SB.PipeTbl[i].CurrentBuff   = NULL;
-        memset(&CFE_SB.PipeTbl[i].PipeName[0],0,OS_MAX_API_NAME);
     }/* end for */
 
 }/* end CFE_SB_InitPipeTbl */

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.c
@@ -488,37 +488,6 @@ CFE_SB_RouteEntry_t* CFE_SB_GetRoutePtrFromIdx(CFE_SB_MsgRouteIdx_t RouteIdx)
     return &CFE_SB.RoutingTbl[CFE_SB_RouteIdxToValue(RouteIdx)];
 } /* end CFE_SB_GetRouteFromIdx */
 
-
-/******************************************************************************
-**  Function:  CFE_SB_GetPipeName()
-**
-**  Purpose:
-**    SB internal function to get the string of the pipe name of the given
-**    Pipe ID.
-**
-**  Arguments:
-**    MsgId  : ID of the message
-**
-**  Return:
-**    Will return a pointer to the PipeName array in the pipe table if the the pipeid
-**    is in range. Otherwise this function returns a pointer to the
-**    PipeName4ErrCase[0], which is initialized with a null terminator.
-**
-*/
-char *CFE_SB_GetPipeName(CFE_SB_PipeId_t PipeId){
-
-    static char PipeName4ErrCase[1] = {'\0'};
-
-    if(PipeId >= CFE_PLATFORM_SB_MAX_PIPES){
-        return &PipeName4ErrCase[0];
-    }else{
-        return &CFE_SB.PipeTbl[PipeId].PipeName[0];
-    }/* end if */
-
-}/* end CFE_SB_GetPipeName */
-
-
-
 /******************************************************************************
 **  Function:  CFE_SB_DuplicateSubscribeCheck()
 **

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.h
@@ -249,7 +249,6 @@ typedef struct {
 typedef struct {
      uint8              InUse;
      CFE_SB_PipeId_t    PipeId;
-     char               PipeName[OS_MAX_API_NAME];
      char               AppName[OS_MAX_API_NAME];
      uint8              Opts;
      uint8              Spare;
@@ -363,7 +362,6 @@ int32  CFE_SB_DuplicateSubscribeCheck(CFE_SB_MsgKey_t MsgKey,CFE_SB_PipeId_t Pip
 void   CFE_SB_SetRoutingTblIdx(CFE_SB_MsgKey_t MsgKey, CFE_SB_MsgRouteIdx_t Value);
 CFE_SB_RouteEntry_t* CFE_SB_GetRoutePtrFromIdx(CFE_SB_MsgRouteIdx_t RouteIdx);
 void   CFE_SB_ResetCounters(void);
-char   *CFE_SB_GetPipeName(CFE_SB_PipeId_t PipeId);
 void   CFE_SB_SetMsgSeqCnt(CFE_SB_MsgPtr_t MsgPtr,uint32 Count);
 char   *CFE_SB_GetAppTskName(uint32 TaskId, char* FullName);
 CFE_SB_BufferD_t *CFE_SB_GetBufferFromPool(CFE_SB_MsgId_t MsgId, uint16 size);

--- a/fsw/cfe-core/src/sb/cfe_sb_task.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_task.c
@@ -898,7 +898,7 @@ int32 CFE_SB_SendRtgInfo(const char *Filename)
                  * the buffer, therefore the initialization above will protect for now 
                  */
                 CFE_ES_GetAppName(&Entry.AppName[0], pd->AppId, sizeof(Entry.AppName));
-                strncpy(&Entry.PipeName[0],CFE_SB_GetPipeName(Entry.PipeId),sizeof(Entry.PipeName));
+                CFE_SB_GetPipeName(Entry.PipeName, sizeof(Entry.PipeName), Entry.PipeId);
 
                 WriteStat = OS_write (fd, &Entry, sizeof(CFE_SB_RoutingFileEntry_t));
                 if(WriteStat != sizeof(CFE_SB_RoutingFileEntry_t)){

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -57,6 +57,8 @@ void OS_Application_Startup(void)
     UT_ADD_TEST(Test_CreatePipe_API);
     UT_ADD_TEST(Test_DeletePipe_API);
     UT_ADD_TEST(Test_PipeOpts_API);
+    UT_ADD_TEST(Test_GetPipeName_API);
+    UT_ADD_TEST(Test_GetPipeIdByName_API);
     UT_ADD_TEST(Test_Subscribe_API);
     UT_ADD_TEST(Test_Unsubscribe_API);
     UT_ADD_TEST(Test_SendMsg_API);
@@ -595,7 +597,7 @@ void Test_SB_AppInit_EVSSendEvtFail(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 3;
+    ExpRtn = 5;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -696,7 +698,7 @@ void Test_SB_AppInit_Sub1Fail(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 2;
+    ExpRtn = 3;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -748,7 +750,7 @@ void Test_SB_AppInit_Sub2Fail(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 3;
+    ExpRtn = 5;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -801,7 +803,7 @@ void Test_SB_AppInit_GetPoolFail(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 3;
+    ExpRtn = 5;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -848,7 +850,7 @@ void Test_SB_AppInit_PutPoolFail(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 3;
+    ExpRtn = 5;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -899,7 +901,7 @@ void Test_SB_Main_RcvErr(void)
     SB_ResetUnitTest();
     UT_SetDeferredRetcode(UT_KEY(OS_QueueGet), 1, -1);
     CFE_SB_TaskMain();
-    ExpRtn = 5;
+    ExpRtn = 8;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -945,7 +947,7 @@ void Test_SB_Main_InitErr(void)
     SB_ResetUnitTest();
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_PutPoolBuf), 1, -1);
     CFE_SB_TaskMain();
-    ExpRtn = 3;
+    ExpRtn = 5;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -1182,7 +1184,7 @@ void Test_SB_Cmds_RoutingInfoDef(void)
     CFE_SB.CmdPipePktPtr = (CFE_SB_MsgPtr_t) &WriteFileCmd;
     CFE_SB_ProcessCmdPipePkt();
 
-    ExpRtn = 5;
+    ExpRtn = 9;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -1413,7 +1415,7 @@ void Test_SB_Cmds_RoutingInfoWriteFail(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 5;
+    ExpRtn = 9;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -1777,7 +1779,7 @@ void Test_SB_Cmds_MapInfoDef(void)
     CFE_SB_Subscribe(MsgId5, PipeId2);
     CFE_SB.CmdPipePktPtr = (CFE_SB_MsgPtr_t) &WriteFileCmd;
     CFE_SB_ProcessCmdPipePkt();
-    ExpRtn = 11;
+    ExpRtn = 18;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -2013,7 +2015,7 @@ void Test_SB_Cmds_MapInfoWriteFail(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 11;
+    ExpRtn = 18;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -2079,7 +2081,7 @@ void Test_SB_Cmds_EnRouteValParam(void)
     EnDisRouteCmd.Payload.Pipe = PipeId;
     CFE_SB.CmdPipePktPtr = (CFE_SB_MsgPtr_t) &EnDisRouteCmd;
     CFE_SB_ProcessCmdPipePkt();
-    ExpRtn = 3;
+    ExpRtn = 4;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -2145,7 +2147,7 @@ void Test_SB_Cmds_EnRouteNonExist(void)
     EnDisRouteCmd.Payload.Pipe = PipeId2;
     CFE_SB.CmdPipePktPtr = (CFE_SB_MsgPtr_t) &EnDisRouteCmd;
     CFE_SB_ProcessCmdPipePkt();
-    ExpRtn = 4;
+    ExpRtn = 5;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -2349,7 +2351,7 @@ void Test_SB_Cmds_DisRouteValParam(void)
     EnDisRouteCmd.Payload.Pipe = PipeId;
     CFE_SB.CmdPipePktPtr = (CFE_SB_MsgPtr_t) &EnDisRouteCmd;
     CFE_SB_ProcessCmdPipePkt();
-    ExpRtn = 3;
+    ExpRtn = 4;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -2414,7 +2416,7 @@ void Test_SB_Cmds_DisRouteNonExist(void)
     EnDisRouteCmd.Payload.Pipe = PipeId2;
     CFE_SB.CmdPipePktPtr = (CFE_SB_MsgPtr_t) &EnDisRouteCmd;
     CFE_SB_ProcessCmdPipePkt();
-    ExpRtn = 4;
+    ExpRtn = 5;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -2676,7 +2678,7 @@ void Test_SB_Cmds_SendPrevSubs(void)
          * */
         if (i != CFE_SB_ALLSUBS_TLM_MID)
         {
-            ++NumEvts;
+            NumEvts += 2;
             ActRtn = CFE_SB_Subscribe(i, PipeId1);
             ExpRtn = CFE_SUCCESS;
 
@@ -2694,7 +2696,7 @@ void Test_SB_Cmds_SendPrevSubs(void)
 
     CFE_SB_SubscribeLocal(MsgId, PipeId2, MsgLim);
     CFE_SB_ProcessCmdPipePkt();
-    NumEvts += 7;  /* +1 for the subscribe, +6 for the SEND_PREV_SUBS_CC */
+    NumEvts += 8;  /* +2 for the subscribe, +6 for the SEND_PREV_SUBS_CC */
     ExpRtn = NumEvts;
     ActRtn = UT_GetNumEventsSent();
 
@@ -2714,7 +2716,7 @@ void Test_SB_Cmds_SendPrevSubs(void)
     {
         ActRtn = CFE_SB_Subscribe(i, PipeId1);
         ExpRtn = CFE_SUCCESS;
-        ++NumEvts;
+        NumEvts += 2;
 
         if (ActRtn != ExpRtn)
         {
@@ -2730,7 +2732,7 @@ void Test_SB_Cmds_SendPrevSubs(void)
 
     CFE_SB_SubscribeLocal(MsgId, PipeId2, MsgLim);
     CFE_SB_ProcessCmdPipePkt();
-    NumEvts += 7;  /* +1 for the subscribe, +6 for the SEND_PREV_SUBS_CC */
+    NumEvts += 8;  /* +2 for the subscribe, +6 for the SEND_PREV_SUBS_CC */
     ExpRtn = NumEvts;
     ActRtn = UT_GetNumEventsSent();
 
@@ -3495,7 +3497,7 @@ void Test_DeletePipe_WithSubs(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 10;
+    ExpRtn = 14;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -3688,7 +3690,7 @@ void Test_DeletePipe_WithAppid(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 10;
+    ExpRtn = 14;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -3724,6 +3726,320 @@ void Test_PipeOpts_API(void)
     UT_Text("End Test_PipeOpts_API\n");
 #endif
 } /* end Test_PipeOpts_API */
+
+/*
+** Function for calling SB get pipe name by id API test functions
+*/
+void Test_GetPipeName_API(void)
+{
+#ifdef UT_VERBOSE
+    UT_Text("Begin Test_GetPipeName_API");
+#endif
+
+    Test_GetPipeName_NullPtr();
+    Test_GetPipeName_InvalidId();
+    Test_GetPipeName();
+
+#ifdef UT_VERBOSE
+    UT_Text("End Test_GetPipeName_API\n");
+#endif
+} /* end Test_GetGetPipeName_API */
+
+/*
+** Call GetPipeName with null pointer.
+*/
+void Test_GetPipeName_NullPtr(void)
+{
+    int32 ExpRtn = 0, ActRtn = 0;
+    int32 TestStat = CFE_PASS;
+#ifdef UT_VERBOSE
+    UT_Text("Begin Test for Cmd - GetPipeName with null ptr");
+#endif
+
+    ExpRtn = CFE_SB_BAD_ARGUMENT;
+    if((ActRtn = CFE_SB_GetPipeName(NULL, OS_MAX_API_NAME, 0)) != ExpRtn)
+    {
+        snprintf(cMsg, UT_MAX_MESSAGE_LENGTH,
+                 "Unexpected rtn from CFE_SB_GetPipeName, exp=%ld, act=%ld",
+                 (long) ExpRtn, (long) ActRtn);
+        UT_Text(cMsg);
+
+        TestStat = CFE_FAIL;
+    }
+
+    if (UT_EventIsInHistory(CFE_SB_GETPIPENAME_NULL_PTR_EID) == false)
+    {
+        UT_Text("CFE_SB_GETPIPENAME_NULL_PTR_EID not sent");
+
+        TestStat = CFE_FAIL;
+    }
+
+    UT_Report(__FILE__, __LINE__,
+        TestStat, "CFE_SB_GetPipeName_NullPtr",
+        "Get pipe name with null ptr");
+} /* end Test_GetPipeName_NullPtr */
+
+/*
+** Call to GetPipeName with an invalid pipe id.
+*/
+void Test_GetPipeName_InvalidId(void)
+{
+    int32 ExpRtn = 0, ActRtn = 0;
+    int32 TestStat = CFE_PASS;
+    char PipeName[OS_MAX_API_NAME];
+#ifdef UT_VERBOSE
+    UT_Text("Begin Test for Cmd - GetPipeName with invalid pipe id");
+#endif
+
+    UT_SetDeferredRetcode(UT_KEY(OS_QueueGetInfo), 1, OS_ERROR);
+
+    ExpRtn = CFE_SB_BAD_ARGUMENT;
+    if((ActRtn = CFE_SB_GetPipeName(PipeName, OS_MAX_API_NAME, 0)) != ExpRtn)
+    {
+        snprintf(cMsg, UT_MAX_MESSAGE_LENGTH,
+                 "Unexpected rtn from CFE_SB_GetPipeName, exp=%ld, act=%ld",
+                 (long) ExpRtn, (long) ActRtn);
+        UT_Text(cMsg);
+
+        TestStat = CFE_FAIL;
+    }
+
+    if (UT_EventIsInHistory(CFE_SB_GETPIPENAME_ID_ERR_EID) == false)
+    {
+        UT_Text("CFE_SB_GETPIPENAME_ID_ERR_EID not sent");
+
+        TestStat = CFE_FAIL;
+    }
+
+    UT_Report(__FILE__, __LINE__,
+        TestStat, "CFE_SB_GetPipeName_InvalidId",
+        "Get pipe name with invalid id");
+} /* end Test_GetPipeName_InvalidId */
+
+/*
+** Successful call to GetPipeName
+*/
+void Test_GetPipeName(void)
+{
+    int32 ExpRtn = 0, ActRtn = 0;
+    int32 TestStat = CFE_PASS;
+    char PipeName[OS_MAX_API_NAME];
+    CFE_SB_PipeId_t PipeId = 0;
+
+    OS_queue_prop_t queue_info = {
+        "TestPipe1", 0
+    };
+
+#ifdef UT_VERBOSE
+    UT_Text("Begin Test for Cmd - GetPipeName");
+#endif
+
+    ExpRtn = CFE_SUCCESS;
+    if((ActRtn = CFE_SB_CreatePipe(&PipeId, 4, "TestPipe1")) != ExpRtn)
+    {
+        snprintf(cMsg, UT_MAX_MESSAGE_LENGTH,
+            "Unexpected rtn from CFE_SB_CreatePipe, exp=%ld, act=%ld",
+            (long) ExpRtn, (long) ActRtn);
+        UT_Text(cMsg);
+
+        UT_Report(__FILE__, __LINE__,
+            CFE_FAIL, "CFE_SB_GetPipeName",
+            "Get pipe name by id");
+        return;
+    }
+
+    UT_SetDataBuffer(
+        UT_KEY(OS_QueueGetInfo),
+        &queue_info, sizeof(queue_info),
+        false);
+
+    ExpRtn = CFE_SUCCESS;
+    if((ActRtn = CFE_SB_GetPipeName(PipeName, OS_MAX_API_NAME, PipeId)) != ExpRtn)
+    {
+        snprintf(cMsg, UT_MAX_MESSAGE_LENGTH,
+                 "Unexpected rtn from CFE_SB_GetPipeName, exp=%ld, act=%ld",
+                 (long) ExpRtn, (long) ActRtn);
+        UT_Text(cMsg);
+
+        TestStat = CFE_FAIL;
+    }
+
+    if (UT_EventIsInHistory(CFE_SB_GETPIPENAME_EID) == false)
+    {
+        UT_Text("CFE_SB_GETPIPENAME_EID not sent");
+
+        TestStat = CFE_FAIL;
+    }
+
+    CFE_SB_DeletePipe(PipeId);
+
+    UT_Report(__FILE__, __LINE__,
+        TestStat, "CFE_SB_GetPipeName",
+        "Get pipe name");
+} /* end Test_GetPipeName */
+
+/*
+** Function for calling SB get pipe id by name API test functions
+*/
+void Test_GetPipeIdByName_API(void)
+{
+#ifdef UT_VERBOSE
+    UT_Text("Begin Test_GetPipeIdByName_API");
+#endif
+
+    Test_GetPipeIdByName_NullPtrs();
+    Test_GetPipeIdByName_InvalidName();
+    Test_GetPipeIdByName();
+
+#ifdef UT_VERBOSE
+    UT_Text("End Test_GetPipeIdByName_API\n");
+#endif
+} /* end Test_GetPipeIdByName_API */
+
+/*
+** Call GetPipeIdByName with null pointers.
+*/
+void Test_GetPipeIdByName_NullPtrs(void)
+{
+    int32 ExpRtn = 0, ActRtn = 0;
+    int32 TestStat = CFE_PASS;
+    CFE_SB_PipeId_t PipeIDOut = 0;
+#ifdef UT_VERBOSE
+    UT_Text("Begin Test for Cmd - GetPipeIdByName with null ptrs");
+#endif
+
+    ExpRtn = CFE_SB_BAD_ARGUMENT;
+    if((ActRtn = CFE_SB_GetPipeIdByName(&PipeIDOut, NULL)) != ExpRtn)
+    {
+        snprintf(cMsg, UT_MAX_MESSAGE_LENGTH,
+                 "Unexpected rtn from CFE_SB_GetPipeIdByName, exp=%ld, act=%ld",
+                 (long) ExpRtn, (long) ActRtn);
+        UT_Text(cMsg);
+
+        TestStat = CFE_FAIL;
+    }
+
+    if (UT_EventIsInHistory(CFE_SB_GETPIPEIDBYNAME_NULL_ERR_EID) == false)
+    {
+        UT_Text("CFE_SB_GETPIPEIDBYNAME_EID not sent");
+
+        TestStat = CFE_FAIL;
+    }
+
+    ExpRtn = CFE_SB_BAD_ARGUMENT;
+    if((ActRtn = CFE_SB_GetPipeIdByName(NULL, "invalid")) != ExpRtn)
+    {
+        snprintf(cMsg, UT_MAX_MESSAGE_LENGTH,
+                 "Unexpected rtn from CFE_SB_GetPipeIdByName, exp=%ld, act=%ld",
+                 (long) ExpRtn, (long) ActRtn);
+        UT_Text(cMsg);
+
+        TestStat = CFE_FAIL;
+    }
+
+    if (UT_EventIsInHistory(CFE_SB_GETPIPEIDBYNAME_NULL_ERR_EID) == false)
+    {
+        UT_Text("CFE_SB_GETPIPEIDBYNAME_EID not sent");
+
+        TestStat = CFE_FAIL;
+    }
+
+    UT_Report(__FILE__, __LINE__,
+        TestStat, "CFE_SB_GetPipeIdByName_NullPtrs",
+        "Get pipe id by name with null ptrs");
+} /* end Test_GetPipeIdByName_NullPtrs */
+
+/*
+** Call to GetPipeId with an invalid pipe name.
+*/
+void Test_GetPipeIdByName_InvalidName(void)
+{
+    int32 ExpRtn = 0, ActRtn = 0;
+    int32 TestStat = CFE_PASS;
+    CFE_SB_PipeId_t PipeIdOut = 0;
+#ifdef UT_VERBOSE
+    UT_Text("Begin Test for Cmd - GetPipeIdByName with invalid pipe name");
+#endif
+
+    ExpRtn = CFE_SB_BAD_ARGUMENT;
+    if((ActRtn = CFE_SB_GetPipeIdByName(&PipeIdOut, "invalid")) != ExpRtn)
+    {
+        snprintf(cMsg, UT_MAX_MESSAGE_LENGTH,
+                 "Unexpected rtn from CFE_SB_GetPipeIdByName, exp=%ld, act=%ld",
+                 (long) ExpRtn, (long) ActRtn);
+        UT_Text(cMsg);
+
+        TestStat = CFE_FAIL;
+    }
+
+    if (UT_EventIsInHistory(CFE_SB_GETPIPEIDBYNAME_NAME_ERR_EID) == false)
+    {
+        UT_Text("CFE_SB_GETPIPEIDBYNAME_EID not sent");
+
+        TestStat = CFE_FAIL;
+    }
+
+    UT_Report(__FILE__, __LINE__,
+        TestStat, "CFE_SB_GetPipeIdByName_InvalidName",
+        "Get pipe id by name with invalid name");
+} /* end Test_GetPipeIdByName_InvalidName */
+
+/*
+** Successful call to GetPipeIdByName
+*/
+void Test_GetPipeIdByName(void)
+{
+    int32 ExpRtn = 0, ActRtn = 0;
+    int32 TestStat = CFE_PASS;
+    CFE_SB_PipeId_t PipeId = 0, PipeIdOut = 0;
+#ifdef UT_VERBOSE
+    UT_Text("Begin Test for Cmd - GetPipeIdByName");
+#endif
+
+    ExpRtn = CFE_SUCCESS;
+    if((ActRtn = CFE_SB_CreatePipe(&PipeId, 4, "TestPipe1")) != ExpRtn)
+    {
+        snprintf(cMsg, UT_MAX_MESSAGE_LENGTH,
+            "Unexpected rtn from CFE_SB_CreatePipe, exp=%ld, act=%ld",
+             (long) ExpRtn, (long) ActRtn);
+        UT_Text(cMsg);
+
+        UT_Report(__FILE__, __LINE__,
+            CFE_FAIL, "CFE_SB_GetPipeIdByName",
+            "Get pipe id by name");
+        return;
+    }
+
+    UT_SetDataBuffer(
+        UT_KEY(OS_QueueGetIdByName),
+        &(CFE_SB.PipeTbl[0].SysQueueId),
+        sizeof(CFE_SB.PipeTbl[0].SysQueueId),
+        false);
+
+    ExpRtn = CFE_SUCCESS;
+    if((ActRtn = CFE_SB_GetPipeIdByName(&PipeIdOut, "TestPipe1")) != ExpRtn)
+    {
+        snprintf(cMsg, UT_MAX_MESSAGE_LENGTH,
+                 "Unexpected rtn from CFE_SB_GetPipeIdByName, exp=%ld, act=%ld",
+                 (long) ExpRtn, (long) ActRtn);
+        UT_Text(cMsg);
+
+        TestStat = CFE_FAIL;
+    }
+
+    if (UT_EventIsInHistory(CFE_SB_GETPIPEIDBYNAME_EID) == false)
+    {
+        UT_Text("CFE_SB_GETPIPEIDBYNAME_EID not sent");
+
+        TestStat = CFE_FAIL;
+    }
+
+    CFE_SB_DeletePipe(PipeId);
+
+    UT_Report(__FILE__, __LINE__,
+        TestStat, "CFE_SB_GetPipeIdByName",
+        "Get pipe id by name");
+} /* end Test_GetPipeIdByName */
 
 /*
 ** Try setting pipe options on an invalid pipe ID
@@ -3994,6 +4310,7 @@ void Test_GetPipeOpts(void)
         "Get pipe opts");
 } /* end Test_GetPipeOpts */
 
+
 /*
 ** Function for calling SB subscribe API test functions
 */
@@ -4054,7 +4371,7 @@ void Test_Subscribe_SubscribeEx(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 2;
+    ExpRtn = 3;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -4112,7 +4429,7 @@ void Test_Subscribe_InvalidPipeId(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 1;
+    ExpRtn = 2;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -4165,7 +4482,7 @@ void Test_Subscribe_InvalidMsgId(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 2;
+    ExpRtn = 3;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -4223,7 +4540,7 @@ void Test_Subscribe_MaxMsgLim(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 2;
+    ExpRtn = 3;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -4291,7 +4608,7 @@ void Test_Subscribe_DuplicateSubscription(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 3;
+    ExpRtn = 5;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -4347,7 +4664,7 @@ void Test_Subscribe_LocalSubscription(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 2;
+    ExpRtn = 3;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -4438,7 +4755,7 @@ void Test_Subscribe_MaxDestCount(void)
         }
     }
 
-    ExpRtn = 2 * (CFE_PLATFORM_SB_MAX_DEST_PER_PKT + 1);
+    ExpRtn = 3 * (CFE_PLATFORM_SB_MAX_DEST_PER_PKT + 1);
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -4568,7 +4885,7 @@ void Test_Subscribe_SendPrevSubs(void)
     CFE_SB.RoutingTbl[2].ListHeadPtr = NULL;
 
     CFE_SB_SendPrevSubsCmd(&SendPrevSubsMsg);
-    ExpRtn = 12;
+    ExpRtn = 19;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -4643,7 +4960,7 @@ void Test_Subscribe_FindGlobalMsgIdCnt(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 10;
+    ExpRtn = 17;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -4698,7 +5015,7 @@ void Test_Subscribe_PipeNonexistent(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 1;
+    ExpRtn = 2;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -4816,7 +5133,7 @@ void Test_Subscribe_SubscriptionReporting(void)
                 }
                 else
                 {
-                    ExpRtn = 8;
+                    ExpRtn = 10;
                     ActRtn = UT_GetNumEventsSent();
 
                     if (ActRtn != ExpRtn)
@@ -4884,7 +5201,7 @@ void Test_Subscribe_InvalidPipeOwner(void)
     /* Choose a value that is sure not to be owner */
     CFE_SB.PipeTbl[PipeId].AppId = RealOwner + 1;
     CFE_SB_Subscribe(MsgId, PipeId);
-    ExpRtn = 2;
+    ExpRtn = 3;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -4967,7 +5284,7 @@ void Test_Unsubscribe_Basic(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 3;
+    ExpRtn = 4;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -5022,7 +5339,7 @@ void Test_Unsubscribe_Local(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 3;
+    ExpRtn = 5;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -5212,7 +5529,7 @@ void Test_Unsubscribe_NoMatch(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 4;
+    ExpRtn = 6;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -5305,7 +5622,7 @@ void Test_Unsubscribe_SubscriptionReporting(void)
             }
             else
             {
-                ExpRtn = 9;
+                ExpRtn = 11;
                 ActRtn = UT_GetNumEventsSent();
 
                 if (ActRtn != ExpRtn)
@@ -5365,7 +5682,7 @@ void Test_Unsubscribe_InvalidPipe(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 3;
+    ExpRtn = 4;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -5439,7 +5756,7 @@ void Test_Unsubscribe_InvalidPipeOwner(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 3;
+    ExpRtn = 4;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -5503,7 +5820,7 @@ void Test_Unsubscribe_FirstDestWithMany(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 7;
+    ExpRtn = 10;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -5568,7 +5885,7 @@ void Test_Unsubscribe_MiddleDestWithMany(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 7;
+    ExpRtn = 10;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -5626,7 +5943,7 @@ void Test_Unsubscribe_GetDestPtr(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 5;
+    ExpRtn = 7;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -5941,7 +6258,7 @@ void Test_SendMsg_BasicSend(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 2;
+    ExpRtn = 3;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -6101,7 +6418,7 @@ void Test_SendMsg_SequenceCount(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 2;
+    ExpRtn = 3;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -6161,7 +6478,7 @@ void Test_SendMsg_QueuePutError(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 3;
+    ExpRtn = 5;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -6236,7 +6553,7 @@ void Test_SendMsg_PipeFull(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 3;
+    ExpRtn = 5;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -6314,7 +6631,7 @@ void Test_SendMsg_MsgLimitExceeded(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 3;
+    ExpRtn = 5;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -6379,7 +6696,7 @@ void Test_SendMsg_GetPoolBufErr(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 3;
+    ExpRtn = 4;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -6643,7 +6960,7 @@ void Test_SendMsg_ZeroCopySend(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 2;
+    ExpRtn = 3;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -6762,7 +7079,7 @@ void Test_SendMsg_ZeroCopyPass(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 2;
+    ExpRtn = 3;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -6986,7 +7303,7 @@ void Test_SendMsg_DisabledDestination(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 2;
+    ExpRtn = 3;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -7059,7 +7376,7 @@ void Test_SendMsg_SendWithMetadata(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 2;
+    ExpRtn = 3;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -7773,7 +8090,7 @@ void Test_RcvMsg_PipeReadError(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 2;
+    ExpRtn = 3;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -7855,7 +8172,7 @@ void Test_RcvMsg_PendForever(void)
 #endif
     }
 
-    ExpRtn = 2;
+    ExpRtn = 3;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -9447,7 +9764,6 @@ void Test_CFE_SB_ValidateMsgId(void)
 void Test_SB_SpecialCases(void)
 {
     Test_OS_MutSem_ErrLogic();
-    Test_GetPipeName_ErrLogic();
     Test_ReqToSendEvent_ErrLogic();
     Test_PutDestBlk_ErrLogic();
     Test_CFE_SB_GetPipeIdx();
@@ -9577,7 +9893,7 @@ void Test_OS_MutSem_ErrLogic(void)
     UT_SetDeferredRetcode(UT_KEY(OS_MutSemGive), 2, CFE_OS_SEM_FAILURE);
     CFE_SB_CreatePipe(&PipeId, PipeDepth, "TestPipe");
     CFE_SB_Subscribe(MsgId, PipeId);
-    ExpRtn = 2;
+    ExpRtn = 3;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -9606,59 +9922,6 @@ void Test_OS_MutSem_ErrLogic(void)
               TestStat, "CFE_SB_(Un)LockSharedData",
               "Semaphore give/take failure test");
 } /* end Test_OS_MutSemTake_ErrLogic */
-
-/*
-** Test getting a pipe name using an invalid pipe ID
-*/
-void Test_GetPipeName_ErrLogic(void)
-{
-    CFE_SB_PipeId_t PipeId;
-    char            *CharStar;
-    uint16          PipeDepth = 50;
-    int32           ExpRtn;
-    int32           ActRtn;
-    int32           TestStat = CFE_PASS;
-
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test GetPipeName Error");
-#endif
-
-    SB_ResetUnitTest();
-    CFE_SB_CreatePipe(&PipeId, PipeDepth, "TestPipe");
-    CharStar = CFE_SB_GetPipeName(CFE_PLATFORM_SB_MAX_PIPES);
-
-    if (*CharStar != '\0')
-    {
-        snprintf(cMsg, UT_MAX_MESSAGE_LENGTH,
-                 "Unexpected rtn from CFE_SB_CreatePipe, exp=NULL, act=%s",
-                 CharStar);
-        UT_Text(cMsg);
-        TestStat = CFE_FAIL;
-    }
-
-    ExpRtn = 1;
-    ActRtn = UT_GetNumEventsSent();
-
-    if (ActRtn != ExpRtn)
-    {
-        snprintf(cMsg, UT_MAX_MESSAGE_LENGTH,
-                 "Unexpected rtn from UT_GetNumEventsSent, exp=%ld, act=%ld",
-                 (long) ExpRtn, (long) ActRtn);
-        UT_Text(cMsg);
-        TestStat = CFE_FAIL;
-    }
-
-    if (UT_EventIsInHistory(CFE_SB_PIPE_ADDED_EID) == false)
-    {
-        UT_Text("CFE_SB_PIPE_ADDED_EID not sent");
-        TestStat = CFE_FAIL;
-    }
-
-    CFE_SB_DeletePipe(PipeId);
-    UT_Report(__FILE__, __LINE__,
-              TestStat, "CFE_SB_GetPipeName",
-              "Get pipe name error test");
-} /* end Test_GetPipeName_ErrLogic */
 
 /*
 ** Test successful recursive event prevention
@@ -10021,7 +10284,7 @@ void Test_CFE_SB_BadPipeInfo(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 3;
+    ExpRtn = 4;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -10134,7 +10397,7 @@ void Test_SB_SendMsgPaths(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 2;
+    ExpRtn = 3;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -10238,7 +10501,7 @@ void Test_SB_SendMsgPaths(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 2;
+    ExpRtn = 3;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -10275,7 +10538,7 @@ void Test_SB_SendMsgPaths(void)
         TestStat = CFE_FAIL;
     }
 
-    ExpRtn = 2;
+    ExpRtn = 3;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)
@@ -10388,7 +10651,7 @@ void Test_RcvMsg_UnsubResubPath(void)
 #endif
     }
 
-    ExpRtn = 4;
+    ExpRtn = 6;
     ActRtn = UT_GetNumEventsSent();
 
     if (ActRtn != ExpRtn)

--- a/fsw/cfe-core/unit-test/sb_UT.h
+++ b/fsw/cfe-core/unit-test/sb_UT.h
@@ -384,6 +384,8 @@ void Test_SB_Main_InitErr(void);
 ** \sa #Test_SB_Cmds_Stats(), #Test_SB_Cmds_RoutingInfoDef(),
 ** \sa #Test_SB_Cmds_RoutingInfoSpec(), #Test_SB_Cmds_RoutingInfoCreateFail(),
 ** \sa #Test_SB_Cmds_PipeOpts(),
+** \sa #Test_SB_Cmds_GetPipeName(),
+** \sa #Test_SB_Cmds_GetPipeIdByName(),
 ** \sa #Test_SB_Cmds_RoutingInfoHdrFail(),
 ** \sa #Test_SB_Cmds_RoutingInfoWriteFail(), #Test_SB_Cmds_PipeInfoDef(),
 ** \sa #Test_SB_Cmds_PipeInfoSpec(), #Test_SB_Cmds_PipeInfoCreateFail(),
@@ -672,6 +674,164 @@ void Test_GetPipeOpts_BadPtr(void);
 **
 ******************************************************************************/
 void Test_GetPipeOpts(void);
+
+/*****************************************************************************/
+/**
+** \brief Function for calling SB get pipe name by id API test functions
+**
+** \par Description
+**        Function for calling SB get pipe name by id API test functions.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+**
+** \sa #Test_GetPipeName
+**
+******************************************************************************/
+void Test_GetPipeName_API(void);
+
+/*****************************************************************************/
+/**
+** \brief Test get pipe name by id response to a null pointer for name buf
+**
+** \par Description
+**        This function tests the get pipe name by id command with
+**        a null pointer for the name buffer.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+**
+** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_CreatePipe,
+** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
+**
+******************************************************************************/
+void Test_GetPipeName_NullPtr(void);
+
+/*****************************************************************************/
+/**
+** \brief Test get pipe name by id response to an non-existant pipe id
+**
+** \par Description
+**        This function tests the get pipe name by id command when
+**        called with a id that doesn't exist.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+**
+** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_CreatePipe,
+** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
+**
+******************************************************************************/
+void Test_GetPipeName_InvalidId(void);
+
+/*****************************************************************************/
+/**
+** \brief Test getting pipe name by id with a valid id.
+**
+** \par Description
+**        This function tests the get pipe name by id command with a valid
+**        id.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+**
+** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_SetCmdCode,
+** \sa #UT_SetOSFail, #UT_GetNumEventsSent,
+** \sa #UT_EventIsInHistory, #UT_Report
+**
+******************************************************************************/
+void Test_GetPipeName(void);
+
+/*****************************************************************************/
+/**
+** \brief Function for calling SB get pipe id by name  API test functions
+**
+** \par Description
+**        Function for calling SB get pipe id by name API test functions.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+**
+** \sa #Test_GetPipeIdByName
+**
+******************************************************************************/
+void Test_GetPipeIdByName_API(void);
+
+/*****************************************************************************/
+/**
+** \brief Test get pipe id by name response to a null pointer for name or pipe id
+**
+** \par Description
+**        This function tests the get pipe id by name command with either
+**        a null pointer for the name or a null pointer for the ID output.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+**
+** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_CreatePipe,
+** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
+**
+******************************************************************************/
+void Test_GetPipeIdByName_NullPtrs(void);
+
+/*****************************************************************************/
+/**
+** \brief Test get pipe id by name response to an non-existant pipe name
+**
+** \par Description
+**        This function tests the get pipe id by name command when
+**        called with a name that doesn't exist.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+**
+** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_CreatePipe,
+** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
+**
+******************************************************************************/
+void Test_GetPipeIdByName_InvalidName(void);
+
+/*****************************************************************************/
+/**
+** \brief Test getting pipe id by name with a valid name.
+**
+** \par Description
+**        This function tests the get pipe id by name command with a valid
+**        name.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+**
+** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_SetCmdCode,
+** \sa #UT_SetOSFail, #UT_GetNumEventsSent,
+** \sa #UT_EventIsInHistory, #UT_Report
+**
+******************************************************************************/
+void Test_GetPipeIdByName(void);
 
 /*****************************************************************************/
 /**
@@ -3202,7 +3362,7 @@ void Test_CFE_SB_ValidateMsgId(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #Test_OS_MutSem_ErrLogic, #Test_GetPipeName_ErrLogic,
+** \sa #UT_Text, #Test_OS_MutSem_ErrLogic,
 ** \sa #Test_ReqToSendEvent_ErrLogic, #Test_PutDestBlk_ErrLogic
 **
 ******************************************************************************/
@@ -3228,26 +3388,6 @@ void Test_SB_SpecialCases(void);
 **
 ******************************************************************************/
 void Test_OS_MutSem_ErrLogic(void);
-
-/*****************************************************************************/
-/**
-** \brief Test getting a pipe name using an invalid pipe ID
-**
-** \par Description
-**        This function tests getting a pipe name using an invalid pipe ID.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-**
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_GetPipeName,
-** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
-** \sa #UT_Report
-**
-******************************************************************************/
-void Test_GetPipeName_ErrLogic(void);
 
 /*****************************************************************************/
 /**

--- a/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
@@ -130,6 +130,102 @@ int32 CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16 Depth,
 
 /*****************************************************************************/
 /**
+** \brief CFE_SB_GetPipeName stub function
+**
+** \par Description
+**        This function is used to mimic the response of the cFE SB function
+**        CFE_SB_GetPipeName.  The user must set the value of UT_pipename prior
+**        to this function being called.  The function uses UT_pipename for the
+**        retrieved pipe name and returns CFE_SUCCESS.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        Returns CFE_SUCCESS.
+**
+******************************************************************************/
+int32 CFE_SB_GetPipeName(char *PipeNameBuf, size_t PipeNameSize, CFE_SB_PipeId_t PipeId)
+{
+    uint32 UserBuffSize;
+    uint32 BuffPosition;
+    const char *NameBuff;
+    int32 status;
+
+    status = UT_DEFAULT_IMPL(CFE_SB_GetPipeName);
+
+    if (status >= 0 && PipeNameSize > 0)
+    {
+        UT_GetDataBuffer(UT_KEY(CFE_SB_GetPipeName), (void**)&NameBuff, &UserBuffSize, &BuffPosition);
+        if (NameBuff == NULL || UserBuffSize == 0)
+        {
+            NameBuff = "UT";
+            UserBuffSize = 2;
+        }
+
+        if (UserBuffSize < PipeNameSize)
+        {
+            BuffPosition = UserBuffSize;
+        }
+        else
+        {
+            BuffPosition = PipeNameSize - 1;
+        }
+
+        strncpy(PipeNameBuf, NameBuff, BuffPosition);
+        PipeNameBuf[BuffPosition] = 0;
+    }
+
+    return status;
+}
+
+/*****************************************************************************/
+/**
+** \brief CFE_SB_GetPipeIdByName stub function
+**
+** \par Description
+**        This function is used to mimic the response of the cFE SB function
+**        CFE_SB_GetPipeIdByName.  The user can adjust the response by setting
+**        the value of UT_pipename prior to this function being called, then
+**        choosing specific values for the pipe name (PipeName) used
+**        when calling this function.  The Pipe ID returned is
+**        dependent on the pipe name provided.  If pipe name
+**        doesn't match the expected values the function returns an error
+**        code.  CFE_SUCCESS is returned otherwise.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        Returns either CFE_SB_BAD_ARGUMENT or CFE_SUCCESS.
+**
+******************************************************************************/
+int32 CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *PipeName)
+{
+    int32 status;
+
+    UT_Stub_RegisterContext(UT_KEY(CFE_SB_GetPipeIdByName), PipeIdPtr);
+    UT_Stub_RegisterContext(UT_KEY(CFE_SB_GetPipeIdByName), PipeName);
+    status = UT_DEFAULT_IMPL(CFE_SB_GetPipeIdByName);
+
+    if (status >= 0)
+    {
+        /* TODO: add GetPipeName */
+        if (UT_Stub_CopyToLocal(UT_KEY(CFE_SB_GetPipeIdByName), (uint8*)PipeIdPtr, sizeof(*PipeIdPtr)) == sizeof(*PipeIdPtr))
+        {
+            status = CFE_SUCCESS;
+        }
+        else
+        {
+            status = CFE_SB_BAD_ARGUMENT;
+            *PipeIdPtr = 0;
+        }
+    }
+
+    return status;
+}
+/*****************************************************************************/
+/**
 ** \brief CFE_SB_GetCmdCode stub function
 **
 ** \par Description


### PR DESCRIPTION
**Describe the contribution**
Fixes issue #210 

**Testing performed**
make mission-all; run cpu1/cfe_core_default_cpu1/unit-test/cfe_core_default_cpu1_sb_UT

**Expected behavior changes**
Adds a new function, CFE_SB_GetPipeIdByName, which retrieves the pipe ID given a name of a pipe. As this would conflict with the removal of the PipeName from the PipeTbl, this code uses the OS_QueueGetIdByName and iterates across the PipeTbl to find the matching entry.

**System(s) tested on:**
Ubuntu 64-bit Linux 19.04.

**Contributor Info**
Chris Knight, NASA Ames Research Center.