### PR TITLE
Fix #429, Const string initialization

### DIFF
--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -10416,10 +10416,10 @@ void Test_RcvMsg_UnsubResubPath(void)
 */
 void Test_MessageString(void)
 {
-	char *SrcString = "abcdefg";
+	const char *SrcString = "abcdefg";
 	char DestString[20];
 	char *DestStringPtr = DestString;
-	char *DefString = "default";
+	const char *DefString = "default";
 
     SB_ResetUnitTest();
 


### PR DESCRIPTION
**Describe the contribution**
Fixes #429

**Testing performed**
Steps taken to test the contribution:
1. make ENABLE_UNIT_TESTS=TRUE SIMULATION=native prep
1. make
1. make install
1. make test

**Expected behavior changes**
No change

**System(s) tested on:**
 - cFS dev server
 - OS: Ubuntu 16.04
 - Versions: master bundle with this commit

**Contributor Info**
Jacob Hageman - NASA/GSFC