### PR TITLE
Set OSAL_SYSTEM_BSPTYPE for native builds

### DIFF
--- a/cmake/arch_build.cmake
+++ b/cmake/arch_build.cmake
@@ -280,6 +280,7 @@ function(prepare)
             "${CMAKE_SYSTEM_NAME}" STREQUAL "CYGWIN")
       # Export the variables determined here up to the parent scope
       SET(CFE_SYSTEM_PSPNAME      "pc-linux" PARENT_SCOPE)
+      SET(OSAL_SYSTEM_BSPTYPE     "pc-linux" PARENT_SCOPE)
       SET(OSAL_SYSTEM_OSTYPE      "posix"    PARENT_SCOPE)
     else ()
       # Not cross compiling and host system is not recognized


### PR DESCRIPTION
**Describe the contribution**

Fix #438

This explicitly specifies the BSP to use when using `SIMULATION=native` flags to the build.  All other example toolchain files already included this setting.

**Testing performed**
Rebuild code with and without `SIMULATION=native` flag.  Confirmed no build issues/changes.

**Expected behavior changes**
No impact - build script change only.

**System(s) tested on:**
Ubuntu 18.04 LTS 64-bit

**Additional context**
This makes it compatible after a related OSAL build script cleanup is also merged (see nasa/osal#312, nasa/osal#261).

**Contributor Info**
Joseph Hickey, Vantage Systems, Inc.

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
