### PR TITLE
Avoid alignment warnings on some CPUs

### DIFF
--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -1802,7 +1802,7 @@ CFE_SB_Msg_t  *CFE_SB_ZeroCopyGetPtr(uint16 MsgSize,
 {
    int32                stat1;
    uint32               AppId = 0xFFFFFFFF;
-   uint8               *address = NULL;
+   cpuaddr              address = 0;
    CFE_SB_ZeroCopyD_t  *zcd = NULL;
    CFE_SB_BufferD_t    *bd = NULL;
 
@@ -1849,7 +1849,7 @@ CFE_SB_Msg_t  *CFE_SB_ZeroCopyGetPtr(uint16 MsgSize,
     }/* end if */
 
     /* first set ptr to actual msg buffer the same as ptr to descriptor */
-    address = (uint8 *)bd;
+    address = (cpuaddr)bd;
 
     /* increment actual msg buffer ptr beyond the descriptor */
     address += sizeof(CFE_SB_BufferD_t);
@@ -1914,6 +1914,7 @@ int32 CFE_SB_ZeroCopyReleasePtr(CFE_SB_Msg_t  *Ptr2Release,
 {
     int32    Status;
     int32    Stat2;
+    cpuaddr  Addr = (cpuaddr)Ptr2Release;
 
     Status = CFE_SB_ZeroCopyReleaseDesc(Ptr2Release, BufferHandle);
 
@@ -1922,7 +1923,7 @@ int32 CFE_SB_ZeroCopyReleasePtr(CFE_SB_Msg_t  *Ptr2Release,
     if(Status == CFE_SUCCESS){
         /* give the buffer back to the buffer pool */
         Stat2 = CFE_ES_PutPoolBuf(CFE_SB.Mem.PoolHdl,
-                                  (uint32 *) (((uint8 *)Ptr2Release) - sizeof(CFE_SB_BufferD_t)));
+                                  (uint32 *) (Addr - sizeof(CFE_SB_BufferD_t)));
         if(Stat2 > 0){
              /* Substract the size of the actual buffer from the Memory in use ctr */
             CFE_SB.StatTlmMsg.Payload.MemInUse-=Stat2;

--- a/fsw/cfe-core/src/sb/cfe_sb_buf.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_buf.c
@@ -116,7 +116,7 @@ CFE_SB_BufferD_t * CFE_SB_GetBufferFromPool(CFE_SB_MsgId_t MsgId, uint16 Size) {
 
 CFE_SB_BufferD_t * CFE_SB_GetBufferFromCaller(CFE_SB_MsgId_t MsgId,
                                               void *Address) {
-   CFE_SB_BufferD_t    *bd = (CFE_SB_BufferD_t *)(((uint8 *)Address) - sizeof(CFE_SB_BufferD_t));
+   CFE_SB_BufferD_t    *bd = (CFE_SB_BufferD_t *)((cpuaddr)Address - sizeof(CFE_SB_BufferD_t));
 
     /* Initialize the MsgId in the buffer descriptor (the rest has already been initialized in this case). */
     bd->MsgId     = MsgId;

--- a/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
@@ -486,7 +486,7 @@ int32 CFE_TBL_RemoveAccessLink(CFE_TBL_Handle_t TblHandle)
         if (RegRecPtr->UserDefAddr == false)
         {
             /* Free memory allocated to buffers */
-            Status = CFE_ES_PutPoolBuf(CFE_TBL_TaskData.Buf.PoolHdl, (uint32 *)RegRecPtr->Buffers[0].BufferPtr);
+            Status = CFE_ES_PutPoolBuf(CFE_TBL_TaskData.Buf.PoolHdl, RegRecPtr->Buffers[0].BufferPtr);
             RegRecPtr->Buffers[0].BufferPtr = NULL;
 
             if (Status < 0)
@@ -498,7 +498,7 @@ int32 CFE_TBL_RemoveAccessLink(CFE_TBL_Handle_t TblHandle)
             /* If a double buffered table, then free the second buffer as well */
             if (RegRecPtr->DoubleBuffered)
             {
-                Status = CFE_ES_PutPoolBuf(CFE_TBL_TaskData.Buf.PoolHdl, (uint32 *)RegRecPtr->Buffers[1].BufferPtr);
+                Status = CFE_ES_PutPoolBuf(CFE_TBL_TaskData.Buf.PoolHdl, RegRecPtr->Buffers[1].BufferPtr);
                 RegRecPtr->Buffers[1].BufferPtr = NULL;
 
                 if (Status < 0)
@@ -986,7 +986,7 @@ int32 CFE_TBL_LoadFromFile(CFE_TBL_LoadBuff_t *WorkingBufferPtr,
                         }
 
                         NumBytes = OS_read(FileDescriptor,
-                                           &WorkingBufferPtr->BufferPtr[TblFileHeader.Offset],
+                                           ((uint8*)WorkingBufferPtr->BufferPtr) + TblFileHeader.Offset,
                                            TblFileHeader.NumBytes);
 
                         if (NumBytes != TblFileHeader.NumBytes)

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task.h
@@ -145,7 +145,7 @@ typedef struct
 */
 typedef struct 
 {
-    uint8         *BufferPtr;                   /**< \brief Pointer to Load Buffer */
+    void          *BufferPtr;                   /**< \brief Pointer to Load Buffer */
     uint32         FileCreateTimeSecs;          /**< \brief File creation time from last file loaded into table */
     uint32         FileCreateTimeSubSecs;       /**< \brief File creation time from last file loaded into table */
     uint32         Crc;                         /**< \brief Last calculated CRC for this buffer's contents */

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.c
@@ -441,7 +441,7 @@ int32 CFE_TBL_LoadCmd(const CFE_TBL_Load_t *data)
                         {
                             /* Copy data from file into working buffer */
                             Status = OS_read(FileDescriptor,
-                                             &WorkingBufferPtr->BufferPtr[TblFileHeader.Offset],
+                                             ((uint8*)WorkingBufferPtr->BufferPtr) + TblFileHeader.Offset,
                                              TblFileHeader.NumBytes);
                                     
                             /* Make sure the appropriate number of bytes were read */

--- a/fsw/cfe-core/unit-test/tbl_UT.c
+++ b/fsw/cfe-core/unit-test/tbl_UT.c
@@ -1688,7 +1688,7 @@ void Test_CFE_TBL_HousekeepingCmd(void)
     CFE_TBL_LoadBuff_t    *DumpBuffPtr = &DumpBuff;
     CFE_TBL_RegistryRec_t RegRecPtr;
     uint8                 Buff;
-    uint8                 *BuffPtr = &Buff;
+    void                  *BuffPtr = &Buff;
     uint32                Secs = 0;
     uint32                SubSecs = 0;
     int32                 LoadInProg = 0;


### PR DESCRIPTION
**Describe the contribution**

Fix #437 and partially address #313 (overlapping issue)

On CPUs with strict alignment requirements, some CFE code that uses a char-type pointer (e.g. uint8*) to compute memory addresses triggers an alignment warning when it gets cast back to the actual data type.

In the mempool implementation, the pointer should be sufficiently aligned already, because the address computation already takes CPU alignment requirements into account when calculating the addresses/offsets.  

- For the CFE_SB pool buffers, using the `cpuaddr` type, which is integer in nature, avoids the warning.
- For the CFE_TBL internal table pointer, use a `void*` internally to store the buffer pointer, rather than a `uint8_t*`.  This changes the casting needs elsewhere.

**Testing performed**
Build CFE with ENABLE_UNIT_TESTS=TRUE
Confirm all unit tests passing
Perform sanity test on CFE (normal startup, send commands from console)
Build for MIPS64 and ensure that (some) alignment warnings are fixed

**Expected behavior changes**
No change to behavior.  Fixes build warnings only.

**System(s) tested on:**
Ubuntu 18.04 LTS  64-bit

**Additional context**
There are still some remaining alignment cast warnings regarding the message types, where a local message buffer is cast to a `CFE_SB_Msg_t*` which has a higher alignment requirement.  This is a little harder to fix as it requires changing the local buffer definition.

**Contributor Info**
Joseph Hickey, Vantage Systems, Inc.

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
