### PR TITLE
Fix #308, Improve SB create pipe error reporting

### DIFF
--- a/fsw/cfe-core/src/inc/cfe_sb_events.h
+++ b/fsw/cfe-core/src/inc/cfe_sb_events.h
@@ -40,7 +40,7 @@
 ** and when you're done adding, set this to the highest EID you used. It may
 ** be worthwhile to, on occasion, re-number the EID's to put them back in order.
 */
-#define CFE_SB_MAX_EID                  61
+#define CFE_SB_MAX_EID                  63
 
 /*
 ** SB task event message ID's.
@@ -857,6 +857,30 @@
 **  found in the message.
 **/
 #define CFE_SB_LEN_ERR_EID              61
+
+/** \brief <tt> 'CreatePipeErr:Name Taken:app=\%s,ptr=0x\%x,depth=\%d,maxdepth=\%d' </tt>
+**  \event <tt> 'CreatePipeErr:Name Taken:app=\%s,ptr=0x\%x,depth=\%d,maxdepth=\%d' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This error event message is issued when the #CFE_SB_CreatePipe API tries to create
+**  a pipe with a name that is in use.
+**/
+#define CFE_SB_CR_PIPE_NAME_TAKEN_EID   62
+
+/** \brief <tt> 'CreatePipeErr:No Free:app=\%s,ptr=0x\%x,depth=\%d,maxdepth=\%d' </tt>
+**  \event <tt> 'CreatePipeErr:No Free:app=\%s,ptr=0x\%x,depth=\%d,maxdepth=\%d' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This error event message is issued when the #CFE_SB_CreatePipe API is unable to
+**  create a queue because there are no queues free.
+**/
+#define CFE_SB_CR_PIPE_NO_FREE_EID      63
 
 
 #endif /* _cfe_sb_events_ */


### PR DESCRIPTION
**Describe the contribution**
Improves error reporting for CFE_SB_CreatePipe()

**Testing performed**
Standard build process, ran SB unit tests.

**Expected behavior changes**
Improvement in error reporting when using a pipe name that is already in use, or when the queue limit has been reached.

**System(s) tested on:**
Debian 9

**Additional context**
Add any other context about the contribution here.

**Contributor Info**
Christopher.D.Knight@nasa.gov

**Community contributors**
N/A