### PR TITLE
Fix #412, Clean up table services comments/references

### DIFF
--- a/fsw/cfe-core/src/tbl/cfe_tbl_api.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_api.c
@@ -1628,7 +1628,7 @@ int32 CFE_TBL_Modified( CFE_TBL_Handle_t TblHandle )
 
     
     return Status;
-}
+} /* End of CFE_TBL_Modified() */
 
 
 /*******************************************************************
@@ -1673,7 +1673,7 @@ int32 CFE_TBL_NotifyByMessage(CFE_TBL_Handle_t TblHandle, CFE_SB_MsgId_t MsgId, 
     }
     
     return Status;
-}
+}  /* End of CFE_TBL_NotifyByMessage() */
 
 /************************/
 /*  End of File Comment */

--- a/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
@@ -255,7 +255,7 @@ int32 CFE_TBL_EarlyInit (void)
     
     return Status;
             
-}/* end CFE_TBL_EarlyInit */
+}/* End CFE_TBL_EarlyInit */
 
 
 /*******************************************************************
@@ -304,7 +304,7 @@ void CFE_TBL_InitRegistryRecord (CFE_TBL_RegistryRec_t *RegRecPtr)
     RegRecPtr->ActiveBufferIndex = 0;
     RegRecPtr->Name[0] = '\0';
     RegRecPtr->LastFileLoaded[0] = '\0';
-}
+} /* End CFE_TBL_InitRegistryRecord */
 
 
 /*******************************************************************
@@ -433,7 +433,7 @@ int32 CFE_TBL_CheckAccessRights(CFE_TBL_Handle_t TblHandle, uint32 ThisAppId)
     }
 
     return Status;
-}
+} /* End of CFE_TBL_CheckAccessRights() */
 
 /*******************************************************************
 **
@@ -1033,7 +1033,7 @@ int32 CFE_TBL_LoadFromFile(CFE_TBL_LoadBuff_t *WorkingBufferPtr,
     }
 
     return Status;
-}
+} /* End of CFE_TBL_LoadFromFile() */
 
 
 /*******************************************************************
@@ -1167,7 +1167,7 @@ void CFE_TBL_NotifyTblUsersOfUpdate(CFE_TBL_RegistryRec_t *RegRecPtr)
 
         AccessIterator = CFE_TBL_TaskData.Handles[AccessIterator].NextLink;
     }
-}
+} /* End of CFE_TBL_NotifyTblUsersOfUpdate() */
 
 /*******************************************************************
 **
@@ -1422,7 +1422,7 @@ int32 CFE_TBL_CleanUpApp(uint32 AppId)
     }
 
     return CFE_SUCCESS;
-}
+} /* End of CFE_TBL_CleanUpApp() */
 
 /*******************************************************************
 **
@@ -1446,7 +1446,7 @@ void CFE_TBL_FindCriticalTblInfo(CFE_TBL_CritRegRec_t **CritRegRecPtr, CFE_ES_CD
             break;
         }
     }
-}
+} /* End of CFE_TBL_FindCriticalTblInfo() */
 
 
 /*******************************************************************
@@ -1500,7 +1500,7 @@ void CFE_TBL_UpdateCriticalTblCDS(CFE_TBL_RegistryRec_t *RegRecPtr)
     }
     
     /* Don't bother notifying the caller of the problem since the active table is still legitimate */
-}
+}   /* End of CFE_TBL_UpdateCriticalTblCDS() */
 
 
 /*******************************************************************
@@ -1543,7 +1543,7 @@ int32 CFE_TBL_SendNotificationMsg(CFE_TBL_RegistryRec_t *RegRecPtr)
     }
     
     return Status;
-}
+} /* End of CFE_TBL_SendNotificationMsg() */
 
 /************************/
 /*  End of File Comment */

--- a/fsw/cfe-core/src/tbl/cfe_tbl_internal.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_internal.h
@@ -590,41 +590,6 @@ void CFE_TBL_UpdateCriticalTblCDS(CFE_TBL_RegistryRec_t *RegRecPtr);
 ******************************************************************************/
 int32 CFE_TBL_SendNotificationMsg(CFE_TBL_RegistryRec_t *RegRecPtr);
 
-
-/*****************************************************************************/
-/**
-** \brief Gathers data and puts it into the Housekeeping Message format
-**
-** \par Description
-**        Gathers data from the Table Services Application, computes necessary data values and identifies
-**        what Table Validation information needs to be reported in Housekeeping Telemetry.
-**
-** \par Assumptions, External Events, and Notes:
-**          None
-**
-** \retval None
-******************************************************************************/
-extern  void CFE_TBL_GetHkData(void);
-
-
-/*****************************************************************************/
-/**
-** \brief Convert Table Registry Entry for a Table into a Message
-**
-** \par Description
-**        Extracts the Table Registry information for the table specified by the
-**        #CFE_TBL_TaskData_t::HkTlmTblRegIndex variable.  It then formats the
-**        Registry contents into a format appropriate for downlink.
-**
-** \par Assumptions, External Events, and Notes:
-**        #CFE_TBL_TaskData_t::HkTlmTblRegIndex is assumed to be a valid index into
-**           the Table Registry.
-**
-** \retval None
-******************************************************************************/
-extern void CFE_TBL_GetTblRegData(void);
-
-
 /*****************************************************************************/
 /**
 ** \brief Performs a byte swap on a uint32 integer

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task.h
@@ -349,6 +349,29 @@ typedef struct
 
 /*****************************************************************************/
 /**
+** \brief Compares message with #CFE_TBL_CmdHandlerTbl to identify the message
+**
+** \par Description
+**          Searches the Command Handler Table for an entry matching the
+**          message ID and, if necessary, the Command Code.  If an entry
+**          is not located, an error code is returned.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in] MessageID message ID of command message received on command pipe
+**
+** \param[in] CommandCode command code from command message received on command pipe
+**
+** \retval #CFE_SUCCESS          \copydoc CFE_SUCCESS
+** \retval #CFE_TBL_BAD_CMD_CODE \copydoc CFE_TBL_BAD_CMD_CODE
+** \retval #CFE_TBL_BAD_MSG_ID   \copydoc CFE_TBL_BAD_MSG_ID
+**
+******************************************************************************/
+extern int16 CFE_TBL_SearchCmdHndlrTbl(CFE_SB_MsgId_t MessageID, uint16 CommandCode);
+
+/*****************************************************************************/
+/**
 ** \brief cFE Table Services Core Application Initialization
 **
 ** \par Description

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.c
@@ -259,7 +259,7 @@ void CFE_TBL_GetHkData(void)
                     sizeof(CFE_TBL_TaskData.Registry[CFE_TBL_TaskData.LastTblUpdated].Name));
         }      
     }
-}
+} /* End of CFE_TBL_GetHkData() */
 
 /*******************************************************************
 **
@@ -315,7 +315,7 @@ void CFE_TBL_GetTblRegData(void)
             sizeof(CFE_TBL_TaskData.TblRegPacket.Payload.LastFileLoaded), sizeof(RegRecPtr->LastFileLoaded));
     CFE_ES_GetAppName(CFE_TBL_TaskData.TblRegPacket.Payload.OwnerAppName, RegRecPtr->OwnerAppId,
             sizeof(CFE_TBL_TaskData.TblRegPacket.Payload.OwnerAppName));
-}
+} /* End of CFE_TBL_GetTblRegData() */
 
 
 /*******************************************************************
@@ -855,7 +855,7 @@ CFE_TBL_CmdProcRet_t CFE_TBL_DumpToFile( const char *DumpFilename, const char *T
     }
     
     return ReturnCode;
-}
+} /* End of CFE_TBL_DumpToFile() */
 
 /*******************************************************************
 **
@@ -1522,7 +1522,7 @@ void CFE_TBL_AbortLoad(CFE_TBL_RegistryRec_t *RegRecPtr)
                       CFE_EVS_EventType_INFORMATION,
                       "Table Load Aborted for '%s'",
                       RegRecPtr->Name);
-}
+} /* End of CFE_TBL_AbortLoad() */
 
 /************************/
 /*  End of File Comment */

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.h
@@ -82,6 +82,38 @@ typedef struct {
 /* Command Message Processing Functions */
 /*****************************************************************************/
 /**
+** \brief Gathers data and puts it into the Housekeeping Message format
+**
+** \par Description
+**        Gathers data from the Table Services Application, computes necessary data values and identifies
+**        what Table Validation information needs to be reported in Housekeeping Telemetry.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \retval None
+******************************************************************************/
+extern  void CFE_TBL_GetHkData(void);
+
+/*****************************************************************************/
+/**
+** \brief Convert Table Registry Entry for a Table into a Message
+**
+** \par Description
+**        Extracts the Table Registry information for the table specified by the
+**        #CFE_TBL_TaskData_t::HkTlmTblRegIndex variable.  It then formats the
+**        Registry contents into a format appropriate for downlink.
+**
+** \par Assumptions, External Events, and Notes:
+**        #CFE_TBL_TaskData_t::HkTlmTblRegIndex is assumed to be a valid index into
+**           the Table Registry.
+**
+** \retval None
+******************************************************************************/
+extern void CFE_TBL_GetTblRegData(void);
+
+/*****************************************************************************/
+/**
 ** \brief Process Housekeeping Request Message
 **
 ** \par Description
@@ -298,31 +330,6 @@ int32 CFE_TBL_AbortLoadCmd(const CFE_TBL_AbortLoad_t *data);
 ******************************************************************************/
 extern CFE_TBL_CmdProcRet_t CFE_TBL_DumpToFile( const char *DumpFilename, const char *TableName,
                                          const void *DumpDataAddr, uint32 TblSizeInBytes);
-
-
-/*****************************************************************************/
-/**
-** \brief Compares message with #CFE_TBL_CmdHandlerTbl to identify the message
-**
-** \par Description
-**          Searches the Command Handler Table for an entry matching the
-**          message ID and, if necessary, the Command Code.  If an entry
-**          is not located, an error code is returned.
-**
-** \par Assumptions, External Events, and Notes:
-**          None
-**
-** \param[in] MessageID message ID of command message received on command pipe
-**
-** \param[in] CommandCode command code from command message received on command pipe
-**
-** \retval #CFE_SUCCESS          \copydoc CFE_SUCCESS
-** \retval #CFE_TBL_BAD_CMD_CODE \copydoc CFE_TBL_BAD_CMD_CODE
-** \retval #CFE_TBL_BAD_MSG_ID   \copydoc CFE_TBL_BAD_MSG_ID
-**
-******************************************************************************/
-
-extern int16 CFE_TBL_SearchCmdHndlrTbl(CFE_SB_MsgId_t MessageID, uint16 CommandCode);
 
 /*****************************************************************************/
 /**


### PR DESCRIPTION
**Describe the contribution**
   Fixes #412

   Note that there were a couple cases where function prototypes were defined in the wrong header
   files.  This was also cleaned up as part of this issue.

**Testing performed**
   Testing consisted of building/running the software and re-running the unit tests.

1. Build steps:
    make prep
    make
    make install
2. Ran software:
   ./core-cpu1

**Expected behavior changes**
   None

**System(s) tested on:**
   Oracle VM VirtualBox
   OS: ubuntu-19.10
   Version: cFE 6.7.3.0; OSAL 5.0.3.0; PSP 1.4.1.0

**Additional context**
   None

**Contributor Info**
   Dan Knutsen
   GSFC/NASA