### PR TITLE
Fix #24 #355, Add compile flag abstractions

### DIFF
--- a/cmake/sample_defs/targets.cmake
+++ b/cmake/sample_defs/targets.cmake
@@ -98,3 +98,21 @@ SET(TGT1_FILELIST cfe_es_startup.scr)
 #SET(TGT3_APPLIST sample_app ci_lab to_lab sch_lab)
 #SET(TGT3_FILELIST cfe_es_startup.scr)
 
+# Set host strict warnings, gets applied to all host compiled elements
+# Note target strict warnings are defined in associated toolchain file
+SET(HOST_STRICT_WARNINGS "-Wall -Werror -std=c99 -D_XOPEN_SOURCE=600 -pedantic -Wstrict-prototypes -Wcast-align -Wwrite-strings")
+
+# Cache related environment variables
+# NOTE - requires distclean and re-"make prep" to change
+set(OMIT_DEPRECATED $ENV{OMIT_DEPRECATED} CACHE STRING "Omit deperecated elements")
+
+# Helper definition to abstract omitting deprecated elements,
+# allows for one setting in CI and used by projects
+if (OMIT_DEPRECATED)
+  message (STATUS "OMIT_DEPRECATED=true: Not including deprecated elements in build")
+  add_definitions(-DCFE_OMIT_DEPRECATED_6_6 -DOSAL_OMIT_DEPRECATED)
+else()
+  message (STATUS "OMIT_DEPRECATED=false: Deprecated elements included in build")
+endif (OMIT_DEPRECATED)
+
+

--- a/cmake/sample_defs/toolchain-cpu1.cmake
+++ b/cmake/sample_defs/toolchain-cpu1.cmake
@@ -23,3 +23,5 @@ SET(CFE_SYSTEM_PSPNAME      "pc-linux")
 SET(OSAL_SYSTEM_BSPNAME     "pc-linux")
 SET(OSAL_SYSTEM_OSTYPE      "posix")
 
+# Define target strict warnings applied to all cross compiled code
+SET(TARGET_STRICT_WARNINGS "-Wall -Werror -std=c99 -D_XOPEN_SOURCE=600 -pedantic -Wstrict-prototypes -Wcast-align -Wwrite-strings")


### PR DESCRIPTION
**Describe the contribution**
Fixes #24, Fixes #355 

Adds STRICT_NO_WARNINGS and OMIT_DEPRECATED
prep options for CI and as example build

**Testing performed**
Built with STRICT_NO_WARNINGS=true, false, and undefined
Built with OMIT_DEPRECATED=true, false, and undefined (note sample_app fails)

Confirmed flags get globally applied (not great scoping, but ensures flag coverage)

**Expected behavior changes**
Simplifies/enables CI based on abstracted flags, see https://github.com/nasa/cFS/issues/39

**System(s) tested on:**
 - cFS Dev Server 2
 - OS: Ubuntu 18.04
 - Versions: Master bundle with this change

**Contributor Info**
Jacob Hageman - NASA/GSFC