### PR TITLE
Fix #315, ES Performance debug messages

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_perf.c
+++ b/fsw/cfe-core/src/es/cfe_es_perf.c
@@ -342,7 +342,7 @@ int32 CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMask_t *data)
         Perf->MetaData.FilterMask[cmd->FilterMaskNum] = cmd->FilterMask;
 
         CFE_EVS_SendEvent(CFE_ES_PERF_FILTMSKCMD_EID, CFE_EVS_EventType_DEBUG,
-                "Set Performance Filter Mask Cmd rcvd, num %u, val 0x%x",
+                "Set Performance Filter Mask Cmd rcvd, num %u, val 0x%08X",
                 (unsigned int)cmd->FilterMaskNum,(unsigned int)cmd->FilterMask);
 
         CFE_ES_TaskData.CommandCounter++;
@@ -372,7 +372,7 @@ int32 CFE_ES_SetPerfTriggerMaskCmd(const CFE_ES_SetPerfTriggerMask_t *data)
         Perf->MetaData.TriggerMask[cmd->TriggerMaskNum] = cmd->TriggerMask;
 
         CFE_EVS_SendEvent(CFE_ES_PERF_TRIGMSKCMD_EID, CFE_EVS_EventType_DEBUG,
-                "Set Performance Trigger Mask Cmd rcvd,num %u, val 0x%x",
+                "Set Performance Trigger Mask Cmd rcvd,num %u, val 0x%08X",
                 (unsigned int)cmd->TriggerMaskNum,(unsigned int)cmd->TriggerMask);
 
         CFE_ES_TaskData.CommandCounter++;

--- a/fsw/cfe-core/src/es/cfe_es_perf.c
+++ b/fsw/cfe-core/src/es/cfe_es_perf.c
@@ -342,14 +342,14 @@ int32 CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMask_t *data)
         Perf->MetaData.FilterMask[cmd->FilterMaskNum] = cmd->FilterMask;
 
         CFE_EVS_SendEvent(CFE_ES_PERF_FILTMSKCMD_EID, CFE_EVS_EventType_DEBUG,
-                "Set Performance Filter Mask Cmd rcvd, num %d, val 0x%x",
-                (int)cmd->FilterMaskNum,(unsigned int)cmd->FilterMaskNum);
+                "Set Performance Filter Mask Cmd rcvd, num %u, val 0x%x",
+                (unsigned int)cmd->FilterMaskNum,(unsigned int)cmd->FilterMask);
 
         CFE_ES_TaskData.CommandCounter++;
     }else{
         CFE_EVS_SendEvent(CFE_ES_PERF_FILTMSKERR_EID, CFE_EVS_EventType_ERROR,
-                "Performance Filter Mask Cmd Error,Index(%d)out of range(%d)",
-                (int)cmd->FilterMaskNum,(int)CFE_ES_PERF_32BIT_WORDS_IN_MASK);
+                "Performance Filter Mask Cmd Error,Index(%u)out of range(%u)",
+                (unsigned int)cmd->FilterMaskNum,(unsigned int)CFE_ES_PERF_32BIT_WORDS_IN_MASK);
 
         CFE_ES_TaskData.CommandErrorCounter++;
 
@@ -372,15 +372,15 @@ int32 CFE_ES_SetPerfTriggerMaskCmd(const CFE_ES_SetPerfTriggerMask_t *data)
         Perf->MetaData.TriggerMask[cmd->TriggerMaskNum] = cmd->TriggerMask;
 
         CFE_EVS_SendEvent(CFE_ES_PERF_TRIGMSKCMD_EID, CFE_EVS_EventType_DEBUG,
-                "Set Performance Trigger Mask Cmd rcvd,num %d, val 0x%x",
-                (int)cmd->TriggerMaskNum,(int)cmd->TriggerMaskNum);
+                "Set Performance Trigger Mask Cmd rcvd,num %u, val 0x%x",
+                (unsigned int)cmd->TriggerMaskNum,(unsigned int)cmd->TriggerMask);
 
         CFE_ES_TaskData.CommandCounter++;
 
     }else{
         CFE_EVS_SendEvent(CFE_ES_PERF_TRIGMSKERR_EID, CFE_EVS_EventType_ERROR,
-                "Performance Trigger Mask Cmd Error,Index(%d)out of range(%d)",
-                (int)cmd->TriggerMaskNum,(int)CFE_ES_PERF_32BIT_WORDS_IN_MASK);
+                "Performance Trigger Mask Cmd Error,Index(%u)out of range(%u)",
+                (unsigned int)cmd->TriggerMaskNum,(unsigned int)CFE_ES_PERF_32BIT_WORDS_IN_MASK);
 
         CFE_ES_TaskData.CommandErrorCounter++;
     }


### PR DESCRIPTION
**Describe the contribution**
   Fixes issue #315, ES Performance debug messages have incorrect parameter 

**Testing performed**
   1. Built with updated cfe_es_perf.c.
   2. Sent SetPerfFilterMaskCmd & SetPerfTriggerMaskCmd commands.
   3. Verified messages are now correct.
   4. Ran unit tests.

**Expected behavior changes**
   DEBUG messages are now correct.

**System(s) tested on:**
   Oracle VM VirtualBox
   OS: ubuntu-19.10
   Version: cFE 6.7.3.0; OSAL 5.0.3.0; PSP 1.4.1.0

**Contributor Info**
Dan Knutsen
GSFC/NASA