### PR TITLE
Add global scope option to omit deprecated items

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,6 +91,12 @@ include(${MISSION_DEFS}/targets.cmake)
 # Scan the list of targets and organize by target system type.
 read_targetconfig()
 
+# Include global-scope build customization
+# Note if this feature is used it should only set basic options
+# that have wide support (e.g. add_definitions).  It should not
+# set anything target or machine specific.
+include("${MISSION_DEFS}/global_build_options.cmake" OPTIONAL)
+
 # Additionally the target mission might require additional
 # custom build steps or override some routines.  In particular
 # some architectures might need some special installation steps

--- a/cmake/sample_defs/global_build_options.cmake
+++ b/cmake/sample_defs/global_build_options.cmake
@@ -1,0 +1,25 @@
+#
+# Example global_build_options.cmake
+# ----------------------------------
+#
+# This may set global definitions that apply to ALL targets in ALL scopes,
+# including FSW code that is cross-compiled for a target as well as code
+# built for the development host itself (native).
+#
+# As such, it should only invoke basic commands that have wide applicability,
+# such as "add_definitions()" for macro definitions that should be set
+# globally.  It should not include any compiler-specific options that might
+# change between compiler vendors or target processor families.
+#
+
+# If the OMIT_DEPRECATED flag is specified, then define the respective macros
+# that omit the deprecated features from the build.  This is conditional in this
+# example for CI purposes, so it can be tested both ways.  Most projects would 
+# likely set this only one way.
+set(OMIT_DEPRECATED $ENV{OMIT_DEPRECATED} CACHE STRING "Omit deprecated elements")
+if (OMIT_DEPRECATED)
+  message (STATUS "OMIT_DEPRECATED=true: Not including deprecated elements in build")
+  add_definitions(-DCFE_OMIT_DEPRECATED_6_6 -DOSAL_OMIT_DEPRECATED)
+else()
+  message (STATUS "OMIT_DEPRECATED=false: Deprecated elements included in build")
+endif (OMIT_DEPRECATED)


### PR DESCRIPTION
**Describe the contribution**

Fix #355

Adds a "global_build_options.cmake" file akin to the existing arch_build/mission_build option files.  Include an example of this file that optionally does add_definitions() to omit the deprected elements for build testing.

**Testing performed**
Build with and without the OMIT_DEPRECATED flag on the prep command, and confirm that it is correctly translated to the `add_definition()` globally for all tools and FSW code.

**Expected behavior changes**
Affects build system only.  No change to runtime behavior.

**System(s) tested on:**
Ubuntu 18.04 LTS 64-bit

**Contributor Info**
Joseph Hickey, Vantage Systems, Inc.

**Community contributors**
You must attach a signed CLA (required for acceptance) or reference one already submitted
