### PR TITLE
CMake: minor changes to improve the CLion IDE CMake experience

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ set(CMAKE_LEGACY_CYGWIN_WIN32 0)
 # Add a path for any locally-supplied CMake modules
 # These would typically be a part of any custom PSPs in use.
 # (this is not required, and the directory can be empty/nonexistent)
-set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../psp/cmake/Modules" ${CMAKE_MODULE_PATH})
+set(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../psp/cmake/Modules" ${CMAKE_MODULE_PATH})
 
 # The minimum CMake version is chosen because 2.6.4 is what is
 # included by default with RHEL/Centos 5.x
@@ -59,7 +59,8 @@ cmake_minimum_required(VERSION 2.6.4)
 # that the subdirectories will at least use the "C" language, so
 # indicate that now.  Doing this early initializes the CFLAGS
 # so they won't change later.
-project(CFETOP C)
+# Note: this line defines the CFE_SOURCE_DIR variable.
+project(CFE C)
 
 # Allow unit tests to be added by any recipe
 enable_testing()

--- a/cmake/mission_build.cmake
+++ b/cmake/mission_build.cmake
@@ -36,7 +36,7 @@ function(initialize_globals)
     # this is the parent (mission) build and variable values must be determined
     # Obtain the "real" top-level source directory and set it in parent scope
     if (NOT DEFINED MISSION_SOURCE_DIR)
-      get_filename_component(MISSION_SOURCE_DIR "${CMAKE_SOURCE_DIR}/.." ABSOLUTE)
+      get_filename_component(MISSION_SOURCE_DIR "${CFE_SOURCE_DIR}/.." ABSOLUTE)
       set(MISSION_SOURCE_DIR ${MISSION_SOURCE_DIR} CACHE PATH "Top level mission source directory")
     endif(NOT DEFINED MISSION_SOURCE_DIR)
 
@@ -211,13 +211,13 @@ function(prepare)
   file(WRITE "${CMAKE_BINARY_DIR}/doc/mission-content.doxyfile"
       ${MISSION_DOXYFILE_USER_CONTENT})
       
-  configure_file("${CMAKE_SOURCE_DIR}/cmake/cfe-common.doxyfile.in"
+  configure_file("${CFE_SOURCE_DIR}/cmake/cfe-common.doxyfile.in"
     "${CMAKE_BINARY_DIR}/doc/cfe-common.doxyfile")
  
- configure_file("${CMAKE_SOURCE_DIR}/cmake/osal-common.doxyfile.in"
+  configure_file("${CFE_SOURCE_DIR}/cmake/osal-common.doxyfile.in"
     "${CMAKE_BINARY_DIR}/doc/osal-common.doxyfile")
    
-  configure_file("${CMAKE_SOURCE_DIR}/cmake/mission-detaildesign.doxyfile.in"
+  configure_file("${CFE_SOURCE_DIR}/cmake/mission-detaildesign.doxyfile.in"
     "${CMAKE_BINARY_DIR}/doc/mission-detaildesign.doxyfile")
     
   # The user guide should include the doxygen from the _public_ API files from CFE + OSAL
@@ -247,10 +247,10 @@ function(prepare)
   set(OSALGUIDE_PREDEFINED 
       "MESSAGE_FORMAT_IS_CCSDS")
  
-  configure_file("${CMAKE_SOURCE_DIR}/cmake/cfe-usersguide.doxyfile.in"
+  configure_file("${CFE_SOURCE_DIR}/cmake/cfe-usersguide.doxyfile.in"
     "${CMAKE_BINARY_DIR}/doc/cfe-usersguide.doxyfile")
 
-  configure_file("${CMAKE_SOURCE_DIR}/cmake/osalguide.doxyfile.in"
+  configure_file("${CFE_SOURCE_DIR}/cmake/osalguide.doxyfile.in"
     "${CMAKE_BINARY_DIR}/doc/osalguide.doxyfile")  
     
   add_custom_target(mission-doc 
@@ -302,7 +302,7 @@ function(prepare)
   add_custom_target(mission-version
     COMMAND 
         ${CMAKE_COMMAND} -D BIN=${CMAKE_BINARY_DIR}
-                         -P ${CMAKE_SOURCE_DIR}/cmake/version.cmake
+                         -P ${CFE_SOURCE_DIR}/cmake/version.cmake
     WORKING_DIRECTORY 
       ${CMAKE_SOURCE_DIR}                             
   )
@@ -345,8 +345,8 @@ function(process_arch TARGETSYSTEM)
     # Find the toolchain file - allow a file in the mission defs dir to supercede one in the compile dir
     if (EXISTS ${MISSION_DEFS}/toolchain-${CURRSYS}.cmake)
       set(TOOLCHAIN_FILE ${MISSION_DEFS}/toolchain-${CURRSYS}.cmake)
-    elseif(EXISTS ${CMAKE_SOURCE_DIR}/cmake/toolchain-${CURRSYS}.cmake)
-      set(TOOLCHAIN_FILE ${CMAKE_SOURCE_DIR}/cmake/toolchain-${CURRSYS}.cmake)
+    elseif(EXISTS ${CFE_SOURCE_DIR}/cmake/toolchain-${CURRSYS}.cmake)
+      set(TOOLCHAIN_FILE ${CFE_SOURCE_DIR}/cmake/toolchain-${CURRSYS}.cmake)
     else()
       message(FATAL_ERROR "Unable to find toolchain file for ${CURRSYS}")
     endif()
@@ -365,7 +365,7 @@ function(process_arch TARGETSYSTEM)
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
         ${SELECTED_TOOLCHAIN_FILE}
-        ${CMAKE_SOURCE_DIR} 
+        ${CFE_SOURCE_DIR}
     WORKING_DIRECTORY 
         "${ARCH_BINARY_DIR}" 
     RESULT_VARIABLE 


### PR DESCRIPTION
**Describe the contribution**

This is needed when CFE's root CMakeLists.txt is not the highest level CMakeLists.txt in the project. My IDE is CLion and it works best when there is the highest level CMakeLists.txt in the root of a project's source code.

This changeset enables a necessary indirection: from `CMAKE_SOURCE_PATH` to `CFE_SOURCE_PATH` and this allows building the project with the CMakeLists.txt file in the top-level mission source directory.

**Step 1.** I have cloned the root cFS repository and have cloned all submodules.
**Step 2.** I have created a CMakeLists.txt file in the cFS folder with the following contents:

```
cmake_minimum_required(VERSION 3.13)
add_subdirectory(cfe)
```

**Step 3.** I have made the changes from this changeset.

After this sequence of steps, the CLion IDE picks up the root-level CMakeLists automatically and I can already start building targets, such as `cpu1-all`, `mission-all` etc. And the only parameter I need to configure CMake is: `-DMISSION_SOURCE_DIR=/sandbox/cFS`.

**Testing performed**

Please see the steps above.

**Expected behavior changes**

With this change, getting IDE to recognize the cFS build targets is way easier if your IDE is CLion.

**System(s) tested on:**
 - OS: macOS 10.14.6
 - Versions cFE and cFS, latest master (https://github.com/nasa/cFE/commit/bb4a6ee52f32c54031ffd752c20a9914cadea914 and https://github.com/nasa/cFS/commit/43590faadc08d893670dce48ae01df0a364f6e9a).

**Contributor Info**

Stanislav Pankevich (PTS GmbH, private German space company).

**Community contributors**

> You must attach a signed CLA (required for acceptance) or reference one already submitted

The corporate CLA has been signed on Feb 17th and sent to the email address as specified in the CLA document.


