### PR TITLE
Fix #274, NumOfChildTasks not decremented

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_api.c
+++ b/fsw/cfe-core/src/es/cfe_es_api.c
@@ -1074,12 +1074,7 @@ int32 CFE_ES_CreateChildTask(uint32 *TaskIdPtr,
                strncpy((char *)CFE_ES_Global.TaskTable[TaskId].TaskName,TaskName,OS_MAX_API_NAME);
                CFE_ES_Global.TaskTable[TaskId].TaskName[OS_MAX_API_NAME - 1] = '\0';
                CFE_ES_Global.RegisteredTasks++;
-
-               /*
-               ** Increment the "Registered" child task count for the App
-               */
-               CFE_ES_Global.AppTable[AppId].TaskInfo.NumOfChildTasks ++;
-
+               
                ReturnCode = CFE_SUCCESS;
             }
             else

--- a/fsw/cfe-core/src/es/cfe_es_apps.c
+++ b/fsw/cfe-core/src/es/cfe_es_apps.c
@@ -572,7 +572,6 @@ int32 CFE_ES_AppCreate(uint32 *ApplicationIdPtr,
       */
       strncpy((char *)CFE_ES_Global.AppTable[i].TaskInfo.MainTaskName, AppName, OS_MAX_API_NAME);
       CFE_ES_Global.AppTable[i].TaskInfo.MainTaskName[OS_MAX_API_NAME - 1] = '\0';
-      CFE_ES_Global.AppTable[i].TaskInfo.NumOfChildTasks = 0;
 
       /*
       ** Fill out the Task State info
@@ -1545,6 +1544,7 @@ void CFE_ES_GetAppInfoInternal(uint32 AppId, CFE_ES_AppInfo_t *AppInfoPtr )
    int32              ReturnCode;
    OS_module_prop_t   ModuleInfo;
    uint32             TaskIndex;
+   uint32             i; 
    
    
    CFE_ES_LockSharedData(__func__,__LINE__);
@@ -1575,7 +1575,19 @@ void CFE_ES_GetAppInfoInternal(uint32 AppId, CFE_ES_AppInfo_t *AppInfoPtr )
    strncpy((char *)AppInfoPtr->MainTaskName, (char *)CFE_ES_Global.AppTable[AppId].TaskInfo.MainTaskName,
            sizeof(AppInfoPtr->MainTaskName) - 1);
    AppInfoPtr->MainTaskName[sizeof(AppInfoPtr->MainTaskName) - 1] = '\0';
-   AppInfoPtr->NumOfChildTasks = CFE_ES_Global.AppTable[AppId].TaskInfo.NumOfChildTasks;
+   
+   /*
+   ** Calculate the number of child tasks
+   */
+   AppInfoPtr->NumOfChildTasks = 0;  
+   for (i=0; i<OS_MAX_TASKS; i++ )
+   {
+      if ( CFE_ES_Global.TaskTable[i].AppId == AppId && CFE_ES_Global.TaskTable[i].RecordUsed == true 
+           && CFE_ES_Global.TaskTable[i].TaskId != AppInfoPtr->MainTaskId )
+      {
+         AppInfoPtr->NumOfChildTasks++;
+      }
+   }
 
    /*
    ** Get the execution counter for the main task

--- a/fsw/cfe-core/src/es/cfe_es_apps.h
+++ b/fsw/cfe-core/src/es/cfe_es_apps.h
@@ -92,8 +92,6 @@ typedef struct
 {
    uint32   MainTaskId;                     /* The Application's Main Task ID */
    char     MainTaskName[OS_MAX_API_NAME];  /* The Application's Main Task ID */
-   uint32   NumOfChildTasks;                /* Number of Child tasks for an App */
-
 } CFE_ES_MainTaskInfo_t;
 
 

--- a/fsw/cfe-core/src/es/cfe_es_start.c
+++ b/fsw/cfe-core/src/es/cfe_es_start.c
@@ -805,7 +805,6 @@ void  CFE_ES_CreateObjects(void)
                */
                strncpy((char *)CFE_ES_Global.AppTable[j].TaskInfo.MainTaskName, (char *)CFE_ES_ObjectTable[i].ObjectName, OS_MAX_API_NAME);
                CFE_ES_Global.AppTable[j].TaskInfo.MainTaskName[OS_MAX_API_NAME - 1] = '\0';
-               CFE_ES_Global.AppTable[j].TaskInfo.NumOfChildTasks = 0;
                
                /*
                ** Create the task

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -4306,8 +4306,8 @@ void TestAPI(void)
     char CDSName[CFE_MISSION_ES_CDS_MAX_NAME_LENGTH + 2];
     int i;
     uint32 ExceptionContext = 0;
-    int32 Return;
-    uint8 Data[12];
+    int32  Return;
+    uint8  Data[12];
     uint32 ResetType;
     uint32 *ResetTypePtr;
     uint32 AppId;
@@ -4318,6 +4318,7 @@ void TestAPI(void)
     uint32 CounterCount;
     CFE_ES_CDSHandle_t CDSHandle;
     CFE_ES_TaskInfo_t TaskInfo;
+    CFE_ES_AppInfo_t AppInfo;
 
 #ifdef UT_VERBOSE
     UT_Text("Begin Test API\n");
@@ -4797,12 +4798,20 @@ void TestAPI(void)
     CFE_ES_Global.AppTable[0].AppState = CFE_ES_AppState_RUNNING;
     CFE_ES_Global.AppTable[0].TaskInfo.MainTaskId = 15;
     OS_TaskCreate(&CFE_ES_Global.TaskTable[1].TaskId, NULL, NULL, NULL,
-                  0, 0, 0);
-    UT_Report(__FILE__, __LINE__,
-              CFE_ES_DeleteChildTask(CFE_ES_Global.TaskTable[1].TaskId) ==
-                CFE_SUCCESS,
-              "CFE_ES_DeleteChildTask",
-              "Delete child task successful");
+                  0, 0, 0);    
+    Return = CFE_ES_GetAppInfo(&AppInfo,CFE_ES_Global.TaskTable[1].AppId);
+    UtAssert_True(Return == CFE_SUCCESS, 
+         "CFE_ES_GetAppInfo() return=%x", (unsigned int)Return); 
+    UtAssert_True(AppInfo.NumOfChildTasks == 1, 
+         "AppInfo.NumOfChildTaskss == %u", (unsigned int)AppInfo.NumOfChildTasks); 
+    Return = CFE_ES_DeleteChildTask(CFE_ES_Global.TaskTable[1].TaskId);  
+    UtAssert_True(Return == CFE_SUCCESS, 
+         "DeleteChildResult() return=%x", (unsigned int)Return);
+    Return = CFE_ES_GetAppInfo(&AppInfo,CFE_ES_Global.TaskTable[1].AppId);
+    UtAssert_True(Return == CFE_SUCCESS, 
+         "CFE_ES_GetAppInfo() return=%x", (unsigned int)Return); 
+    UtAssert_True(AppInfo.NumOfChildTasks == 0, 
+         "AppInfo.NumOfChildTaskss == %u", (unsigned int)AppInfo.NumOfChildTasks);   
 
     /* Test deleting a child task with an OS task delete failure */
     ES_ResetUnitTest();


### PR DESCRIPTION
**Describe the contribution**
Fixes #274, NumOfChildTasks not decremented

**Testing performed**
Steps taken to test the contribution:
1. Nominal build process.
2. Ran unit tests.

**Expected behavior changes**
 NumOfChildTasks will now be decremented when a child task is deleted.

**System(s) tested on**
Oracle VM VirtualBox
OS: ubuntu-19.10
Version: cFE 6.7.3.0; OSAL 5.0.3.0; PSP 1.4.1.0

**Contributor Info - All information REQUIRED for consideration of pull request**
Dan Knutsen
GSFC/NASA
