### PR TITLE
Fix #489, Add usersguide/osalguide to local targets

### DIFF
--- a/cmake/Makefile.sample
+++ b/cmake/Makefile.sample
@@ -44,6 +44,12 @@
 #  doc -- Build all doxygen source documentation.  The HTML documentation will be
 #      generated under the build tree specified by "O". 
 #
+#  usersguide -- Build all API/Cmd/Tlm doxygen documentation.  The HTML documentation
+#      will be generated under the build tree specified by "O".
+#
+#  osalguide -- Build OSAL API doxygen documentation.  The HTML documentation will
+#      be generated under the build tree specified by "O".
+#
 #  test -- Run all unit tests defined in the build.  Unit tests will typically only
 #      be executable when building with the "SIMULATION=native" option.  Otherwise
 #      it is up to the user to copy the executables to the target and run them.
@@ -70,7 +76,7 @@ endif
 
 # The "LOCALTGTS" defines the top-level targets that are implemented in this makefile
 # Any other target may also be given, in that case it will simply be passed through.
-LOCALTGTS := doc prep all clean install distclean test lcov
+LOCALTGTS := doc usersguide osalguide prep all clean install distclean test lcov
 OTHERTGTS := $(filter-out $(LOCALTGTS),$(MAKECMDGOALS))
 
 # As this makefile does not build any real files, treat everything as a PHONY target


### PR DESCRIPTION
**Describe the contribution**
Added userguide and osalguide to the local target list to avoid makefile warning
Fix #489 

**Testing performed**
Steps taken to test the contribution:
1. Ran make userguide and osalguide and confirmed no longer outputs warnings

**Expected behavior changes**
Passes enhanced CI

**System(s) tested on**
 - Hardware: cFS Dev Server 2
 - OS: Ubuntu 18.04
 - Versions: Master bundle with this change

**Additional context**
N/A

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC