### PR TITLE
Fix #487, CFE_TIME_print format fix

### DIFF
--- a/fsw/cfe-core/ut-stubs/ut_time_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_time_stubs.c
@@ -102,11 +102,10 @@ void CFE_TIME_TaskMain(void)
 void CFE_TIME_Print(char *PrintBuffer, CFE_TIME_SysTime_t TimeToPrint)
 {
     snprintf(PrintBuffer,
-            CFE_TIME_PRINTED_STRING_SIZE,
-             "UT %lu.%lu -",
-             (unsigned long)TimeToPrint.Seconds,
-             (unsigned long)TimeToPrint.Subseconds);
-
+             CFE_TIME_PRINTED_STRING_SIZE,
+             "UT %u.%u -",
+             (unsigned int)TimeToPrint.Seconds,
+             (unsigned int)TimeToPrint.Subseconds);
 
     UT_Stub_RegisterContext(UT_KEY(CFE_TIME_Print), PrintBuffer);
     UT_Stub_RegisterContext(UT_KEY(CFE_TIME_Print), &TimeToPrint);


### PR DESCRIPTION
Describe the contribution
Fix #487, CFE_TIME_print format fix

Testing performed
Build process:
 - make distclean
 - make ENABLE_UNIT_TESTS=TRUE SIMULATION=native prep
 - make 
 - make install

Verified nominal/clean build.
Ran unit tests.

Expected behavior changes
Clean build 

System(s) tested on
Oracle VM VirtualBox
OS: ubuntu-18.04.3
Versions: cFE 6.7.6.0, OSAL 5.0.6.0, PSP 1.4.4.0

Contributor Info
Dan Knutsen
GSFC/NASA