### PR TITLE
Fix #358, Add native permissive mode configuration

### DIFF
--- a/cmake/sample_defs/native_osconfig.h
+++ b/cmake/sample_defs/native_osconfig.h
@@ -1,0 +1,4 @@
+/* SIMULATION=native specific osconfig options */
+
+/* See parameter description in default_osconfig.h */
+#define OSAL_DEBUG_PERMISSIVE_MODE


### PR DESCRIPTION
**Describe the contribution**
This adds the native_osconfig.h which is included after
the default_osconfig.h if SIMULATION=native is set.
Fix #358

**Testing performed**
Steps taken to test the contribution:
1. copy cfe/cmake/sample_defs to top dir (per standard setup instructions)
1. make SIMULATION=native prep
1. make; make install;
1. Execute core-cpu1 in build/exe/cpu1 and confirmed permissive mode
1. Also did steps above with just make prep, and confirmed permissive mode wasn't set

**Expected behavior changes**
No longer requires sed "hack" to change the setting in default_config.h

**System(s) tested on**
 - Hardware: cFS Dev server 2
 - OS: Ubuntu 18.04
 - Versions: master bundle with this branch

**Additional context**
Update related README's and CI to no longer perform sed "hack"

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC