### PR TITLE
Fix #535 and #537, User's guide doxygen issues

### DIFF
--- a/cmake/cfe-usersguide.doxyfile.in
+++ b/cmake/cfe-usersguide.doxyfile.in
@@ -23,6 +23,4 @@ INPUT                 += @MISSION_SOURCE_DIR@/cfe/docs/src/cfe_usersguide.dox
 PREDEFINED            += @USERGUIDE_PREDEFINED@
 
 # Bring in the cFE header files for the documentation of the various API calls
-INPUT                 += \
-@MISSION_USERGUIDE_HEADERFILES@ \
-@USERGUIDE_MISC_ADDITION@                
+INPUT                 += @MISSION_USERGUIDE_HEADERFILES@

--- a/cmake/mission_build.cmake
+++ b/cmake/mission_build.cmake
@@ -232,14 +232,6 @@ function(prepare)
     "${osal_MISSION_DIR}/src/os/inc/*.h")
   string(REPLACE ";" " \\\n" MISSION_OSAL_HEADERFILES "${MISSION_OSAL_HEADERFILES}") 
 
-  # Addition to usersguide
-  file(GLOB USERGUIDE_MISC_ADDITION
-       "${cfe-core_MISSION_DIR}/src/inc/private/*.h"
-       "${cfe-core_MISSION_DIR}/src/sb/*"
-       "${cfe-core_MISSION_DIR}/src/es/*"
-       "${cfe-core_MISSION_DIR}/src/evs/*")
-  string(REPLACE ";" " \\\n" USERGUIDE_MISC_ADDITION "${USERGUIDE_MISC_ADDITION}")
-
   # PREDEFINED
   set(USERGUIDE_PREDEFINED 
       "MESSAGE_FORMAT_IS_CCSDS")

--- a/fsw/cfe-core/src/inc/cfe_es.h
+++ b/fsw/cfe-core/src/inc/cfe_es.h
@@ -561,9 +561,9 @@ bool CFE_ES_RunLoop(uint32 *ExitStatus);
 ** \param[in]  MinSystemState        Determine the state of the App
 **
 ** \returns
-**      CFE_SUCCESS if state was successfully achieved
-**      CFE_ES_OPERATION_TIMED_OUT if the timeout was reached
-**      (or other defined error code in case of error)
+** \retcode #CFE_SUCCESS                \retdesc State successfully achieved \endcode
+** \retcode #CFE_ES_OPERATION_TIMED_OUT \retdesc Timeout was reached         \endcode
+** \endreturns
 **
 ** \sa #CFE_ES_RunLoop
 **
@@ -969,7 +969,6 @@ int32 CFE_ES_WriteToSysLog(const char *SpecStringPtr, ...) OS_PRINTF(1,2);
 **                          a single value.  Nominally, the user should set this value to zero.
 **
 ** \param[in]   TypeCRC     One of the following CRC algorithm selections:
-**
 **                          \arg \c CFE_MISSION_ES_CRC_8 - (Not currently implemented)
 **                          \arg \c CFE_MISSION_ES_CRC_16 - a CRC-16 algorithm
 **                          \arg \c CFE_MISSION_ES_CRC_32 - (not currently implemented)


### PR DESCRIPTION
**Describe the contribution**
Fix #535 - removed an extra line that caused breakage
Fix #537 - removed private paths from user's guide processing

**Testing performed**
Steps taken to test the contribution:
1. make prep
1. make usersguide
1. cd buid/doc/users_guide/latex
1. make

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - PDF file now generated by process above

**System(s) tested on**
 - Hardware: cFS Dev Server 3
 - OS: Ubuntu 18.04
 - Versions: current bundle w/ this change

**Additional context**
N/A

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC