### PR TITLE
Fix #539, build failure in UT stubs with multiple CPUs

### DIFF
--- a/fsw/cfe-core/unit-test/CMakeLists.txt
+++ b/fsw/cfe-core/unit-test/CMakeLists.txt
@@ -32,42 +32,47 @@ add_library(ut_${CFE_CORE_TARGET}_support STATIC
 # UT version of the real module (compiled with coverage flags)
 foreach(MODULE ${CFE_CORE_MODULES})
 
+  # The "UT_TARGET_NAME" is a concatenation of the configuration name with the current module
+  # This avoids target name duplication in case more than one configuration is used
+  # (All  targets should be based on this name)
+  set(UT_TARGET_NAME "${CFE_CORE_TARGET}_${MODULE}")
+  
   set(CFE_MODULE_FILES)
   aux_source_directory(${cfe-core_MISSION_DIR}/src/${MODULE} CFE_MODULE_FILES)
   
   # Compile the unit(s) under test as an object library
   # this allows easy configuration of special flags and include paths
   # in particular this should use the UT_C_FLAGS for coverage instrumentation
-  add_library(ut_cfe_${MODULE}_object OBJECT 
+  add_library(ut_${UT_TARGET_NAME}_object OBJECT 
       ${CFE_MODULE_FILES})
   
   # Apply the UT_C_FLAGS to the units under test
   # This should enable coverage analysis on platforms that support this
-  set_target_properties(ut_cfe_${MODULE}_object PROPERTIES
+  set_target_properties(ut_${UT_TARGET_NAME}_object PROPERTIES
       COMPILE_FLAGS "${UT_C_FLAGS}")
         
   # For this object target only, the "override" includes should be injected
   # into the include path BEFORE any other include path.  This is so the
   # override will take precedence over any system-provided version.
-  target_include_directories(ut_cfe_${MODULE}_object BEFORE PRIVATE
+  target_include_directories(ut_${UT_TARGET_NAME}_object BEFORE PRIVATE
       ${CMAKE_CURRENT_SOURCE_DIR}/modules/inc/overrides)
         
-  add_executable(${CFE_CORE_TARGET}_${MODULE}_UT 
+  add_executable(${UT_TARGET_NAME}_UT 
     ${MODULE}_UT.c 
-    $<TARGET_OBJECTS:ut_cfe_${MODULE}_object>)
+    $<TARGET_OBJECTS:ut_${UT_TARGET_NAME}_object>)
   
-  target_link_libraries(${CFE_CORE_TARGET}_${MODULE}_UT
+  target_link_libraries(${UT_TARGET_NAME}_UT
         ut_${CFE_CORE_TARGET}_support
         ut_cfe-core_stubs
         ut_assert)
     
   # Also add the C FLAGS to the link command    
   # This should enable coverage analysis on platforms that support this
-  set_target_properties(${CFE_CORE_TARGET}_${MODULE}_UT PROPERTIES 
+  set_target_properties(${UT_TARGET_NAME}_UT PROPERTIES 
     LINK_FLAGS "${UT_C_FLAGS}")
         
-  add_test(${CFE_CORE_TARGET}_${MODULE}_UT ${CFE_CORE_TARGET}_${MODULE}_UT)
-  install(TARGETS ${CFE_CORE_TARGET}_${MODULE}_UT DESTINATION ${TGTNAME}/${UT_INSTALL_SUBDIR})
+  add_test(${UT_TARGET_NAME}_UT ${UT_TARGET_NAME}_UT)
+  install(TARGETS ${UT_TARGET_NAME}_UT DESTINATION ${TGTNAME}/${UT_INSTALL_SUBDIR})
 endforeach(MODULE ${CFE_CORE_MODULES})
 
 # Generate the FS test input files

--- a/fsw/cfe-core/ut-stubs/ut_evs_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_evs_stubs.c
@@ -34,7 +34,6 @@
 */
 #include <string.h>
 #include "cfe.h"
-#include "cfe_platform_cfg.h"
 #include "utstubs.h"
 
 /*

--- a/fsw/cfe-core/ut-stubs/ut_fs_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_fs_stubs.c
@@ -34,7 +34,6 @@
 */
 #include <string.h>
 #include "cfe.h"
-#include "cfe_platform_cfg.h"
 #include "utstubs.h"
 
 

--- a/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
@@ -34,7 +34,6 @@
 */
 #include <string.h>
 #include "cfe.h"
-#include "cfe_platform_cfg.h"
 #include "utstubs.h"
 
 /*

--- a/fsw/cfe-core/ut-stubs/ut_tbl_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_tbl_stubs.c
@@ -23,7 +23,6 @@
 */
 #include <string.h>
 #include "cfe.h"
-#include "cfe_platform_cfg.h"
 #include "utstubs.h"
 
 /*


### PR DESCRIPTION
**Describe the contribution**

Fix #539 

Removes dependencies on `cfe_platform_cfg.h` from the unit test stub code.  The behavior of the stubs should not be dependent on the FSW runtime config.

This also fixes a duplicate name collision where different configs exist within the same architecture, causing a conflict on the UT target names.

**Testing performed**
Build with ENABLE_UNIT_TESTS=TRUE for both native and cross environments, with both a default config (single CPU/config) and a more complex two CPU config.  

Execute unit tests and confirm all passing in all configs.

**Expected behavior changes**
The two CPU config originally fails and now builds and runs UT with this change.
No changes to FSW, only UT.

**System(s) tested on**
Ubuntu 18.04 LTS 64 bit
Cross build for 32-bit architecture

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc. (CLA on file)
