### PR TITLE
Fix #561, Add branch coverage reporting

### DIFF
--- a/cmake/Makefile.sample
+++ b/cmake/Makefile.sample
@@ -139,9 +139,8 @@ test:
 	(cd $(O)/$(ARCH) && ctest -O ctest.log)
 
 lcov:
-	lcov --capture --directory $(O)/$(ARCH) --output-file $(O)/$(ARCH)/coverage_test.info
-	lcov --add-tracefile $(O)/$(ARCH)/coverage_base.info --add-tracefile $(O)/$(ARCH)/coverage_test.info --output-file $(O)/$(ARCH)/coverage_total.info
-	lcov --remove $(O)/$(ARCH)/coverage_total.info 'unit-test/*' --output-file $(O)/$(ARCH)/coverage_filtered.info
+	lcov --capture --rc lcov_branch_coverage=1 --directory $(O)/$(ARCH) --output-file $(O)/$(ARCH)/coverage_test.info
+	lcov --rc lcov_branch_coverage=1 --add-tracefile $(O)/$(ARCH)/coverage_base.info --add-tracefile $(O)/$(ARCH)/coverage_test.info --output-file $(O)/$(ARCH)/coverage_total.info
 	genhtml $(O)/$(ARCH)/coverage_filtered.info --output-directory $(O)/$(ARCH)/lcov
 	@/bin/echo -e "\n\nCoverage Report Link: file:$(CURDIR)/$(O)/$(ARCH)/lcov/index.html\n"
 


### PR DESCRIPTION
**Describe the contribution**
Fix #561, Adds branch coverage and removes no-longer-needed report file manipulation to exclude unit test code from coverage report

**Testing performed**
Steps taken to test the contribution:
1. Standard build/test/lcov (same as enhanced CI)
1. Confirmed branch coverage reported (~91%)

**Expected behavior changes**
No changes to operational behavior

**System(s) tested on**
 - Hardware: cFS Dev Server 3
 - OS: Ubuntu 18.04
 - Versions: Master bundle w/ this change

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC