### PR TITLE
Fix #297, CCSDS Command Secondary Header Endian Agnostic

### DIFF
--- a/fsw/cfe-core/src/inc/ccsds.h
+++ b/fsw/cfe-core/src/inc/ccsds.h
@@ -107,11 +107,12 @@ typedef struct {
 
 typedef struct {
 
-   uint16  Command;      /* command secondary header */
-      /*  bits  shift   ------------ description ---------------- */
-      /* 0x00FF    0  : checksum, calculated by ground system     */
-      /* 0x7F00    8  : command function code                     */
-      /* 0x8000   15  : reserved, set to 0                        */
+   uint8 FunctionCode; /* Command Function Code */
+                       /* bits shift ---------description-------- */
+                       /* 0x7F  0    Command function code        */
+                       /* 0x80  7    Reserved                     */
+
+   uint8 Checksum;     /* Command checksum  (all bits, 0xFF)      */
 
 } CCSDS_CmdSecHdr_t;
 
@@ -326,14 +327,14 @@ typedef CCSDS_TelemetryPacket_t   CCSDS_TlmPkt_t;
                                    (((phdr).Length[1] = ((value) - 7) & 0xff)) )
 
 /* Read function code from command secondary header. */
-#define CCSDS_RD_FC(shdr)           CCSDS_RD_BITS((shdr).Command, 0x7F00, 8)
+#define CCSDS_RD_FC(shdr)           CCSDS_RD_BITS((shdr).FunctionCode, 0x7F, 0)
 /* Write function code to command secondary header. */
-#define CCSDS_WR_FC(shdr,value)     CCSDS_WR_BITS((shdr).Command, 0x7F00, 8, value)
+#define CCSDS_WR_FC(shdr,value)     CCSDS_WR_BITS((shdr).FunctionCode, 0x7F, 0, value)
 
 /* Read checksum from command secondary header. */
-#define CCSDS_RD_CHECKSUM(shdr)     CCSDS_RD_BITS((shdr).Command, 0x00FF, 0)
+#define CCSDS_RD_CHECKSUM(shdr)     ((shdr).Checksum)
 /* Write checksum to command secondary header. */
-#define CCSDS_WR_CHECKSUM(shdr,val) CCSDS_WR_BITS((shdr).Command, 0x00FF, 0, val)
+#define CCSDS_WR_CHECKSUM(shdr,val) ((shdr).Checksum = (val))
 
 /* Define additional APID Qualifier macros. */
 
@@ -378,7 +379,8 @@ typedef CCSDS_TelemetryPacket_t   CCSDS_TlmPkt_t;
 
 /* Clear command secondary header. */
 #define CCSDS_CLR_CMDSEC_HDR(shdr) \
-  ( (shdr).Command = (CCSDS_INIT_CHECKSUM << 0) | (CCSDS_INIT_FC << 8) )
+  ( (shdr).FunctionCode = CCSDS_INIT_FC,\
+    (shdr).Checksum = CCSDS_INIT_CHECKSUM )
 
 
 #define CCSDS_WR_SEC_HDR_SEC(shdr, value)    shdr.Time[0] = ((value>>24) & 0xFF),  \

--- a/fsw/cfe-core/unit-test/ut_support.c
+++ b/fsw/cfe-core/unit-test/ut_support.c
@@ -481,30 +481,28 @@ int16 UT_GetActualPktLenField(CFE_SB_MsgPtr_t MsgPtr)
 uint8 UT_GetActualCmdCodeField(CFE_SB_MsgPtr_t MsgPtr)
 {
     /*
-     * CFE 6.4.0 tried to make all headers big-endian.
-     * CFE 6.4.1 made secondary headers native-endian again.
-     *
      * This function is used to "go around" the structure field
      * definitions and access macro definitions, to look for the
      * bits of the function code in the exact spot where we are
      * expecting to find them.
      *
      * The CCSDS Command Function Code is defined as living in
-     * bits 8 through 14 (mask 0x7F00) of the 16-bit unsigned
-     * value encoded in NATIVE endianness in the two bytes
-     * stored at offsets 6 and 7 in the packet for CCSDS version 1
-     * and offsets 10 and 11 for CCSDS Version 2
+     * the first byte of the command secondary header (mask 0x7F)
+     * NOTE: this definition is endian agnostic
+     *
+     * CCSDS version 1 - cmd sec header is offset 6 bytes
+     * CCSDS Version 2 - cmd sec header is offset 10 bytes
      */
 
-    uint8 CmdCodeWordFieldIndex; /* Field index (in WORDS) */
-    uint16 *w = (uint16 *)MsgPtr;
+    uint8 Index; /* Field index (in BYTES) */
+    uint8 *w = (uint8 *)MsgPtr;
 
 #ifndef MESSAGE_FORMAT_IS_CCSDS_VER_2
-    CmdCodeWordFieldIndex = 3;
+    Index = 6;
 #else
-    CmdCodeWordFieldIndex = 5;
+    Index = 10;
 #endif
-    return (w[CmdCodeWordFieldIndex] & 0x7F00) >> 8;
+    return (w[Index] & 0x7F);
 }
 
 


### PR DESCRIPTION
**Describe the contribution**
Implement CCSDS command secondary header such that it is endian agnostic in code and unit test support.
Fix #297 

**Testing performed**
Steps taken to test the contribution:
1. Tested via bundle CI (including non-zero command send to reset)
1. Also tested locally with enabling TO via cFS-GroundSystem

This covered both direct cmdUtil call and cFS-GroundSystem use.

**Expected behavior changes**
Cmd code (and checksum) are always in the same place (matches GSFC spec for command secondary header)

**System(s) tested on**
 - Hardware: CI and cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: test bundle with this change and https://github.com/nasa/cFS-GroundSystem/pull/66 in cFS-GroundStation

**Additional context**
See also https://github.com/nasa/cFS-GroundSystem/pull/66 these should be merged together

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC