### PR TITLE
Fix #617, Updates comments to note that the length limit of OS_MAX_PATH_LEN and OS_MAX_API_NAME includes null terminator

### DIFF
--- a/cmake/sample_defs/default_osconfig.h
+++ b/cmake/sample_defs/default_osconfig.h
@@ -44,7 +44,7 @@
 #define OS_MAX_MUTEXES              20
 
 /*
-** Maximum length for an absolute path name
+** Maximum length (including terminator) for an absolute path name
 */
 #define OS_MAX_PATH_LEN     64
 
@@ -56,7 +56,7 @@
 #define OS_MAX_LOCAL_PATH_LEN (OS_MAX_PATH_LEN + OS_FS_PHYS_NAME_LEN)
 
 /* 
-** The maxium length allowed for a object (task,queue....) name 
+** The maxium length allowed for a object name (task, queue, etc.), including terminating null
 */
 #define OS_MAX_API_NAME     20
 
@@ -66,7 +66,7 @@
 #define OS_MAX_FILE_NAME    20
 
 /* 
-** These defines are for OS_printf
+** Buffer for OS_printf, includes terminator.  Longer messages will be truncated
 */
 #define OS_BUFFER_SIZE 172
 #define OS_BUFFER_MSG_DEPTH 100

--- a/fsw/cfe-core/src/inc/cfe_fs.h
+++ b/fsw/cfe-core/src/inc/cfe_fs.h
@@ -286,7 +286,7 @@ int32 CFE_FS_GetUncompressedFile(char *OutputNameBuffer, uint32 OutputNameBuffer
 ** \par Assumptions, External Events, and Notes:
 **        -# The paths and filenames used here are the standard unix style
 **            filenames separated by "/" characters.
-**        -# The extracted filename is no longer than #OS_MAX_PATH_LEN
+**        -# The extracted filename (including terminator) is no longer than #OS_MAX_PATH_LEN 
 **
 ** \param[in] OriginalPath The original path.
 ** \param[out] FileNameOnly The filename that is extracted from the path.

--- a/fsw/cfe-core/src/inc/cfe_sb.h
+++ b/fsw/cfe-core/src/inc/cfe_sb.h
@@ -188,7 +188,8 @@ typedef struct {
 **
 ** \param[in]  PipeName     A string to be used to identify this pipe in error messages 
 **                          and routing information telemetry.  The string must be no 
-**                          longer than #OS_MAX_API_NAME.  Longer strings will be truncated. 
+**                          longer than #OS_MAX_API_NAME (including terminator).  
+**                          Longer strings will be truncated. 
 **
 ** \param[out] *PipeIdPtr   The identifier for the created pipe. 
 **

--- a/fsw/cfe-core/src/inc/cfe_tbl_events.h
+++ b/fsw/cfe-core/src/inc/cfe_tbl_events.h
@@ -313,7 +313,7 @@
 **
 **  -# The filename was misspelled
 **  -# The path to the file was incorrect
-**  -# The length of the filename and/or path exceeds the 
+**  -# The length (including terminator) of the filename and/or path exceeds the 
 **     allowable length (see #OS_MAX_PATH_LEN and #OS_MAX_FILE_NAME, respectively)
 **
 **  The \c Status field in the event message indicates the error code returned by the #OS_open


### PR DESCRIPTION
**Describe the contribution**
Fixes #617

Related to nasa/osal#88, updates documentation to note that the actual length limit of OS_MAX_PATH_LEN and OS_MAX_API_NAME  include the null terminator.

**Testing performed**
Ran unit tests.

**System(s) tested on**
Oracle VM VirtualBox
OS: ubuntu-19.10
Versions: cFE 6.7.11.0, OSAL 5.0.9.0, PSP 1.4.7.0

Contributor Info
Dan Knutsen
NASA/Goddard
