### PR TITLE
Fix #240, removes MESSAGE_FORMAT_IS_CCSDS ifdefs from code

### DIFF
--- a/cmake/mission_build.cmake
+++ b/cmake/mission_build.cmake
@@ -232,13 +232,6 @@ function(prepare)
     "${osal_MISSION_DIR}/src/os/inc/*.h")
   string(REPLACE ";" " \\\n" MISSION_OSAL_HEADERFILES "${MISSION_OSAL_HEADERFILES}") 
 
-  # PREDEFINED
-  set(USERGUIDE_PREDEFINED 
-      "MESSAGE_FORMAT_IS_CCSDS")
-
-  set(OSALGUIDE_PREDEFINED 
-      "MESSAGE_FORMAT_IS_CCSDS")
- 
   configure_file("${CFE_SOURCE_DIR}/cmake/cfe-usersguide.doxyfile.in"
     "${CMAKE_BINARY_DIR}/doc/cfe-usersguide.doxyfile")
 

--- a/cmake/sample_defs/sample_mission_cfg.h
+++ b/cmake/sample_defs/sample_mission_cfg.h
@@ -60,11 +60,9 @@
 **   
 **  \par Limits
 **      All versions of the cFE currently support only CCSDS as the message format
-**      Defining only MESSAGE_FORMAT_IS_CCSDS implements the 11 bit APID format in the primary header
-**      Also defining MESSAGE_FORMAT_IS_CCSDS_VER_2 implements the APID extended header format
-**      MESSAGE_FORMAT_IS_CCSDS must be defined for all cFE deployments. MESSAGE_FORMAT_IS_CCSDS_VER_2 is optional
+**      Defining MESSAGE_FORMAT_IS_CCSDS_VER_2 implements the APID extended header format
+**      MESSAGE_FORMAT_IS_CCSDS_VER_2 is optional
 */
-#define MESSAGE_FORMAT_IS_CCSDS
 /* #define MESSAGE_FORMAT_IS_CCSDS_VER_2 */
 #undef MESSAGE_FORMAT_IS_CCSDS_VER_2
 

--- a/fsw/cfe-core/src/inc/cfe_sb.h
+++ b/fsw/cfe-core/src/inc/cfe_sb.h
@@ -98,26 +98,23 @@
 /*
 ** Type Definitions
 */
-#ifdef MESSAGE_FORMAT_IS_CCSDS
 
-    /** \brief Generic Software Bus Message Type Definition */
-    typedef union {
-        CCSDS_PriHdr_t      Hdr;   /**< \brief CCSDS Primary Header #CCSDS_PriHdr_t */
-        CCSDS_SpacePacket_t SpacePacket;
-        uint32              Dword; /**< \brief Forces minimum of 32-bit alignment for this object */
-        uint8               Byte[sizeof(CCSDS_PriHdr_t)];   /**< \brief Allows byte-level access */
-    }CFE_SB_Msg_t;
+/** \brief Generic Software Bus Message Type Definition */
+typedef union {
+    CCSDS_PriHdr_t      Hdr;   /**< \brief CCSDS Primary Header #CCSDS_PriHdr_t */
+    CCSDS_SpacePacket_t SpacePacket;
+    uint32              Dword; /**< \brief Forces minimum of 32-bit alignment for this object */
+    uint8               Byte[sizeof(CCSDS_PriHdr_t)];   /**< \brief Allows byte-level access */
+}CFE_SB_Msg_t;
         
-    /** \brief Generic Software Bus Command Header Type Definition */
-    typedef CCSDS_CommandPacket_t   CFE_SB_CmdHdr_t;
+/** \brief Generic Software Bus Command Header Type Definition */
+typedef CCSDS_CommandPacket_t   CFE_SB_CmdHdr_t;
 
-    /** \brief Generic Software Bus Telemetry Header Type Definition */
-    typedef CCSDS_TelemetryPacket_t CFE_SB_TlmHdr_t;
+/** \brief Generic Software Bus Telemetry Header Type Definition */
+typedef CCSDS_TelemetryPacket_t CFE_SB_TlmHdr_t;
 
-    #define CFE_SB_CMD_HDR_SIZE     (sizeof(CFE_SB_CmdHdr_t))/**< \brief Size of #CFE_SB_CmdHdr_t in bytes */
-    #define CFE_SB_TLM_HDR_SIZE     (sizeof(CFE_SB_TlmHdr_t))/**< \brief Size of #CFE_SB_TlmHdr_t in bytes */
-
-#endif /* MESSAGE_FORMAT_IS_CCSDS */
+#define CFE_SB_CMD_HDR_SIZE     (sizeof(CFE_SB_CmdHdr_t))/**< \brief Size of #CFE_SB_CmdHdr_t in bytes */
+#define CFE_SB_TLM_HDR_SIZE     (sizeof(CFE_SB_TlmHdr_t))/**< \brief Size of #CFE_SB_TlmHdr_t in bytes */
 
 /** \brief  CFE_SB_TimeOut_t to primitive type definition
 ** 

--- a/fsw/cfe-core/src/sb/cfe_sb_init.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_init.c
@@ -216,7 +216,6 @@ void CFE_SB_InitPipeTbl(void){
 */
 void CFE_SB_InitMsgMap(void){
 
-#ifdef MESSAGE_FORMAT_IS_CCSDS
     CFE_SB_MsgKey_Atom_t   KeyVal;
 
     for (KeyVal=0; KeyVal < CFE_SB_MAX_NUMBER_OF_MSG_KEYS; KeyVal++)
@@ -228,7 +227,6 @@ void CFE_SB_InitMsgMap(void){
     CFE_ES_WriteToSysLog("SB internal message format: CCSDS Space Packet Protocol version 1\n");
 #else   /* VER_2 is the same now but will change for larger and/or distributed systems */
     CFE_ES_WriteToSysLog("SB internal message format: Space Packet Protocol version 2 (extended hdr)\n");
-#endif
 #endif
 
 }/* end CFE_SB_InitMsgMap */

--- a/fsw/cfe-core/src/sb/cfe_sb_msg_id_util.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_msg_id_util.c
@@ -122,8 +122,6 @@ CFE_SB_MsgId_t CFE_SB_GetMsgId(const CFE_SB_Msg_t *MsgPtr)
 {
    CFE_SB_MsgId_t MsgId = 0;
 
-#ifdef MESSAGE_FORMAT_IS_CCSDS
-
 #ifndef MESSAGE_FORMAT_IS_CCSDS_VER_2  
     MsgId = CCSDS_RD_SID(MsgPtr->Hdr);
 #else
@@ -147,7 +145,6 @@ CFE_SB_MsgId_t CFE_SB_GetMsgId(const CFE_SB_Msg_t *MsgPtr)
 /*      SystemId = CCSDS_RD_SYSTEM_ID(HdrPtr->ApidQ);            */
 /*      MsgId = (MsgId | (SystemId << 16)); */
 
-#endif
 #endif
 
 return MsgId;

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.c
@@ -551,9 +551,7 @@ int32 CFE_SB_DuplicateSubscribeCheck(CFE_SB_MsgKey_t MsgKey,
 */
 void CFE_SB_SetMsgSeqCnt(CFE_SB_MsgPtr_t MsgPtr,uint32 Count){
 
-#ifdef MESSAGE_FORMAT_IS_CCSDS
     CCSDS_WR_SEQ(MsgPtr->Hdr,Count);
-#endif
 
 }/* end CFE_SB_SetMsgSeqCnt */
 

--- a/fsw/cfe-core/src/sb/cfe_sb_util.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_util.c
@@ -97,8 +97,6 @@ void CFE_SB_InitMsg(void           *MsgPtr,
 uint16 CFE_SB_MsgHdrSize(const CFE_SB_Msg_t *MsgPtr)
 {
 
-#ifdef MESSAGE_FORMAT_IS_CCSDS
-
     uint16 size;
     const CCSDS_PriHdr_t  *HdrPtr;
 
@@ -121,8 +119,6 @@ uint16 CFE_SB_MsgHdrSize(const CFE_SB_Msg_t *MsgPtr)
 
    return size;
 
-#endif
-
 }/* end CFE_SB_MsgHdrSize */
 
 
@@ -131,7 +127,6 @@ uint16 CFE_SB_MsgHdrSize(const CFE_SB_Msg_t *MsgPtr)
  */
 void *CFE_SB_GetUserData(CFE_SB_MsgPtr_t MsgPtr)
 {
-#ifdef MESSAGE_FORMAT_IS_CCSDS
     uint8           *BytePtr;
     uint16          HdrSize;
 
@@ -139,7 +134,6 @@ void *CFE_SB_GetUserData(CFE_SB_MsgPtr_t MsgPtr)
     HdrSize = CFE_SB_MsgHdrSize(MsgPtr);
 
     return (BytePtr + HdrSize);
-#endif
 }/* end CFE_SB_GetUserData */
 
 
@@ -148,7 +142,6 @@ void *CFE_SB_GetUserData(CFE_SB_MsgPtr_t MsgPtr)
  */
 uint16 CFE_SB_GetUserDataLength(const CFE_SB_Msg_t *MsgPtr)
 {
-#ifdef MESSAGE_FORMAT_IS_CCSDS
     uint16 TotalMsgSize;
     uint16 HdrSize;
 
@@ -156,7 +149,6 @@ uint16 CFE_SB_GetUserDataLength(const CFE_SB_Msg_t *MsgPtr)
     HdrSize = CFE_SB_MsgHdrSize(MsgPtr);
 
     return (TotalMsgSize - HdrSize);
-#endif
 }/* end CFE_SB_GetUserDataLength */
 
 
@@ -165,15 +157,12 @@ uint16 CFE_SB_GetUserDataLength(const CFE_SB_Msg_t *MsgPtr)
  */
 void CFE_SB_SetUserDataLength(CFE_SB_MsgPtr_t MsgPtr, uint16 DataLength)
 {
-#ifdef MESSAGE_FORMAT_IS_CCSDS
-
     uint32 TotalMsgSize, HdrSize;
 
     HdrSize = CFE_SB_MsgHdrSize(MsgPtr);
     TotalMsgSize = HdrSize + DataLength;
     CCSDS_WR_LEN(MsgPtr->Hdr,TotalMsgSize);
 
-#endif
 }/* end CFE_SB_SetUserDataLength */
 
 
@@ -182,11 +171,9 @@ void CFE_SB_SetUserDataLength(CFE_SB_MsgPtr_t MsgPtr, uint16 DataLength)
  */
 uint16 CFE_SB_GetTotalMsgLength(const CFE_SB_Msg_t *MsgPtr)
 {
-#ifdef MESSAGE_FORMAT_IS_CCSDS
 
     return CCSDS_RD_LEN(MsgPtr->Hdr);
 
-#endif
 }/* end CFE_SB_GetTotalMsgLength */
 
 
@@ -195,11 +182,9 @@ uint16 CFE_SB_GetTotalMsgLength(const CFE_SB_Msg_t *MsgPtr)
  */
 void CFE_SB_SetTotalMsgLength(CFE_SB_MsgPtr_t MsgPtr,uint16 TotalLength)
 {
-#ifdef MESSAGE_FORMAT_IS_CCSDS
 
     CCSDS_WR_LEN(MsgPtr->Hdr,TotalLength);
 
-#endif
 }/* end CFE_SB_SetTotalMsgLength */
 
 
@@ -211,8 +196,6 @@ CFE_TIME_SysTime_t CFE_SB_GetMsgTime(CFE_SB_MsgPtr_t MsgPtr)
     CFE_TIME_SysTime_t TimeFromMsg;
     uint32 LocalSecs32 = 0;
     uint32 LocalSubs32 = 0;
-
-    #ifdef MESSAGE_FORMAT_IS_CCSDS
 
     #if (CFE_MISSION_SB_PACKET_TIME_FORMAT == CFE_MISSION_SB_TIME_32_16_SUBS)
     uint16 LocalSubs16;
@@ -249,8 +232,6 @@ CFE_TIME_SysTime_t CFE_SB_GetMsgTime(CFE_SB_MsgPtr_t MsgPtr)
         #endif
     }
 
-    #endif
-
     /* return the packet time converted to CFE_TIME_SysTime_t format */
     TimeFromMsg.Seconds    = LocalSecs32;
     TimeFromMsg.Subseconds = LocalSubs32;
@@ -266,8 +247,6 @@ CFE_TIME_SysTime_t CFE_SB_GetMsgTime(CFE_SB_MsgPtr_t MsgPtr)
 int32 CFE_SB_SetMsgTime(CFE_SB_MsgPtr_t MsgPtr, CFE_TIME_SysTime_t NewTime)
 {
     int32 Result = CFE_SB_WRONG_MSG_TYPE;
-
-    #ifdef MESSAGE_FORMAT_IS_CCSDS
 
     CFE_SB_TlmHdr_t *TlmHdrPtr;
 
@@ -310,8 +289,6 @@ int32 CFE_SB_SetMsgTime(CFE_SB_MsgPtr_t MsgPtr, CFE_TIME_SysTime_t NewTime)
         #endif
     }
 
-    #endif
-
     return Result;
 
 }/* end CFE_SB_SetMsgTime */
@@ -332,8 +309,6 @@ void CFE_SB_TimeStampMsg(CFE_SB_MsgPtr_t MsgPtr)
  */
 uint16 CFE_SB_GetCmdCode(CFE_SB_MsgPtr_t MsgPtr)
 {
-#ifdef MESSAGE_FORMAT_IS_CCSDS
-
     CFE_SB_CmdHdr_t     *CmdHdrPtr;
 
     /* if msg type is telemetry or there is no secondary hdr, return 0 */
@@ -345,8 +320,6 @@ uint16 CFE_SB_GetCmdCode(CFE_SB_MsgPtr_t MsgPtr)
     CmdHdrPtr = (CFE_SB_CmdHdr_t *)MsgPtr;
 
     return CCSDS_RD_FC(CmdHdrPtr->Sec);
-
-#endif
 }/* end CFE_SB_GetCmdCode */
 
 
@@ -356,8 +329,6 @@ uint16 CFE_SB_GetCmdCode(CFE_SB_MsgPtr_t MsgPtr)
 int32 CFE_SB_SetCmdCode(CFE_SB_MsgPtr_t MsgPtr,
                       uint16 CmdCode)
 {
-#ifdef MESSAGE_FORMAT_IS_CCSDS
-
     CFE_SB_CmdHdr_t     *CmdHdrPtr;
 
     /* if msg type is telemetry or there is no secondary hdr... */
@@ -372,8 +343,6 @@ int32 CFE_SB_SetCmdCode(CFE_SB_MsgPtr_t MsgPtr,
 
     return CFE_SUCCESS;
 
-#endif
-
 }/* end CFE_SB_SetCmdCode */
 
 
@@ -382,7 +351,6 @@ int32 CFE_SB_SetCmdCode(CFE_SB_MsgPtr_t MsgPtr,
  */
 uint16 CFE_SB_GetChecksum(CFE_SB_MsgPtr_t MsgPtr)
 {
-#ifdef MESSAGE_FORMAT_IS_CCSDS
 
     CFE_SB_CmdHdr_t     *CmdHdrPtr;
 
@@ -396,7 +364,6 @@ uint16 CFE_SB_GetChecksum(CFE_SB_MsgPtr_t MsgPtr)
 
     return CCSDS_RD_CHECKSUM(CmdHdrPtr->Sec);
 
-#endif
 }/* end CFE_SB_GetChecksum */
 
 
@@ -405,7 +372,6 @@ uint16 CFE_SB_GetChecksum(CFE_SB_MsgPtr_t MsgPtr)
  */
 void CFE_SB_GenerateChecksum(CFE_SB_MsgPtr_t MsgPtr)
 {
-#ifdef MESSAGE_FORMAT_IS_CCSDS
 
     CCSDS_CommandPacket_t    *CmdPktPtr;
 
@@ -418,7 +384,6 @@ void CFE_SB_GenerateChecksum(CFE_SB_MsgPtr_t MsgPtr)
 
     CCSDS_LoadCheckSum(CmdPktPtr);
 
-#endif
 }/* end CFE_SB_GenerateChecksum */
 
 
@@ -427,7 +392,6 @@ void CFE_SB_GenerateChecksum(CFE_SB_MsgPtr_t MsgPtr)
  */
 bool CFE_SB_ValidateChecksum(CFE_SB_MsgPtr_t MsgPtr)
 {
-#ifdef MESSAGE_FORMAT_IS_CCSDS
 
     CCSDS_CommandPacket_t    *CmdPktPtr;
 
@@ -440,7 +404,6 @@ bool CFE_SB_ValidateChecksum(CFE_SB_MsgPtr_t MsgPtr)
 
     return CCSDS_ValidCheckSum (CmdPktPtr);
 
-#endif
 }/* end CFE_SB_ValidateChecksum */
 
 

--- a/fsw/cfe-core/src/sb/cfe_sb_verify.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_verify.h
@@ -80,10 +80,6 @@
     #error CFE_PLATFORM_SB_BUF_MEMORY_BYTES cannot be greater than UINT32_MAX (4 Gigabytes)!
 #endif
 
-#ifndef MESSAGE_FORMAT_IS_CCSDS
-    #error There is no message format (MESSAGE_FORMAT_IS_CCSDS) specified!
-#endif
-
 #ifndef CFE_MISSION_SB_PACKET_TIME_FORMAT
     #error CFE_MISSION_SB_PACKET_TIME_FORMAT must be defined!
 #elif ((CFE_MISSION_SB_PACKET_TIME_FORMAT != CFE_MISSION_SB_TIME_32_16_SUBS) && \

--- a/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
@@ -279,7 +279,6 @@ CFE_SB_MsgId_t CFE_SB_GetMsgId(const CFE_SB_Msg_t *MsgPtr)
 
     if (UT_Stub_CopyToLocal(UT_KEY(CFE_SB_GetMsgId), &MsgId, sizeof(MsgId)) < sizeof(MsgId))
     {
-#ifdef MESSAGE_FORMAT_IS_CCSDS
 
 #ifndef MESSAGE_FORMAT_IS_CCSDS_VER_2  
         MsgId = CCSDS_RD_SID(MsgPtr->Hdr);
@@ -303,7 +302,6 @@ CFE_SB_MsgId_t CFE_SB_GetMsgId(const CFE_SB_Msg_t *MsgPtr)
 /*      uint16            SystemId;                              */
 /*      SystemId = CCSDS_RD_SYSTEM_ID(HdrPtr->ApidQ);            */
 /*      MsgId = (MsgId | (SystemId << 16)) */
-#endif
 #endif
 
     }


### PR DESCRIPTION
**Describe the contribution**
Fixes #240, removes MESSAGE_FORMAT_IS_CCSDS ifdefs from CFS code

Testing performed
Ran unit tests

System(s) tested on
Oracle VM VirtualBox
OS: ubuntu-19.10
Versions: cFE 6.7.10.0, OSAL 5.0.8.0, PSP 1.4.7.0,

Contributor Info
Dan Knutsen
NASA/Goddard
