### PR TITLE
Fix #580, Deprecate CFE_OS_ abstracted error codes

### DIFF
--- a/cmake/sample_defs/global_build_options.cmake
+++ b/cmake/sample_defs/global_build_options.cmake
@@ -19,7 +19,7 @@
 set(OMIT_DEPRECATED $ENV{OMIT_DEPRECATED} CACHE STRING "Omit deprecated elements")
 if (OMIT_DEPRECATED)
   message (STATUS "OMIT_DEPRECATED=true: Not including deprecated elements in build")
-  add_definitions(-DCFE_OMIT_DEPRECATED_6_6 -DOSAL_OMIT_DEPRECATED)
+  add_definitions(-DCFE_OMIT_DEPRECATED_6_7 -DCFE_OMIT_DEPRECATED_6_6 -DOSAL_OMIT_DEPRECATED)
 else()
   message (STATUS "OMIT_DEPRECATED=false: Deprecated elements included in build")
 endif (OMIT_DEPRECATED)

--- a/fsw/cfe-core/src/inc/cfe_error.h
+++ b/fsw/cfe-core/src/inc/cfe_error.h
@@ -783,37 +783,38 @@
  */
 #define CFE_FS_NOT_IMPLEMENTED  ((int32)0xc600ffff)
 
+#ifndef CFE_OMIT_DEPRECATED_6_7 
 /*
 ************* OSAPI STATUS CODES *************
 */
 
-#define CFE_OS_ERROR                    (OS_ERROR)  /**< @copydoc OS_ERROR */
-#define CFE_OS_INVALID_POINTER          (OS_INVALID_POINTER) /**< @copydoc OS_INVALID_POINTER */
-#define CFE_OS_ERROR_ADDRESS_MISALIGNED (OS_ERROR_ADDRESS_MISALIGNED) /**< @copydoc OS_ERROR_ADDRESS_MISALIGNED */
-#define CFE_OS_ERROR_TIMEOUT            (OS_ERROR_TIMEOUT) /**< @copydoc OS_ERROR_TIMEOUT */
-#define CFE_OS_INVALID_INT_NUM          (OS_INVALID_INT_NUM) /**< @copydoc OS_INVALID_INT_NUM */
-#define CFE_OS_SEM_FAILURE              (OS_SEM_FAILURE) /**< @copydoc OS_SEM_FAILURE */
-#define CFE_OS_SEM_TIMEOUT              (OS_SEM_TIMEOUT) /**< @copydoc OS_SEM_TIMEOUT */
-#define CFE_OS_QUEUE_EMPTY              (OS_QUEUE_EMPTY) /**< @copydoc OS_QUEUE_EMPTY */
-#define CFE_OS_QUEUE_FULL               (OS_QUEUE_FULL) /**< @copydoc OS_QUEUE_FULL */
-#define CFE_OS_QUEUE_TIMEOUT            (OS_QUEUE_TIMEOUT) /**< @copydoc OS_QUEUE_TIMEOUT */
-#define CFE_OS_QUEUE_INVALID_SIZE       (OS_QUEUE_INVALID_SIZE) /**< @copydoc OS_QUEUE_INVALID_SIZE */
-#define CFE_OS_QUEUE_ID_ERROR           (OS_QUEUE_ID_ERROR) /**< @copydoc OS_QUEUE_ID_ERROR */
-#define CFE_OS_ERR_NAME_TOO_LONG        (OS_ERR_NAME_TOO_LONG) /**< @copydoc OS_ERR_NAME_TOO_LONG */
-#define CFE_OS_ERR_NO_FREE_IDS          (OS_ERR_NO_FREE_IDS) /**< @copydoc OS_ERR_NO_FREE_IDS */
-#define CFE_OS_ERR_NAME_TAKEN           (OS_ERR_NAME_TAKEN) /**< @copydoc OS_ERR_NAME_TAKEN */
-#define CFE_OS_ERR_INVALID_ID           (OS_ERR_INVALID_ID) /**< @copydoc OS_ERR_INVALID_ID */
-#define CFE_OS_ERR_NAME_NOT_FOUND       (OS_ERR_NAME_NOT_FOUND) /**< @copydoc OS_ERR_NAME_NOT_FOUND */
-#define CFE_OS_ERR_SEM_NOT_FULL         (OS_ERR_SEM_NOT_FULL) /**< @copydoc OS_ERR_SEM_NOT_FULL */
-#define CFE_OS_ERR_INVALID_PRIORITY     (OS_ERR_INVALID_PRIORITY) /**< @copydoc OS_ERR_INVALID_PRIORITY */
-#define CFE_OS_ERROR_TASK_ID            (OS_ERROR_TASK_ID) /**< @brief This doesn't actually exist */
-#define CFE_OS_SEM_UNAVAILABLE          (OS_SEM_UNAVAILABLE) /**< @brief This doesn't actually exist */
-#define CFE_OS_FS_ERROR                 (OS_FS_ERROR) /**< @copydoc OS_FS_ERROR */
-#define CFE_OS_FS_ERR_INVALID_POINTER   (OS_FS_ERR_INVALID_POINTER) /**< @copydoc OS_FS_ERR_INVALID_POINTER */
-#define CFE_OS_FS_ERR_PATH_TOO_LONG     (OS_FS_ERR_PATH_TOO_LONG) /**< @copydoc OS_FS_ERR_PATH_TOO_LONG */
-#define CFE_OS_FS_ERR_NAME_TOO_LONG     (OS_FS_ERR_NAME_TOO_LONG) /**< @copydoc OS_FS_ERR_NAME_TOO_LONG */
-#define CFE_OS_FS_ERR_DRIVE_NOT_CREATED (OS_FS_ERR_DRIVE_NOT_CREATED) /**< @copydoc OS_FS_ERR_DRIVE_NOT_CREATED */
-#define CFE_OSAPI_NOT_IMPLEMENTED       (OS_FS_UNIMPLEMENTED) /**< @copydoc OS_FS_UNIMPLEMENTED */
+#define CFE_OS_ERROR                    (OS_ERROR)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_INVALID_POINTER          (OS_INVALID_POINTER)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_ERROR_ADDRESS_MISALIGNED (OS_ERROR_ADDRESS_MISALIGNED)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_ERROR_TIMEOUT            (OS_ERROR_TIMEOUT)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_INVALID_INT_NUM          (OS_INVALID_INT_NUM)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_SEM_FAILURE              (OS_SEM_FAILURE)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_SEM_TIMEOUT              (OS_SEM_TIMEOUT)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_QUEUE_EMPTY              (OS_QUEUE_EMPTY)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_QUEUE_FULL               (OS_QUEUE_FULL)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_QUEUE_TIMEOUT            (OS_QUEUE_TIMEOUT)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_QUEUE_INVALID_SIZE       (OS_QUEUE_INVALID_SIZE)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_QUEUE_ID_ERROR           (OS_QUEUE_ID_ERROR)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_ERR_NAME_TOO_LONG        (OS_ERR_NAME_TOO_LONG)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_ERR_NO_FREE_IDS          (OS_ERR_NO_FREE_IDS)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_ERR_NAME_TAKEN           (OS_ERR_NAME_TAKEN)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_ERR_INVALID_ID           (OS_ERR_INVALID_ID)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_ERR_NAME_NOT_FOUND       (OS_ERR_NAME_NOT_FOUND)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_ERR_SEM_NOT_FULL         (OS_ERR_SEM_NOT_FULL)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_ERR_INVALID_PRIORITY     (OS_ERR_INVALID_PRIORITY)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_FS_ERROR                 (OS_FS_ERROR)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_FS_ERR_INVALID_POINTER   (OS_FS_ERR_INVALID_POINTER)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_FS_ERR_PATH_TOO_LONG     (OS_FS_ERR_PATH_TOO_LONG)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_FS_ERR_NAME_TOO_LONG     (OS_FS_ERR_NAME_TOO_LONG)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OS_FS_ERR_DRIVE_NOT_CREATED (OS_FS_ERR_DRIVE_NOT_CREATED)  /**< @brief DEPRECATED @deprecated */
+#define CFE_OSAPI_NOT_IMPLEMENTED       (OS_FS_UNIMPLEMENTED)  /**< @brief DEPRECATED @deprecated */
+
+#endif /* CFE_OMIT_DEPRECATED_6_7 */
 
 /*
 ************* SOFTWARE BUS SERVICES STATUS CODES *************

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -9813,8 +9813,8 @@ void Test_OS_MutSem_ErrLogic(void)
 #endif
 
     SB_ResetUnitTest();
-    UT_SetDeferredRetcode(UT_KEY(OS_MutSemTake), 1, CFE_OS_SEM_FAILURE);
-    UT_SetDeferredRetcode(UT_KEY(OS_MutSemGive), 2, CFE_OS_SEM_FAILURE);
+    UT_SetDeferredRetcode(UT_KEY(OS_MutSemTake), 1, OS_SEM_FAILURE);
+    UT_SetDeferredRetcode(UT_KEY(OS_MutSemGive), 2, OS_SEM_FAILURE);
     CFE_SB_CreatePipe(&PipeId, PipeDepth, "TestPipe");
     CFE_SB_Subscribe(MsgId, PipeId);
     ExpRtn = 3;


### PR DESCRIPTION
**Describe the contribution**
Fix #580 - deprecates CFE_OS_ abstracted OS error codes
Added CFE_OMIT_DEPRECATED_6_7 just to be consistent
Also fix #552 - removes non-existent codes

**Testing performed**
Steps taken to test the contribution:
1. CI - see https://travis-ci.com/github/skliper/cFS/builds/157872188

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: AMD
 - OS: Ubuntu 18.04
 - Versions: bundle + this change

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC