### PR TITLE
Fix #335: Shell unsigned pkt length bug

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_shell.c
+++ b/fsw/cfe-core/src/es/cfe_es_shell.c
@@ -170,7 +170,7 @@ int32 CFE_ES_ShellOutputCommand(const char * CmdString, const char *Filename)
                 /* start processing the chunks. We want to have one packet left so we are sure this for loop
                 * won't run over */
         
-                for (CurrFilePtr=0; CurrFilePtr < (FileSize - CFE_MISSION_ES_MAX_SHELL_PKT); CurrFilePtr += CFE_MISSION_ES_MAX_SHELL_PKT)
+                for (CurrFilePtr=0; (CurrFilePtr + CFE_MISSION_ES_MAX_SHELL_PKT) < FileSize ; CurrFilePtr += CFE_MISSION_ES_MAX_SHELL_PKT)
                 {
                     OS_read(fd, CFE_ES_TaskData.ShellPacket.Payload.ShellOutput, CFE_MISSION_ES_MAX_SHELL_PKT);
 


### PR DESCRIPTION
**Describe the contribution**
Fix #335 
Really just avoids problems if users mistakenly define CFE_MISSION_ES_MAX_SHELL_PKT as an unsigned value (2000u, for example)

**Testing performed**
Steps taken to test the contribution:
1. CI

Suggest requester (@krmoore) confirm it works as requested

**Expected behavior changes**
None, except if someone defines this value as unsigned it won't break...

**System(s) tested on**
 - Hardware: AMD
 - OS: Ubuntu 18.04
 - Versions: bundle + this change

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC