### PR TITLE
Fix #581, Propagate the OSAL compile definitions to CFE build

### DIFF
--- a/cmake/arch_build.cmake
+++ b/cmake/arch_build.cmake
@@ -339,6 +339,20 @@ function(process_arch SYSVAR)
   include_directories(${MISSION_SOURCE_DIR}/cfe/fsw/cfe-core/src/inc)
   include_directories(${MISSION_SOURCE_DIR}/cfe/cmake/target/inc)
     
+  # propagate any OSAL interface compile definitions and include directories to this build
+  # This is set as a directory property here at the top level so it will apply to all code.
+  # This includes MODULE libraries that do not directly/statically link with OSAL but still
+  # should be compiled with these flags.
+  get_target_property(OSAL_COMPILE_DEFINITIONS osal INTERFACE_COMPILE_DEFINITIONS)
+  get_target_property(OSAL_INCLUDE_DIRECTORIES osal INTERFACE_INCLUDE_DIRECTORIES)
+
+  if (OSAL_COMPILE_DEFINITIONS)
+    set_directory_properties(PROPERTIES COMPILE_DEFINITIONS "${OSAL_COMPILE_DEFINITIONS}")
+  endif (OSAL_COMPILE_DEFINITIONS)
+  if (OSAL_INCLUDE_DIRECTORIES)
+    include_directories(${OSAL_INCLUDE_DIRECTORIES})
+  endif (OSAL_INCLUDE_DIRECTORIES)
+
   # Append the PSP and OSAL selections to the Doxyfile so it will be included
   # in the generated documentation automatically.
   # Also extract the "-D" options within CFLAGS and inform Doxygen about these


### PR DESCRIPTION
**Describe the contribution**
Use the `INTERFACE_COMPILE_DEFINITIONS` and `INTERFACE_INCLUDE_DIRECTORIES` properties from the osal target and apply them to the entire CFE build as a directory-scope property.

At this time, the OSAL library build does not use/export these properties so this is effectively a no-op for the CFE build and can be merged with no effect.  However, in a future version (specifically after nasa/osal#312 gets fixed), the OSAL library will export these interface properties and this will become important.

Fixes #581 

**Testing performed**
Built for all three test platforms (ppc-vxworks6.9, i686-rtems4.11, native/x86-64 Linux).  Sanity Check CFE build boots and runs, unit tests run.

**Expected behavior changes**
No impact to behavior - build is identical because these properties are currently empty/not set in the current OSAL build.

**System(s) tested on**
Ubuntu 18.04 LTS 64 bit.

**Additional context**
Also locally tested against a version of OSAL+PSP that includes all the latest proposed changes and confirm that this still works.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
