### PR TITLE
Fix# 543, Expose CFE_SB_GetPktType

### DIFF
--- a/fsw/cfe-core/src/inc/cfe_sb.h
+++ b/fsw/cfe-core/src/inc/cfe_sb.h
@@ -55,6 +55,15 @@
 
 #define CFE_SB_INVALID_MSG_ID           0xFFFF /**< \brief Initializer for #CFE_SB_MsgId_t values that will not match any real MsgId */
 
+/**
+ * \defgroup CFESBPktTypeDefs cFE SB Packet Type Defines
+ * \{
+ */
+#define CFE_SB_PKTTYPE_INVALID          0      /**< \brief #CFE_SB_GetPktType response if message type can not be determined */
+#define CFE_SB_PKTTYPE_CMD              1      /**< \brief #CFE_SB_GetPktType response for command packets */
+#define CFE_SB_PKTTYPE_TLM              2      /**< \brief #CFE_SB_GetPktType response for telemetry packets */
+/** \} */
+
 /*
 ** Macro Definitions
 */
@@ -1358,6 +1367,20 @@ static inline CFE_SB_MsgId_t CFE_SB_ValueToMsgId(CFE_SB_MsgId_Atom_t MsgIdValue)
 {
     return MsgIdValue;
 }
+
+/*****************************************************************************/
+/**
+ * \brief Identifies packet type given message ID
+ *
+ * Provides the packet type associated with the given message ID
+ *
+ * \return Packet type
+ * \retval #CFE_SB_PKTTYPE_CMD     Command packet type
+ * \retval #CFE_SB_PKTTYPE_TLM     Telemetry packet type
+ * \retval #CFE_SB_PKTTYPE_INVALID Invalid/unknown packet type
+ */
+uint32 CFE_SB_GetPktType(CFE_SB_MsgId_t MsgId);
+
 /**@}*/
 
 #endif  /* _cfe_sb_ */

--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -1296,7 +1296,7 @@ int32  CFE_SB_SendMsgFull(CFE_SB_Msg_t    *MsgPtr,
     RtgTblPtr = CFE_SB_GetRoutePtrFromIdx(RtgTblIdx);
 
     /* For Tlm packets, increment the seq count if requested */
-    if((CFE_SB_GetPktType(MsgId)==CFE_SB_TLM) &&
+    if((CFE_SB_GetPktType(MsgId)==CFE_SB_PKTTYPE_TLM) &&
        (TlmCntIncrements==CFE_SB_INCREMENT_TLM)){
         RtgTblPtr->SeqCnt++;
         CFE_SB_SetMsgSeqCnt((CFE_SB_Msg_t *)BufDscPtr->Buffer,

--- a/fsw/cfe-core/src/sb/cfe_sb_msg_id_util.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_msg_id_util.c
@@ -33,7 +33,9 @@
 **      combination of bits from the primary header SID (StreamId) and the secondary header APID Qualifiers
 **      
 **      Implementation is based on CCSDS Space Packet Protocol 133.0.B-1 with Technical Corrigendum 2, September 2012
-**      The extended secondary header is expected in an upcoming revision of 133.0.B-1
+**      Multi-mission Interoperable extended secondary headers should be registered in Space
+**      Assigned Numbers Authority (SANA). The process for SANA registration is documented in
+**      133.0.B-2. Mission specific headers need not be registered
 **
 **      For  MESSAGE_FORMAT_IS_CCSDS_VER_2 the default setup will combine:
 **       1 bit for the command/telemetry flag 
@@ -185,3 +187,37 @@ void CFE_SB_SetMsgId(CFE_SB_MsgPtr_t MsgPtr,
 
 #endif 
 }/* end CFE_SB_SetMsgId */
+
+/*
+ * Function: CFE_SB_GetPktType - See API and header file for details
+ */
+uint32 CFE_SB_GetPktType(CFE_SB_MsgId_t MsgId)
+{
+
+  CFE_SB_MsgId_Atom_t Val = MsgId;
+  uint8 PktType;
+
+  if (CFE_SB_IsValidMsgId(MsgId))
+  {
+#ifndef MESSAGE_FORMAT_IS_CCSDS_VER_2
+    if (CFE_TST(Val,12))
+    {
+      PktType = CFE_SB_PKTTYPE_CMD;
+    } else {
+      PktType = CFE_SB_PKTTYPE_TLM;
+    }
+#else
+    if (CFE_SB_RD_TYPE_FROM_MSGID(Val) == 1)
+    {
+      PktType = CFE_SB_PKTTYPE_CMD;
+    } else {
+      PktType = CFE_SB_PKTTYPE_TLM;
+    }
+#endif /* MESSAGE_FORMAT_IS_CCSDS_VER_2 */
+  } else {
+    PktType = CFE_SB_PKTTYPE_INVALID;
+  }
+
+  return PktType;
+
+}/* end CFE_SB_GetPktType */

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.c
@@ -659,36 +659,6 @@ char *CFE_SB_GetAppTskName(uint32 TaskId,char *FullName){
 
 }/* end CFE_SB_GetAppTskName */
 
-
-/******************************************************************************
-**  Function:  CFE_SB_GetPktType()
-**
-**  Purpose:
-**    For CCSDS packets, this function returns the state of the cmd/tlm bit(12).
-**    For cmd pkts, the state is 1. For tlm pkts, the state is 0.
-**
-**  Arguments:
-**
-**  Return:
-**    None
-*/
-uint8 CFE_SB_GetPktType(CFE_SB_MsgId_t MsgId)
-{
-
-#ifdef MESSAGE_FORMAT_IS_CCSDS
-    CFE_SB_MsgId_Atom_t Val = MsgId;
-
-#ifndef MESSAGE_FORMAT_IS_CCSDS_VER_2
-        return CFE_TST(Val,12);
-#else
-        return CFE_SB_RD_TYPE_FROM_MSGID(Val);
-#endif /* MESSAGE_FORMAT_IS_CCSDS_VER_2 */
-        
-#endif /* MESSAGE_FORMAT_IS_CCSDS */
-
-}/* end CFE_SB_GetPktType */
-
-
 /******************************************************************************
 **  Function:  CFE_SB_RequestToSendEvent()
 **

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.h
@@ -63,9 +63,6 @@
 #define CFE_SB_GLOBAL                   0
 #define CFE_SB_LOCAL                    1
 
-#define CFE_SB_TLM                      0
-#define CFE_SB_CMD                      1
-
 #define CFE_SB_SEND_ZEROCOPY            0
 #define CFE_SB_SEND_ONECOPY             1
 
@@ -391,7 +388,6 @@ int32 CFE_SB_ZeroCopyReleaseAppId(uint32         AppId);
 int32 CFE_SB_DecrBufUseCnt(CFE_SB_BufferD_t *bd);
 int32 CFE_SB_ValidateMsgId(CFE_SB_MsgId_t MsgId);
 int32 CFE_SB_ValidatePipeId(CFE_SB_PipeId_t PipeId);
-uint8 CFE_SB_GetPktType(CFE_SB_MsgId_t MsgId);
 void CFE_SB_IncrCmdCtr(int32 status);
 void CFE_SB_FileWriteByteCntErr(const char *Filename,uint32 Requested,uint32 Actual);
 void CFE_SB_SetSubscriptionReporting(uint32 state);

--- a/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
@@ -873,3 +873,12 @@ void CFE_SB_SetTotalMsgLength (CFE_SB_MsgPtr_t MsgPtr,uint16 TotalLength)
     UT_Stub_CopyFromLocal(UT_KEY(CFE_SB_SetTotalMsgLength), &TotalLength, sizeof(TotalLength));
 }
 
+uint32 CFE_SB_GetPktType(CFE_SB_MsgId_t MsgId)
+{
+    int32 status;
+
+    status = UT_DEFAULT_IMPL(CFE_SB_GetPktType);
+
+    return status;
+}
+


### PR DESCRIPTION
**Describe the contribution**
Fix #543 
Note this only exposes and adds the stub.  Requirement (#587)/functional test/coverage test still in work.

**Testing performed**
Steps taken to test the contribution:
1. Built with SIMULATION=native and ENABLE_UNIT_TESTS=true
1. Tests passed
1. Ran with cFS-GroundStation and observed reported sequence counter that wasn't reporting actual sequence count
1. Note it does pass the sequence count test, which is what SB uses GetPktType for

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: cFS Dev Server 3
 - OS: Ubuntu 18.04
 - Versions: Bundle w/ this change

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC