### PR TITLE
Fix #456, Perf log threading and concurrency issues

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_backgroundtask.c
+++ b/fsw/cfe-core/src/es/cfe_es_backgroundtask.c
@@ -1,0 +1,250 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/*
+** File: cfe_es_backgroundtask.c
+**
+** Purpose: This file contains the implementation of the ES "background task"
+**
+** This task sits idle most of the time, but is woken by the ES application
+** for various maintenance duties that may take time to execute, such as
+** writing status/log files.
+**
+*/
+
+/*
+** Include Section
+*/
+
+#include <string.h>
+
+#include "osapi.h"
+#include "private/cfe_private.h"
+#include "cfe_es_perf.h"
+#include "cfe_es_global.h"
+#include "cfe_es_task.h"
+
+#define CFE_ES_BACKGROUND_SEM_NAME             "ES_BackgroundSem"
+#define CFE_ES_BACKGROUND_CHILD_NAME           "ES_BackgroundTask"
+#define CFE_ES_BACKGROUND_CHILD_STACK_PTR      NULL
+#define CFE_ES_BACKGROUND_CHILD_STACK_SIZE     CFE_PLATFORM_ES_PERF_CHILD_STACK_SIZE
+#define CFE_ES_BACKGROUND_CHILD_PRIORITY       CFE_PLATFORM_ES_PERF_CHILD_PRIORITY
+#define CFE_ES_BACKGROUND_CHILD_FLAGS          0
+#define CFE_ES_BACKGROUND_MAX_IDLE_DELAY       30000        /* 30 seconds */
+
+
+typedef struct
+{
+    bool (*RunFunc)(uint32 ElapsedTime, void *Arg);
+    void *JobArg;
+    uint32 ActivePeriod;            /**< max wait/delay time between calls when job is active */
+    uint32 IdlePeriod;              /**< max wait/delay time between calls when job is idle */
+} CFE_ES_BackgroundJobEntry_t;
+
+/*
+ * List of "background jobs"
+ *
+ * This is just a list of functions to periodically call from the context of the background task,
+ * and can be added/extended as needed.
+ *
+ * Each Job function returns a boolean, and should return "true" if it is active, or "false" if it is idle.
+ *
+ * This uses "cooperative multitasking" -- the function should do some limited work, then return to the
+ * background task.  It will be called again after a delay period to do more work.
+ */
+const CFE_ES_BackgroundJobEntry_t CFE_ES_BACKGROUND_JOB_TABLE[] =
+{
+        {   /* Performance Log Data Dump to file */
+                .RunFunc = CFE_ES_RunPerfLogDump,
+                .JobArg = &CFE_ES_TaskData.BackgroundPerfDumpState,
+                .ActivePeriod = CFE_PLATFORM_ES_PERF_CHILD_MS_DELAY,
+                .IdlePeriod = CFE_PLATFORM_ES_PERF_CHILD_MS_DELAY * 1000
+        }
+};
+
+#define CFE_ES_BACKGROUND_NUM_JOBS          (sizeof(CFE_ES_BACKGROUND_JOB_TABLE) / sizeof(CFE_ES_BACKGROUND_JOB_TABLE[0]))
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Name: CFE_ES_BackgroundTask                                                   */
+/*                                                                               */
+/* Purpose: A helper task for low priority routines that may take time to        */
+/* execute, such as writing log files.                                           */
+/*                                                                               */
+/* Assumptions and Notes: This is started from the ES initialization, and        */
+/* pends on a semaphore until a work request comes in.  This is intended to      */
+/* avoid the need to create a child task "on demand" when work items arrive,     */
+/* which is a form of dynamic allocation.                                        */
+/*                                                                               */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void CFE_ES_BackgroundTask(void)
+{
+    int32 status;
+    uint32 JobTotal;
+    uint32 NumJobsRunning;
+    uint32 NextDelay;
+    uint32 ElapsedTime;
+    OS_time_t CurrTime;
+    OS_time_t LastTime;
+    const CFE_ES_BackgroundJobEntry_t *JobPtr;
+
+    status = CFE_ES_RegisterChildTask();
+    if (status != CFE_SUCCESS)
+    {
+        /* should never occur */
+        CFE_ES_WriteToSysLog("CFE_ES: Background Task Failed to register: %08lx\n", (unsigned long)status);
+        return;
+    }
+
+    CFE_PSP_GetTime(&LastTime);
+
+    while (true)
+    {
+        /*
+         * compute the elapsed time (difference) between last
+         * execution and now, in microseconds.
+         *
+         * Note this calculation is done as a uint32 which will overflow
+         * after about 35 minutes, but the max delays ensure that this
+         * executes at least every few seconds, so that should never happen.
+         */
+        CFE_PSP_GetTime(&CurrTime);
+        ElapsedTime = 1000000 * (CurrTime.seconds - LastTime.seconds);
+        ElapsedTime += CurrTime.microsecs;
+        ElapsedTime -= LastTime.microsecs;
+        LastTime = CurrTime;
+
+        /*
+         * convert to milliseconds.
+         * we do not really need high precision
+         * for background task timings
+         */
+        ElapsedTime /= 1000;
+
+        NextDelay = CFE_ES_BACKGROUND_MAX_IDLE_DELAY;   /* default; will be adjusted based on active jobs */
+        JobPtr = CFE_ES_BACKGROUND_JOB_TABLE;
+        JobTotal = CFE_ES_BACKGROUND_NUM_JOBS;
+        NumJobsRunning = 0;
+
+        while (JobTotal > 0)
+        {
+            /*
+             * call the background job -
+             * if it returns "true" that means it is active,
+             * if it returns "false" that means it is idle
+             */
+            if (JobPtr->RunFunc != NULL && JobPtr->RunFunc(ElapsedTime, JobPtr->JobArg))
+            {
+                ++NumJobsRunning;
+
+                if (JobPtr->ActivePeriod != 0 && NextDelay > JobPtr->ActivePeriod)
+                {
+                    /* next delay is based on this active job wait time */
+                    NextDelay = JobPtr->ActivePeriod;
+                }
+            }
+            else if (JobPtr->IdlePeriod != 0 && NextDelay > JobPtr->IdlePeriod)
+            {
+                /* next delay is based on this idle job wait time */
+                NextDelay = JobPtr->IdlePeriod;
+            }
+            --JobTotal;
+            ++JobPtr;
+        }
+
+        CFE_ES_Global.BackgroundTask.NumJobsRunning = NumJobsRunning;
+
+        status = OS_BinSemTimedWait(CFE_ES_Global.BackgroundTask.WorkSem, NextDelay);
+        if (status != OS_SUCCESS && status != OS_SEM_TIMEOUT)
+        {
+            /* should never occur */
+            CFE_ES_WriteToSysLog("CFE_ES: Failed to take background sem: %08lx\n", (unsigned long)status);
+            break;
+        }
+
+    }
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Name: CFE_ES_BackgroundInit                                                   */
+/*                                                                               */
+/* Purpose: Initialize the background task                                       */
+/*                                                                               */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+int32 CFE_ES_BackgroundInit(void)
+{
+    int32 status;
+
+    status = OS_BinSemCreate(&CFE_ES_Global.BackgroundTask.WorkSem, CFE_ES_BACKGROUND_SEM_NAME, 0, 0);
+    if (status != OS_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("CFE_ES: Failed to create background sem: %08lx\n", (unsigned long)status);
+        return status;
+    }
+
+    /* Spawn a task to write the performance data to a file */
+    status = CFE_ES_CreateChildTask(&CFE_ES_Global.BackgroundTask.TaskID,
+            CFE_ES_BACKGROUND_CHILD_NAME,
+            CFE_ES_BackgroundTask,
+            CFE_ES_BACKGROUND_CHILD_STACK_PTR,
+            CFE_ES_BACKGROUND_CHILD_STACK_SIZE,
+            CFE_ES_BACKGROUND_CHILD_PRIORITY,
+            CFE_ES_BACKGROUND_CHILD_FLAGS);
+
+    if (status != OS_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("CFE_ES: Failed to create background task: %08lx\n", (unsigned long)status);
+        return status;
+    }
+
+    return CFE_SUCCESS;
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Name: CFE_ES_BackgroundCleanup                                                */
+/*                                                                               */
+/* Purpose: Exit/Stop the background task                                        */
+/*                                                                               */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void CFE_ES_BackgroundCleanup(void)
+{
+    CFE_ES_DeleteChildTask(CFE_ES_Global.BackgroundTask.TaskID);
+    OS_BinSemDelete(CFE_ES_Global.BackgroundTask.WorkSem);
+
+    CFE_ES_Global.BackgroundTask.TaskID = 0;
+    CFE_ES_Global.BackgroundTask.WorkSem = 0;
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/* Name: CFE_ES_BackgroundWakeup                                                 */
+/*                                                                               */
+/* Purpose: Wake up the background task                                          */
+/* Notifies the background task to perform an extra poll for new work            */
+/*                                                                               */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+void CFE_ES_BackgroundWakeup(void)
+{
+    /* wake up the background task by giving the sem.
+     * This is "informational" and not strictly required,
+     * but it will make the task immediately wake up and check for new
+     * work if it was idle. */
+    OS_BinSemGive(CFE_ES_Global.BackgroundTask.WorkSem);
+}
+
+

--- a/fsw/cfe-core/src/es/cfe_es_global.h
+++ b/fsw/cfe-core/src/es/cfe_es_global.h
@@ -19,8 +19,8 @@
 */
 
 /*
-**  File: 
-**  cfe_es_global.h 
+**  File:
+**  cfe_es_global.h
 **
 **  Purpose:
 **  This file contains the ES global data definitions.
@@ -66,13 +66,23 @@ typedef struct
 {
    bool           RecordUsed;                     /* Is the record used(1) or available(0) ? */
    uint32         Counter;
-   char           CounterName[OS_MAX_API_NAME];   /* Counter Name */      
+   char           CounterName[OS_MAX_API_NAME];   /* Counter Name */
 } CFE_ES_GenCounterRecord_t;
+
+/*
+ * Encapsulates the state of the ES background task
+ */
+typedef struct
+{
+    uint32 TaskID;          /**< OSAL ID of the background task */
+    uint32 WorkSem;         /**< Semaphore that is given whenever background work is pending */
+    uint32 NumJobsRunning;  /**< Current Number of active jobs (updated by background task) */
+} CFE_ES_BackgroundTaskState_t;
 
 
 /*
 ** Executive Services Global Memory Data
-** This is the regular global data that is not preserved on a 
+** This is the regular global data that is not preserved on a
 **  processor reset.
 */
 typedef struct
@@ -81,12 +91,17 @@ typedef struct
    ** Debug Variables
    */
    CFE_ES_DebugVariables_t DebugVars;
-   
+
    /*
    ** Shared Data Semaphore
    */
    uint32 SharedDataMutex;
-   
+
+   /*
+   ** Performance Data Mutex
+   */
+   uint32 PerfDataMutex;
+
    /*
    ** Startup Sync
    */
@@ -94,7 +109,7 @@ typedef struct
 
    /*
    ** ES Task Table
-   */ 
+   */
    uint32              RegisteredTasks;
    CFE_ES_TaskRecord_t TaskTable[OS_MAX_TASKS];
 
@@ -104,7 +119,7 @@ typedef struct
    uint32             RegisteredCoreApps;
    uint32             RegisteredExternalApps;
    CFE_ES_AppRecord_t AppTable[CFE_PLATFORM_ES_MAX_APPLICATIONS];
-   
+
    /*
    ** ES Shared Library Table
    */
@@ -121,12 +136,19 @@ typedef struct
    */
    CFE_ES_CDSVariables_t CDSVars;
 
+   /*
+    * Background task for handling long-running, non real time tasks
+    * such as maintenance, file writes, and other items.
+    */
+   CFE_ES_BackgroundTaskState_t BackgroundTask;
+
+
 } CFE_ES_Global_t;
 
 /*
 ** The Executive Services Global Data declaration
 */
-extern CFE_ES_Global_t CFE_ES_Global; 
+extern CFE_ES_Global_t CFE_ES_Global;
 
 /*
 ** The Executive Services Nonvolatile Data declaration

--- a/fsw/cfe-core/src/es/cfe_es_perf.h
+++ b/fsw/cfe-core/src/es/cfe_es_perf.h
@@ -49,10 +49,6 @@
 /*
 **  Defines
 */
-#define CFE_ES_PERF_CHILD_NAME           "ES_PerfFileWriter"
-#define CFE_ES_PERF_CHILD_STACK_PTR      0
-#define CFE_ES_PERF_CHILD_FLAGS          0
-
 
 enum CFE_ES_PerfState_t {
     CFE_ES_PERF_IDLE = 0,
@@ -68,14 +64,78 @@ enum CFE_ES_PerfMode_t {
     CFE_ES_PERF_MAX_MODES
 };
 
-typedef struct {
-    uint32                         DataToWrite;
-    uint32                         ChildID;
-    char                           DataFileName[OS_MAX_PATH_LEN];
-    int32                          DataFileDescriptor;
-} CFE_ES_PerfLogDump_t;
+/*
+ * Perflog Dump Background Job states
+ *
+ * Writing performance log data is now handled by a state machine that runs
+ * as a background job in Executive services.  When a performance log dump is
+ * pending, each iteration of the state machine performs a limited amount of
+ * work.  Each iteration resumes work where the last iteration left off.
+ */
+typedef enum
+{
+    CFE_ES_PerfDumpState_IDLE,                  /* Placeholder for idle, no action */
+    CFE_ES_PerfDumpState_INIT,                  /* Placeholder for entry/init, no action */
+    CFE_ES_PerfDumpState_OPEN_FILE,             /* Opening of the output file */
+    CFE_ES_PerfDumpState_DELAY,                 /* Wait-state to ensure in-progress writes are finished */
+    CFE_ES_PerfDumpState_LOCK_DATA,             /* Locking of the global data structure */
+    CFE_ES_PerfDumpState_WRITE_FS_HDR,          /* Write the CFE FS file header */
+    CFE_ES_PerfDumpState_WRITE_PERF_METADATA,   /* Write the Perf global metadata */
+    CFE_ES_PerfDumpState_WRITE_PERF_ENTRIES,    /* Write the Perf Log entries (throttled) */
+    CFE_ES_PerfDumpState_CLEANUP,               /* Placeholder for cleanup, no action */
+    CFE_ES_PerfDumpState_UNLOCK_DATA,           /* Unlocking of the global data structure */
+    CFE_ES_PerfDumpState_CLOSE_FILE,            /* Closing of the output file */
+    CFE_ES_PerfDumpState_MAX                    /* Placeholder for last state, no action, always last */
+} CFE_ES_PerfDumpState_t;
 
-extern CFE_ES_PerfLogDump_t    CFE_ES_PerfLogDumpStatus;
+/*
+ * Performance log dump state structure
+ *
+ * This structure is stored in global memory and keeps the state
+ * of the performance log dump from one iteration to the next.
+ *
+ * When state is IDLE, the background task does nothing and does not
+ * access or update any other members.
+ *
+ * The first state transition (IDLE->INIT) is triggered via ES command,
+ * where the command processor sets the PendingState.
+ *
+ * Once state is non-IDLE, the structure becomes owned by the background
+ * task.  It will progress through the remainder of the state machine, 
+ * eventually arriving back at IDLE when the request is completed.
+ */
+typedef struct
+{
+    CFE_ES_PerfDumpState_t  CurrentState;   /* the current state of the job */
+    CFE_ES_PerfDumpState_t  PendingState;   /* the pending/next state, if transitioning */
+
+    char                DataFileName[OS_MAX_PATH_LEN];  /* output file name from dump command */
+    int32               FileDesc;                       /* file descriptor for writing */
+    uint32              WorkCredit;                     /* accumulator based on the passage of time */
+    uint32              StateCounter;                   /* number of blocks/items left in current state */
+    uint32              DataPos;                        /* last position within the Perf Log */
+    uint32              FileSize;                       /* Total file size, for progress reporing in telemetry */
+} CFE_ES_PerfDumpGlobal_t;
+
+/*
+ * Helper function to obtain the progress/remaining items from
+ * the background task that is writing the performance log data
+ *
+ * This is no longer just simply reading a single value from a struct,
+ * as it depends on the state of the overall process.  The return value
+ * from this should mimic the value which was historically
+ * returned in the ES telemetry to report progress on this task.
+ *
+ * Foreground tasks/telemetry code shouldn't directly "peek"
+ * into data structures which it does not own.
+ */
+uint32 CFE_ES_GetPerfLogDumpRemaining(void);
+
+/*
+ * Implementation of the background state machine for writing
+ * performance log data.
+ */
+bool CFE_ES_RunPerfLogDump(uint32 ElapsedTime, void *Arg);
 
 #endif /* _cfe_es_perf_ */
 

--- a/fsw/cfe-core/src/es/cfe_es_start.c
+++ b/fsw/cfe-core/src/es/cfe_es_start.c
@@ -132,6 +132,32 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const cha
    } /* end if */
 
    /*
+   ** Also Create the ES Performance Data Mutex
+   ** This is to separately protect against concurrent writes to the global performance log data
+   */
+   ReturnCode = OS_MutSemCreate(&CFE_ES_Global.PerfDataMutex, "ES_PERF_MUTEX", 0);
+   if (ReturnCode != OS_SUCCESS)
+   {
+       CFE_ES_SysLogWrite_Unsync("ES Startup: Error: ES Performance Data Mutex could not be created. RC=0x%08X\n",
+               (unsigned int)ReturnCode);
+
+       /*
+       ** Delay to allow the message to be read
+       */
+       OS_TaskDelay(CFE_ES_PANIC_DELAY);
+
+       /*
+       ** cFE Cannot continue to start up.
+       */
+       CFE_PSP_Panic(CFE_PSP_PANIC_STARTUP_SEM);
+
+       /*
+        * Normally CFE_PSP_Panic() will not return but it will under UT
+        */
+       return;
+   }
+
+   /*
    ** Announce the startup
    */
    CFE_ES_WriteToSysLog("ES Startup: CFE_ES_Main in EARLY_INIT state\n");

--- a/fsw/cfe-core/src/es/cfe_es_task.c
+++ b/fsw/cfe-core/src/es/cfe_es_task.c
@@ -61,10 +61,10 @@
 #define CFE_ES_PERF_FILTERMASK_INT_SIZE     (sizeof(CFE_ES_ResetDataPtr->Perf.MetaData.FilterMask) / sizeof(uint32))
 #define CFE_ES_PERF_FILTERMASK_EXT_SIZE     (sizeof(CFE_ES_TaskData.HkPacket.Payload.PerfFilterMask) / sizeof(uint32))
 
-/* 
-** This define should be put in the OS API headers -- Right now it matches what the OS API uses 
+/*
+** This define should be put in the OS API headers -- Right now it matches what the OS API uses
 */
-#define OS_MAX_PRIORITY 255 
+#define OS_MAX_PRIORITY 255
 
 /*
 ** Executive Services (ES) task global data.
@@ -83,7 +83,7 @@ void CFE_ES_TaskMain(void)
     uint32  TimeOut = CFE_PLATFORM_ES_APP_SCAN_RATE;
     uint32  AppRunStatus = CFE_ES_RunStatus_APP_RUN;
 
-    
+
     /*
     ** Performance Time Stamp Entry
     */
@@ -99,13 +99,13 @@ void CFE_ES_TaskMain(void)
        ** Create a syslog entry
        */
        CFE_ES_WriteToSysLog("ES:Application Init Failed,RC=0x%08X\n", (unsigned int)Status);
-      
+
 
        /*
-       ** Allow Core App to Exit 
+       ** Allow Core App to Exit
        */
        AppRunStatus = CFE_ES_RunStatus_CORE_APP_INIT_ERROR;
-       
+
     } /* end if */
 
     /*
@@ -128,7 +128,7 @@ void CFE_ES_TaskMain(void)
         **  use the RunLoop call.
         */
         CFE_ES_IncrementTaskCounter();
-        
+
         /*
         ** Performance Time Stamp Exit
         */
@@ -159,7 +159,7 @@ void CFE_ES_TaskMain(void)
            ** Process Software Bus message.
            */
            CFE_ES_TaskPipe(CFE_ES_TaskData.MsgPtr);
-           
+
            /*
            ** Scan the App Table for changes after processing a command
            */
@@ -168,24 +168,24 @@ void CFE_ES_TaskMain(void)
         else
         {
             /*
-            ** SB Error: Write a SysLog Message 
+            ** SB Error: Write a SysLog Message
             */
             CFE_ES_WriteToSysLog("ES:Error reading cmd pipe,RC=0x%08X\n",(unsigned int)Status);
 
             /*
-            ** Allow Core App to Exit 
+            ** Allow Core App to Exit
             */
             AppRunStatus = CFE_ES_RunStatus_CORE_APP_RUNTIME_ERROR;
 
         }  /* end if */
-        
-    } /* end while */    
-    
+
+    } /* end while */
+
     /*
     ** Performance Time Stamp Exit
     */
     CFE_ES_PerfLogExit(CFE_MISSION_ES_MAIN_PERF_ID);
-       
+
     /*
     ** Exit the application, CFE_ES_ExitApp will not return.
     */
@@ -216,7 +216,7 @@ int32 CFE_ES_TaskInit(void)
     {
         CFE_ES_WriteToSysLog("ES:Call to CFE_ES_RegisterApp Failed, RC = 0x%08X\n", (unsigned int)Status);
         return(Status);
-    }    
+    }
 
     /*
     ** Initialize task command execution counters
@@ -232,7 +232,7 @@ int32 CFE_ES_TaskInit(void)
 
     CFE_ES_TaskData.LimitHK   = 2;
     CFE_ES_TaskData.LimitCmd  = 4;
-    
+
     /*
     ** Initialize systemlog to default mode
     */
@@ -266,7 +266,7 @@ int32 CFE_ES_TaskInit(void)
     /*
     ** Initialize memory pool statistics telemetry packet
     */
-    CFE_SB_InitMsg(&CFE_ES_TaskData.MemStatsPacket, CFE_ES_MEMSTATS_TLM_MID, 
+    CFE_SB_InitMsg(&CFE_ES_TaskData.MemStatsPacket, CFE_ES_MEMSTATS_TLM_MID,
                    sizeof(CFE_ES_TaskData.MemStatsPacket), true);
 
     /*
@@ -278,7 +278,7 @@ int32 CFE_ES_TaskInit(void)
         CFE_ES_WriteToSysLog("ES:Cannot Create SB Pipe, RC = 0x%08X\n", (unsigned int)Status);
         return(Status);
     }
-    
+
     /*
     ** Subscribe to Housekeeping request commands
     */
@@ -303,12 +303,12 @@ int32 CFE_ES_TaskInit(void)
 
     /*
     ** Compute the CRC for the cfe core code segment and place
-    ** in ES Housekeeping pkt.   
+    ** in ES Housekeeping pkt.
     */
     Status = CFE_PSP_GetCFETextSegmentInfo( &CfeSegmentAddr, &SizeofCfeSegment);
-   
+
     if ( Status == CFE_PSP_SUCCESS )
-    { 
+    {
        CFE_ES_TaskData.HkPacket.Payload.CFECoreChecksum = CFE_ES_CalculateCRC(
                                   (void *)(CfeSegmentAddr), SizeofCfeSegment, 0, CFE_MISSION_ES_DEFAULT_CRC);
     }
@@ -339,12 +339,12 @@ int32 CFE_ES_TaskInit(void)
     {
         CFE_ES_WriteToSysLog("ES:Error sending init event:RC=0x%08X\n", (unsigned int)Status);
         return(Status);
-    }                      
+    }
 
     Status = CFE_EVS_SendEvent(CFE_ES_INITSTATS_INF_EID,
                       CFE_EVS_EventType_INFORMATION,
                       "Versions:cFE %d.%d.%d.%d, OSAL %d.%d.%d.%d, PSP %d.%d.%d.%d, chksm %d",
-                      CFE_MAJOR_VERSION,CFE_MINOR_VERSION,CFE_REVISION,CFE_MISSION_REV,                      
+                      CFE_MAJOR_VERSION,CFE_MINOR_VERSION,CFE_REVISION,CFE_MISSION_REV,
                       OS_MAJOR_VERSION,OS_MINOR_VERSION,OS_REVISION,OS_MISSION_REV,
                       CFE_PSP_MAJOR_VERSION,CFE_PSP_MINOR_VERSION,CFE_PSP_REVISION,CFE_PSP_MISSION_REV,
                       (int)CFE_ES_TaskData.HkPacket.Payload.CFECoreChecksum);
@@ -398,9 +398,20 @@ int32 CFE_ES_TaskInit(void)
        return(Status);
     }
 
+    /*
+     * Initialize the "background task" which is a low priority child task
+     * devoted to maintence duties that do not need to execute on a 
+     * strict/precise schedule.
+     */
+    Status = CFE_ES_BackgroundInit();
+    if ( Status != CFE_SUCCESS )
+    {
+       CFE_ES_WriteToSysLog("ES:Error initializing background task:RC=0x%08X\n", (unsigned int)Status);
+       return(Status);
+    }
 
    return(CFE_SUCCESS);
-   
+
 } /* End of CFE_ES_TaskInit() */
 
 
@@ -654,7 +665,7 @@ int32 CFE_ES_HousekeepingCmd(const CCSDS_CommandPacket_t *data)
 
     CFE_ES_TaskData.HkPacket.Payload.ERLogIndex      = CFE_ES_ResetDataPtr->ERLogIndex;
     CFE_ES_TaskData.HkPacket.Payload.ERLogEntries    = CFE_ES_ResetDataPtr->ERLogEntries;
-    
+
     CFE_ES_TaskData.HkPacket.Payload.RegisteredCoreApps      = CFE_ES_Global.RegisteredCoreApps;
     CFE_ES_TaskData.HkPacket.Payload.RegisteredExternalApps  = CFE_ES_Global.RegisteredExternalApps;
     CFE_ES_TaskData.HkPacket.Payload.RegisteredTasks         = CFE_ES_Global.RegisteredTasks;
@@ -672,7 +683,7 @@ int32 CFE_ES_HousekeepingCmd(const CCSDS_CommandPacket_t *data)
     CFE_ES_TaskData.HkPacket.Payload.PerfDataStart = CFE_ES_ResetDataPtr->Perf.MetaData.DataStart;
     CFE_ES_TaskData.HkPacket.Payload.PerfDataEnd = CFE_ES_ResetDataPtr->Perf.MetaData.DataEnd;
     CFE_ES_TaskData.HkPacket.Payload.PerfDataCount = CFE_ES_ResetDataPtr->Perf.MetaData.DataCount;
-    CFE_ES_TaskData.HkPacket.Payload.PerfDataToWrite = CFE_ES_PerfLogDumpStatus.DataToWrite;
+    CFE_ES_TaskData.HkPacket.Payload.PerfDataToWrite = CFE_ES_GetPerfLogDumpRemaining();
 
     /*
      * Fill out the perf trigger/filter mask objects
@@ -763,10 +774,10 @@ int32 CFE_ES_NoopCmd(const CFE_ES_Noop_t *Cmd)
     CFE_ES_TaskData.CommandCounter++;
     CFE_EVS_SendEvent(CFE_ES_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION,
                      "No-op command. Versions:cFE %d.%d.%d.%d, OSAL %d.%d.%d.%d, PSP %d.%d.%d.%d",
-                     CFE_MAJOR_VERSION,CFE_MINOR_VERSION,CFE_REVISION,CFE_MISSION_REV,                      
+                     CFE_MAJOR_VERSION,CFE_MINOR_VERSION,CFE_REVISION,CFE_MISSION_REV,
                      OS_MAJOR_VERSION,OS_MINOR_VERSION,OS_REVISION,OS_MISSION_REV,
                      CFE_PSP_MAJOR_VERSION,CFE_PSP_MINOR_VERSION,CFE_PSP_REVISION,CFE_PSP_MISSION_REV);
-        
+
     return CFE_SUCCESS;
 } /* End of CFE_ES_NoopCmd() */
 
@@ -948,7 +959,7 @@ int32 CFE_ES_StartAppCmd(const CFE_ES_StartApp_t *data)
        Result = CFE_ES_AppCreate(&AppID, LocalFile,
                    LocalEntryPt,
                    LocalAppName,
-                   (uint32) cmd->Priority, 
+                   (uint32) cmd->Priority,
                    (uint32) cmd->StackSize,
                    (uint32) cmd->ExceptionAction);
 
@@ -1261,7 +1272,7 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAll_t *data)
         {
             if(CFE_ES_Global.AppTable[i].AppState != CFE_ES_AppState_UNDEFINED)
             {
-                /* 
+                /*
                 ** zero out the local entry
                 */
                 memset(&AppInfo,0,sizeof(CFE_ES_AppInfo_t));
@@ -1386,7 +1397,7 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasks_t *data)
         {
             if(CFE_ES_Global.TaskTable[i].RecordUsed != false)
             {
-                /* 
+                /*
                 ** zero out the local entry
                 */
                 memset(&TaskInfo,0,sizeof(CFE_ES_TaskInfo_t));
@@ -1618,12 +1629,12 @@ int32 CFE_ES_ERLogDump(const char *Filename)
     CFE_FS_InitHeader(&FileHdr, CFE_ES_ER_LOG_DESC, CFE_FS_SubType_ES_ERLOG);
 
     /* write the cFE header to the file */
-    WriteStat = CFE_FS_WriteHeader(fd, &FileHdr);    
+    WriteStat = CFE_FS_WriteHeader(fd, &FileHdr);
     if(WriteStat != sizeof(CFE_FS_Header_t))
     {
         CFE_ES_FileWriteByteCntErr(Filename,sizeof(CFE_FS_Header_t),WriteStat);
         OS_close(fd);
-        return CFE_ES_FILE_IO_ERR;        
+        return CFE_ES_FILE_IO_ERR;
     }/* end if */
     FileSize = WriteStat;
 
@@ -1634,7 +1645,7 @@ int32 CFE_ES_ERLogDump(const char *Filename)
         CFE_EVS_SendEvent(CFE_ES_RST_ACCESS_EID, CFE_EVS_EventType_ERROR,
                 "Error accessing ER Log,%s not written. RC = 0x%08X",Filename,(unsigned int)BspStat);
         OS_close(fd);
-        return CFE_ES_RST_ACCESS_ERR;        
+        return CFE_ES_RST_ACCESS_ERR;
     }/* end if */
 
     /* write a single ER log entry on each pass */
@@ -1645,11 +1656,11 @@ int32 CFE_ES_ERLogDump(const char *Filename)
         {
             CFE_ES_FileWriteByteCntErr(Filename,sizeof(CFE_ES_ERLog_t),WriteStat);
             OS_close(fd);
-            return CFE_ES_FILE_IO_ERR;        
-        }/* end if */        
+            return CFE_ES_FILE_IO_ERR;
+        }/* end if */
         FileSize += WriteStat;
         ResetDataAddr+=sizeof(CFE_ES_ERLog_t);
-    }/* end for */   
+    }/* end for */
 
     OS_close(fd);
 
@@ -1714,16 +1725,16 @@ int32 CFE_ES_ResetPRCountCmd(const CFE_ES_ResetPRCount_t *data)
     CFE_ES_TaskData.CommandCounter++;
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_ResetPRCountCmd() */                                            
+} /* End of CFE_ES_ResetPRCountCmd() */
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */              
-/*                                                                 */              
-/* CFE_ES_SetMaxPRCountCmd() -- Set Maximum Processor reset count  */              
-/*                                                                 */              
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */              
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_ES_SetMaxPRCountCmd() -- Set Maximum Processor reset count  */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 int32 CFE_ES_SetMaxPRCountCmd(const CFE_ES_SetMaxPRCount_t *data)
-{                                                                                  
+{
     const CFE_ES_SetMaxPRCountCmd_Payload_t *cmd = &data->Payload;
 
     /*
@@ -1740,16 +1751,16 @@ int32 CFE_ES_SetMaxPRCountCmd(const CFE_ES_SetMaxPRCount_t *data)
     CFE_ES_TaskData.CommandCounter++;
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_RestartCmd() */ 
+} /* End of CFE_ES_RestartCmd() */
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */              
-/*                                                                 */              
-/* CFE_ES_DeleteCDSCmd() -- Delete Specified Critical Data Store   */              
-/*                                                                 */              
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */              
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_ES_DeleteCDSCmd() -- Delete Specified Critical Data Store   */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 int32 CFE_ES_DeleteCDSCmd(const CFE_ES_DeleteCDS_t *data)
-{                                                                                  
+{
     int32   Status;
     const CFE_ES_DeleteCDSCmd_Payload_t *cmd = &data->Payload;
     char LocalCdsName[CFE_ES_CDS_MAX_FULL_NAME_LEN];
@@ -1798,19 +1809,19 @@ int32 CFE_ES_DeleteCDSCmd(const CFE_ES_DeleteCDS_t *data)
     }
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_DeleteCDSCmd() */ 
+} /* End of CFE_ES_DeleteCDSCmd() */
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */              
-/*                                                                   */              
-/* CFE_ES_SendMemPoolStatsCmd() -- Telemeter Memory Pool Statistics  */              
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 /*                                                                   */
-/* Note: The "Application" parameter of the                          */ 
+/* CFE_ES_SendMemPoolStatsCmd() -- Telemeter Memory Pool Statistics  */
+/*                                                                   */
+/* Note: The "Application" parameter of the                          */
 /*       CFE_ES_TlmPoolStats_t structure is not used.                */
-/*                                                                   */              
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */              
+/*                                                                   */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 int32 CFE_ES_SendMemPoolStatsCmd(const CFE_ES_SendMemPoolStats_t *data)
-{                                                                                  
+{
     const CFE_ES_SendMemPoolStatsCmd_Payload_t *Cmd;
     CFE_ES_MemHandle_t        MemHandle;
     bool                      ValidHandle;
@@ -1848,13 +1859,13 @@ int32 CFE_ES_SendMemPoolStatsCmd(const CFE_ES_SendMemPoolStats_t *data)
     }
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_SendMemPoolStatsCmd() */ 
+} /* End of CFE_ES_SendMemPoolStatsCmd() */
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */              
-/*                                                                 */              
-/* CFE_ES_DumpCDSRegistryCmd() -- Dump CDS Registry to a file           */              
-/*                                                                 */              
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */              
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_ES_DumpCDSRegistryCmd() -- Dump CDS Registry to a file           */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistry_t *data)
 {
@@ -1913,7 +1924,7 @@ int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistry_t *data)
                                       sizeof(CFE_ES_CDSRegDumpRec_t));
 
                     FileSize += Status;
-                    NumEntries++;      
+                    NumEntries++;
                 }
 
                 /* Look at the next entry in the Registry */
@@ -1928,7 +1939,7 @@ int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistry_t *data)
                         DumpFilename, (int)FileSize, (int)NumEntries);
 
                 /* Increment Successful Command Counter */
-                CFE_ES_TaskData.CommandCounter++;      
+                CFE_ES_TaskData.CommandCounter++;
             }
             else
             {
@@ -1937,8 +1948,8 @@ int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistry_t *data)
                         "Error writing CDS Registry to '%s', Status=0x%08X",
                         DumpFilename, (unsigned int)Status);
 
-                /* Increment Command Error Counter */      
-                CFE_ES_TaskData.CommandErrorCounter++;      
+                /* Increment Command Error Counter */
+                CFE_ES_TaskData.CommandErrorCounter++;
             }
         }
         else
@@ -1948,8 +1959,8 @@ int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistry_t *data)
                     "Error writing cFE File Header to '%s', Status=0x%08X",
                     DumpFilename, (unsigned int)Status);
 
-            /* Increment Command Error Counter */      
-            CFE_ES_TaskData.CommandErrorCounter++;      
+            /* Increment Command Error Counter */
+            CFE_ES_TaskData.CommandErrorCounter++;
         }
 
         /* We are done outputting data to the dump file.  Close it. */
@@ -1962,8 +1973,8 @@ int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistry_t *data)
                 "Error creating CDS dump file '%s', Status=0x%08X",
                 DumpFilename, (unsigned int)FileDescriptor);
 
-        /* Increment Command Error Counter */      
-        CFE_ES_TaskData.CommandErrorCounter++;      
+        /* Increment Command Error Counter */
+        CFE_ES_TaskData.CommandErrorCounter++;
     }
 
     return CFE_SUCCESS;
@@ -1983,7 +1994,7 @@ void CFE_ES_FileWriteByteCntErr(const char *Filename,uint32 Requested,uint32 Act
                        Filename,(unsigned int)Requested,(unsigned int)Actual);
 
 
-}/* End of CFE_ES_FileWriteByteCntErr() */                                                
+}/* End of CFE_ES_FileWriteByteCntErr() */
 
 /************************/
 /*  End of File Comment */

--- a/fsw/cfe-core/src/es/cfe_es_task.h
+++ b/fsw/cfe-core/src/es/cfe_es_task.h
@@ -28,7 +28,7 @@
 **     Flight Software Branch C Coding Standard Version 1.0a
 **     cFE Flight Software Application Developers Guide
 **
-**  Notes: 
+**  Notes:
 **
 */
 /*************************************************************************/
@@ -43,6 +43,7 @@
 #include "cfe_es_apps.h"
 #include "cfe_es_events.h"
 #include "cfe_es_msg.h"
+#include "cfe_es_perf.h"
 
 /*************************************************************************/
 
@@ -97,7 +98,7 @@ typedef struct
   */
   CFE_SB_MsgPtr_t       MsgPtr;
   CFE_SB_PipeId_t       CmdPipe;
-  
+
   /*
   ** ES Task initialization data (not reported in housekeeping)
   */
@@ -106,6 +107,11 @@ typedef struct
 
   uint8                 LimitHK;
   uint8                 LimitCmd;
+
+  /*
+   * Persistent state data associated with performance log data file writes
+   */
+  CFE_ES_PerfDumpGlobal_t    BackgroundPerfDumpState;
 
 } CFE_ES_TaskData_t;
 
@@ -125,6 +131,14 @@ void  CFE_ES_TaskMain(void);
 int32 CFE_ES_TaskInit(void);
 void  CFE_ES_TaskPipe(CFE_SB_MsgPtr_t Msg);
 
+
+/*
+ * Functions related to the ES background helper task for low-priority tasks
+ */
+int32 CFE_ES_BackgroundInit(void);
+void  CFE_ES_BackgroundTask(void);
+void  CFE_ES_BackgroundWakeup(void);
+void  CFE_ES_BackgroundCleanup(void);
 
 /*
 ** ES Task message dispatch functions

--- a/fsw/cfe-core/src/inc/cfe_es_events.h
+++ b/fsw/cfe-core/src/inc/cfe_es_events.h
@@ -1013,23 +1013,6 @@
 #define CFE_ES_PERF_STOPCMD_EID       60
 
 
-/** \brief <tt> 'Stop performance data cmd,Error creating child task RC=0x\%08X' </tt>
-**  \event <tt> 'Stop performance data cmd,Error creating child task RC=0x\%08X' </tt> 
-**
-**  \par Type: ERROR
-**
-**  \par Cause:
-**
-**  This event message is generated upon receipt of an unsuccessful Performance Data Stop
-**  Command after receiving the cFE Executive Services \link #CFE_ES_STOP_PERF_DATA_CC Stop 
-**  Performance Analyzer Data Collection Command \endlink
-**
-**  The \c 'RC' field specifies, in hex, the error code returned by the #CFE_ES_CreateChildTask API
-**  
-**/
-#define CFE_ES_PERF_STOPCMD_ERR1_EID       61
-
-
 /** \brief <tt> 'Stop performance data cmd ignored,perf data write in progress' </tt>
 **  \event <tt> 'Stop performance data cmd ignored,perf data write in progress' </tt> 
 **

--- a/fsw/cfe-core/src/inc/private/cfe_es_perfdata_typedef.h
+++ b/fsw/cfe-core/src/inc/private/cfe_es_perfdata_typedef.h
@@ -49,7 +49,14 @@ typedef struct {
     uint8                          Spare[2];
     uint32                         TimerTicksPerSecond;
     uint32                         TimerLow32Rollover;
-    uint32                         State;
+    /*
+     * The "State" member is marked volatile to help
+     * ensure that an optimizing compiler does not rearrange
+     * or eliminate reads/writes of this value.  It is read
+     * outside of any locking to determine whether or not
+     * the performance log function is enabled.
+     */
+    volatile uint32                State;
     uint32                         Mode;
     uint32                         TriggerCount;
     uint32                         DataStart;

--- a/fsw/cfe-core/unit-test/es_UT.h
+++ b/fsw/cfe-core/unit-test/es_UT.h
@@ -217,6 +217,23 @@ void TestTask(void);
 
 /*****************************************************************************/
 /**
+** \brief Performs tests of the background task contained in
+**        cfe_es_backgroundtask.c
+**
+** \par Description
+**        Gets Coverage on all lines/functions in this unit
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+**
+******************************************************************************/
+void TestBackground(void);
+
+/*****************************************************************************/
+/**
 ** \brief Performs tests on the functions that implement the software timing
 **        performance marker functions contained in cfe_es_perf.c
 **


### PR DESCRIPTION
**Describe the contribution**

Replaces the `OS_IntLock` with a standard OSAL mutex for protecting the shared/global perflog data structure.  This may introduce unexpected task switches when contention occurs, but it ensures proper exclusion with respect to the data structures.

Removes the temporary child worker task that was spawned for writing the log data to a file, and replace with a more generic CFE ES background task.  The background task is started at boot and
pends on a semaphore until there is work to do.

The background performance log dump is implemented as a state machine which is called repeatedly over time from the background job task.  This performs a limited amount of work on each invocation, and resumes where it left from the previous invocation.

Fixes #456 

**Testing performed**
Build CFE with ENABLE_UNIT_TESTS=TRUE
Confirm all unit tests pass
Confirm near 100% coverage on all newly added/modified code
Run CFE and send commands to start performance logging
Send other CFE commands to generate performance log activity
Send command to stop performance log and generate a dump file
Confirm validity of dump file by opening with Java tool.  No errors reported when opening file.

**Expected behavior changes**
No impact to behavior.  Previously the perf log dump file frequently contained errors due to out of order or otherwise corrupted entries, which is now fixed.

**System(s) tested on**
 - Ubuntu 18.04 LTS 64-bit (native)
- MIPS 32 target running in QEMU (big endian)

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
