### PR TITLE
Fix #263, expose IsValidMsgID and partially address #245 Consistent use of MsgId types

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_task.c
+++ b/fsw/cfe-core/src/es/cfe_es_task.c
@@ -251,23 +251,30 @@ int32 CFE_ES_TaskInit(void)
     /*
     ** Initialize housekeeping packet (clear user data area)
     */
-    CFE_SB_InitMsg(&CFE_ES_TaskData.HkPacket, CFE_ES_HK_TLM_MID, sizeof(CFE_ES_TaskData.HkPacket), true);
+    CFE_SB_InitMsg(&CFE_ES_TaskData.HkPacket,
+            CFE_SB_ValueToMsgId(CFE_ES_HK_TLM_MID),
+            sizeof(CFE_ES_TaskData.HkPacket), true);
 
     /*
     ** Initialize shell output packet (clear user data area)
     */
-    CFE_SB_InitMsg(&CFE_ES_TaskData.ShellPacket, CFE_ES_SHELL_TLM_MID, sizeof(CFE_ES_TaskData.ShellPacket), true);
+    CFE_SB_InitMsg(&CFE_ES_TaskData.ShellPacket,
+            CFE_SB_ValueToMsgId(CFE_ES_SHELL_TLM_MID),
+            sizeof(CFE_ES_TaskData.ShellPacket), true);
 
     /*
     ** Initialize single application telemetry packet
     */
-    CFE_SB_InitMsg(&CFE_ES_TaskData.OneAppPacket, CFE_ES_APP_TLM_MID, sizeof(CFE_ES_TaskData.OneAppPacket), true);
+    CFE_SB_InitMsg(&CFE_ES_TaskData.OneAppPacket,
+            CFE_SB_ValueToMsgId(CFE_ES_APP_TLM_MID),
+            sizeof(CFE_ES_TaskData.OneAppPacket), true);
 
     /*
     ** Initialize memory pool statistics telemetry packet
     */
-    CFE_SB_InitMsg(&CFE_ES_TaskData.MemStatsPacket, CFE_ES_MEMSTATS_TLM_MID,
-                   sizeof(CFE_ES_TaskData.MemStatsPacket), true);
+    CFE_SB_InitMsg(&CFE_ES_TaskData.MemStatsPacket,
+            CFE_SB_ValueToMsgId(CFE_ES_MEMSTATS_TLM_MID),
+            sizeof(CFE_ES_TaskData.MemStatsPacket), true);
 
     /*
     ** Create Software Bus message pipe
@@ -282,7 +289,7 @@ int32 CFE_ES_TaskInit(void)
     /*
     ** Subscribe to Housekeeping request commands
     */
-    Status = CFE_SB_SubscribeEx(CFE_ES_SEND_HK_MID, CFE_ES_TaskData.CmdPipe,
+    Status = CFE_SB_SubscribeEx(CFE_SB_ValueToMsgId(CFE_ES_SEND_HK_MID), CFE_ES_TaskData.CmdPipe,
                                 CFE_SB_Default_Qos, CFE_ES_TaskData.LimitHK);
     if ( Status != CFE_SUCCESS )
     {
@@ -293,8 +300,8 @@ int32 CFE_ES_TaskInit(void)
     /*
     ** Subscribe to ES task ground command packets
     */
-    Status = CFE_SB_SubscribeEx(CFE_ES_CMD_MID, CFE_ES_TaskData.CmdPipe,
-                       CFE_SB_Default_Qos, CFE_ES_TaskData.LimitCmd);
+    Status = CFE_SB_SubscribeEx(CFE_SB_ValueToMsgId(CFE_ES_CMD_MID), CFE_ES_TaskData.CmdPipe,
+                                CFE_SB_Default_Qos, CFE_ES_TaskData.LimitCmd);
     if ( Status != CFE_SUCCESS )
     {
         CFE_ES_WriteToSysLog("ES:Cannot Subscribe to ES ground commands, RC = 0x%08X\n", (unsigned int)Status);
@@ -427,7 +434,7 @@ void CFE_ES_TaskPipe(CFE_SB_MsgPtr_t Msg)
     uint16         CommandCode;
 
     MessageID = CFE_SB_GetMsgId(Msg);
-    switch (MessageID)
+    switch (CFE_SB_MsgIdToValue(MessageID))
     {
         /*
         ** Housekeeping telemetry request
@@ -622,7 +629,7 @@ void CFE_ES_TaskPipe(CFE_SB_MsgPtr_t Msg)
                 default:
                     CFE_EVS_SendEvent(CFE_ES_CC1_ERR_EID, CFE_EVS_EventType_ERROR,
                      "Invalid ground command code: ID = 0x%X, CC = %d",
-                                      (unsigned int)MessageID, (int)CommandCode);
+                     (unsigned int)CFE_SB_MsgIdToValue(MessageID), (int)CommandCode);
                     CFE_ES_TaskData.CommandErrorCounter++;
                     break;
             }
@@ -632,7 +639,7 @@ void CFE_ES_TaskPipe(CFE_SB_MsgPtr_t Msg)
 
             CFE_EVS_SendEvent(CFE_ES_MID_ERR_EID, CFE_EVS_EventType_ERROR,
                              "Invalid command pipe message ID: 0x%X",
-                              (unsigned int)MessageID);
+                              (unsigned int)CFE_SB_MsgIdToValue(MessageID));
             CFE_ES_TaskData.CommandErrorCounter++;
             break;
     }
@@ -1692,7 +1699,7 @@ bool CFE_ES_VerifyCmdLength(CFE_SB_MsgPtr_t Msg, uint16 ExpectedLength)
 
         CFE_EVS_SendEvent(CFE_ES_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
                 "Invalid cmd length: ID = 0x%X, CC = %d, Exp Len = %d, Len = %d",
-                (unsigned int)MessageID, (int)CommandCode, (int)ExpectedLength, (int)ActualLength);
+                (unsigned int)CFE_SB_MsgIdToValue(MessageID), (int)CommandCode, (int)ExpectedLength, (int)ActualLength);
         result = false;
         CFE_ES_TaskData.CommandErrorCounter++;
     }

--- a/fsw/cfe-core/src/evs/cfe_evs_utils.c
+++ b/fsw/cfe-core/src/evs/cfe_evs_utils.c
@@ -364,7 +364,8 @@ void EVS_GenerateEventTelemetry(uint32 AppID, uint16 EventID, uint16 EventType, 
     int                      ExpandedLength;
 
     /* Initialize EVS event packets */
-    CFE_SB_InitMsg(&LongEventTlm, CFE_EVS_LONG_EVENT_MSG_MID, sizeof(LongEventTlm), true);
+    CFE_SB_InitMsg(&LongEventTlm, CFE_SB_ValueToMsgId(CFE_EVS_LONG_EVENT_MSG_MID),
+                   sizeof(LongEventTlm), true);
     LongEventTlm.Payload.PacketID.EventID   = EventID;
     LongEventTlm.Payload.PacketID.EventType = EventType;
 
@@ -408,7 +409,8 @@ void EVS_GenerateEventTelemetry(uint32 AppID, uint16 EventID, uint16 EventType, 
          *
          * This goes out on a separate message ID.
          */
-        CFE_SB_InitMsg(&ShortEventTlm, CFE_EVS_SHORT_EVENT_MSG_MID, sizeof(ShortEventTlm), true);
+        CFE_SB_InitMsg(&ShortEventTlm, CFE_SB_ValueToMsgId(CFE_EVS_SHORT_EVENT_MSG_MID),
+                       sizeof(ShortEventTlm), true);
         CFE_SB_SetMsgTime((CFE_SB_Msg_t *) &ShortEventTlm, *TimeStamp);
         ShortEventTlm.Payload.PacketID = LongEventTlm.Payload.PacketID;
         CFE_SB_SendMsg((CFE_SB_Msg_t *) &ShortEventTlm);

--- a/fsw/cfe-core/src/inc/cfe_sb.h
+++ b/fsw/cfe-core/src/inc/cfe_sb.h
@@ -58,12 +58,36 @@
 /* ------------------------------------------------------ */
 
 /**
+ * \brief Translation macro to convert from MsgId integer values to opaque/abstract API values
+ *
+ * This conversion exists in macro form to allow compile-time evaluation for constants, and
+ * should not be used directly in application code.
+ *
+ * For applications, use the CFE_SB_ValueToMsgId() inline function instead.
+ *
+ * \sa CFE_SB_ValueToMsgId()
+ */
+#define CFE_SB_MSGID_WRAP_VALUE(val)     ((CFE_SB_MsgId_t)(val))
+
+/**
+ * \brief Translation macro to convert to MsgId integer values from opaque/abstract API values
+ *
+ * This conversion exists in macro form to allow compile-time evaluation for constants, and
+ * should not be used directly in application code.
+ *
+ * For applications, use the CFE_SB_MsgIdToValue() inline function instead.
+ *
+ * \sa CFE_SB_MsgIdToValue()
+ */
+#define CFE_SB_MSGID_UNWRAP_VALUE(mid)   ((CFE_SB_MsgId_Atom_t)(mid))
+
+/**
  * \brief Reserved value for CFE_SB_MsgId_t that will not match any valid MsgId
  *
  * This rvalue macro can be used for static/compile-time data initialization to ensure that
  * the initialized value does not alias to a valid MsgId object.
  */
-#define CFE_SB_MSGID_RESERVED            ((CFE_SB_MsgId_t)(-1))
+#define CFE_SB_MSGID_RESERVED            CFE_SB_MSGID_WRAP_VALUE(-1)
 
 /**
  * \brief A literal of the CFE_SB_MsgId_t type representing an invalid ID
@@ -1333,7 +1357,7 @@ bool CFE_SB_IsValidMsgId(CFE_SB_MsgId_t MsgId);
  */
 static inline bool CFE_SB_MsgId_Equal(CFE_SB_MsgId_t MsgId1, CFE_SB_MsgId_t MsgId2)
 {
-    return (MsgId1 == MsgId2);
+    return CFE_SB_MSGID_UNWRAP_VALUE(MsgId1) == CFE_SB_MSGID_UNWRAP_VALUE(MsgId2);
 }
 
 /*****************************************************************************/
@@ -1364,7 +1388,7 @@ static inline bool CFE_SB_MsgId_Equal(CFE_SB_MsgId_t MsgId1, CFE_SB_MsgId_t MsgI
  */
 static inline CFE_SB_MsgId_Atom_t CFE_SB_MsgIdToValue(CFE_SB_MsgId_t MsgId)
 {
-    return MsgId;
+    return CFE_SB_MSGID_UNWRAP_VALUE(MsgId);
 }
 
 /*****************************************************************************/
@@ -1393,7 +1417,8 @@ static inline CFE_SB_MsgId_Atom_t CFE_SB_MsgIdToValue(CFE_SB_MsgId_t MsgId)
  */
 static inline CFE_SB_MsgId_t CFE_SB_ValueToMsgId(CFE_SB_MsgId_Atom_t MsgIdValue)
 {
-    return MsgIdValue;
+    CFE_SB_MsgId_t Result = CFE_SB_MSGID_WRAP_VALUE(MsgIdValue);
+    return Result;
 }
 /**@}*/
 

--- a/fsw/cfe-core/src/inc/cfe_sb.h
+++ b/fsw/cfe-core/src/inc/cfe_sb.h
@@ -53,7 +53,30 @@
 #define CFE_SB_SUBSCRIPTION             0      /**< \brief Subtype specifier used in #CFE_SB_SingleSubscriptionTlm_t by SBN App */
 #define CFE_SB_UNSUBSCRIPTION           1      /**< \brief Subtype specified used in #CFE_SB_SingleSubscriptionTlm_t by SBN App */
 
-#define CFE_SB_INVALID_MSG_ID           0xFFFF /**< \brief Initializer for #CFE_SB_MsgId_t values that will not match any real MsgId */
+/* ------------------------------------------------------ */
+/* Macro Constants for use with the CFE_SB_MsgId_t type   */
+/* ------------------------------------------------------ */
+
+/**
+ * \brief Reserved value for CFE_SB_MsgId_t that will not match any valid MsgId
+ *
+ * This rvalue macro can be used for static/compile-time data initialization to ensure that
+ * the initialized value does not alias to a valid MsgId object.
+ */
+#define CFE_SB_MSGID_RESERVED            ((CFE_SB_MsgId_t)(-1))
+
+/**
+ * \brief A literal of the CFE_SB_MsgId_t type representing an invalid ID
+ *
+ * This value should be used for runtime initialization of CFE_SB_MsgId_t values.
+ *
+ * \note This may be a compound literal in a future revision.  Per C99, compound
+ * literals are lvalues, not rvalues, so this value should not be used in
+ * static/compile-time data initialization.  For static data initialization
+ * purposes (rvalue), #CFE_SB_MSGID_RESERVED should be used instead.
+ * However, in the current implementation, they are equivalent.
+ */
+#define CFE_SB_INVALID_MSG_ID            CFE_SB_MSGID_RESERVED
 
 /*
 ** Macro Definitions
@@ -1278,7 +1301,21 @@ bool CFE_SB_ValidateChecksum(CFE_SB_MsgPtr_t MsgPtr);
 
 /*****************************************************************************/
 /**
- * \brief Identifies whether a two #CFE_SB_MsgId_t values are equal
+ * \brief Identifies whether a given CFE_SB_MsgId_t is valid
+ *
+ * \par Description
+ *    Implements a basic sanity check on the value provided
+ *
+ * \return Boolean message ID validity indicator
+ * \retval true  Message ID is within the valid range
+ * \retval false Message ID is not within the valid range
+ */
+bool CFE_SB_IsValidMsgId(CFE_SB_MsgId_t MsgId);
+
+
+/*****************************************************************************/
+/**
+ * \brief Identifies whether two #CFE_SB_MsgId_t values are equal
  *
  * \par Description
  *    In cases where the #CFE_SB_MsgId_t type is not a simple integer

--- a/fsw/cfe-core/src/inc/cfe_sb_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_sb_msg.h
@@ -681,7 +681,7 @@ typedef struct{
 ** Structure of one element of the map information in response to #CFE_SB_SEND_MAP_INFO_CC
 */
 typedef struct{
-    CFE_SB_MsgId_Atom_t        MsgId;/**< \brief Message Id which has been subscribed to */
+    CFE_SB_MsgId_t             MsgId;/**< \brief Message Id which has been subscribed to */
     CFE_SB_MsgRouteIdx_Atom_t  Index;/**< \brief Routing table index where pipe destinations are found */
 }CFE_SB_MsgMapFileEntry_t;
 

--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -741,8 +741,8 @@ int32  CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
       CFE_SB.HKTlmMsg.Payload.SubscribeErrorCounter++;
       CFE_SB_UnlockSharedData(__func__,__LINE__);
       CFE_EVS_SendEventWithAppID(CFE_SB_SUB_INV_PIPE_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
-          "Subscribe Err:Invalid Pipe Id,Msg=0x%x,PipeId=%d,App %s",(unsigned int)MsgId,(int)PipeId,
-          CFE_SB_GetAppTskName(TskId,FullName));
+          "Subscribe Err:Invalid Pipe Id,Msg=0x%x,PipeId=%d,App %s",(unsigned int)CFE_SB_MsgIdToValue(MsgId),
+          (int)PipeId, CFE_SB_GetAppTskName(TskId,FullName));
       return CFE_SB_BAD_ARGUMENT;
     }/* end if */
 
@@ -752,7 +752,7 @@ int32  CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
       CFE_SB_UnlockSharedData(__func__,__LINE__);
       CFE_EVS_SendEventWithAppID(CFE_SB_SUB_INV_CALLER_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
           "Subscribe Err:Caller(%s) is not the owner of pipe %d,Msg=0x%x",
-          CFE_SB_GetAppTskName(TskId,FullName),(int)PipeId,(unsigned int)MsgId);
+          CFE_SB_GetAppTskName(TskId,FullName),(int)PipeId,(unsigned int)CFE_SB_MsgIdToValue(MsgId));
       return CFE_SB_BAD_ARGUMENT;
     }/* end if */
 
@@ -763,7 +763,8 @@ int32  CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
         CFE_SB_UnlockSharedData(__func__,__LINE__);
         CFE_EVS_SendEventWithAppID(CFE_SB_SUB_ARG_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
           "Subscribe Err:Bad Arg,MsgId 0x%x,PipeId %d,app %s,scope %d",
-          (unsigned int)MsgId,(int)PipeId,CFE_SB_GetAppTskName(TskId,FullName),Scope);
+          (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+          (int)PipeId,CFE_SB_GetAppTskName(TskId,FullName),Scope);
         return CFE_SB_BAD_ARGUMENT;
     }/* end if */
 
@@ -776,7 +777,8 @@ int32  CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
         CFE_SB_UnlockSharedData(__func__,__LINE__);
         CFE_EVS_SendEventWithAppID(CFE_SB_DUP_SUBSCRIP_EID,CFE_EVS_EventType_INFORMATION,CFE_SB.AppId,
           "Duplicate Subscription,MsgId 0x%x on %s pipe,app %s",
-           (unsigned int)MsgId,PipeName,CFE_SB_GetAppTskName(TskId,FullName));
+           (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+           PipeName,CFE_SB_GetAppTskName(TskId,FullName));
         return CFE_SUCCESS;
     }/* end if */
 
@@ -811,7 +813,9 @@ int32  CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
             CFE_SB_UnlockSharedData(__func__,__LINE__);
             CFE_EVS_SendEventWithAppID(CFE_SB_MAX_MSGS_MET_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
               "Subscribe Err:Max Msgs(%d)In Use,MsgId 0x%x,pipe %s,app %s",
-              CFE_PLATFORM_SB_MAX_MSG_IDS,(unsigned int)MsgId,PipeName,CFE_SB_GetAppTskName(TskId,FullName));
+              CFE_PLATFORM_SB_MAX_MSG_IDS,
+              (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+              PipeName,CFE_SB_GetAppTskName(TskId,FullName));
             return CFE_SB_MAX_MSGS_MET;
         }/* end if */
 
@@ -835,8 +839,9 @@ int32  CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
         CFE_SB_UnlockSharedData(__func__,__LINE__);
         CFE_EVS_SendEventWithAppID(CFE_SB_MAX_DESTS_MET_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
             "Subscribe Err:Max Dests(%d)In Use For Msg 0x%x,pipe %s,app %s",
-             CFE_PLATFORM_SB_MAX_DEST_PER_PKT,(unsigned int)MsgId,PipeName,
-             CFE_SB_GetAppTskName(TskId,FullName));
+             CFE_PLATFORM_SB_MAX_DEST_PER_PKT,
+             (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+             PipeName, CFE_SB_GetAppTskName(TskId,FullName));
 
         return CFE_SB_MAX_DESTS_MET;
     }/* end if */
@@ -845,7 +850,8 @@ int32  CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
     if(DestBlkPtr == NULL){
         CFE_SB_UnlockSharedData(__func__,__LINE__);
         CFE_EVS_SendEventWithAppID(CFE_SB_DEST_BLK_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
-            "Subscribe Err:Request for Destination Blk failed for Msg 0x%x", (unsigned int)MsgId);
+            "Subscribe Err:Request for Destination Blk failed for Msg 0x%x", 
+            (unsigned int)CFE_SB_MsgIdToValue(MsgId));
         return CFE_SB_BUF_ALOC_ERR;
     }/* end if */
 
@@ -880,7 +886,8 @@ int32  CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
       Stat = CFE_SB_SendMsg((CFE_SB_Msg_t *)&CFE_SB.SubRprtMsg);
       CFE_EVS_SendEventWithAppID(CFE_SB_SUBSCRIPTION_RPT_EID,CFE_EVS_EventType_DEBUG,CFE_SB.AppId,
             "Sending Subscription Report Msg=0x%x,Pipe=%d,Stat=0x%x",
-            (unsigned int)MsgId,(int)PipeId,(unsigned int)Stat);
+            (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+            (int)PipeId,(unsigned int)Stat);
       CFE_SB_LockSharedData(__func__,__LINE__);/* to prevent back-to-back unlock */
     }/* end if */
 
@@ -889,7 +896,8 @@ int32  CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
 
     CFE_EVS_SendEventWithAppID(CFE_SB_SUBSCRIPTION_RCVD_EID,CFE_EVS_EventType_DEBUG,CFE_SB.AppId,
         "Subscription Rcvd:MsgId 0x%x on %s(%d),app %s",
-         (unsigned int)MsgId,PipeName,(int)PipeId,CFE_SB_GetAppTskName(TskId,FullName));
+         (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+         PipeName,(int)PipeId,CFE_SB_GetAppTskName(TskId,FullName));
 
     return CFE_SUCCESS;
 
@@ -1020,7 +1028,8 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId,CFE_SB_PipeId_t PipeId,
       CFE_SB_UnlockSharedData(__func__,__LINE__);
       CFE_EVS_SendEventWithAppID(CFE_SB_UNSUB_INV_PIPE_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
             "Unsubscribe Err:Invalid Pipe Id Msg=0x%x,Pipe=%d,app=%s",
-            (unsigned int)MsgId,(int)PipeId,CFE_SB_GetAppTskName(TskId,FullName));
+            (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+            (int)PipeId,CFE_SB_GetAppTskName(TskId,FullName));
       return CFE_SB_BAD_ARGUMENT;
     }/* end if */
 
@@ -1029,7 +1038,8 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId,CFE_SB_PipeId_t PipeId,
       CFE_SB_UnlockSharedData(__func__,__LINE__);
       CFE_EVS_SendEventWithAppID(CFE_SB_UNSUB_INV_CALLER_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
             "Unsubscribe Err:Caller(%s) is not the owner of pipe %d,Msg=0x%x",
-            CFE_SB_GetAppTskName(TskId,FullName),(int)PipeId,(unsigned int)MsgId);
+            CFE_SB_GetAppTskName(TskId,FullName),(int)PipeId,
+            (unsigned int)CFE_SB_MsgIdToValue(MsgId));
       return CFE_SB_BAD_ARGUMENT;
     }/* end if */
 
@@ -1041,7 +1051,8 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId,CFE_SB_PipeId_t PipeId,
         CFE_SB_UnlockSharedData(__func__,__LINE__);
         CFE_EVS_SendEventWithAppID(CFE_SB_UNSUB_ARG_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
             "UnSubscribe Err:Bad Arg,MsgId 0x%x,PipeId %d,app %s,scope %d",
-            (unsigned int)MsgId,(int)PipeId,CFE_SB_GetAppTskName(TskId,FullName),(int)Scope);
+            (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+            (int)PipeId,CFE_SB_GetAppTskName(TskId,FullName),(int)Scope);
         return CFE_SB_BAD_ARGUMENT;
     }/* end if */
 
@@ -1059,7 +1070,8 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId,CFE_SB_PipeId_t PipeId,
 
         CFE_EVS_SendEventWithAppID(CFE_SB_UNSUB_NO_SUBS_EID,CFE_EVS_EventType_INFORMATION,CFE_SB.AppId,
             "Unsubscribe Err:No subs for Msg 0x%x on %s,app %s",
-            (unsigned int)MsgId,PipeName,CFE_SB_GetAppTskName(TskId,FullName));
+            (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+            PipeName,CFE_SB_GetAppTskName(TskId,FullName));
         return CFE_SUCCESS;
     }/* end if */
 
@@ -1094,7 +1106,8 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId,CFE_SB_PipeId_t PipeId,
 
     CFE_EVS_SendEventWithAppID(CFE_SB_SUBSCRIPTION_REMOVED_EID,CFE_EVS_EventType_DEBUG,CFE_SB.AppId,
             "Subscription Removed:Msg 0x%x on pipe %d,app %s",
-            (unsigned int)MsgId,(int)PipeId,CFE_SB_GetAppTskName(TskId,FullName));
+            (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+            (int)PipeId,CFE_SB_GetAppTskName(TskId,FullName));
 
     return CFE_SUCCESS;
 
@@ -1205,7 +1218,8 @@ int32  CFE_SB_SendMsgFull(CFE_SB_Msg_t    *MsgPtr,
         CFE_SB_UnlockSharedData(__func__,__LINE__);
         CFE_EVS_SendEventWithAppID(CFE_SB_SEND_INV_MSGID_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
             "Send Err:Invalid MsgId(0x%x)in msg,App %s",
-            (unsigned int)MsgId,CFE_SB_GetAppTskName(TskId,FullName));
+            (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+            CFE_SB_GetAppTskName(TskId,FullName));
         return CFE_SB_BAD_ARGUMENT;
     }/* end if */
 
@@ -1223,7 +1237,8 @@ int32  CFE_SB_SendMsgFull(CFE_SB_Msg_t    *MsgPtr,
         CFE_SB_UnlockSharedData(__func__,__LINE__);
         CFE_EVS_SendEventWithAppID(CFE_SB_MSG_TOO_BIG_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
             "Send Err:Msg Too Big MsgId=0x%x,app=%s,size=%d,MaxSz=%d",
-            (unsigned int)MsgId,CFE_SB_GetAppTskName(TskId,FullName),(int)TotalMsgSize,CFE_MISSION_SB_MAX_SB_MSG_SIZE);
+            (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+            CFE_SB_GetAppTskName(TskId,FullName),(int)TotalMsgSize,CFE_MISSION_SB_MAX_SB_MSG_SIZE);
         return CFE_SB_MSG_TOO_BIG;
     }/* end if */
 
@@ -1252,7 +1267,8 @@ int32  CFE_SB_SendMsgFull(CFE_SB_Msg_t    *MsgPtr,
 
            CFE_EVS_SendEventWithAppID(CFE_SB_SEND_NO_SUBS_EID,CFE_EVS_EventType_INFORMATION,CFE_SB.AppId,
               "No subscribers for MsgId 0x%x,sender %s",
-              (unsigned int)MsgId,CFE_SB_GetAppTskName(TskId,FullName));
+              (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+              CFE_SB_GetAppTskName(TskId,FullName));
 
            /* clear the bit so the task may send this event again */
            CFE_SB_FinishSendEvent(TskId,CFE_SB_SEND_NO_SUBS_EID_BIT);
@@ -1277,7 +1293,8 @@ int32  CFE_SB_SendMsgFull(CFE_SB_Msg_t    *MsgPtr,
 
             CFE_EVS_SendEventWithAppID(CFE_SB_GET_BUF_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
               "Send Err:Request for Buffer Failed. MsgId 0x%x,app %s,size %d",
-              (unsigned int)MsgId,CFE_SB_GetAppTskName(TskId,FullName),(int)TotalMsgSize);
+              (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+              CFE_SB_GetAppTskName(TskId,FullName),(int)TotalMsgSize);
 
             /* clear the bit so the task may send this event again */
             CFE_SB_FinishSendEvent(TskId,CFE_SB_GET_BUF_ERR_EID_BIT);
@@ -1427,8 +1444,8 @@ int32  CFE_SB_SendMsgFull(CFE_SB_Msg_t    *MsgPtr,
 
               CFE_EVS_SendEventWithAppID(CFE_SB_MSGID_LIM_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
                 "Msg Limit Err,MsgId 0x%x,pipe %s,sender %s",
-                (unsigned int)RtgTblPtr->MsgId, PipeName,
-                CFE_SB_GetAppTskName(TskId,FullName));
+                (unsigned int)CFE_SB_MsgIdToValue(RtgTblPtr->MsgId),
+                PipeName, CFE_SB_GetAppTskName(TskId,FullName));
 
               /* clear the bit so the task may send this event again */
               CFE_SB_FinishSendEvent(TskId,CFE_SB_MSGID_LIM_ERR_EID_BIT);
@@ -1446,8 +1463,8 @@ int32  CFE_SB_SendMsgFull(CFE_SB_Msg_t    *MsgPtr,
 
               CFE_EVS_SendEventWithAppID(CFE_SB_Q_FULL_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
                   "Pipe Overflow,MsgId 0x%x,pipe %s,sender %s",
-                  (unsigned int)RtgTblPtr->MsgId, PipeName,
-                  CFE_SB_GetAppTskName(TskId,FullName));
+                  (unsigned int)CFE_SB_MsgIdToValue(RtgTblPtr->MsgId),
+                  PipeName, CFE_SB_GetAppTskName(TskId,FullName));
 
                /* clear the bit so the task may send this event again */
               CFE_SB_FinishSendEvent(TskId,CFE_SB_Q_FULL_ERR_EID_BIT);
@@ -1462,8 +1479,8 @@ int32  CFE_SB_SendMsgFull(CFE_SB_Msg_t    *MsgPtr,
 
               CFE_EVS_SendEventWithAppID(CFE_SB_Q_WR_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
                 "Pipe Write Err,MsgId 0x%x,pipe %s,sender %s,stat 0x%x",
-                (unsigned int)RtgTblPtr->MsgId, PipeName,
-                CFE_SB_GetAppTskName(TskId,FullName),
+                (unsigned int)CFE_SB_MsgIdToValue(RtgTblPtr->MsgId),
+                PipeName, CFE_SB_GetAppTskName(TskId,FullName),
                 (unsigned int)SBSndErr.EvtBuf[i].ErrStat);
 
                /* clear the bit so the task may send this event again */

--- a/fsw/cfe-core/src/sb/cfe_sb_init.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_init.c
@@ -123,7 +123,7 @@ int32 CFE_SB_EarlyInit (void) {
     
     /* Initialize the SB Statistics Pkt */
     CFE_SB_InitMsg(&CFE_SB.StatTlmMsg,
-                   CFE_SB_STATS_TLM_MID,
+                   CFE_SB_ValueToMsgId(CFE_SB_STATS_TLM_MID),
                    sizeof(CFE_SB.StatTlmMsg),
                    true);    
 

--- a/fsw/cfe-core/src/sb/cfe_sb_msg_id_util.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_msg_id_util.c
@@ -110,7 +110,7 @@
 */
 CFE_SB_MsgKey_t CFE_SB_ConvertMsgIdtoMsgKey( CFE_SB_MsgId_t MsgId)
 {
-    return CFE_SB_ValueToMsgKey(MsgId);
+    return CFE_SB_ValueToMsgKey(CFE_SB_MsgIdToValue(MsgId));
 }/* CFE_SB_ConvertMsgIdtoMsgKey */
 
 /*
@@ -118,24 +118,24 @@ CFE_SB_MsgKey_t CFE_SB_ConvertMsgIdtoMsgKey( CFE_SB_MsgId_t MsgId)
  */
 CFE_SB_MsgId_t CFE_SB_GetMsgId(const CFE_SB_Msg_t *MsgPtr)
 {
-   CFE_SB_MsgId_t MsgId = 0;
+   CFE_SB_MsgId_Atom_t MsgIdVal = 0;
 
 #ifdef MESSAGE_FORMAT_IS_CCSDS
 
 #ifndef MESSAGE_FORMAT_IS_CCSDS_VER_2  
-    MsgId = CCSDS_RD_SID(MsgPtr->Hdr);
+    MsgIdVal = CCSDS_RD_SID(MsgPtr->Hdr);
 #else
 
     uint32            SubSystemId;
 
-    MsgId = CCSDS_RD_APID(MsgPtr->Hdr); /* Primary header APID  */
+    MsgIdVal = CCSDS_RD_APID(MsgPtr->Hdr); /* Primary header APID  */
      
     if ( CCSDS_RD_TYPE(MsgPtr->Hdr) == CCSDS_CMD)
-      MsgId = MsgId | CFE_SB_CMD_MESSAGE_TYPE;  
+      MsgIdVal = MsgIdVal | CFE_SB_CMD_MESSAGE_TYPE;  
 
     /* Add in the SubSystem ID as needed */
     SubSystemId = CCSDS_RD_SUBSYSTEM_ID(MsgPtr->SpacePacket.ApidQ);
-    MsgId = (MsgId | (SubSystemId << 8));
+    MsgIdVal = (MsgIdVal | (SubSystemId << 8));
 
 /* Example code to add in the System ID as needed. */
 /*   The default is to init this field to the Spacecraft ID but ignore for routing.   */
@@ -143,12 +143,12 @@ CFE_SB_MsgId_t CFE_SB_GetMsgId(const CFE_SB_Msg_t *MsgPtr)
 /*   prohibitively large routing and index tables. */
 /*      uint16            SystemId;                              */
 /*      SystemId = CCSDS_RD_SYSTEM_ID(HdrPtr->ApidQ);            */
-/*      MsgId = (MsgId | (SystemId << 16)); */
+/*      MsgIdVal = (MsgIdVal | (SystemId << 16)); */
 
 #endif
 #endif
 
-return MsgId;
+return CFE_SB_ValueToMsgId(MsgIdVal);
 
 }/* end CFE_SB_GetMsgId */
 
@@ -159,16 +159,17 @@ return MsgId;
 void CFE_SB_SetMsgId(CFE_SB_MsgPtr_t MsgPtr,
                      CFE_SB_MsgId_t MsgId)
 {
+    CFE_SB_MsgId_Atom_t MsgIdVal = CFE_SB_MsgIdToValue(MsgId);
 
 #ifndef MESSAGE_FORMAT_IS_CCSDS_VER_2  
-    CCSDS_WR_SID(MsgPtr->Hdr, MsgId);
+    CCSDS_WR_SID(MsgPtr->Hdr, MsgIdVal);
 #else
   CCSDS_WR_VERS(MsgPtr->SpacePacket.Hdr, 1);
 
   /* Set the stream ID APID in the primary header. */
-  CCSDS_WR_APID(MsgPtr->SpacePacket.Hdr, CFE_SB_RD_APID_FROM_MSGID(MsgId) );
+  CCSDS_WR_APID(MsgPtr->SpacePacket.Hdr, CFE_SB_RD_APID_FROM_MSGID(MsgIdVal) );
   
-  CCSDS_WR_TYPE(MsgPtr->SpacePacket.Hdr, CFE_SB_RD_TYPE_FROM_MSGID(MsgId) );
+  CCSDS_WR_TYPE(MsgPtr->SpacePacket.Hdr, CFE_SB_RD_TYPE_FROM_MSGID(MsgIdVal) );
   
   
   CCSDS_CLR_SEC_APIDQ(MsgPtr->SpacePacket.ApidQ);
@@ -179,7 +180,7 @@ void CFE_SB_SetMsgId(CFE_SB_MsgPtr_t MsgPtr,
   
   CCSDS_WR_PLAYBACK(MsgPtr->SpacePacket.ApidQ, false);
   
-  CCSDS_WR_SUBSYSTEM_ID(MsgPtr->SpacePacket.ApidQ, CFE_SB_RD_SUBSYS_ID_FROM_MSGID(MsgId));
+  CCSDS_WR_SUBSYSTEM_ID(MsgPtr->SpacePacket.ApidQ, CFE_SB_RD_SUBSYS_ID_FROM_MSGID(MsgIdVal));
   
   CCSDS_WR_SYSTEM_ID(MsgPtr->SpacePacket.ApidQ, CFE_SPACECRAFT_ID);
 

--- a/fsw/cfe-core/src/sb/cfe_sb_msg_id_util.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_msg_id_util.c
@@ -185,3 +185,15 @@ void CFE_SB_SetMsgId(CFE_SB_MsgPtr_t MsgPtr,
 
 #endif 
 }/* end CFE_SB_SetMsgId */
+
+/*
+ * Function: CFE_SB_IsValidMsgId - See API and header file for details
+ */
+bool CFE_SB_IsValidMsgId(CFE_SB_MsgId_t MsgId)
+{
+    return (!CFE_SB_MsgId_Equal(MsgId, CFE_SB_INVALID_MSG_ID) &&
+            CFE_SB_MsgIdToValue(MsgId) <= CFE_SB_HIGHEST_VALID_MSGID);
+} /* end CFE_SB_IsValidMsgId */
+
+
+

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.c
@@ -676,7 +676,7 @@ uint8 CFE_SB_GetPktType(CFE_SB_MsgId_t MsgId)
 {
 
 #ifdef MESSAGE_FORMAT_IS_CCSDS
-    CFE_SB_MsgId_Atom_t Val = MsgId;
+    CFE_SB_MsgId_Atom_t Val = CFE_SB_MsgIdToValue(MsgId);
 
 #ifndef MESSAGE_FORMAT_IS_CCSDS_VER_2
         return CFE_TST(Val,12);

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.h
@@ -473,19 +473,6 @@ extern cfe_sb_t CFE_SB;
  * --------------------------------------------------------- */
 
 /**
- * @brief Identifies whether a given CFE_SB_MsgId_t is valid
- *
- * Implements a basic sanity check on the value provided
- *
- * @returns true if sanity checks passed, false otherwise.
- */
-static inline bool CFE_SB_IsValidMsgId(CFE_SB_MsgId_t MsgId)
-{
-    /* cppcheck-suppress redundantCondition */
-    return (MsgId != CFE_SB_INVALID_MSG_ID && MsgId <= CFE_PLATFORM_SB_HIGHEST_VALID_MSGID);
-}
-
-/**
  * @brief Identifies whether a given CFE_SB_MsgKey_t is valid
  *
  * Implements a basic sanity check on the value provided

--- a/fsw/cfe-core/src/sb/cfe_sb_task.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_task.c
@@ -217,17 +217,17 @@ int32 CFE_SB_AppInit(void){
     CFE_ES_WriteToSysLog("SB:Registered %d events for filtering\n",(int)CfgFileEventsToFilter);
 
     CFE_SB_InitMsg(&CFE_SB.HKTlmMsg,
-                   CFE_SB_HK_TLM_MID,
+                   CFE_SB_ValueToMsgId(CFE_SB_HK_TLM_MID),
                    sizeof(CFE_SB.HKTlmMsg),
                    true);
 
     CFE_SB_InitMsg(&CFE_SB.PrevSubMsg,
-                   CFE_SB_ALLSUBS_TLM_MID,
+                   CFE_SB_ValueToMsgId(CFE_SB_ALLSUBS_TLM_MID),
                    sizeof(CFE_SB.PrevSubMsg),
                    true);
 
     CFE_SB_InitMsg(&CFE_SB.SubRprtMsg,
-                   CFE_SB_ONESUB_TLM_MID,
+                   CFE_SB_ValueToMsgId(CFE_SB_ONESUB_TLM_MID),
                    sizeof(CFE_SB.SubRprtMsg),
                    true);    
 
@@ -250,14 +250,14 @@ int32 CFE_SB_AppInit(void){
       return Status;
     }/* end if */                                
 
-    Status = CFE_SB_Subscribe(CFE_SB_CMD_MID,CFE_SB.CmdPipe);
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_SB_CMD_MID),CFE_SB.CmdPipe);
 
     if(Status != CFE_SUCCESS){
       CFE_ES_WriteToSysLog("SB:Subscribe to Cmds Failed:RC=0x%08X\n",(unsigned int)Status);
       return Status;
     }/* end if */
         
-    Status = CFE_SB_Subscribe(CFE_SB_SEND_HK_MID,CFE_SB.CmdPipe);
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_SB_SEND_HK_MID),CFE_SB.CmdPipe);
 
     if(Status != CFE_SUCCESS){
       CFE_ES_WriteToSysLog("SB:Subscribe to HK Request Failed:RC=0x%08X\n",(unsigned int)Status);
@@ -323,7 +323,8 @@ bool CFE_SB_VerifyCmdLength(CFE_SB_MsgPtr_t Msg, uint16 ExpectedLength)
 
         CFE_EVS_SendEvent(CFE_SB_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
                 "Invalid cmd length: ID = 0x%X, CC = %d, Exp Len = %d, Len = %d",
-                (unsigned int)MessageID, (int)CommandCode, (int)ExpectedLength, (int)ActualLength);
+                (unsigned int)CFE_SB_MsgIdToValue(MessageID), (int)CommandCode,
+                (int)ExpectedLength, (int)ActualLength);
         result = false;
         ++CFE_SB.HKTlmMsg.Payload.CommandErrorCounter;
     }
@@ -347,7 +348,11 @@ bool CFE_SB_VerifyCmdLength(CFE_SB_MsgPtr_t Msg, uint16 ExpectedLength)
 **    none
 */
 void CFE_SB_ProcessCmdPipePkt(void) {
-   switch(CFE_SB_GetMsgId(CFE_SB.CmdPipePktPtr)){
+   CFE_SB_MsgId_t MessageID;
+
+   MessageID = CFE_SB_GetMsgId(CFE_SB.CmdPipePktPtr);
+
+   switch(CFE_SB_MsgIdToValue(MessageID)){
 
       case CFE_SB_SEND_HK_MID:
          /* Note: Command counter not incremented for this command */
@@ -446,7 +451,7 @@ void CFE_SB_ProcessCmdPipePkt(void) {
          default:
             CFE_EVS_SendEvent(CFE_SB_BAD_MSGID_EID,CFE_EVS_EventType_ERROR,
                   "Invalid Cmd, Unexpected Msg Id: 0x%04x",
-                  (unsigned int)CFE_SB_GetMsgId(CFE_SB.CmdPipePktPtr));
+                  (unsigned int)CFE_SB_MsgIdToValue(MessageID));
             CFE_SB.HKTlmMsg.Payload.CommandErrorCounter++;
             break;
 
@@ -606,7 +611,8 @@ int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRoute_t *data)
        (CFE_SB_ValidatePipeId(PipeId) != CFE_SUCCESS))
     {
         CFE_EVS_SendEvent(CFE_SB_ENBL_RTE3_EID,CFE_EVS_EventType_ERROR,
-                      "Enbl Route Cmd:Invalid Param.Msg 0x%x,Pipe %d",(unsigned int)MsgId,(int)PipeId);
+                      "Enbl Route Cmd:Invalid Param.Msg 0x%x,Pipe %d",
+                      (unsigned int)CFE_SB_MsgIdToValue(MsgId),(int)PipeId);
         CFE_SB.HKTlmMsg.Payload.CommandErrorCounter++;
         /*
          * returning "success" here as there is no other recourse;
@@ -618,7 +624,8 @@ int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRoute_t *data)
     DestPtr = CFE_SB_GetDestPtr(CFE_SB_ConvertMsgIdtoMsgKey(MsgId), PipeId);
     if(DestPtr == NULL){
         CFE_EVS_SendEvent(CFE_SB_ENBL_RTE1_EID,CFE_EVS_EventType_ERROR,
-                "Enbl Route Cmd:Route does not exist.Msg 0x%x,Pipe %d",(unsigned int)MsgId,(int)PipeId);
+                "Enbl Route Cmd:Route does not exist.Msg 0x%x,Pipe %d",
+                (unsigned int)CFE_SB_MsgIdToValue(MsgId),(int)PipeId);
         CFE_SB.HKTlmMsg.Payload.CommandErrorCounter++;
         /*
          * returning "success" here as there is no other recourse;
@@ -629,7 +636,8 @@ int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRoute_t *data)
 
     DestPtr->Active = CFE_SB_ACTIVE;
     CFE_EVS_SendEvent(CFE_SB_ENBL_RTE2_EID,CFE_EVS_EventType_DEBUG,
-                      "Enabling Route,Msg 0x%x,Pipe %d",(unsigned int)MsgId,(int)PipeId);
+                      "Enabling Route,Msg 0x%x,Pipe %d",
+                      (unsigned int)CFE_SB_MsgIdToValue(MsgId),(int)PipeId);
 
     CFE_SB.HKTlmMsg.Payload.CommandCounter++;
 
@@ -667,7 +675,8 @@ int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRoute_t *data)
     if(!CFE_SB_IsValidMsgId(MsgId) ||
        (CFE_SB_ValidatePipeId(PipeId) != CFE_SUCCESS)){
         CFE_EVS_SendEvent(CFE_SB_DSBL_RTE3_EID,CFE_EVS_EventType_ERROR,
-                   "Disable Route Cmd:Invalid Param.Msg 0x%x,Pipe %d",(unsigned int)MsgId,(int)PipeId);
+                   "Disable Route Cmd:Invalid Param.Msg 0x%x,Pipe %d",
+                   (unsigned int)CFE_SB_MsgIdToValue(MsgId),(int)PipeId);
         CFE_SB.HKTlmMsg.Payload.CommandErrorCounter++;
         /*
          * returning "success" here as there is no other recourse;
@@ -679,7 +688,8 @@ int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRoute_t *data)
     DestPtr = CFE_SB_GetDestPtr(CFE_SB_ConvertMsgIdtoMsgKey(MsgId), PipeId);
     if(DestPtr == NULL){
         CFE_EVS_SendEvent(CFE_SB_DSBL_RTE1_EID,CFE_EVS_EventType_ERROR,
-            "Disable Route Cmd:Route does not exist,Msg 0x%x,Pipe %d",(unsigned int)MsgId,(int)PipeId);
+            "Disable Route Cmd:Route does not exist,Msg 0x%x,Pipe %d",
+            (unsigned int)CFE_SB_MsgIdToValue(MsgId),(int)PipeId);
         CFE_SB.HKTlmMsg.Payload.CommandErrorCounter++;
         /*
          * returning "success" here as there is no other recourse;
@@ -691,7 +701,8 @@ int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRoute_t *data)
     DestPtr->Active = CFE_SB_INACTIVE;
 
     CFE_EVS_SendEvent(CFE_SB_DSBL_RTE2_EID,CFE_EVS_EventType_DEBUG,
-                      "Route Disabled,Msg 0x%x,Pipe %d",(unsigned int)MsgId,(int)PipeId);
+                      "Route Disabled,Msg 0x%x,Pipe %d",
+                      (unsigned int)CFE_SB_MsgIdToValue(MsgId),(int)PipeId);
     CFE_SB.HKTlmMsg.Payload.CommandCounter++;
 
     return CFE_SUCCESS;

--- a/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
@@ -145,14 +145,14 @@ int32 CFE_TBL_EarlyInit (void)
     ** Initialize housekeeping packet (clear user data area)...
     */
     CFE_SB_InitMsg(&CFE_TBL_TaskData.HkPacket,
-                    CFE_TBL_HK_TLM_MID,
+                    CFE_SB_ValueToMsgId(CFE_TBL_HK_TLM_MID),
                     sizeof(CFE_TBL_TaskData.HkPacket), true);
 
     /*
     ** Initialize table registry report packet (clear user data area)...
     */
     CFE_SB_InitMsg(&CFE_TBL_TaskData.TblRegPacket,
-                    CFE_TBL_REG_TLM_MID,
+                    CFE_SB_ValueToMsgId(CFE_TBL_REG_TLM_MID),
                     sizeof(CFE_TBL_TaskData.TblRegPacket), true);
 
     /* Initialize memory partition and allocate shared table buffers. */

--- a/fsw/cfe-core/src/time/cfe_time_task.c
+++ b/fsw/cfe-core/src/time/cfe_time_task.c
@@ -274,7 +274,7 @@ int32 CFE_TIME_TaskInit(void)
     }/* end if */
 
 
-    Status = CFE_SB_Subscribe(CFE_TIME_SEND_HK_MID,
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_SEND_HK_MID),
                               CFE_TIME_TaskData.CmdPipe);
     if(Status != CFE_SUCCESS)
     {
@@ -287,12 +287,12 @@ int32 CFE_TIME_TaskInit(void)
     ** Subscribe to time at the tone "signal" commands...
     */
     #if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
-    Status = CFE_SB_Subscribe(CFE_TIME_TONE_CMD_MID,
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_TONE_CMD_MID),
                               CFE_TIME_TaskData.CmdPipe);
     #endif
     
     #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
-    Status = CFE_SB_SubscribeLocal(CFE_TIME_TONE_CMD_MID,
+    Status = CFE_SB_SubscribeLocal(CFE_SB_ValueToMsgId(CFE_TIME_TONE_CMD_MID),
                               CFE_TIME_TaskData.CmdPipe,4);
     #endif
     if(Status != CFE_SUCCESS)
@@ -306,12 +306,12 @@ int32 CFE_TIME_TaskInit(void)
     ** Subscribe to time at the tone "data" commands...
     */
     #if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
-    Status = CFE_SB_Subscribe(CFE_TIME_DATA_CMD_MID,
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_DATA_CMD_MID),
                               CFE_TIME_TaskData.CmdPipe);
     #endif
     
     #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
-    Status = CFE_SB_SubscribeLocal(CFE_TIME_DATA_CMD_MID,
+    Status = CFE_SB_SubscribeLocal(CFE_SB_ValueToMsgId(CFE_TIME_DATA_CMD_MID),
                               CFE_TIME_TaskData.CmdPipe,4);
     #endif
     if(Status != CFE_SUCCESS)
@@ -325,12 +325,12 @@ int32 CFE_TIME_TaskInit(void)
     ** Subscribe to 1Hz signal commands...
     */
     #if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
-    Status = CFE_SB_Subscribe(CFE_TIME_1HZ_CMD_MID,
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_1HZ_CMD_MID),
                               CFE_TIME_TaskData.CmdPipe);
     #endif
     
     #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
-    Status = CFE_SB_SubscribeLocal(CFE_TIME_1HZ_CMD_MID,
+    Status = CFE_SB_SubscribeLocal(CFE_SB_ValueToMsgId(CFE_TIME_1HZ_CMD_MID),
                                    CFE_TIME_TaskData.CmdPipe,4);
     #endif
     
@@ -345,7 +345,7 @@ int32 CFE_TIME_TaskInit(void)
     ** Subscribe to time at the tone "request data" commands...
     */
     #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
-    Status = CFE_SB_Subscribe(CFE_TIME_SEND_CMD_MID,
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_SEND_CMD_MID),
                                   CFE_TIME_TaskData.CmdPipe);
     if(Status != CFE_SUCCESS)
     {
@@ -357,7 +357,7 @@ int32 CFE_TIME_TaskInit(void)
     /*
     ** Subscribe to Time task ground command packets...
     */
-    Status = CFE_SB_Subscribe(CFE_TIME_CMD_MID,
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_CMD_MID),
                               CFE_TIME_TaskData.CmdPipe);
     if(Status != CFE_SUCCESS)
     {
@@ -442,7 +442,8 @@ bool CFE_TIME_VerifyCmdLength(CFE_SB_MsgPtr_t Msg, uint16 ExpectedLength)
 
         CFE_EVS_SendEvent(CFE_TIME_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
                 "Invalid cmd length: ID = 0x%X, CC = %d, Exp Len = %d, Len = %d",
-                (unsigned int)MessageID, (int)CommandCode, (int)ExpectedLength, (int)ActualLength);
+                (unsigned int)CFE_SB_MsgIdToValue(MessageID), 
+                (int)CommandCode, (int)ExpectedLength, (int)ActualLength);
         result = false;
         ++CFE_TIME_TaskData.CommandErrorCounter;
     }
@@ -464,7 +465,7 @@ void CFE_TIME_TaskPipe(CFE_SB_MsgPtr_t MessagePtr)
     uint16 CommandCode;
 
     MessageID = CFE_SB_GetMsgId(MessagePtr);
-    switch (MessageID)
+    switch (CFE_SB_MsgIdToValue(MessageID))
     {
         /*
         ** Housekeeping telemetry request...
@@ -634,7 +635,8 @@ void CFE_TIME_TaskPipe(CFE_SB_MsgPtr_t MessagePtr)
                     CFE_TIME_TaskData.CommandErrorCounter++;
                     CFE_EVS_SendEvent(CFE_TIME_CC_ERR_EID, CFE_EVS_EventType_ERROR,
                              "Invalid command code -- ID = 0x%X, CC = %d",
-                                      (unsigned int)MessageID, (int)CommandCode);
+                                      (unsigned int)CFE_SB_MsgIdToValue(MessageID), 
+                                      (int)CommandCode);
                     break;
             } /* switch (CFE_TIME_CMD_MID -- command code)*/
             break;
@@ -647,7 +649,7 @@ void CFE_TIME_TaskPipe(CFE_SB_MsgPtr_t MessagePtr)
             */
             CFE_EVS_SendEvent(CFE_TIME_ID_ERR_EID, CFE_EVS_EventType_ERROR,
                              "Invalid message ID -- ID = 0x%X",
-                              (unsigned int)MessageID);
+                              (unsigned int)CFE_SB_MsgIdToValue(MessageID));
             break;
 
     } /* switch (message ID) */

--- a/fsw/cfe-core/src/time/cfe_time_utils.c
+++ b/fsw/cfe-core/src/time/cfe_time_utils.c
@@ -389,21 +389,21 @@ void CFE_TIME_InitData(void)
     ** Initialize housekeeping packet (clear user data area)...
     */
     CFE_SB_InitMsg(&CFE_TIME_TaskData.HkPacket,
-                    CFE_TIME_HK_TLM_MID,
+                    CFE_SB_ValueToMsgId(CFE_TIME_HK_TLM_MID),
                     sizeof(CFE_TIME_TaskData.HkPacket), true);
 
     /*
     ** Initialize diagnostic packet (clear user data area)...
     */
     CFE_SB_InitMsg(&CFE_TIME_TaskData.DiagPacket,
-                    CFE_TIME_DIAG_TLM_MID,
+                    CFE_SB_ValueToMsgId(CFE_TIME_DIAG_TLM_MID),
                     sizeof(CFE_TIME_TaskData.DiagPacket), true);
 
     /*
     ** Initialize "time at the tone" signal command packet...
     */
     CFE_SB_InitMsg(&CFE_TIME_TaskData.ToneSignalCmd,
-                    CFE_TIME_TONE_CMD_MID,
+                    CFE_SB_ValueToMsgId(CFE_TIME_TONE_CMD_MID),
                     sizeof(CFE_TIME_TaskData.ToneSignalCmd), true);
 
     /*
@@ -411,7 +411,7 @@ void CFE_TIME_InitData(void)
     */
     #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
     CFE_SB_InitMsg(&CFE_TIME_TaskData.ToneDataCmd,
-                    CFE_TIME_DATA_CMD_MID,
+                    CFE_SB_ValueToMsgId(CFE_TIME_DATA_CMD_MID),
                     sizeof(CFE_TIME_TaskData.ToneDataCmd), true);
     #endif
 
@@ -420,7 +420,7 @@ void CFE_TIME_InitData(void)
     */
 #if (CFE_MISSION_TIME_CFG_FAKE_TONE == true)
     CFE_SB_InitMsg(&CFE_TIME_TaskData.ToneSendCmd,
-                    CFE_TIME_SEND_CMD_MID,
+                    CFE_SB_ValueToMsgId(CFE_TIME_SEND_CMD_MID),
                     sizeof(CFE_TIME_TaskData.ToneSendCmd), true);
 #endif
 
@@ -428,7 +428,7 @@ void CFE_TIME_InitData(void)
     ** Initialize local 1Hz "wake-up" command packet (optional)...
     */
     CFE_SB_InitMsg(&CFE_TIME_TaskData.Local1HzCmd,
-                    CFE_TIME_1HZ_CMD_MID,
+                    CFE_SB_ValueToMsgId(CFE_TIME_1HZ_CMD_MID),
                     sizeof(CFE_TIME_TaskData.Local1HzCmd), true);
 
     return;

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -68,141 +68,142 @@ char StartupScript[MAX_STARTUP_SCRIPT];
 
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_NOOP_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_NOOP_CC
 };
 
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_RESET_COUNTERS_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_RESET_COUNTERS_CC
 };
 
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_RESTART_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_RESTART_CC
 };
 
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_SHELL_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_SHELL_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_START_APP_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_START_APP_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_STOP_APP_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_STOP_APP_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_RESTART_APP_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_RESTART_APP_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_RELOAD_APP_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_RELOAD_APP_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_QUERY_ONE_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
-        .CommandCode = CFE_ES_QUERY_ONE_CC };
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
+        .CommandCode = CFE_ES_QUERY_ONE_CC 
+};
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_QUERY_ALL_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_QUERY_ALL_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_QUERY_ALL_TASKS_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_QUERY_ALL_TASKS_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_CLEAR_SYSLOG_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_CLEAR_SYSLOG_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_WRITE_SYSLOG_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_OVER_WRITE_SYSLOG_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_OVER_WRITE_SYSLOG_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_CLEAR_ER_LOG_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_CLEAR_ER_LOG_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_WRITE_ER_LOG_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_WRITE_ER_LOG_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_START_PERF_DATA_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_START_PERF_DATA_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_STOP_PERF_DATA_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_STOP_PERF_DATA_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_SET_PERF_FILTER_MASK_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_SET_PERF_FILTER_MASK_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_SET_PERF_TRIGGER_MASK_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_SET_PERF_TRIGGER_MASK_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_RESET_PR_COUNT_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_RESET_PR_COUNT_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_SET_MAX_PR_COUNT_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_SET_MAX_PR_COUNT_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_DELETE_CDS_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_DELETE_CDS_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_SEND_MEM_POOL_STATS_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_SEND_MEM_POOL_STATS_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_DUMP_CDS_REGISTRY_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_DUMP_CDS_REGISTRY_CC
 };
 
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_CMD_INVALID_CC =
 {
-        .MsgId = CFE_ES_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
         .CommandCode = CFE_ES_DUMP_CDS_REGISTRY_CC + 2
 };
 
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_SEND_HK =
 {
-        .MsgId = CFE_ES_SEND_HK_MID
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_SEND_HK_MID)
 };
 
 

--- a/fsw/cfe-core/unit-test/evs_UT.c
+++ b/fsw/cfe-core/unit-test/evs_UT.c
@@ -61,135 +61,135 @@ static const char *EVS_SYSLOG_MSGS[] =
 
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_EVS_CMD_NOOP_CC =
 {
-        .MsgId = CFE_EVS_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
         .CommandCode = CFE_EVS_NOOP_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_RESET_COUNTERS_CC =
 {
-        .MsgId = CFE_EVS_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
         .CommandCode = CFE_EVS_RESET_COUNTERS_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_ENABLE_EVENT_TYPE_CC =
 {
-        .MsgId = CFE_EVS_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
         .CommandCode = CFE_EVS_ENABLE_EVENT_TYPE_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_DISABLE_EVENT_TYPE_CC =
 {
-        .MsgId = CFE_EVS_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
         .CommandCode = CFE_EVS_DISABLE_EVENT_TYPE_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_SET_EVENT_FORMAT_MODE_CC =
 {
-        .MsgId = CFE_EVS_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
         .CommandCode = CFE_EVS_SET_EVENT_FORMAT_MODE_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_ENABLE_APP_EVENT_TYPE_CC =
 {
-        .MsgId = CFE_EVS_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
         .CommandCode = CFE_EVS_ENABLE_APP_EVENT_TYPE_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_DISABLE_APP_EVENT_TYPE_CC =
 {
-        .MsgId = CFE_EVS_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
         .CommandCode = CFE_EVS_DISABLE_APP_EVENT_TYPE_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_ENABLE_APP_EVENTS_CC =
 {
-        .MsgId = CFE_EVS_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
         .CommandCode = CFE_EVS_ENABLE_APP_EVENTS_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_DISABLE_APP_EVENTS_CC =
 {
-        .MsgId = CFE_EVS_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
         .CommandCode = CFE_EVS_DISABLE_APP_EVENTS_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_RESET_APP_COUNTER_CC =
 {
-        .MsgId = CFE_EVS_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
         .CommandCode = CFE_EVS_RESET_APP_COUNTER_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_SET_FILTER_CC =
 {
-        .MsgId = CFE_EVS_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
         .CommandCode = CFE_EVS_SET_FILTER_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_ENABLE_PORTS_CC =
 {
-        .MsgId = CFE_EVS_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
         .CommandCode = CFE_EVS_ENABLE_PORTS_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_DISABLE_PORTS_CC =
 {
-        .MsgId = CFE_EVS_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
         .CommandCode = CFE_EVS_DISABLE_PORTS_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_RESET_FILTER_CC =
 {
-        .MsgId = CFE_EVS_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
         .CommandCode = CFE_EVS_RESET_FILTER_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_RESET_ALL_FILTERS_CC =
 {
-        .MsgId = CFE_EVS_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
         .CommandCode = CFE_EVS_RESET_ALL_FILTERS_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_ADD_EVENT_FILTER_CC =
 {
-        .MsgId = CFE_EVS_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
         .CommandCode = CFE_EVS_ADD_EVENT_FILTER_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_DELETE_EVENT_FILTER_CC =
 {
-        .MsgId = CFE_EVS_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
         .CommandCode = CFE_EVS_DELETE_EVENT_FILTER_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_WRITE_APP_DATA_FILE_CC =
 {
-        .MsgId = CFE_EVS_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
         .CommandCode = CFE_EVS_WRITE_APP_DATA_FILE_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_WRITE_LOG_DATA_FILE_CC =
 {
-        .MsgId = CFE_EVS_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
         .CommandCode = CFE_EVS_WRITE_LOG_DATA_FILE_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_SET_LOG_MODE_CC =
 {
-        .MsgId = CFE_EVS_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
         .CommandCode = CFE_EVS_SET_LOG_MODE_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_CLEAR_LOG_CC =
 {
-        .MsgId = CFE_EVS_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
         .CommandCode = CFE_EVS_CLEAR_LOG_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_EVS_INVALID_MID =
 {
-        .MsgId = 0xFFFF,
+        .MsgId = CFE_SB_MSGID_RESERVED,
         .CommandCode = 0
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_EVS_CMD_INVALID_CC =
 {
-        .MsgId = CFE_EVS_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
         .CommandCode = 0x7F
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_EVS_SEND_HK =
 {
-        .MsgId = CFE_EVS_SEND_HK_MID
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_SEND_HK_MID)
 };
 
 
 static const UT_SoftwareBusSnapshot_Entry_t UT_EVS_LONGFMT_SNAPSHOTDATA =
 {
-        .MsgId = CFE_EVS_LONG_EVENT_MSG_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_LONG_EVENT_MSG_MID),
         .SnapshotOffset = offsetof(CFE_EVS_LongEventTlm_t, Payload.PacketID.EventID),
         .SnapshotSize = sizeof(uint16)
 };
 
 static const UT_SoftwareBusSnapshot_Entry_t UT_EVS_SHORTFMT_SNAPSHOTDATA =
 {
-        .MsgId = CFE_EVS_SHORT_EVENT_MSG_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_SHORT_EVENT_MSG_MID),
         .SnapshotOffset = offsetof(CFE_EVS_ShortEventTlm_t, Payload.PacketID.EventID),
         .SnapshotSize = sizeof(uint16)
 };
@@ -892,14 +892,14 @@ void Test_Format(void)
     CFE_EVS_PacketID_t           CapturedMsg;
     UT_SoftwareBusSnapshot_Entry_t LongFmtSnapshotData =
     {
-            .MsgId = CFE_EVS_LONG_EVENT_MSG_MID,
+            .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_LONG_EVENT_MSG_MID),
             .SnapshotBuffer = &CapturedMsg,
             .SnapshotOffset = offsetof(CFE_EVS_LongEventTlm_t, Payload.PacketID),
             .SnapshotSize = sizeof(CapturedMsg)
     };
     UT_SoftwareBusSnapshot_Entry_t ShortFmtSnapshotData =
     {
-            .MsgId = CFE_EVS_SHORT_EVENT_MSG_MID,
+            .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_SHORT_EVENT_MSG_MID),
             .SnapshotBuffer = &CapturedMsg,
             .SnapshotOffset = offsetof(CFE_EVS_ShortEventTlm_t, Payload.PacketID),
             .SnapshotSize = sizeof(CapturedMsg)
@@ -1052,7 +1052,7 @@ void Test_Ports(void)
     CFE_EVS_BitMaskCmd_t    bitmaskcmd;
     UT_SoftwareBusSnapshot_Entry_t LocalSnapshotData =
     {
-            .MsgId = CFE_EVS_LONG_EVENT_MSG_MID
+            .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_LONG_EVENT_MSG_MID)
     };
 
 #ifdef UT_VERBOSE
@@ -1922,7 +1922,7 @@ void Test_EventCmd(void)
     CFE_EVS_AppNameCmd_t        appnamecmd;
     UT_SoftwareBusSnapshot_Entry_t LocalSnapshotData =
     {
-        .MsgId = CFE_EVS_LONG_EVENT_MSG_MID
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_LONG_EVENT_MSG_MID)
     };
 
 #ifdef UT_VERBOSE
@@ -2663,7 +2663,7 @@ void Test_Misc(void)
     char               msg[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH + 2];
     UT_SoftwareBusSnapshot_Entry_t HK_SnapshotData =
     {
-            .MsgId = CFE_EVS_HK_TLM_MID
+            .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_HK_TLM_MID)
     };
 
 

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -40,6 +40,66 @@
 */
 #include "sb_UT.h"
 
+/*
+ * MSG ID constants for unit testing:
+ * Unit test cases should not directly use integer MsgId values
+ *
+ * The following constants are of the CFE_SB_MsgId_t type
+ */
+
+const CFE_SB_MsgId_t SB_UT_CMD_MID  = CFE_SB_MSGID_WRAP_VALUE(SB_UT_CMD_MID_VALUE_BASE);
+const CFE_SB_MsgId_t SB_UT_TLM_MID  = CFE_SB_MSGID_WRAP_VALUE(SB_UT_TLM_MID_VALUE_BASE);
+
+const CFE_SB_MsgId_t SB_UT_CMD_MID1 = CFE_SB_MSGID_WRAP_VALUE(SB_UT_CMD_MID_VALUE_BASE+1);
+const CFE_SB_MsgId_t SB_UT_CMD_MID2 = CFE_SB_MSGID_WRAP_VALUE(SB_UT_CMD_MID_VALUE_BASE+2);
+const CFE_SB_MsgId_t SB_UT_CMD_MID3 = CFE_SB_MSGID_WRAP_VALUE(SB_UT_CMD_MID_VALUE_BASE+3);
+const CFE_SB_MsgId_t SB_UT_CMD_MID4 = CFE_SB_MSGID_WRAP_VALUE(SB_UT_CMD_MID_VALUE_BASE+4);
+const CFE_SB_MsgId_t SB_UT_CMD_MID5 = CFE_SB_MSGID_WRAP_VALUE(SB_UT_CMD_MID_VALUE_BASE+5);
+const CFE_SB_MsgId_t SB_UT_CMD_MID6 = CFE_SB_MSGID_WRAP_VALUE(SB_UT_CMD_MID_VALUE_BASE+6);
+
+const CFE_SB_MsgId_t SB_UT_TLM_MID1 = CFE_SB_MSGID_WRAP_VALUE(SB_UT_TLM_MID_VALUE_BASE+1);
+const CFE_SB_MsgId_t SB_UT_TLM_MID2 = CFE_SB_MSGID_WRAP_VALUE(SB_UT_TLM_MID_VALUE_BASE+2);
+const CFE_SB_MsgId_t SB_UT_TLM_MID3 = CFE_SB_MSGID_WRAP_VALUE(SB_UT_TLM_MID_VALUE_BASE+3);
+const CFE_SB_MsgId_t SB_UT_TLM_MID4 = CFE_SB_MSGID_WRAP_VALUE(SB_UT_TLM_MID_VALUE_BASE+4);
+const CFE_SB_MsgId_t SB_UT_TLM_MID5 = CFE_SB_MSGID_WRAP_VALUE(SB_UT_TLM_MID_VALUE_BASE+5);
+const CFE_SB_MsgId_t SB_UT_TLM_MID6 = CFE_SB_MSGID_WRAP_VALUE(SB_UT_TLM_MID_VALUE_BASE+6);
+
+/*
+ * A MsgId value which still qualifies as valid
+ *
+ * This is a  "borderline" value to test the limits of the validity checking
+ * The specific value depends on how MsgId is actually defined internally
+ */
+const CFE_SB_MsgId_t SB_UT_LAST_VALID_MID = CFE_SB_MSGID_WRAP_VALUE(CFE_PLATFORM_SB_HIGHEST_VALID_MSGID);
+
+/*
+ * A MsgId value which still qualifies as valid
+ *
+ * This is a  "borderline" value to test the limits of the validity checking
+ * The specific value depends on how MsgId is actually defined internally
+ */
+const CFE_SB_MsgId_t SB_UT_FIRST_VALID_MID = CFE_SB_MSGID_WRAP_VALUE(0);
+
+/*
+ * A MsgId value which is in the middle of the valid range
+ *
+ * The specific value depends on how MsgId is actually defined internally
+ */
+const CFE_SB_MsgId_t SB_UT_INTERMEDIATE_VALID_MID = CFE_SB_MSGID_WRAP_VALUE(CFE_PLATFORM_SB_HIGHEST_VALID_MSGID / 2 + 1);
+
+/*
+ * A MsgId value which is not valid but also not equal to CFE_SB_INVALID_MSG_ID
+ * Like CFE_SB_INVALID_MSG_ID, this should also _not_ pass the validity check.
+ */
+const CFE_SB_MsgId_t SB_UT_ALTERNATE_INVALID_MID = CFE_SB_MSGID_WRAP_VALUE(CFE_PLATFORM_SB_HIGHEST_VALID_MSGID + 1);
+
+
+/*
+ * A MsgId value which is valid per CCSDS but does not have the secondary header bit set
+ */
+const CFE_SB_MsgId_t SB_UT_BARE_MID3 = CFE_SB_MSGID_WRAP_VALUE(0x0003);
+
+
 static char    cMsg[UT_MAX_MESSAGE_LENGTH];
 
 /*
@@ -1029,7 +1089,7 @@ void Test_SB_Cmds_Noop(void)
 #endif
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&NoParamCmd, CFE_SB_CMD_MID, sizeof(NoParamCmd), true);
+    CFE_SB_InitMsg(&NoParamCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID), sizeof(NoParamCmd), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &NoParamCmd, CFE_SB_NOOP_CC);
     CFE_SB.CmdPipePktPtr = (CFE_SB_MsgPtr_t) &NoParamCmd;
     CFE_SB_ProcessCmdPipePkt();
@@ -1071,7 +1131,7 @@ void Test_SB_Cmds_RstCtrs(void)
 #endif
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&NoParamCmd, CFE_SB_CMD_MID, sizeof(NoParamCmd), true);
+    CFE_SB_InitMsg(&NoParamCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID), sizeof(NoParamCmd), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &NoParamCmd, CFE_SB_RESET_COUNTERS_CC);
     CFE_SB.CmdPipePktPtr = (CFE_SB_MsgPtr_t) &NoParamCmd;
     CFE_SB_ProcessCmdPipePkt();
@@ -1113,7 +1173,7 @@ void Test_SB_Cmds_Stats(void)
 #endif
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&NoParamCmd, CFE_SB_CMD_MID, sizeof(NoParamCmd), true);
+    CFE_SB_InitMsg(&NoParamCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID), sizeof(NoParamCmd), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &NoParamCmd, CFE_SB_SEND_SB_STATS_CC);
     CFE_SB.CmdPipePktPtr = (CFE_SB_MsgPtr_t) &NoParamCmd;
     CFE_SB_ProcessCmdPipePkt();
@@ -1162,7 +1222,7 @@ void Test_SB_Cmds_RoutingInfoDef(void)
 #endif
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&WriteFileCmd, CFE_SB_CMD_MID,
+    CFE_SB_InitMsg(&WriteFileCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID),
                    sizeof(WriteFileCmd), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &WriteFileCmd,
                       CFE_SB_SEND_ROUTING_INFO_CC);
@@ -1242,7 +1302,7 @@ void Test_SB_Cmds_RoutingInfoSpec(void)
 #endif
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&WriteFileCmd, CFE_SB_CMD_MID,
+    CFE_SB_InitMsg(&WriteFileCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID),
                    sizeof(WriteFileCmd), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &WriteFileCmd,
                       CFE_SB_SEND_ROUTING_INFO_CC);
@@ -1287,7 +1347,7 @@ void Test_SB_Cmds_RoutingInfoCreateFail(void)
 #endif
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&WriteFileCmd, CFE_SB_CMD_MID,
+    CFE_SB_InitMsg(&WriteFileCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID),
                    sizeof(WriteFileCmd), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &WriteFileCmd,
                       CFE_SB_SEND_ROUTING_INFO_CC);
@@ -1476,7 +1536,7 @@ void Test_SB_Cmds_PipeInfoDef(void)
 #endif
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&WriteFileCmd, CFE_SB_CMD_MID,
+    CFE_SB_InitMsg(&WriteFileCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID),
                    sizeof(WriteFileCmd), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &WriteFileCmd,
                       CFE_SB_SEND_PIPE_INFO_CC);
@@ -1535,7 +1595,7 @@ void Test_SB_Cmds_PipeInfoSpec(void)
 #endif
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&WriteFileCmd, CFE_SB_CMD_MID,
+    CFE_SB_InitMsg(&WriteFileCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID),
                    sizeof(WriteFileCmd), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &WriteFileCmd,
                       CFE_SB_SEND_PIPE_INFO_CC);
@@ -1744,12 +1804,12 @@ void Test_SB_Cmds_MapInfoDef(void)
     CFE_SB_PipeId_t           PipeId1;
     CFE_SB_PipeId_t           PipeId2;
     CFE_SB_PipeId_t           PipeId3;
-    CFE_SB_MsgId_t            MsgId0 = SB_UT_TLM_MID + 1;
-    CFE_SB_MsgId_t            MsgId1 = SB_UT_TLM_MID + 2;
-    CFE_SB_MsgId_t            MsgId2 = SB_UT_TLM_MID + 3;
-    CFE_SB_MsgId_t            MsgId3 = SB_UT_TLM_MID + 4;
-    CFE_SB_MsgId_t            MsgId4 = SB_UT_TLM_MID + 5;
-    CFE_SB_MsgId_t            MsgId5 = SB_UT_TLM_MID + 6;
+    CFE_SB_MsgId_t            MsgId0 = SB_UT_TLM_MID1;
+    CFE_SB_MsgId_t            MsgId1 = SB_UT_TLM_MID2;
+    CFE_SB_MsgId_t            MsgId2 = SB_UT_TLM_MID3;
+    CFE_SB_MsgId_t            MsgId3 = SB_UT_TLM_MID4;
+    CFE_SB_MsgId_t            MsgId4 = SB_UT_TLM_MID5;
+    CFE_SB_MsgId_t            MsgId5 = SB_UT_TLM_MID6;
     uint16                    PipeDepth = 10;
     int32                     ExpRtn;
     int32                     ActRtn;
@@ -1760,7 +1820,7 @@ void Test_SB_Cmds_MapInfoDef(void)
 #endif
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&WriteFileCmd, CFE_SB_CMD_MID,
+    CFE_SB_InitMsg(&WriteFileCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID),
                    sizeof(WriteFileCmd), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &WriteFileCmd,
                       CFE_SB_SEND_MAP_INFO_CC);
@@ -1832,7 +1892,7 @@ void Test_SB_Cmds_MapInfoSpec(void)
 #endif
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&WriteFileCmd, CFE_SB_CMD_MID,
+    CFE_SB_InitMsg(&WriteFileCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID),
                    sizeof(WriteFileCmd), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &WriteFileCmd,
                       CFE_SB_SEND_MAP_INFO_CC);
@@ -1973,12 +2033,12 @@ void Test_SB_Cmds_MapInfoWriteFail(void)
     CFE_SB_PipeId_t PipeId1;
     CFE_SB_PipeId_t PipeId2;
     CFE_SB_PipeId_t PipeId3;
-    CFE_SB_MsgId_t  MsgId0 = SB_UT_TLM_MID + 1;
-    CFE_SB_MsgId_t  MsgId1 = SB_UT_TLM_MID + 2;
-    CFE_SB_MsgId_t  MsgId2 = SB_UT_TLM_MID + 3;
-    CFE_SB_MsgId_t  MsgId3 = SB_UT_TLM_MID + 4;
-    CFE_SB_MsgId_t  MsgId4 = SB_UT_TLM_MID + 5;
-    CFE_SB_MsgId_t  MsgId5 = SB_UT_TLM_MID + 6;
+    CFE_SB_MsgId_t  MsgId0 = SB_UT_TLM_MID1;
+    CFE_SB_MsgId_t  MsgId1 = SB_UT_TLM_MID2;
+    CFE_SB_MsgId_t  MsgId2 = SB_UT_TLM_MID3;
+    CFE_SB_MsgId_t  MsgId3 = SB_UT_TLM_MID4;
+    CFE_SB_MsgId_t  MsgId4 = SB_UT_TLM_MID5;
+    CFE_SB_MsgId_t  MsgId5 = SB_UT_TLM_MID6;
     uint16          PipeDepth = 10;
     int32           ExpRtn;
     int32           ActRtn;
@@ -2073,7 +2133,7 @@ void Test_SB_Cmds_EnRouteValParam(void)
     SB_ResetUnitTest();
     CFE_SB_CreatePipe(&PipeId, PipeDepth, "EnRouteTestPipe");
     CFE_SB_Subscribe(MsgId, PipeId);
-    CFE_SB_InitMsg(&EnDisRouteCmd, CFE_SB_CMD_MID,
+    CFE_SB_InitMsg(&EnDisRouteCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID),
                    sizeof(EnDisRouteCmd), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &EnDisRouteCmd,
                       CFE_SB_ENABLE_ROUTE_CC);
@@ -2139,7 +2199,7 @@ void Test_SB_Cmds_EnRouteNonExist(void)
     CFE_SB_CreatePipe(&PipeId1, PipeDepth, "EnRouteTestPipe1");
     CFE_SB_CreatePipe(&PipeId2, PipeDepth, "EnRouteTestPipe2");
     CFE_SB_Subscribe(MsgId, PipeId1);
-    CFE_SB_InitMsg(&EnDisRouteCmd, CFE_SB_CMD_MID,
+    CFE_SB_InitMsg(&EnDisRouteCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID),
                    sizeof(EnDisRouteCmd), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &EnDisRouteCmd,
                       CFE_SB_ENABLE_ROUTE_CC);
@@ -2199,11 +2259,11 @@ void Test_SB_Cmds_EnRouteInvParam(void)
 #endif
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&EnDisRouteCmd, CFE_SB_CMD_MID,
+    CFE_SB_InitMsg(&EnDisRouteCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID),
                    sizeof(EnDisRouteCmd), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &EnDisRouteCmd,
                       CFE_SB_ENABLE_ROUTE_CC);
-    EnDisRouteCmd.Payload.MsgId = CFE_PLATFORM_SB_HIGHEST_VALID_MSGID;
+    EnDisRouteCmd.Payload.MsgId = SB_UT_LAST_VALID_MID;
     EnDisRouteCmd.Payload.Pipe = 3;
     CFE_SB.CmdPipePktPtr = (CFE_SB_MsgPtr_t) &EnDisRouteCmd;
     CFE_SB_ProcessCmdPipePkt();
@@ -2245,7 +2305,7 @@ void Test_SB_Cmds_EnRouteInvParam2(void)
 #endif
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&EnDisRouteCmd, CFE_SB_CMD_MID,
+    CFE_SB_InitMsg(&EnDisRouteCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID),
                    sizeof(EnDisRouteCmd), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &EnDisRouteCmd,
                       CFE_SB_ENABLE_ROUTE_CC);
@@ -2292,11 +2352,11 @@ void Test_SB_Cmds_EnRouteInvParam3(void)
 #endif
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&EnDisRouteCmd, CFE_SB_CMD_MID,
+    CFE_SB_InitMsg(&EnDisRouteCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID),
                    sizeof(EnDisRouteCmd), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &EnDisRouteCmd,
                       CFE_SB_ENABLE_ROUTE_CC);
-    EnDisRouteCmd.Payload.MsgId = CFE_PLATFORM_SB_HIGHEST_VALID_MSGID + 1;
+    EnDisRouteCmd.Payload.MsgId = SB_UT_ALTERNATE_INVALID_MID;
     EnDisRouteCmd.Payload.Pipe = 0;
     CFE_SB.CmdPipePktPtr = (CFE_SB_MsgPtr_t) &EnDisRouteCmd;
     CFE_SB_ProcessCmdPipePkt();
@@ -2343,7 +2403,7 @@ void Test_SB_Cmds_DisRouteValParam(void)
     SB_ResetUnitTest();
     CFE_SB_CreatePipe(&PipeId, PipeDepth, "DisRouteTestPipe");
     CFE_SB_Subscribe(MsgId, PipeId);
-    CFE_SB_InitMsg(&EnDisRouteCmd, CFE_SB_CMD_MID,
+    CFE_SB_InitMsg(&EnDisRouteCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID),
                    sizeof(EnDisRouteCmd), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &EnDisRouteCmd,
                       CFE_SB_DISABLE_ROUTE_CC);
@@ -2408,7 +2468,7 @@ void Test_SB_Cmds_DisRouteNonExist(void)
     CFE_SB_CreatePipe(&PipeId1, PipeDepth, "DisRouteTestPipe1");
     CFE_SB_CreatePipe(&PipeId2, PipeDepth, "DisRouteTestPipe2");
     CFE_SB_Subscribe(MsgId, PipeId1);
-    CFE_SB_InitMsg(&EnDisRouteCmd, CFE_SB_CMD_MID,
+    CFE_SB_InitMsg(&EnDisRouteCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID),
                    sizeof(EnDisRouteCmd), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &EnDisRouteCmd,
                       CFE_SB_DISABLE_ROUTE_CC);
@@ -2468,11 +2528,11 @@ void Test_SB_Cmds_DisRouteInvParam(void)
 #endif
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&EnDisRouteCmd, CFE_SB_CMD_MID,
+    CFE_SB_InitMsg(&EnDisRouteCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID),
                    sizeof(EnDisRouteCmd), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &EnDisRouteCmd,
                       CFE_SB_DISABLE_ROUTE_CC);
-    EnDisRouteCmd.Payload.MsgId = CFE_PLATFORM_SB_HIGHEST_VALID_MSGID;
+    EnDisRouteCmd.Payload.MsgId = SB_UT_LAST_VALID_MID;
     EnDisRouteCmd.Payload.Pipe = 3;
     CFE_SB.CmdPipePktPtr = (CFE_SB_MsgPtr_t) &EnDisRouteCmd;
     CFE_SB_ProcessCmdPipePkt();
@@ -2514,7 +2574,7 @@ void Test_SB_Cmds_DisRouteInvParam2(void)
 #endif
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&EnDisRouteCmd, CFE_SB_CMD_MID,
+    CFE_SB_InitMsg(&EnDisRouteCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID),
                    sizeof(EnDisRouteCmd), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &EnDisRouteCmd,
                       CFE_SB_DISABLE_ROUTE_CC);
@@ -2561,11 +2621,11 @@ void Test_SB_Cmds_DisRouteInvParam3(void)
 #endif
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&EnDisRouteCmd, CFE_SB_CMD_MID,
+    CFE_SB_InitMsg(&EnDisRouteCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID),
                    sizeof(EnDisRouteCmd), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &EnDisRouteCmd,
                       CFE_SB_DISABLE_ROUTE_CC);
-    EnDisRouteCmd.Payload.MsgId = CFE_PLATFORM_SB_HIGHEST_VALID_MSGID + 1;
+    EnDisRouteCmd.Payload.MsgId = SB_UT_ALTERNATE_INVALID_MID;
     EnDisRouteCmd.Payload.Pipe = 0;
     CFE_SB.CmdPipePktPtr = (CFE_SB_MsgPtr_t) &EnDisRouteCmd;
     CFE_SB_ProcessCmdPipePkt();
@@ -2607,7 +2667,7 @@ void Test_SB_Cmds_SendHK(void)
 #endif
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&NoParamCmd, CFE_SB_SEND_HK_MID,
+    CFE_SB_InitMsg(&NoParamCmd, CFE_SB_ValueToMsgId(CFE_SB_SEND_HK_MID),
                    sizeof(NoParamCmd), true);
     CFE_SB.CmdPipePktPtr = (CFE_SB_MsgPtr_t) &NoParamCmd;
 
@@ -2644,7 +2704,7 @@ void Test_SB_Cmds_SendPrevSubs(void)
     CFE_SB_SendPrevSubs_t NoParamCmd;
     CFE_SB_PipeId_t PipeId1;
     CFE_SB_PipeId_t PipeId2;
-    CFE_SB_MsgId_t  MsgId = 0x0003;
+    CFE_SB_MsgId_t  MsgId = SB_UT_BARE_MID3;
     uint16          MsgLim = 4;
     uint16          PipeDepth = 50;
     int32           i;
@@ -2658,7 +2718,7 @@ void Test_SB_Cmds_SendPrevSubs(void)
 #endif
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&NoParamCmd, CFE_SB_CMD_MID, sizeof(CFE_SB_SendPrevSubs_t), true);
+    CFE_SB_InitMsg(&NoParamCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID), sizeof(CFE_SB_SendPrevSubs_t), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &NoParamCmd, CFE_SB_SEND_PREV_SUBS_CC);
     CFE_SB.CmdPipePktPtr = (CFE_SB_MsgPtr_t) &NoParamCmd;
     CFE_SB_CreatePipe(&PipeId1, PipeDepth, "TestPipe1");
@@ -2679,7 +2739,7 @@ void Test_SB_Cmds_SendPrevSubs(void)
         if (i != CFE_SB_ALLSUBS_TLM_MID)
         {
             NumEvts += 2;
-            ActRtn = CFE_SB_Subscribe(i, PipeId1);
+            ActRtn = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(i), PipeId1);
             ExpRtn = CFE_SUCCESS;
 
             if (ActRtn != ExpRtn)
@@ -2714,7 +2774,7 @@ void Test_SB_Cmds_SendPrevSubs(void)
      */
     for (; i < CFE_SB_SUB_ENTRIES_PER_PKT * 3; i++)
     {
-        ActRtn = CFE_SB_Subscribe(i, PipeId1);
+        ActRtn = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(i), PipeId1);
         ExpRtn = CFE_SUCCESS;
         NumEvts += 2;
 
@@ -2792,7 +2852,7 @@ void Test_SB_Cmds_SubRptOn(void)
 #endif
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&NoParamCmd, CFE_SB_CMD_MID,
+    CFE_SB_InitMsg(&NoParamCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID),
                    sizeof(NoParamCmd), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &NoParamCmd,
                       CFE_SB_ENABLE_SUB_REPORTING_CC);
@@ -2830,7 +2890,7 @@ void Test_SB_Cmds_SubRptOff(void)
 #endif
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&NoParamCmd, CFE_SB_CMD_MID,
+    CFE_SB_InitMsg(&NoParamCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID),
                    sizeof(NoParamCmd), true);
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &NoParamCmd,
                       CFE_SB_DISABLE_SUB_REPORTING_CC);
@@ -2868,7 +2928,7 @@ void Test_SB_Cmds_UnexpCmdCode(void)
 #endif
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&NoParamCmd, CFE_SB_CMD_MID, sizeof(NoParamCmd), true);
+    CFE_SB_InitMsg(&NoParamCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID), sizeof(NoParamCmd), true);
 
     /* Use a command code known to be invalid */
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &NoParamCmd, 99);
@@ -2911,7 +2971,7 @@ void Test_SB_Cmds_BadCmdLength(void)
     int32           TestStat = CFE_PASS;
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&EnableRouteCmd, CFE_SB_CMD_MID, sizeof(EnableRouteCmd) - 1, true);
+    CFE_SB_InitMsg(&EnableRouteCmd, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID), sizeof(EnableRouteCmd) - 1, true);
 
     /* Use a command code known to be invalid */
     CFE_SB_SetCmdCode((CFE_SB_MsgPtr_t) &EnableRouteCmd, CFE_SB_ENABLE_ROUTE_CC);
@@ -3466,10 +3526,10 @@ void Test_DeletePipe_NoSubs(void)
 void Test_DeletePipe_WithSubs(void)
 {
     CFE_SB_PipeId_t PipedId;
-    CFE_SB_MsgId_t  MsgId0 = SB_UT_CMD_MID + 1;
-    CFE_SB_MsgId_t  MsgId1 = SB_UT_CMD_MID + 2;
-    CFE_SB_MsgId_t  MsgId2 = SB_UT_CMD_MID + 3;
-    CFE_SB_MsgId_t  MsgId3 = SB_UT_CMD_MID + 4;
+    CFE_SB_MsgId_t  MsgId0 = SB_UT_CMD_MID1;
+    CFE_SB_MsgId_t  MsgId1 = SB_UT_CMD_MID2;
+    CFE_SB_MsgId_t  MsgId2 = SB_UT_CMD_MID3;
+    CFE_SB_MsgId_t  MsgId3 = SB_UT_CMD_MID4;
     uint16          PipeDepth = 10;
     int32           ExpRtn;
     int32           ActRtn;
@@ -3657,10 +3717,10 @@ void Test_DeletePipe_InvalidPipeOwner(void)
 void Test_DeletePipe_WithAppid(void)
 {
     CFE_SB_PipeId_t PipedId;
-    CFE_SB_MsgId_t  MsgId0 = SB_UT_CMD_MID + 1;
-    CFE_SB_MsgId_t  MsgId1 = SB_UT_CMD_MID + 2;
-    CFE_SB_MsgId_t  MsgId2 = SB_UT_CMD_MID + 3;
-    CFE_SB_MsgId_t  MsgId3 = SB_UT_CMD_MID + 4;
+    CFE_SB_MsgId_t  MsgId0 = SB_UT_CMD_MID1;
+    CFE_SB_MsgId_t  MsgId1 = SB_UT_CMD_MID2;
+    CFE_SB_MsgId_t  MsgId2 = SB_UT_CMD_MID3;
+    CFE_SB_MsgId_t  MsgId3 = SB_UT_CMD_MID4;
     uint32          AppId = 0;
     uint16          PipeDepth = 10;
     int32           ExpRtn;
@@ -4406,7 +4466,7 @@ void Test_Subscribe_SubscribeEx(void)
 void Test_Subscribe_InvalidPipeId(void)
 {
     CFE_SB_PipeId_t PipeId = 2;
-    CFE_SB_MsgId_t  MsgId = CFE_PLATFORM_SB_HIGHEST_VALID_MSGID + 1;
+    CFE_SB_MsgId_t  MsgId = SB_UT_ALTERNATE_INVALID_MID;
     int32           ExpRtn;
     int32           ActRtn;
     int32           TestStat = CFE_PASS;
@@ -4457,7 +4517,7 @@ void Test_Subscribe_InvalidPipeId(void)
 void Test_Subscribe_InvalidMsgId(void)
 {
     CFE_SB_PipeId_t PipeId;
-    CFE_SB_MsgId_t  MsgId = CFE_PLATFORM_SB_HIGHEST_VALID_MSGID + 1;
+    CFE_SB_MsgId_t  MsgId = SB_UT_ALTERNATE_INVALID_MID;
     uint16          PipeDepth = 10;
     int32           ExpRtn;
     int32           ActRtn;
@@ -4810,7 +4870,7 @@ void Test_Subscribe_MaxMsgIdCount(void)
 
     for (i = 0; i < CFE_PLATFORM_SB_MAX_MSG_IDS + 1; i++)
     {
-        ActRtn = CFE_SB_Subscribe(i, PipeId2);
+        ActRtn = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(i), PipeId2);
 
         if (i < CFE_PLATFORM_SB_MAX_MSG_IDS)
         {
@@ -4854,9 +4914,9 @@ void Test_Subscribe_SendPrevSubs(void)
     CFE_SB_PipeId_t PipeId0;
     CFE_SB_PipeId_t PipeId1;
     CFE_SB_PipeId_t PipeId2;
-    CFE_SB_MsgId_t  MsgId0 = SB_UT_TLM_MID + 1;
-    CFE_SB_MsgId_t  MsgId1 = SB_UT_TLM_MID + 2;
-    CFE_SB_MsgId_t  MsgId2 = SB_UT_TLM_MID + 3;
+    CFE_SB_MsgId_t  MsgId0 = SB_UT_TLM_MID1;
+    CFE_SB_MsgId_t  MsgId1 = SB_UT_TLM_MID2;
+    CFE_SB_MsgId_t  MsgId2 = SB_UT_TLM_MID3;
     uint16          PipeDepth = 50;
     int32           ExpRtn;
     int32           ActRtn;
@@ -4921,9 +4981,9 @@ void Test_Subscribe_FindGlobalMsgIdCnt(void)
     CFE_SB_PipeId_t PipeId0;
     CFE_SB_PipeId_t PipeId1;
     CFE_SB_PipeId_t PipeId2;
-    CFE_SB_MsgId_t  MsgId0 = SB_UT_TLM_MID + 1;
-    CFE_SB_MsgId_t  MsgId1 = SB_UT_TLM_MID + 2;
-    CFE_SB_MsgId_t  MsgId2 = SB_UT_TLM_MID + 3;
+    CFE_SB_MsgId_t  MsgId0 = SB_UT_TLM_MID1;
+    CFE_SB_MsgId_t  MsgId1 = SB_UT_TLM_MID2;
+    CFE_SB_MsgId_t  MsgId2 = SB_UT_TLM_MID3;
     uint16          PipeDepth = 50;
     uint16          MsgLim = 4;
     int32           ExpRtn;
@@ -5260,7 +5320,7 @@ void Test_Unsubscribe_API(void)
 void Test_Unsubscribe_Basic(void)
 {
     CFE_SB_PipeId_t TestPipe;
-    CFE_SB_MsgId_t  MsgId = CFE_PLATFORM_SB_HIGHEST_VALID_MSGID / 2 + 1;
+    CFE_SB_MsgId_t  MsgId = SB_UT_INTERMEDIATE_VALID_MID;
     uint16          PipeDepth = 50;
     int32           ExpRtn;
     int32           ActRtn;
@@ -5329,7 +5389,7 @@ void Test_Unsubscribe_Local(void)
     CFE_SB_CreatePipe(&TestPipe, PipeDepth, "TestPipe");
     CFE_SB_Subscribe(MsgId, TestPipe);
     ExpRtn = CFE_SUCCESS;
-    ActRtn = CFE_SB_UnsubscribeLocal(CFE_PLATFORM_SB_HIGHEST_VALID_MSGID, TestPipe);
+    ActRtn = CFE_SB_UnsubscribeLocal(SB_UT_LAST_VALID_MID, TestPipe);
 
     if (ActRtn != ExpRtn)
     {
@@ -5387,7 +5447,7 @@ void Test_Unsubscribe_InvalParam(void)
 
     /* Perform test using a bad message ID */
     ExpRtn = CFE_SB_BAD_ARGUMENT;
-    ActRtn = CFE_SB_Unsubscribe(CFE_PLATFORM_SB_HIGHEST_VALID_MSGID + 1, TestPipe);
+    ActRtn = CFE_SB_Unsubscribe(SB_UT_ALTERNATE_INVALID_MID, TestPipe);
 
     if (ActRtn != ExpRtn)
     {
@@ -5416,7 +5476,7 @@ void Test_Unsubscribe_InvalParam(void)
     {
         /* Perform test using a bad scope value */
         ExpRtn = CFE_SB_BAD_ARGUMENT;
-        ActRtn = CFE_SB_UnsubscribeFull(0, TestPipe, CFE_SB_LOCAL + 1,
+        ActRtn = CFE_SB_UnsubscribeFull(SB_UT_FIRST_VALID_MID, TestPipe, CFE_SB_LOCAL + 1,
                                         CallerId);
 
         if (ActRtn != ExpRtn)
@@ -5439,7 +5499,7 @@ void Test_Unsubscribe_InvalParam(void)
             SavedPipeId = CFE_SB.PipeTbl[0].PipeId;
             CFE_SB.PipeTbl[0].PipeId = CFE_PLATFORM_SB_MAX_PIPES;
             CFE_SB.PipeTbl[0].InUse = 1;
-            ActRtn = CFE_SB_Unsubscribe(0, CFE_PLATFORM_SB_MAX_PIPES);
+            ActRtn = CFE_SB_Unsubscribe(SB_UT_FIRST_VALID_MID, CFE_PLATFORM_SB_MAX_PIPES);
 
             if (ActRtn != ExpRtn)
             {
@@ -5502,7 +5562,7 @@ void Test_Unsubscribe_NoMatch(void)
     CFE_SB_CreatePipe(&TestPipe, PipeDepth, "TestPipe");
     CFE_SB_Subscribe(MsgId, TestPipe);
     ExpRtn = CFE_SUCCESS;
-    ActRtn = CFE_SB_Unsubscribe(MsgId + 1, TestPipe);
+    ActRtn = CFE_SB_Unsubscribe(SB_UT_TLM_MID1, TestPipe);
 
     if (ActRtn != ExpRtn)
     {
@@ -5971,10 +6031,10 @@ void Test_SendMsg_InvalidMsgId(void)
 #endif
 
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&TlmPkt, CFE_PLATFORM_SB_HIGHEST_VALID_MSGID + 1,
+    CFE_SB_InitMsg(&TlmPkt, SB_UT_ALTERNATE_INVALID_MID,
                    sizeof(TlmPkt), true);
     
-    CFE_SB_SetMsgId(TlmPktPtr, 0xFFFF);
+    CFE_SB_SetMsgId(TlmPktPtr, CFE_SB_INVALID_MSG_ID);
 
     
     CCSDS_WR_APID(TlmPktPtr->Hdr, 0x7FF );
@@ -7344,7 +7404,7 @@ void Test_SendMsg_InvalidMsgId_ZeroCopy(void)
     }
     else
     {
-        CFE_SB_InitMsg(TlmPktPtr, CFE_PLATFORM_SB_HIGHEST_VALID_MSGID + 1,
+        CFE_SB_InitMsg(TlmPktPtr, SB_UT_ALTERNATE_INVALID_MID,
         		       sizeof(SB_UT_Test_Tlm_t), true);
         ActRtn = CFE_SB_SendMsgFull(TlmPktPtr, CFE_SB_INCREMENT_TLM,
                                     CFE_SB_SEND_ZEROCOPY);
@@ -8090,7 +8150,8 @@ void Test_RcvMsg_PendForever(void)
     if (PtrToMsg != NULL)
     {
         snprintf(cMsg, UT_MAX_MESSAGE_LENGTH,
-                 "Received Msg 0x%x", (unsigned int)CFE_SB_GetMsgId(PtrToMsg));
+                 "Received Msg 0x%x",
+                 (unsigned int)CFE_SB_MsgIdToValue(CFE_SB_GetMsgId(PtrToMsg)));
 #ifdef UT_VERBOSE
         UT_Text(cMsg);
 #endif
@@ -8308,7 +8369,7 @@ void Test_CFE_SB_InitMsg_True(void)
 
     /* Set entire cmd packet to all f's */
     memset(SBCmdPtr, 0xff, sizeof(SBCmd));
-    CFE_SB_InitMsg(SBCmdPtr, CFE_SB_CMD_MID, sizeof(SBCmd), true);
+    CFE_SB_InitMsg(SBCmdPtr, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID), sizeof(SBCmd), true);
     result = SBCmd.Cmd32Param1 == 0 &&
              SBCmd.Cmd16Param1 == 0 &&
              SBCmd.Cmd16Param2 == 0 &&
@@ -8345,7 +8406,7 @@ void Test_CFE_SB_InitMsg_False(void)
              SBCmd.Cmd8Param2 == 0xff &&
              SBCmd.Cmd8Param3 == 0xff &&
              SBCmd.Cmd8Param4 == 0xff;
-    CFE_SB_InitMsg(SBCmdPtr, CFE_SB_CMD_MID, sizeof(SBCmd), false);
+    CFE_SB_InitMsg(SBCmdPtr, CFE_SB_ValueToMsgId(CFE_SB_CMD_MID), sizeof(SBCmd), false);
     UT_Report(__FILE__, __LINE__,
               result, "SB_TestInitMsg_False",
               "Leave message content");
@@ -8595,6 +8656,7 @@ void Test_CFE_SB_SetGetMsgId(void)
     SB_UT_Test_Cmd_t SBCmd;
     CFE_SB_MsgPtr_t  SBCmdPtr = (CFE_SB_MsgPtr_t) &SBCmd;
     CFE_SB_MsgId_t   MsgIdReturned;
+    CFE_SB_MsgId_t   MsgIdSet;
     uint32           TestStat;
     uint32           i;
 
@@ -8608,15 +8670,16 @@ void Test_CFE_SB_SetGetMsgId(void)
 
     /* Set entire command packet to all f's */
     memset(SBCmdPtr, 0xff, sizeof(SBCmd));
-    CFE_SB_SetMsgId(SBCmdPtr, CFE_SB_CMD_MID);
+    MsgIdSet = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
+    CFE_SB_SetMsgId(SBCmdPtr, MsgIdSet);
     MsgIdReturned = CFE_SB_GetMsgId(SBCmdPtr);
 
-    if (MsgIdReturned != CFE_SB_CMD_MID)
+    if (!CFE_SB_MsgId_Equal(MsgIdReturned, MsgIdSet))
     {
         snprintf(cMsg, UT_MAX_MESSAGE_LENGTH,
                  "CFE_SB_GetMsgId returned 0x%lx, expected 0x%lx",
-                 (unsigned long) MsgIdReturned,
-                 (unsigned long) CFE_SB_CMD_MID);
+                 (unsigned long) CFE_SB_MsgIdToValue(MsgIdReturned),
+                 (unsigned long) CFE_SB_MsgIdToValue(MsgIdSet));
         UT_Text(cMsg);
         TestStat = CFE_FAIL;
     }
@@ -8635,9 +8698,11 @@ void Test_CFE_SB_SetGetMsgId(void)
     /* Looping through every value from 0 to 0xffff */
     for (i = 0; i <= 0xFFFF; i++)
     {
-        CFE_SB_SetMsgId(SBCmdPtr, i);
+        MsgIdSet = CFE_SB_ValueToMsgId(i);
+        CFE_SB_SetMsgId(SBCmdPtr, MsgIdSet);
+        MsgIdReturned = CFE_SB_GetMsgId(SBCmdPtr);
         
-        if (CFE_SB_GetMsgId(SBCmdPtr) != i)
+        if (!CFE_SB_MsgId_Equal(MsgIdReturned, MsgIdSet))
         {
             break;
         }
@@ -9444,7 +9509,7 @@ void Test_CFE_SB_ChecksumUtils(void)
     TestStat = CFE_PASS;
 
     /* Initialize pkt, setting data to zero */
-    CFE_SB_InitMsg(SBCmdPtr, 0x1805, sizeof(SBCmd), true);
+    CFE_SB_InitMsg(SBCmdPtr, CFE_SB_ValueToMsgId(0x1805), sizeof(SBCmd), true);
 
     CCSDS_WR_SID( (*((CCSDS_PriHdr_t*) SBCmdPtr)), 0x1805 );
     
@@ -9502,7 +9567,7 @@ void Test_CFE_SB_ChecksumUtils(void)
     TestStat = CFE_PASS;
 
     /* Initialize pkt, setting data to zero */
-    CFE_SB_InitMsg(SBNoSecHdrPktPtr, 0x1005,
+    CFE_SB_InitMsg(SBNoSecHdrPktPtr, CFE_SB_ValueToMsgId(0x1005),
                    sizeof(SBNoSecHdrPkt), true);
 
     
@@ -9557,7 +9622,7 @@ void Test_CFE_SB_ChecksumUtils(void)
     TestStat = CFE_PASS;
 
     /* Initialize pkt, setting data to zero */
-    CFE_SB_InitMsg(SBTlmPtr, 0x0805, sizeof(SBTlm), true);
+    CFE_SB_InitMsg(SBTlmPtr, CFE_SB_ValueToMsgId(0x0805), sizeof(SBTlm), true);
 
     /* Set checksum field */
     CFE_SB_GenerateChecksum(SBTlmPtr);
@@ -9582,7 +9647,7 @@ void Test_CFE_SB_ChecksumUtils(void)
     /* Change 1 byte in pkt and verify checksum is no longer valid.
      * Increment MsgId by 1 to 0x0806.  Validation expected to return false
      */
-    CFE_SB_SetMsgId(SBTlmPtr, 0x1806);
+    CFE_SB_SetMsgId(SBTlmPtr, CFE_SB_ValueToMsgId(0x1806));
     RtnFrmValidate = CFE_SB_ValidateChecksum(SBTlmPtr);
     ExpRtnFrmVal = false;
 
@@ -9605,7 +9670,7 @@ void Test_CFE_SB_ChecksumUtils(void)
     TestStat = CFE_PASS;
 
     /* Initialize pkt, setting data to zero */
-    CFE_SB_InitMsg(SBNoSecHdrPktPtr, 0x0005,
+    CFE_SB_InitMsg(SBNoSecHdrPktPtr, CFE_SB_ValueToMsgId(0x0005),
                    sizeof(SBNoSecHdrPkt), true);
 
     /* Setting checksum field */
@@ -9632,7 +9697,7 @@ void Test_CFE_SB_ChecksumUtils(void)
      * Increment MsgId by 1 to 0x0006.  Validation expected to
      * return false
      */
-    CFE_SB_SetMsgId(SBNoSecHdrPktPtr, 0x0006);
+    CFE_SB_SetMsgId(SBNoSecHdrPktPtr, CFE_SB_ValueToMsgId(0x0006));
     RtnFrmValidate = CFE_SB_ValidateChecksum(SBNoSecHdrPktPtr);
     ExpRtnFrmVal = false;
 
@@ -9664,7 +9729,7 @@ void Test_CFE_SB_ValidateMsgId(void)
     SB_ResetUnitTest();
     
     /* Validate Msg Id */
-    MsgId = CFE_PLATFORM_SB_HIGHEST_VALID_MSGID;
+    MsgId = SB_UT_LAST_VALID_MID;
     ActualReturn = CFE_SB_ValidateMsgId(MsgId);
 
     UT_Report(__FILE__, __LINE__,
@@ -9673,7 +9738,7 @@ void Test_CFE_SB_ValidateMsgId(void)
               "Testing validation for a valid MsgId");
     
     /* Test for invalid msg id */
-    MsgId = CFE_PLATFORM_SB_HIGHEST_VALID_MSGID + 1;
+    MsgId = SB_UT_ALTERNATE_INVALID_MID;
     ActualReturn = CFE_SB_ValidateMsgId(MsgId);
     
     UT_Report(__FILE__, __LINE__,
@@ -10018,7 +10083,7 @@ void Test_CFE_SB_Buffers(void)
     SB_ResetUnitTest();
     CFE_SB.StatTlmMsg.Payload.MemInUse = 0;
     CFE_SB.StatTlmMsg.Payload.PeakMemInUse = ExpRtn;
-    bd = CFE_SB_GetBufferFromPool(0, 0);
+    bd = CFE_SB_GetBufferFromPool(SB_UT_FIRST_VALID_MID, 0);
     ActRtn = CFE_SB.StatTlmMsg.Payload.PeakMemInUse;
 
     if (ActRtn != ExpRtn)
@@ -10196,7 +10261,7 @@ void Test_CFE_SB_BadPipeInfo(void)
 
     TestStat = CFE_PASS;
     ExpRtn = CFE_SB_BAD_ARGUMENT;
-    ActRtn = CFE_SB_SubscribeFull(0 ,0, CFE_SB_Default_Qos,
+    ActRtn = CFE_SB_SubscribeFull(SB_UT_FIRST_VALID_MID ,0, CFE_SB_Default_Qos,
                                   CFE_PLATFORM_SB_DEFAULT_MSG_LIMIT, 2);
 
     if (ActRtn != ExpRtn)
@@ -10249,7 +10314,7 @@ void Test_SB_SendMsgPaths(void)
 
     /* Test inhibiting sending a "no subscriptions for a message ID" message */
     SB_ResetUnitTest();
-    CFE_SB_InitMsg(&NoParamCmd, CFE_SB_SEND_HK_MID,
+    CFE_SB_InitMsg(&NoParamCmd, CFE_SB_ValueToMsgId(CFE_SB_SEND_HK_MID),
                    sizeof(NoParamCmd), true);
     CFE_SB.CmdPipePktPtr = (CFE_SB_MsgPtr_t) &NoParamCmd;
     CFE_SB.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_SEND_NO_SUBS_EID_BIT);
@@ -10569,7 +10634,7 @@ void Test_RcvMsg_UnsubResubPath(void)
     {
         snprintf(cMsg, UT_MAX_MESSAGE_LENGTH,
                  "Received Msg 0x%x",
-                 (unsigned int) CFE_SB_GetMsgId(PtrToMsg));
+                 (unsigned int) CFE_SB_MsgIdToValue(CFE_SB_GetMsgId(PtrToMsg)));
 #ifdef UT_VERBOSE
         UT_Text(cMsg);
 #endif

--- a/fsw/cfe-core/unit-test/sb_UT.h
+++ b/fsw/cfe-core/unit-test/sb_UT.h
@@ -88,8 +88,8 @@ typedef struct {
      uint16       Tlm16Param2;
 } SB_UT_TstPktWoSecHdr_t;
 
-#define SB_UT_CMD_MID CFE_MISSION_CMD_MID_BASE1 + 1
-#define SB_UT_TLM_MID CFE_MISSION_TLM_MID_BASE1 + 1
+#define SB_UT_CMD_MID_VALUE_BASE    CFE_MISSION_CMD_MID_BASE1 + 1
+#define SB_UT_TLM_MID_VALUE_BASE    CFE_MISSION_TLM_MID_BASE1 + 1
 
 /* SB unit test functions */
 /*****************************************************************************/

--- a/fsw/cfe-core/unit-test/tbl_UT.c
+++ b/fsw/cfe-core/unit-test/tbl_UT.c
@@ -61,22 +61,22 @@ void **ArrayOfPtrsToTblPtrs[2];
 
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_TBL_CMD_NOOP_CC =
 {
-        .MsgId = CFE_TBL_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_CMD_MID),
         .CommandCode = CFE_TBL_NOOP_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_TBL_CMD_RESET_COUNTERS_CC =
 {
-        .MsgId = CFE_TBL_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_CMD_MID),
         .CommandCode = CFE_TBL_RESET_COUNTERS_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_TBL_INVALID_MID =
 {
-        .MsgId = 0xFFFF,
+        .MsgId = CFE_SB_MSGID_RESERVED,
         .CommandCode = 0
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_TBL_CMD_INVALID_CC =
 {
-        .MsgId = CFE_TBL_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_CMD_MID),
         .CommandCode = 0x7F
 };
 
@@ -378,7 +378,7 @@ void Test_CFE_TBL_InitData(void)
     UT_SetDataBuffer(UT_KEY(CFE_SB_SetMsgId), MsgIdBuf, sizeof(MsgIdBuf), false);
     CFE_TBL_InitData();
     UT_Report(__FILE__, __LINE__,
-              MsgIdBuf[1] == CFE_TBL_REG_TLM_MID &&
+              CFE_SB_MsgId_Equal(MsgIdBuf[1], CFE_SB_ValueToMsgId(CFE_TBL_REG_TLM_MID)) &&
               UT_GetStubCount(UT_KEY(CFE_SB_SetMsgId)) == 2,
               "CFE_TBL_SearchCmdHndlrTbl",
               "Initialize data");
@@ -399,7 +399,7 @@ void Test_CFE_TBL_SearchCmdHndlrTbl(void)
 
     /* Test successfully finding a matching message ID and command code */
     UT_InitData();
-    MsgID = CFE_TBL_CMD_MID;
+    MsgID = CFE_SB_ValueToMsgId(CFE_TBL_CMD_MID);
     CmdCode = CFE_TBL_NOOP_CC;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_SearchCmdHndlrTbl(MsgID, CmdCode) == TblIndex,
@@ -411,7 +411,7 @@ void Test_CFE_TBL_SearchCmdHndlrTbl(void)
      */
     UT_InitData();
     TblIndex = 0;
-    MsgID = CFE_TBL_SEND_HK_MID;
+    MsgID = CFE_SB_ValueToMsgId(CFE_TBL_SEND_HK_MID);
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_SearchCmdHndlrTbl(MsgID, CmdCode) == TblIndex,
               "CFE_TBL_SearchCmdHndlrTbl",
@@ -422,7 +422,7 @@ void Test_CFE_TBL_SearchCmdHndlrTbl(void)
      */
     UT_InitData();
     TblIndex = CFE_TBL_BAD_CMD_CODE;
-    MsgID = CFE_TBL_CMD_MID;
+    MsgID = CFE_SB_ValueToMsgId(CFE_TBL_CMD_MID);
     CmdCode = 0xffff;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_SearchCmdHndlrTbl(MsgID, CmdCode) == TblIndex,
@@ -432,7 +432,7 @@ void Test_CFE_TBL_SearchCmdHndlrTbl(void)
     /* Test with a message ID that does not match */
     UT_InitData();
     TblIndex = CFE_TBL_BAD_MSG_ID;
-    MsgID = 0xffff;
+    MsgID = CFE_SB_INVALID_MSG_ID;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_SearchCmdHndlrTbl(MsgID, CmdCode) == TblIndex,
               "CFE_TBL_SearchCmdHndlrTbl",
@@ -2713,7 +2713,7 @@ void Test_CFE_TBL_NotifyByMessage(void)
     /* Test successful notification */
     UT_InitData();
     EventsCorrect = (UT_GetNumEventsSent() == 0);
-    RtnCode = CFE_TBL_NotifyByMessage(App1TblHandle1, 1, 1, 1);
+    RtnCode = CFE_TBL_NotifyByMessage(App1TblHandle1, CFE_SB_ValueToMsgId(1), 1, 1);
     UT_Report(__FILE__, __LINE__,
               RtnCode == CFE_SUCCESS && EventsCorrect,
               "CFE_TBL_NotifyByMessage",
@@ -2725,7 +2725,7 @@ void Test_CFE_TBL_NotifyByMessage(void)
     UT_InitData();
     CFE_TBL_TaskData.Registry[0].OwnerAppId = CFE_TBL_NOT_OWNED;
     EventsCorrect = (UT_GetNumEventsSent() == 0);
-    RtnCode = CFE_TBL_NotifyByMessage(App1TblHandle1, 1, 1, 1);
+    RtnCode = CFE_TBL_NotifyByMessage(App1TblHandle1, CFE_SB_ValueToMsgId(1), 1, 1);
     UT_Report(__FILE__, __LINE__,
               RtnCode == CFE_TBL_ERR_NO_ACCESS && EventsCorrect,
               "CFE_TBL_NotifyByMessage",
@@ -2735,7 +2735,7 @@ void Test_CFE_TBL_NotifyByMessage(void)
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppID), 1, CFE_ES_ERR_APPID);
     EventsCorrect = (UT_GetNumEventsSent() == 0);
-    RtnCode = CFE_TBL_NotifyByMessage(App1TblHandle1, 1, 1, 1);
+    RtnCode = CFE_TBL_NotifyByMessage(App1TblHandle1, CFE_SB_ValueToMsgId(1), 1, 1);
     UT_Report(__FILE__, __LINE__,
               RtnCode == CFE_ES_ERR_APPID && EventsCorrect,
               "CFE_TBL_NotifyByMessage",

--- a/fsw/cfe-core/unit-test/time_UT.c
+++ b/fsw/cfe-core/unit-test/time_UT.c
@@ -56,116 +56,116 @@ const char *TIME_SYSLOG_MSGS[] =
 
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_SEND_HK =
 {
-        .MsgId = CFE_TIME_SEND_HK_MID
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_SEND_HK_MID)
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_TONE_CMD =
 {
-        .MsgId = CFE_TIME_TONE_CMD_MID
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_TONE_CMD_MID)
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_DATA_CMD =
 {
-        .MsgId = CFE_TIME_DATA_CMD_MID
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_DATA_CMD_MID)
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_1HZ_CMD =
 {
-        .MsgId = CFE_TIME_1HZ_CMD_MID
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_1HZ_CMD_MID)
 };
 
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_SEND_CMD =
 {
-        .MsgId = CFE_TIME_SEND_CMD_MID
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_SEND_CMD_MID)
 };
 #endif
 
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_NOOP_CC =
 {
-        .MsgId = CFE_TIME_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID),
         .CommandCode = CFE_TIME_NOOP_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_RESET_COUNTERS_CC =
 {
-        .MsgId = CFE_TIME_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID),
         .CommandCode = CFE_TIME_RESET_COUNTERS_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SEND_DIAGNOSTIC_TLM_CC =
 {
-        .MsgId = CFE_TIME_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID),
         .CommandCode = CFE_TIME_SEND_DIAGNOSTIC_TLM_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_STATE_CC =
 {
-        .MsgId = CFE_TIME_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID),
         .CommandCode = CFE_TIME_SET_STATE_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_SOURCE_CC =
 {
-        .MsgId = CFE_TIME_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID),
         .CommandCode = CFE_TIME_SET_SOURCE_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_SIGNAL_CC =
 {
-        .MsgId = CFE_TIME_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID),
         .CommandCode = CFE_TIME_SET_SIGNAL_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_ADD_DELAY_CC =
 {
-        .MsgId = CFE_TIME_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID),
         .CommandCode = CFE_TIME_ADD_DELAY_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SUB_DELAY_CC =
 {
-        .MsgId = CFE_TIME_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID),
         .CommandCode = CFE_TIME_SUB_DELAY_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_TIME_CC =
 {
-        .MsgId = CFE_TIME_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID),
         .CommandCode = CFE_TIME_SET_TIME_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_MET_CC =
 {
-        .MsgId = CFE_TIME_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID),
         .CommandCode = CFE_TIME_SET_MET_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_STCF_CC =
 {
-        .MsgId = CFE_TIME_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID),
         .CommandCode = CFE_TIME_SET_STCF_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_LEAP_SECONDS_CC =
 {
-        .MsgId = CFE_TIME_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID),
         .CommandCode = CFE_TIME_SET_LEAP_SECONDS_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_ADD_ADJUST_CC =
 {
-        .MsgId = CFE_TIME_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID),
         .CommandCode = CFE_TIME_ADD_ADJUST_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SUB_ADJUST_CC =
 {
-        .MsgId = CFE_TIME_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID),
         .CommandCode = CFE_TIME_SUB_ADJUST_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_ADD_1HZ_ADJUSTMENT_CC =
 {
-        .MsgId = CFE_TIME_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID),
         .CommandCode = CFE_TIME_ADD_1HZ_ADJUSTMENT_CC
 };
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SUB_1HZ_ADJUSTMENT_CC =
 {
-        .MsgId = CFE_TIME_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID),
         .CommandCode = CFE_TIME_SUB_1HZ_ADJUSTMENT_CC
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_TIME_INVALID_MID =
 {
-        .MsgId = 0xFFFF,
+        .MsgId = CFE_SB_MSGID_RESERVED,
         .CommandCode = 0
 };
 static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_TIME_CMD_INVALID_CC =
 {
-        .MsgId = CFE_TIME_CMD_MID,
+        .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID),
         .CommandCode = 0x7F
 };
 
@@ -1889,7 +1889,7 @@ void Test_PipeCmds(void)
 
     UT_SoftwareBusSnapshot_Entry_t LocalSnapshotData =
     {
-            .MsgId = CFE_TIME_HK_TLM_MID
+            .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_HK_TLM_MID)
     };
 
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)

--- a/fsw/cfe-core/unit-test/ut_support.c
+++ b/fsw/cfe-core/unit-test/ut_support.c
@@ -258,7 +258,7 @@ int32 UT_SoftwareBusSnapshotHook(void *UserObj, int32 StubRetcode, uint32 CallCo
     }
 
     if (MsgPtr != NULL && Snapshot != NULL &&
-            Snapshot->MsgId == CFE_SB_GetMsgId((CFE_SB_MsgPtr_t)MsgPtr))
+            CFE_SB_MsgId_Equal(Snapshot->MsgId, CFE_SB_GetMsgId((CFE_SB_MsgPtr_t)MsgPtr)))
     {
         ++Snapshot->Count;
         if (Snapshot->SnapshotSize > 0 && Snapshot->SnapshotBuffer != NULL)

--- a/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
@@ -273,28 +273,29 @@ uint16 CFE_SB_GetCmdCode(CFE_SB_MsgPtr_t MsgPtr)
 ******************************************************************************/
 CFE_SB_MsgId_t CFE_SB_GetMsgId(const CFE_SB_Msg_t *MsgPtr)
 {
-    CFE_SB_MsgId_t MsgId = 0;
+    CFE_SB_MsgId_t Result = CFE_SB_INVALID_MSG_ID;
+    CFE_SB_MsgId_Atom_t MsgIdVal = 0;
 
     UT_DEFAULT_IMPL(CFE_SB_GetMsgId);
 
-    if (UT_Stub_CopyToLocal(UT_KEY(CFE_SB_GetMsgId), &MsgId, sizeof(MsgId)) < sizeof(MsgId))
+    if (UT_Stub_CopyToLocal(UT_KEY(CFE_SB_GetMsgId), &Result, sizeof(Result)) < sizeof(Result))
     {
 #ifdef MESSAGE_FORMAT_IS_CCSDS
 
 #ifndef MESSAGE_FORMAT_IS_CCSDS_VER_2  
-        MsgId = CCSDS_RD_SID(MsgPtr->Hdr);
+        MsgIdVal = CCSDS_RD_SID(MsgPtr->Hdr);
 #else
 
         uint32            SubSystemId;
 
-        MsgId = CCSDS_RD_APID(MsgPtr->Hdr); /* Primary header APID  */
+        MsgIdVal = CCSDS_RD_APID(MsgPtr->Hdr); /* Primary header APID  */
      
         if ( CCSDS_RD_TYPE(MsgPtr->Hdr) == CCSDS_CMD)
-              MsgId = MsgId | CFE_SB_CMD_MESSAGE_TYPE;  
+              MsgIdVal = MsgIdVal | CFE_SB_CMD_MESSAGE_TYPE;  
 
         /* Add in the SubSystem ID as needed */
         SubSystemId = CCSDS_RD_SUBSYSTEM_ID(MsgPtr->SpacePacket.ApidQ);
-        MsgId = (MsgId | (SubSystemId << 8));
+        MsgIdVal = (MsgIdVal | (SubSystemId << 8));
 
 /* Example code to add in the System ID as needed. */
 /*   The default is to init this field to the Spacecraft ID but ignore for routing.   */
@@ -302,13 +303,14 @@ CFE_SB_MsgId_t CFE_SB_GetMsgId(const CFE_SB_Msg_t *MsgPtr)
 /*   prohibitively large routing and index tables. */
 /*      uint16            SystemId;                              */
 /*      SystemId = CCSDS_RD_SYSTEM_ID(HdrPtr->ApidQ);            */
-/*      MsgId = (MsgId | (SystemId << 16)) */
+/*      MsgIdVal = (MsgIdVal | (SystemId << 16)) */
 #endif
 #endif
+        Result = CFE_SB_ValueToMsgId(MsgIdVal);
 
     }
 
-return MsgId;
+    return Result;
 }
 
 /*****************************************************************************/
@@ -491,15 +493,16 @@ void CFE_SB_SetMsgId(CFE_SB_MsgPtr_t MsgPtr, CFE_SB_MsgId_t MsgId)
 {
     UT_DEFAULT_IMPL(CFE_SB_SetMsgId);
     UT_Stub_CopyFromLocal(UT_KEY(CFE_SB_SetMsgId), (uint8*)&MsgId, sizeof(MsgId));
-#ifndef MESSAGE_FORMAT_IS_CCSDS_VER_2  
-    CCSDS_WR_SID(MsgPtr->Hdr, MsgId);
+    CFE_SB_MsgId_Atom_t MsgIdVal = CFE_SB_MsgIdToValue(MsgId);
+#ifndef MESSAGE_FORMAT_IS_CCSDS_VER_2
+    CCSDS_WR_SID(MsgPtr->Hdr, MsgIdVal);
 #else
   CCSDS_WR_VERS(MsgPtr->SpacePacket.Hdr, 1);
 
   /* Set the stream ID APID in the primary header. */
-  CCSDS_WR_APID(MsgPtr->SpacePacket.Hdr, CFE_SB_RD_APID_FROM_MSGID(MsgId) );
+  CCSDS_WR_APID(MsgPtr->SpacePacket.Hdr, CFE_SB_RD_APID_FROM_MSGID(MsgIdVal) );
   
-  CCSDS_WR_TYPE(MsgPtr->SpacePacket.Hdr, CFE_SB_RD_TYPE_FROM_MSGID(MsgId) );
+  CCSDS_WR_TYPE(MsgPtr->SpacePacket.Hdr, CFE_SB_RD_TYPE_FROM_MSGID(MsgIdVal) );
   
   
   CCSDS_CLR_SEC_APIDQ(MsgPtr->SpacePacket.ApidQ);
@@ -510,7 +513,7 @@ void CFE_SB_SetMsgId(CFE_SB_MsgPtr_t MsgPtr, CFE_SB_MsgId_t MsgId)
   
   CCSDS_WR_PLAYBACK(MsgPtr->SpacePacket.ApidQ, false);
   
-  CCSDS_WR_SUBSYSTEM_ID(MsgPtr->SpacePacket.ApidQ, CFE_SB_RD_SUBSYS_ID_FROM_MSGID(MsgId));
+  CCSDS_WR_SUBSYSTEM_ID(MsgPtr->SpacePacket.ApidQ, CFE_SB_RD_SUBSYS_ID_FROM_MSGID(MsgIdVal));
   
   CCSDS_WR_SYSTEM_ID(MsgPtr->SpacePacket.ApidQ, CFE_SPACECRAFT_ID);
 


### PR DESCRIPTION
**Describe the contribution**

Fixes #263

This exposes the `CFE_SB_IsValidMsgId()` in the CFE SB public API, rather than confining it to the private/internal API.

Partially addresses #245 

This also includes a number of internal changes to make CFE core apps consistent in their use of the CFE_SB_MsgId type and with the CFE SB API.  This employs the appropriate CFE SB abstraction API whenever any of the following needs to happen:

- Use of a CFE_SB_MsgId_t value within a printf (event, syslog, etc).
- Initialization of a CFE_SB_MsgId_t from an integer value
- Comparison of two CFE_SB_MsgId_t values
- Checking if a CFE_SB_MsgId_t value is within the valid set

Notable exception to integer conversion rules is for the MID `#define` values, which are not changed for backward compatibility reasons.  These are still defined as integers, and used directly in the code.

Also worth noting - this replaces the switch/case constructs used in message dispatch with a nested if/else based on CFE_SB_MsgId_Equal(), as the switch statement can only be used with an integer.

A few new macros are introduced, mainly because the inline functions that already existed for this purpose cannot be used where evaluation must be done at compile time (e.g. constants, struct initialization).  These are initially just typecasts, but could become more interesting
in future revisions.

**Testing performed**
Build with SIMULATION=native ENABLE_UNIT_TESTS=TRUE
- Run all unit tests and confirm passing
- Run sanity check on CFE, boot up and issue commands to each core app using `cmdUtil`.  Ensure no changes to message routing/processing for every core app.

**Expected behavior changes**
This exposes the `CFE_SB_IsValidMsgId()` for application usage.
No other API or behavior changes.  All other changes are transparent.

**System(s) tested on**
Ubuntu 18.04 LTS 64 bit

**Additional context**
This is a step in the direction of related issue #245 but does not do anything that would affect backward compatibility with the way the MID integers are currently defined and used.  It does introduce a few of the macros that will become more relevant/necessary (i.e. so they can evolve beyond a simple typecast/passthrough).

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

*EDIT* added reference for MsgId handling
