### PR TITLE
Fix #494, Updates CFE_SB_GetLastSenderID to check if message has been sent on pipe

### DIFF
--- a/fsw/cfe-core/src/inc/cfe_error.h
+++ b/fsw/cfe-core/src/inc/cfe_error.h
@@ -980,6 +980,16 @@
 
 
 /**
+ * @brief No Message Recieved
+ *
+ *  When trying to determine the last senders ID, this return 
+ *  value indicates that there was not a message recived on the pipe.
+ *
+ */
+#define CFE_SB_NO_MSG_RECV       ((int32)0xca00000f)
+
+
+/**
  * @brief Not Implemented
  *
  *  Current version of cFE does not have the function or the feature

--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -1651,12 +1651,20 @@ uint32  CFE_SB_GetLastSenderId(CFE_SB_SenderId_t **Ptr,CFE_SB_PipeId_t  PipeId)
     /* Get ptr to buffer descriptor for the last msg received on the given pipe */
     Ptr2BufDescriptor = CFE_SB.PipeTbl[PipeId].CurrentBuff;
 
-    /* Set the receivers pointer to the adr of 'Sender' struct in buf descriptor */
-    *Ptr = (CFE_SB_SenderId_t *) &Ptr2BufDescriptor -> Sender;
-
-    CFE_SB_UnlockSharedData(__func__,__LINE__);
-
-    return CFE_SUCCESS;
+    if ( Ptr2BufDescriptor == NULL  )
+    {
+        *Ptr = NULL;
+        CFE_SB.PipeTbl[PipeId].LastSender = CFE_SB_INVALID_MSG_ID;
+        CFE_SB_UnlockSharedData(__func__,__LINE__);
+        return CFE_SB_NO_MSG_RECV; 
+    }
+    else
+    {
+        /* Set the receivers pointer to the adr of 'Sender' struct in buf descriptor */
+        *Ptr = (CFE_SB_SenderId_t *) &Ptr2BufDescriptor -> Sender;
+        CFE_SB_UnlockSharedData(__func__,__LINE__);
+        return CFE_SUCCESS;
+    }
 
 }/* end CFE_SB_GetLastSenderId */
 

--- a/fsw/cfe-core/unit-test/sb_UT.h
+++ b/fsw/cfe-core/unit-test/sb_UT.h
@@ -2948,6 +2948,27 @@ void Test_RcvMsg_GetLastSenderInvalidCaller(void);
 
 /*****************************************************************************/
 /**
+** \brief Test receive last message response when there is no last sender
+**
+** \par Description
+**        This function tests the receive last message response when no last
+**        sender.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+**
+** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe,
+** \sa #CFE_SB_GetLastSenderId, #UT_GetNumEventsSent, #UT_EventIsInHistory,
+** \sa #CFE_SB_DeletePipe, #UT_Report
+**
+******************************************************************************/
+void Test_RcvMsg_GetLastSenderNoValidSender(void);
+
+/*****************************************************************************/
+/**
 ** \brief Test successful receive last message request
 **
 ** \par Description


### PR DESCRIPTION
**Describe the contribution**
Updates CFE_SB_GetLastSenderID to check if a message has been sent on the associated pipe prior to setting the receivers pointer to the associated address of 'sender' in the buffer descriptor.

Includes associated unit test addition to cover the additional path added to CFE_SB_GetLastSenderID.

Includes an addition of a SB status code  and event ID.

Fix #494

**Testing performed**
1. Ran unit tests.
2. Reviewed coverage test results to ensure that additional path added is covered with the updated unit test.

**Expected behavior changes**
CFE_SB_GetLastSenderID will now detect if it is being called prior to a message being sent on a given pipe.

System(s) tested on
Oracle VM VirtualBox
OS: ubuntu-19.10
Versions: cFE 6.7.11.0, OSAL 5.0.9.0, PSP 1.4.7.0

Contributor Info
Dan Knutsen
NASA/Goddard
