### PR TITLE
Fix #591, Avoid deadlock in CFE_ES_CreatObjects

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_start.c
+++ b/fsw/cfe-core/src/es/cfe_es_start.c
@@ -869,7 +869,7 @@ void  CFE_ES_CreateObjects(void)
                   */
                   if ( CFE_ES_Global.TaskTable[TaskIndex].RecordUsed == true )
                   {
-                     CFE_ES_WriteToSysLog("ES Startup: CFE_ES_Global.TaskTable record used error for App: %s, continuing.\n",
+                     CFE_ES_SysLogWrite_Unsync("ES Startup: CFE_ES_Global.TaskTable record used error for App: %s, continuing.\n",
                                            CFE_ES_ObjectTable[i].ObjectName);
                   }
                   else
@@ -881,7 +881,7 @@ void  CFE_ES_CreateObjects(void)
                   strncpy((char *)CFE_ES_Global.TaskTable[TaskIndex].TaskName, (char *)CFE_ES_Global.AppTable[j].TaskInfo.MainTaskName, OS_MAX_API_NAME);
                   CFE_ES_Global.TaskTable[TaskIndex].TaskName[OS_MAX_API_NAME - 1] = '\0';
 
-                  CFE_ES_WriteToSysLog("ES Startup: Core App: %s created. App ID: %d\n",
+                  CFE_ES_SysLogWrite_Unsync("ES Startup: Core App: %s created. App ID: %d\n",
                                        CFE_ES_ObjectTable[i].ObjectName,j);
                                        
                   /*


### PR DESCRIPTION
**Describe the contribution**
Now uses CFE_ES_SysLogWrite_Unsync inside shared data lock
Fixes #591 

**Testing performed**
1. CI - https://travis-ci.com/github/skliper/cFS/builds/160449984

**Expected behavior changes**
No longer locks while locked (no issue observed on linux/posix, but user reported issue on FreeRTOS 10)

**System(s) tested on**
 - Hardware: CI
 - OS: Ubuntu 18.04
 - Versions: bundle w/ this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC