### PR TITLE
Fix #121, Add check for UsedFlag and sets APID to CFE_TBL_NOT_OWNED

### DIFF
--- a/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
@@ -1391,7 +1391,7 @@ int32 CFE_TBL_CleanUpApp(uint32 AppId)
     for (i=0; i<CFE_PLATFORM_TBL_MAX_NUM_HANDLES; i++)
     {
         /* Check to see if the Handle belongs to the Application being deleted */
-        if (CFE_TBL_TaskData.Handles[i].AppId == AppId)
+        if (CFE_TBL_TaskData.Handles[i].AppId == AppId && CFE_TBL_TaskData.Handles[i].UsedFlag == TRUE)
         {
             /* Delete the handle (and the table, if the App owned it) */
             /* Get a pointer to the relevant Access Descriptor */
@@ -1418,6 +1418,9 @@ int32 CFE_TBL_CleanUpApp(uint32 AppId)
             /* NOTE: If this removes the last access link, then   */
             /*       memory buffers are set free as well.         */
             CFE_TBL_RemoveAccessLink(i);
+	    
+            CFE_TBL_TaskData.Handles[i].AppId = (uint32)CFE_TBL_NOT_OWNED;
+
         }
     }
 


### PR DESCRIPTION
Describe the contribution
Updates CFE_TBL_CleanUpApp such that it now checks the 'used flag' prior to calling CFE_TBL_RemoveAccessLink for a given TblHandle.  Also sets the AppId to CFE_TBL_NOT_OWNED after removing the access descriptor link from linked list.

Fix #121

Testing performed:
1. Modified cfe_es_runloop such that if AppSate == cfe_es_appstate_waiting, then it will not return false.  This was done to allow the restart command to work.
2. Created a test app that uses tables.
3. Modified table Noop command such that it prints out Table Access Descriptor data when received. 
4. Ran the following test - Note that I sent a noop after each step to review data (test results attached)
   a. Started CFE
   b. Deleted Test App
   c. Restarted Sample App
   d. Restarted Sample App

Ran test twice - Once to ensure I could recreate the error. Once to ensure changes corrected error.

5. Ran unit tests

Expected behavior changes
Will no longer receive 'CFE_TBL:RemoveAccessLink-PutPoolBuf[0] Fail' error.

System(s) tested on
Oracle VM VirtualBox
OS: ubuntu-19.10
Versions: 6.7.12.0, OSAL 5.0.9.0, PSP 1.4.7.0

Contributor Info
Dan Knutsen
NASA/Goddard


[issue_121_w_Fix.txt](https://github.com/nasa/cFE/files/4489244/issue_121_w_Fix.txt)
[issue_121_wo_Fix.txt](https://github.com/nasa/cFE/files/4489245/issue_121_wo_Fix.txt)
