### PR TITLE
Fix #410, separate SYSLOG configurable defaults for power on and proc…

### DIFF
--- a/cmake/sample_defs/cpu1_platform_cfg.h
+++ b/cmake/sample_defs/cpu1_platform_cfg.h
@@ -1005,22 +1005,40 @@
 #define CFE_PLATFORM_ES_DEFAULT_CDS_REG_DUMP_FILE     "/ram/cfe_cds_reg.log"
 
 /**
-**  \cfeescfg Define Default System Log Mode
+**  \cfeescfg Define Default System Log Mode following Power On Reset
 **
 **  \par Description:
-**       Defines the default mode for the operation of the ES System log. The log may
-**       operate in either Overwrite mode = 0, where once the log becomes full the
-**       oldest message in the log will be overwritten, or Discard mode = 1, where
-**       once the log becomes full the contents of the log are preserved and the new
-**       event is discarded.  This constant may hold a value of either 0 or 1
-**       depending on the desired default log mode.  Overwrite Mode = 0, Discard
-**       Mode = 1.
+**       Defines the default mode for the operation of the ES System log following a power
+**       on reset. The log may operate in either Overwrite mode = 0, where once the
+**       log becomes full the oldest message in the log will be overwritten, or
+**       Discard mode = 1, where once the log becomes full the contents of the log are
+**       preserved and the new event is discarded.  This constant may hold a value of
+**       either 0 or 1 depending on the desired default.
+**       Overwrite Mode = 0, Discard Mode = 1.
 **
 **  \par Limits
 **       There is a lower limit of 0 and an upper limit of 1 on this configuration
 **       paramater.
 */
-#define CFE_PLATFORM_ES_DEFAULT_SYSLOG_MODE      1
+#define CFE_PLATFORM_ES_DEFAULT_POR_SYSLOG_MODE      0
+
+/**
+**  \cfeescfg Define Default System Log Mode following Processor Reset
+**
+**  \par Description:
+**       Defines the default mode for the operation of the ES System log following a
+**       processor reset. The log may operate in either Overwrite mode = 0, where once
+**       the log becomes full the oldest message in the log will be overwritten, or
+**       Discard mode = 1, where once the log becomes full the contents of the log are
+**       preserved and the new event is discarded.  This constant may hold a value of
+**       either 0 or 1 depending on the desired default.
+**       Overwrite Mode = 0, Discard Mode = 1.
+**
+**  \par Limits
+**       There is a lower limit of 0 and an upper limit of 1 on this configuration
+**       paramater.
+*/
+#define CFE_PLATFORM_ES_DEFAULT_PR_SYSLOG_MODE      1
 
 /**
 **  \cfeescfg Define Max Number of Performance IDs
@@ -1997,7 +2015,7 @@
 #define CFE_ES_DEFAULT_ER_LOG_FILE          CFE_PLATFORM_ES_DEFAULT_ER_LOG_FILE
 #define CFE_ES_DEFAULT_PERF_DUMP_FILENAME   CFE_PLATFORM_ES_DEFAULT_PERF_DUMP_FILENAME
 #define CFE_ES_DEFAULT_CDS_REG_DUMP_FILE    CFE_PLATFORM_ES_DEFAULT_CDS_REG_DUMP_FILE
-#define CFE_ES_DEFAULT_SYSLOG_MODE          CFE_PLATFORM_ES_DEFAULT_SYSLOG_MODE
+#define CFE_ES_DEFAULT_SYSLOG_MODE          CFE_PLATFORM_ES_DEFAULT_PR_SYSLOG_MODE
 #define CFE_ES_PERF_MAX_IDS                 CFE_PLATFORM_ES_PERF_MAX_IDS
 #define CFE_ES_PERF_DATA_BUFFER_SIZE        CFE_PLATFORM_ES_PERF_DATA_BUFFER_SIZE
 #define CFE_ES_PERF_FILTMASK_NONE           CFE_PLATFORM_ES_PERF_FILTMASK_NONE

--- a/fsw/cfe-core/src/es/cfe_es_task.c
+++ b/fsw/cfe-core/src/es/cfe_es_task.c
@@ -234,9 +234,16 @@ int32 CFE_ES_TaskInit(void)
     CFE_ES_TaskData.LimitCmd  = 4;
 
     /*
-    ** Initialize systemlog to default mode
+    ** Initialize systemlog to default Power On or Processor Reset mode
     */
-    CFE_ES_ResetDataPtr->SystemLogMode = CFE_PLATFORM_ES_DEFAULT_SYSLOG_MODE;
+    if (CFE_ES_GetResetType(NULL) == CFE_PSP_RST_TYPE_POWERON)                                                                   
+    {
+        CFE_ES_ResetDataPtr->SystemLogMode = CFE_PLATFORM_ES_DEFAULT_POR_SYSLOG_MODE;
+    }
+    else
+    {
+        CFE_ES_ResetDataPtr->SystemLogMode = CFE_PLATFORM_ES_DEFAULT_PR_SYSLOG_MODE;
+    }
 
     /*
     ** Register event filter table.

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -2526,15 +2526,27 @@ void TestTask(void)
               "CFE_ES_TaskInit",
               "Checksum fail");
 
-    /* Test successful task main process loop */
+    /* Test successful task main process loop - Power On Reset Path */
     ES_ResetUnitTest();
     CFE_ES_Global.TaskTable[1].RecordUsed = true; /* this is needed so CFE_ES_GetAppId works */
     CFE_ES_Global.TaskTable[1].AppId = 1;
+    CFE_ES_ResetDataPtr->ResetVars.ResetType = 2;
     UT_Report(__FILE__, __LINE__,
               CFE_ES_TaskInit() == CFE_SUCCESS &&
               CFE_ES_TaskData.HkPacket.Payload.CFECoreChecksum != 0xFFFF,
               "CFE_ES_TaskInit",
-              "Checksum success");
+              "Checksum success, POR Path");
+
+    /* Test successful task main process loop - Processor Reset Path */
+    ES_ResetUnitTest();
+    CFE_ES_Global.TaskTable[1].RecordUsed = true; /* this is needed so CFE_ES_GetAppId works */
+    CFE_ES_Global.TaskTable[1].AppId = 1;
+    CFE_ES_ResetDataPtr->ResetVars.ResetType = 1;
+    UT_Report(__FILE__, __LINE__,
+              CFE_ES_TaskInit() == CFE_SUCCESS &&
+              CFE_ES_TaskData.HkPacket.Payload.CFECoreChecksum != 0xFFFF,
+              "CFE_ES_TaskInit",
+              "Checksum success, PR Path");
 
     /* Test task main process loop with a register app failure */
     ES_ResetUnitTest();


### PR DESCRIPTION
Describe the contribution
Fix #410 .
Separates configurable defaults for power on and processor reset. Default power on set to overwrite and default processor reset to discard.
Added an additional unit test to cover the path added to CFE_ES_TaskInit.

Testing performed:
Ran unit tests

Expected behavior changes
Upon power on reset, default system log mode set to overwrite.
Upon processor reset, default system log mode set to discard.

System(s) tested on
Oracle VM VirtualBox
OS: ubuntu-19.10
Versions: 6.7.12.0, OSAL 5.0.11.0, PSP 1.4.7.0

Contributor Info
Dan Knutsen
NASA/Goddard