### PR TITLE
Fix #629, Define BSP type in sample config

### DIFF
--- a/cmake/sample_defs/toolchain-cpu1.cmake
+++ b/cmake/sample_defs/toolchain-cpu1.cmake
@@ -20,6 +20,6 @@ SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE   NEVER)
 # These variable settings are specific to cFE/OSAL and determines which 
 # abstraction layers are built when using this toolchain
 SET(CFE_SYSTEM_PSPNAME      "pc-linux")
-SET(OSAL_SYSTEM_BSPNAME     "pc-linux")
+SET(OSAL_SYSTEM_BSPTYPE     "pc-linux")
 SET(OSAL_SYSTEM_OSTYPE      "posix")
 

--- a/cmake/sample_defs/toolchain-cpu2.cmake
+++ b/cmake/sample_defs/toolchain-cpu2.cmake
@@ -20,6 +20,6 @@ SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE   NEVER)
 # These variable settings are specific to cFE/OSAL and determines which 
 # abstraction layers are built when using this toolchain
 SET(CFE_SYSTEM_PSPNAME      "pc-linux")
-SET(OSAL_SYSTEM_BSPNAME     "pc-linux")
+SET(OSAL_SYSTEM_BSPTYPE     "pc-linux")
 SET(OSAL_SYSTEM_OSTYPE      "posix")
 

--- a/cmake/sample_defs/toolchain-cpu3.cmake
+++ b/cmake/sample_defs/toolchain-cpu3.cmake
@@ -20,6 +20,6 @@ SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE   NEVER)
 # These variable settings are specific to cFE/OSAL and determines which 
 # abstraction layers are built when using this toolchain
 SET(CFE_SYSTEM_PSPNAME      "pc-linux")
-SET(OSAL_SYSTEM_BSPNAME     "pc-linux")
+SET(OSAL_SYSTEM_BSPTYPE     "pc-linux")
 SET(OSAL_SYSTEM_OSTYPE      "posix")
 


### PR DESCRIPTION
**Describe the contribution**
Update of OSAL_SYSTEM_BSPNAME to OSAL_SYSTEM_BSPTYPE in sample toolchains.
Fix #629 

**Testing performed**
Steps taken to test the contribution:
1. Readme build steps

**Expected behavior changes**
Builds out of the box with sample config

**System(s) tested on**
 - Hardware: cFS Dev Server 3
 - OS: Ubuntu 18.04
 - Versions: Master bundle + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC