### PR TITLE
Fix #632, Infer OSAL_SYSTEM_BSPTYPE from CFE_SYSTEM_PSP_NAME

### DIFF
--- a/cmake/arch_build.cmake
+++ b/cmake/arch_build.cmake
@@ -272,21 +272,19 @@ function(prepare)
     add_definitions(-DSIMULATION=${SIMULATION})
   endif (SIMULATION)
   
-  # Check that PSPNAME, BSPTYPE, and OSTYPE are set properly for this arch
-  if (NOT CFE_SYSTEM_PSPNAME OR NOT OSAL_SYSTEM_OSTYPE)
+  # Check that PSPNAME is set properly for this arch
+  if (NOT CFE_SYSTEM_PSPNAME)
     if (CMAKE_CROSSCOMPILING)
-      message(FATAL_ERROR "Cross-compile toolchain ${CMAKE_TOOLCHAIN_FILE} must define CFE_SYSTEM_PSPNAME and OSAL_SYSTEM_OSTYPE")
+      message(FATAL_ERROR "Cross-compile toolchain ${CMAKE_TOOLCHAIN_FILE} must define CFE_SYSTEM_PSPNAME")
     elseif ("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux" OR 
             "${CMAKE_SYSTEM_NAME}" STREQUAL "CYGWIN")
       # Export the variables determined here up to the parent scope
       SET(CFE_SYSTEM_PSPNAME      "pc-linux" PARENT_SCOPE)
-      SET(OSAL_SYSTEM_BSPTYPE     "pc-linux" PARENT_SCOPE)
-      SET(OSAL_SYSTEM_OSTYPE      "posix"    PARENT_SCOPE)
     else ()
       # Not cross compiling and host system is not recognized
-      message(FATAL_ERROR "Do not know how to set CFE_SYSTEM_PSPNAME and OSAL_SYSTEM_OSTYPE on ${CMAKE_SYSTEM_NAME} system")
+      message(FATAL_ERROR "Do not know how to set CFE_SYSTEM_PSPNAME on ${CMAKE_SYSTEM_NAME} system")
     endif()
-  endif (NOT CFE_SYSTEM_PSPNAME OR NOT OSAL_SYSTEM_OSTYPE)
+  endif (NOT CFE_SYSTEM_PSPNAME)
   
   # Truncate the global TGTSYS_LIST to be only the target architecture
   set(TGTSYS_LIST ${TARGETSYSTEM} PARENT_SCOPE)
@@ -318,9 +316,22 @@ function(process_arch SYSVAR)
     endif(NOT TGTNAME)
     list(APPEND INSTALL_TARGET_LIST ${TGTNAME})
   endforeach()
+  
+  # Assume use of an OSAL BSP of the same name as the CFE PSP
+  # This can be overridden by the PSP-specific build_options but normally this is expected.
+  set(CFE_PSP_EXPECTED_OSAL_BSPTYPE ${CFE_SYSTEM_PSPNAME})
        
   # Include any specific compiler flags or config from the selected PSP
   include(${MISSION_SOURCE_DIR}/psp/fsw/${CFE_SYSTEM_PSPNAME}/make/build_options.cmake)
+  
+  if (NOT DEFINED OSAL_SYSTEM_BSPTYPE)
+      # Implicitly use the OSAL BSP that corresponds with the CFE PSP
+      set(OSAL_SYSTEM_BSPTYPE ${CFE_PSP_EXPECTED_OSAL_BSPTYPE})
+  elseif (NOT OSAL_SYSTEM_BSPTYPE STREQUAL CFE_PSP_EXPECTED_OSAL_BSPTYPE)
+      # Generate a warning about the BSPTYPE not being expected.
+      # Not calling this a fatal error because it could possibly be intended during development
+      message(WARNING "Mismatched PSP/BSP: ${CFE_SYSTEM_PSPNAME} implies ${CFE_PSP_EXPECTED_OSAL_BSPTYPE}, but ${OSAL_SYSTEM_BSPTYPE} is configured")
+  endif()
     
   # The "inc" directory in the binary dir contains the generated wrappers, if any
   include_directories(${MISSION_BINARY_DIR}/inc)


### PR DESCRIPTION
**Describe the contribution**
Normally the CFE PSP uses/links with an OSAL BSP of the same name. This removes the need to explicitly specify OSAL_SYSTEM_BSPTYPE in the toolchain file, as it can be reliably inferred.

Fixes #632 

This is also another alternative way to fix #629 

**Testing performed**
Build with defaults (as in README, e.g. a simple `make prep`), as well as `SIMULATION=native`, and for i686-rtems4.11 platform.  Confirm successful build.

Also "forced" a mismatch by hacking the i686-rtems4.11 toolchain to request bad combinations, and confirm that the build system warns of the mismatch now:

If `OSAL_SYSTEM_BSPTYPE` is set to `pc-linux`, the following warning happens in `make prep`
```
CMake Warning at cmake/arch_build.cmake:334 (message):
  Mismatched PSP/BSP: pc-rtems implies pc-rtems, but pc-linux is configured
Call Stack (most recent call first):
  CMakeLists.txt:119 (process_arch)
```
Likewise if the `OSAL_SYSTEM_OSTYPE` is set to `posix`, the follow is seen (from OSAL):
```
CMake Warning at /home/joe/code/cfecfs/github/osal/CMakeLists.txt:138 (message):
  Mismatched BSP/OS: pc-rtems implies rtems, but posix is configured
```

Finally removed settings of OSAL_SYSTEM_OSTYPE and OSAL_SYSTEM_BSPTYPE from the toolchain and confirmed that code correctly builds without issue, using the pc-rtems BSP and rtems OS layers, as expected for this toolchain.

**Expected behavior changes**
- Mismatches between PSP/BSP/OS are now detected and warned about during make prep
- Only the CFE_SYSTEM_PSPNAME is actually required to be specified for a CFE build now.  Others can be omitted.

**System(s) tested on**
Ubuntu 18.04 LTS 64 bit, with i686-rtems4.11 cross target

**Additional context**
The related change to infer OSAL_SYSTEM_OSTYPE from OSAL_SYSTEM_BSPTYPE is in nasa/osal#432 and pull request nasa/osal#427.  If it is desired to merge separately this can still be merged but it will have to continue setting OSAL_SYSTEM_OSTYPE.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
