### PR TITLE
Fix #639, Remove ES_APP_DEBUG functionality

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_apps.c
+++ b/fsw/cfe-core/src/es/cfe_es_apps.c
@@ -53,9 +53,6 @@
 */
 #define ES_START_BUFF_SIZE 128
 
-/* For extra debug code */
-#undef ES_APP_DEBUG
-
 /*
 **
 **  Global Variables
@@ -1238,11 +1235,6 @@ int32 CFE_ES_CleanUpApp(uint32 AppId)
    uint32 MainTaskId;
    int32  ReturnCode = CFE_SUCCESS;
 
-   #ifdef ES_APP_DEBUG
-      OS_printf("------------- Starting App Cleanup: AppID = %d -----------\n",AppId);
-      CFE_ES_ListResourcesDebug();
-   #endif
-
    /*
    ** Call the Table Clean up function
    */
@@ -1332,12 +1324,6 @@ int32 CFE_ES_CleanUpApp(uint32 AppId)
 
    CFE_ES_Global.AppTable[AppId].AppState = CFE_ES_AppState_UNDEFINED;
 
-    #ifdef ES_APP_DEBUG
-       OS_TaskDelay(1000);
-       CFE_ES_ListResourcesDebug();
-       printf("--------- Finished CFE_ES_CleanUpApp-------------\n");
-    #endif
-
    CFE_ES_UnlockSharedData(__func__,__LINE__);
 
    return(ReturnCode);
@@ -1348,8 +1334,7 @@ int32 CFE_ES_CleanUpApp(uint32 AppId)
 /*
  * Simple state structure used when cleaning up objects associated with tasks
  *
- * This is used locally between CFE_ES_CleanupTaskResources and the
- * CFE_ES_CountObjectCallback helper function.
+ * This is used locally by CFE_ES_CleanupTaskResources
  */
 typedef struct
 {
@@ -1362,9 +1347,9 @@ typedef struct
 
 /*
 **---------------------------------------------------------------------------------------
-**   Name: CFE_ES_CountObjectCallback
+**   Name: CFE_ES_CleanupObjectCallback
 **
-**   Purpose: Helper function for CFE_ES_ListResourcesDebug to count all objects.
+**   Purpose: Helper function clean up all objects.
 **
 **   NOTE: This is called while holding the ES global lock
 **---------------------------------------------------------------------------------------
@@ -1525,53 +1510,6 @@ int32 CFE_ES_CleanupTaskResources(uint32 TaskId)
 
     CFE_ES_Global.RegisteredTasks--;
     return(Result);
-
-}
-
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_CountObjectCallback
-**
-**   Purpose: Helper function for CFE_ES_ListResourcesDebug to count all objects.
-**---------------------------------------------------------------------------------------
-*/
-void CFE_ES_CountObjectCallback(uint32 ObjectId, void *arg)
-{
-    uint32                 *CountState;
-    uint32                 idtype;
-
-    CountState = (uint32 *)arg;
-    idtype = OS_IdentifyObject(ObjectId);
-    if (idtype < OS_OBJECT_TYPE_USER)
-    {
-        ++CountState[idtype];
-    }
-}
-
-
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_ListResourcesDebug
-**
-**   Purpose: List the resources.
-**---------------------------------------------------------------------------------------
-*/
-int32 CFE_ES_ListResourcesDebug(void)
-{
-    uint32   CountState[OS_OBJECT_TYPE_USER];
-
-    memset(CountState,0,sizeof(CountState));
-    OS_ForEachObject (0, CFE_ES_CountObjectCallback, CountState);
-
-    OS_printf("OS Resources in Use:\n");
-    OS_printf("Number of Tasks: %d\n", (int) CountState[OS_OBJECT_TYPE_OS_TASK]);
-    OS_printf("Number of Queues: %d\n", (int) CountState[OS_OBJECT_TYPE_OS_QUEUE]);
-    OS_printf("Number of Counting Semaphores: %d\n",(int) CountState[OS_OBJECT_TYPE_OS_COUNTSEM]);
-    OS_printf("Number of Binary Semaphores: %d\n",(int) CountState[OS_OBJECT_TYPE_OS_BINSEM]);
-    OS_printf("Number of Mutexes: %d\n", (int) CountState[OS_OBJECT_TYPE_OS_MUTEX]);
-    OS_printf("Number of Open Files: %d\n",(int) CountState[OS_OBJECT_TYPE_OS_STREAM]);
-
-    return CFE_SUCCESS;
 
 }
 

--- a/fsw/cfe-core/src/es/cfe_es_apps.h
+++ b/fsw/cfe-core/src/es/cfe_es_apps.h
@@ -224,11 +224,6 @@ int32 CFE_ES_CleanUpApp(uint32 AppId);
 int32 CFE_ES_CleanupTaskResources(uint32 TaskId);
 
 /*
-** Debug function to print out resource utilization
-*/
-int32 CFE_ES_ListResourcesDebug(void);
-
-/*
 ** Populate the cFE_ES_AppInfo structure with the data for an app
 ** This is an internal function for use in ES.
 ** The newer external API is : CFE_ES_GetAppInfo

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -1687,16 +1687,6 @@ void TestApps(void)
     /* Test listing the OS resources in use */
     ES_ResetUnitTest();
 
-    /* Fail the first time, then succeed on the second in order to test
-     * both paths
-     */
-    UT_SetDeferredRetcode(UT_KEY(OS_TaskGetInfo), 2, OS_ERROR);
-    UT_Report(__FILE__, __LINE__,
-              CFE_ES_ListResourcesDebug() == CFE_SUCCESS &&
-              UT_GetStubCount(UT_KEY(OS_printf)) == 7,
-              "CFE_ES_ListResourcesDebug",
-              "Get task info failed");
-
     /* Test populating the application information structure with data */
     ES_ResetUnitTest();
     OS_TaskCreate(&TestObjId, "UT", NULL, NULL, 0, 0, 0);
@@ -2091,21 +2081,6 @@ void TestApps(void)
     UT_Report(__FILE__, __LINE__,
               CFE_ES_CleanupTaskResources(TestObjId) == CFE_SUCCESS,
               "CFE_ES_CleanupTaskResources",
-              "Get OS information failures");
-
-    /* Test cleaning up the OS resources for a task with failure to
-     * obtain information on mutex, binary, and counter semaphores, and
-     * queues, timers, and file descriptors
-     */
-    ES_ResetUnitTest();
-    UT_SetDeferredRetcode(UT_KEY(OS_MutSemGetInfo), 1, OS_ERROR);
-    UT_SetDeferredRetcode(UT_KEY(OS_BinSemGetInfo), 1, OS_ERROR);
-    UT_SetDeferredRetcode(UT_KEY(OS_CountSemGetInfo), 1, OS_ERROR);
-    UT_SetDeferredRetcode(UT_KEY(OS_QueueGetInfo), 1, OS_ERROR);
-    UT_SetDeferredRetcode(UT_KEY(OS_FDGetInfo), 1, OS_ERROR);
-    UT_Report(__FILE__, __LINE__,
-              CFE_ES_ListResourcesDebug() == CFE_SUCCESS,
-              "CFE_ES_ListResourcesDebug",
               "Get OS information failures");
 }
 

--- a/fsw/cfe-core/unit-test/es_UT.h
+++ b/fsw/cfe-core/unit-test/es_UT.h
@@ -137,7 +137,7 @@ void TestStartupErrorPaths(void);
 ** \sa #UT_Report, #UT_SetOSFail, #CFE_ES_ParseFileEntry
 ** \sa #UT_SetBSPloadAppFileResult, #CFE_ES_AppCreate, #UT_SetDummyFuncRtn
 ** \sa #CFE_ES_LoadLibrary, #CFE_ES_ScanAppTable, #CFE_ES_ProcessControlRequest
-** \sa #CFE_ES_ListResourcesDebug, #CFE_ES_GetAppInfo, #CFE_ES_CleanUpApp
+** \sa #CFE_ES_GetAppInfo, #CFE_ES_CleanUpApp
 ** \sa #CFE_ES_CleanupTaskResources
 **
 ******************************************************************************/


### PR DESCRIPTION
**Describe the contribution**
Deletes now unused CFE_ES_CountObjectCallback
and CFE_ES_ListResourcesDebug.
Fix #639 

**Testing performed**
CI - https://travis-ci.com/github/skliper/cFS/builds/162476743

**Expected behavior changes**
None, flag was undefined

**System(s) tested on**
 - Hardware: CI
 - OS: Ubuntu 18.04
 - Versions: Master bundle + this branch

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC