### PR TITLE
Fix #488, Remove compiler added padding in tlm packets

### DIFF
--- a/fsw/cfe-core/src/inc/ccsds.h
+++ b/fsw/cfe-core/src/inc/ccsds.h
@@ -122,6 +122,12 @@ typedef struct {
 
    uint8  Time[CCSDS_TIME_SIZE];
 
+#if ( CCSDS_TIME_SIZE == 6 )
+   uint8  tempPad1[4];
+#elif ( CCSDS_TIME_SIZE == 8 )
+   uint8  tempPad1[2];
+#endif
+
 } CCSDS_TlmSecHdr_t;
 
 /*----- CCSDS Endian Flag in the APID Qualifier Field. -----*/

--- a/fsw/cfe-core/src/inc/cfe_es_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_es_msg.h
@@ -1412,8 +1412,8 @@ typedef struct
 **/
 typedef struct
 {
-  char                  Application[CFE_MISSION_MAX_API_LEN];   /**< \brief - RESERVED - should be all zeroes */
-  CFE_ES_MemHandle_t    PoolHandle;                     /**< \brief Handle of Pool whose statistics are to be telemetered */
+  char                  Application[CFE_MISSION_MAX_API_LEN];   /**< \brief Application Name */
+  CFE_ES_MemHandle_t    PoolHandle;                             /**< \brief Handle of Pool whose statistics are to be telemetered */
 
 } CFE_ES_SendMemPoolStatsCmd_Payload_t;
 
@@ -1469,6 +1469,7 @@ typedef struct
   CFE_ES_MemHandle_t    PoolHandle;                     /**< \cfetlmmnemonic \ES_POOLHANDLE
                                                              \brief Handle of memory pool whose stats are being telemetered */
   CFE_ES_MemPoolStats_t PoolStats;                      /**< \brief For more info, see #CFE_ES_MemPoolStats_t */
+  uint32                AlignPad;                       /**< \brief Spare word to maintain alignment */
 } CFE_ES_PoolStatsTlm_Payload_t;
 
 typedef struct

--- a/fsw/cfe-core/src/inc/cfe_tbl_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_tbl_msg.h
@@ -744,7 +744,7 @@ typedef struct
     */
     uint8                 NumFreeSharedBufs;                    /**< \cfetlmmnemonic \TBL_NUMFREESHRBUF 
                                                                      \brief Number of free Shared Working Buffers */
-    uint8                 ByteAlignPad1;                        /**< \cfetlmmnemonic \TBL_BYTEALIGNPAD1 
+    uint8                 ByteAlignPad1[3];                     /**< \cfetlmmnemonic \TBL_BYTEALIGNPAD1 
                                                                      \brief Spare byte to ensure longword alignment */
     CFE_ES_MemHandle_t    MemPoolHandle;                        /**< \cfetlmmnemonic \TBL_MEMPOOLHANDLE 
                                                                      \brief Handle to TBL's memory pool */
@@ -794,7 +794,7 @@ typedef struct
                                                                      \brief Flag indicating an inactive buffer is ready to be copied */
     bool                        DumpOnly;                       /**< \cfetlmmnemonic \TBL_DUMPONLY 
                                                                      \brief Flag indicating Table is NOT to be loaded */
-    bool                        DoubleBuffered;                    /**< \cfetlmmnemonic \TBL_DBLBUFFERED 
+    bool                        DoubleBuffered;                 /**< \cfetlmmnemonic \TBL_DBLBUFFERED 
                                                                      \brief Flag indicating Table has a dedicated inactive buffer */
     char                        Name[CFE_MISSION_TBL_MAX_FULL_NAME_LEN];/**< \cfetlmmnemonic \TBL_NAME
                                                                      \brief Processor specific table name */
@@ -804,7 +804,7 @@ typedef struct
                                                                      \brief Name of owning application */
     bool                        Critical;                       /**< \cfetlmmnemonic \TBL_CRITICAL
                                                                      \brief Indicates whether table is Critical or not */
-    uint8                       ByteAlign4;                     /**< \cfetlmmnemonic \TBL_SPARE4
+    uint8                       ByteAlign4[7];                  /**< \cfetlmmnemonic \TBL_SPARE4
                                                                      \brief Spare byte to maintain byte alignment */
 } CFE_TBL_TblRegPacket_Payload_t;
 


### PR DESCRIPTION
**Describe the contribution**
Fix #488 
Removes compiler added padding by padding CCSDS_TlmSecHdr_t such that the payload will always start on a 64-bit boundary.  Also adjusts packet alignment such that packets with 64 bit variables are aligned correctly.

Related to nasa/cFS-GroundSystem#81
Intended to be delivered with nasa/cFS-GroundSystem#82

**Testing performed**
Steps taken to test the contribution:
1. Modified GroundSystem.py to display raw packets as they are being decommed
2. Bit busted packets to ensure no compiler added padding is being applied.
3. Ran unit tests.

**Expected behavior changes**
Compiler added padding will no longer be applied to packets.

**System(s) tested on**
Oracle VM VirtualBox
OS: ubuntu-19.10
Versions: cFE 6.7.14.0, OSAL 5.0.13.0, PSP 1.4.9.0


**Contributor Info - All information REQUIRED for consideration of pull request**
Dan Knutsen
NASA/Goddard