### PR TITLE
Fix #551, Remove duplicate CFE_TIME_Local1HzISR prototype

### DIFF
--- a/fsw/cfe-core/src/time/cfe_time_utils.h
+++ b/fsw/cfe-core/src/time/cfe_time_utils.h
@@ -460,7 +460,6 @@ void CFE_TIME_NotifyTimeSynchApps(void);
 /*
 ** Function prototypes (local 1Hz interrupt)...
 */
-void CFE_TIME_Local1HzISR(void);
 void CFE_TIME_Local1HzTask(void);
 void CFE_TIME_Local1HzStateMachine(void);
 void CFE_TIME_Local1HzTimerCallback(uint32 TimerId, void *Arg);


### PR DESCRIPTION
**Describe the contribution**
Removed duplicate prototype in cfe_time_utils.h
Fix #551

**Testing performed**
Standard make w/ unit tests

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: cFS Dev Server 3
 - OS: Ubuntu 18.04
 - Versions: Master bundle w/ this commit

**Additional context**
Bigger time service cleanup referenced in #302

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC