### PR TITLE
Fix #519, Deprecate CFS/FS time conversion APIs

### DIFF
--- a/fsw/cfe-core/src/inc/cfe_time.h
+++ b/fsw/cfe-core/src/inc/cfe_time.h
@@ -535,7 +535,7 @@ CFE_TIME_Compare_t  CFE_TIME_Compare(CFE_TIME_SysTime_t TimeA, CFE_TIME_SysTime_
 ** \return Spacecraft Time (UTC or TAI) corresponding to the specified MET
 **
 ** \sa #CFE_TIME_GetMET, #CFE_TIME_GetMETseconds, #CFE_TIME_GetMETsubsecs,
-**     #CFE_TIME_Sub2MicroSecs, #CFE_TIME_Micro2SubSecs, #CFE_TIME_CFE2FSSeconds, #CFE_TIME_FS2CFESeconds
+**     #CFE_TIME_Sub2MicroSecs, #CFE_TIME_Micro2SubSecs
 **
 ******************************************************************************/
 CFE_TIME_SysTime_t CFE_TIME_MET2SCTime (CFE_TIME_SysTime_t METTime);
@@ -556,7 +556,6 @@ CFE_TIME_SysTime_t CFE_TIME_MET2SCTime (CFE_TIME_SysTime_t METTime);
 ** \return The equivalent number of microseconds.
 **
 ** \sa #CFE_TIME_MET2SCTime, #CFE_TIME_Micro2SubSecs, 
-**     #CFE_TIME_CFE2FSSeconds, #CFE_TIME_FS2CFESeconds
 **
 ******************************************************************************/
 uint32  CFE_TIME_Sub2MicroSecs(uint32 SubSeconds);
@@ -579,14 +578,17 @@ uint32  CFE_TIME_Sub2MicroSecs(uint32 SubSeconds);
 **         value is equal to \c 0xffffffff.
 **
 ** \sa #CFE_TIME_MET2SCTime, #CFE_TIME_Sub2MicroSecs, 
-**     #CFE_TIME_CFE2FSSeconds, #CFE_TIME_FS2CFESeconds
 **
 ******************************************************************************/
 uint32  CFE_TIME_Micro2SubSecs(uint32 MicroSeconds);
 
+#ifndef CFE_OMIT_DEPRECATED_6_7
 /*****************************************************************************/
 /**
-** \brief Converts cFE seconds into the File System's seconds
+** \brief DEPRECATED: Converts cFE seconds into the File System's seconds
+** \deprecated Utilize #CFE_FS_Header_t time fields for the creation
+**             time in mission format, or syncronize local OS time
+**             with mission time for use with stat command.
 **
 ** \par Description
 **        File systems use specific time epochs for their time tagging of files.
@@ -612,7 +614,10 @@ uint32 CFE_TIME_CFE2FSSeconds(uint32 SecondsCFE);
 
 /*****************************************************************************/
 /**
-** \brief Converts a file system's seconds into cFE seconds
+** \brief DEPRECATED: Converts a file system's seconds into cFE seconds
+** \deprecated Utilize #CFE_FS_Header_t time fields for the creation
+**             time in mission format, or syncronize local OS time
+**             with mission time for use with stat command.
 **
 ** \par Description
 **        File systems use specific time epochs for their time tagging of files.
@@ -635,6 +640,7 @@ uint32 CFE_TIME_CFE2FSSeconds(uint32 SecondsCFE);
 **
 ******************************************************************************/
 uint32 CFE_TIME_FS2CFESeconds(uint32 SecondsFS);
+#endif /* CFE_OMIT_DEPRECATED_6_7 */
 /**@}*/
 
 /** @defgroup CFEAPITIMEExternSource cFE External Time Source APIs

--- a/fsw/cfe-core/src/time/cfe_time_api.c
+++ b/fsw/cfe-core/src/time/cfe_time_api.c
@@ -600,7 +600,7 @@ uint32  CFE_TIME_Micro2SubSecs(uint32 MicroSeconds)
 
 } /* End of CFE_TIME_Micro2SubSecs() */
 
-
+#ifndef CFE_OMIT_DEPRECATED_6_7
 /*
  * Function: CFE_TIME_CFE2FSSeconds - See API and header file for details
  */
@@ -658,7 +658,7 @@ uint32 CFE_TIME_FS2CFESeconds(uint32 SecondsFS)
     return(SecondsCFE);
 
 } /* End of CFE_TIME_FS2CFESeconds() */
-
+#endif /* CFE_OMIT_DEPRECATED_6_7 */
 
 /*
  * Function: CFE_TIME_Print - See API and header file for details

--- a/fsw/cfe-core/unit-test/time_UT.c
+++ b/fsw/cfe-core/unit-test/time_UT.c
@@ -210,7 +210,6 @@ void UtTest_Setup(void)
     UT_ADD_TEST(Test_GetTime);
     UT_ADD_TEST(Test_TimeOp);
     UT_ADD_TEST(Test_ConvertTime);
-    UT_ADD_TEST(Test_ConvertCFEFS);
     UT_ADD_TEST(Test_Print);
     UT_ADD_TEST(Test_RegisterSyncCallbackTrue);
     UT_ADD_TEST(Test_ExternalTone);
@@ -1144,116 +1143,6 @@ void Test_ConvertTime(void)
               CFE_TIME_Micro2SubSecs(0xffffffff) == 0xffffffff,
               "CFE_TIME_Micro2SubSecs",
               "Microseconds exceeds maximum; set maximum subseconds value");
-}
-
-/*
-** Test function for converting cFE seconds to file system (FS) seconds and
-** vice versa
-*/
-void Test_ConvertCFEFS(void)
-{
-    uint32 result;
-
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Convert cFE and FS Seconds\n");
-#endif
-
-    /* Test cFE to FS conversion using 0 for the cFE seconds value */
-    UT_InitData();
-
-    /* Calculate expected result based on macro value */
-    if (CFE_MISSION_TIME_FS_FACTOR < 0 && -CFE_MISSION_TIME_FS_FACTOR > 0)
-    {
-        result = 0;
-    }
-    else
-    {
-        result = CFE_MISSION_TIME_FS_FACTOR;
-    }
-
-    UT_Report(__FILE__, __LINE__,
-              CFE_TIME_CFE2FSSeconds(0) == result,
-              "CFE_TIME_CFE2FSSeconds",
-              "Convert 0 cFE seconds to FS seconds");
-
-    /* Test cFE to FS conversion using mid-range value for cFE seconds */
-    UT_InitData();
-
-    /* Calculate expected result based on macro value */
-    if (CFE_MISSION_TIME_FS_FACTOR < 0 && -CFE_MISSION_TIME_FS_FACTOR > 0xffff)
-    {
-        result = 0;
-    }
-    else
-    {
-        result = CFE_MISSION_TIME_FS_FACTOR + 0xffff;
-    }
-
-    UT_Report(__FILE__, __LINE__,
-              CFE_TIME_CFE2FSSeconds(0xffff) == result,
-              "CFE_TIME_CFE2FSSeconds",
-              "Convert mid-range cFE seconds to FS seconds");
-
-    /* Test cFE to FS conversion using the maximum cFE seconds value */
-    UT_InitData();
-    UT_Report(__FILE__, __LINE__,
-              CFE_TIME_CFE2FSSeconds(0xffffffff) ==
-              (uint32) (CFE_MISSION_TIME_FS_FACTOR - 1),
-              "CFE_TIME_CFE2FSSeconds",
-              "Maximum cFE seconds value");
-
-    /* Test FS to cFE conversion using 0 for the FS seconds value */
-    UT_InitData();
-
-    if (CFE_MISSION_TIME_FS_FACTOR > 0)
-    {
-        result = 0;
-    }
-    else
-    {
-        result = -(uint32) CFE_MISSION_TIME_FS_FACTOR;
-    }
-
-    UT_Report(__FILE__, __LINE__,
-              CFE_TIME_FS2CFESeconds(0) == result,
-              "CFE_TIME_FS2CFESeconds",
-              "Convert 0 FS seconds to cFE seconds");
-
-    /* Test FS to cFE conversion response to a FS seconds value that results
-     * in a negative cFE time (forces cFE seconds to zero)
-     */
-    UT_InitData();
-    UT_Report(__FILE__, __LINE__,
-              CFE_TIME_FS2CFESeconds(CFE_MISSION_TIME_FS_FACTOR - 1) == 0,
-              "CFE_TIME_FS2CFESeconds",
-              "Negative cFE seconds conversion (force to zero)");
-
-    /* Test FS to cFE conversion using the minimum convertible FS
-     * seconds value
-     */
-    UT_InitData();
-
-    if (CFE_MISSION_TIME_FS_FACTOR > (uint32) (CFE_MISSION_TIME_FS_FACTOR + 1))
-    {
-        result = 0;
-    }
-    else
-    {
-        result = 1;
-    }
-
-    UT_Report(__FILE__, __LINE__,
-              CFE_TIME_FS2CFESeconds(CFE_MISSION_TIME_FS_FACTOR + 1) == result,
-              "CFE_TIME_FS2CFESeconds",
-              "Minimum convertible FS seconds value");
-
-    /* Test FS to cFE conversion using the maximum FS seconds value */
-    UT_InitData();
-    UT_Report(__FILE__, __LINE__,
-              CFE_TIME_FS2CFESeconds(0xffffffff) == 0xffffffff -
-              CFE_MISSION_TIME_FS_FACTOR,
-              "CFE_TIME_FS2CFESeconds",
-              "Maximum FS seconds value");
 }
 
 /*

--- a/fsw/cfe-core/unit-test/time_UT.h
+++ b/fsw/cfe-core/unit-test/time_UT.h
@@ -155,27 +155,6 @@ void Test_ConvertTime(void);
 
 /*****************************************************************************/
 /**
-** \brief Test function for converting cFE seconds to file system (FS) seconds
-**        and vice versa
-**
-** \par Description
-**        This function tests the function for converting cFE seconds to file
-**        system (FS) seconds and vice versa.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-**
-** \sa #UT_Text, #UT_InitData, #UT_Report, #CFE_TIME_CFE2FSSeconds,
-** \sa #CFE_TIME_FS2CFESeconds
-**
-******************************************************************************/
-void Test_ConvertCFEFS(void);
-
-/*****************************************************************************/
-/**
 ** \brief Test function for creating a text string representing the date
 **        and time
 **


### PR DESCRIPTION
**Describe the contribution**
Deprecates CFE_TIME_CFE2FSSeconds and CFE_TIME_FS2CFESeconds - in short the conversion/management of local OS time vs mission time isn't within the scope of cFE (it doesn't manage local OS time, so doesn't maintain an appropriate conversion factor).  Utilize the CFE_FS_Header_t time for file creation if needed, synchronize local OS time with mission time, or use the return from stat as a relative (with reset caveats)
Fix #519 

**Testing performed**
Build and unit test - SIMULATION=native ENABLE_UNIT_TESTS=true with and without OMIT_DEPRECATED=true
All passes

**Expected behavior changes**
None other than no longer supporting 

**System(s) tested on**
 - Hardware: cFS Dev Server 3
 - OS: Ubuntu 18.04
 - Versions: Master bundle + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC