### PR TITLE
Fix #618, stubs must not depend on real msgid implementation

### DIFF
--- a/fsw/cfe-core/unit-test/evs_UT.c
+++ b/fsw/cfe-core/unit-test/evs_UT.c
@@ -2703,6 +2703,8 @@ void Test_Misc(void)
 
     /* Test housekeeping report with log enabled */
     UT_InitData();
+    CFE_SB_InitMsg((CFE_SB_Msg_t *) &CFE_EVS_GlobalData.EVS_TlmPkt, HK_SnapshotData.MsgId,
+            sizeof(CFE_EVS_GlobalData.EVS_TlmPkt), false);
     CFE_EVS_GlobalData.EVS_TlmPkt.Payload.LogEnabled = true;
     HK_SnapshotData.Count = 0;
     UT_SetHookFunction(UT_KEY(CFE_SB_SendMsg), UT_SoftwareBusSnapshotHook, &HK_SnapshotData);
@@ -2729,6 +2731,8 @@ void Test_Misc(void)
 
     /* Test housekeeping report with log disabled */
     UT_InitData();
+    CFE_SB_InitMsg((CFE_SB_Msg_t *) &CFE_EVS_GlobalData.EVS_TlmPkt, HK_SnapshotData.MsgId,
+            sizeof(CFE_EVS_GlobalData.EVS_TlmPkt), false);
     CFE_EVS_GlobalData.EVS_TlmPkt.Payload.LogEnabled = false;
     HK_SnapshotData.Count = 0;
     UT_SetHookFunction(UT_KEY(CFE_SB_SendMsg), UT_SoftwareBusSnapshotHook, &HK_SnapshotData);

--- a/fsw/cfe-core/unit-test/tbl_UT.c
+++ b/fsw/cfe-core/unit-test/tbl_UT.c
@@ -367,19 +367,17 @@ void Test_CFE_TBL_TaskInit(void)
 */
 void Test_CFE_TBL_InitData(void)
 {
-    CFE_SB_MsgId_t MsgIdBuf[2];
-
 #ifdef UT_VERBOSE
     UT_Text("Begin Test Init Data\n");
 #endif
 
     /* This function has only one possible path with no return code */
     UT_InitData();
-    UT_SetDataBuffer(UT_KEY(CFE_SB_SetMsgId), MsgIdBuf, sizeof(MsgIdBuf), false);
     CFE_TBL_InitData();
     UT_Report(__FILE__, __LINE__,
-              CFE_SB_MsgId_Equal(MsgIdBuf[1], CFE_SB_ValueToMsgId(CFE_TBL_REG_TLM_MID)) &&
-              UT_GetStubCount(UT_KEY(CFE_SB_SetMsgId)) == 2,
+              CFE_SB_MsgId_Equal(CFE_SB_GetMsgId((CFE_SB_Msg_t*)&CFE_TBL_TaskData.HkPacket), CFE_SB_ValueToMsgId(CFE_TBL_HK_TLM_MID)) &&
+              CFE_SB_MsgId_Equal(CFE_SB_GetMsgId((CFE_SB_Msg_t*)&CFE_TBL_TaskData.TblRegPacket), CFE_SB_ValueToMsgId(CFE_TBL_REG_TLM_MID)) &&
+              UT_GetStubCount(UT_KEY(CFE_SB_InitMsg)) == 2,
               "CFE_TBL_SearchCmdHndlrTbl",
               "Initialize data");
 }

--- a/fsw/cfe-core/unit-test/time_UT.c
+++ b/fsw/cfe-core/unit-test/time_UT.c
@@ -284,7 +284,7 @@ void Test_Init(void)
     ExpRtn++;
     CFE_TIME_EarlyInit();
     UT_Report(__FILE__, __LINE__,
-              UT_GetStubCount(UT_KEY(CFE_SB_SetMsgId)) == ExpRtn,
+              UT_GetStubCount(UT_KEY(CFE_SB_InitMsg)) == ExpRtn,
               "CFE_TIME_EarlyInit",
               "Successful");
 
@@ -1904,6 +1904,8 @@ void Test_PipeCmds(void)
 
     /* Test sending the housekeeping telemetry request command */
     UT_InitData();
+    CFE_SB_InitMsg((CFE_SB_Msg_t *) &CFE_TIME_TaskData.HkPacket, LocalSnapshotData.MsgId,
+            sizeof(CFE_TIME_TaskData.HkPacket), false);
     UT_SetHookFunction(UT_KEY(CFE_SB_SendMsg), UT_SoftwareBusSnapshotHook, &LocalSnapshotData);
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.cmd),
             UT_TPID_CFE_TIME_SEND_HK);

--- a/fsw/cfe-core/unit-test/ut_support.c
+++ b/fsw/cfe-core/unit-test/ut_support.c
@@ -232,8 +232,7 @@ void UT_CallTaskPipe(void (*TaskPipeFunc)(CFE_SB_MsgPtr_t), CFE_SB_MsgPtr_t Msg,
      * macros (not stubs) to read this info direct from
      * the buffer.
      */
-    CCSDS_WR_LEN(Msg->Hdr, MsgSize);
-    CCSDS_WR_SHDR(Msg->Hdr, 1);
+    CFE_SB_SetTotalMsgLength(Msg, MsgSize);
     CFE_SB_SetMsgId(Msg, DispatchId.MsgId);
     CFE_SB_SetCmdCode(Msg, DispatchId.CommandCode);
 


### PR DESCRIPTION
**Describe the contribution**
This makes the SB stubs which access message structures into actual stubs, not a replica of the normal implementation.  Stubs manipulate a local (stored in the UT framework) out-of-band buffer to hold the metadata about the message.

This removes the dependency on the actual definition of MsgId used by the mission and makes them agnostic to the setting of extended headers.

This revealed a few other minor issues in test cases where they were depending on values sitting in globals (also fixed).

Fixes #618 

**Testing performed**
Build unit tests with SIMULATION=native ENABLE_UNIT_TESTS=TRUE with and without configuration for extended headers.  Confirm passing.

**Expected behavior changes**
Unit tests now build and run when `MESSAGE_FORMAT_IS_CCSDS_VER_2` is configured.

**System(s) tested on**
Ubuntu 20.04 LTS 64 bit

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.