### PR TITLE
Fix #676, reference to deprecated CFE_SPACECRAFT_ID

### DIFF
--- a/fsw/cfe-core/src/sb/cfe_sb_msg_id_util.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_msg_id_util.c
@@ -181,7 +181,7 @@ void CFE_SB_SetMsgId(CFE_SB_MsgPtr_t MsgPtr,
   
   CCSDS_WR_SUBSYSTEM_ID(MsgPtr->SpacePacket.ApidQ, CFE_SB_RD_SUBSYS_ID_FROM_MSGID(MsgIdVal));
   
-  CCSDS_WR_SYSTEM_ID(MsgPtr->SpacePacket.ApidQ, CFE_SPACECRAFT_ID);
+  CCSDS_WR_SYSTEM_ID(MsgPtr->SpacePacket.ApidQ, CFE_MISSION_SPACECRAFT_ID);
 
 #endif 
 }/* end CFE_SB_SetMsgId */


### PR DESCRIPTION
**Describe the contribution**
Change to `CFE_MISSION_SPACECRAFT_ID`, which is the non-deprecated symbol.

Fixes #676 

**Testing performed**
Build with extended header and `OMIT_DEPRECATED` and confirm success.

**Expected behavior changes**
Build now works with both extended headers and OMIT_DEPRECATED options set.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.