### PR TITLE
Fix #675, whole-archive unrecognized when compiling with VxWorks spar…

### DIFF
--- a/cmake/target/CMakeLists.txt
+++ b/cmake/target/CMakeLists.txt
@@ -82,8 +82,13 @@ if (TGT${TGTID}_APPLIST)
   
   if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
     # The option pair for GNU gcc/ld tools
-    set(START_WHOLE_ARCHIVE "--whole-archive")
-    set(STOP_WHOLE_ARCHIVE  "--no-whole-archive")
+    if("${CPU}" STREQUAL "SPARC")
+       set(START_WHOLE_ARCHIVE "-Wl,--whole-archive")
+       set(STOP_WHOLE_ARCHIVE  "-Wl,--no-whole-archive")
+   else()
+       set(START_WHOLE_ARCHIVE "--whole-archive")
+       set(STOP_WHOLE_ARCHIVE  "--no-whole-archive")
+     endif()
     
     # the linker option prefix may or may not be needed, see below
     set(COMPILER_LINKER_OPTION_PREFIX "-Wl,")  


### PR DESCRIPTION
…c compiler

In START_WHOLE_ARCHIVE and STOP_WHOLE_ARCHIVE, it is missing "-Wl," when compiling for vxworks.

**Describe the contribution**
A clear and concise description of what the contribution is.
- Include explicitly what issue it addresses [e.g. Fixes #X]

**Testing performed**
Steps taken to test the contribution:
1. Build steps '...'
1. Execution steps '...'

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - API Change: xxx (if applicable)
 - Behavior Change: xxx (if applicable)
 - Or no impact to behavior

**System(s) tested on**
 - Hardware: [e.g. PC, SP0, MCP750]
 - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
- If NASA Civil Servant Employee or GSFC Contractor on SES II
  - Address/email/phone and contract/task information (if applicable) must be on file
- Else if Company
  - **HAND SIGNED** Company CLA must be on file (once per release): [Company CLA](../docs/GSC_18128_Corp_CLA_form_1219.pdf)
- Else if Individual
  - **HAND SIGNED** Individual CLA must be on file (once per release): [Individual CLA](../docs/GSC_18128_Ind_CLA_form_1219.pdf)
