### PR TITLE
Fix #684, order of CleanupTaskResources

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_apps.c
+++ b/fsw/cfe-core/src/es/cfe_es_apps.c
@@ -1281,23 +1281,11 @@ int32 CFE_ES_CleanUpApp(uint32 AppId)
    MainTaskId = CFE_ES_Global.AppTable[AppId].TaskInfo.MainTaskId;
 
    /*
-   ** Delete all of the OS resources, close files, and delete the main task
-   */
-   Status = CFE_ES_CleanupTaskResources(MainTaskId);
-   if ( Status != CFE_SUCCESS )
-   {
-      CFE_ES_SysLogWrite_Unsync("CFE_ES_CleanUpApp: CleanUpTaskResources for Task ID:%d returned Error: 0x%08X\n",
-                               (int)MainTaskId, (unsigned int)Status);
-      ReturnCode = CFE_ES_APP_CLEANUP_ERR;
-
-   }
-
-   /*
    ** Delete any child tasks associated with this app
    */
    for ( i = 0; i < OS_MAX_TASKS; i++ )
    {
-      /* delete only CHILD tasks - not the MainTaskId, which is already deleted (above) */
+      /* delete only CHILD tasks - not the MainTaskId, which will be deleted later (below) */
       if ((CFE_ES_Global.TaskTable[i].RecordUsed == true) &&
           (CFE_ES_Global.TaskTable[i].AppId == AppId) &&
           (CFE_ES_Global.TaskTable[i].TaskId != MainTaskId))
@@ -1311,6 +1299,18 @@ int32 CFE_ES_CleanUpApp(uint32 AppId)
          }
       } /* end if */
    } /* end for */
+
+   /*
+   ** Delete all of the OS resources, close files, and delete the main task
+   */
+   Status = CFE_ES_CleanupTaskResources(MainTaskId);
+   if ( Status != CFE_SUCCESS )
+   {
+      CFE_ES_SysLogWrite_Unsync("CFE_ES_CleanUpApp: CleanUpTaskResources for Task ID:%d returned Error: 0x%08X\n",
+                               (int)MainTaskId, (unsigned int)Status);
+      ReturnCode = CFE_ES_APP_CLEANUP_ERR;
+
+   }
 
    /*
    ** Remove the app from the AppTable


### PR DESCRIPTION
**Describe the contribution**
When cleaning up a task the child task resources should be cleaned first, followed by the main task resources.

This is because child tasks are also associated with the original creator within OSAL and will be found through OSAL ForEachObject, and also via links within the ES task table.

By cleaning child tasks first, this avoids attempting to delete the child task twice.

Fixes #684

**Testing performed**
Hack "sample_app" to create a child thread AND trigger an exception after period of time.  Confirmed the original bug report where the attempt to clean up the sample_app resources results in `CFE_ES_TASK_DELETE_ERR` in the unmodified master branch.

Then apply this patch and re-test, and confirm that "sample_app" is successfully restarted.  

Also confirm unit tests passing.

**Expected behavior changes**
Both the main task and the child task(s) are successfully deleted and restarted after the exception occurs.

**System(s) tested on**
Ubuntu 20.04 

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.