### PR TITLE
Fix #681, Resolve doxygen warnings for tbl

### DIFF
--- a/fsw/cfe-core/src/tbl/cfe_tbl_internal.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_internal.h
@@ -370,6 +370,8 @@ int32   CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr,
 ** \par Assumptions, External Events, and Notes:
 **        -# This function assumes parameters have been verified.
 **
+** \param[in]  AppName          The name of the application loading the table.
+**
 ** \param[in]  WorkingBufferPtr Pointer to a working buffer that is to be loaded
 **                              with the contents of the specified file
 **


### PR DESCRIPTION
**Describe the contribution**
Fixes doxygen warnings for the tbl subsystem.

Fix #681

**Testing performed**
make doc, grep "TBL" build/doc/warnings.log

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov