### PR TITLE
Fix #689, Align all software bus message definitions

### DIFF
--- a/fsw/cfe-core/src/inc/cfe_es_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_es_msg.h
@@ -1120,7 +1120,7 @@
 */
 typedef struct
 {
-  uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];     /**< \brief cFE Software Bus Command Message Header */
+  CFE_SB_CmdHdr_t CmdHeader;     /**< \brief cFE Software Bus Command Message Header */
 
 } CFE_ES_NoArgsCmd_t;
 
@@ -1151,7 +1151,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader;    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_RestartCmd_Payload_t Payload;
 } CFE_ES_Restart_t;
 
@@ -1176,7 +1176,7 @@ typedef struct
  */
 typedef struct
 {
-    uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader;    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_ShellCmd_Payload_t   Payload;
 } CFE_ES_Shell_t;
 #endif /* CFE_OMIT_DEPRECATED_6_7 */
@@ -1198,7 +1198,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader;    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_FileNameCmd_Payload_t Payload;
 } CFE_ES_FileNameCmd_t;
 
@@ -1226,7 +1226,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                               CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader;    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_OverWriteSysLogCmd_Payload_t Payload;
 } CFE_ES_OverWriteSyslog_t;
 
@@ -1255,7 +1255,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader;    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_StartAppCmd_Payload_t    Payload;
 } CFE_ES_StartApp_t;
 
@@ -1272,7 +1272,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader;    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_AppNameCmd_Payload_t Payload;
 } CFE_ES_AppNameCmd_t;
 
@@ -1300,7 +1300,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader;    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_AppReloadCmd_Payload_t   Payload;
 } CFE_ES_ReloadApp_t;
 
@@ -1318,7 +1318,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                               CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader;    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_SetMaxPRCountCmd_Payload_t   Payload;
 } CFE_ES_SetMaxPRCount_t;
 
@@ -1336,7 +1336,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader;    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_DeleteCDSCmd_Payload_t   Payload;
 } CFE_ES_DeleteCDS_t;
 
@@ -1353,7 +1353,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader;    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_StartPerfCmd_Payload_t   Payload;
 } CFE_ES_StartPerfData_t;
 
@@ -1371,7 +1371,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader;    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_StopPerfCmd_Payload_t    Payload;
 } CFE_ES_StopPerfData_t;
 
@@ -1391,7 +1391,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader;    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_SetPerfFilterMaskCmd_Payload_t Payload;
 } CFE_ES_SetPerfFilterMask_t;
 
@@ -1410,7 +1410,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                               CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader;    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_SetPerfTrigMaskCmd_Payload_t Payload;
 } CFE_ES_SetPerfTriggerMask_t;
 
@@ -1429,7 +1429,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                               CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader;    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_SendMemPoolStatsCmd_Payload_t    Payload;
 } CFE_ES_SendMemPoolStats_t;
 
@@ -1447,7 +1447,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader;    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_DumpCDSRegistryCmd_Payload_t  Payload;
 
 } CFE_ES_DumpCDSRegistry_t;
@@ -1467,7 +1467,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                       TlmHeader[CFE_SB_TLM_HDR_SIZE]; /**< \brief cFE Software Bus Telemetry Message Header */
+    CFE_SB_TlmHdr_t TlmHeader; /**< \brief cFE Software Bus Telemetry Message Header */
     CFE_ES_OneAppTlm_Payload_t  Payload;
 } CFE_ES_OneAppTlm_t;
 
@@ -1483,7 +1483,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                           TlmHeader[CFE_SB_TLM_HDR_SIZE]; /**< \brief cFE Software Bus Telemetry Message Header */
+    CFE_SB_TlmHdr_t TlmHeader; /**< \brief cFE Software Bus Telemetry Message Header */
     CFE_ES_PoolStatsTlm_Payload_t   Payload;
 } CFE_ES_MemStatsTlm_t;
 
@@ -1580,7 +1580,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                       TlmHeader[CFE_SB_TLM_HDR_SIZE]; /**< \brief cFE Software Bus Telemetry Message Header */
+    CFE_SB_TlmHdr_t TlmHeader; /**< \brief cFE Software Bus Telemetry Message Header */
     CFE_ES_HousekeepingTlm_Payload_t   Payload;
   
 } CFE_ES_HousekeepingTlm_t;

--- a/fsw/cfe-core/src/inc/cfe_evs_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_evs_msg.h
@@ -919,7 +919,7 @@
 ** \brief Command with no additional arguments
 **/
 typedef struct {
-   uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];
+   CFE_SB_CmdHdr_t CmdHeader;
 } CFE_EVS_NoArgsCmd_t;
 
 /*
@@ -942,7 +942,7 @@ typedef struct {
 } CFE_EVS_LogFileCmd_Payload_t;
 
 typedef struct {
-   uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];
+   CFE_SB_CmdHdr_t CmdHeader;
    CFE_EVS_LogFileCmd_Payload_t Payload;
 } CFE_EVS_WriteLogDataFile_t;
 
@@ -958,7 +958,7 @@ typedef struct {
 } CFE_EVS_AppDataCmd_Payload_t;
 
 typedef struct {
-   uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];
+   CFE_SB_CmdHdr_t CmdHeader;
    CFE_EVS_AppDataCmd_Payload_t Payload;
 } CFE_EVS_WriteAppDataFile_t;
 
@@ -974,7 +974,7 @@ typedef struct {
 } CFE_EVS_SetLogMode_Payload_t;
 
 typedef struct {
-   uint8                     CmdHeader[CFE_SB_CMD_HDR_SIZE];
+   CFE_SB_CmdHdr_t CmdHeader;
    CFE_EVS_SetLogMode_Payload_t Payload;
 } CFE_EVS_SetLogMode_t;
 
@@ -990,7 +990,7 @@ typedef struct {
 } CFE_EVS_SetEventFormatMode_Payload_t;
 
 typedef struct {
-   uint8                     CmdHeader[CFE_SB_CMD_HDR_SIZE];
+   CFE_SB_CmdHdr_t CmdHeader;
    CFE_EVS_SetEventFormatMode_Payload_t Payload;
 } CFE_EVS_SetEventFormatMode_t;
 
@@ -1007,7 +1007,7 @@ typedef struct {
 } CFE_EVS_BitMaskCmd_Payload_t;
 
 typedef struct {
-   uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];
+   CFE_SB_CmdHdr_t CmdHeader;
    CFE_EVS_BitMaskCmd_Payload_t Payload;
 } CFE_EVS_BitMaskCmd_t;
 
@@ -1033,7 +1033,7 @@ typedef struct {
 } CFE_EVS_AppNameCmd_Payload_t;
 
 typedef struct {
-   uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];
+   CFE_SB_CmdHdr_t CmdHeader;
    CFE_EVS_AppNameCmd_Payload_t Payload;
 } CFE_EVS_AppNameCmd_t;
 
@@ -1059,7 +1059,7 @@ typedef struct {
 } CFE_EVS_AppNameEventIDCmd_Payload_t;
 
 typedef struct {
-   uint8                                CmdHeader[CFE_SB_CMD_HDR_SIZE];
+   CFE_SB_CmdHdr_t CmdHeader;
    CFE_EVS_AppNameEventIDCmd_Payload_t  Payload;
 } CFE_EVS_AppNameEventIDCmd_t;
 
@@ -1084,7 +1084,7 @@ typedef struct {
 } CFE_EVS_AppNameBitMaskCmd_Payload_t;
 
 typedef struct {
-   uint8                     CmdHeader[CFE_SB_CMD_HDR_SIZE];
+   CFE_SB_CmdHdr_t CmdHeader;
    CFE_EVS_AppNameBitMaskCmd_Payload_t Payload;
 } CFE_EVS_AppNameBitMaskCmd_t;
 
@@ -1110,7 +1110,7 @@ typedef struct {
 } CFE_EVS_AppNameEventIDMaskCmd_Payload_t;
 
 typedef struct {
-   uint8                                    CmdHeader[CFE_SB_CMD_HDR_SIZE];
+   CFE_SB_CmdHdr_t CmdHeader;
    CFE_EVS_AppNameEventIDMaskCmd_Payload_t  Payload;
 } CFE_EVS_AppNameEventIDMaskCmd_t;
 
@@ -1181,7 +1181,7 @@ typedef struct {
 } CFE_EVS_HousekeepingTlm_Payload_t;
 
 typedef struct {
-   uint8                    TlmHeader[CFE_SB_TLM_HDR_SIZE];
+   CFE_SB_TlmHdr_t TlmHeader;
    CFE_EVS_HousekeepingTlm_Payload_t Payload;
 } CFE_EVS_HousekeepingTlm_t;
 
@@ -1224,13 +1224,13 @@ typedef struct {
 } CFE_EVS_ShortEventTlm_Payload_t;
 
 typedef struct {
-   uint8                    TlmHeader[CFE_SB_TLM_HDR_SIZE];
+   CFE_SB_TlmHdr_t TlmHeader;
    CFE_EVS_LongEventTlm_Payload_t Payload;
 
 } CFE_EVS_LongEventTlm_t;
 
 typedef struct {
-   uint8                    TlmHeader[CFE_SB_TLM_HDR_SIZE];
+   CFE_SB_TlmHdr_t TlmHeader;
    CFE_EVS_ShortEventTlm_Payload_t Payload;
 
 } CFE_EVS_ShortEventTlm_t;

--- a/fsw/cfe-core/src/inc/cfe_tbl_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_tbl_msg.h
@@ -492,7 +492,7 @@
 */
 typedef struct
 {
-    uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];   /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader;   /**< \brief cFE Software Bus Command Message Header */
 
 } CFE_TBL_NoArgsCmd_t;
 
@@ -519,7 +519,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_LoadCmd_Payload_t   Payload;
 } CFE_TBL_Load_t;
 
@@ -546,7 +546,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_DumpCmd_Payload_t   Payload;
 } CFE_TBL_Dump_t;
 
@@ -570,7 +570,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_ValidateCmd_Payload_t   Payload;
 } CFE_TBL_Validate_t;
 
@@ -588,7 +588,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_ActivateCmd_Payload_t   Payload;
 } CFE_TBL_Activate_t;
 
@@ -607,7 +607,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_DumpRegistryCmd_Payload_t    Payload;
 } CFE_TBL_DumpRegistry_t;
 
@@ -627,7 +627,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_SendRegistryCmd_Payload_t Payload;
 } CFE_TBL_SendRegistry_t;
 
@@ -647,7 +647,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_DelCDSCmd_Payload_t Payload;
 } CFE_TBL_DeleteCDS_t;
 
@@ -665,7 +665,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_AbortLoadCmd_Payload_t    Payload;
 } CFE_TBL_AbortLoad_t;
 
@@ -690,7 +690,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
+    CFE_SB_CmdHdr_t CmdHeader; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_NotifyCmd_Payload_t Payload;
 } CFE_TBL_NotifyCmd_t;
 
@@ -762,7 +762,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                       TlmHeader[CFE_SB_TLM_HDR_SIZE];       /**< \brief cFE Software Bus Telemetry Message Header */
+    CFE_SB_TlmHdr_t TlmHeader;       /**< \brief cFE Software Bus Telemetry Message Header */
     CFE_TBL_HousekeepingTlm_Payload_t  Payload;
 } CFE_TBL_HousekeepingTlm_t;
 
@@ -810,7 +810,7 @@ typedef struct
 
 typedef struct
 {
-    uint8                           TlmHeader[CFE_SB_TLM_HDR_SIZE];       /**< \brief cFE Software Bus Telemetry Message Header */
+    CFE_SB_TlmHdr_t TlmHeader;       /**< \brief cFE Software Bus Telemetry Message Header */
     CFE_TBL_TblRegPacket_Payload_t  Payload;
 } CFE_TBL_TableRegistryTlm_t;
 

--- a/fsw/cfe-core/src/inc/cfe_time_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_time_msg.h
@@ -728,7 +728,7 @@
 */
 typedef struct
 {
-  uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];
+    CFE_SB_CmdHdr_t                 CmdHeader;
 
 } CFE_TIME_NoArgsCmd_t;
 
@@ -751,8 +751,8 @@ typedef struct
 
 typedef struct
 {
-  uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
-  CFE_TIME_LeapsCmd_Payload_t   Payload;
+    CFE_SB_CmdHdr_t                 CmdHeader;
+    CFE_TIME_LeapsCmd_Payload_t     Payload;
 } CFE_TIME_SetLeapSeconds_t;
 
 
@@ -769,8 +769,8 @@ typedef struct
 
 typedef struct
 {
-  uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
-  CFE_TIME_StateCmd_Payload_t   Payload;
+    CFE_SB_CmdHdr_t                 CmdHeader;
+    CFE_TIME_StateCmd_Payload_t     Payload;
 } CFE_TIME_SetState_t;
 
 
@@ -786,8 +786,8 @@ typedef struct
 
 typedef struct
 {
-  uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
-  CFE_TIME_SourceCmd_Payload_t  Payload;
+    CFE_SB_CmdHdr_t               CmdHeader;
+    CFE_TIME_SourceCmd_Payload_t  Payload;
 } CFE_TIME_SetSource_t;
 
 
@@ -803,7 +803,7 @@ typedef struct
 
 typedef struct
 {
-  uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
+  CFE_SB_CmdHdr_t               CmdHeader;
   CFE_TIME_SignalCmd_Payload_t  Payload;
 
 } CFE_TIME_SetSignal_t;
@@ -820,7 +820,7 @@ typedef struct
 
 typedef struct
 {
-  uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
+  CFE_SB_CmdHdr_t                 CmdHeader;
   CFE_TIME_TimeCmd_Payload_t    Payload;
 } CFE_TIME_TimeCmd_t;
 
@@ -850,8 +850,8 @@ typedef struct
 
 typedef struct
 {
-  uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
-  CFE_TIME_OneHzAdjustmentCmd_Payload_t  Payload;
+    CFE_SB_CmdHdr_t                 CmdHeader;
+    CFE_TIME_OneHzAdjustmentCmd_Payload_t  Payload;
 
 } CFE_TIME_OneHzAdjustmentCmd_t;
 
@@ -868,7 +868,7 @@ typedef CFE_TIME_OneHzAdjustmentCmd_t CFE_TIME_Sub1HZAdjustment_t;
 */
 typedef struct
 {
-  uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];
+    CFE_SB_CmdHdr_t                 CmdHeader;
 
 } CFE_TIME_1HzCmd_t;
 
@@ -906,7 +906,7 @@ typedef struct
 
 typedef struct
 {
-  uint8                             CmdHeader[CFE_SB_CMD_HDR_SIZE];
+  CFE_SB_CmdHdr_t CmdHeader;
   CFE_TIME_ToneDataCmd_Payload_t    Payload;
 } CFE_TIME_ToneDataCmd_t;
 
@@ -977,7 +977,7 @@ typedef struct
 
 typedef struct
 {
-  uint8                         TlmHeader[CFE_SB_TLM_HDR_SIZE];
+  CFE_SB_TlmHdr_t TlmHeader;
   CFE_TIME_HousekeepingTlm_Payload_t   Payload;
 } CFE_TIME_HousekeepingTlm_t;
 
@@ -1135,7 +1135,7 @@ typedef struct
 
 typedef struct
 {
-  uint8                 		TlmHeader[CFE_SB_TLM_HDR_SIZE];
+  CFE_SB_TlmHdr_t TlmHeader;
   CFE_TIME_DiagnosticTlm_Payload_t Payload;
 } CFE_TIME_DiagnosticTlm_t;
 


### PR DESCRIPTION
**Describe the contribution**
Replace uint8[] arrays which reserve space for the header with an instance of the header struct as defined by SB.
    
Note this structure was the basis for the array size, so it is the same size, but by actually using the structure  the resulting message will have the correct alignment.

Fixes #689

**Testing performed**
Execute all unit tests and confirm passing
Sanity check on CFE, builds and runs and processes commands
Also Build and run on 32-bit platform with strict alignment and confirm no warnings/issues

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04 LTS (native, little endian 64 bit)
MIPS 32-bit via QEMU (big endian, strict alignment requirements)

**Additional context**
Just applies the same fix from #678 to all messages.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
