### PR TITLE
Fix #679, Alignment warnings in unit test

### DIFF
--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -3933,6 +3933,7 @@ void TestAPI(void)
     uint32 Id;
     uint32 TestObjId;
     char AppName[32];
+    uint32 StackBuf[8];
     char CounterName[11];
     char CDSName[CFE_MISSION_ES_CDS_MAX_NAME_LENGTH + 2];
     int i;
@@ -4299,8 +4300,8 @@ void TestAPI(void)
     Return = CFE_ES_CreateChildTask(&TaskId,
                                     "TaskName",
                                     TestAPI,
-                                    (uint32*) AppName,
-                                    32,
+                                    StackBuf,
+                                    sizeof(StackBuf),
                                     400,
                                     0);
     UT_Report(__FILE__, __LINE__,
@@ -4315,8 +4316,8 @@ void TestAPI(void)
     Return = CFE_ES_CreateChildTask(&TaskId,
                                     "TaskName",
                                     TestAPI,
-                                    (uint32*) AppName,
-                                    32,
+                                    StackBuf,
+                                    sizeof(StackBuf),
                                     400,
                                     0);
     UT_Report(__FILE__, __LINE__,
@@ -4329,8 +4330,8 @@ void TestAPI(void)
     Return = CFE_ES_CreateChildTask(NULL,
                                     "TaskName",
                                     TestAPI,
-                                    (uint32*) AppName,
-                                    32,
+                                    StackBuf,
+                                    sizeof(StackBuf),
                                     400,
                                     0);
     UT_Report(__FILE__, __LINE__,
@@ -4343,8 +4344,8 @@ void TestAPI(void)
     Return = CFE_ES_CreateChildTask(&TaskId,
                                     NULL,
                                     TestAPI,
-                                    (uint32*) AppName,
-                                    32,
+                                    StackBuf,
+                                    sizeof(StackBuf),
                                     400,
                                     0);
     UT_Report(__FILE__, __LINE__,
@@ -4357,8 +4358,8 @@ void TestAPI(void)
     Return = CFE_ES_CreateChildTask(NULL,
                                     NULL,
                                     TestAPI,
-                                    (uint32*) AppName,
-                                    32,
+                                    StackBuf,
+                                    sizeof(StackBuf),
                                     400,
                                     0);
     UT_Report(__FILE__, __LINE__,
@@ -4371,8 +4372,8 @@ void TestAPI(void)
     Return = CFE_ES_CreateChildTask(&TaskId,
                                     "TaskName",
                                     NULL,
-                                    (uint32*) AppName,
-                                    32,
+                                    StackBuf,
+                                    sizeof(StackBuf),
                                     2,
                                     0);
     UT_Report(__FILE__, __LINE__,
@@ -4391,8 +4392,8 @@ void TestAPI(void)
     Return = CFE_ES_CreateChildTask(&TaskId,
                                     "TaskName",
                                     TestAPI,
-                                    (uint32*) AppName,
-                                    32,
+                                    StackBuf,
+                                    sizeof(StackBuf),
                                     400,
                                     0);
     UT_Report(__FILE__, __LINE__,
@@ -4411,8 +4412,8 @@ void TestAPI(void)
     Return = CFE_ES_CreateChildTask(&TaskId,
                                     "TaskName",
                                     TestAPI,
-                                    (uint32*) AppName,
-                                    32,
+                                    StackBuf,
+                                    sizeof(StackBuf),
                                     400,
                                     0);
     UT_Report(__FILE__, __LINE__,
@@ -5798,8 +5799,8 @@ void TestESMempool(void)
 {
     CFE_ES_MemHandle_t    HandlePtr;
     uint8                 Buffer[CFE_PLATFORM_ES_MAX_BLOCK_SIZE];
-    uint8                 *address = NULL;
-    uint8                 *address2 = NULL;
+    uint32                *address = NULL;
+    uint32                *address2 = NULL;
     Pool_t                *PoolPtr;
     CFE_ES_MemPoolStats_t Stats;
     uint32                BlockSizes[4];
@@ -5858,7 +5859,7 @@ void TestESMempool(void)
     /* Test successfully getting the size of an existing pool buffer */
     ES_ResetUnitTest();
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_GetPoolBufInfo(HandlePtr, (uint32 *) address) > 0,
+              CFE_ES_GetPoolBufInfo(HandlePtr, address) > 0,
               "CFE_ES_GetPoolBufInfo",
               "Get pool buffer size; successful");
 
@@ -5868,7 +5869,7 @@ void TestESMempool(void)
     ES_ResetUnitTest();
     ((Pool_t *) HandlePtr)->UseMutex = CFE_ES_NO_MUTEX;
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_GetPoolBufInfo(HandlePtr, (uint32 *) address) > 0,
+              CFE_ES_GetPoolBufInfo(HandlePtr, address) > 0,
               "CFE_ES_GetPoolBufInfo",
               "Get pool buffer size; successful (no mutex)");
     ((Pool_t *) HandlePtr)->UseMutex = CFE_ES_USE_MUTEX;
@@ -5876,14 +5877,14 @@ void TestESMempool(void)
     /* Test successfully returning a pool buffer to the memory pool */
     ES_ResetUnitTest();
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_PutPoolBuf(HandlePtr, (uint32 *) address) > 0,
+              CFE_ES_PutPoolBuf(HandlePtr, address) > 0,
               "CFE_ES_PutPoolBuf",
               "Return buffer to the memory pool; successful");
 
     /* Test successfully allocating an additional pool buffer */
     ES_ResetUnitTest();
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_GetPoolBuf((uint32 **) &address, HandlePtr, 256) > 0,
+              CFE_ES_GetPoolBuf(&address, HandlePtr, 256) > 0,
               "CFE_ES_GetPoolBuf",
               "Allocate pool buffer [2]; successful");
 
@@ -5893,7 +5894,7 @@ void TestESMempool(void)
     ES_ResetUnitTest();
     ((Pool_t *) HandlePtr)->UseMutex = CFE_ES_NO_MUTEX;
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_PutPoolBuf(HandlePtr, (uint32 *) address) > 0,
+              CFE_ES_PutPoolBuf(HandlePtr, address) > 0,
               "CFE_ES_PutPoolBuf",
               "Return buffer to the second memory pool; successful");
     ((Pool_t *) HandlePtr)->UseMutex = CFE_ES_USE_MUTEX;
@@ -5923,7 +5924,7 @@ void TestESMempool(void)
      */
     ES_ResetUnitTest();
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_GetPoolBuf((uint32 **) &address,
+              CFE_ES_GetPoolBuf(&address,
                                 HandlePtr2,
                                 256) == CFE_ES_ERR_MEM_HANDLE,
               "CFE_ES_GetPoolBuf",
@@ -5944,7 +5945,7 @@ void TestESMempool(void)
      */
     ES_ResetUnitTest();
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_GetPoolBuf((uint32 **) &address,
+              CFE_ES_GetPoolBuf(&address,
                                 HandlePtr,
                                 75000) == CFE_ES_ERR_MEM_BLOCK_SIZE,
               "CFE_ES_GetPoolBuf",
@@ -5955,7 +5956,7 @@ void TestESMempool(void)
      */
     ES_ResetUnitTest();
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_GetPoolBufInfo(HandlePtr, (uint32 *) address) ==
+              CFE_ES_GetPoolBufInfo(HandlePtr, address) ==
                   CFE_ES_BUFFER_NOT_IN_POOL,
               "CFE_ES_GetPoolBufInfo",
               "Invalid memory pool handle");
@@ -5964,7 +5965,7 @@ void TestESMempool(void)
     ES_ResetUnitTest();
     UT_Report(__FILE__, __LINE__,
               CFE_ES_PutPoolBuf(HandlePtr,
-                                (uint32 *) address) == CFE_ES_ERR_MEM_HANDLE,
+                                address) == CFE_ES_ERR_MEM_HANDLE,
               "CFE_ES_PutPoolBuf",
               "Invalid memory block");
 
@@ -6083,7 +6084,7 @@ void TestESMempool(void)
     BdPtr->Allocated = 717;
     UT_Report(__FILE__, __LINE__,
               CFE_ES_GetPoolBufInfo(HandlePtr,
-                                    (uint32 *) address) ==
+                                    address) ==
                   CFE_ES_ERR_MEM_HANDLE,
               "CFE_ES_GetPoolBufInfo",
               "Invalid memory pool handle; unallocated block");
@@ -6096,8 +6097,7 @@ void TestESMempool(void)
     BdPtr = ((BD_t *)address) - 1;
     BdPtr->Allocated = 717;
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_GetPoolBufInfo(HandlePtr,
-                                    (uint32 *) address) ==
+              CFE_ES_GetPoolBufInfo(HandlePtr, address) ==
                   CFE_ES_ERR_MEM_HANDLE,
               "CFE_ES_GetPoolBufInfo",
               "Invalid memory pool handle; unallocated block (no mutex)");
@@ -6106,8 +6106,7 @@ void TestESMempool(void)
     /* Test returning a pool buffer using an unallocated block */
     ES_ResetUnitTest();
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_PutPoolBuf(HandlePtr,
-                                (uint32 *) address) == CFE_ES_ERR_MEM_HANDLE,
+              CFE_ES_PutPoolBuf(HandlePtr, address) == CFE_ES_ERR_MEM_HANDLE,
               "CFE_ES_PutPoolBuf",
               "Deallocate an unallocated block");
 
@@ -6117,8 +6116,7 @@ void TestESMempool(void)
     ES_ResetUnitTest();
     ((Pool_t *) HandlePtr)->UseMutex = CFE_ES_NO_MUTEX;
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_PutPoolBuf(HandlePtr,
-                                (uint32 *) address) == CFE_ES_ERR_MEM_HANDLE,
+              CFE_ES_PutPoolBuf(HandlePtr, address) == CFE_ES_ERR_MEM_HANDLE,
               "CFE_ES_PutPoolBuf",
               "Deallocate an unallocated block (no mutex)");
     ((Pool_t *) HandlePtr)->UseMutex = CFE_ES_USE_MUTEX;
@@ -6130,8 +6128,7 @@ void TestESMempool(void)
     BdPtr->Allocated = 0xaaaa;
     BdPtr->CheckBits = 717;
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_GetPoolBufInfo(HandlePtr,
-                                    (uint32 *) address) ==
+              CFE_ES_GetPoolBufInfo(HandlePtr, address) ==
                   CFE_ES_ERR_MEM_HANDLE,
               "CFE_ES_GetPoolBufInfo",
               "Invalid memory pool handle; check bit pattern");
@@ -6145,8 +6142,7 @@ void TestESMempool(void)
     BdPtr->Allocated = 0xaaaa;
     BdPtr->CheckBits = 717;
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_GetPoolBufInfo(HandlePtr,
-                                    (uint32 *) address) ==
+              CFE_ES_GetPoolBufInfo(HandlePtr, address) ==
                   CFE_ES_ERR_MEM_HANDLE,
               "CFE_ES_GetPoolBufInfo",
               "Invalid memory pool handle; check bit pattern (no mutex)");
@@ -6157,8 +6153,7 @@ void TestESMempool(void)
      */
     ES_ResetUnitTest();
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_PutPoolBuf(HandlePtr,
-                                (uint32 *) address) ==
+              CFE_ES_PutPoolBuf(HandlePtr, address) ==
                   CFE_ES_ERR_MEM_HANDLE,
               "CFE_ES_PutPoolBuf",
               "Invalid/corrupted memory descriptor");
@@ -6169,8 +6164,7 @@ void TestESMempool(void)
     ES_ResetUnitTest();
     ((Pool_t *) HandlePtr)->UseMutex = CFE_ES_NO_MUTEX;
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_PutPoolBuf(HandlePtr,
-                                (uint32 *) address) ==
+              CFE_ES_PutPoolBuf(HandlePtr, address) ==
                   CFE_ES_ERR_MEM_HANDLE,
               "CFE_ES_PutPoolBuf",
               "Invalid/corrupted memory descriptor (no mutex)");
@@ -6193,7 +6187,7 @@ void TestESMempool(void)
     ES_ResetUnitTest();
     ((Pool_t *) HandlePtr)->UseMutex = CFE_ES_NO_MUTEX;
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_GetPoolBuf((uint32 **) &address, HandlePtr, 256) > 0,
+              CFE_ES_GetPoolBuf(&address, HandlePtr, 256) > 0,
               "CFE_ES_GetPoolBuf",
               "Allocate pool buffer [4]; successful");
     ((Pool_t *) HandlePtr)->UseMutex = CFE_ES_USE_MUTEX;
@@ -6205,8 +6199,7 @@ void TestESMempool(void)
     BdPtr->CheckBits = 0x5a5a;
     BdPtr->Size =CFE_PLATFORM_ES_MAX_BLOCK_SIZE +1;
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_PutPoolBuf(HandlePtr,
-                                (uint32 *) address) == CFE_ES_ERR_MEM_HANDLE,
+              CFE_ES_PutPoolBuf(HandlePtr, address) == CFE_ES_ERR_MEM_HANDLE,
               "CFE_ES_PutPoolBuf",
               "Pool buffer size exceeds maximum");
 
@@ -6218,8 +6211,7 @@ void TestESMempool(void)
     BdPtr->CheckBits = 0x5a5a;
     BdPtr->Size =CFE_PLATFORM_ES_MAX_BLOCK_SIZE +1;
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_PutPoolBuf(HandlePtr,
-                                (uint32 *) address) == CFE_ES_ERR_MEM_HANDLE,
+              CFE_ES_PutPoolBuf(HandlePtr, address) == CFE_ES_ERR_MEM_HANDLE,
               "CFE_ES_PutPoolBuf",
               "Pool buffer size exceeds maximum (no mutex)");
     ((Pool_t *) HandlePtr)->UseMutex = CFE_ES_USE_MUTEX;
@@ -6229,7 +6221,7 @@ void TestESMempool(void)
      */
     ES_ResetUnitTest();
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_GetPoolBuf((uint32 **) &address2,
+              CFE_ES_GetPoolBuf(&address2,
                                 HandlePtr,
                                 99000) == CFE_ES_ERR_MEM_BLOCK_SIZE,
               "CFE_ES_GetPoolBuf",
@@ -6245,15 +6237,14 @@ void TestESMempool(void)
     /* Test returning a pool buffer using a null handle */
     ES_ResetUnitTest();
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_PutPoolBuf(0,
-                                (uint32 *) address) == CFE_ES_ERR_MEM_HANDLE,
+              CFE_ES_PutPoolBuf(0, address) == CFE_ES_ERR_MEM_HANDLE,
               "CFE_ES_PutPoolBuf",
               "NULL memory handle");
 
     /* Test allocating a pool buffer using a null handle */
     ES_ResetUnitTest();
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_GetPoolBuf((uint32 **) &address,
+              CFE_ES_GetPoolBuf(&address,
                                 0,
                                 256) == CFE_ES_ERR_MEM_HANDLE,
               "CFE_ES_GetPoolBuf",
@@ -6262,8 +6253,7 @@ void TestESMempool(void)
     /* Test getting the size of an existing pool buffer using a null handle */
     ES_ResetUnitTest();
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_GetPoolBufInfo(0,
-                                    (uint32 *) address) ==
+              CFE_ES_GetPoolBufInfo(0, address) ==
                   CFE_ES_ERR_MEM_HANDLE,
               "CFE_ES_GetPoolBufInfo",
               "NULL memory handle");
@@ -6288,7 +6278,7 @@ void TestESMempool(void)
     ES_ResetUnitTest();
     ((Pool_t *) HandlePtr)->UseMutex = CFE_ES_NO_MUTEX;
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_GetPoolBuf((uint32 **) &address2,
+              CFE_ES_GetPoolBuf(&address2,
                                 HandlePtr,
                                 32) == CFE_ES_ERR_MEM_BLOCK_SIZE,
               "CFE_ES_GetPoolBuf",
@@ -6313,8 +6303,7 @@ void TestESMempool(void)
     ((Pool_t *) HandlePtr)->UseMutex = CFE_ES_NO_MUTEX;
     for (i=0; i < 25; ++i)
     {
-        if (CFE_ES_GetPoolBuf((uint32 **) &address,
-                          HandlePtr,
+        if (CFE_ES_GetPoolBuf(&address, HandlePtr,
                           12) == CFE_ES_ERR_MEM_BLOCK_SIZE)
         {
             break;

--- a/fsw/cfe-core/ut-stubs/ut_es_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_es_stubs.c
@@ -376,34 +376,29 @@ int32 CFE_ES_GetPoolBuf(uint32 **BufPtr,
         CFE_ES_PoolAlign_t Align;
         uint8 Bytes[CFE_UT_ES_POOL_STATIC_BLOCK_SIZE];
     } Buffer;
+
     uint32 PoolSize;
-    uint32 Position;
-    uint8 *PoolPtr;
+    uint32 PositionStart;
+    uint32 PositionEnd;
+    void *PoolPtr;
+    cpuaddr BufAddrStart;
+    cpuaddr BufAddrEnd;
     int32 status;
+
+    /*
+     * Determine the actual alignment of the CFE_ES_PoolAlign_t structure.
+     * This is done by checking the offset of a struct member of that type following a single byte.
+     */
+    const cpuaddr AlignMask = ((cpuaddr)&((struct { char Byte; CFE_ES_PoolAlign_t Align; } *)0)->Align) - 1;
+
 
     status = UT_DEFAULT_IMPL_RC(CFE_ES_GetPoolBuf, Size);
 
     if (status > 0)
     {
         Size = status;
-        if (Size < sizeof(CFE_ES_PoolAlign_t))
-        {
-            Size = sizeof(CFE_ES_PoolAlign_t) - 1;
-        }
-        else
-        {
-            --Size;
-        }
 
-        /* find next higher power of 2 */
-        Size |= Size >> 1;
-        Size |= Size >> 2;
-        Size |= Size >> 4;
-        Size |= Size >> 8;
-        Size |= Size >> 16;
-        ++Size;
-
-        UT_GetDataBuffer(UT_KEY(CFE_ES_GetPoolBuf), (void **)&PoolPtr, &PoolSize, &Position);
+        UT_GetDataBuffer(UT_KEY(CFE_ES_GetPoolBuf), (void **)&PoolPtr, &PoolSize, &PositionStart);
         if (PoolSize == 0)
         {
             /*
@@ -412,20 +407,25 @@ int32 CFE_ES_GetPoolBuf(uint32 **BufPtr,
              */
             PoolPtr = Buffer.Bytes;
             PoolSize = sizeof(Buffer);
+            PositionStart = 0;
         }
 
-        if ((Position + Size) < PoolSize)
+        BufAddrStart = (cpuaddr)PoolPtr + PositionStart;
+        BufAddrStart = (BufAddrStart + AlignMask) & ~AlignMask;
+        BufAddrEnd = (BufAddrStart + Size + AlignMask) & ~AlignMask;
+        PositionEnd = BufAddrEnd - (cpuaddr)PoolPtr;
+
+        if (PositionEnd <= PoolSize)
         {
-            PoolPtr += Position;
-            *BufPtr = (uint32 *)PoolPtr;
-            status = Size;
-            memset(PoolPtr, 0x55, Size);
+            *BufPtr = (uint32 *)BufAddrStart;
+            memset((void*)BufAddrStart, 0x55, Size);
 
             /*
              * Unfortunately the UT assert stub library is missing
              * the ability to set the buffer position, the only way
              * to do it is by calling CopyFromLocal to advance the position.
              */
+            Size = PositionEnd - PositionStart;
             while (Size > sizeof(Buffer))
             {
                 UT_Stub_CopyFromLocal(UT_KEY(CFE_ES_GetPoolBuf), &Buffer,
@@ -443,8 +443,8 @@ int32 CFE_ES_GetPoolBuf(uint32 **BufPtr,
              * use UT_SetDataBuffer() to register a pool buffer that is
              * sufficient for the code under test.
              */
-            UtAssert_Failed("Pool buffer empty in %s: need at least %lu bytes",
-                    __func__, (unsigned long)(Position + Size));
+            UtAssert_Failed("Pool buffer empty in %s: need at least %lu bytes, given %lu",
+                    __func__, (unsigned long)PositionEnd, (unsigned long)PoolSize);
             status = -1;
         }
     }


### PR DESCRIPTION
**Describe the contribution**
Resolve remaining alignment warnings in the unit test and stub code.

**Testing performed**
Build with ENABLE_UNIT_TESTS=true for native arch and a cross target with strict alignment requirements.
confirm no warnings on either build, all unit tests pass.

**Expected behavior changes**
No compiler warnings or errors on cross build.

**System(s) tested on**
Ubuntu 20.04 (host, little endian, 64-bit, lax alignment)
MIPS via QEMU (cross target, big endian, 32-bit, strict alignment)

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.