### PR TITLE
Fix #707, Resolve highest MsgID of 0xFFFF bug

### DIFF
--- a/cmake/sample_defs/cpu1_platform_cfg.h
+++ b/cmake/sample_defs/cpu1_platform_cfg.h
@@ -178,7 +178,8 @@
 **       The recommended case to to have this value the same across all mission platforms
 **
 **  \par Limits
-**       This parameter has a lower limit of 1 and an upper limit of 0xFFFF. 
+**       This parameter has a lower limit of 1 and an upper limit of 0xFFFF. Note there
+**       is one MsgId value reserved as invalid, so the table is this size + 1. 
 */
 #define CFE_PLATFORM_SB_HIGHEST_VALID_MSGID      0x1FFF
 

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.h
@@ -119,7 +119,7 @@
 **           be used directly, except by internal table lookups.
 **
 */
-typedef uint16  CFE_SB_MsgKey_Atom_t;
+typedef uint32  CFE_SB_MsgKey_Atom_t;
 
 /******************************************************************************
 **  Typedef:  CFE_SB_MsgKey_t


### PR DESCRIPTION
**Describe the contribution**
Changes Message Key from uint16 to uint32 to avoid rollover and system hang
Fix #707 
Fix #414

**Testing performed**
Steps taken to test the contribution:
1. Set CFE_PLATFORM_SB_HIGHEST_VALID_MSGID to 0xFFFF
1. Built (SIMULATION=native) and ran, confirmed startup
1. CI - https://travis-ci.com/github/skliper/cFS/builds/166553342

**Expected behavior changes**
Full message ID range available

**System(s) tested on**
 - Hardware: cFS Dev 3
 - OS: Ubuntu 18.04
 - Versions: Bundle w/ this change

**Additional context**
Identified/resolved by JSC

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC