### PR TITLE
Fix #603, Full context info for EVS event stubs

### DIFF
--- a/fsw/cfe-core/ut-stubs/ut_es_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_es_stubs.c
@@ -333,9 +333,13 @@ int32 CFE_ES_RegisterChildTask(void)
 int32 CFE_ES_WriteToSysLog(const char *pSpecString, ...)
 {
     int32   status;
+    va_list va;
+
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_WriteToSysLog), pSpecString); // allow this input to be used by hook functions
 
-    status = UT_DEFAULT_IMPL(CFE_ES_WriteToSysLog);
+    va_start(va,pSpecString);
+    status = UT_DEFAULT_IMPL_VARARGS(CFE_ES_WriteToSysLog, va);
+    va_end(va);
 
     if (status >= 0)
     {

--- a/fsw/cfe-core/ut-stubs/ut_evs_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_evs_stubs.c
@@ -109,11 +109,14 @@ int32 CFE_EVS_SendEvent(uint16 EventID,
                         ...)
 {
     int32 status;
+    va_list va;
 
     UT_Stub_RegisterContext(UT_KEY(CFE_EVS_SendEvent), &EventID);
     UT_Stub_RegisterContext(UT_KEY(CFE_EVS_SendEvent), &EventType);
     UT_Stub_RegisterContext(UT_KEY(CFE_EVS_SendEvent), Spec);
-    status = UT_DEFAULT_IMPL(CFE_EVS_SendEvent);
+    va_start(va, Spec);
+    status = UT_DEFAULT_IMPL_VARARGS(CFE_EVS_SendEvent, va);
+    va_end(va);
 
     if (status >= 0)
     {
@@ -145,9 +148,15 @@ int32 CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time,
                              ...)
 {
     int32 status;
+    va_list va;
 
     UT_Stub_RegisterContext(UT_KEY(CFE_EVS_SendEvent), &EventID);
-    status = UT_DEFAULT_IMPL(CFE_EVS_SendEvent);
+    UT_Stub_RegisterContext(UT_KEY(CFE_EVS_SendEvent), &EventType);
+    UT_Stub_RegisterContext(UT_KEY(CFE_EVS_SendEvent), &Time);
+    UT_Stub_RegisterContext(UT_KEY(CFE_EVS_SendEvent), Spec);
+    va_start(va, Spec);
+    status = UT_DefaultStubImplWithArgs(__func__, UT_KEY(CFE_EVS_SendTimedEvent), CFE_SUCCESS, va);
+    va_end(va);
 
     if (status >= 0)
     {
@@ -218,9 +227,15 @@ int32 CFE_EVS_SendEventWithAppID(uint16 EventID,
                                  ...)
 {
     int32 status;
+    va_list va;
 
     UT_Stub_RegisterContext(UT_KEY(CFE_EVS_SendEvent), &EventID);
-    status = UT_DEFAULT_IMPL(CFE_EVS_SendEventWithAppID);
+    UT_Stub_RegisterContext(UT_KEY(CFE_EVS_SendEvent), &EventType);
+    UT_Stub_RegisterContext(UT_KEY(CFE_EVS_SendEvent), &AppID);
+    UT_Stub_RegisterContext(UT_KEY(CFE_EVS_SendEvent), Spec);
+    va_start(va, Spec);
+    status = UT_DefaultStubImplWithArgs(__func__, UT_KEY(CFE_EVS_SendEventWithAppID), CFE_SUCCESS, va);
+    va_end(va);
 
     if (status >= 0)
     {


### PR DESCRIPTION
**Describe the contribution**
Create a va_list object to capture the full set of variable arguments passed to CFE_EVS_SendEvent and variants (TimedEvent, WithAppID).  Use the variable argument form of the stub implementation to pass all info through to a (possible) hook function.

Fixes #603 

**Testing performed**
Build all unit tests and confirm normal operation, all passing.

**Expected behavior changes**
Hook functions may now use the va_list form and obtain the full context info.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
see also nasa/osal#479, nasa/sample_app#66 for other related enhancements.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.