### PR TITLE
Fix #704, Added stub for CFE_SB_DeletePipe in ut_sb_stubs.c

### DIFF
--- a/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
@@ -160,6 +160,35 @@ int32 CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16 Depth,
 
 /*****************************************************************************/
 /**
+** \brief CFE_SB_DeletePipe stub function
+**
+** \par Description
+**        This function is used to mimic the response of the cFE SB function
+**        CFE_SB_DeletePipe.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        Returns CFE_SUCCESS.
+**
+******************************************************************************/
+int32 CFE_SB_DeletePipe(CFE_SB_PipeId_t PipeId)
+{
+  int32 status;
+
+  status = UT_DEFAULT_IMPL(CFE_SB_DeletePipe);
+
+  if (status >= 0)
+  {
+        UT_Stub_CopyFromLocal(UT_KEY(CFE_SB_DeletePipe), &PipeId, sizeof(PipeId));
+  }
+
+  return status;
+}
+
+/*****************************************************************************/
+/**
 ** \brief CFE_SB_GetPipeName stub function
 **
 ** \par Description

--- a/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
@@ -170,7 +170,7 @@ int32 CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16 Depth,
 **        None
 **
 ** \returns
-**        Returns CFE_SUCCESS.
+**        Returns either a user-defined status flag or CFE_SUCCESS.
 **
 ******************************************************************************/
 int32 CFE_SB_DeletePipe(CFE_SB_PipeId_t PipeId)


### PR DESCRIPTION
**Describe the contribution**
Fixes #704. Added stub for CFE_SB_DeletePipe.
Stub takes PipeId argument and using UT_Stub_CopyFromLocal, saves it into the data buffer.

**Testing performed**
Steps taken to test the contribution:
1. Build steps: 'make ENABLE_UNIT_TESTS=TRUE SIMULATION=native'
Execution steps: 
1. Created simple unit test in cfs_cf calling CFE_SB_DeletePipe directly.
2. PipeId was set as the data buffer pointer and given an initial value.
3. expectedPipeId given a different value than PipeId
4. UtAssert_True used to show they are not equal(fails)
5. Call to CFE_SB_DeletePipe with expectedPipeId as argument
6. UtAssert_True used to show they are equal(pass)
7. Ran unit test from build/native/apps/cfs_cf/unit-test
Please note: this test was not saved to any repo.
Output:
[BEGIN] 04 Test_check_sb_stubs
[ FAIL] 04.001 cf_app_tests.c:77 - PipeId = 0x00000005, exp = 0x00000006
[ PASS] 04.002 cf_app_tests.c:83 - PipeId = 0x00000006, exp = 0x00000006
[  END] 04 Test_check_sb_stubs  TOTAL::2     PASS::1     FAIL::1      MIR::0      TSF::0      N/A::0  

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - API Change: cFE ut_sb_stubs now has CFE_SB_DeletePipe available.
 - Behavior Change: App unit tests requiring this will not fail to build due to undefined reference to `CFE_SB_DeletePipe'

**System(s) tested on**
 - Hardware: PC
 - OS: RHEL-7.6 (Maipo) Linux 3.10.0-1062.1.2.el7.x86_64
 - Versions: cFE 6.7

**Additional context**
None.

**Third party code**
None.

**Contributor Info - All information REQUIRED for consideration of pull request**
Alan Gibson, NASA, GSFC-0587
