### PR TITLE
Fix #718, add user-specified extra modules to build

### DIFF
--- a/cmake/mission_build.cmake
+++ b/cmake/mission_build.cmake
@@ -127,7 +127,7 @@ function(prepare)
   # so this is run in a loop until the list of unfound apps is empty
   string(REPLACE ":" ";" CFS_APP_PATH "$ENV{CFS_APP_PATH}")
   list(APPEND CFS_APP_PATH "apps" "apps/CFS" "libs" "psp/fsw/modules")
-  set(MISSION_DEPS "cfe-core" "osal")
+  set(MISSION_DEPS "cfe-core" "osal" ${MISSION_CORE_MODULES})
   set(APP_MISSING_COUNT 0)
   
   # Set the search path of those dependency components which are fixed

--- a/cmake/target/CMakeLists.txt
+++ b/cmake/target/CMakeLists.txt
@@ -110,6 +110,7 @@ endif (TGT${TGTID}_APPLIST)
 # This depends on whether any special features are included or not
 set(CFE_LINK_WHOLE_LIBS
     ${CFE_CORE_TARGET}
+    ${MISSION_CORE_MODULES}
     psp-${CFE_SYSTEM_PSPNAME} 
     osal
 )


### PR DESCRIPTION
**Describe the contribution**
Add a new setting that can be set in targets.cmake, to enable users to add extra custom functions/modules to CFE core executable.

This can be used, among other things, for future support of a modular/customizable message header structure.

Fixes #718

**Testing performed**
Build and execute CFE, confirm normal operation/sanity check.
Build and execute all unit tests, confirm passing.

**Expected behavior changes**
Any user-supplied library can be added to the build.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
This general concept can also be used to provide replacement implementations of core modules (e.g. TBL, FS) with some additional tweaking to exclude those modules from the subsequent build of CFE core.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
