### PR TITLE
Fix #719, remove refs to ccsds data structures

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_task.c
+++ b/fsw/cfe-core/src/es/cfe_es_task.c
@@ -447,7 +447,7 @@ void CFE_ES_TaskPipe(CFE_SB_MsgPtr_t Msg)
         ** Housekeeping telemetry request
         */
         case CFE_ES_SEND_HK_MID:
-            CFE_ES_HousekeepingCmd((CCSDS_CommandPacket_t*)Msg);
+            CFE_ES_HousekeepingCmd((CFE_SB_CmdHdr_t*)Msg);
             break;
 
         /*
@@ -662,7 +662,7 @@ void CFE_ES_TaskPipe(CFE_SB_MsgPtr_t Msg)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 CFE_ES_HousekeepingCmd(const CCSDS_CommandPacket_t *data)
+int32 CFE_ES_HousekeepingCmd(const CFE_SB_CmdHdr_t *data)
 {
     OS_heap_prop_t HeapProp;
     int32          stat;

--- a/fsw/cfe-core/src/es/cfe_es_task.h
+++ b/fsw/cfe-core/src/es/cfe_es_task.h
@@ -175,7 +175,7 @@ void  CFE_ES_BackgroundCleanup(void);
 /*
 ** ES Task message dispatch functions
 */
-int32 CFE_ES_HousekeepingCmd(const CCSDS_CommandPacket_t *data);
+int32 CFE_ES_HousekeepingCmd(const CFE_SB_CmdHdr_t *data);
 int32 CFE_ES_NoopCmd(const CFE_ES_Noop_t *Cmd);
 int32 CFE_ES_ResetCountersCmd(const CFE_ES_ResetCounters_t *data);
 int32 CFE_ES_RestartCmd(const CFE_ES_Restart_t *data);

--- a/fsw/cfe-core/src/evs/cfe_evs_task.c
+++ b/fsw/cfe-core/src/evs/cfe_evs_task.c
@@ -368,7 +368,7 @@ void CFE_EVS_ProcessCommandPacket ( CFE_SB_MsgPtr_t EVS_MsgPtr )
 
         case CFE_EVS_SEND_HK_MID:
             /* Housekeeping request */
-            CFE_EVS_ReportHousekeepingCmd((CCSDS_CommandPacket_t*)EVS_MsgPtr);
+            CFE_EVS_ReportHousekeepingCmd((CFE_SB_CmdHdr_t*)EVS_MsgPtr);
             break;
 
         default:
@@ -687,7 +687,7 @@ int32 CFE_EVS_ClearLogCmd(const CFE_EVS_ClearLog_t *data)
 ** Assumptions and Notes:
 **
 */
-int32 CFE_EVS_ReportHousekeepingCmd (const CCSDS_CommandPacket_t *data)
+int32 CFE_EVS_ReportHousekeepingCmd (const CFE_SB_CmdHdr_t *data)
 {
    uint32 i, j;
 

--- a/fsw/cfe-core/src/evs/cfe_evs_task.h
+++ b/fsw/cfe-core/src/evs/cfe_evs_task.h
@@ -144,7 +144,7 @@ extern void  CFE_EVS_ProcessCommandPacket ( CFE_SB_MsgPtr_t EVS_MsgPtr );
 /*
  * EVS Message Handler Functions
  */
-int32 CFE_EVS_ReportHousekeepingCmd (const CCSDS_CommandPacket_t *data);
+int32 CFE_EVS_ReportHousekeepingCmd (const CFE_SB_CmdHdr_t *data);
 int32 CFE_EVS_NoopCmd(const CFE_EVS_Noop_t *data);
 int32 CFE_EVS_ClearLogCmd(const CFE_EVS_ClearLog_t *data);
 int32 CFE_EVS_ResetCountersCmd(const CFE_EVS_ResetCounters_t *data);

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.h
@@ -437,7 +437,7 @@ int32 CFE_SB_NoopCmd(const CFE_SB_Noop_t *data);
 int32 CFE_SB_ResetCountersCmd(const CFE_SB_ResetCounters_t *data);
 int32 CFE_SB_EnableSubReportingCmd(const CFE_SB_EnableSubReporting_t *data);
 int32 CFE_SB_DisableSubReportingCmd(const CFE_SB_DisableSubReporting_t *data);
-int32 CFE_SB_SendHKTlmCmd(const CCSDS_CommandPacket_t *data);
+int32 CFE_SB_SendHKTlmCmd(const CFE_SB_CmdHdr_t *data);
 int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRoute_t *data);
 int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRoute_t *data);
 int32 CFE_SB_SendStatsCmd(const CFE_SB_SendSbStats_t *data);

--- a/fsw/cfe-core/src/sb/cfe_sb_task.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_task.c
@@ -363,7 +363,7 @@ void CFE_SB_ProcessCmdPipePkt(void) {
 
       case CFE_SB_SEND_HK_MID:
          /* Note: Command counter not incremented for this command */
-         CFE_SB_SendHKTlmCmd((CCSDS_CommandPacket_t *)CFE_SB.CmdPipePktPtr);
+         CFE_SB_SendHKTlmCmd((CFE_SB_CmdHdr_t *)CFE_SB.CmdPipePktPtr);
          break;
 
       case CFE_SB_SUB_RPT_CTRL_MID:
@@ -556,7 +556,7 @@ int32 CFE_SB_DisableSubReportingCmd(const CFE_SB_DisableSubReporting_t *data)
 **  Return:
 **    none
 */
-int32 CFE_SB_SendHKTlmCmd(const CCSDS_CommandPacket_t *data)
+int32 CFE_SB_SendHKTlmCmd(const CFE_SB_CmdHdr_t *data)
 {
     CFE_SB.HKTlmMsg.Payload.MemInUse        = CFE_SB.StatTlmMsg.Payload.MemInUse;
     CFE_SB.HKTlmMsg.Payload.UnmarkedMem     = CFE_PLATFORM_SB_BUF_MEMORY_BYTES - CFE_SB.StatTlmMsg.Payload.PeakMemInUse;

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task.c
@@ -54,7 +54,7 @@ CFE_TBL_TaskData_t    CFE_TBL_TaskData;
  *  For generic message entries, which only have a MID and a handler function (no command payload)
  */
 #define CFE_TBL_MESSAGE_ENTRY(mid,handlerfunc) \
-        { CFE_SB_MSGID_WRAP_VALUE(mid), 0, sizeof(CCSDS_CommandPacket_t), (CFE_TBL_MsgProcFuncPtr_t)handlerfunc, CFE_TBL_MSG_MSGTYPE }
+        { CFE_SB_MSGID_WRAP_VALUE(mid), 0, sizeof(CFE_SB_CmdHdr_t), (CFE_TBL_MsgProcFuncPtr_t)handlerfunc, CFE_TBL_MSG_MSGTYPE }
 
 /*
  * Macros to assist in building the CFE_TBL_CmdHandlerTbl -

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.c
@@ -53,7 +53,7 @@
 ** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
 ********************************************************************/
 
-int32 CFE_TBL_HousekeepingCmd(const CCSDS_CommandPacket_t *data)
+int32 CFE_TBL_HousekeepingCmd(const CFE_SB_CmdHdr_t *data)
 {
     int32                     Status;
     uint32                    i;

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.h
@@ -126,7 +126,7 @@ extern void CFE_TBL_GetTblRegData(void);
 **
 ** \retval #CFE_TBL_DONT_INC_CTR \copydoc CFE_TBL_DONT_INC_CTR
 ******************************************************************************/
-int32 CFE_TBL_HousekeepingCmd(const CCSDS_CommandPacket_t *data);
+int32 CFE_TBL_HousekeepingCmd(const CFE_SB_CmdHdr_t *data);
 
 /*****************************************************************************/
 /**

--- a/fsw/cfe-core/src/time/cfe_time_task.c
+++ b/fsw/cfe-core/src/time/cfe_time_task.c
@@ -46,12 +46,12 @@ CFE_TIME_TaskData_t CFE_TIME_TaskData;
 /*
 ** Command handler for "HK request"...
 */
-int32 CFE_TIME_HousekeepingCmd(const CCSDS_CommandPacket_t *data);
+int32 CFE_TIME_HousekeepingCmd(const CFE_SB_CmdHdr_t *data);
 
 /*
 ** Command handler for "tone signal detected"...
 */
-int32 CFE_TIME_ToneSignalCmd(const CCSDS_CommandPacket_t *data);
+int32 CFE_TIME_ToneSignalCmd(const CFE_SB_CmdHdr_t *data);
 
 /*
 ** Command handler for "time at the tone"...
@@ -61,7 +61,7 @@ int32 CFE_TIME_ToneDataCmd(const CFE_TIME_ToneDataCmd_t *data);
 /*
 ** Command handler for 1Hz signal...
 */
-int32 CFE_TIME_OneHzCmd(const CCSDS_CommandPacket_t *data);
+int32 CFE_TIME_OneHzCmd(const CFE_SB_CmdHdr_t *data);
 
 /*
 ** Command handler for "request time at the tone"...
@@ -79,7 +79,7 @@ int32 CFE_TIME_OneHzCmd(const CCSDS_CommandPacket_t *data);
 **       non-fake tone mode.
 */
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
-int32 CFE_TIME_ToneSendCmd(const CCSDS_CommandPacket_t *data);
+int32 CFE_TIME_ToneSendCmd(const CFE_SB_CmdHdr_t *data);
 #endif
 
 /*
@@ -471,14 +471,14 @@ void CFE_TIME_TaskPipe(CFE_SB_MsgPtr_t MessagePtr)
         ** Housekeeping telemetry request...
         */
         case CFE_TIME_SEND_HK_MID:
-            CFE_TIME_HousekeepingCmd((CCSDS_CommandPacket_t *)MessagePtr);
+            CFE_TIME_HousekeepingCmd((CFE_SB_CmdHdr_t *)MessagePtr);
             break;
 
         /*
         ** Time at the tone "signal"...
         */
         case CFE_TIME_TONE_CMD_MID:
-            CFE_TIME_ToneSignalCmd((CCSDS_CommandPacket_t *)MessagePtr);
+            CFE_TIME_ToneSignalCmd((CFE_SB_CmdHdr_t *)MessagePtr);
             break;
 
         /*
@@ -492,7 +492,7 @@ void CFE_TIME_TaskPipe(CFE_SB_MsgPtr_t MessagePtr)
         ** Run time state machine at 1Hz...
         */
         case CFE_TIME_1HZ_CMD_MID:
-            CFE_TIME_OneHzCmd((CCSDS_CommandPacket_t *)MessagePtr);
+            CFE_TIME_OneHzCmd((CFE_SB_CmdHdr_t *)MessagePtr);
             break;
 
         /*
@@ -500,7 +500,7 @@ void CFE_TIME_TaskPipe(CFE_SB_MsgPtr_t MessagePtr)
         */
         #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
         case CFE_TIME_SEND_CMD_MID:
-            CFE_TIME_ToneSendCmd((CCSDS_CommandPacket_t *)MessagePtr);
+            CFE_TIME_ToneSendCmd((CFE_SB_CmdHdr_t *)MessagePtr);
             break;
         #endif
 
@@ -665,7 +665,7 @@ void CFE_TIME_TaskPipe(CFE_SB_MsgPtr_t MessagePtr)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 CFE_TIME_HousekeepingCmd(const CCSDS_CommandPacket_t *data)
+int32 CFE_TIME_HousekeepingCmd(const CFE_SB_CmdHdr_t *data)
 {
     CFE_TIME_Reference_t Reference;
 
@@ -705,7 +705,7 @@ int32 CFE_TIME_HousekeepingCmd(const CCSDS_CommandPacket_t *data)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 CFE_TIME_ToneSignalCmd(const CCSDS_CommandPacket_t *data)
+int32 CFE_TIME_ToneSignalCmd(const CFE_SB_CmdHdr_t *data)
 {
     /*
     ** Indication that tone signal occurred recently...
@@ -754,7 +754,7 @@ int32 CFE_TIME_ToneDataCmd(const CFE_TIME_ToneDataCmd_t *data)
  * as we do not need a separate MID for this job.
  *
  * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 CFE_TIME_OneHzCmd(const CCSDS_CommandPacket_t *data)
+int32 CFE_TIME_OneHzCmd(const CFE_SB_CmdHdr_t *data)
 {
     /*
      * Run the state machine updates required at 1Hz.
@@ -787,7 +787,7 @@ int32 CFE_TIME_OneHzCmd(const CCSDS_CommandPacket_t *data)
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
-int32 CFE_TIME_ToneSendCmd(const CCSDS_CommandPacket_t *data)
+int32 CFE_TIME_ToneSendCmd(const CFE_SB_CmdHdr_t *data)
 {
     /*
     ** Request for "time at tone" data packet (probably scheduler)...

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -4648,7 +4648,7 @@ void Test_CFE_SB_SetGetUserDataLength(void)
         SizeReturned = CFE_SB_GetUserDataLength(SBCmdPtr);
         ActualPktLenField = UT_GetActualPktLenField(SBCmdPtr);
 
-        ExpPktLenField = sizeof(CCSDS_CommandPacket_t) + SetSize - sizeof(CCSDS_PriHdr_t) - 1; /* SecHdrSize + data - 1 */
+        ExpPktLenField = sizeof(CFE_SB_CmdHdr_t) + SetSize - sizeof(CCSDS_PriHdr_t) - 1; /* SecHdrSize + data - 1 */
 
         if (SizeReturned != SetSize ||
             ActualPktLenField != ExpPktLenField)

--- a/fsw/cfe-core/unit-test/time_UT.c
+++ b/fsw/cfe-core/unit-test/time_UT.c
@@ -1754,7 +1754,7 @@ void Test_PipeCmds(void)
     union
     {
         CFE_SB_Msg_t message;
-        CCSDS_CommandPacket_t cmd;
+        CFE_SB_CmdHdr_t cmd;
         CFE_TIME_ToneDataCmd_t tonedatacmd;
         CFE_TIME_Noop_t noopcmd;
         CFE_TIME_ResetCounters_t resetcountercmd;


### PR DESCRIPTION
**Describe the contribution**

Replace all direct references to data types defined in `ccsds.h` with the abstract type defined in `cfe_sb.h`.

Fixes #719 

**Testing performed**
Build and run CFE, sanity check, confirm all unit test pass.

**Expected behavior changes**
No impact to behavior.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
There are similar changes to apps, too, which will be separate PRs (not submitted yet).

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.