### PR TITLE
Fix #739, add global module list and mission default file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,9 @@ initialize_globals()
 
 # Load the target configuration information (used by all builds)
 # This is at the top level so all vars set in here will become globals.
+# The "defaults" file is included first, which the user-supplied targets
+# file may override as necessary.
+include("cmake/mission_defaults.cmake")
 include(${MISSION_DEFS}/targets.cmake)
     
 # Scan the list of targets and organize by target system type.

--- a/cmake/global_functions.cmake
+++ b/cmake/global_functions.cmake
@@ -122,6 +122,17 @@ function(read_targetconfig)
     # save the unmodified name for future reference
     set(SYSID_${SYSVAR} "${CURRSYS}" PARENT_SCOPE)
     
+    # if the "global" applist is not empty, append to every CPU applist
+    if (MISSION_GLOBAL_APPLIST)
+      list(APPEND TGT${TGTID}_APPLIST ${MISSION_GLOBAL_APPLIST})
+      set(TGT${TGTID}_APPLIST ${TGT${TGTID}_APPLIST} PARENT_SCOPE)
+    endif (MISSION_GLOBAL_APPLIST)
+
+    if (MISSION_GLOBAL_STATIC_APPLIST)
+      list(APPEND TGT${TGTID}_STATIC_APPLIST ${MISSION_GLOBAL_STATIC_APPLIST})
+      set(TGT${TGTID}_STATIC_APPLIST ${TGT${TGTID}_STATIC_APPLIST} PARENT_SCOPE)
+    endif (MISSION_GLOBAL_STATIC_APPLIST)
+
     # Append to global lists
     list(APPEND TGTSYS_LIST "${SYSVAR}")
     list(APPEND TGTSYS_${SYSVAR} "${TGTID}")

--- a/cmake/mission_defaults.cmake
+++ b/cmake/mission_defaults.cmake
@@ -22,3 +22,21 @@ set(MISSION_GLOBAL_APPLIST)
 # but the apps are statically linked.  
 # This list is effectively appended to every TGTx_STATIC_APPLIST in targets.cmake.  
 set(MISSION_GLOBAL_STATIC_APPLIST)
+
+# The "MISSION_MODULE_SEARCH_PATH" is a list of subdirectories
+# which will be searched for modules (apps and libs) specified in 
+# the targets.cmake file.  It may also be locally extended by setting 
+# the environment variable "CFS_APP_PATH"
+set(MISSION_MODULE_SEARCH_PATH
+    "apps"                  # general purpose $[top}/apps directory
+    "libs"                  # general purpose $[top}/libs directory
+    "psp/fsw/modules"       # modules for optional platform abstraction, associated with PSP
+    "cfe/modules"           # modules for optional core functions, associated with CFE
+)
+
+# The path for specific components can also be set via
+# a variable named "<component>_SEARCH_PATH".  This is
+# used for locating cfe-core and osal which are not part
+# of the standard search path.
+set(cfe-core_SEARCH_PATH "cfe/fsw")
+set(osal_SEARCH_PATH ".")

--- a/cmake/mission_defaults.cmake
+++ b/cmake/mission_defaults.cmake
@@ -1,0 +1,24 @@
+##################################################################
+#
+# cFS Mission default values
+#
+# This file provides default values for mission applications
+# and module/library selection.
+#
+##################################################################
+
+# The "MISSION_CORE_MODULES" will be built and statically linked as part
+# of the CFE core executable on every target.  These can be used to amend
+# or override parts of the CFE core on a mission-specific basis.
+set(MISSION_CORE_MODULES)
+
+# The "MISSION_GLOBAL_APPLIST" is a set of apps/libs that will be built
+# for every defined and target.  These are built as dynamic modules
+# and must be loaded explicitly via startup script or command.
+# This list is effectively appended to every TGTx_APPLIST in targets.cmake.  
+set(MISSION_GLOBAL_APPLIST)
+
+# The "MISSION_GLOBAL_STATIC_APPLIST" is similar to MISSION_GLOBAL_APPLIST
+# but the apps are statically linked.  
+# This list is effectively appended to every TGTx_STATIC_APPLIST in targets.cmake.  
+set(MISSION_GLOBAL_STATIC_APPLIST)

--- a/cmake/sample_defs/targets.cmake
+++ b/cmake/sample_defs/targets.cmake
@@ -75,9 +75,23 @@ SET(MISSION_NAME "SampleMission")
 # should be an integer.
 SET(SPACECRAFT_ID 42)
 
-# UI_INSTALL_SUBDIR indicates where the UI data files (included in some apps) should
-# be copied during the install process.
-SET(UI_INSTALL_SUBDIR "host/ui")
+# The "MISSION_CORE_MODULES" will be built and statically linked as part
+# of the CFE core executable on every target.  These can be used to amend
+# or override parts of the CFE core on a mission-specific basis.
+set(MISSION_CORE_MODULES)
+
+# The "MISSION_GLOBAL_APPLIST" is a set of apps/libs that will be built
+# for every defined and target.  These are built as dynamic modules
+# and must be loaded explicitly via startup script or command.
+# This list is effectively appended to every TGTx_APPLIST in targets.cmake.  
+# Example:
+list(APPEND MISSION_GLOBAL_APPLIST sample_app sample_lib)
+
+# The "MISSION_GLOBAL_STATIC_APPLIST" is similar to MISSION_GLOBAL_APPLIST
+# but the apps are statically linked.  
+# This list is effectively appended to every TGTx_STATIC_APPLIST in targets.cmake.  
+# Example:
+#   list(APPEND MISSION_GLOBAL_STATIC_APPLIST my_static_app)
 
 # FT_INSTALL_SUBDIR indicates where the black box test data files (lua scripts) should
 # be copied during the install process.
@@ -85,16 +99,16 @@ SET(FT_INSTALL_SUBDIR "host/functional-test")
 
 # Each target board can have its own HW arch selection and set of included apps
 SET(TGT1_NAME cpu1)
-SET(TGT1_APPLIST sample_app sample_lib ci_lab to_lab sch_lab)
+SET(TGT1_APPLIST ci_lab to_lab sch_lab)
 SET(TGT1_FILELIST cfe_es_startup.scr)
 
 # CPU2/3 are duplicates of CPU1.  These are not built by default anymore but are
 # commented out to serve as an example of how one would configure multiple cpus.
 #SET(TGT2_NAME cpu2)
-#SET(TGT2_APPLIST sample_app ci_lab to_lab sch_lab)
+#SET(TGT2_APPLIST ci_lab to_lab sch_lab)
 #SET(TGT2_FILELIST cfe_es_startup.scr)
 
 #SET(TGT3_NAME cpu3)
-#SET(TGT3_APPLIST sample_app ci_lab to_lab sch_lab)
+#SET(TGT3_APPLIST ci_lab to_lab sch_lab)
 #SET(TGT3_FILELIST cfe_es_startup.scr)
 

--- a/cmake/target/CMakeLists.txt
+++ b/cmake/target/CMakeLists.txt
@@ -110,6 +110,7 @@ endif (TGT${TGTID}_APPLIST)
 # This depends on whether any special features are included or not
 set(CFE_LINK_WHOLE_LIBS
     ${CFE_CORE_TARGET}
+    ${MISSION_CORE_MODULES}
     psp-${CFE_SYSTEM_PSPNAME} 
     osal
 )


### PR DESCRIPTION
**Describe the contribution**
Add more hooks for additional flexibility when adding modular code blobs into the build.

Three new directives are added:

- `MISSION_CORE_MODULES` :  for modular components which are direct dependencies of CFE core and/or extend its functionality.

- `MISSION_GLOBAL_APPLIST` :  for applications/libraries which should be built for every target, as if they were listed in every `TGTx_APPLIST` setting.

- `MISSION_GLOBAL_STATIC_APPLIST` : same as above but for the `TGTx_STATIC_APPLIST` setting.

This also simplifies/reworks the search path to remove some logic that was never really utilized.

Fixes #739 
Also Fixes #718 (supercedes/includes previous PR #720)

**Testing performed**
Build, sanity check CFE and unit test.
Tested adding modules to the new lists and confirm the modules are found and built as expected.

**Expected behavior changes**
Users have additional flexibility when configuring/customizing their CFE build.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
The initial intent with `MISSION_CORE_MODULES` is to provide a simple place for something like #711.

The initial intent with `MISSION_GLOBAL_APPLIST` is that we can easily tack on extra libraries when unit testing is enabled, e.g.

```
if (ENABLE_UNIT_TESTS)
   list(APPEND MISSION_GLOBAL_APPLIST cfe_assert)
endif (ENABLE_UNIT_TESTS)
```

This will automatically build the assert library for every target when unit testing is turned on, but it is still up the user to actually load it, but that can be done at runtime - it doesn't change the core CFE environment.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
