### PR TITLE
Fix #604, Added cFE User's Guide Reference to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains NASA's Core Flight Executive (cFE), which is a framewor
 
 This is a collection of services and associated framework to be located in the `cfe` subdirectory of a cFS Mission Tree. The Core Flight System is bundled at <https://github.com/nasa/cFS>, which includes build and execution instructions.
 
+The detailed cFE user's guide can be found at <https://github.com/nasa/cFS/blob/gh-pages/cFE_Users_Guide.pdf>.
+
 ## Version History
 
 ### Development Build: 6.7.19

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains NASA's Core Flight Executive (cFE), which is a framewor
 
 This is a collection of services and associated framework to be located in the `cfe` subdirectory of a cFS Mission Tree. The Core Flight System is bundled at <https://github.com/nasa/cFS>, which includes build and execution instructions.
 
-The detailed cFE user's guide can be found at <https://github.com/nasa/cFS/blob/gh-pages/cFE_Users_Guide.pdf>.
+The detailed cFE user's guide can be viewed at <https://github.com/nasa/cFS/blob/gh-pages/cFE_Users_Guide.pdf>.
 
 ## Version History
 


### PR DESCRIPTION
**Describe the contribution**
Added a reference to the cFE user's guide (https://github.com/nasa/cFS/blob/gh-pages/cFE_Users_Guide.pdf) in the cFE README.md.

The reference was placed toward the top of the document, above the "Version History" section.

Resolves: #604 

**Testing performed**
N/A

**Expected behavior changes**
N/A

**System(s) tested on**
N/A

**Additional context**
This is a simple document enhancement.

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Contribution by: Jandlyn Bentley, NASA GSFC
