### PR TITLE
Fix #747, Update CFE_SB_TimeStampMsg to save the message pointer argument

### DIFF
--- a/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
@@ -668,6 +668,7 @@ int32 CFE_SB_SubscribeLocal(CFE_SB_MsgId_t MsgId,
 void CFE_SB_TimeStampMsg(CFE_SB_MsgPtr_t MsgPtr)
 {
     UT_DEFAULT_IMPL(CFE_SB_TimeStampMsg);
+    UT_Stub_CopyFromLocal(UT_KEY(CFE_SB_TimeStampMsg), &MsgPtr, sizeof(MsgPtr));
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
… UT_Stub_CopyFromLocal so that unit tests can check it

**Describe the contribution**
A clear and concise description of what the contribution is.
Fixes #747 

**Testing performed**
Wrote test that failed when using original version of SB stub CFE_SB_TimeStampMsg.
`[ FAIL] 01.001 cf_app_tests.c:90 - CFE_SB_TimeStampMsg received 0xc8230eadc0 and should be 0x61b180`
Changed to have stub UT_Stub_CopyFromLocal passed in argument.
`[ PASS] 01.001 cf_app_tests.c:90 - CFE_SB_TimeStampMsg received 0x61b180 and should be 0x61b180`


**Expected behavior changes**
Passed in argument value is now available to a test that uses UT_SetDataBuffer for CFE_SB_TimeStampMsg.

**System(s) tested on**
 - Hardware: PC
 - OS: RHEL7 3.10.0-1062.1.2.el7.x86_64
 - Versions: cFE 6.7

**Additional context**
None.

**Third party code**
None.

**Contributor Info - All information REQUIRED for consideration of pull request**
Alan Gibson, GSFC-0587
