### PR TITLE
fix #744 - update LastSender in pipe description and add AppId to buf…

### DIFF
--- a/fsw/cfe-core/src/inc/cfe_sb.h
+++ b/fsw/cfe-core/src/inc/cfe_sb.h
@@ -215,6 +215,7 @@ extern CFE_SB_Qos_t CFE_SB_Default_Qos;/**< \brief  Defines a default priority a
 **/
 typedef struct {
     uint32  ProcessorId;/**< \brief Processor Id from which the message was sent */
+    uint32  AppId;/**< \brief Application Id from which the message was sent */
     char    AppName[OS_MAX_API_NAME];/**< \brief Application that sent the message */
 } CFE_SB_SenderId_t;
 

--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -1324,6 +1324,7 @@ int32  CFE_SB_SendMsgFull(CFE_SB_Msg_t    *MsgPtr,
     if(CFE_SB.SenderReporting != 0)
     {
        BufDscPtr->Sender.ProcessorId = CFE_PSP_GetProcessorId();
+       BufDscPtr->Sender.AppId = CFE_SB.AppId;
        strncpy(&BufDscPtr->Sender.AppName[0],CFE_SB_GetAppTskName(TskId,FullName),OS_MAX_API_NAME);
     }
 
@@ -1346,6 +1347,8 @@ int32  CFE_SB_SendMsgFull(CFE_SB_Msg_t    *MsgPtr,
         }/*end if */
 
         PipeDscPtr = &CFE_SB.PipeTbl[DestPtr->PipeId];
+
+        PipeDscPtr->LastSender = CFE_SB.AppId;
 
         if(PipeDscPtr->Opts & CFE_SB_PIPEOPTS_IGNOREMINE)
         {


### PR DESCRIPTION
**Describe the contribution**
fix #744 
This adds AppId to the buff description (used by `CFE_SB_GetLastSenderId()`) and updates the LastSender field in the CFE_SB_PipeD_t struct for each pipe that receives the message.

**Testing performed**
Built and ran in debugger to inspect values.

**Expected behavior changes**
Adds a field to the CFE_SB_SenderId_t struct, properly populates the CFE_SB_PipeD_t private struct (which is used for HK tlm.)

**System(s) tested on**
Debian 10.3

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov