### PR TITLE
Fix #745 - getlastsenderid now returns appid

### DIFF
--- a/fsw/cfe-core/src/inc/cfe_sb.h
+++ b/fsw/cfe-core/src/inc/cfe_sb.h
@@ -208,16 +208,6 @@ typedef  struct {
 extern CFE_SB_Qos_t CFE_SB_Default_Qos;/**< \brief  Defines a default priority and reliabilty for off-board routing */
 
 
-/** \brief Message Sender Identification Type Definition
-**
-** Parameter used in #CFE_SB_GetLastSenderId API which allows the receiver of a message
-** to validate the sender of the message.
-**/
-typedef struct {
-    uint32  ProcessorId;/**< \brief Processor Id from which the message was sent */
-    char    AppName[OS_MAX_API_NAME];/**< \brief Application that sent the message */
-} CFE_SB_SenderId_t;
-
 /****************** Function Prototypes **********************/
 
 /** @defgroup CFEAPISBPipe cFE Pipe Management APIs
@@ -1186,23 +1176,14 @@ CFE_TIME_SysTime_t CFE_SB_GetMsgTime(CFE_SB_MsgPtr_t MsgPtr);
 **          random. Therefore, it is recommended that the return code be tested
 **          for CFE_SUCCESS before reading the sender information.
 **
-** \param[in]  Ptr       A pointer to a local variable of type #CFE_SB_SenderId_t.
-**                       Typically a caller declares a ptr of type CFE_SB_SenderId_t
-**                       (i.e. CFE_SB_SenderId_t *Ptr) then gives the address of that
-**                       pointer (&Ptr) for this parameter. After a successful call
-**                       to this API, *Ptr will point to the first byte of the
-**                       CFE_SB_SenderId_t structure containing the sender information
-**                       for the last message received on the given pipe. This should
-**                       be used as a read-only pointer (in systems with an MMU, writes
-**                       to this pointer may cause a memory protection fault).  The *Ptr
-**                       is valid only until the next call to CFE_SB_RcvMsg for the
-**                       same pipe.
+** \param[out]  SenderAppIdPtr       A pointer to a buffer to receive the AppId of
+**                       the last sender.
 **
 ** \param[in]  PipeId    The pipe ID of the pipe the message was taken from.
 **
-** \return The last sender's application ID
+** \return CFE_SUCCESS
 **/
-uint32  CFE_SB_GetLastSenderId(CFE_SB_SenderId_t **Ptr,CFE_SB_PipeId_t  PipeId);
+int32  CFE_SB_GetLastSenderId(uint32 *AppIdPtr, CFE_SB_PipeId_t  PipeId);
 
 /******************************************************************************/
 /**

--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -1340,6 +1340,8 @@ int32  CFE_SB_SendMsgFull(CFE_SB_Msg_t    *MsgPtr,
 
         PipeDscPtr = &CFE_SB.PipeTbl[DestPtr->PipeId];
 
+        PipeDscPtr->LastSender = CFE_SB.AppId;
+
         if(PipeDscPtr->Opts & CFE_SB_PIPEOPTS_IGNOREMINE)
         {
             uint32 AppId = 0xFFFFFFFF;

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.h
@@ -172,7 +172,6 @@ typedef struct {
      uint16            UseCount;
      uint32            Size;
      void              *Buffer;
-     CFE_SB_SenderId_t Sender;
 } CFE_SB_BufferD_t;
 
 

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -3432,12 +3432,12 @@ void Test_RcvMsg_GetLastSenderInvalidPipe(void)
 {
     CFE_SB_PipeId_t   PipeId;
     CFE_SB_PipeId_t   InvalidPipeId = 250;
-    CFE_SB_SenderId_t *GLSPtr;
+    uint32            AppId;
     uint32            PipeDepth = 10;
 
     SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "RcvMsgTestPipe"));
 
-    ASSERT_EQ(CFE_SB_GetLastSenderId(&GLSPtr, InvalidPipeId), CFE_SB_BAD_ARGUMENT);
+    ASSERT_EQ(CFE_SB_GetLastSenderId(&AppId, InvalidPipeId), CFE_SB_BAD_ARGUMENT);
 
     EVTCNT(2);
 
@@ -3453,7 +3453,7 @@ void Test_RcvMsg_GetLastSenderInvalidPipe(void)
 void Test_RcvMsg_GetLastSenderInvalidCaller(void)
 {
     CFE_SB_PipeId_t   PipeId;
-    CFE_SB_SenderId_t *GLSPtr;
+    uint32            AppId;
     uint32            PipeDepth = 10;
     uint32            OrigPipeOwner;
 
@@ -3462,7 +3462,7 @@ void Test_RcvMsg_GetLastSenderInvalidCaller(void)
     /* Change pipe owner ID to execute 'invalid caller' code */
     OrigPipeOwner = CFE_SB.PipeTbl[PipeId].AppId;
     CFE_SB.PipeTbl[PipeId].AppId = OrigPipeOwner + 1;
-    ASSERT_EQ(CFE_SB_GetLastSenderId(&GLSPtr, PipeId), CFE_SB_BAD_ARGUMENT);
+    ASSERT_EQ(CFE_SB_GetLastSenderId(&AppId, PipeId), CFE_SB_BAD_ARGUMENT);
 
     EVTCNT(2);
 
@@ -3478,11 +3478,11 @@ void Test_RcvMsg_GetLastSenderInvalidCaller(void)
 void Test_RcvMsg_GetLastSenderNoValidSender(void)
 {
     CFE_SB_PipeId_t   PipeId;
-    CFE_SB_SenderId_t *GLSPtr;
+    uint32            AppId;
     uint32            PipeDepth = 10;
 
     SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "RcvMsgTestPipe"));
-    ASSERT_EQ(CFE_SB_GetLastSenderId(&GLSPtr, PipeId), CFE_SB_NO_MSG_RECV);
+    ASSERT_EQ(CFE_SB_GetLastSenderId(&AppId, PipeId), CFE_SB_NO_MSG_RECV);
 
     EVTCNT(1);
   
@@ -3497,7 +3497,7 @@ void Test_RcvMsg_GetLastSenderNoValidSender(void)
 void Test_RcvMsg_GetLastSenderSuccess(void)
 {
     CFE_SB_PipeId_t    PipeId;
-    CFE_SB_SenderId_t  *GLSPtr;
+    uint32             AppId;
     SB_UT_Test_Tlm_t   TlmPkt;
     CFE_SB_MsgPtr_t    TlmPktPtr = (CFE_SB_MsgPtr_t) &TlmPkt;
     CFE_SB_MsgPtr_t    PtrToMsg;
@@ -3508,7 +3508,7 @@ void Test_RcvMsg_GetLastSenderSuccess(void)
     SETUP(CFE_SB_Subscribe(SB_UT_TLM_MID, PipeId));
     SETUP(CFE_SB_SendMsg(TlmPktPtr));
     SETUP(CFE_SB_RcvMsg(&PtrToMsg, PipeId,CFE_SB_PEND_FOREVER));
-    ASSERT(CFE_SB_GetLastSenderId(&GLSPtr, PipeId));
+    ASSERT(CFE_SB_GetLastSenderId(&AppId, PipeId));
 
     EVTCNT(3);
 


### PR DESCRIPTION
Fix for #745 - This removes the CFE_SB_SenderID_t struct and, instead, the CFE_SB_GetLastSenderId() function now takes a pointer to an AppId (uint32) that it uses as an out parameter for the call.

**Testing performed**
Built with ENABLE_UNIT_TESTS

**Expected behavior changes**
Significantly changes the GetLastSenderId() function, will break any users of this API (particularly SBN.)

**System(s) tested on**
Debian 10.3

**Additional context**
This obviates #744 and I recommend closing that ticket with this fix.

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov