### PR TITLE
fix #759 - removes CFE_SB_GetLastSenderId() and adds CFE_SB_RcvMsgSenderId()

### DIFF
--- a/docs/cFE Application Developers Guide.md
+++ b/docs/cFE Application Developers Guide.md
@@ -1769,7 +1769,6 @@ for extracting that field from the header:
 | Total Message Length        | CFE_SB_GetTotalMsgLength                | Command & Telemetry |
 | User Data Message Length    | CFE_SB_GetUserDataLength                | Command & Telemetry |
 | Command Code                | CFE_SB_GetCmdCode                       | Command Only        |
-| Sender ID                   | CFE_SB_GetLastSenderId                  | Command & Telemetry |
 | Checksum                    | CFE_SB_GetChecksum                      | Command Only        |
 
 In addition to the function for reading the checksum field, there is
@@ -1777,15 +1776,6 @@ another API that automatically calculates the checksum for the packet
 and compares it to the checksum in the header. The API is called
 CFE_SB_ValidateChecksum() and it simply returns a success or failure
 indication.
-
-It should be noted that the function, CFE_SB_GetLastSendId, is ideal
-for verifying that critical commands are arriving from a legitimate
-source. This function allows the Developer(s) to define a strict ICD
-between two or more Applications to ensure that an erroneous Application
-does not accidentally issue a critical command. However, its use for
-routine command verification is discouraged since it would increase the
-cross-coupling between Applications and require multiple Applications to
-be modified if a command's source changes.
 
 If the Application's data structure definitions don't include the header
 information, then the CFE_SB_GetUserData API could be used to obtain
@@ -1879,6 +1869,25 @@ a CFE_SB_NO_MESSAGE status code.
 After a message is received, the SB Message Header accessor functions (as
 described in Section 6.5.3) should be used to identify the message so that
 the application can react to it appropriately.  
+
+An enhanced method `CFE_SB_RcvMsgSenderId` will also return the ID of the
+application that sent the message. For example:
+
+```
+uint32 SenderAppId;
+
+SB_Status = CFE_SB_RcvMsgSenderId(&SAMPLE_AppData.MsgPtr, &SenderAppId,
+                SAMPLE_AppData.CmdPipe, CFE_SB_PEND_FOREVER);
+```
+
+It should be noted that the variant is ideal
+for verifying that critical commands are arriving from a legitimate
+source. This function allows the Developer(s) to define a strict ICD
+between two or more Applications to ensure that an erroneous Application
+does not accidentally issue a critical command. However, its use for
+routine command verification is discouraged since it would increase the
+cross-coupling between Applications and require multiple Applications to
+be modified if a command's source changes.
 
 
 #### 6.8 Improving Message Transfer Performance for Large SB Messages

--- a/docs/src/cfe_api.dox
+++ b/docs/src/cfe_api.dox
@@ -142,6 +142,7 @@
       <LI> #CFE_SB_SendMsg - \copybrief CFE_SB_SendMsg
       <LI> #CFE_SB_PassMsg - \copybrief CFE_SB_PassMsg
       <LI> #CFE_SB_RcvMsg - \copybrief CFE_SB_RcvMsg
+      <LI> #CFE_SB_RcvMsgSenderId - \copybrief CFE_SB_RcvMsgSenderId
     </UL>
     <LI> \ref CFEAPISBZeroCopy
     <UL>
@@ -169,7 +170,6 @@
       <LI> #CFE_SB_GetTotalMsgLength - \copybrief CFE_SB_GetTotalMsgLength
       <LI> #CFE_SB_GetMsgTime - \copybrief CFE_SB_GetMsgTime
       <LI> #CFE_SB_GetCmdCode - \copybrief CFE_SB_GetCmdCode
-      <LI> #CFE_SB_GetLastSenderId - \copybrief CFE_SB_GetLastSenderId
       <LI> #CFE_SB_MessageStringGet - \copybrief CFE_SB_MessageStringGet
     </UL>
     <LI> \ref CFEAPISBChecksum

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.h
@@ -172,7 +172,7 @@ typedef struct {
      uint16            UseCount;
      uint32            Size;
      void              *Buffer;
-     CFE_SB_SenderId_t Sender;
+     uint32            SenderId;
 } CFE_SB_BufferD_t;
 
 

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -3332,15 +3332,11 @@ void Test_RcvMsg_API(void)
     SB_UT_ADD_SUBTEST(Test_RcvMsg_InvalidPipeId);
     SB_UT_ADD_SUBTEST(Test_RcvMsg_InvalidTimeout);
     SB_UT_ADD_SUBTEST(Test_RcvMsg_Poll);
-    SB_UT_ADD_SUBTEST(Test_RcvMsg_GetLastSenderNull);
-    SB_UT_ADD_SUBTEST(Test_RcvMsg_GetLastSenderInvalidPipe);
-    SB_UT_ADD_SUBTEST(Test_RcvMsg_GetLastSenderInvalidCaller);
-    SB_UT_ADD_SUBTEST(Test_RcvMsg_GetLastSenderNoValidSender);
-    SB_UT_ADD_SUBTEST(Test_RcvMsg_GetLastSenderSuccess);
     SB_UT_ADD_SUBTEST(Test_RcvMsg_Timeout);
     SB_UT_ADD_SUBTEST(Test_RcvMsg_PipeReadError);
     SB_UT_ADD_SUBTEST(Test_RcvMsg_PendForever);
     SB_UT_ADD_SUBTEST(Test_RcvMsg_InvalidBufferPtr);
+    SB_UT_ADD_SUBTEST(Test_RcvMsg_SenderId);
 } /* end Test_RcvMsg_API */
 
 /*
@@ -3404,117 +3400,6 @@ void Test_RcvMsg_Poll(void)
     TEARDOWN(CFE_SB_DeletePipe(PipeId));
 
 } /* end Test_RcvMsg_Poll */
-
-/*
-** Test receive last message response to a null sender ID
-*/
-void Test_RcvMsg_GetLastSenderNull(void)
-{
-    CFE_SB_PipeId_t PipeId;
-    uint32          PipeDepth = 10;
-
-    SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "RcvMsgTestPipe"));
-
-    ASSERT_EQ(CFE_SB_GetLastSenderId(NULL, PipeId), CFE_SB_BAD_ARGUMENT);
-
-    EVTCNT(2);
-
-    EVTSENT(CFE_SB_LSTSNDER_ERR1_EID);
-
-    TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_RcvMsg_GetLastSenderNull */
-
-/*
-** Test receive last message response to an invalid pipe ID
-*/
-void Test_RcvMsg_GetLastSenderInvalidPipe(void)
-{
-    CFE_SB_PipeId_t   PipeId;
-    CFE_SB_PipeId_t   InvalidPipeId = 250;
-    CFE_SB_SenderId_t *GLSPtr;
-    uint32            PipeDepth = 10;
-
-    SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "RcvMsgTestPipe"));
-
-    ASSERT_EQ(CFE_SB_GetLastSenderId(&GLSPtr, InvalidPipeId), CFE_SB_BAD_ARGUMENT);
-
-    EVTCNT(2);
-
-    EVTSENT(CFE_SB_LSTSNDER_ERR2_EID);
-
-    TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_RcvMsg_GetLastSenderInvalidPipe */
-
-/*
-** Test receive last message response to an invalid owner ID
-*/
-void Test_RcvMsg_GetLastSenderInvalidCaller(void)
-{
-    CFE_SB_PipeId_t   PipeId;
-    CFE_SB_SenderId_t *GLSPtr;
-    uint32            PipeDepth = 10;
-    uint32            OrigPipeOwner;
-
-    SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "RcvMsgTestPipe"));
-
-    /* Change pipe owner ID to execute 'invalid caller' code */
-    OrigPipeOwner = CFE_SB.PipeTbl[PipeId].AppId;
-    CFE_SB.PipeTbl[PipeId].AppId = OrigPipeOwner + 1;
-    ASSERT_EQ(CFE_SB_GetLastSenderId(&GLSPtr, PipeId), CFE_SB_BAD_ARGUMENT);
-
-    EVTCNT(2);
-
-    EVTSENT(CFE_SB_GLS_INV_CALLER_EID);
-
-    /* Restore original pipe owner apid */
-    CFE_SB.PipeTbl[PipeId].AppId = OrigPipeOwner;
-    TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_RcvMsg_GetLastSenderInvalidCaller */
-
-
-void Test_RcvMsg_GetLastSenderNoValidSender(void)
-{
-    CFE_SB_PipeId_t   PipeId;
-    CFE_SB_SenderId_t *GLSPtr;
-    uint32            PipeDepth = 10;
-
-    SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "RcvMsgTestPipe"));
-    ASSERT_EQ(CFE_SB_GetLastSenderId(&GLSPtr, PipeId), CFE_SB_NO_MSG_RECV);
-
-    EVTCNT(1);
-  
-    TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_RcvMsg_GetLastSenderNoValidSender */
-
-
-/*
-** Test successful receive last message request
-*/
-void Test_RcvMsg_GetLastSenderSuccess(void)
-{
-    CFE_SB_PipeId_t    PipeId;
-    CFE_SB_SenderId_t  *GLSPtr;
-    SB_UT_Test_Tlm_t   TlmPkt;
-    CFE_SB_MsgPtr_t    TlmPktPtr = (CFE_SB_MsgPtr_t) &TlmPkt;
-    CFE_SB_MsgPtr_t    PtrToMsg;
-    uint32             PipeDepth = 10;
-
-    SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "RcvMsgTestPipe"));
-    CFE_SB_InitMsg(&TlmPkt, SB_UT_TLM_MID, sizeof(TlmPkt), true);
-    SETUP(CFE_SB_Subscribe(SB_UT_TLM_MID, PipeId));
-    SETUP(CFE_SB_SendMsg(TlmPktPtr));
-    SETUP(CFE_SB_RcvMsg(&PtrToMsg, PipeId,CFE_SB_PEND_FOREVER));
-    ASSERT(CFE_SB_GetLastSenderId(&GLSPtr, PipeId));
-
-    EVTCNT(3);
-
-    TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_RcvMsg_GetLastSenderSuccess */
 
 /*
 ** Test receiving a message response to a timeout
@@ -3650,6 +3535,47 @@ void Test_RcvMsg_InvalidBufferPtr(void)
     TEARDOWN(CFE_SB_DeletePipe(PipeId));
 
 } /* end Test_RcvMsg_InvalidBufferPtr */
+
+/*
+** Test receiving a message response with the sender app id
+*/
+void Test_RcvMsg_SenderId(void)
+{
+    CFE_SB_MsgPtr_t  PtrToMsg;
+    CFE_SB_MsgId_t   MsgId = SB_UT_TLM_MID;
+    CFE_SB_PipeId_t  PipeId;
+    SB_UT_Test_Tlm_t TlmPkt;
+    CFE_SB_MsgPtr_t  TlmPktPtr = (CFE_SB_MsgPtr_t) &TlmPkt;
+    CFE_SB_PipeD_t   *PipeDscPtr;
+    uint32           PipeDepth = 10;
+    uint32           SavedAppId, SenderId;
+
+    SavedAppId = CFE_SB.AppId;
+    CFE_SB.AppId = 1234;
+
+    SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "RcvMsgTestPipe"));
+    CFE_SB_InitMsg(&TlmPkt, MsgId, sizeof(TlmPkt), true);
+    SETUP(CFE_SB_Subscribe(MsgId, PipeId));
+    SETUP(CFE_SB_SendMsg(TlmPktPtr));
+
+    ASSERT(CFE_SB_RcvMsgSenderId(&PtrToMsg, &SenderId, PipeId, CFE_SB_PEND_FOREVER));
+  
+    ASSERT_TRUE(SenderId == CFE_SB.AppId);
+
+    ASSERT_TRUE(PtrToMsg != NULL);
+
+    EVTCNT(3);
+
+    EVTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+
+    PipeDscPtr = CFE_SB_GetPipePtr(PipeId);
+    PipeDscPtr->ToTrashBuff = PipeDscPtr->CurrentBuff;
+    PipeDscPtr->CurrentBuff = NULL;
+    
+    TEARDOWN(CFE_SB_DeletePipe(PipeId));
+
+    CFE_SB.AppId = SavedAppId; /* reset after deleting the pipe */
+} /* end Test_RcvMsg_SenderId */
 
 /*
 ** Test SB Utility APIs

--- a/fsw/cfe-core/unit-test/sb_UT.h
+++ b/fsw/cfe-core/unit-test/sb_UT.h
@@ -2825,10 +2825,7 @@ void Test_SendMsg_MaxMsgSizePlusOne_ZeroCopy(void);
 **        This function does not return a value.
 **
 ** \sa #UT_Text, #Test_RcvMsg_InvalidPipeId, #Test_RcvMsg_InvalidTimeout,
-** \sa #Test_RcvMsg_Poll, #Test_RcvMsg_GetLastSenderNull,
-** \sa #Test_RcvMsg_GetLastSenderInvalidPipe,
-** \sa #Test_RcvMsg_GetLastSenderInvalidCaller,
-** \sa #Test_RcvMsg_GetLastSenderSuccess, #Test_RcvMsg_Timeout,
+** \sa #Test_RcvMsg_Poll, #Test_RcvMsg_SenderId, #Test_RcvMsg_Timeout,
 ** \sa #Test_RcvMsg_PipeReadError, #Test_RcvMsg_PendForever
 **
 ******************************************************************************/
@@ -2897,110 +2894,6 @@ void Test_RcvMsg_InvalidTimeout(void);
 **
 ******************************************************************************/
 void Test_RcvMsg_Poll(void);
-
-/*****************************************************************************/
-/**
-** \brief Test receive last message response to a null sender ID
-**
-** \par Description
-**        This function tests the receive last message response to a null
-**        sender ID.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-**
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe,
-** \sa #CFE_SB_GetLastSenderId, #UT_GetNumEventsSent, #UT_EventIsInHistory,
-** \sa #CFE_SB_DeletePipe, #UT_Report
-**
-******************************************************************************/
-void Test_RcvMsg_GetLastSenderNull(void);
-
-/*****************************************************************************/
-/**
-** \brief Test receive last message response to an invalid pipe ID
-**
-** \par Description
-**        This function tests the receive last message response to an invalid
-**        pipe ID.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-**
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe,
-** \sa #CFE_SB_GetLastSenderId, #UT_GetNumEventsSent, #UT_EventIsInHistory,
-** \sa #CFE_SB_DeletePipe, #UT_Report
-**
-******************************************************************************/
-void Test_RcvMsg_GetLastSenderInvalidPipe(void);
-
-/*****************************************************************************/
-/**
-** \brief Test receive last message response to an invalid owner ID
-**
-** \par Description
-**        This function tests the receive last message response to an invalid
-**        owner ID.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-**
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe,
-** \sa #CFE_SB_GetLastSenderId, #UT_GetNumEventsSent, #UT_EventIsInHistory,
-** \sa #CFE_SB_DeletePipe, #UT_Report
-**
-******************************************************************************/
-void Test_RcvMsg_GetLastSenderInvalidCaller(void);
-
-/*****************************************************************************/
-/**
-** \brief Test receive last message response when there is no last sender
-**
-** \par Description
-**        This function tests the receive last message response when no last
-**        sender.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-**
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe,
-** \sa #CFE_SB_GetLastSenderId, #UT_GetNumEventsSent, #UT_EventIsInHistory,
-** \sa #CFE_SB_DeletePipe, #UT_Report
-**
-******************************************************************************/
-void Test_RcvMsg_GetLastSenderNoValidSender(void);
-
-/*****************************************************************************/
-/**
-** \brief Test successful receive last message request
-**
-** \par Description
-**        This function tests the successful receive last message request.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-**
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe,
-** \sa #CFE_SB_GetLastSenderId, #UT_GetNumEventsSent, #CFE_SB_DeletePipe,
-** \sa #UT_Report
-**
-******************************************************************************/
-void Test_RcvMsg_GetLastSenderSuccess(void);
 
 /*****************************************************************************/
 /**
@@ -3085,6 +2978,27 @@ void Test_RcvMsg_PendForever(void);
 **
 ******************************************************************************/
 void Test_RcvMsg_InvalidBufferPtr(void);
+
+/*****************************************************************************/
+/**
+** \brief Test receiving a message response and getting the app id of the sender
+**
+** \par Description
+**        This function tests receiving a message from a pipe and also receiving
+**        the sender's application id.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+**
+** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_RcvMsg,
+** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
+** \sa #CFE_SB_RcvMsgSenderId, #UT_Report
+**
+******************************************************************************/
+void Test_RcvMsg_SenderId(void);
 
 /*****************************************************************************/
 /**


### PR DESCRIPTION
Fix #759

**Describe the contribution**
This removes the significantly-broken `CFE_SB_GetLastSenderId()` function and adds a new variant `CFE_SB_RcvMsgSenderId()` that returns (via an out parameter) the AppId of the application that sent the message being read off the pipe.

Note that, to reduce the redundant code, `CFE_SB_RcvMsg()` calls `CFE_SB_RcvMsgSenderId()` with a null pointer. It may be better to use a #define macro for improved performance, or deprecate the RcvMsg() API eventually.

**Testing performed**
Built and ran updated unit tests.

**System(s) tested on**
Debian 10.3

**Additional context**
GetLastSenderId() is basically broken, I suggest this be merged into 6.8, removing the function entirely (no deprecation). It will break any users of GetLastSenderId(), obv. (SBN being the only one I am aware of.)

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov