### PR TITLE
Fix #752, use OS_READ_ONLY, not O_RDONLY

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Behavior Change: App unit tests requiring this will not fail to build due to und
 - Fix strlen in CFE_ES_TaskInit <https://github.com/nasa/cFE/pull/23>
 - Minor bug fixes (see <https://github.com/nasa/cFE/pull/378>)
 
-### **_OFFICIAL RELEASE: 6.7.0_**
+### **_OFFICIAL RELEASE: 6.7.0 - Aquila_**
 
 - This is a point release from an internal repository
 - Changes are detailed in [cFS repo](https://github.com/nasa/cFS) release documentation

--- a/fsw/cfe-core/src/es/cfe_es_apps.c
+++ b/fsw/cfe-core/src/es/cfe_es_apps.c
@@ -94,7 +94,7 @@ void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath )
       /*
       ** Open the file in the volatile disk.
       */
-      AppFile = OS_open( CFE_PLATFORM_ES_VOLATILE_STARTUP_FILE, O_RDONLY, 0);
+      AppFile = OS_open( CFE_PLATFORM_ES_VOLATILE_STARTUP_FILE, OS_READ_ONLY, 0);
 
       if ( AppFile >= 0 )
       {
@@ -119,7 +119,7 @@ void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath )
       /*
       ** Try to Open the file passed in to the cFE start.
       */
-      AppFile = OS_open( (const char *)StartFilePath, O_RDONLY, 0);
+      AppFile = OS_open( (const char *)StartFilePath, OS_READ_ONLY, 0);
 
       if ( AppFile >= 0 )
       {


### PR DESCRIPTION
**Describe the contribution**

Calls to OS_open() must use the OSAL-defined symbol, not the POSIX symbol.  This was a long-standing bug but happened to work because they are both zero.

Fixes #752

**Testing performed**
Build and sanity check CFE
Build and run unit tests

**Expected behavior changes**
None.

**System(s) tested on**
Ubuntu 20.04
RTEMS 4.11.3

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
