### PR TITLE
Resolve #770, add baseline and buildnumber to version.h

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_task.c
+++ b/fsw/cfe-core/src/es/cfe_es_task.c
@@ -351,13 +351,20 @@ int32 CFE_ES_TaskInit(void)
         return(Status);
     }
 
-    Status = CFE_EVS_SendEvent(CFE_ES_INITSTATS_INF_EID,
-                      CFE_EVS_EventType_INFORMATION,
-                      "Versions:cFE %d.%d.%d.%d, OSAL %d.%d.%d.%d, PSP %d.%d.%d.%d, chksm %d",
-                      CFE_MAJOR_VERSION,CFE_MINOR_VERSION,CFE_REVISION,CFE_MISSION_REV,
-                      OS_MAJOR_VERSION,OS_MINOR_VERSION,OS_REVISION,OS_MISSION_REV,
-                      CFE_PSP_MAJOR_VERSION,CFE_PSP_MINOR_VERSION,CFE_PSP_REVISION,CFE_PSP_MISSION_REV,
-                      (int)CFE_ES_TaskData.HkPacket.Payload.CFECoreChecksum);
+#ifdef CFE_PSP_VERSION 
+    Status = CFE_EVS_SendEvent(CFE_ES_INITSTATS_INF_EID, CFE_EVS_EventType_INFORMATION, 
+                                "\n%s\n,cFE chksm %d",
+                                CFS_VERSIONS, (int)CFE_ES_TaskData.HkPacket.Payload.CFECoreChecksum);
+
+#else  /* CFE_PSP_VERSION */
+    Status = CFE_EVS_SendEvent(CFE_ES_INITSTATS_INF_EID, CFE_EVS_EventType_INFORMATION, 
+                                "\n%sv%d.%d.%d.%d\n cFE chksm %d",
+                                CFS_VERSIONS, 
+                                CFE_PSP_MAJOR_VERSION, CFE_PSP_MINOR_VERSION, CFE_PSP_REVISION, CFE_PSP_MISSION_REV,
+                                (int)CFE_ES_TaskData.HkPacket.Payload.CFECoreChecksum);
+
+#endif  /* CFE_PSP_VERSION */
+
     if ( Status != CFE_SUCCESS )
     {
         CFE_ES_WriteToSysLog("ES:Error sending version event:RC=0x%08X\n", (unsigned int)Status);
@@ -788,11 +795,12 @@ int32 CFE_ES_NoopCmd(const CFE_ES_Noop_t *Cmd)
     ** This command will always succeed.
     */
     CFE_ES_TaskData.CommandCounter++;
+
+                    
+
     CFE_EVS_SendEvent(CFE_ES_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION,
-                     "No-op command. Versions:cFE %d.%d.%d.%d, OSAL %d.%d.%d.%d, PSP %d.%d.%d.%d",
-                     CFE_MAJOR_VERSION,CFE_MINOR_VERSION,CFE_REVISION,CFE_MISSION_REV,
-                     OS_MAJOR_VERSION,OS_MINOR_VERSION,OS_REVISION,OS_MISSION_REV,
-                     CFE_PSP_MAJOR_VERSION,CFE_PSP_MINOR_VERSION,CFE_PSP_REVISION,CFE_PSP_MISSION_REV);
+                      "No-op command:\n %s",                    
+                        CFS_VERSIONS);
 
     return CFE_SUCCESS;
 } /* End of CFE_ES_NoopCmd() */

--- a/fsw/cfe-core/src/evs/cfe_evs_task.c
+++ b/fsw/cfe-core/src/evs/cfe_evs_task.c
@@ -333,8 +333,7 @@ int32 CFE_EVS_TaskInit ( void )
   
    /* Write the AppID to the global location, now that the rest of initialization is done */
    CFE_EVS_GlobalData.EVS_AppID = AppID;
-   EVS_SendEvent(CFE_EVS_STARTUP_EID, CFE_EVS_EventType_INFORMATION, "cFE EVS Initialized. cFE Version %d.%d.%d.%d",
-                 CFE_MAJOR_VERSION,CFE_MINOR_VERSION,CFE_REVISION,CFE_MISSION_REV);
+   EVS_SendEvent(CFE_EVS_STARTUP_EID, CFE_EVS_EventType_INFORMATION, "cFE EVS Initialized.\n%s", CFE_VERSION_STRING);
 
    return CFE_SUCCESS;
 
@@ -644,8 +643,8 @@ bool CFE_EVS_VerifyCmdLength(CFE_SB_MsgPtr_t Msg, uint16 ExpectedLength)
 */
 int32 CFE_EVS_NoopCmd(const CFE_EVS_Noop_t *data)
 {
-   EVS_SendEvent(CFE_EVS_NOOP_EID, CFE_EVS_EventType_INFORMATION,"No-op command. cFE Version %d.%d.%d.%d",
-                 CFE_MAJOR_VERSION,CFE_MINOR_VERSION,CFE_REVISION,CFE_MISSION_REV);
+   EVS_SendEvent(CFE_EVS_NOOP_EID, CFE_EVS_EventType_INFORMATION,"No-op command. %s",
+                 CFE_VERSION_STRING);
    return CFE_SUCCESS;
 }
 

--- a/fsw/cfe-core/src/inc/cfe_version.h
+++ b/fsw/cfe-core/src/inc/cfe_version.h
@@ -19,40 +19,42 @@
 */
 
 /*
-**  File: cfe_version.h
-**
-**  Purpose:
-**     Provide version identifiers for the cFE core.
-*/
+ *  File: cfe_version.h
+ *
+ *  Purpose:
+ *     Provide version identifiers for the cFE core.
+ */
 
-/**
+/*
  * \page cfeversion Version Numbers
  *
  * <H2> Version Number Semantics </H2>
  *
  * The version number is a sequence of four numbers, generally separated by dots when written. These are, in order,
- * the Major number, the Minor number, the Implementation Revision number, and the Mission Revision number. At
+ * the Major number, the Minor number, the Revision number, and the Mission Revision number. At
  * their option, Missions may modify the Mission Revision information as needed to suit their needs.
  *
- * The Major number shall be incremented on release to indicate when there is a change to an API
- * that may cause existing correctly-written cFS components to stop working. It may also be incremented for a
+ * It is important to note that Major, Minor, and Revision numbers are only updated upon official releases of tagged
+ * versions, \b NOT on development builds.
+ *
+ * The MAJOR number shall be incremented on release to indicate when there is a change to an API
+ * that may cause existing, correctly-written cFS components to stop working. It may also be incremented for a
  * release that contains changes deemed to be of similar impact, even if there are no actual changes to the API.
  *
- * The Minor number shall be incremented on release to indicate the addition of features to the API,
+ * The MINOR number shall be incremented on release to indicate the addition of features to the API
  * which do not break the existing code.  It may also be incremented for a release that contains changes deemed
  * to be of similar impact, even if there are no actual updates to the API.
  *
- * The Implementation Revision Version number shall be incremented on changes to software in the master branch,
- * or other changes that benefit from unique identification. It is used for identifying open source development
- * versions.  It is important to note that Major and Minor numbers are only updated upon official releases
- * of tagged versions (see the release tab), \b NOT on development version updates in the master branch.
+ * The REVISION number shall be incremented on changes that benefit from unique identification such as bug fixes or
+ * major documentation updates. The Revision number may also be updated if there are other changes contained within a
+ * release that make it desirable for applications to distinguish one release from another.
  *
- * The Major, Minor, and Implementation Revision numbers are provided in this header file as part of the API
+ * The Major, Minor, and Revision numbers are provided in this header file as part of the API
  * definition; this macro must expand to a simple integer value, so that it can be used in simple if directives
  * by the macro preprocessor.
  *
  * The Mission Version number shall be set to zero in all officially released packages, and is entirely reserved
- * for the use of the mission.  The Mission Version is provided as a simple macro defined in the cfe_platform_cfg.h
+ * for the use of the mission. The Mission Version is provided as a simple macro defined in the cfe_platform_cfg.h
  * header file.
  *
  * <H2> Version Number Flexibility </H2>
@@ -63,20 +65,29 @@
  * The minor number may increment when there have been no augmentations to the API, if changes are as significant as
  * additions to the public API.
  *
- * The revision numbers may update in implementations where no actual implementation-specific code has changed, if
+ * The revision numbers may increment in implementations where no actual implementation-specific code has changed, if
  * there are other changes within the release with similar significance.
  *
  * <H2> How and Where Defined </H2>
  *
  * The Major, Minor, and Revision components of the version are provided as simple macros defined in the cfe_version.h
- * header file as part of the API definition; these macros must expand to simple integer values, so that they can be used
- * in simple if directives by the macro preprocessor.
+ * header file as part of the API definition; these macros must expand to simple integer values, so that they can be
+ * used in simple if directives by the macro preprocessor.
  *
  * The Mission Version is provided as a simple macro defined in the cfe_platform_cfg.h header file. As delivered in
  * official releases, these macros must expand to simple integer values, so that they can be used in simple macro
  * preprocessor conditions, but delivered code should not prevent a mission from, for example, deciding that the Mission
  * Version is actually a text string.
  *
+ * <H2> Identification of development builds </H2>
+ *
+ * In order to distinguish between development versions, we also provide a BUILDNUMBER.
+ *
+ * The BUILD_NUMBER reflects the number of commits since a specified baseline git tag for each particular component. The
+ * BUILD_NUMBER integer increases monotonically for a given development cycle. The development cycle can be identified by
+ * the git tag baseline in the CFE_VERSION macro, which looks like vX.Y.Z+dev, or by the codename in the version string.
+ * When a new baseline tag and codename are created, the the BUILDNUMBER resets to zero and begins increasing from that
+ * new epoch.
  */
 
 #ifndef _cfe_version_
@@ -90,12 +101,96 @@
 #include <target_config.h>
 
 
+
+/* Development Build Macro Definitions */
+#define CFE_BUILD_NUMBER 295 /* Number of commits since baseline */
+#define CFE_BUILD_BASELINE "v6.7.0+dev" /* Number of commits since baseline */
+
 /*
-** Macro Definitions
+* Version Macro Definitions
+* ONLY APPLY for OFFICIAL releases
 */
-#define CFE_MAJOR_VERSION         6
-#define CFE_MINOR_VERSION         7
-#define CFE_REVISION              21
+#define CFE_MAJOR_VERSION 6 /**< @brief Major version number */
+#define CFE_MINOR_VERSION 7 /**< @brief Minor version number */
+#define CFE_REVISION      0 /**< @brief Revision number */
+#define CFE_MISSION_REV   0 /**< @brief Mission revision */
+
+/* Helper functions to concatenate strings from integer macros */
+#define CFE_STR_HELPER(x) #x
+#define CFE_STR(x)        CFE_STR_HELPER(x)
+
+/* Baseling git tag + Number of commits since baseline */ 
+#define CFE_VERSION CFE_BUILD_BASELINE CFE_STR(CFE_BUILD_NUMBER) 
+
+/* Used to report the full version */          
+#define CFE_VERSION_STRING                                                          \
+    " cFE Development Build\n "                                                     \
+    CFE_VERSION " (Codename: Bootes)"       /* Codename for current development */  \
+    "\n Last Offical Release: cfe v6.7.0"   /* For full support please use this version */
 
 
-#endif  /* _cfe_version_ */
+/* TEMPLATES for Official Releases */
+
+/* Official Release format for CFE_VERSION */
+  /*
+  #define CFE_VERSION \
+      CFE_STR(CFE_MAJOR_VERSION) "." \
+      CFE_STR(CFE_MINOR_VERSION) "." \
+      CFE_STR(CFE_REVISION) "."      \
+      CFE_STR(CFE_MISSION_REV)
+  */
+  
+  /* Official Release OS_VERSION_STRING Format */
+  /*
+  #define CFE_VERSION_STRING "cFE version " CFE_VERSION      
+  */
+
+/* END TEMPLATES */
+
+
+/* Component Version Definitions */
+/* Here for backwards compatibility for integration test
+*/
+#ifndef OS_VERSION /* This will be defined by osal in the future */
+#define OS_VERSION                  \
+    CFE_STR(OS_MAJOR_VERSION) "."   \
+    CFE_STR(OS_MINOR_VERSION) "."   \
+    CFE_STR(OS_REVISION) "."        \
+    CFE_STR(OS_MISSION_REV)
+#endif
+
+/* Combined string with formated combination of all major component versions */
+/* Keeping as a conditional definition based on PSP intricacies */
+#ifdef CFE_PSP_VERSION
+#define CFS_VERSIONS                              \
+"cFS Development Version (Codename: Bootes)\n"    \
+  " cfe:  "  CFE_VERSION "\n"                     \
+  " osal: " OS_VERSION "\n"                       \
+  " psp:  "  CFE_PSP_VERSION   
+#else 
+#define CFS_VERSIONS                              \
+"cFS Development Version (Codename: Bootes)\n"    \
+  " cfe:  "  CFE_VERSION "\n"                     \
+  " osal: " OS_VERSION "\n"                       \
+  " psp:  "       
+#endif
+     
+/* Use the following templates for Official Releases ONLY */
+  /* Official Release format for CFE_VERSION */
+  /* 
+  #define CFE_VERSION "v"            \
+      CFE_STR(CFE_MAJOR_VERSION) "." \
+      CFE_STR(CFE_MINOR_VERSION) "." \
+      CFE_STR(CFE_REVISION) "."      \
+      CFE_STR(CFE_MISSION_REV)
+  */ 
+
+  /* Official Release format for CFE_VERSION_STRING */
+  /*
+  #define CFE_VERSION_STRING "cFE " CFE_VERSION
+  */
+/* END TEMPLATES */
+
+    
+
+#endif /* _cfe_version_ */

--- a/fsw/cfe-core/src/sb/cfe_sb_task.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_task.c
@@ -490,8 +490,7 @@ void CFE_SB_ProcessCmdPipePkt(void) {
 int32 CFE_SB_NoopCmd(const CFE_SB_Noop_t *data)
 {
     CFE_EVS_SendEvent(CFE_SB_CMD0_RCVD_EID,CFE_EVS_EventType_INFORMATION,
-            "No-op Cmd Rcvd. cFE Version %d.%d.%d.%d",
-            CFE_MAJOR_VERSION,CFE_MINOR_VERSION,CFE_REVISION,CFE_MISSION_REV);
+            "No-op Cmd Rcvd. %s", CFE_VERSION_STRING);
     CFE_SB.HKTlmMsg.Payload.CommandCounter++;
 
     return CFE_SUCCESS;

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task.c
@@ -214,8 +214,7 @@ int32 CFE_TBL_TaskInit(void)
     /*
     ** Task startup event message
     */
-    Status = CFE_EVS_SendEvent(CFE_TBL_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "cFE TBL Initialized.  cFE Version %d.%d.%d.%d",
-                               CFE_MAJOR_VERSION,CFE_MINOR_VERSION,CFE_REVISION,CFE_MISSION_REV);
+    Status = CFE_EVS_SendEvent(CFE_TBL_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "cFE TBL Initialized.\n%s", CFE_VERSION_STRING);
 
     if(Status != CFE_SUCCESS)
     {

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.c
@@ -328,8 +328,7 @@ void CFE_TBL_GetTblRegData(void)
 int32 CFE_TBL_NoopCmd(const CFE_TBL_Noop_t *data)
 {
     /* Acknowledge receipt of NOOP with Event Message */
-    CFE_EVS_SendEvent(CFE_TBL_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op command. cFE Version %d.%d.%d.%d",
-                      CFE_MAJOR_VERSION,CFE_MINOR_VERSION,CFE_REVISION,CFE_MISSION_REV);
+    CFE_EVS_SendEvent(CFE_TBL_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op command. %s", CFE_VERSION_STRING);
 
     return CFE_TBL_INC_CMD_CTR;
 

--- a/fsw/cfe-core/src/time/cfe_time_task.c
+++ b/fsw/cfe-core/src/time/cfe_time_task.c
@@ -815,8 +815,7 @@ int32 CFE_TIME_NoopCmd(const CFE_TIME_Noop_t *data)
     CFE_TIME_TaskData.CommandCounter++;
 
     CFE_EVS_SendEvent(CFE_TIME_NOOP_EID, CFE_EVS_EventType_INFORMATION,
-                     "No-op command. cFE Version %d.%d.%d.%d",
-                     CFE_MAJOR_VERSION,CFE_MINOR_VERSION,CFE_REVISION,CFE_MISSION_REV);
+                     "No-op command. %s", CFE_VERSION_STRING);
 
     return CFE_SUCCESS;
 


### PR DESCRIPTION
**Describe the contribution**
Resolve #770 

**Testing performed**
Steps taken to test the contribution:
Built on top of current integration candidate
Built with other integration candidates as well as with nasa/osal#532 and nasa/psp#178

**Expected behavior changes**
New macros defined. Startup reporting now looks like 
<img width="331" alt="Screen Shot 2020-07-15 at 8 56 43 AM" src="https://user-images.githubusercontent.com/59618057/87557256-ab977000-c685-11ea-893c-a27e54441639.png">
<img width="340" alt="Screen Shot 2020-07-15 at 8 56 52 AM" src="https://user-images.githubusercontent.com/59618057/87557332-c5d14e00-c685-11ea-8fd7-4ad987984e72.png">
<img width="208" alt="Screen Shot 2020-07-15 at 8 56 35 AM" src="https://user-images.githubusercontent.com/59618057/87557452-ebf6ee00-c685-11ea-8914-c4ea6844fde4.png">


**System(s) tested on**
Docker Ubuntu-based gcc image on OSX

**Additional context**
Also Tested with nasa/osal#532 and nasa/psp#178 

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Gerardo E. Cruz-Ortiz, NASA-GSFC