### PR TITLE
Fix #710, Specify ProcessorID in targets.cmake

### DIFF
--- a/cmake/sample_defs/targets.cmake
+++ b/cmake/sample_defs/targets.cmake
@@ -5,11 +5,15 @@
 # This file indicates the architecture and configuration of the
 # target boards that will run core flight software.
 #
-# The following variables are defined per board, where <x> is the 
-# CPU number starting with 1:
+# The following variables are defined per board, where <x> is a
+# sequential index number starting with 1:
 #
 #  TGT<x>_NAME : the user-friendly name of the cpu.  Should be simple
 #       word with no punctuation.  This MUST be specified.
+#  TGT<x>_PROCESSORID : the default numeric ID for this processor at
+#       runtime.  If not specified, then the sequential index number is
+#       used.  This translates to the numeric value returned by
+#       CFE_PSP_GetProcessorId() at runtime.
 #  TGT<x>_APPLIST : list of applications to build and install on the CPU.
 #       These are built as dynamically-loaded applications and installed
 #       as files in the non-volatile storage of the target, and loaded

--- a/cmake/target/CMakeLists.txt
+++ b/cmake/target/CMakeLists.txt
@@ -48,7 +48,11 @@ include_directories(${CMAKE_BINARY_DIR}/${CFE_CORE_TARGET}/inc)
 
 # The CPU ID and name are defined by the build scripts for this target
 if (DEFINED TGTID)
-  add_definitions(-DCFE_CPU_ID_VALUE=${TGTID})
+  if (DEFINED TGT${TGTID}_PROCESSORID)
+      add_definitions(-DCFE_CPU_ID_VALUE=${TGT${TGTID}_PROCESSORID})
+  else()
+      add_definitions(-DCFE_CPU_ID_VALUE=${TGTID})
+  endif()
 endif()
 if (DEFINED SPACECRAFT_ID)
   add_definitions(-DCFE_SPACECRAFT_ID_VALUE=${SPACECRAFT_ID})


### PR DESCRIPTION
**Describe the contribution**
Allow explicitly setting of the processor ID in `targets.cmake`

**Testing performed**
Build and sanity-check CFE
Build and run all unit tests.
Confirm that `CFE_PSP_GetProcessorId()` now returns the expected value.

**Expected behavior changes**
The `TGTx_PROCESSOR_ID` setting in `targets.cmake` will be passed to the final build/link of CFE core as the CPU ID.  If unspecified then the CMake index value is used instead (backward compatible).

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Minimal/simple fix that at least should address part of the problem.  Note this value isn't passed to `elf2cfetbl` for table builds at the moment, this only affects the CFE runtime value of processor ID.

At least on pc-linux one can still provide the value on the command line which takes precedence over anything in the build.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
