### PR TITLE
Fix #774,  do not generate empty include file

### DIFF
--- a/cmake/global_functions.cmake
+++ b/cmake/global_functions.cmake
@@ -106,14 +106,17 @@ function(generate_config_includefile)
     # then check for and use the fallback file. 
     # (if specified by the caller it should always exist)
     # Also produce a message on the console showing whether mission config or fallback was used
-    if (NOT ITEM_FOUND AND GENCONFIG_ARG_FALLBACK_FILE)
+    if (ITEM_FOUND)
+        message(STATUS "Generated ${GENCONFIG_ARG_FILE_NAME} from ${MISSION_DEFS} configuration")
+    elseif (GENCONFIG_ARG_FALLBACK_FILE)
         file(TO_NATIVE_PATH "${GENCONFIG_ARG_FALLBACK_FILE}" SRC_NATIVE_PATH)
         list(APPEND WRAPPER_FILE_CONTENT 
             "\n\n/* No configuration for ${GENCONFIG_ARG_FILE_NAME}, using fallback */\n"
             "#include \"${GENCONFIG_ARG_FALLBACK_FILE}\"\n")
         message(STATUS "Using ${GENCONFIG_ARG_FALLBACK_FILE} for ${GENCONFIG_ARG_FILE_NAME}")
     else()
-        message(STATUS "Generated ${GENCONFIG_ARG_FILE_NAME} from ${MISSION_DEFS} configuration")
+        message("ERROR: No implementation for ${GENCONFIG_ARG_FILE_NAME} found")
+        message(FATAL_ERROR "Tested: ${CHECK_PATH_LIST}")
     endif()
     
     # Generate a header file


### PR DESCRIPTION
**Describe the contribution**
Detect the condition where no files were present to fulfill an config include file requirement, and report as an error rather than generating an empty file.

Fixes #774

**Testing performed**
Create a test config that refers to a nonexistent platform config called "foobar" by setting this in `targets.cmake`:
`SET(TGT1_PLATFORM foobar)`

_Without_ this change, `make prep` still (seemingly) completes successfully but the `cfe_platform_cfg.h` is actually empty, which results in a later compiler error.

**Expected behavior changes**
After applying this change, the issue is reported as a `make prep` error instead, along with a list of files it checked for.

Example:
```
ERROR: No implementation for cfe_platform_cfg.h found
CMake Error at cmake/global_functions.cmake:119 (message):
  Tested:
  /home/joe/code/cfecfs/github/sample_defs/cfe_platform_cfg.h;/home/joe/code/cfecfs/github/sample_defs/foobar_platform_cfg.h
Call Stack (most recent call first):
  fsw/cfe-core/arch_build.cmake:14 (generate_config_includefile)
  cmake/arch_build.cmake:307 (include)
  CMakeLists.txt:119 (prepare)
```

No FSW changes - just reporting this configuration error.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
