### PR TITLE
Fix #265, implement cmake name based targets

### DIFF
--- a/cmake/sample_defs/cpu1_platform_cfg.h
+++ b/cmake/sample_defs/cpu1_platform_cfg.h
@@ -41,16 +41,6 @@
 */
 #include "cfe_mission_cfg.h"
 
-/*
-** CPU Id for target Processor
-*/
-#define CFE_PLATFORM_CPU_ID 1
-
-/*
-** CPU Name for target Processor
-*/
-#define CFE_PLATFORM_CPU_NAME "CPU1"
-
 /**
 **  \cfesbcfg Maximum Number of Unique Message IDs SB Routing Table can hold
 **
@@ -1786,7 +1776,7 @@
 **  \par Limits
 **       This value can be any 32 bit unsigned integer.
 */
-#define CFE_PLATFORM_TBL_VALID_PRID_1            (CFE_PLATFORM_CPU_ID)
+#define CFE_PLATFORM_TBL_VALID_PRID_1            (10)
 #define CFE_PLATFORM_TBL_VALID_PRID_2            (CFE_PLATFORM_TBL_U32FROM4CHARS('a', 'b', 'c', 'd'))
 #define CFE_PLATFORM_TBL_VALID_PRID_3            0
 #define CFE_PLATFORM_TBL_VALID_PRID_4            0

--- a/cmake/sample_defs/targets.cmake
+++ b/cmake/sample_defs/targets.cmake
@@ -1,74 +1,70 @@
 ######################################################################
-# 
+#
 # Master config file for cFS target boards
 #
 # This file indicates the architecture and configuration of the
 # target boards that will run core flight software.
 #
-# The following variables are defined per board, where <x> is a
-# sequential index number starting with 1:
+# The following variables are defined per board, where <x> is the
+# CPU number starting with 1:
 #
-#  TGT<x>_NAME : the user-friendly name of the cpu.  Should be simple
+#  <cpuname>_NAME : the user-friendly name of the cpu.  Should be simple
 #       word with no punctuation.  This MUST be specified.
-#  TGT<x>_PROCESSORID : the default numeric ID for this processor at
-#       runtime.  If not specified, then the sequential index number is
-#       used.  This translates to the numeric value returned by
-#       CFE_PSP_GetProcessorId() at runtime.
-#  TGT<x>_APPLIST : list of applications to build and install on the CPU.
+#  <cpuname>_APPLIST : list of applications to build and install on the CPU.
 #       These are built as dynamically-loaded applications and installed
 #       as files in the non-volatile storage of the target, and loaded
 #       at runtime via the startup script or commands.
-#  TGT<x>_STATIC_APPLIST : list of applications to build and statically
+#  <cpuname>_STATIC_APPLIST : list of applications to build and statically
 #       link with the CFE executable.  This is similar to the "APPLIST"
 #       except the application is built with STATIC linkage, and it is
 #       included directly when linking the CFE core executable itself.
-#       No separate application file is generated for these apps. 
-#  TGT<x>_STATIC_SYMLIST : list of symbols to include in the OSAL static
+#       No separate application file is generated for these apps.
+#  <cpuname>_STATIC_SYMLIST : list of symbols to include in the OSAL static
 #       symbol lookup table.  Each entry is a comma-separated pair containing
-#       the symbol name and virtual module/app name, such as   
+#       the symbol name and virtual module/app name, such as
 #           My_C_Function_Name,MY_APP
 #       The first item must be a publicly-exposed C symbol name available to
 #       the linker at static link time, generally the entry point/main function
 #       of the a module or library (see STATIC_APPLIST).  The second item is the
-#       module name that should match the name used in the CFE startup script 
+#       module name that should match the name used in the CFE startup script
 #       (4th parameter).
-#       IMPORTANT:  For this to work, the OS_STATIC_LOADER configuration option 
+#       IMPORTANT:  For this to work, the OS_STATIC_LOADER configuration option
 #       must be specified in the osconfig.h for that CPU.
-#  TGT<x>_PSP_MODULELIST : additional PSP "modules" to link into the
+#  <cpuname>_PSP_MODULELIST : additional PSP "modules" to link into the
 #       CFE executable for this target.  These can be device drivers or
 #       other bits of modular PSP functionality that provide I/O or other
 #       low level functions.
-#  TGT<x>_FILELIST : list of extra files to copy onto the target.  No
+#  <cpuname>_FILELIST : list of extra files to copy onto the target.  No
 #       modifications of the file will be made.  In order to differentiate
 #       between different versions of files with the same name, priority
 #       will be given to a file named <cpuname>_<filename> to be installed
 #       as simply <filename> on that cpu (prefix will be removed).  These
 #       files are intended to be copied to the non-volatile storage on the
 #       target for use during runtime.
-#  TGT<x>_EMBED_FILELIST : list of extra files which are to be converted
-#       into data arrays and linked with/embedded into the CFE executable, 
+#  <cpuname>_EMBED_FILELIST : list of extra files which are to be converted
+#       into data arrays and linked with/embedded into the CFE executable,
 #       so the content of the files can be available at runtime on systems
 #       that do not have run time non-volatile storage.  The format of each
 #       list entry is a comma-separated pair of variable and file name:
 #            VARIABLE_NAME,FILE_NAME
 #       The binary contents of the file will subsequently be available as:
-#            extern const char VARIABLE_NAME_DATA[] and 
+#            extern const char VARIABLE_NAME_DATA[] and
 #            extern const unsigned long VARIABLE_NAME_SIZE
 #       The same prefix-based filename mapping as used on FILELIST is also
-#       employed here, allowing CPU-specific data files to be used. 
-#  TGT<x>_SYSTEM : the toolchain to use for building all code.  This
+#       employed here, allowing CPU-specific data files to be used.
+#  <cpuname>_SYSTEM : the toolchain to use for building all code.  This
 #       will map to a CMake toolchain file called "toolchain-<ZZZ>"
 #       If not specified then it will default to "cpu<x>" so that
 #       each CPU will have a dedicated toolchain file and no objects
-#       will be shared across CPUs.  
-#       Otherwise any code built using the same toolchain may be 
+#       will be shared across CPUs.
+#       Otherwise any code built using the same toolchain may be
 #       copied to multiple CPUs for more efficient builds.
-#  TGT<x>_PLATFORM : configuration for the CFE core to use for this
+#  <cpuname>_PLATFORM : configuration for the CFE core to use for this
 #       cpu.  This determines the cfe_platform_cfg.h to use during the
 #       build.  Multiple files/components may be concatenated together
-#       allowing the config to be generated in a modular fashion.  If 
+#       allowing the config to be generated in a modular fashion.  If
 #       not specified then it will be assumed as "default <cpuname>".
-# 
+#
 
 # The MISSION_NAME will be compiled into the target build data structure
 # as well as being passed to "git describe" to filter the tags when building
@@ -102,17 +98,15 @@ list(APPEND MISSION_GLOBAL_APPLIST sample_app sample_lib)
 SET(FT_INSTALL_SUBDIR "host/functional-test")
 
 # Each target board can have its own HW arch selection and set of included apps
-SET(TGT1_NAME cpu1)
-SET(TGT1_APPLIST ci_lab to_lab sch_lab)
-SET(TGT1_FILELIST cfe_es_startup.scr)
+SET(MISSION_CPUNAMES cpu1)
+
+SET(cpu1_PROCESSORID 10)
+SET(cpu1_APPLIST ci_lab to_lab sch_lab)
+SET(cpu1_FILELIST cfe_es_startup.scr)
 
 # CPU2/3 are duplicates of CPU1.  These are not built by default anymore but are
 # commented out to serve as an example of how one would configure multiple cpus.
-#SET(TGT2_NAME cpu2)
-#SET(TGT2_APPLIST ci_lab to_lab sch_lab)
-#SET(TGT2_FILELIST cfe_es_startup.scr)
-
-#SET(TGT3_NAME cpu3)
-#SET(TGT3_APPLIST ci_lab to_lab sch_lab)
-#SET(TGT3_FILELIST cfe_es_startup.scr)
+SET(cpu2_PROCESSORID 11)
+SET(cpu2_APPLIST ci_lab to_lab sch_lab)
+SET(cpu2_FILELIST cfe_es_startup.scr)
 

--- a/cmake/target/CMakeLists.txt
+++ b/cmake/target/CMakeLists.txt
@@ -12,13 +12,22 @@
 
 project(CFETARGET C)
 
+# Sanity check on inputs - these should be set in the parent script(s)
+if (NOT DEFINED TGTNAME)
+  message(FATAL_ERROR "TGTNAME must be defined to link a final exe")
+endif (NOT DEFINED TGTNAME)
+
+if (NOT DEFINED ${TGTNAME}_PROCESSORID)
+  message(FATAL_ERROR "${TGTNAME}_PROCESSORID must be defined to link a final exe")
+endif (NOT DEFINED ${TGTNAME}_PROCESSORID)
+
 # Create a file for the statically-linked module list for this target
 # do this for both PSP and CFS static modules
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/psp_module_list.inc.tmp" 
     "/* Automatically generated based on target config */\n")
-foreach(PSPMOD ${TGT${TGTID}_PSP_MODULELIST})
+foreach(PSPMOD ${${TGTNAME}_PSP_MODULELIST})
   file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/psp_module_list.inc.tmp" "LOAD_PSP_MODULE(${PSPMOD})\n")
-endforeach(PSPMOD ${TGT${TGTID}_PSP_MODULELIST})
+endforeach(PSPMOD ${${TGTNAME}_PSP_MODULELIST})
 execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different 
     "${CMAKE_CURRENT_BINARY_DIR}/psp_module_list.inc.tmp" 
     "${CMAKE_CURRENT_BINARY_DIR}/psp_module_list.inc")
@@ -26,35 +35,27 @@ file (REMOVE "${CMAKE_CURRENT_BINARY_DIR}/psp_module_list.inc.tmp")
 
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/cfs_static_symbol_list.inc.tmp" 
     "/* Automatically generated based on target config */\n")
-foreach(CFSSYM ${TGT${TGTID}_STATIC_SYMLIST})
+foreach(CFSSYM ${${TGTNAME}_STATIC_SYMLIST})
   file(APPEND "${CMAKE_CURRENT_BINARY_DIR}/cfs_static_symbol_list.inc.tmp" "STATIC_CFS_SYMBOL(${CFSSYM})\n")
-endforeach(CFSSYM ${TGT${TGTID}_STATIC_SYMLIST})
+endforeach(CFSSYM ${${TGTNAME}_STATIC_SYMLIST})
 execute_process(COMMAND ${CMAKE_COMMAND} -E copy_if_different 
     "${CMAKE_CURRENT_BINARY_DIR}/cfs_static_symbol_list.inc.tmp" 
     "${CMAKE_CURRENT_BINARY_DIR}/cfs_static_symbol_list.inc")
 file (REMOVE "${CMAKE_CURRENT_BINARY_DIR}/cfs_static_symbol_list.inc.tmp")
 
-
-# Include the current binary dir for the driver list
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
-
-# The CPU ID and name are defined by the build scripts for this target
-if (DEFINED TGTID)
-  if (DEFINED TGT${TGTID}_PROCESSORID)
-      add_definitions(-DCFE_CPU_ID_VALUE=${TGT${TGTID}_PROCESSORID})
-  else()
-      add_definitions(-DCFE_CPU_ID_VALUE=${TGTID})
-  endif()
-endif()
-if (DEFINED SPACECRAFT_ID)
-  add_definitions(-DCFE_SPACECRAFT_ID_VALUE=${SPACECRAFT_ID})
-endif()
-if (DEFINED TGTNAME)
-  add_definitions(-DCFE_CPU_NAME_VALUE="${TGTNAME}")
-endif()
-
 # Target for the final executable
 add_executable(core-${TGTNAME} src/target_config.c)
+
+target_compile_definitions(core-${TGTNAME} PRIVATE 
+    CFE_CPU_NAME_VALUE="${TGTNAME}"
+    CFE_SPACECRAFT_ID_VALUE=${SPACECRAFT_ID}
+    CFE_CPU_ID_VALUE=${${TGTNAME}_PROCESSORID}
+)
+
+target_include_directories(core-${TGTNAME} PRIVATE 
+    "${CMAKE_CURRENT_BINARY_DIR}"
+    "${CMAKE_BINARY_DIR}/${CFE_CORE_TARGET}/inc"
+)
 
 # This next section provides a method for adding the "-u" switch to the 
 # linker in order to make sure the linker includes certain symbols in the link.
@@ -72,7 +73,7 @@ set_target_properties(core-${TGTNAME} PROPERTIES LINK_FLAGS "${TARGET_LINK_FLAGS
 # (enabled by the ENABLE_EXPORTS property) does not apply to static libs on the link line
 # This is only a concern when relying on the dynamic module loader, if we are statically
 # linking the entire CFE system into a single binary then no special help is needed.
-if (TGT${TGTID}_APPLIST)
+if (${TGTNAME}_APPLIST)
 
   set_target_properties(core-${TGTNAME} PROPERTIES ENABLE_EXPORTS TRUE)
   
@@ -100,7 +101,7 @@ if (TGT${TGTID}_APPLIST)
     set(STOP_WHOLE_ARCHIVE "${COMPILER_LINKER_OPTION_PREFIX}${STOP_WHOLE_ARCHIVE}")
   endif()
                 
-endif (TGT${TGTID}_APPLIST)
+endif (${TGTNAME}_APPLIST)
 
 # Collect any additional libraries that should be included on the link line
 # This depends on whether any special features are included or not
@@ -108,15 +109,15 @@ set(CFE_LINK_WHOLE_LIBS
     ${MISSION_CORE_MODULES}
 )
 set(CFE_LINK_NORMAL_LIBS 
-    ${TGT${TGTID}_PSP_MODULELIST}
-    ${TGT${TGTID}_STATIC_APPLIST}
+    ${${TGTNAME}_PSP_MODULELIST}
+    ${${TGTNAME}_STATIC_APPLIST}
 )
 
 # Handle the list of "embedded files" that should be linked into CFE.
 # These are arbitrary files in the mission config that are converted
 # into C data structures and linked with the executable.  This is 
 # a helpful feature for use when statically linking the CFE.
-if (DEFINED TGT${TGTID}_EMBED_FILELIST)
+if (DEFINED ${TGTNAME}_EMBED_FILELIST)
 
   set(EMBFILE_GENSRC_LIST)  # a list of C source files to compile
   set(EMBFILE_CONTENT_LIST) # a list of content targets for dependencies
@@ -127,7 +128,7 @@ if (DEFINED TGT${TGTID}_EMBED_FILELIST)
   # Where "VARIABLE_NAME" indicates the name to use for the 
   # generated C data structure, and FILE_NAME is the data file
   # that it is sourced from (no paths, it will be searched).
-  foreach(LISTENT ${TGT${TGTID}_EMBED_FILELIST})
+  foreach(LISTENT ${${TGTNAME}_EMBED_FILELIST})
     string(REPLACE "," ";" LISTENT ${LISTENT}) # split on the comma
     list(GET LISTENT 0 EMBNAME)  # EMBNAME => C variable name
     list(GET LISTENT 1 EMBFILE)  # EMBFILE => File name
@@ -163,7 +164,7 @@ if (DEFINED TGT${TGTID}_EMBED_FILELIST)
     list(APPEND EMBFILE_GENSRC_LIST "${CMAKE_CURRENT_BINARY_DIR}/embed/${EMBNAME}.c")
     list(APPEND EMBFILE_CONTENT_LIST "${CMAKE_CURRENT_BINARY_DIR}/embed/${EMBNAME}.inc")
        
-  endforeach(LISTENT ${TGT${TGTID}_EMBED_FILELIST})
+  endforeach(LISTENT ${${TGTNAME}_EMBED_FILELIST})
 
   # Finally, generate a static library that contains all embeded binary files
   # and add this to the list of libraries that the CFE will be linked with.
@@ -174,7 +175,7 @@ if (DEFINED TGT${TGTID}_EMBED_FILELIST)
   add_dependencies(${TGTNAME}_embed_files ${TGTNAME}_embed_content)
   list(APPEND CFE_LINK_NORMAL_LIBS ${TGTNAME}_embed_files)
   
-endif (DEFINED TGT${TGTID}_EMBED_FILELIST)    
+endif (DEFINED ${TGTNAME}_EMBED_FILELIST)    
 
 target_link_libraries(core-${TGTNAME}
     # The following libs should be included whole, even if they

--- a/fsw/cfe-core/unit-test/CMakeLists.txt
+++ b/fsw/cfe-core/unit-test/CMakeLists.txt
@@ -69,7 +69,9 @@ foreach(MODULE ${CFE_CORE_MODULES})
         ut_assert)
     
   add_test(${UT_TARGET_NAME}_UT ${UT_TARGET_NAME}_UT)
-  install(TARGETS ${UT_TARGET_NAME}_UT DESTINATION ${TGTNAME}/${UT_INSTALL_SUBDIR})
+  foreach(TGTNAME ${TGTSYS_${SYSVAR}})
+      install(TARGETS ${UT_TARGET_NAME}_UT DESTINATION ${TGTNAME}/${UT_INSTALL_SUBDIR})
+  endforeach(TGTNAME ${TGTSYS_${SYSVAR}})
 endforeach(MODULE ${CFE_CORE_MODULES})
 
 # Generate the FS test input files


### PR DESCRIPTION
**Describe the contribution**
Allow targets to be configured in `targets.cmake` by name, rather than a numeric index.  This is more user friendly, allows more configuration flexibility, and cleans up a bunch of extra logic too.

Fixes #265 

**Testing performed**
Build system, sanity check CFE, and run all unit tests

Testing not fully completed - Initially submitting PR for design review/feedback.

**Expected behavior changes**
No change to FSW, but changes the way targets are defined in `targets.cmake`.
This includes backward compatibility for existing files/configs, however.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Also related to #710, this cleans up hardcoded CPU IDs that were in the platform config header file.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

