### PR TITLE
Fix #778, add cfe assert and example lib

### DIFF
--- a/cmake/arch_build.cmake
+++ b/cmake/arch_build.cmake
@@ -215,7 +215,6 @@ function(add_unit_test_exe UT_NAME UT_SRCS)
     add_test(${UT_NAME} ${UT_NAME})
 endfunction(add_unit_test_exe)
 
-
 ##################################################################
 #
 # FUNCTION: cfe_exec_do_install

--- a/cmake/arch_build.cmake
+++ b/cmake/arch_build.cmake
@@ -215,6 +215,7 @@ function(add_unit_test_exe UT_NAME UT_SRCS)
     add_test(${UT_NAME} ${UT_NAME})
 endfunction(add_unit_test_exe)
 
+
 ##################################################################
 #
 # FUNCTION: cfe_exec_do_install

--- a/cmake/mission_defaults.cmake
+++ b/cmake/mission_defaults.cmake
@@ -45,3 +45,10 @@ set(MISSION_MODULE_SEARCH_PATH
 set(cfe-core_SEARCH_PATH "cfe/fsw")
 set(osal_SEARCH_PATH ".")
 set(psp_SEARCH_PATH ".")
+
+# If ENABLE_UNIT_TEST is enabled, then include the cfe_assert library in
+# all targets.  This can still be overridden in targets.cmake.
+if (ENABLE_UNIT_TESTS)
+    list(APPEND MISSION_GLOBAL_APPLIST cfe_assert cfe_test)
+endif (ENABLE_UNIT_TESTS)
+

--- a/modules/cfe_assert/CMakeLists.txt
+++ b/modules/cfe_assert/CMakeLists.txt
@@ -1,0 +1,12 @@
+project(CFE_ASSERT C)
+
+include_directories("${CFE_ASSERT_SOURCE_DIR}/inc")
+include_directories("${UT_ASSERT_SOURCE_DIR}/inc")
+
+# Create the app module
+add_cfe_app(cfe_assert
+    src/cfe_assert_io.c
+    src/cfe_assert_main.c
+    $<TARGET_OBJECTS:ut_assert_pic>
+)
+

--- a/modules/cfe_assert/inc/cfe_assert.h
+++ b/modules/cfe_assert/inc/cfe_assert.h
@@ -1,0 +1,63 @@
+/*************************************************************************
+**
+**      GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**      Copyright (c) 2006-2019 United States Government as represented by
+**      the Administrator of the National Aeronautics and Space Administration.
+**      All Rights Reserved.
+**
+**      Licensed under the Apache License, Version 2.0 (the "License");
+**      you may not use this file except in compliance with the License.
+**      You may obtain a copy of the License at
+**
+**        http://www.apache.org/licenses/LICENSE-2.0
+**
+**      Unless required by applicable law or agreed to in writing, software
+**      distributed under the License is distributed on an "AS IS" BASIS,
+**      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**      See the License for the specific language governing permissions and
+**      limitations under the License.
+**
+** File: cfe_assert.h
+**
+** Purpose:
+**   Specification for the CFE assert (UT assert wrapper) functions.
+**
+*************************************************************************/
+#ifndef cfe_assert_h_
+#define cfe_assert_h_
+
+/************************************************************************
+** Includes
+*************************************************************************/
+#include <common_types.h>
+
+/************************************************************************
+** Type Definitions
+*************************************************************************/
+
+/*************************************************************************
+** Exported Functions
+*************************************************************************/
+
+/************************************************************************/
+/** \brief Application Entry Point Function
+**
+**  \par Description
+**        This function should be specified in the cfe_es_startup.scr file
+**        as part of starting this application.
+**
+**  \par Assumptions, External Events, and Notes:
+**        None
+**
+**  \return Execution status, see \ref CFEReturnCodes
+**
+**
+*************************************************************************/
+void CFE_Assert_AppMain(void);
+
+#endif /* cfe_assert_h_ */
+
+/************************/
+/*  End of File Comment */
+/************************/

--- a/modules/cfe_assert/src/cfe_assert_io.c
+++ b/modules/cfe_assert/src/cfe_assert_io.c
@@ -62,23 +62,23 @@ void UT_BSP_StartTestSegment(uint32 SegmentNumber, const char *SegmentName)
 void UT_BSP_DoText(uint8 MessageType, const char *OutputMessage)
 {
     const char *Prefix;
-    uint32      MsgEnabled   = BSP_UT_Global.CurrVerbosity >> MessageType;
+    uint32      MsgEnabled = BSP_UT_Global.CurrVerbosity >> MessageType;
 
     if (MsgEnabled & 1)
     {
         switch (MessageType)
         {
             case UTASSERT_CASETYPE_ABORT:
-                Prefix       = "ABORT";
+                Prefix = "ABORT";
                 break;
             case UTASSERT_CASETYPE_FAILURE:
-                Prefix       = "FAIL";
+                Prefix = "FAIL";
                 break;
             case UTASSERT_CASETYPE_MIR:
-                Prefix       = "MIR";
+                Prefix = "MIR";
                 break;
             case UTASSERT_CASETYPE_TSF:
-                Prefix       = "TSF";
+                Prefix = "TSF";
                 break;
             case UTASSERT_CASETYPE_TTF:
                 Prefix = "TTF";
@@ -93,7 +93,7 @@ void UT_BSP_DoText(uint8 MessageType, const char *OutputMessage)
                 Prefix = "END";
                 break;
             case UTASSERT_CASETYPE_PASS:
-                Prefix       = "PASS";
+                Prefix = "PASS";
                 break;
             case UTASSERT_CASETYPE_INFO:
                 Prefix = "INFO";
@@ -131,7 +131,7 @@ void UT_BSP_EndTest(const UtAssert_TestCounter_t *TestCounters)
     }
 
     CFE_ES_WriteToSysLog("TEST COMPLETE: %u tests Segment(s) executed\n\n",
-             (unsigned int)TestCounters->TestSegmentCount);
+                         (unsigned int)TestCounters->TestSegmentCount);
 
     OS_TaskExit();
 }

--- a/modules/cfe_assert/src/cfe_assert_io.c
+++ b/modules/cfe_assert/src/cfe_assert_io.c
@@ -1,0 +1,137 @@
+/*************************************************************************
+**
+**      GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**      Copyright (c) 2006-2019 United States Government as represented by
+**      the Administrator of the National Aeronautics and Space Administration.
+**      All Rights Reserved.
+**
+**      Licensed under the Apache License, Version 2.0 (the "License");
+**      you may not use this file except in compliance with the License.
+**      You may obtain a copy of the License at
+**
+**        http://www.apache.org/licenses/LICENSE-2.0
+**
+**      Unless required by applicable law or agreed to in writing, software
+**      distributed under the License is distributed on an "AS IS" BASIS,
+**      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**      See the License for the specific language governing permissions and
+**      limitations under the License.
+**
+** File: cfe_assert_io.c
+**
+** Purpose:
+**   Implementation of the CFE assert (UT assert wrapper) functions.
+**
+*************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdbool.h>
+
+#include <cfe.h>
+
+#include "utbsp.h"
+#include "uttest.h"
+
+/*
+**  Local Variables
+*/
+typedef struct
+{
+    uint32 CurrVerbosity;
+} BSP_UT_GlobalData_t;
+
+BSP_UT_GlobalData_t BSP_UT_Global;
+
+void UT_BSP_Setup(void)
+{
+    BSP_UT_Global.CurrVerbosity = (2 << UTASSERT_CASETYPE_PASS) - 1;
+    UT_BSP_DoText(UTASSERT_CASETYPE_BEGIN, "CFE FUNCTIONAL TEST");
+}
+
+void UT_BSP_StartTestSegment(uint32 SegmentNumber, const char *SegmentName)
+{
+    char ReportBuffer[128];
+
+    snprintf(ReportBuffer, sizeof(ReportBuffer), "%02u %s", (unsigned int)SegmentNumber, SegmentName);
+    UT_BSP_DoText(UTASSERT_CASETYPE_BEGIN, ReportBuffer);
+}
+
+void UT_BSP_DoText(uint8 MessageType, const char *OutputMessage)
+{
+    const char *Prefix;
+    uint32      MsgEnabled   = BSP_UT_Global.CurrVerbosity >> MessageType;
+
+    if (MsgEnabled & 1)
+    {
+        switch (MessageType)
+        {
+            case UTASSERT_CASETYPE_ABORT:
+                Prefix       = "ABORT";
+                break;
+            case UTASSERT_CASETYPE_FAILURE:
+                Prefix       = "FAIL";
+                break;
+            case UTASSERT_CASETYPE_MIR:
+                Prefix       = "MIR";
+                break;
+            case UTASSERT_CASETYPE_TSF:
+                Prefix       = "TSF";
+                break;
+            case UTASSERT_CASETYPE_TTF:
+                Prefix = "TTF";
+                break;
+            case UTASSERT_CASETYPE_NA:
+                Prefix = "N/A";
+                break;
+            case UTASSERT_CASETYPE_BEGIN:
+                Prefix = "BEGIN";
+                break;
+            case UTASSERT_CASETYPE_END:
+                Prefix = "END";
+                break;
+            case UTASSERT_CASETYPE_PASS:
+                Prefix       = "PASS";
+                break;
+            case UTASSERT_CASETYPE_INFO:
+                Prefix = "INFO";
+                break;
+            case UTASSERT_CASETYPE_DEBUG:
+                Prefix = "DEBUG";
+                break;
+            default:
+                Prefix = "OTHER";
+                break;
+        }
+
+        CFE_ES_WriteToSysLog("[%5s] %s\n", Prefix, OutputMessage);
+    }
+
+    /*
+     * If any ABORT (major failure) message is thrown,
+     * then call a BSP-provided routine to stop the test and possibly dump a core
+     */
+    if (MessageType == UTASSERT_CASETYPE_ABORT)
+    {
+        OS_TaskExit();
+    }
+}
+
+void UT_BSP_EndTest(const UtAssert_TestCounter_t *TestCounters)
+{
+    /*
+     * Only output a "summary" if there is more than one test Segment.
+     * Otherwise it is a duplicate of the report already given.
+     */
+    if (TestCounters->TestSegmentCount > 1)
+    {
+        UtAssert_DoTestSegmentReport("SUMMARY", TestCounters);
+    }
+
+    CFE_ES_WriteToSysLog("TEST COMPLETE: %u tests Segment(s) executed\n\n",
+             (unsigned int)TestCounters->TestSegmentCount);
+
+    OS_TaskExit();
+}

--- a/modules/cfe_assert/src/cfe_assert_main.c
+++ b/modules/cfe_assert/src/cfe_assert_main.c
@@ -1,0 +1,135 @@
+/*************************************************************************
+**
+**      GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**      Copyright (c) 2006-2019 United States Government as represented by
+**      the Administrator of the National Aeronautics and Space Administration.
+**      All Rights Reserved.
+**
+**      Licensed under the Apache License, Version 2.0 (the "License");
+**      you may not use this file except in compliance with the License.
+**      You may obtain a copy of the License at
+**
+**        http://www.apache.org/licenses/LICENSE-2.0
+**
+**      Unless required by applicable law or agreed to in writing, software
+**      distributed under the License is distributed on an "AS IS" BASIS,
+**      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**      See the License for the specific language governing permissions and
+**      limitations under the License.
+**
+** File: cfe_assert_main.c
+**
+** Purpose:
+**   Implementation of the CFE assert (UT assert wrapper) functions.
+**
+*************************************************************************/
+
+/*
+ * Includes
+ */
+
+#include <cfe.h>
+
+#include "cfe_assert.h"
+
+#include "uttest.h"
+#include "utbsp.h"
+
+/*
+ * The maximum amount of time that the application will delay to
+ * wait for other apps to complete startup before running the tests.
+ *
+ * The value is in milliseconds.  Normally this shouldn't be more than
+ * a second or two for apps to all reach their respective main loop(s).
+ */
+#define CFE_ASSERT_MAX_STARTUP_WAIT       30000
+
+/*
+ * Small Extra delay before starting tests.
+ *
+ * This is not strictly necessary, but it does give a bit of time for other apps
+ * to settle their final syslog writes/events such that they will not be intermixed
+ * with test messages in the syslog.
+ *
+ * The value is in milliseconds.
+ */
+#define CFE_ASSERT_START_DELAY            4000
+
+
+/*
+ * Entry point for this application
+ */
+void CFE_Assert_AppMain(void)
+{
+    int32 rc;
+    uint32 RunStatus;
+
+    /*
+    ** Register the app with Executive services
+    */
+    rc = CFE_ES_RegisterApp();
+    if (rc != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("Error in CFE_ES_RegisterApp(): %08lx\n", (unsigned long)rc);
+        return;
+    }
+
+    UtTest_EarlyInit();
+    UT_BSP_Setup();
+
+    /*
+     * Start a test case for all startup logic.
+     *
+     * Test libs may use assert statements within their init function and these
+     * will be reported as a "startup" test case.
+     */
+    UtAssert_BeginTest("CFE-STARTUP");
+
+    /*
+     * Delay until the system reaches "operational" state -- this is when all libs have initialized
+     * and all apps have reached their RunLoop.
+     */
+    rc = CFE_ES_WaitForSystemState(CFE_ES_SystemState_OPERATIONAL, CFE_ASSERT_MAX_STARTUP_WAIT);
+    if (rc != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("Error while waiting for OPERATIONAL state: %08lx\n", (unsigned long)rc);
+        return;
+    }
+
+    /*
+     * Startup Phase has ended.
+     */
+    UtAssert_EndTest();
+
+    /*
+     * Note - in a normal app this would be a while loop,
+     * but is just an "if" right now as it only runs once.
+     *
+     * A future enhancement to this app might be to create an SB pipe
+     * and execute tests based on the receipt of a command to do so.
+     *
+     * For now, it just works in a one-shot mode to run tests that were
+     * registered during startup, then it self-exits.
+     */
+    RunStatus = CFE_ES_RunStatus_APP_RUN;
+    if(CFE_ES_RunLoop(&RunStatus))
+    {
+        OS_TaskDelay(CFE_ASSERT_START_DELAY);
+
+        /*
+         * Run all registered test cases.
+         */
+        UtTest_Run();
+
+        /*
+         * Exit the main task.
+         */
+        RunStatus = CFE_ES_RunStatus_APP_EXIT;
+    }
+
+
+    CFE_ES_ExitApp(RunStatus);
+}
+
+

--- a/modules/cfe_assert/src/cfe_assert_main.c
+++ b/modules/cfe_assert/src/cfe_assert_main.c
@@ -43,7 +43,7 @@
  * The value is in milliseconds.  Normally this shouldn't be more than
  * a second or two for apps to all reach their respective main loop(s).
  */
-#define CFE_ASSERT_MAX_STARTUP_WAIT       30000
+#define CFE_ASSERT_MAX_STARTUP_WAIT 30000
 
 /*
  * Small Extra delay before starting tests.
@@ -54,15 +54,14 @@
  *
  * The value is in milliseconds.
  */
-#define CFE_ASSERT_START_DELAY            4000
-
+#define CFE_ASSERT_START_DELAY 4000
 
 /*
  * Entry point for this application
  */
 void CFE_Assert_AppMain(void)
 {
-    int32 rc;
+    int32  rc;
     uint32 RunStatus;
 
     /*
@@ -113,7 +112,7 @@ void CFE_Assert_AppMain(void)
      * registered during startup, then it self-exits.
      */
     RunStatus = CFE_ES_RunStatus_APP_RUN;
-    if(CFE_ES_RunLoop(&RunStatus))
+    if (CFE_ES_RunLoop(&RunStatus))
     {
         OS_TaskDelay(CFE_ASSERT_START_DELAY);
 
@@ -128,8 +127,5 @@ void CFE_Assert_AppMain(void)
         RunStatus = CFE_ES_RunStatus_APP_EXIT;
     }
 
-
     CFE_ES_ExitApp(RunStatus);
 }
-
-

--- a/modules/cfe_test/CMakeLists.txt
+++ b/modules/cfe_test/CMakeLists.txt
@@ -1,0 +1,8 @@
+include_directories("${CFE_ASSERT_SOURCE_DIR}/inc")
+include_directories("${UT_ASSERT_SOURCE_DIR}/inc")
+
+# Create the app module
+add_cfe_app(cfe_test
+    src/cfe_test.c
+    src/es_test.c
+)

--- a/modules/cfe_test/src/cfe_test.c
+++ b/modules/cfe_test/src/cfe_test.c
@@ -1,0 +1,45 @@
+/*************************************************************************
+**
+**      GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**      Copyright (c) 2006-2019 United States Government as represented by
+**      the Administrator of the National Aeronautics and Space Administration.
+**      All Rights Reserved.
+**
+**      Licensed under the Apache License, Version 2.0 (the "License");
+**      you may not use this file except in compliance with the License.
+**      You may obtain a copy of the License at
+**
+**        http://www.apache.org/licenses/LICENSE-2.0
+**
+**      Unless required by applicable law or agreed to in writing, software
+**      distributed under the License is distributed on an "AS IS" BASIS,
+**      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**      See the License for the specific language governing permissions and
+**      limitations under the License.
+**
+** File: cfe_test.c
+**
+** Purpose:
+**   Initialization routine for CFE functional test
+**   Demonstration of how to register and use the UT assert functions.
+**
+*************************************************************************/
+
+/*
+ * Includes
+ */
+
+#include "cfe_test.h"
+
+/*
+ * Initialization function
+ * Register this test routine with CFE Assert
+ */
+int32 CFE_Test_Init(int32 LibId)
+{
+    UtTest_Add(ES_Test_AppId, NULL, NULL, "ES AppID");
+    return CFE_SUCCESS;
+}
+
+

--- a/modules/cfe_test/src/cfe_test.c
+++ b/modules/cfe_test/src/cfe_test.c
@@ -41,5 +41,3 @@ int32 CFE_Test_Init(int32 LibId)
     UtTest_Add(ES_Test_AppId, NULL, NULL, "ES AppID");
     return CFE_SUCCESS;
 }
-
-

--- a/modules/cfe_test/src/cfe_test.h
+++ b/modules/cfe_test/src/cfe_test.h
@@ -38,8 +38,7 @@
 #include "uttest.h"
 #include "utassert.h"
 
-void ES_Test_AppId(void);
+void  ES_Test_AppId(void);
 int32 CFE_Test_Init(int32 LibId);
-
 
 #endif /* CFE_TEST_H */

--- a/modules/cfe_test/src/cfe_test.h
+++ b/modules/cfe_test/src/cfe_test.h
@@ -1,0 +1,45 @@
+/*************************************************************************
+**
+**      GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**      Copyright (c) 2006-2019 United States Government as represented by
+**      the Administrator of the National Aeronautics and Space Administration.
+**      All Rights Reserved.
+**
+**      Licensed under the Apache License, Version 2.0 (the "License");
+**      you may not use this file except in compliance with the License.
+**      You may obtain a copy of the License at
+**
+**        http://www.apache.org/licenses/LICENSE-2.0
+**
+**      Unless required by applicable law or agreed to in writing, software
+**      distributed under the License is distributed on an "AS IS" BASIS,
+**      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**      See the License for the specific language governing permissions and
+**      limitations under the License.
+**
+** File: cfe_test.c
+**
+** Purpose:
+**   Initialization routine for CFE functional test
+**   Demonstration of how to register and use the UT assert functions.
+**
+*************************************************************************/
+
+#ifndef CFE_TEST_H
+#define CFE_TEST_H
+
+/*
+ * Includes
+ */
+
+#include <cfe.h>
+
+#include "uttest.h"
+#include "utassert.h"
+
+void ES_Test_AppId(void);
+int32 CFE_Test_Init(int32 LibId);
+
+
+#endif /* CFE_TEST_H */

--- a/modules/cfe_test/src/es_test.c
+++ b/modules/cfe_test/src/es_test.c
@@ -33,14 +33,12 @@
 
 #include "cfe_test.h"
 
-
 void ES_Test_AppId(void)
 {
     uint32 AppId;
-    char AppNameBuf[OS_MAX_API_NAME+4];
+    char   AppNameBuf[OS_MAX_API_NAME + 4];
 
     UtAssert_INT32_EQ(CFE_ES_GetAppID(&AppId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetAppName(AppNameBuf, AppId, sizeof(AppNameBuf)), CFE_SUCCESS);
     UtAssert_StrCmp(AppNameBuf, "ASSERT_APP", "CFE_ES_GetAppName() returned ASSERT_APP");
 }
-

--- a/modules/cfe_test/src/es_test.c
+++ b/modules/cfe_test/src/es_test.c
@@ -1,0 +1,46 @@
+/*************************************************************************
+**
+**      GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**      Copyright (c) 2006-2019 United States Government as represented by
+**      the Administrator of the National Aeronautics and Space Administration.
+**      All Rights Reserved.
+**
+**      Licensed under the Apache License, Version 2.0 (the "License");
+**      you may not use this file except in compliance with the License.
+**      You may obtain a copy of the License at
+**
+**        http://www.apache.org/licenses/LICENSE-2.0
+**
+**      Unless required by applicable law or agreed to in writing, software
+**      distributed under the License is distributed on an "AS IS" BASIS,
+**      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**      See the License for the specific language governing permissions and
+**      limitations under the License.
+**
+** File: es_test.c
+**
+** Purpose:
+**   Functional test of basic ES APIs
+**
+**   Demonstration of how to register and use the UT assert functions.
+**
+*************************************************************************/
+
+/*
+ * Includes
+ */
+
+#include "cfe_test.h"
+
+
+void ES_Test_AppId(void)
+{
+    uint32 AppId;
+    char AppNameBuf[OS_MAX_API_NAME+4];
+
+    UtAssert_INT32_EQ(CFE_ES_GetAppID(&AppId), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_GetAppName(AppNameBuf, AppId, sizeof(AppNameBuf)), CFE_SUCCESS);
+    UtAssert_StrCmp(AppNameBuf, "ASSERT_APP", "CFE_ES_GetAppName() returned ASSERT_APP");
+}
+


### PR DESCRIPTION
**Describe the contribution**
Add a module for functional testing called "cfe_assert". 
This is using the UT assert object code and linking it with some CFE glue so it is loadable as a CFE library.
Also included is the start of an example for CFE testing, which just calls some basic ES appid functions.

Fixes #778 

**Testing performed**
Build and sanity check CFE.
Load these new test apps/libs and confirm all tests pass.

**Expected behavior changes**
This is all NEW test code which is compiled as separate modules and only loaded on demand.  It is independent of existing FSW or other software modules.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
A similar example for testing PSP will be included in PSP repo, and apps/libs can provide the same with the app/lib.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.