### PR TITLE
fix #759 - deprecates GetLastSenderId()

### DIFF
--- a/cmake/sample_defs/global_build_options.cmake
+++ b/cmake/sample_defs/global_build_options.cmake
@@ -19,7 +19,7 @@
 set(OMIT_DEPRECATED $ENV{OMIT_DEPRECATED} CACHE STRING "Omit deprecated elements")
 if (OMIT_DEPRECATED)
   message (STATUS "OMIT_DEPRECATED=true: Not including deprecated elements in build")
-  add_definitions(-DCFE_OMIT_DEPRECATED_6_7 -DCFE_OMIT_DEPRECATED_6_6 -DOSAL_OMIT_DEPRECATED)
+  add_definitions(-DCFE_OMIT_DEPRECATED_6_8 -DCFE_OMIT_DEPRECATED_6_7 -DCFE_OMIT_DEPRECATED_6_6 -DOSAL_OMIT_DEPRECATED)
 else()
   message (STATUS "OMIT_DEPRECATED=false: Deprecated elements included in build")
 endif (OMIT_DEPRECATED)

--- a/docs/cFE Application Developers Guide.md
+++ b/docs/cFE Application Developers Guide.md
@@ -1769,7 +1769,6 @@ for extracting that field from the header:
 | Total Message Length        | CFE_SB_GetTotalMsgLength                | Command & Telemetry |
 | User Data Message Length    | CFE_SB_GetUserDataLength                | Command & Telemetry |
 | Command Code                | CFE_SB_GetCmdCode                       | Command Only        |
-| Sender ID                   | CFE_SB_GetLastSenderId                  | Command & Telemetry |
 | Checksum                    | CFE_SB_GetChecksum                      | Command Only        |
 
 In addition to the function for reading the checksum field, there is
@@ -1777,15 +1776,6 @@ another API that automatically calculates the checksum for the packet
 and compares it to the checksum in the header. The API is called
 CFE_SB_ValidateChecksum() and it simply returns a success or failure
 indication.
-
-It should be noted that the function, CFE_SB_GetLastSendId, is ideal
-for verifying that critical commands are arriving from a legitimate
-source. This function allows the Developer(s) to define a strict ICD
-between two or more Applications to ensure that an erroneous Application
-does not accidentally issue a critical command. However, its use for
-routine command verification is discouraged since it would increase the
-cross-coupling between Applications and require multiple Applications to
-be modified if a command's source changes.
 
 If the Application's data structure definitions don't include the header
 information, then the CFE_SB_GetUserData API could be used to obtain

--- a/fsw/cfe-core/src/inc/cfe_sb.h
+++ b/fsw/cfe-core/src/inc/cfe_sb.h
@@ -208,7 +208,10 @@ typedef  struct {
 extern CFE_SB_Qos_t CFE_SB_Default_Qos;/**< \brief  Defines a default priority and reliabilty for off-board routing */
 
 
-/** \brief Message Sender Identification Type Definition
+#ifndef CFE_OMIT_DEPRECATED_6_8
+
+/** \brief DEPRECATED; Message Sender Identification Type Definition
+** \deprecated
 **
 ** Parameter used in #CFE_SB_GetLastSenderId API which allows the receiver of a message
 ** to validate the sender of the message.
@@ -217,6 +220,8 @@ typedef struct {
     uint32  ProcessorId;/**< \brief Processor Id from which the message was sent */
     char    AppName[OS_MAX_API_NAME];/**< \brief Application that sent the message */
 } CFE_SB_SenderId_t;
+
+#endif /* CFE_OMIT_DEPRECATED_6_8 */
 
 /****************** Function Prototypes **********************/
 
@@ -1173,9 +1178,12 @@ uint16 CFE_SB_GetCmdCode(CFE_SB_MsgPtr_t MsgPtr);
 **/
 CFE_TIME_SysTime_t CFE_SB_GetMsgTime(CFE_SB_MsgPtr_t MsgPtr);
 
+#ifndef CFE_OMIT_DEPRECATED_6_8
+
 /*****************************************************************************/
 /**
-** \brief Retrieve the application Info of the sender for the last message.
+** \brief DEPRECATED; Retrieve the application Info of the sender for the last message.
+** \deprecated
 **
 ** \par Description
 **          This routine can be used after a successful #CFE_SB_RcvMsg call
@@ -1203,6 +1211,8 @@ CFE_TIME_SysTime_t CFE_SB_GetMsgTime(CFE_SB_MsgPtr_t MsgPtr);
 ** \return The last sender's application ID
 **/
 uint32  CFE_SB_GetLastSenderId(CFE_SB_SenderId_t **Ptr,CFE_SB_PipeId_t  PipeId);
+
+#endif /* CFE_OMIT_DEPRECATED_6_8 */
 
 /******************************************************************************/
 /**

--- a/fsw/cfe-core/src/inc/cfe_sb_events.h
+++ b/fsw/cfe-core/src/inc/cfe_sb_events.h
@@ -568,6 +568,8 @@
 #define CFE_SB_CMD1_RCVD_EID            29
 
 
+#ifndef CFE_OMIT_DEPRECATED_6_8
+
 /** \brief <tt> 'SB GetLastSender Err:Rcvd Null Ptr,Pipe=%d,App=%s' </tt>
 **  \event <tt> 'SB GetLastSender Err:Rcvd Null Ptr,Pipe=%d,App=%s' </tt>
 **
@@ -591,6 +593,8 @@
 **  caller of CFE_SB_GetLastSenderId.
 **/
 #define CFE_SB_LSTSNDER_ERR2_EID        31
+
+#endif /* CFE_OMIT_DEPRECATED_6_8 */
 
 
 /** \brief <tt> 'Software Bus Statistics packet sent' </tt>
@@ -712,6 +716,8 @@
 #define CFE_SB_SND_RTG_ERR1_EID         40
 
 
+#ifndef CFE_OMIT_DEPRECATED_6_8
+
 /** \brief <tt> 'SB GetLastSender Err:Caller(\%s) is not the owner of pipe \%d' </tt>
 **  \event <tt> 'SB GetLastSender Err:Caller(\%s) is not the owner of pipe \%d' </tt>
 **
@@ -724,6 +730,7 @@
 **/
 #define CFE_SB_GLS_INV_CALLER_EID       41
 
+#endif /* CFE_OMIT_DEPRECATED_6_8 */
 
 /** \brief <tt> 'Invalid Cmd, Unexpected Command Code \%d' </tt>
 **  \event <tt> 'Invalid Cmd, Unexpected Command Code \%d' </tt>

--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -1320,12 +1320,14 @@ int32  CFE_SB_SendMsgFull(CFE_SB_Msg_t    *MsgPtr,
                 RtgTblPtr->SeqCnt);
     }/* end if */
 
+    #ifndef CFE_OMIT_DEPRECATED_6_8
     /* store the sender information */
     if(CFE_SB.SenderReporting != 0)
     {
        BufDscPtr->Sender.ProcessorId = CFE_PSP_GetProcessorId();
        strncpy(&BufDscPtr->Sender.AppName[0],CFE_SB_GetAppTskName(TskId,FullName),OS_MAX_API_NAME);
     }
+    #endif /* CFE_OMIT_DEPRECATED_6_8 */
 
     /* At this point there must be at least one destination for pkt */
 
@@ -1620,6 +1622,8 @@ int32  CFE_SB_RcvMsg(CFE_SB_MsgPtr_t    *BufPtr,
 }/* end CFE_SB_RcvMsg */
 
 
+#ifndef CFE_OMIT_DEPRECATED_6_8
+
 /*
  * Function: CFE_SB_GetLastSenderId - See API and header file for details
  */
@@ -1684,6 +1688,8 @@ uint32  CFE_SB_GetLastSenderId(CFE_SB_SenderId_t **Ptr,CFE_SB_PipeId_t  PipeId)
     }
 
 }/* end CFE_SB_GetLastSenderId */
+
+#endif /* CFE_OMIT_DEPRECATED_6_8 */
 
 
 /*

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.h
@@ -172,7 +172,9 @@ typedef struct {
      uint16            UseCount;
      uint32            Size;
      void              *Buffer;
+#ifndef CFE_OMIT_DEPRECATED_6_8
      CFE_SB_SenderId_t Sender;
+#endif /* CFE_OMIT_DEPRECATED_6_8 */
 } CFE_SB_BufferD_t;
 
 

--- a/fsw/cfe-core/unit-test/sb_UT.h
+++ b/fsw/cfe-core/unit-test/sb_UT.h
@@ -2825,10 +2825,7 @@ void Test_SendMsg_MaxMsgSizePlusOne_ZeroCopy(void);
 **        This function does not return a value.
 **
 ** \sa #UT_Text, #Test_RcvMsg_InvalidPipeId, #Test_RcvMsg_InvalidTimeout,
-** \sa #Test_RcvMsg_Poll, #Test_RcvMsg_GetLastSenderNull,
-** \sa #Test_RcvMsg_GetLastSenderInvalidPipe,
-** \sa #Test_RcvMsg_GetLastSenderInvalidCaller,
-** \sa #Test_RcvMsg_GetLastSenderSuccess, #Test_RcvMsg_Timeout,
+** \sa #Test_RcvMsg_Poll, #Test_RcvMsg_Timeout,
 ** \sa #Test_RcvMsg_PipeReadError, #Test_RcvMsg_PendForever
 **
 ******************************************************************************/
@@ -2897,110 +2894,6 @@ void Test_RcvMsg_InvalidTimeout(void);
 **
 ******************************************************************************/
 void Test_RcvMsg_Poll(void);
-
-/*****************************************************************************/
-/**
-** \brief Test receive last message response to a null sender ID
-**
-** \par Description
-**        This function tests the receive last message response to a null
-**        sender ID.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-**
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe,
-** \sa #CFE_SB_GetLastSenderId, #UT_GetNumEventsSent, #UT_EventIsInHistory,
-** \sa #CFE_SB_DeletePipe, #UT_Report
-**
-******************************************************************************/
-void Test_RcvMsg_GetLastSenderNull(void);
-
-/*****************************************************************************/
-/**
-** \brief Test receive last message response to an invalid pipe ID
-**
-** \par Description
-**        This function tests the receive last message response to an invalid
-**        pipe ID.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-**
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe,
-** \sa #CFE_SB_GetLastSenderId, #UT_GetNumEventsSent, #UT_EventIsInHistory,
-** \sa #CFE_SB_DeletePipe, #UT_Report
-**
-******************************************************************************/
-void Test_RcvMsg_GetLastSenderInvalidPipe(void);
-
-/*****************************************************************************/
-/**
-** \brief Test receive last message response to an invalid owner ID
-**
-** \par Description
-**        This function tests the receive last message response to an invalid
-**        owner ID.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-**
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe,
-** \sa #CFE_SB_GetLastSenderId, #UT_GetNumEventsSent, #UT_EventIsInHistory,
-** \sa #CFE_SB_DeletePipe, #UT_Report
-**
-******************************************************************************/
-void Test_RcvMsg_GetLastSenderInvalidCaller(void);
-
-/*****************************************************************************/
-/**
-** \brief Test receive last message response when there is no last sender
-**
-** \par Description
-**        This function tests the receive last message response when no last
-**        sender.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-**
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe,
-** \sa #CFE_SB_GetLastSenderId, #UT_GetNumEventsSent, #UT_EventIsInHistory,
-** \sa #CFE_SB_DeletePipe, #UT_Report
-**
-******************************************************************************/
-void Test_RcvMsg_GetLastSenderNoValidSender(void);
-
-/*****************************************************************************/
-/**
-** \brief Test successful receive last message request
-**
-** \par Description
-**        This function tests the successful receive last message request.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-**
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe,
-** \sa #CFE_SB_GetLastSenderId, #UT_GetNumEventsSent, #CFE_SB_DeletePipe,
-** \sa #UT_Report
-**
-******************************************************************************/
-void Test_RcvMsg_GetLastSenderSuccess(void);
 
 /*****************************************************************************/
 /**

--- a/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
@@ -988,6 +988,8 @@ uint16 CFE_SB_GetChecksum(CFE_SB_MsgPtr_t MsgPtr)
     return status;
 }
 
+#ifndef CFE_OMIT_DEPRECATED_6_8
+
 uint32 CFE_SB_GetLastSenderId(CFE_SB_SenderId_t **Ptr, CFE_SB_PipeId_t PipeId)
 {
     UT_Stub_RegisterContext(UT_KEY(CFE_SB_GetLastSenderId), Ptr);
@@ -999,6 +1001,8 @@ uint32 CFE_SB_GetLastSenderId(CFE_SB_SenderId_t **Ptr, CFE_SB_PipeId_t PipeId)
 
     return status;
 }
+
+#endif /* CFE_OMIT_DEPRECATED_6_8 */
 
 int32 CFE_SB_GetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 *OptPtr)
 {


### PR DESCRIPTION
**Describe the contribution**
Fixes #759 - deprecates CFE_SB_GetLastSenderId() API.
Fixes #608

**Testing performed**
make with and without OMIT_DEPRECATED defined.

**System(s) tested on**
Debian 10.3

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov