### PR TITLE
Fix #822, Remove iterator modification in loop

### DIFF
--- a/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.c
@@ -1375,7 +1375,7 @@ int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDS_t *data)
             if (strncmp(CFE_TBL_TaskData.CritReg[i].Name, TableName, CFE_TBL_MAX_FULL_NAME_LEN) == 0)
             {
                 CritRegRecPtr = &CFE_TBL_TaskData.CritReg[i];
-                i=CFE_PLATFORM_TBL_MAX_CRITICAL_TABLES;
+                break;
             }
         }
         


### PR DESCRIPTION
**Describe the contribution**
Fix #822 - removed iterator modification from within the loop... replaced with break.

**Testing performed**
Built and ran unit tests.

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: bundle (and cfe/osal main) + this change

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC