### PR TITLE
Fix #828, Spacecraft ID sample set to historical value (0x42)

### DIFF
--- a/cmake/sample_defs/targets.cmake
+++ b/cmake/sample_defs/targets.cmake
@@ -77,7 +77,7 @@ SET(MISSION_NAME "SampleMission")
 
 # SPACECRAFT_ID gets compiled into the build data structure and the PSP may use it.
 # should be an integer.
-SET(SPACECRAFT_ID 42)
+SET(SPACECRAFT_ID 0x42)
 
 # The "MISSION_CORE_MODULES" will be built and statically linked as part
 # of the CFE core executable on every target.  These can be used to amend


### PR DESCRIPTION
**Describe the contribution**
Fix #828 - set spacecraft ID in sample targets.cmake to 0x42

**Testing performed**
Nominal build and test

**Expected behavior changes**
Spacecraft ID back to historical value (some toolchains depend on it).  Verified at PSP startup, reported as 66 (0x42).

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: bundle main (w/ cfe/osal main) + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC