### PR TITLE
Fix #818, Return message address from CFE_SB_SendMsg stub

### DIFF
--- a/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
@@ -486,8 +486,7 @@ int32 CFE_SB_SendMsg(CFE_SB_Msg_t *MsgPtr)
 
     if (status >= 0)
     {
-        UT_Stub_CopyFromLocal(UT_KEY(CFE_SB_SendMsg), MsgPtr->Byte,
-                CFE_SB_StubMsg_GetMetaData(MsgPtr)->TotalLength);
+        UT_Stub_CopyFromLocal(UT_KEY(CFE_SB_SendMsg), &MsgPtr, sizeof(MsgPtr));
     }
 
     return status;


### PR DESCRIPTION
**Describe the contribution**
Fix #818, CFE_SB_SendMsg stub now behaves the same as CFE_SB_TimeStampMsg (copies message pointer from local)
Fix #825, No longer need to emulate CFE_SB_InitMsg from test code, set the API/stub data buffers directly.

**Testing performed**
Built with tests, tests ran and passed.  Depends on update to unit test in sample_app, nasa/sample_app#90.

**Expected behavior changes**
Stub returns message address instead of copy of message.

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: bundle main (+cfe/osal main) + this commit.

**Additional context**
nasa/sample_app#90

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC