### PR TITLE
HOTFIX: Deprecated time format verify logic fix

### DIFF
--- a/fsw/cfe-core/src/sb/cfe_sb_verify.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_verify.h
@@ -80,8 +80,11 @@
     #error CFE_PLATFORM_SB_BUF_MEMORY_BYTES cannot be greater than UINT32_MAX (4 Gigabytes)!
 #endif
 
-#if ((CFE_MISSION_SB_PACKET_TIME_FORMAT == CFE_MISSION_SB_TIME_32_32_SUBS) || \
-     (CFE_MISSION_SB_PACKET_TIME_FORMAT == CFE_MISSION_SB_TIME_32_32_M_20))
+/*
+ * Legacy time formats no longer supported in core cFE, this will pass
+ * if default is selected or if both defines are removed
+ */
+#if (CFE_MISSION_SB_PACKET_TIME_FORMAT != CFE_MISSION_SB_TIME_32_16_SUBS)
     #error Legacy CFE_MISSION_SB_PACKET_TIME_FORMAT implementations no longer supported in core
 #endif
 


### PR DESCRIPTION
**Describe the contribution**
HOTFIX - Changes the time format compile time verification logic.  Old logic would report error if none of the defines exist, new logic only reports error if the time format is not the default (also works if neither are defined).

**Testing performed**
Built with time format set to default, time format defines not defined, and time format set to non-default.  Responded as expected.

**Expected behavior changes**
No longer reports error if defines are removed (as is the case in the sample config)

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: integration candidate bundle + this change

**Additional context**
Fix to PR #801

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC