### PR TITLE
HOTFIX - no longer add unit tests from within unit tests in msg UT

### DIFF
--- a/modules/msg/unit-test-coverage/msg_UT.c
+++ b/modules/msg/unit-test-coverage/msg_UT.c
@@ -45,9 +45,9 @@ void UtTest_Setup(void)
     UT_Text("Message header coverage test...");
 
     UT_ADD_TEST(Test_MSG_Init);
-    UT_ADD_TEST(Test_MSG_CCSDSPri);
-    UT_ADD_TEST(Test_MSG_CCSDSExt);
-    UT_ADD_TEST(Test_MSG_MsgId_Shared);
+    Test_MSG_CCSDSPri();
+    Test_MSG_CCSDSExt();
+    Test_MSG_MsgId_Shared();
     UT_ADD_TEST(Test_MSG_MsgId);
     UT_ADD_TEST(Test_MSG_Checksum);
     UT_ADD_TEST(Test_MSG_FcnCode);


### PR DESCRIPTION
**Describe the contribution**
HOTFIX - unit tests added from within unit tests will not execute, replaced this pattern with direct calls to the main subtest setup routine.

**Testing performed**
Build unit tests and ran, all tests (including subtests) ran.

**Expected behavior changes**
All tests run

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: integration candidate bundle + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC