### PR TITLE
Fix #836, Replace CFE_MISSION_SPACECRAFT_ID with CFE_PSP_GetSpacecraftId()

### DIFF
--- a/modules/msg/src/cfe_msg_ccsdsext.c
+++ b/modules/msg/src/cfe_msg_ccsdsext.c
@@ -25,6 +25,7 @@
 #include "cfe_msg_priv.h"
 #include "cfe_msg_defaults.h"
 #include "cfe_error.h"
+#include "cfe_psp.h"
 
 /* CCSDS Extended definitions */
 #define CFE_MSG_EDSVER_SHIFT  11     /**< \brief CCSDS EDS version shift */
@@ -49,7 +50,7 @@ void CFE_MSG_SetDefaultCCSDSExt(CFE_MSG_Message_t *MsgPtr)
 
     /* Default bits of the subsystem, for whatever isn't set by MsgId */
     CFE_MSG_SetSubsystem(MsgPtr, (CFE_MSG_Subsystem_t)CFE_PLATFORM_DEFAULT_SUBSYS);
-    CFE_MSG_SetSystem(MsgPtr, (CFE_MSG_System_t)CFE_MISSION_SPACECRAFT_ID);
+    CFE_MSG_SetSystem(MsgPtr, (CFE_MSG_System_t)CFE_PSP_GetSpacecraftId());
 }
 
 /******************************************************************************

--- a/modules/msg/unit-test-coverage/test_cfe_msg_ccsdsext.c
+++ b/modules/msg/unit-test-coverage/test_cfe_msg_ccsdsext.c
@@ -57,12 +57,16 @@ void Test_MSG_Init_Ext(void)
     CFE_MSG_System_t        system;
     CFE_MSG_Endian_t        endian;
     bool                    is_v1;
+    int                     sc_id = 0xab;
 
     /* Get msgid version by checking if msgid sets header version */
     memset(&msg, 0xFF, sizeof(msg));
     ASSERT_EQ(CFE_MSG_SetMsgId(&msg, CFE_SB_ValueToMsgId(0)), CFE_SUCCESS);
     ASSERT_EQ(CFE_MSG_GetHeaderVersion(&msg, &hdrver), CFE_SUCCESS);
     is_v1 = (hdrver == 0);
+
+    /* Set up return */
+    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_GetSpacecraftId), 1, sc_id);
 
     UT_Text("Set to all F's, msgid value = 0, and run with clearing");
     memset(&msg, 0xFF, sizeof(msg));
@@ -83,7 +87,7 @@ void Test_MSG_Init_Ext(void)
 
     /* Default system check */
     ASSERT_EQ(CFE_MSG_GetSystem(&msg, &system), CFE_SUCCESS);
-    ASSERT_EQ(system, CFE_MISSION_SPACECRAFT_ID);
+    ASSERT_EQ(system, sc_id);
 
     /* Default endian check */
     ASSERT_EQ(CFE_MSG_GetEndian(&msg, &endian), CFE_SUCCESS);


### PR DESCRIPTION
**Describe the contribution**
Fix #836 - replaced CFE_MISSION_SPACECRAFT_ID use with CFE_PSP_GetSpacecraftId() and updated unit test

**Testing performed**
Built version 2 with unit tests, executed and passed

**Expected behavior changes**
No longer uses soon to be deprecated CFE_MISSION_SPACECRAFT_ID

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: bundle integration candidate + this change

**Additional context**
Depends on changes in integration candidate

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC