### PR TITLE
Integration Candidate: 2020-08-26

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,15 @@ The detailed cFE user's guide can be viewed at <https://github.com/nasa/cFS/blob
 
 ## Version History
 
+### Development Build: 6.8.0-rc1+dev42
+
+- Removes reference from documentation.
+- CFE_SB_SendMsg stub now behaves the same as CFE_SB_TimeStampMsg (copies message pointer from local). No longer need to emulate CFE_SB_InitMsg from test code, set the API/stub data buffers directly.
+- Removed iterator modification from within the loop... replaced with break.
+- Resolves loop iterator size too small for comparison.
+- Replaced CFE_MISSION_SPACECRAFT_ID use with CFE_PSP_GetSpacecraftId() and updated unit test
+- See <https://github.com/nasa/cFE/pull/849>
+
 ### Development Build: 6.8.0-rc1+dev28
 
 - Add msg stubs, update SB_UT to use them, and remove msg module include from unit tests

--- a/docs/cFE Application Developers Guide.md
+++ b/docs/cFE Application Developers Guide.md
@@ -605,14 +605,8 @@ Application Developer are the following:
    multiple processors on the same spacecraft.
 
 For understanding and compensating for the processor timer on a
-particular platform, the following two functions provide important
+particular platform, the following function provides important
 information.
-
--  OS_Milli2Ticks converts a given number of milliseconds into the
-appropriate number of processor clock ticks for a given amount of time.
-The Developer should never hard-code a time related value in clock
-ticks. When the code is ported to another processor, it is important for
-any time values to automatically adjust appropriately.
 
 -  OS_InfoGetTicks returns the number of microseconds per operating system
 clock tick. This can also be used to calculate the appropriate number of

--- a/docs/src/osalmain.dox
+++ b/docs/src/osalmain.dox
@@ -19,10 +19,6 @@
         <LI> \ref OSAPIMsgQueue
         <LI> \ref OSAPISem
         <LI> \ref OSAPITime
-        <LI> \ref OSAPIExc
-        <LI> \ref OSAPIFPUExc
-        <LI> \ref OSAPIInterrupt
-        <LI> \ref OSAPIShMem
         <LI> \ref OSAPIHeap
         <LI> \ref OSAPIError
         <LI> \ref OSAPISelect
@@ -36,7 +32,6 @@
       <LI> \subpage osalfsfd
       <LI> \ref OSFileAccess
       <LI> \ref OSFileOffset
-      <LI> \ref OSVolType
       <LI> APIs
       <UL>
         <LI> \ref OSAPIFile

--- a/fsw/cfe-core/src/inc/cfe_version.h
+++ b/fsw/cfe-core/src/inc/cfe_version.h
@@ -35,7 +35,7 @@
 
 
 /* Development Build Macro Definitions */
-#define CFE_BUILD_NUMBER 28 /*!< Development Build: Number of commits since baseline */
+#define CFE_BUILD_NUMBER 42 /*!< Development Build: Number of commits since baseline */
 #define CFE_BUILD_BASELINE "v6.8.0-rc1" /*!< Development Build: git tag that is the base for the current development */
 
 /* Version Macro Definitions */

--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -1182,7 +1182,7 @@ int32  CFE_SB_SendMsgFull(CFE_SB_Msg_t    *MsgPtr,
     uint16                  TotalMsgSize;
     CFE_SB_MsgRouteIdx_t    RtgTblIdx;
     uint32                  TskId = 0;
-    uint16                  i;
+    uint32                  i;
     char                    FullName[(OS_MAX_API_NAME * 2)];
     CFE_SB_EventBuf_t       SBSndErr;
     char                    PipeName[OS_MAX_API_NAME] = {'\0'};

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.c
@@ -1375,7 +1375,7 @@ int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDS_t *data)
             if (strncmp(CFE_TBL_TaskData.CritReg[i].Name, TableName, CFE_TBL_MAX_FULL_NAME_LEN) == 0)
             {
                 CritRegRecPtr = &CFE_TBL_TaskData.CritReg[i];
-                i=CFE_PLATFORM_TBL_MAX_CRITICAL_TABLES;
+                break;
             }
         }
         

--- a/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
@@ -486,8 +486,7 @@ int32 CFE_SB_SendMsg(CFE_SB_Msg_t *MsgPtr)
 
     if (status >= 0)
     {
-        UT_Stub_CopyFromLocal(UT_KEY(CFE_SB_SendMsg), MsgPtr->Byte,
-                CFE_SB_StubMsg_GetMetaData(MsgPtr)->TotalLength);
+        UT_Stub_CopyFromLocal(UT_KEY(CFE_SB_SendMsg), &MsgPtr, sizeof(MsgPtr));
     }
 
     return status;

--- a/modules/msg/src/cfe_msg_ccsdsext.c
+++ b/modules/msg/src/cfe_msg_ccsdsext.c
@@ -25,6 +25,7 @@
 #include "cfe_msg_priv.h"
 #include "cfe_msg_defaults.h"
 #include "cfe_error.h"
+#include "cfe_psp.h"
 
 /* CCSDS Extended definitions */
 #define CFE_MSG_EDSVER_SHIFT  11     /**< \brief CCSDS EDS version shift */
@@ -49,7 +50,7 @@ void CFE_MSG_SetDefaultCCSDSExt(CFE_MSG_Message_t *MsgPtr)
 
     /* Default bits of the subsystem, for whatever isn't set by MsgId */
     CFE_MSG_SetSubsystem(MsgPtr, (CFE_MSG_Subsystem_t)CFE_PLATFORM_DEFAULT_SUBSYS);
-    CFE_MSG_SetSystem(MsgPtr, (CFE_MSG_System_t)CFE_MISSION_SPACECRAFT_ID);
+    CFE_MSG_SetSystem(MsgPtr, (CFE_MSG_System_t)CFE_PSP_GetSpacecraftId());
 }
 
 /******************************************************************************

--- a/modules/msg/unit-test-coverage/test_cfe_msg_ccsdsext.c
+++ b/modules/msg/unit-test-coverage/test_cfe_msg_ccsdsext.c
@@ -57,12 +57,16 @@ void Test_MSG_Init_Ext(void)
     CFE_MSG_System_t        system;
     CFE_MSG_Endian_t        endian;
     bool                    is_v1;
+    int                     sc_id = 0xab;
 
     /* Get msgid version by checking if msgid sets header version */
     memset(&msg, 0xFF, sizeof(msg));
     ASSERT_EQ(CFE_MSG_SetMsgId(&msg, CFE_SB_ValueToMsgId(0)), CFE_SUCCESS);
     ASSERT_EQ(CFE_MSG_GetHeaderVersion(&msg, &hdrver), CFE_SUCCESS);
     is_v1 = (hdrver == 0);
+
+    /* Set up return */
+    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_GetSpacecraftId), 1, sc_id);
 
     UT_Text("Set to all F's, msgid value = 0, and run with clearing");
     memset(&msg, 0xFF, sizeof(msg));
@@ -83,7 +87,7 @@ void Test_MSG_Init_Ext(void)
 
     /* Default system check */
     ASSERT_EQ(CFE_MSG_GetSystem(&msg, &system), CFE_SUCCESS);
-    ASSERT_EQ(system, CFE_MISSION_SPACECRAFT_ID);
+    ASSERT_EQ(system, sc_id);
 
     /* Default endian check */
     ASSERT_EQ(CFE_MSG_GetEndian(&msg, &endian), CFE_SUCCESS);


### PR DESCRIPTION
**Describe the contribution**
Fix #798 
Fix #818 
Fix #822 
Fix #825 
Fix #831 
Fix #836 

**Testing performed**
Bundle CI - https://github.com/nasa/cFS/pull/134/checks

**Expected behavior changes**
PR #799 - Removes reference from documentation.

PR #834 - CFE_SB_SendMsg stub now behaves the same as CFE_SB_TimeStampMsg (copies message pointer from local).  No longer need to emulate CFE_SB_InitMsg from test code, set the API/stub data buffers directly.

PR #826 - Removed iterator modification from within the loop... replaced with break.

PR #832 - Resolves loop iterator size too small for comparison.

PR #842 - Replaced `CFE_MISSION_SPACECRAFT_ID` use with `CFE_PSP_GetSpacecraftId()` and updated unit test

**System(s) tested on**
Ubuntu - CI

**Additional context**
https://github.com/nasa/cFS/pull/134

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman, NASA-GSFC