### PR TITLE
Hotfix IC-20200826: Remove deprecated doxygen references

### DIFF
--- a/docs/src/osalmain.dox
+++ b/docs/src/osalmain.dox
@@ -19,10 +19,6 @@
         <LI> \ref OSAPIMsgQueue
         <LI> \ref OSAPISem
         <LI> \ref OSAPITime
-        <LI> \ref OSAPIExc
-        <LI> \ref OSAPIFPUExc
-        <LI> \ref OSAPIInterrupt
-        <LI> \ref OSAPIShMem
         <LI> \ref OSAPIHeap
         <LI> \ref OSAPIError
         <LI> \ref OSAPISelect
@@ -36,7 +32,6 @@
       <LI> \subpage osalfsfd
       <LI> \ref OSFileAccess
       <LI> \ref OSFileOffset
-      <LI> \ref OSVolType
       <LI> APIs
       <UL>
         <LI> \ref OSAPIFile


### PR DESCRIPTION
**Describe the contribution**
Hotfix  IC-20200826, Removes deprecated doxygen references from osalmain.dox to fix cFS bundle build errors

**Testing performed**
Generated doxygen files and ensured there were not errors or warnings

**System(s) tested on**
cFS Dev Server
OS: Ubuntu 18.04

**Additional context**
Add any other context about the contribution here.

**Contributor Info - All information REQUIRED for consideration of pull request**
Yasir Majeed Khan, Emergent Space Tech