### PR TITLE
Fix #851, Pass aligned message into CFE_MSG_ComputeCheckSum

### DIFF
--- a/modules/msg/src/cfe_msg_sechdr_checksum.c
+++ b/modules/msg/src/cfe_msg_sechdr_checksum.c
@@ -78,8 +78,9 @@ int32 CFE_MSG_GenerateChecksum(CFE_MSG_Message_t *MsgPtr)
     /* Zero checksum so new checksum will be correct */
     cmd->Sec.Checksum = 0;
 
-    /* Compute and set */
-    cmd->Sec.Checksum = CFE_MSG_ComputeCheckSum((CFE_MSG_Message_t *)cmd);
+    /* Compute using aligned MsgPtr and set, suppress false style warning */
+    /* cppcheck-suppress redundantAssignment */
+    cmd->Sec.Checksum = CFE_MSG_ComputeCheckSum(MsgPtr);
 
     return CFE_SUCCESS;
 }


### PR DESCRIPTION
**Describe the contribution**
Fix #851 - Fixes the cast-align error (use the aligned Msg since it's available already)

**Testing performed**
Standard build and unit test, passes

**Expected behavior changes**
No more alignment error

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC