### PR TITLE
Fix #823, avoid infinite loop in CDS registry find

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_cds.c
+++ b/fsw/cfe-core/src/es/cfe_es_cds.c
@@ -637,13 +637,10 @@ int32 CFE_ES_UnlockCDSRegistry(void)
 int32 CFE_ES_FindCDSInRegistry(const char *CDSName)
 {
     int32 RegIndx = CFE_ES_CDS_NOT_FOUND;
-    int32 i = -1;
+    uint32 i = 0;
 
-    do
+    while ( (RegIndx == CFE_ES_CDS_NOT_FOUND) && (i < CFE_ES_Global.CDSVars.MaxNumRegEntries) )
     {
-        /* Point to next record in the CDS Registry */
-        i++;
-
         /* Check to see if the record is currently being used */
         if (CFE_ES_Global.CDSVars.Registry[i].Taken == true)
         {
@@ -654,7 +651,11 @@ int32 CFE_ES_FindCDSInRegistry(const char *CDSName)
                 RegIndx = i;
             }
         }
-    } while ( (RegIndx == CFE_ES_CDS_NOT_FOUND) && (i < (CFE_ES_Global.CDSVars.MaxNumRegEntries-1)) );
+
+        /* Point to next record in the CDS Registry */
+        i++;
+
+    };
 
     return RegIndx;
 }   /* End of CFE_ES_FindCDSInRegistry() */
@@ -670,7 +671,7 @@ int32 CFE_ES_FindCDSInRegistry(const char *CDSName)
 int32 CFE_ES_FindFreeCDSRegistryEntry(void)
 {
     int32 RegIndx = CFE_ES_CDS_NOT_FOUND;
-    int32 i = 0;
+    uint32 i = 0;
 
     while ( (RegIndx == CFE_ES_CDS_NOT_FOUND) && (i < CFE_ES_Global.CDSVars.MaxNumRegEntries) )
     {


### PR DESCRIPTION
**Describe the contribution**
The CFE_ES_FindCDSInRegistry function had an unusual loop control structure with mixed types of signed and unsigned.  This has the possibility of being infinite if the MaxNumRegEntries is zero due to the way the end condition is structured.  Simplify to be like other loops and use unsigned int control variable.

Fixes #823 

**Testing performed**
Build and sanity check CFE
Run all unit tests

**Expected behavior changes**
No impact to behavior so long as CFE was configured where the number of CDS entries is not zero.
If configured to be zero, this avoids an infinite loop.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
