### PR TITLE
Fix #797, refactor internal table/id management

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_apps.h
+++ b/fsw/cfe-core/src/es/cfe_es_apps.h
@@ -101,7 +101,7 @@ typedef struct
 */
 typedef struct
 {
-   CFE_ES_AppState_Enum_t  AppState;                 /* Is the app running, or stopped, or waiting? */
+   CFE_ES_AppState_Enum_t  AppState;                    /* Is the app running, or stopped, or waiting? */
    uint32                  Type;                        /* The type of App: CORE or EXTERNAL */
    CFE_ES_AppStartParams_t StartParams;                 /* The start parameters for an App */
    CFE_ES_ControlReq_t     ControlReq;                  /* The Control Request Record for External cFE Apps */
@@ -211,12 +211,12 @@ bool CFE_ES_RunERLogDump(uint32 ElapsedTime, void *Arg);
 /*
 ** Perform the requested control action for an application
 */
-void CFE_ES_ProcessControlRequest(uint32 AppID);
+void CFE_ES_ProcessControlRequest(CFE_ES_AppRecord_t *AppRecPtr);
 
 /*
 ** Clean up all app resources and delete it
 */
-int32 CFE_ES_CleanUpApp(uint32 AppId);
+int32 CFE_ES_CleanUpApp(CFE_ES_AppRecord_t *AppRecPtr);
 
 /*
 ** Clean up all Task resources and detete the task
@@ -228,6 +228,13 @@ int32 CFE_ES_CleanupTaskResources(uint32 TaskId);
 ** This is an internal function for use in ES.
 ** The newer external API is : CFE_ES_GetAppInfo
 */
-void CFE_ES_GetAppInfoInternal(uint32 AppId, CFE_ES_AppInfo_t *AppInfoPtr );
+int32 CFE_ES_GetAppInfoInternal(CFE_ES_AppRecord_t *AppRecPtr, CFE_ES_AppInfo_t *AppInfoPtr );
+
+/*
+ * Populate the CFE_ES_TaskInfo_t structure with the data for a task
+ * This is an internal function for use in ES.
+ * (Equivalent pattern to CFE_ES_GetAppInfoInternal() but for tasks)
+ */
+int32 CFE_ES_GetTaskInfoInternal(CFE_ES_TaskRecord_t *TaskRecPtr, CFE_ES_TaskInfo_t *TaskInfoPtr );
 
 #endif  /* _cfe_es_apps_ */

--- a/fsw/cfe-core/src/es/cfe_es_cds.c
+++ b/fsw/cfe-core/src/es/cfe_es_cds.c
@@ -528,35 +528,6 @@ int32 CFE_ES_UpdateCDSRegistry(void)
     return Status;
 }
 
-/*******************************************************************
-**
-** CFE_ES_CDS_ValidateAppID
-**
-** NOTE: For complete prolog information, see 'cfe_es_cds.h'
-********************************************************************/
-
-int32 CFE_ES_CDS_ValidateAppID(uint32 *AppIdPtr)
-{
-    int32 Status = CFE_ES_GetAppID(AppIdPtr);
-
-    if (Status == CFE_SUCCESS)
-    {
-        if (*AppIdPtr >= CFE_PLATFORM_ES_MAX_APPLICATIONS)
-        {
-            Status = CFE_ES_ERR_APPID;
-
-            CFE_ES_WriteToSysLog("CFE_CDS:ValidateAppID-AppId=%d > Max Apps (%d)\n",
-                                 (int)(*AppIdPtr), CFE_PLATFORM_ES_MAX_APPLICATIONS);
-        }
-    }
-    else
-    {
-        CFE_ES_WriteToSysLog("CFE_CDS:ValidateAppID-GetAppID failed (Stat=0x%08X)\n", (unsigned int)Status);
-    }
-
-    return Status;
-}   /* End of CFE_ES_CDS_ValidateAppID() */
-
 
 /*******************************************************************
 **

--- a/fsw/cfe-core/src/es/cfe_es_cds.h
+++ b/fsw/cfe-core/src/es/cfe_es_cds.h
@@ -111,27 +111,6 @@ int32 CFE_ES_CDS_EarlyInit(void);
 int32 CFE_ES_UpdateCDSRegistry(void);
 
 
-/*****************************************************************************/
-/**
-** \brief Validates the Application ID associated with calling Application
-**
-** \par Description
-**        Validates Application ID of calling App.  Validation
-**        consists of ensuring the AppID is between zero and
-**        #CFE_PLATFORM_ES_MAX_APPLICATIONS.
-**
-** \par Assumptions, External Events, and Notes:
-**          None
-**
-** \param[in, out]  AppIdPtr Pointer to value that will hold AppID on return. *AppIdPtr is the AppID as obtained from #CFE_ES_GetAppID.
-** 
-**
-** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
-** \retval #CFE_ES_ERR_APPID                \copydoc CFE_ES_ERR_APPID
-**                     
-******************************************************************************/
-int32 CFE_ES_CDS_ValidateAppID(uint32 *AppIdPtr);
-
 
 /*****************************************************************************/
 /**

--- a/fsw/cfe-core/src/es/cfe_es_erlog.c
+++ b/fsw/cfe-core/src/es/cfe_es_erlog.c
@@ -318,6 +318,7 @@ bool CFE_ES_RunExceptionScan(uint32 ElapsedTime, void *Arg)
     uint32              ExceptionTaskID;
     uint32              ResetType;
     CFE_ES_LogEntryType_Enum_t LogType;
+    CFE_ES_AppRecord_t  *AppRecPtr;
 
     if (CFE_PSP_Exception_GetCount() == 0)
     {
@@ -361,13 +362,19 @@ bool CFE_ES_RunExceptionScan(uint32 ElapsedTime, void *Arg)
         /*
          * The App ID was found, now see if the ExceptionAction is set for a reset
          */
-        if (Status == CFE_SUCCESS &&
-                CFE_ES_Global.AppTable[EsTaskInfo.AppId].StartParams.ExceptionAction == CFE_ES_ExceptionAction_RESTART_APP)
+        if (Status == CFE_SUCCESS)
         {
-            /*
-             * Log the Application reset
-             */
-            ResetType = CFE_ES_APP_RESTART;
+            AppRecPtr = CFE_ES_LocateAppRecordByID(EsTaskInfo.AppId);
+            CFE_ES_LockSharedData(__func__,__LINE__);
+            if (CFE_ES_AppRecordIsMatch(AppRecPtr, EsTaskInfo.AppId) &&
+                AppRecPtr->StartParams.ExceptionAction == CFE_ES_ExceptionAction_RESTART_APP)
+            {
+                /*
+                 * Log the Application reset
+                 */
+                ResetType = CFE_ES_APP_RESTART;
+            }
+            CFE_ES_UnlockSharedData(__func__,__LINE__);
         }
     }
 

--- a/fsw/cfe-core/src/es/cfe_es_global.h
+++ b/fsw/cfe-core/src/es/cfe_es_global.h
@@ -155,6 +155,221 @@ extern CFE_ES_Global_t CFE_ES_Global;
 */
 extern CFE_ES_ResetData_t *CFE_ES_ResetDataPtr;
 
+/**
+ * @brief Locate the app table entry correlating with a given app ID.
+ *
+ * This only returns a pointer to the table entry and does _not_
+ * otherwise check/validate the entry.
+ *
+ * @param[in]   AppID   the app ID to locate
+ * @return pointer to App Table entry for the given app ID
+ */
+extern CFE_ES_AppRecord_t* CFE_ES_LocateAppRecordByID(uint32 AppID);
+
+/**
+ * @brief Locate the task table entry correlating with a given task ID.
+ *
+ * This only returns a pointer to the table entry and does _not_
+ * otherwise check/validate the entry.
+ *
+ * @param[in]   TaskID   the task ID to locate
+ * @return pointer to Task Table entry for the given task ID
+ */
+extern CFE_ES_TaskRecord_t* CFE_ES_LocateTaskRecordByID(uint32 TaskID);
+
+/**
+ * @brief Check if an app record is in use or free/empty
+ *
+ * This routine checks if the App table entry is in use or if it is free
+ *
+ * As this dereferences fields within the record, global data must be
+ * locked prior to invoking this function.
+ *
+ * @param[in]   AppRecPtr   pointer to app table entry
+ * @returns true if the entry is in use/configured, or false if it is free/empty
+ */
+static inline bool CFE_ES_AppRecordIsUsed(const CFE_ES_AppRecord_t *AppRecPtr)
+{
+    return (AppRecPtr->AppState != CFE_ES_AppState_UNDEFINED);
+}
+
+/**
+ * @brief Get the ID value from an app table entry
+ *
+ * This routine converts the table entry back to an abstract ID.
+ *
+ * @param[in]   AppRecPtr   pointer to app table entry
+ * @returns AppID of entry
+ */
+static inline uint32 CFE_ES_AppRecordGetID(const CFE_ES_AppRecord_t *AppRecPtr)
+{
+    /*
+     * The initial implementation does not store the ID in the entry;
+     * the ID is simply the zero-based index into the table.
+     */
+    return (AppRecPtr - CFE_ES_Global.AppTable);
+}
+
+/**
+ * @brief Marks an app table entry as used (not free)
+ *
+ * This sets the internal field(s) within this entry, and marks
+ * it as being associated with the given app ID.
+ *
+ * As this dereferences fields within the record, global data must be
+ * locked prior to invoking this function.
+ *
+ * @param[in]   AppRecPtr   pointer to app table entry
+ * @param[in]   AppID       the app ID of this entry
+ */
+static inline void CFE_ES_AppRecordSetUsed(CFE_ES_AppRecord_t *AppRecPtr, uint32 AppID)
+{
+    AppRecPtr->AppState = CFE_ES_AppState_EARLY_INIT;
+}
+
+/**
+ * @brief Set an app record table entry free (not used)
+ *
+ * This clears the internal field(s) within this entry, and allows the
+ * memory to be re-used in the future.
+ *
+ * As this dereferences fields within the record, global data must be
+ * locked prior to invoking this function.
+ *
+ * @param[in]   AppRecPtr   pointer to app table entry
+ */
+static inline void CFE_ES_AppRecordSetFree(CFE_ES_AppRecord_t *AppRecPtr)
+{
+    AppRecPtr->AppState = CFE_ES_AppState_UNDEFINED;
+}
+
+/**
+ * @brief Check if an app record is a match for the given AppID
+ *
+ * This routine confirms that the previously-located record is valid
+ * and matches the expected app ID.
+ *
+ * As this dereferences fields within the record, global data must be
+ * locked prior to invoking this function.
+ *
+ * @param[in]   AppRecPtr   pointer to app table entry
+ * @param[in]   AppID       expected app ID
+ * @returns true if the entry matches the given app ID
+ */
+static inline bool CFE_ES_AppRecordIsMatch(const CFE_ES_AppRecord_t *AppRecPtr, uint32 AppID)
+{
+    return (AppRecPtr != NULL && CFE_ES_AppRecordIsUsed(AppRecPtr) &&
+            CFE_ES_AppRecordGetID(AppRecPtr) == AppID);
+}
+
+/**
+ * @brief Get the ID value from an Task table entry
+ *
+ * This routine converts the table entry back to an abstract ID.
+ *
+ * As this dereferences fields within the record, global data must be
+ * locked prior to invoking this function.
+ *
+ * @param[in]   TaskRecPtr   pointer to Task table entry
+ * @returns TaskID of entry
+ */
+static inline uint32 CFE_ES_TaskRecordGetID(const CFE_ES_TaskRecord_t *TaskRecPtr)
+{
+    return (TaskRecPtr->TaskId);
+}
+
+/**
+ * @brief Check if a Task record is in use or free/empty
+ *
+ * This routine checks if the Task table entry is in use or if it is free
+ *
+ * As this dereferences fields within the record, global data must be
+ * locked prior to invoking this function.
+ *
+ * @param[in]   TaskRecPtr   pointer to task table entry
+ * @returns true if the entry is in use/configured, or false if it is free/empty
+ */
+static inline bool CFE_ES_TaskRecordIsUsed(const CFE_ES_TaskRecord_t *TaskRecPtr)
+{
+    return (TaskRecPtr->RecordUsed);
+}
+
+/**
+ * @brief Marks an Task table entry as used (not free)
+ *
+ * This sets the internal field(s) within this entry, and marks
+ * it as being associated with the given Task ID.
+ *
+ * As this dereferences fields within the record, global data must be
+ * locked prior to invoking this function.
+ *
+ * @param[in]   TaskRecPtr   pointer to Task table entry
+ * @param[in]   TaskID       the Task ID of this entry
+ */
+static inline void CFE_ES_TaskRecordSetUsed(CFE_ES_TaskRecord_t *TaskRecPtr, uint32 TaskID)
+{
+    TaskRecPtr->TaskId = TaskID;
+    TaskRecPtr->RecordUsed = true;
+}
+
+/**
+ * @brief Set a Task record table entry free
+ *
+ * This allows the table entry to be re-used by another Task.
+ *
+ * As this dereferences fields within the record, global data must be
+ * locked prior to invoking this function.
+ *
+ * @param[in]   TaskRecPtr   pointer to task table entry
+ * @returns true if the entry is in use/configured, or false if it is free/empty
+ */
+static inline void CFE_ES_TaskRecordSetFree(CFE_ES_TaskRecord_t *TaskRecPtr)
+{
+    TaskRecPtr->TaskId = 0;
+    TaskRecPtr->RecordUsed = false;
+}
+
+/**
+ * @brief Check if a Task record is a match for the given TaskID
+ *
+ * This routine confirms that the previously-located record is valid
+ * and matches the expected Task ID.
+ *
+ * As this dereferences fields within the record, global data must be
+ * locked prior to invoking this function.
+ *
+ * @param[in]   TaskRecPtr   pointer to task table entry
+ * @returns true if the entry matches the given task ID
+ */
+static inline bool CFE_ES_TaskRecordIsMatch(const CFE_ES_TaskRecord_t *TaskRecPtr, uint32 TaskID)
+{
+    return (TaskRecPtr != NULL && CFE_ES_TaskRecordIsUsed(TaskRecPtr) &&
+            CFE_ES_TaskRecordGetID(TaskRecPtr) == TaskID);
+}
+
+/**
+ * Locate and validate the app record for the calling context.
+ *
+ * Finds and validates the ES AppTable entry corresponding to the
+ * caller. This confirms that the fields within the table entry match the
+ * expected value(s), otherwise NULL is returned if no matching entry
+ * is found.
+ *
+ * The global data lock should be obtained prior to invoking this function.
+ */
+extern CFE_ES_AppRecord_t* CFE_ES_GetAppRecordByContext(void);
+
+/**
+ * Locate and validate the task record for the calling context.
+ *
+ * Finds and validates the ES TaskTable entry corresponding to the
+ * caller. This confirms that the fields within the table entry match the
+ * expected value(s), otherwise NULL is returned if no matching entry
+ * is found.
+ *
+ * The global data lock should be obtained prior to invoking this function.
+ */
+extern CFE_ES_TaskRecord_t* CFE_ES_GetTaskRecordByContext(void);
 
 /*
 ** Functions used to lock/unlock shared data

--- a/fsw/cfe-core/src/es/cfe_es_start.c
+++ b/fsw/cfe-core/src/es/cfe_es_start.c
@@ -85,6 +85,8 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const cha
 {
    uint32 i;
    int32 ReturnCode;
+   CFE_ES_AppRecord_t *AppRecPtr;
+   CFE_ES_TaskRecord_t *TaskRecPtr;
 
    /*
    ** Indicate that the CFE is the earliest initialization state
@@ -176,18 +178,22 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const cha
    ** Initialize the ES Application Table
    ** to mark all entries as unused.
    */
+   AppRecPtr = CFE_ES_Global.AppTable;
    for ( i = 0; i < CFE_PLATFORM_ES_MAX_APPLICATIONS; i++ )
    {
-      CFE_ES_Global.AppTable[i].AppState = CFE_ES_AppState_UNDEFINED;
+       CFE_ES_AppRecordSetFree(AppRecPtr);
+       ++AppRecPtr;
    }
    
    /*
    ** Initialize the ES Task Table
    ** to mark all entries as unused.
    */
+   TaskRecPtr = CFE_ES_Global.TaskTable;
    for ( i = 0; i < OS_MAX_TASKS; i++ )
    {
-      CFE_ES_Global.TaskTable[i].RecordUsed = false;
+       CFE_ES_TaskRecordSetFree(TaskRecPtr);
+       ++TaskRecPtr;
    }
 
    /*
@@ -764,10 +770,12 @@ void CFE_ES_InitializeFileSystems(uint32 StartType)
 void  CFE_ES_CreateObjects(void)
 {
     int32     ReturnCode;
-    uint32    TaskIndex;
     bool      AppSlotFound;
     uint16    i;
     uint16    j;
+    uint32    OsalId;
+    CFE_ES_AppRecord_t *AppRecPtr;
+    CFE_ES_TaskRecord_t *TaskRecPtr;
 
     CFE_ES_WriteToSysLog("ES Startup: Starting Object Creation calls.\n");
 
@@ -782,13 +790,15 @@ void  CFE_ES_CreateObjects(void)
             ** Allocate an ES AppTable entry
             */
             AppSlotFound = false;
+            AppRecPtr = CFE_ES_Global.AppTable;
             for ( j = 0; j < CFE_PLATFORM_ES_MAX_APPLICATIONS; j++ )
             {
-               if ( CFE_ES_Global.AppTable[j].AppState == CFE_ES_AppState_UNDEFINED )
+               if ( !CFE_ES_AppRecordIsUsed(AppRecPtr) )
                {
                   AppSlotFound = true;
                   break;
                }
+               ++AppRecPtr;
             }
 
             /*
@@ -802,38 +812,38 @@ void  CFE_ES_CreateObjects(void)
                /*
                ** Allocate and populate the ES_AppTable entry
                */
-               memset ( &(CFE_ES_Global.AppTable[j]), 0, sizeof(CFE_ES_AppRecord_t));
+               memset ( AppRecPtr, 0, sizeof(CFE_ES_AppRecord_t));
                /*
                ** Core apps still have the notion of an init/running state
                ** Set the state here to mark the record as used.
                */
-               CFE_ES_Global.AppTable[j].AppState = CFE_ES_AppState_EARLY_INIT;
+               CFE_ES_AppRecordSetUsed(AppRecPtr, j);
                
-               CFE_ES_Global.AppTable[j].Type = CFE_ES_AppType_CORE;
+               AppRecPtr->Type = CFE_ES_AppType_CORE;
                
                /*
                ** Fill out the parameters in the AppStartParams sub-structure
                */         
-               strncpy((char *)CFE_ES_Global.AppTable[j].StartParams.Name, (char *)CFE_ES_ObjectTable[i].ObjectName, OS_MAX_API_NAME);
-               CFE_ES_Global.AppTable[j].StartParams.Name[OS_MAX_API_NAME - 1] = '\0';
+               strncpy((char *)AppRecPtr->StartParams.Name, (char *)CFE_ES_ObjectTable[i].ObjectName, OS_MAX_API_NAME);
+               AppRecPtr->StartParams.Name[OS_MAX_API_NAME - 1] = '\0';
                /* EntryPoint field is not valid here for base apps */
                /* FileName is not valid for base apps, either */
-               CFE_ES_Global.AppTable[j].StartParams.StackSize = CFE_ES_ObjectTable[i].ObjectSize;
-               CFE_ES_Global.AppTable[j].StartParams.StartAddress = (cpuaddr)CFE_ES_ObjectTable[i].FuncPtrUnion.VoidPtr;
-               CFE_ES_Global.AppTable[j].StartParams.ExceptionAction = CFE_ES_ExceptionAction_PROC_RESTART;
-               CFE_ES_Global.AppTable[j].StartParams.Priority = CFE_ES_ObjectTable[i].ObjectPriority;
+               AppRecPtr->StartParams.StackSize = CFE_ES_ObjectTable[i].ObjectSize;
+               AppRecPtr->StartParams.StartAddress = (cpuaddr)CFE_ES_ObjectTable[i].FuncPtrUnion.VoidPtr;
+               AppRecPtr->StartParams.ExceptionAction = CFE_ES_ExceptionAction_PROC_RESTART;
+               AppRecPtr->StartParams.Priority = CFE_ES_ObjectTable[i].ObjectPriority;
                
                
                /*
                ** Fill out the Task Info
                */
-               strncpy((char *)CFE_ES_Global.AppTable[j].TaskInfo.MainTaskName, (char *)CFE_ES_ObjectTable[i].ObjectName, OS_MAX_API_NAME);
-               CFE_ES_Global.AppTable[j].TaskInfo.MainTaskName[OS_MAX_API_NAME - 1] = '\0';
+               strncpy((char *)AppRecPtr->TaskInfo.MainTaskName, (char *)CFE_ES_ObjectTable[i].ObjectName, OS_MAX_API_NAME);
+               AppRecPtr->TaskInfo.MainTaskName[OS_MAX_API_NAME - 1] = '\0';
                
                /*
                ** Create the task
                */
-               ReturnCode = OS_TaskCreate(&CFE_ES_Global.AppTable[j].TaskInfo.MainTaskId, /* task id */
+               ReturnCode = OS_TaskCreate(&OsalId,                               /* task id */
                                   CFE_ES_ObjectTable[i].ObjectName,              /* task name */
                                   CFE_ES_ObjectTable[i].FuncPtrUnion.MainAppPtr, /* task function pointer */
                                   NULL,                                          /* stack pointer */
@@ -843,7 +853,7 @@ void  CFE_ES_CreateObjects(void)
 
                if(ReturnCode != OS_SUCCESS)
                {
-                  CFE_ES_Global.AppTable[j].AppState = CFE_ES_AppState_UNDEFINED;
+                  CFE_ES_AppRecordSetFree(AppRecPtr);
                   CFE_ES_UnlockSharedData(__func__,__LINE__);
 
                   CFE_ES_WriteToSysLog("ES Startup: OS_TaskCreate error creating core App: %s: EC = 0x%08X\n",
@@ -862,27 +872,25 @@ void  CFE_ES_CreateObjects(void)
                }
                else
                {
-                  OS_ConvertToArrayIndex(CFE_ES_Global.AppTable[j].TaskInfo.MainTaskId, &TaskIndex);
+                  AppRecPtr->TaskInfo.MainTaskId = OsalId;
+                  TaskRecPtr = CFE_ES_LocateTaskRecordByID(AppRecPtr->TaskInfo.MainTaskId);
 
                   /*
                   ** Allocate and populate the CFE_ES_Global.TaskTable entry
                   */
-                  if ( CFE_ES_Global.TaskTable[TaskIndex].RecordUsed == true )
+                  if ( CFE_ES_TaskRecordIsUsed(TaskRecPtr) )
                   {
                      CFE_ES_SysLogWrite_Unsync("ES Startup: CFE_ES_Global.TaskTable record used error for App: %s, continuing.\n",
                                            CFE_ES_ObjectTable[i].ObjectName);
                   }
-                  else
-                  {
-                     CFE_ES_Global.TaskTable[TaskIndex].RecordUsed = true;
-                  }
-                  CFE_ES_Global.TaskTable[TaskIndex].AppId = j;
-                  CFE_ES_Global.TaskTable[TaskIndex].TaskId = CFE_ES_Global.AppTable[j].TaskInfo.MainTaskId;
-                  strncpy((char *)CFE_ES_Global.TaskTable[TaskIndex].TaskName, (char *)CFE_ES_Global.AppTable[j].TaskInfo.MainTaskName, OS_MAX_API_NAME);
-                  CFE_ES_Global.TaskTable[TaskIndex].TaskName[OS_MAX_API_NAME - 1] = '\0';
+                  CFE_ES_TaskRecordSetUsed(TaskRecPtr, AppRecPtr->TaskInfo.MainTaskId);
+                  TaskRecPtr->AppId = CFE_ES_AppRecordGetID(AppRecPtr);
+                  strncpy((char *)TaskRecPtr->TaskName, (char *)AppRecPtr->TaskInfo.MainTaskName, OS_MAX_API_NAME);
+                  TaskRecPtr->TaskName[OS_MAX_API_NAME - 1] = '\0';
 
-                  CFE_ES_SysLogWrite_Unsync("ES Startup: Core App: %s created. App ID: %d\n",
-                                       CFE_ES_ObjectTable[i].ObjectName,j);
+                  CFE_ES_SysLogWrite_Unsync("ES Startup: Core App: %s created. App ID: %lu\n",
+                                       CFE_ES_ObjectTable[i].ObjectName,
+                                       CFE_ES_ResourceID_ToInteger(CFE_ES_AppRecordGetID(AppRecPtr)));
                                        
                   /*
                   ** Increment the registered App and Registered External Task variables.
@@ -988,6 +996,7 @@ int32 CFE_ES_MainTaskSyncDelay(uint32 AppStateId, uint32 TimeOutMilliseconds)
     uint32 WaitTime;
     uint32 WaitRemaining;
     uint32 AppNotReadyCounter;
+    CFE_ES_AppRecord_t *AppRecPtr;
 
     Status = CFE_ES_OPERATION_TIMED_OUT;
     WaitRemaining = TimeOutMilliseconds;
@@ -999,13 +1008,15 @@ int32 CFE_ES_MainTaskSyncDelay(uint32 AppStateId, uint32 TimeOutMilliseconds)
          * Count the number of apps that are NOT in (at least) in the state requested
          */
         CFE_ES_LockSharedData(__func__,__LINE__);
+        AppRecPtr = CFE_ES_Global.AppTable;
         for ( i = 0; i < CFE_PLATFORM_ES_MAX_APPLICATIONS; i++ )
         {
-           if (CFE_ES_Global.AppTable[i].AppState != CFE_ES_AppState_UNDEFINED &&
-               (CFE_ES_Global.AppTable[i].AppState < AppStateId))
+           if ( CFE_ES_AppRecordIsUsed(AppRecPtr) &&
+               (AppRecPtr->AppState < AppStateId))
            {
                ++AppNotReadyCounter;
            }
+           ++AppRecPtr;
         }
         CFE_ES_UnlockSharedData(__func__,__LINE__);
 

--- a/fsw/cfe-core/src/es/cfe_es_task.c
+++ b/fsw/cfe-core/src/es/cfe_es_task.c
@@ -1003,8 +1003,8 @@ int32 CFE_ES_StartAppCmd(const CFE_ES_StartApp_t *data)
         {
             CFE_ES_TaskData.CommandCounter++;
             CFE_EVS_SendEvent(CFE_ES_START_INF_EID, CFE_EVS_EventType_INFORMATION,
-                    "Started %s from %s, AppID = %d",
-                    LocalAppName, LocalFile, (int)AppID);
+                    "Started %s from %s, AppID = %lu",
+                    LocalAppName, LocalFile, CFE_ES_ResourceID_ToInteger(AppID));
         }
         else
         {
@@ -1192,13 +1192,16 @@ int32 CFE_ES_QueryOneCmd(const CFE_ES_QueryOne_t *data)
 
     Result = CFE_ES_GetAppIDByName(&AppID, LocalApp);
 
+    if (Result == CFE_SUCCESS)
+    {
+        Result = CFE_ES_GetAppInfo(&(CFE_ES_TaskData.OneAppPacket.Payload.AppInfo), AppID);
+    }
+
     /*
     ** Send appropriate event message...
     */
     if (Result == CFE_SUCCESS)
     {
-
-        CFE_ES_GetAppInfoInternal(AppID, &(CFE_ES_TaskData.OneAppPacket.Payload.AppInfo));
         /*
         ** Send application status telemetry packet.
         */
@@ -1246,6 +1249,7 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAll_t *data)
     CFE_ES_AppInfo_t      AppInfo;
     const CFE_ES_FileNameCmd_Payload_t *CmdPtr = &data->Payload;
     char                  QueryAllFilename[OS_MAX_PATH_LEN];
+    CFE_ES_AppRecord_t    *AppRecPtr;
 
     /*
     ** Copy the commanded filename into local buffer to ensure size limitation and to allow for modification
@@ -1301,20 +1305,22 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAll_t *data)
         /*
         ** Loop through the ES AppTable for main applications
         */
+        AppRecPtr = CFE_ES_Global.AppTable;
         for(i=0;i<CFE_PLATFORM_ES_MAX_APPLICATIONS;i++)
         {
-            if(CFE_ES_Global.AppTable[i].AppState != CFE_ES_AppState_UNDEFINED)
+            /*
+            ** zero out the local entry
+            */
+            memset(&AppInfo,0,sizeof(CFE_ES_AppInfo_t));
+
+            /*
+            ** Populate the AppInfo entry
+            ** The internal routine checks the status of the entry
+            */
+            Result = CFE_ES_GetAppInfoInternal(AppRecPtr, &AppInfo);
+
+            if ( Result == CFE_SUCCESS )
             {
-                /*
-                ** zero out the local entry
-                */
-                memset(&AppInfo,0,sizeof(CFE_ES_AppInfo_t));
-
-                /*
-                ** Populate the AppInfo entry
-                */
-                CFE_ES_GetAppInfoInternal(i, &AppInfo);
-
                 /*
                 ** Write the local entry to file
                 */
@@ -1336,6 +1342,8 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAll_t *data)
                 FileSize += Result;
                 EntryCount ++;
             }
+
+            ++AppRecPtr;
         } /* end for */
 
         OS_close(FileDescriptor);
@@ -1371,7 +1379,7 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasks_t *data)
     CFE_ES_TaskInfo_t          TaskInfo;
     const CFE_ES_FileNameCmd_Payload_t *CmdPtr = &data->Payload;
     char                       QueryAllFilename[OS_MAX_PATH_LEN];
-
+    CFE_ES_TaskRecord_t        *TaskRecPtr;
     /*
     ** Copy the commanded filename into local buffer to ensure size limitation and to allow for modification
     */
@@ -1426,20 +1434,21 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasks_t *data)
         /*
         ** Loop through the ES AppTable for main applications
         */
+        TaskRecPtr = CFE_ES_Global.TaskTable;
         for(i=0;i<OS_MAX_TASKS;i++)
         {
-            if(CFE_ES_Global.TaskTable[i].RecordUsed != false)
+            /*
+            ** zero out the local entry
+            */
+            memset(&TaskInfo,0,sizeof(CFE_ES_TaskInfo_t));
+
+            /*
+            ** Populate the TaskInfo entry
+            */
+            Result = CFE_ES_GetTaskInfoInternal(TaskRecPtr, &TaskInfo);
+
+            if(Result == CFE_SUCCESS)
             {
-                /*
-                ** zero out the local entry
-                */
-                memset(&TaskInfo,0,sizeof(CFE_ES_TaskInfo_t));
-
-                /*
-                ** Populate the AppInfo entry
-                */
-                CFE_ES_GetTaskInfo(&TaskInfo,CFE_ES_Global.TaskTable[i].TaskId);
-
                 /*
                 ** Write the local entry to file
                 */
@@ -1461,6 +1470,8 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasks_t *data)
                 FileSize += Result;
                 EntryCount ++;
             }
+
+            ++TaskRecPtr;
 
         } /* end for */
 

--- a/fsw/cfe-core/src/es/cfe_esmempool.c
+++ b/fsw/cfe-core/src/es/cfe_esmempool.c
@@ -318,14 +318,16 @@ int32 CFE_ES_GetPoolBuf(uint32             **BufPtr,
       if (Handle != PoolPtr->PoolHandle)
       {
          CFE_ES_GetAppID(&AppId);
-         CFE_ES_WriteToSysLog("CFE_ES:getPoolBuf err:Bad handle(0x%08lX) AppId=%d\n",(unsigned long)Handle,(int)AppId);
+         CFE_ES_WriteToSysLog("CFE_ES:getPoolBuf err:Bad handle(0x%08lX) AppId=%lu\n",
+                 (unsigned long)Handle, CFE_ES_ResourceID_ToInteger(AppId));
          return(CFE_ES_ERR_MEM_HANDLE);
       }
    }
    else
    {
       CFE_ES_GetAppID(&AppId);
-      CFE_ES_WriteToSysLog("CFE_ES:getPoolBuf err:Bad handle(0x%08lX) AppId=%d\n",(unsigned long)Handle,(int)AppId);
+      CFE_ES_WriteToSysLog("CFE_ES:getPoolBuf err:Bad handle(0x%08lX) AppId=%lu\n",
+                 (unsigned long)Handle, CFE_ES_ResourceID_ToInteger(AppId));
       return(CFE_ES_ERR_MEM_HANDLE);
    }
 
@@ -636,7 +638,8 @@ int32 CFE_ES_GetMemPoolStats(CFE_ES_MemPoolStats_t *BufPtr,
     if (PoolPtr == NULL || Handle != PoolPtr->PoolHandle)
     {
         CFE_ES_GetAppID(&AppId);
-        CFE_ES_WriteToSysLog("CFE_ES:getMemPoolStats err:Bad handle(0x%08lX) AppId=%d\n", (unsigned long)Handle, (int)AppId);
+        CFE_ES_WriteToSysLog("CFE_ES:getMemPoolStats err:Bad handle(0x%08lX) AppId=%lu\n",
+                (unsigned long)Handle, CFE_ES_ResourceID_ToInteger(AppId));
         return(CFE_ES_ERR_MEM_HANDLE);
     }
 

--- a/fsw/cfe-core/src/evs/cfe_evs_utils.h
+++ b/fsw/cfe-core/src/evs/cfe_evs_utils.h
@@ -51,21 +51,125 @@
 
 /* ==============   Section III: Function Prototypes =========== */
 
-int32 EVS_GetAppID(uint32 *AppIdPtr);
+/**
+ * @brief Obtain the EVS app record for the given ID
+ *
+ * This only obtains a pointer to where the record should be, it does
+ * not check/confirm that the record actually is for the given AppID.
+ * Use EVS_AppDataIsMatch() to determine if the record is valid.
+ *
+ * @sa EVS_AppDataIsMatch()
+ *
+ * @param[in]   AppID   AppID to find
+ * @returns Pointer to app table entry, or NULL if ID is invalid.
+ */
+EVS_AppData_t *EVS_GetAppDataByID (uint32 AppID);
 
-int32 EVS_GetApplicationInfo(uint32 *pAppID, const char *pAppName);
+/**
+ * @brief Obtain the context information for the currently running app
+ *
+ * Obtains both the AppData record (pointer) and AppID for the current context.
+ *
+ * @param[out]   AppDataOut     Location to store App Data record pointer
+ * @param[out]   AppIDOut       Location to store AppID
+ * @returns CFE_SUCCESS if successful, or relevant error code.
+ */
+int32 EVS_GetCurrentContext (EVS_AppData_t **AppDataOut, uint32 *AppIDOut);
 
-int32 EVS_NotRegistered(uint32 AppID);
 
-bool EVS_IsFiltered(uint32 AppID, uint16 EventID, uint16 EventType);
+/**
+ * @brief Check if an EVS app record is in use or free/empty
+ *
+ * This routine checks if the EVS app entry is in use or if it is free
+ *
+ * As this dereferences fields within the record, global data must be
+ * locked prior to invoking this function.
+ *
+ * @param[in]   AppDataPtr   pointer to app table entry
+ * @returns true if the entry is in use/configured, or false if it is free/empty
+ */
+static inline bool EVS_AppDataIsUsed(EVS_AppData_t *AppDataPtr)
+{
+    return (AppDataPtr->RegisterFlag);
+}
+
+/**
+ * @brief Get the ID value from an EVS table entry
+ *
+ * This routine converts the table entry back to an abstract ID.
+ *
+ * @param[in]   AppDataPtr   pointer to app table entry
+ * @returns AppID of entry
+ */
+static inline uint32 EVS_AppDataGetID(EVS_AppData_t *AppDataPtr)
+{
+    /*
+     * The initial implementation does not store the ID in the entry;
+     * the ID is simply the zero-based index into the table.
+     */
+    return (AppDataPtr - CFE_EVS_GlobalData.AppData);
+}
+
+/**
+ * @brief Marks an EVS table entry as used (not free)
+ *
+ * This sets the internal field(s) within this entry, and marks
+ * it as being associated with the given app ID.
+ *
+ * As this dereferences fields within the record, global data must be
+ * locked prior to invoking this function.
+ *
+ * @param[in]   AppDataPtr   pointer to app table entry
+ * @param[in]   AppID       the app ID of this entry
+ */
+static inline void EVS_AppDataSetUsed(EVS_AppData_t *AppDataPtr, uint32 AppID)
+{
+    AppDataPtr->RegisterFlag = true;
+}
+
+/**
+ * @brief Set an EVS table entry free (not used)
+ *
+ * This clears the internal field(s) within this entry, and allows the
+ * memory to be re-used in the future.
+ *
+ * @param[in]   AppDataPtr   pointer to app table entry
+ */
+static inline void EVS_AppDataSetFree(EVS_AppData_t *AppDataPtr)
+{
+    AppDataPtr->RegisterFlag = false;
+}
+
+/**
+ * @brief Check if an EVS record is a match for the given AppID
+ *
+ * This routine confirms that the previously-located record is valid
+ * and matches the expected app ID.
+ *
+ * @param[in]   AppDataPtr   pointer to app table entry
+ * @param[in]   AppID       expected app ID
+ * @returns true if the entry matches the given app ID
+ */
+static inline bool EVS_AppDataIsMatch(EVS_AppData_t *AppDataPtr, uint32 AppID)
+{
+    return (AppDataPtr != NULL && EVS_AppDataIsUsed(AppDataPtr) &&
+            EVS_AppDataGetID(AppDataPtr) == AppID);
+}
+
+
+
+int32 EVS_GetApplicationInfo(EVS_AppData_t **AppDataOut, const char *pAppName);
+
+int32 EVS_NotRegistered (EVS_AppData_t *AppDataPtr, uint32 AppID);
+
+bool EVS_IsFiltered(EVS_AppData_t *AppDataPtr, uint16 EventID, uint16 EventType);
 
 EVS_BinFilter_t *EVS_FindEventID(int16 EventID, EVS_BinFilter_t *FilterArray);
 
-void EVS_EnableTypes(uint8 BitMask, uint32 AppID);
+void EVS_EnableTypes (EVS_AppData_t *AppDataPtr, uint8 BitMask);
+void EVS_DisableTypes (EVS_AppData_t *AppDataPtr, uint8 BitMask);
 
-void EVS_DisableTypes(uint8 BitMask, uint32 AppID);
-
-void EVS_GenerateEventTelemetry(uint32 AppID, uint16 EventID, uint16 EventType,
+void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint16 EventType,
         const CFE_TIME_SysTime_t *Time, const char *MsgSpec, va_list ArgPtr);
 
 int32 EVS_SendEvent (uint16 EventID, uint16 EventType, const char *Spec, ... );

--- a/fsw/cfe-core/src/fs/cfe_fs_priv.c
+++ b/fsw/cfe-core/src/fs/cfe_fs_priv.c
@@ -99,8 +99,8 @@ void CFE_FS_LockSharedData(const char *FunctionName)
     {
         CFE_ES_GetAppID(&AppId);
 
-        CFE_ES_WriteToSysLog("FS SharedData Mutex Take Err Stat=0x%x,App=%d,Function=%s\n",
-                (unsigned int)Status,(int)AppId,FunctionName);
+        CFE_ES_WriteToSysLog("FS SharedData Mutex Take Err Stat=0x%x,App=%lu,Function=%s\n",
+                (unsigned int)Status,CFE_ES_ResourceID_ToInteger(AppId),FunctionName);
 
     }/* end if */
 
@@ -130,8 +130,8 @@ void CFE_FS_UnlockSharedData(const char *FunctionName)
    if (Status != OS_SUCCESS) 
    {
        CFE_ES_GetAppID(&AppId);
-       CFE_ES_WriteToSysLog("FS SharedData Mutex Give Err Stat=0x%x,App=%d,Function=%s\n",
-               (unsigned int)Status,(int)AppId,FunctionName);
+       CFE_ES_WriteToSysLog("FS SharedData Mutex Give Err Stat=0x%x,App=%lu,Function=%s\n",
+               (unsigned int)Status,CFE_ES_ResourceID_ToInteger(AppId),FunctionName);
 
    }/* end if */
    return;

--- a/fsw/cfe-core/src/inc/cfe_es.h
+++ b/fsw/cfe-core/src/inc/cfe_es.h
@@ -199,6 +199,103 @@
 typedef cpuaddr CFE_ES_MemHandle_t;
 
 /**
+ * @brief Convert a resource ID to an integer.
+ *
+ * This is primarily intended for logging purposes, such was writing
+ * to debug console, event messages, or log files, using printf-like APIs.
+ *
+ * For compatibility with C library APIs, this returns an "unsigned long"
+ * type and should be used with the "%lx" format specifier in a printf
+ * format string.
+ *
+ * @note No assumptions should be made about the actual integer value,
+ * such as its base/range.  It may be printed, but should not be modified
+ * or tested/compared using other arithmetic ops, and should never be used
+ * as the index to an array or table.  See the related function
+ * CFE_ES_ResourceID_ToIndex() for cases where a zero-based array/table index
+ * is needed.
+ *
+ * @sa CFE_ES_ResourceID_FromInteger()
+ *
+ * @param   id[in]    Resource ID to convert
+ * @returns Integer value corresponding to ID
+ */
+static inline unsigned long CFE_ES_ResourceID_ToInteger(uint32 id)
+{
+    return (id);
+}
+
+/**
+ * @brief Convert an integer to a resource ID.
+ *
+ * This is the inverse of CFE_ES_ResourceID_ToInteger(), and reconstitutes
+ * the original CFE_ES_ResourceID_t value from the integer representation.
+ *
+ * This may be used, for instance, where an ID value is parsed from a text
+ * file or message using C library APIs such as scanf() or strtoul().
+ *
+ * @sa CFE_ES_ResourceID_ToInteger()
+ *
+ * @param   Value[in]    Integer value to convert
+ * @returns ID value corresponding to integer
+ */
+static inline uint32 CFE_ES_ResourceID_FromInteger(unsigned long Value)
+{
+    return (Value);
+}
+
+
+/**
+ * @brief Obtain an index value correlating to an ES Application ID
+ *
+ * This calculates a zero based integer value that may be used for indexing
+ * into a local resource table/array.
+ *
+ * Index values are only guaranteed to be unique for resources of the same
+ * type.  For instance, the indices corresponding to two [valid] application
+ * IDs will never overlap, but the index of an application and a library ID
+ * may be the same.  Furthermore, indices may be reused if a resource is
+ * deleted and re-created.
+ *
+ * @note There is no inverse of this function - indices cannot be converted
+ * back to the original AppID value.  The caller should retain the original ID
+ * for future use.
+ *
+ * @param   AppID[in]   Application ID to convert
+ * @param   Idx[out]    Buffer where the calculated index will be stored
+ *
+ * @return Execution status, see @ref CFEReturnCodes
+ * @retval #CFE_SUCCESS                 @copybrief CFE_SUCCESS
+ * @retval #CFE_ES_RESOURCE_ID_INVALID  @copybrief CFE_ES_RESOURCE_ID_INVALID
+ */
+int32 CFE_ES_AppID_ToIndex(uint32 AppID, uint32 *Idx);
+
+/**
+ * @brief Obtain an index value correlating to an ES Task ID
+ *
+ * This calculates a zero based integer value that may be used for indexing
+ * into a local resource table/array.
+ *
+ * Index values are only guaranteed to be unique for resources of the same
+ * type.  For instance, the indices corresponding to two [valid] Task
+ * IDs will never overlap, but the index of an Task and a library ID
+ * may be the same.  Furthermore, indices may be reused if a resource is
+ * deleted and re-created.
+ *
+ * @note There is no inverse of this function - indices cannot be converted
+ * back to the original TaskID value.  The caller should retain the original ID
+ * for future use.
+ *
+ * @param   TaskID[in]  Task ID to convert
+ * @param   Idx[out]    Buffer where the calculated index will be stored
+ *
+ * @return Execution status, see @ref CFEReturnCodes
+ * @retval #CFE_SUCCESS                 @copybrief CFE_SUCCESS
+ * @retval #CFE_ES_RESOURCE_ID_INVALID  @copybrief CFE_ES_RESOURCE_ID_INVALID
+ */
+int32 CFE_ES_TaskID_ToIndex(uint32 TaskID, uint32 *Idx);
+
+/**
  * \brief Application Information
  * 
  * Structure that is used to provide information about an app.
@@ -683,6 +780,28 @@ int32 CFE_ES_GetResetType(uint32 *ResetSubtypePtr);
 **
 ******************************************************************************/
 int32 CFE_ES_GetAppID(uint32 *AppIdPtr);
+
+/*****************************************************************************/
+/**
+** \brief Get the task ID of the calling context
+**
+** \par Description
+**        This retrieves the current task context from OSAL
+**
+** \par Assumptions, External Events, and Notes:
+**        Applications which desire to call other CFE ES services such as
+**        CFE_ES_TaskGetInfo() should use this API rather than getting the ID
+**        from OSAL directly via OS_TaskGetId().
+**
+** \param[out]   TaskIdPtr      Pointer to variable that is to receive the ID.
+**                              Will be set to the ID of the calling task.
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS          \copybrief CFE_SUCCESS
+** \retval #CFE_ES_ERR_TASKID    \copybrief CFE_ES_ERR_TASKID
+**
+******************************************************************************/
+int32 CFE_ES_GetTaskID(uint32 *TaskIdPtr);
 
 /*****************************************************************************/
 /**

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.c
@@ -288,8 +288,8 @@ void CFE_SB_LockSharedData(const char *FuncName, int32 LineNumber){
 
         CFE_ES_GetAppID(&AppId);
 
-        CFE_ES_WriteToSysLog("SB SharedData Mutex Take Err Stat=0x%x,App=%d,Func=%s,Line=%d\n",
-                (unsigned int)Status,(int)AppId,FuncName,(int)LineNumber);
+        CFE_ES_WriteToSysLog("SB SharedData Mutex Take Err Stat=0x%x,App=%lu,Func=%s,Line=%d\n",
+                (unsigned int)Status,CFE_ES_ResourceID_ToInteger(AppId),FuncName,(int)LineNumber);
 
     }/* end if */
 
@@ -323,8 +323,8 @@ void CFE_SB_UnlockSharedData(const char *FuncName, int32 LineNumber){
 
         CFE_ES_GetAppID(&AppId);
 
-        CFE_ES_WriteToSysLog("SB SharedData Mutex Give Err Stat=0x%x,App=%d,Func=%s,Line=%d\n",
-                (unsigned int)Status,(int)AppId,FuncName,(int)LineNumber);
+        CFE_ES_WriteToSysLog("SB SharedData Mutex Give Err Stat=0x%x,App=%lu,Func=%s,Line=%d\n",
+                (unsigned int)Status,CFE_ES_ResourceID_ToInteger(AppId),FuncName,(int)LineNumber);
 
     }/* end if */
 
@@ -673,17 +673,22 @@ char *CFE_SB_GetAppTskName(uint32 TaskId,char *FullName){
 */
 uint32 CFE_SB_RequestToSendEvent(uint32 TaskId, uint32 Bit){
 
-    OS_ConvertToArrayIndex(TaskId, &TaskId);
+    uint32 Indx;
+
+    if (CFE_ES_TaskID_ToIndex(TaskId, &Indx) != CFE_SUCCESS)
+    {
+        return CFE_SB_DENIED;
+    }
 
     /* if bit is set... */
-    if(CFE_TST(CFE_SB.StopRecurseFlags[TaskId],Bit))
+    if(CFE_TST(CFE_SB.StopRecurseFlags[Indx],Bit))
     {
 
       return CFE_SB_DENIED;
 
     }else{
 
-      CFE_SET(CFE_SB.StopRecurseFlags[TaskId],Bit);
+      CFE_SET(CFE_SB.StopRecurseFlags[Indx],Bit);
       return CFE_SB_GRANTED;
 
     }/* end if */
@@ -705,10 +710,15 @@ uint32 CFE_SB_RequestToSendEvent(uint32 TaskId, uint32 Bit){
 */
 void CFE_SB_FinishSendEvent(uint32 TaskId, uint32 Bit){
 
-    OS_ConvertToArrayIndex(TaskId, &TaskId);
+    uint32 Indx;
+
+    if (CFE_ES_TaskID_ToIndex(TaskId, &Indx) != CFE_SUCCESS)
+    {
+        return;
+    }
 
     /* clear the bit so the task may send this event again */
-    CFE_CLR(CFE_SB.StopRecurseFlags[TaskId],Bit);
+    CFE_CLR(CFE_SB.StopRecurseFlags[Indx],Bit);
 }/* end CFE_SB_RequestToSendEvent */
 
 

--- a/fsw/cfe-core/src/tbl/cfe_tbl_api.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_api.c
@@ -67,7 +67,7 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
     CFE_TBL_Handle_t            AccessIndex;
 
     /* Check to make sure calling application is legit */
-    Status = CFE_TBL_ValidateAppID(&ThisAppId);
+    Status = CFE_ES_GetAppID(&ThisAppId);
 
     if (Status == CFE_SUCCESS)
     {
@@ -147,7 +147,8 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
     }
     else  /* Application ID was invalid */
     {
-        CFE_ES_WriteToSysLog("CFE_TBL:Register-Bad AppId(%d)\n", (int)ThisAppId);
+        CFE_ES_WriteToSysLog("CFE_TBL:Register-Bad AppId(%lu)\n",
+                CFE_ES_ResourceID_ToInteger(ThisAppId));
     }
 
     /* If input parameters appear acceptable, register the table */
@@ -208,8 +209,9 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
             {
                 Status = CFE_TBL_ERR_DUPLICATE_NOT_OWNED;
 
-                CFE_ES_WriteToSysLog("CFE_TBL:Register-App(%d) Registering Duplicate Table '%s' owned by App(%d)\n",
-                                     (int)ThisAppId, TblName, (int)RegRecPtr->OwnerAppId);
+                CFE_ES_WriteToSysLog("CFE_TBL:Register-App(%lu) Registering Duplicate Table '%s' owned by App(%lu)\n",
+                                     CFE_ES_ResourceID_ToInteger(ThisAppId), TblName,
+                                     CFE_ES_ResourceID_ToInteger(RegRecPtr->OwnerAppId));
             }
         }
         else  /* Table not already in registry */
@@ -515,7 +517,7 @@ int32 CFE_TBL_Share( CFE_TBL_Handle_t *TblHandlePtr,
     char    AppName[OS_MAX_API_NAME] = {"UNKNOWN"};
 
     /* Get a valid Application ID for calling App */
-    Status = CFE_TBL_ValidateAppID(&ThisAppId);
+    Status = CFE_ES_GetAppID(&ThisAppId);
 
     if (Status == CFE_SUCCESS)
     {
@@ -579,7 +581,8 @@ int32 CFE_TBL_Share( CFE_TBL_Handle_t *TblHandlePtr,
     }
     else  /* Application ID was invalid */
     {
-        CFE_ES_WriteToSysLog("CFE_TBL:Share-Bad AppId(%d)\n", (int)ThisAppId);
+        CFE_ES_WriteToSysLog("CFE_TBL:Share-Bad AppId(%lu)\n",
+                CFE_ES_ResourceID_ToInteger(ThisAppId));
     }
 
     /* On Error conditions, notify ground of screw up */
@@ -629,7 +632,7 @@ int32 CFE_TBL_Unregister ( CFE_TBL_Handle_t TblHandle )
             /* NOTE: Allocated memory is freed when all Access Links have been    */
             /*       removed.  This allows Applications to continue to use the    */
             /*       data until they acknowledge that the table has been removed. */
-            RegRecPtr->OwnerAppId = (uint32)CFE_TBL_NOT_OWNED;
+            RegRecPtr->OwnerAppId = CFE_TBL_NOT_OWNED;
 
             /* Remove Table Name */
             RegRecPtr->Name[0] = '\0';
@@ -642,8 +645,8 @@ int32 CFE_TBL_Unregister ( CFE_TBL_Handle_t TblHandle )
     }
     else
     {
-        CFE_ES_WriteToSysLog("CFE_TBL:Unregister-App(%d) does not have access to Tbl Handle=%d\n",
-                             (int)ThisAppId, (int)TblHandle);
+        CFE_ES_WriteToSysLog("CFE_TBL:Unregister-App(%lu) does not have access to Tbl Handle=%d\n",
+                CFE_ES_ResourceID_ToInteger(ThisAppId), (int)TblHandle);
     }
 
     /* On Error conditions, notify ground of screw up */
@@ -925,13 +928,14 @@ int32 CFE_TBL_Update( CFE_TBL_Handle_t TblHandle )
 
         if (Status != CFE_SUCCESS)
         {
-            CFE_ES_WriteToSysLog("CFE_TBL:Update-App(%d) fail to update Tbl '%s' (Stat=0x%08X)\n",
-                                 (int)ThisAppId, RegRecPtr->Name, (unsigned int)Status);
+            CFE_ES_WriteToSysLog("CFE_TBL:Update-App(%lu) fail to update Tbl '%s' (Stat=0x%08X)\n",
+                    CFE_ES_ResourceID_ToInteger(ThisAppId), RegRecPtr->Name, (unsigned int)Status);
         }
     }
     else
     {
-        CFE_ES_WriteToSysLog("CFE_TBL:Update-App(%d) does not have access to Tbl Handle=%d\n", (int)ThisAppId, (int)TblHandle);
+        CFE_ES_WriteToSysLog("CFE_TBL:Update-App(%lu) does not have access to Tbl Handle=%d\n",
+                CFE_ES_ResourceID_ToInteger(ThisAppId), (int)TblHandle);
     }
 
     if (Status != CFE_TBL_ERR_BAD_APP_ID)
@@ -993,7 +997,7 @@ int32 CFE_TBL_GetAddress( void **TblPtr,
     *TblPtr = NULL;
 
     /* Validate the calling application's AppID */
-    Status = CFE_TBL_ValidateAppID(&ThisAppId);
+    Status = CFE_ES_GetAppID(&ThisAppId);
 
     if (Status == CFE_SUCCESS)
     {
@@ -1005,7 +1009,8 @@ int32 CFE_TBL_GetAddress( void **TblPtr,
     }
     else
     {
-        CFE_ES_WriteToSysLog("CFE_TBL:GetAddress-Bad AppId=%d\n", (int)ThisAppId);
+        CFE_ES_WriteToSysLog("CFE_TBL:GetAddress-Bad AppId=%lu\n",
+                CFE_ES_ResourceID_ToInteger(ThisAppId));
     }
 
     return Status;
@@ -1036,8 +1041,8 @@ int32 CFE_TBL_ReleaseAddress( CFE_TBL_Handle_t TblHandle )
     }
     else
     {
-        CFE_ES_WriteToSysLog("CFE_TBL:ReleaseAddress-App(%d) does not have access to Tbl Handle=%d\n",
-                             (int)ThisAppId, (int)TblHandle);
+        CFE_ES_WriteToSysLog("CFE_TBL:ReleaseAddress-App(%lu) does not have access to Tbl Handle=%u\n",
+                CFE_ES_ResourceID_ToInteger(ThisAppId), (unsigned int)TblHandle);
     }
 
     return Status;
@@ -1061,7 +1066,7 @@ int32 CFE_TBL_GetAddresses( void **TblPtrs[],
     }
 
     /* Validate the calling application's AppID */
-    Status = CFE_TBL_ValidateAppID(&ThisAppId);
+    Status = CFE_ES_GetAppID(&ThisAppId);
 
     if (Status == CFE_SUCCESS)
     {
@@ -1082,7 +1087,8 @@ int32 CFE_TBL_GetAddresses( void **TblPtrs[],
     }
     else
     {
-        CFE_ES_WriteToSysLog("CFE_TBL:GetAddresses-Bad AppId=%d\n", (int)ThisAppId);
+        CFE_ES_WriteToSysLog("CFE_TBL:GetAddresses-Bad AppId=%lu\n",
+                CFE_ES_ResourceID_ToInteger(ThisAppId));
     }
 
     return Status;
@@ -1184,8 +1190,8 @@ int32 CFE_TBL_Validate( CFE_TBL_Handle_t TblHandle )
                 
                 if (Status > CFE_SUCCESS)
                 {
-                    CFE_ES_WriteToSysLog("CFE_TBL:Validate-App(%u) Validation func return code invalid (Stat=0x%08X) for '%s'\n",
-                            (unsigned int)CFE_TBL_TaskData.TableTaskAppId, (unsigned int)Status, RegRecPtr->Name);
+                    CFE_ES_WriteToSysLog("CFE_TBL:Validate-App(%lu) Validation func return code invalid (Stat=0x%08X) for '%s'\n",
+                            CFE_ES_ResourceID_ToInteger(CFE_TBL_TaskData.TableTaskAppId), (unsigned int)Status, RegRecPtr->Name);
                 }
             }
 
@@ -1233,8 +1239,8 @@ int32 CFE_TBL_Validate( CFE_TBL_Handle_t TblHandle )
                 
                 if (Status > CFE_SUCCESS)
                 {
-                    CFE_ES_WriteToSysLog("CFE_TBL:Validate-App(%u) Validation func return code invalid (Stat=0x%08X) for '%s'\n",
-                            (unsigned int)CFE_TBL_TaskData.TableTaskAppId, (unsigned int)Status, RegRecPtr->Name);
+                    CFE_ES_WriteToSysLog("CFE_TBL:Validate-App(%lu) Validation func return code invalid (Stat=0x%08X) for '%s'\n",
+                            CFE_ES_ResourceID_ToInteger(CFE_TBL_TaskData.TableTaskAppId), (unsigned int)Status, RegRecPtr->Name);
                 }
             }
 
@@ -1256,8 +1262,8 @@ int32 CFE_TBL_Validate( CFE_TBL_Handle_t TblHandle )
     }
     else
     {
-        CFE_ES_WriteToSysLog("CFE_TBL:Validate-App(%d) does not have access to Tbl Handle=%d\n",
-                             (int)ThisAppId, (int)TblHandle);
+        CFE_ES_WriteToSysLog("CFE_TBL:Validate-App(%lu) does not have access to Tbl Handle=%d\n",
+                CFE_ES_ResourceID_ToInteger(ThisAppId), (int)TblHandle);
     }
 
     return Status;
@@ -1356,8 +1362,8 @@ int32 CFE_TBL_GetStatus( CFE_TBL_Handle_t TblHandle )
     }
     else
     {
-        CFE_ES_WriteToSysLog("CFE_TBL:GetStatus-App(%d) does not have access to Tbl Handle=%d\n",
-                             (int)ThisAppId, (int)TblHandle);
+        CFE_ES_WriteToSysLog("CFE_TBL:GetStatus-App(%lu) does not have access to Tbl Handle=%d\n",
+                CFE_ES_ResourceID_ToInteger(ThisAppId), (int)TblHandle);
     }
 
     return Status;
@@ -1519,8 +1525,8 @@ int32 CFE_TBL_Modified( CFE_TBL_Handle_t TblHandle )
     }
     else
     {
-        CFE_ES_WriteToSysLog("CFE_TBL:Modified-App(%d) does not have access to Tbl Handle=%d\n",
-                             (int)ThisAppId, (int)TblHandle);
+        CFE_ES_WriteToSysLog("CFE_TBL:Modified-App(%lu) does not have access to Tbl Handle=%d\n",
+                CFE_ES_ResourceID_ToInteger(ThisAppId), (int)TblHandle);
     }
 
     
@@ -1558,8 +1564,8 @@ int32 CFE_TBL_NotifyByMessage(CFE_TBL_Handle_t TblHandle, CFE_SB_MsgId_t MsgId, 
         else
         {
             Status = CFE_TBL_ERR_NO_ACCESS;
-            CFE_ES_WriteToSysLog("CFE_TBL:NotifyByMsg-App(%d) does not own Tbl Handle=%d\n",
-                                 (int)ThisAppId, (int)TblHandle);
+            CFE_ES_WriteToSysLog("CFE_TBL:NotifyByMsg-App(%lu) does not own Tbl Handle=%d\n",
+                    CFE_ES_ResourceID_ToInteger(ThisAppId), (int)TblHandle);
         }
     }
     

--- a/fsw/cfe-core/src/tbl/cfe_tbl_internal.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_internal.h
@@ -49,27 +49,6 @@
 
 /*****************************************************************************/
 /**
-** \brief Validates the Application ID associated with calling Application
-**
-** \par Description
-**        Validates Application ID of calling App.  Validation
-**        consists of ensuring the AppID is between zero and
-**        #CFE_PLATFORM_ES_MAX_APPLICATIONS.
-**
-** \par Assumptions, External Events, and Notes:
-**          None
-**
-** \param[in, out]  AppIdPtr Pointer to value that will hold AppID on return. *AppIdPtr is the AppID as obtained from #CFE_ES_GetAppID
-** 
-**
-** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
-** \retval #CFE_TBL_ERR_BAD_APP_ID          \copydoc CFE_TBL_ERR_BAD_APP_ID
-**                     
-******************************************************************************/
-int32   CFE_TBL_ValidateAppID(uint32 *AppIdPtr);
-
-/*****************************************************************************/
-/**
 ** \brief Validates specified handle to ensure legality
 **
 ** \par Description

--- a/fsw/cfe-core/src/time/cfe_time_api.c
+++ b/fsw/cfe-core/src/time/cfe_time_api.c
@@ -819,22 +819,27 @@ int32  CFE_TIME_RegisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPt
 {
     int32  Status;
     uint32 AppId;
+    uint32 AppIndex;
 
     Status = CFE_ES_GetAppID(&AppId);
+    if (Status == CFE_SUCCESS)
+    {
+        Status = CFE_ES_AppID_ToIndex(AppId, &AppIndex);
+    }
     if (Status != CFE_SUCCESS)
     {
         /* Called from an invalid context */
         return Status;
     }
 
-    if (AppId >= (sizeof(CFE_TIME_TaskData.SynchCallback) / sizeof(CFE_TIME_TaskData.SynchCallback[0])) ||
-        CFE_TIME_TaskData.SynchCallback[AppId].Ptr != NULL)
+    if (AppIndex >= (sizeof(CFE_TIME_TaskData.SynchCallback) / sizeof(CFE_TIME_TaskData.SynchCallback[0])) ||
+        CFE_TIME_TaskData.SynchCallback[AppIndex].Ptr != NULL)
     {
         Status = CFE_TIME_TOO_MANY_SYNCH_CALLBACKS;
     }
     else
     {
-        CFE_TIME_TaskData.SynchCallback[AppId].Ptr = CallbackFuncPtr;
+        CFE_TIME_TaskData.SynchCallback[AppIndex].Ptr = CallbackFuncPtr;
     }
     
     return Status;
@@ -848,22 +853,27 @@ int32  CFE_TIME_UnregisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFunc
 {
     int32  Status;
     uint32 AppId;
+    uint32 AppIndex;
 
     Status = CFE_ES_GetAppID(&AppId);
+    if (Status == CFE_SUCCESS)
+    {
+        Status = CFE_ES_AppID_ToIndex(AppId, &AppIndex);
+    }
     if (Status != CFE_SUCCESS)
     {
         /* Called from an invalid context */
         return Status;
     }
 
-    if (AppId >= (sizeof(CFE_TIME_TaskData.SynchCallback) / sizeof(CFE_TIME_TaskData.SynchCallback[0])) ||
-            CFE_TIME_TaskData.SynchCallback[AppId].Ptr != CallbackFuncPtr)
+    if (AppIndex >= (sizeof(CFE_TIME_TaskData.SynchCallback) / sizeof(CFE_TIME_TaskData.SynchCallback[0])) ||
+            CFE_TIME_TaskData.SynchCallback[AppIndex].Ptr != CallbackFuncPtr)
     {
         Status = CFE_TIME_CALLBACK_NOT_REGISTERED;
     }
     else
     {
-        CFE_TIME_TaskData.SynchCallback[AppId].Ptr = NULL;
+        CFE_TIME_TaskData.SynchCallback[AppIndex].Ptr = NULL;
     }
     
     return Status;

--- a/fsw/cfe-core/src/time/cfe_time_utils.c
+++ b/fsw/cfe-core/src/time/cfe_time_utils.c
@@ -1139,11 +1139,16 @@ void CFE_TIME_Set1HzAdj(CFE_TIME_SysTime_t NewAdjust, int16 Direction)
 int32 CFE_TIME_CleanUpApp(uint32 AppId)
 {
     int32 Status;
+    uint32 AppIndex;
 
-    if (AppId < (sizeof(CFE_TIME_TaskData.SynchCallback) / sizeof(CFE_TIME_TaskData.SynchCallback[0])))
+    Status = CFE_ES_AppID_ToIndex(AppId, &AppIndex);
+    if (Status != CFE_SUCCESS)
     {
-        CFE_TIME_TaskData.SynchCallback[AppId].Ptr = NULL;
-        Status = CFE_SUCCESS;
+        /* Do nothing */
+    }
+    else if (AppIndex < (sizeof(CFE_TIME_TaskData.SynchCallback) / sizeof(CFE_TIME_TaskData.SynchCallback[0])))
+    {
+        CFE_TIME_TaskData.SynchCallback[AppIndex].Ptr = NULL;
     }
     else
     {

--- a/fsw/cfe-core/unit-test/es_UT.h
+++ b/fsw/cfe-core/unit-test/es_UT.h
@@ -333,5 +333,6 @@ void TestCDSMempool(void);
 void TestESMempool(void);
 
 void TestSysLog(void);
+void TestGenericCounterAPI(void);
 
 #endif /* _es_ut_h_ */

--- a/fsw/cfe-core/unit-test/fs_UT.c
+++ b/fsw/cfe-core/unit-test/fs_UT.c
@@ -43,8 +43,8 @@
 const char *FS_SYSLOG_MSGS[] =
 {
         NULL,
-        "FS SharedData Mutex Take Err Stat=0x%x,App=%d,Function=%s\n",
-        "FS SharedData Mutex Give Err Stat=0x%x,App=%d,Function=%s\n"
+        "FS SharedData Mutex Take Err Stat=0x%x,App=%lu,Function=%s\n",
+        "FS SharedData Mutex Give Err Stat=0x%x,App=%lu,Function=%s\n"
 };
 
 /*

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -112,6 +112,15 @@ const CFE_SB_MsgId_t SB_UT_ALTERNATE_INVALID_MID = CFE_SB_MSGID_WRAP_VALUE(CFE_P
 const CFE_SB_MsgId_t SB_UT_BARE_CMD_MID3 = CFE_SB_MSGID_WRAP_VALUE(0x1003);
 const CFE_SB_MsgId_t SB_UT_BARE_TLM_MID3 = CFE_SB_MSGID_WRAP_VALUE(0x0003);
 
+/*
+ * Helper function to "corrupt" a resource ID value in a consistent/predicatble way,
+ * which can also be un-done easily.
+ */
+uint32 UT_SB_ResourceID_Modify(uint32 InitialID, int32 Modifier)
+{
+    uint32 NewValue = InitialID + Modifier;
+    return (NewValue);
+}
 
 /*
 ** Functions
@@ -1731,7 +1740,7 @@ void Test_DeletePipe_InvalidPipeOwner(void)
     RealOwner = CFE_SB.PipeTbl[PipedId].AppId;
 
     /* Choose a value that is sure not to be owner */
-    CFE_SB.PipeTbl[PipedId].AppId = RealOwner + 1;
+    CFE_SB.PipeTbl[PipedId].AppId = UT_SB_ResourceID_Modify(RealOwner, 1);
     ASSERT_EQ(CFE_SB_DeletePipe(PipedId), CFE_SB_BAD_ARGUMENT);
 
     EVTCNT(2);
@@ -2391,7 +2400,7 @@ void Test_Subscribe_InvalidPipeOwner(void)
     CFE_SB_PipeId_t PipeId;
     CFE_SB_MsgId_t  MsgId = SB_UT_TLM_MID;
     uint16          PipeDepth = 10;
-    int32           RealOwner;
+    uint32          RealOwner;
 
     SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "TestPipe"));
 
@@ -2399,7 +2408,7 @@ void Test_Subscribe_InvalidPipeOwner(void)
     RealOwner = CFE_SB.PipeTbl[PipeId].AppId;
 
     /* Choose a value that is sure not to be owner */
-    CFE_SB.PipeTbl[PipeId].AppId = RealOwner + 1;
+    CFE_SB.PipeTbl[PipeId].AppId = UT_SB_ResourceID_Modify(RealOwner, 1);
     CFE_SB_Subscribe(MsgId, PipeId);
 
     EVTCNT(3);
@@ -2583,7 +2592,7 @@ void Test_Unsubscribe_InvalidPipeOwner(void)
     RealOwner = CFE_SB.PipeTbl[PipeId].AppId;
 
     /* Choose a value that is sure not be owner */
-    CFE_SB.PipeTbl[PipeId].AppId = RealOwner + 1;
+    CFE_SB.PipeTbl[PipeId].AppId = UT_SB_ResourceID_Modify(RealOwner, 1);
     ASSERT_EQ(CFE_SB_Unsubscribe(MsgId, PipeId), CFE_SB_BAD_ARGUMENT);
 
     EVTCNT(4);
@@ -3533,6 +3542,9 @@ void Test_CleanupApp_API(void)
     CFE_SB_PipeId_t         PipeId;
     CFE_SB_ZeroCopyHandle_t ZeroCpyBufHndl = 0;
     uint16                  PipeDepth = 50;
+    uint32     AppID;
+
+    CFE_ES_GetAppID(&AppID);
 
     SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "TestPipe"));
     CFE_SB_ZeroCopyGetPtr(PipeDepth, &ZeroCpyBufHndl);
@@ -3540,17 +3552,17 @@ void Test_CleanupApp_API(void)
 
     /* Set second application ID to provide complete branch path coverage */
     CFE_SB.PipeTbl[1].InUse = CFE_SB_IN_USE;
-    CFE_SB.PipeTbl[1].AppId = 1;
+    CFE_SB.PipeTbl[1].AppId = AppID;
 
     ASSERT_TRUE(CFE_SB.ZeroCopyTail != NULL);
 
     /* Attempt with a bad application ID first in order to get full branch path
      * coverage in CFE_SB_ZeroCopyReleaseAppId
      */
-    CFE_SB_CleanUpApp(1);
+    CFE_SB_CleanUpApp(0);
 
     /* Attempt again with a valid application ID */
-    CFE_SB_CleanUpApp(0);
+    CFE_SB_CleanUpApp(AppID);
 
     ASSERT_TRUE(CFE_SB.ZeroCopyTail == NULL);
 
@@ -3901,13 +3913,14 @@ void Test_OS_MutSem_ErrLogic(void)
 */
 void Test_ReqToSendEvent_ErrLogic(void)
 {
-    uint32 TaskId = 13;
+    uint32 TaskId;
     uint32 Bit = 5;
 
     /* Clear task bits, then call function, which should set the bit for
      * the specified task
      */
-    CFE_SB.StopRecurseFlags[TaskId] = 0x0000;
+    CFE_ES_GetTaskID(&TaskId);
+    CFE_SB.StopRecurseFlags[0] = 0x0000;
     ASSERT_EQ(CFE_SB_RequestToSendEvent(TaskId, Bit), CFE_SB_GRANTED);
 
     /* Call the function a second time; the result should indicate that the
@@ -3992,13 +4005,15 @@ void Test_CFE_SB_BadPipeInfo(void)
     CFE_SB_PipeId_t PipeId;
     uint16          PipeDepth = 10;
     CFE_SB_Qos_t    CFE_SB_Default_Qos;
+    uint32          AppID;
 
     SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "TestPipe1"));
 
     /* Set the pipe ID to an erroneous value and attempt to delete the pipe */
     CFE_SB.PipeTbl[0].PipeId = 1;
     CFE_SB.PipeTbl[0].InUse = 1;
-    ASSERT_EQ(CFE_SB_DeletePipeFull(0, 0), CFE_SB_BAD_ARGUMENT);
+    CFE_ES_GetAppID(&AppID);
+    ASSERT_EQ(CFE_SB_DeletePipeFull(0, AppID), CFE_SB_BAD_ARGUMENT);
 
     EVTCNT(2);
 

--- a/fsw/cfe-core/unit-test/time_UT.c
+++ b/fsw/cfe-core/unit-test/time_UT.c
@@ -3297,6 +3297,7 @@ void Test_CleanUpApp(void)
     uint16   i;
     uint16 Count;
     int32  Status = CFE_SUCCESS;
+    uint32 AppIndex;
     uint32 TestAppId;
 
 #ifdef UT_VERBOSE
@@ -3313,16 +3314,19 @@ void Test_CleanUpApp(void)
     }
 
     /* Add callbacks for 3 apps into callback registry table */
-    UT_SetAppID(1);
+    AppIndex = 1;
+    UT_SetDataBuffer(UT_KEY(CFE_ES_AppID_ToIndex), &AppIndex, sizeof(AppIndex), false);
     CFE_TIME_RegisterSynchCallback(&ut_time_MyCallbackFunc);
-    UT_SetAppID(2);
+    AppIndex = 2;
+    UT_SetDataBuffer(UT_KEY(CFE_ES_AppID_ToIndex), &AppIndex, sizeof(AppIndex), false);
     CFE_TIME_RegisterSynchCallback(&ut_time_MyCallbackFunc);
-    UT_SetAppID(3);
+    AppIndex = 3;
+    UT_SetDataBuffer(UT_KEY(CFE_ES_AppID_ToIndex), &AppIndex, sizeof(AppIndex), false);
     CFE_TIME_RegisterSynchCallback(&ut_time_MyCallbackFunc);
 
     /* Clean up an app which did not have a callback */
-    TestAppId = 4;
-    UT_SetAppID(TestAppId);
+    AppIndex = 4;
+    UT_SetDataBuffer(UT_KEY(CFE_ES_AppID_ToIndex), &AppIndex, sizeof(AppIndex), false);
     Status = CFE_TIME_CleanUpApp(TestAppId);
     UT_Report(__FILE__, __LINE__,
               Status == CFE_SUCCESS,
@@ -3345,8 +3349,8 @@ void Test_CleanUpApp(void)
               "No Sync Callback entry cleared");
 
     /* Clean up an app which did have a callback */
-    TestAppId = 2;
-    UT_SetAppID(TestAppId);
+    AppIndex = 2;
+    UT_SetDataBuffer(UT_KEY(CFE_ES_AppID_ToIndex), &AppIndex, sizeof(AppIndex), false);
     Status = CFE_TIME_CleanUpApp(TestAppId);
     UT_Report(__FILE__, __LINE__,
               Status == CFE_SUCCESS,
@@ -3370,8 +3374,7 @@ void Test_CleanUpApp(void)
 
     /* Test response to a bad application ID -
      * This is effectively a no-op but here for coverage */
-    UT_SetAppID(CFE_PLATFORM_ES_MAX_APPLICATIONS);
-    Status = CFE_TIME_CleanUpApp(CFE_PLATFORM_ES_MAX_APPLICATIONS);
+    Status = CFE_TIME_CleanUpApp(99999);
     UT_Report(__FILE__, __LINE__,
               Status == CFE_TIME_CALLBACK_NOT_REGISTERED,
               "CFE_TIME_CleanUpApp",

--- a/fsw/cfe-core/unit-test/ut_osprintf_stubs.c
+++ b/fsw/cfe-core/unit-test/ut_osprintf_stubs.c
@@ -160,5 +160,7 @@ const char *UT_OSP_MESSAGES[] =
         [UT_OSP_NO_FREE_CORE_APP_SLOTS] = "ES Startup: Error, No free application slots available for CORE App!\n",
         /* ES Startup: CFE_ES_Global.TaskTable record used error for App: CFE_EVS, continuing. */
         [UT_OSP_RECORD_USED] = "ES Startup: CFE_ES_Global.TaskTable record used error for App: %s, continuing.\n",
+        /* CFE_ES_ExitChildTask called from invalid task context */
+        [UT_OSP_TASKEXIT_BAD_CONTEXT] = "CFE_ES_ExitChildTask called from invalid task context\n",
 };
 

--- a/fsw/cfe-core/unit-test/ut_osprintf_stubs.h
+++ b/fsw/cfe-core/unit-test/ut_osprintf_stubs.h
@@ -95,6 +95,7 @@
 #define UT_OSP_NO_FREE_CORE_APP_SLOTS     66
 #define UT_OSP_STARTUP_SYNC_FAIL_2        67
 #define UT_OSP_MODULE_UNLOAD_FAILED       68
+#define UT_OSP_TASKEXIT_BAD_CONTEXT       69
 
 #endif
 


### PR DESCRIPTION
**Describe the contribution**
Introduce wrapper/accessor functions to look up table entries by ID for ES & EVS subsystems.

__Do not use AppID as a table index__.

Note - This does not change existing external APIs and AppIDs are still zero-based uint32.  This only changes the internal
structures to remove use of ID as an array index, and to use a lookup function to locate the table entry from an ID.  All entry access is then performed via the table entry pointer, rather than as an array index.

This provides the groundwork for abstract IDs without actually changing anything fundamental about resource IDs.

Fixes #797 

**Testing performed**
Build and sanity check CFE - start up apps and send commands, confirm normal operation
Run all unit tests.

**Expected behavior changes**
No impact to behavior - internal refactoring only.
API additions to support more abstract resource IDs.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
