### PR TITLE
Fix #863, Add debug message from SendEvents

### DIFF
--- a/fsw/cfe-core/ut-stubs/ut_evs_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_evs_stubs.c
@@ -35,6 +35,7 @@
 #include <string.h>
 #include "cfe.h"
 #include "utstubs.h"
+#include "uttools.h"
 
 /*
 ** Functions
@@ -112,6 +113,8 @@ int32 CFE_EVS_SendEvent(uint16 EventID,
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_EVS_SendEvent), EventType);
     UT_Stub_RegisterContext(UT_KEY(CFE_EVS_SendEvent), Spec);
 
+    UtDebug("CFE_EVS_SendEvent: %u - %s", EventID, Spec);
+
     int32 status;
     va_list va;
 
@@ -162,6 +165,8 @@ int32 CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time,
 
     int32 status;
     va_list va;
+
+    UtDebug("CFE_EVS_SendTimedEvent: %u - %s", EventID, Spec);
 
     va_start(va, Spec);
     status = UT_DefaultStubImplWithArgs(__func__, UT_KEY(CFE_EVS_SendTimedEvent), CFE_SUCCESS, va);
@@ -246,6 +251,8 @@ int32 CFE_EVS_SendEventWithAppID(uint16 EventID,
 
     int32 status;
     va_list va;
+
+    UtDebug("CFE_EVS_SendEventWithAppID: %u - %s", EventID, Spec);
 
     va_start(va, Spec);
     status = UT_DefaultStubImplWithArgs(__func__, UT_KEY(CFE_EVS_SendEventWithAppID), CFE_SUCCESS, va);


### PR DESCRIPTION
**Describe the contribution**
Fix #863 - added debug message

**Testing performed**
Built and ran test (used to debug failure in https://github.com/nasa/cFS/pull/136)

**Expected behavior changes**
Now prints EID and Spec when stub APIs are called in debug mode.

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: main bundle + this commit

**Additional context**
None.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC