### PR TITLE
fix #862 - unsub of a message ID that is already unsubbed

### DIFF
--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -2535,7 +2535,7 @@ void Test_Unsubscribe_NoMatch(void)
     CFE_SB.RoutingTbl[CFE_SB_RouteIdxToValue(Idx)].ListHeadPtr->Next = NULL;
     ASSERT(CFE_SB_Unsubscribe(MsgId, TestPipe));
 
-    EVTCNT(6);
+    EVTCNT(7);
 
     EVTSENT(CFE_SB_UNSUB_NO_SUBS_EID);
 


### PR DESCRIPTION
Closes #862 

**Describe the contribution**
After the changes implemented in #101, there may be routing table entries with no subscribers (RoutePtr->ListHeadPtr would be NULL.) This could cause a seg-fault. Also, even if there are entries in the routing table, there will be no event generated if the unsubscribe does not find a matching route entry.

**Testing performed**
Ran unit test (with updated event count.)

**Expected behavior changes**
Repeated unsubscriptions should function fine, generating an informational event if there is not a current subscription.

**System(s) tested on**
Debian 10.5

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov