### PR TITLE
HOTFIX-20200902, Fix sb unit test setup issue

### DIFF
--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -133,8 +133,9 @@ void UtTest_Setup(void)
     Test_Subscribe_API();
     Test_Unsubscribe_API();
     Test_SendMsg_API();
-    UtTest_Add(Test_RcvMsg_API, NULL, Test_CleanupApp_API, "Test_RcvMsg_API");
-    UT_ADD_TEST(Test_SB_Utils);
+    Test_RcvMsg_API();
+    SB_UT_ADD_SUBTEST(Test_CleanupApp_API);
+    Test_SB_Utils();
 
     Test_SB_SpecialCases();
 


### PR DESCRIPTION
**Describe the contribution**
Fix integration-candidate - there was some convoluted test setup logic which actually caused some of the tests to be skipped and the CleanApp API test wasn't proceeded by a test reset so the event count didn't match expected.  Caused a TTF.

Basically just straightened out the setup (no actual test changes.)

**Testing performed**
Make, make test - passed

**Expected behavior changes**
Tests pass, no TTF.

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: bundle IC + this change

**Additional context**
nasa/cFS#136

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC