### PR TITLE
Fix #788, Simplified CFE_EVS_SendEvent macros

### DIFF
--- a/fsw/cfe-core/src/inc/cfe_evs.h
+++ b/fsw/cfe-core/src/inc/cfe_evs.h
@@ -59,6 +59,14 @@
 #define OS_PRINTF(m,n) 
 #endif
 
+/*
+** Utility macros to make for simpler/more compact/readable code.
+*/
+#define CFE_EVS_SendDbg(E,...) CFE_EVS_SendEvent((E), CFE_EVS_EventType_DEBUG, __VA_ARGS__)
+#define CFE_EVS_SendInfo(E,...) CFE_EVS_SendEvent((E), CFE_EVS_EventType_INFORMATION, __VA_ARGS__)
+#define CFE_EVS_SendErr(E,...) CFE_EVS_SendEvent((E), CFE_EVS_EventType_ERROR, __VA_ARGS__)
+#define CFE_EVS_SendCrit(E,...) CFE_EVS_SendEvent((E), CFE_EVS_EventType_CRITICAL, __VA_ARGS__)
+
 /** \name Common Event Filter Mask Values  */
 /** \{ */
 #define  CFE_EVS_NO_FILTER        0x0000       /**< \brief Stops any filtering.  All messages are sent. */

--- a/fsw/cfe-core/src/inc/cfe_evs.h
+++ b/fsw/cfe-core/src/inc/cfe_evs.h
@@ -62,10 +62,11 @@
 /*
 ** Utility macros to make for simpler/more compact/readable code.
 */
-#define CFE_EVS_SendDbg(E,...) CFE_EVS_SendEvent((E), CFE_EVS_EventType_DEBUG, __VA_ARGS__)
-#define CFE_EVS_SendInfo(E,...) CFE_EVS_SendEvent((E), CFE_EVS_EventType_INFORMATION, __VA_ARGS__)
-#define CFE_EVS_SendErr(E,...) CFE_EVS_SendEvent((E), CFE_EVS_EventType_ERROR, __VA_ARGS__)
-#define CFE_EVS_SendCrit(E,...) CFE_EVS_SendEvent((E), CFE_EVS_EventType_CRITICAL, __VA_ARGS__)
+#define CFE_EVS_Send(E,T,...) CFE_EVS_SendEvent((E), CFE_EVS_EventType_##T, __VA_ARGS__)
+#define CFE_EVS_SendDbg(E,...) CFE_EVS_Send(E, DEBUG, __VA_ARGS__)
+#define CFE_EVS_SendInfo(E,...) CFE_EVS_Send(E, INFORMATION, __VA_ARGS__)
+#define CFE_EVS_SendErr(E,...) CFE_EVS_Send(E, ERROR, __VA_ARGS__)
+#define CFE_EVS_SendCrit(E,...) CFE_EVS_Send(E, CRITICAL, __VA_ARGS__)
 
 /** \name Common Event Filter Mask Values  */
 /** \{ */


### PR DESCRIPTION
Closes #788 

**Describe the contribution**
Macros for more compact calls to CFE_EVS_SendEvent, making the type be part of the fn name.

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov