### PR TITLE
Fix #858, use osal id typedef

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_apps.h
+++ b/fsw/cfe-core/src/es/cfe_es_apps.h
@@ -76,7 +76,7 @@ typedef struct
 
   uint32                StackSize;
   cpuaddr               StartAddress;
-  uint32                ModuleId;
+  osal_id_t             ModuleId;
 
   uint16                ExceptionAction;
   uint16                Priority;

--- a/fsw/cfe-core/src/es/cfe_es_backgroundtask.c
+++ b/fsw/cfe-core/src/es/cfe_es_backgroundtask.c
@@ -246,7 +246,7 @@ void CFE_ES_BackgroundCleanup(void)
     OS_BinSemDelete(CFE_ES_Global.BackgroundTask.WorkSem);
 
     CFE_ES_Global.BackgroundTask.TaskID = 0;
-    CFE_ES_Global.BackgroundTask.WorkSem = 0;
+    CFE_ES_Global.BackgroundTask.WorkSem = OS_OBJECT_ID_UNDEFINED;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/cfe-core/src/es/cfe_es_cds.h
+++ b/fsw/cfe-core/src/es/cfe_es_cds.h
@@ -75,7 +75,7 @@ typedef struct
 
 typedef struct
 {
-    uint32               RegistryMutex;                         /**< \brief Mutex that controls access to CDS Registry */
+    osal_id_t            RegistryMutex;                         /**< \brief Mutex that controls access to CDS Registry */
     uint32               CDSSize;                               /**< \brief Total size of the CDS as reported by BSP */
     uint32               MemPoolSize;
     uint32               MaxNumRegEntries;                      /**< \brief Maximum number of Registry entries */

--- a/fsw/cfe-core/src/es/cfe_es_cds_mempool.h
+++ b/fsw/cfe-core/src/es/cfe_es_cds_mempool.h
@@ -81,7 +81,7 @@ typedef struct {
    int32    SizeIndex;
    uint16   CheckErrCntr;
    uint16   RequestCntr;
-   uint32   MutexId;
+   osal_id_t   MutexId;
    uint32   MinBlockSize;
    CFE_ES_CDSBlockSizeDesc_t SizeDesc[CFE_ES_CDS_NUM_BLOCK_SIZES];
 } CFE_ES_CDSPool_t;

--- a/fsw/cfe-core/src/es/cfe_es_global.h
+++ b/fsw/cfe-core/src/es/cfe_es_global.h
@@ -75,7 +75,7 @@ typedef struct
 typedef struct
 {
     uint32 TaskID;          /**< OSAL ID of the background task */
-    uint32 WorkSem;         /**< Semaphore that is given whenever background work is pending */
+    osal_id_t WorkSem;      /**< Semaphore that is given whenever background work is pending */
     uint32 NumJobsRunning;  /**< Current Number of active jobs (updated by background task) */
 } CFE_ES_BackgroundTaskState_t;
 
@@ -95,12 +95,12 @@ typedef struct
    /*
    ** Shared Data Semaphore
    */
-   uint32 SharedDataMutex;
+   osal_id_t SharedDataMutex;
 
    /*
    ** Performance Data Mutex
    */
-   uint32 PerfDataMutex;
+   osal_id_t PerfDataMutex;
 
    /*
    ** Startup Sync
@@ -371,6 +371,47 @@ extern CFE_ES_AppRecord_t* CFE_ES_GetAppRecordByContext(void);
  * The global data lock should be obtained prior to invoking this function.
  */
 extern CFE_ES_TaskRecord_t* CFE_ES_GetTaskRecordByContext(void);
+
+/**
+ * @brief Convert an ES Task ID to an OSAL task ID
+ *
+ * Task IDs created via CFE ES are also OSAL task IDs, but technically
+ * do refer to a different scope and therefore have a different type
+ * to represent them.
+ *
+ * This function facilitates converting between the types.
+ *
+ * @note Currently the numeric values are the same and can be interchanged
+ * for backward compatibility, however they may diverge in a future version.
+ * New code should not assume equivalence between OSAL and ES task IDs.
+ *
+ * @sa CFE_ES_ResourceID_FromOSAL
+ *
+ * @param[in] id    The ES task ID
+ * @returns         The OSAL task ID
+ */
+osal_id_t CFE_ES_ResourceID_ToOSAL(uint32 id);
+
+/**
+ * @brief Convert an ES Task ID to an OSAL task ID
+ *
+ * Task IDs created via CFE ES are also OSAL task IDs, but technically
+ * do refer to a different scope and therefore have a different type
+ * to represent them.
+ *
+ * This function facilitates converting between the types.
+ *
+ * @note Currently the numeric values are the same and can be interchanged
+ * for backward compatibility, however they may diverge in a future version.
+ * New code should not assume equivalence between OSAL and ES task IDs.
+ *
+ * @sa CFE_ES_ResourceID_ToOSAL
+ *
+ * @param[in] id    The OSAL task ID
+ * @returns         The ES task ID
+ */
+uint32 CFE_ES_ResourceID_FromOSAL(osal_id_t id);
+
 
 /*
 ** Functions used to lock/unlock shared data

--- a/fsw/cfe-core/src/es/cfe_es_perf.h
+++ b/fsw/cfe-core/src/es/cfe_es_perf.h
@@ -110,7 +110,7 @@ typedef struct
     CFE_ES_PerfDumpState_t  PendingState;   /* the pending/next state, if transitioning */
 
     char                DataFileName[OS_MAX_PATH_LEN];  /* output file name from dump command */
-    int32               FileDesc;                       /* file descriptor for writing */
+    osal_id_t           FileDesc;                       /* file descriptor for writing */
     uint32              WorkCredit;                     /* accumulator based on the passage of time */
     uint32              StateCounter;                   /* number of blocks/items left in current state */
     uint32              DataPos;                        /* last position within the Perf Log */

--- a/fsw/cfe-core/src/es/cfe_es_start.c
+++ b/fsw/cfe-core/src/es/cfe_es_start.c
@@ -773,7 +773,7 @@ void  CFE_ES_CreateObjects(void)
     bool      AppSlotFound;
     uint16    i;
     uint16    j;
-    uint32    OsalId;
+    osal_id_t OsalId;
     CFE_ES_AppRecord_t *AppRecPtr;
     CFE_ES_TaskRecord_t *TaskRecPtr;
 
@@ -872,7 +872,7 @@ void  CFE_ES_CreateObjects(void)
                }
                else
                {
-                  AppRecPtr->TaskInfo.MainTaskId = OsalId;
+                  AppRecPtr->TaskInfo.MainTaskId = CFE_ES_ResourceID_FromOSAL(OsalId);
                   TaskRecPtr = CFE_ES_LocateTaskRecordByID(AppRecPtr->TaskInfo.MainTaskId);
 
                   /*

--- a/fsw/cfe-core/src/es/cfe_es_syslog.c
+++ b/fsw/cfe-core/src/es/cfe_es_syslog.c
@@ -468,7 +468,7 @@ void CFE_ES_SysLog_snprintf(char *Buffer, size_t BufferSize, const char *SpecStr
  */
 int32 CFE_ES_SysLogDump(const char *Filename)
 {
-    int32   fd;
+    osal_id_t   fd;
     int32   Status;
     size_t  WritePos;
     size_t  TotalSize;
@@ -479,14 +479,16 @@ int32 CFE_ES_SysLogDump(const char *Filename)
         CFE_FS_Header_t FileHdr;
     } Buffer;
 
-    fd = OS_creat(Filename, OS_WRITE_ONLY);
-    if(fd < 0)
+    Status = OS_creat(Filename, OS_WRITE_ONLY);
+    if(Status < 0)
     {
         CFE_EVS_SendEvent(CFE_ES_SYSLOG2_ERR_EID,CFE_EVS_EventType_ERROR,
                 "Error creating file %s, RC = 0x%08X",
-                Filename,(unsigned int)fd);
+                Filename,(unsigned int)Status);
         return CFE_ES_FILE_IO_ERR;
     }/* end if */
+
+    fd = OS_ObjectIdFromInteger(Status);
 
     CFE_FS_InitHeader(&Buffer.FileHdr, CFE_ES_SYS_LOG_DESC, CFE_FS_SubType_ES_SYSLOG);
 

--- a/fsw/cfe-core/src/es/cfe_es_task.c
+++ b/fsw/cfe-core/src/es/cfe_es_task.c
@@ -1175,7 +1175,7 @@ int32 CFE_ES_QueryOneCmd(const CFE_ES_QueryOne_t *data)
 int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAll_t *data)
 {
     CFE_FS_Header_t       FileHeader;
-    int32                 FileDescriptor;
+    osal_id_t             FileDescriptor;
     uint32                i;
     uint32                EntryCount = 0;
     uint32                FileSize = 0;
@@ -1194,9 +1194,10 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAll_t *data)
     /*
     ** Check to see if the file already exists
     */
-    FileDescriptor = OS_open(QueryAllFilename, OS_READ_ONLY, 0);
-    if (FileDescriptor >= 0)
+    Result = OS_open(QueryAllFilename, OS_READ_ONLY, 0);
+    if (Result >= 0)
     {
+        FileDescriptor = OS_ObjectIdFromInteger(Result);
         OS_close(FileDescriptor);
         OS_remove(QueryAllFilename);
     }
@@ -1204,9 +1205,10 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAll_t *data)
     /*
     ** Create ES task log data file
     */
-    FileDescriptor = OS_creat(QueryAllFilename, OS_WRITE_ONLY);
-    if (FileDescriptor >= 0)
+    Result = OS_creat(QueryAllFilename, OS_WRITE_ONLY);
+    if (Result >= 0)
     {
+        FileDescriptor = OS_ObjectIdFromInteger(Result);
         /*
         ** Initialize cFE file header
         */
@@ -1290,7 +1292,7 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAll_t *data)
     {
         CFE_ES_TaskData.CommandErrorCounter++;
         CFE_EVS_SendEvent(CFE_ES_OSCREATE_ERR_EID, CFE_EVS_EventType_ERROR,
-                "Failed to write App Info file, OS_creat RC = 0x%08X",(unsigned int)FileDescriptor);
+                "Failed to write App Info file, OS_creat RC = 0x%08X",(unsigned int)Result);
     }
 
     return CFE_SUCCESS;
@@ -1305,7 +1307,7 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAll_t *data)
 int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasks_t *data)
 {
     CFE_FS_Header_t            FileHeader;
-    int32                      FileDescriptor;
+    osal_id_t                  FileDescriptor;
     uint32                     i;
     uint32                     EntryCount = 0;
     uint32                     FileSize = 0;
@@ -1323,9 +1325,10 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasks_t *data)
     /*
     ** Check to see if the file already exists
     */
-    FileDescriptor = OS_open(QueryAllFilename, OS_READ_ONLY, 0);
-    if (FileDescriptor >= 0)
+    Result = OS_open(QueryAllFilename, OS_READ_ONLY, 0);
+    if (Result >= 0)
     {
+        FileDescriptor = OS_ObjectIdFromInteger(Result);
         OS_close(FileDescriptor);
         OS_remove(QueryAllFilename);
     }
@@ -1333,9 +1336,10 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasks_t *data)
     /*
     ** Create ES task log data file
     */
-    FileDescriptor = OS_creat(QueryAllFilename, OS_WRITE_ONLY);
-    if (FileDescriptor >= 0)
+    Result = OS_creat(QueryAllFilename, OS_WRITE_ONLY);
+    if (Result >= 0)
     {
+        FileDescriptor = OS_ObjectIdFromInteger(Result);
         /*
         ** Initialize cFE file header
         */
@@ -1419,7 +1423,7 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasks_t *data)
     {
         CFE_ES_TaskData.CommandErrorCounter++;
         CFE_EVS_SendEvent(CFE_ES_TASKINFO_OSCREATE_ERR_EID, CFE_EVS_EventType_ERROR,
-                "Failed to write Task Info file, OS_creat RC = 0x%08X",(unsigned int)FileDescriptor);
+                "Failed to write Task Info file, OS_creat RC = 0x%08X",(unsigned int)Result);
     }
 
     return CFE_SUCCESS;
@@ -1784,7 +1788,7 @@ int32 CFE_ES_SendMemPoolStatsCmd(const CFE_ES_SendMemPoolStats_t *data)
 int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistry_t *data)
 {
     CFE_FS_Header_t               StdFileHeader;
-    int32                         FileDescriptor;
+    osal_id_t                     FileDescriptor;
     int32                         Status;
     int16                         RegIndex=0;
     const CFE_ES_DumpCDSRegistryCmd_Payload_t *CmdPtr = &data->Payload;
@@ -1799,10 +1803,12 @@ int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistry_t *data)
             OS_MAX_PATH_LEN, sizeof(CmdPtr->DumpFilename));
 
     /* Create a new dump file, overwriting anything that may have existed previously */
-    FileDescriptor = OS_creat(DumpFilename, OS_WRITE_ONLY);
+    Status = OS_creat(DumpFilename, OS_WRITE_ONLY);
 
-    if (FileDescriptor >= OS_SUCCESS)
+    if (Status >= OS_SUCCESS)
     {
+        FileDescriptor = OS_ObjectIdFromInteger(Status);
+
         /* Initialize the standard cFE File Header for the Dump File */
         CFE_FS_InitHeader(&StdFileHeader, "CDS_Registry", CFE_FS_SubType_ES_CDS_REG);
 
@@ -1886,7 +1892,7 @@ int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistry_t *data)
         CFE_EVS_SendEvent(CFE_ES_CREATING_CDS_DUMP_ERR_EID,
                 CFE_EVS_EventType_ERROR,
                 "Error creating CDS dump file '%s', Status=0x%08X",
-                DumpFilename, (unsigned int)FileDescriptor);
+                DumpFilename, (unsigned int)Status);
 
         /* Increment Command Error Counter */
         CFE_ES_TaskData.CommandErrorCounter++;

--- a/fsw/cfe-core/src/es/cfe_esmempool.h
+++ b/fsw/cfe-core/src/es/cfe_esmempool.h
@@ -68,7 +68,7 @@ typedef struct
    BlockSizeDesc_t *SizeDescPtr;
    uint16           CheckErrCntr;
    uint16           RequestCntr;
-   uint32           MutexId;
+   osal_id_t        MutexId;
    uint32           UseMutex;
    BlockSizeDesc_t  SizeDesc[CFE_ES_MAX_MEMPOOL_BLOCK_SIZES];
 } Pool_t;

--- a/fsw/cfe-core/src/evs/cfe_evs_log.c
+++ b/fsw/cfe-core/src/evs/cfe_evs_log.c
@@ -154,7 +154,7 @@ int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFile_t *data)
     int32           Result;
     int32           LogIndex;
     int32           BytesWritten;
-    int32           LogFileHandle;
+    osal_id_t       LogFileHandle;
     uint32          i;
     CFE_FS_Header_t LogFileHdr;
     char            LogFilename[OS_MAX_PATH_LEN];
@@ -172,18 +172,19 @@ int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFile_t *data)
                 OS_MAX_PATH_LEN, sizeof(CmdPtr->LogFilename));
 
         /* Create the log file */
-        LogFileHandle = OS_creat(LogFilename, OS_WRITE_ONLY);
+        Result = OS_creat(LogFilename, OS_WRITE_ONLY);
 
-        if (LogFileHandle < OS_SUCCESS)
+        if (Result < OS_SUCCESS)
         {
             EVS_SendEvent(CFE_EVS_ERR_CRLOGFILE_EID, CFE_EVS_EventType_ERROR,
                     "Write Log File Command Error: OS_creat = 0x%08X, filename = %s",
-                    (unsigned int)LogFileHandle, LogFilename);
+                    (unsigned int)Result, LogFilename);
 
-            Result = LogFileHandle;
         }
         else
         {
+            LogFileHandle = OS_ObjectIdFromInteger(Result);
+
             /* Result will be overridden if everything works */
             Result = CFE_EVS_FILE_WRITE_ERROR;
 

--- a/fsw/cfe-core/src/evs/cfe_evs_task.c
+++ b/fsw/cfe-core/src/evs/cfe_evs_task.c
@@ -1737,7 +1737,7 @@ int32 CFE_EVS_DeleteEventFilterCmd(const CFE_EVS_DeleteEventFilter_t *data)
 int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFile_t *data)
 {
    int32                             Result;
-   int32                             FileHandle;
+   osal_id_t                         FileHandle;
    int32                             BytesWritten;
    uint32                            EntryCount = 0;
    uint32                            i;
@@ -1752,18 +1752,18 @@ int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFile_t *data)
            OS_MAX_PATH_LEN, sizeof(CmdPtr->AppDataFilename));
 
    /* Create Application Data File */
-   FileHandle = OS_creat(LocalName, OS_WRITE_ONLY);
+   Result = OS_creat(LocalName, OS_WRITE_ONLY);
 
-   if (FileHandle < OS_SUCCESS)
+   if (Result < OS_SUCCESS)
    {
       EVS_SendEvent(CFE_EVS_ERR_CRDATFILE_EID, CFE_EVS_EventType_ERROR,
                    "Write App Data Command Error: OS_creat = 0x%08X, filename = %s",
-                    (unsigned int)FileHandle, LocalName);
-
-      Result = FileHandle;
+                    (unsigned int)Result, LocalName);
    }
    else
    {
+      FileHandle = OS_ObjectIdFromInteger(Result);
+
       /* Result will be overridden if everything works */
       Result = CFE_EVS_FILE_WRITE_ERROR;
 

--- a/fsw/cfe-core/src/evs/cfe_evs_task.h
+++ b/fsw/cfe-core/src/evs/cfe_evs_task.h
@@ -122,7 +122,7 @@ typedef struct
    */
    CFE_EVS_HousekeepingTlm_t    EVS_TlmPkt;
    CFE_SB_PipeId_t     EVS_CommandPipe;
-   uint32              EVS_SharedDataMutexID;
+   osal_id_t           EVS_SharedDataMutexID;
    uint32              EVS_AppID;
 
 } CFE_EVS_GlobalData_t;

--- a/fsw/cfe-core/src/fs/cfe_fs_api.c
+++ b/fsw/cfe-core/src/fs/cfe_fs_api.c
@@ -46,7 +46,7 @@
 /*
 ** CFE_FS_ReadHeader() - See API and header file for details
 */
-int32 CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, int32 FileDes)
+int32 CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, osal_id_t FileDes)
 {
     int32   Result;
     int32   EndianCheck = 0x01020304;
@@ -89,7 +89,7 @@ void CFE_FS_InitHeader(CFE_FS_Header_t *Hdr, const char *Description, uint32 Sub
 /*
 ** CFE_FS_WriteHeader() - See API and header file for details
 */
-int32 CFE_FS_WriteHeader(int32 FileDes, CFE_FS_Header_t *Hdr)
+int32 CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr)
 {
     CFE_TIME_SysTime_t Time;
     int32   Result;
@@ -158,7 +158,7 @@ int32 CFE_FS_WriteHeader(int32 FileDes, CFE_FS_Header_t *Hdr)
 /*
 ** CFE_FS_SetTimestamp - See API and header file for details
 */
-int32 CFE_FS_SetTimestamp(int32 FileDes, CFE_TIME_SysTime_t NewTimestamp)
+int32 CFE_FS_SetTimestamp(osal_id_t FileDes, CFE_TIME_SysTime_t NewTimestamp)
 {
     int32              Result;
     CFE_FS_Header_t    TempHdr;

--- a/fsw/cfe-core/src/fs/cfe_fs_priv.h
+++ b/fsw/cfe-core/src/fs/cfe_fs_priv.h
@@ -57,7 +57,7 @@
 */
 typedef struct 
 {
-    uint32              SharedDataMutexId;
+    osal_id_t              SharedDataMutexId;
 
 } CFE_FS_t;
 

--- a/fsw/cfe-core/src/inc/cfe_es.h
+++ b/fsw/cfe-core/src/inc/cfe_es.h
@@ -224,7 +224,7 @@ typedef struct
 
    uint32   StackSize;                      /**< \cfetlmmnemonic \ES_STACKSIZE
                                                  \brief The Stack Size of the Application */
-   uint32   ModuleId;                       /**< \cfetlmmnemonic \ES_MODULEID
+   osal_id_t   ModuleId;                       /**< \cfetlmmnemonic \ES_MODULEID
                                                  \brief The ID of the Loadable Module for the Application */
    uint32   AddressesAreValid;              /**< \cfetlmmnemonic \ES_ADDRVALID
                                                  \brief Indicates that the Code, Data, and BSS addresses/sizes are valid */

--- a/fsw/cfe-core/src/inc/cfe_fs.h
+++ b/fsw/cfe-core/src/inc/cfe_fs.h
@@ -70,7 +70,7 @@
 ** \sa #CFE_FS_WriteHeader
 **
 ******************************************************************************/
-int32 CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, int32 FileDes);
+int32 CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, osal_id_t FileDes);
 
 /*****************************************************************************/
 /**
@@ -128,7 +128,7 @@ void CFE_FS_InitHeader(CFE_FS_Header_t *Hdr, const char *Description, uint32 Sub
 ** \sa #CFE_FS_ReadHeader
 **
 ******************************************************************************/
-int32 CFE_FS_WriteHeader(int32 FileDes, CFE_FS_Header_t *Hdr);
+int32 CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr);
 
 /*****************************************************************************/
 /**
@@ -153,7 +153,7 @@ int32 CFE_FS_WriteHeader(int32 FileDes, CFE_FS_Header_t *Hdr);
 ** \return Execution status, see \ref CFEReturnCodes
 **               
 ******************************************************************************/
-int32 CFE_FS_SetTimestamp(int32 FileDes, CFE_TIME_SysTime_t NewTimestamp);
+int32 CFE_FS_SetTimestamp(osal_id_t FileDes, CFE_TIME_SysTime_t NewTimestamp);
 /**@}*/
 
 

--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -82,7 +82,7 @@ int32  CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16  Depth, const char *
 {
     uint32          AppId = 0xFFFFFFFF;
     uint32          TskId = 0;
-    uint32          SysQueueId = 0;
+    osal_id_t       SysQueueId;
     int32           Status;
     CFE_SB_PipeId_t OriginalPipeIdParamValue = (PipeIdPtr == NULL) ? 0 : (*PipeIdPtr);
     CFE_SB_PipeId_t PipeTblIdx;
@@ -561,7 +561,7 @@ int32 CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *PipeName)
     int32         Status = CFE_SUCCESS;
     int32         RtnFromVal = 0;
     uint32        TskId = 0;
-    uint32        QueueId = 0;
+    osal_id_t     QueueId;
     char          FullName[(OS_MAX_API_NAME * 2)];
 
     /* get TaskId of caller for events */
@@ -593,7 +593,7 @@ int32 CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *PipeName)
                 PipeTblIdx++)
             {
                 if(CFE_SB.PipeTbl[PipeTblIdx].InUse != 0
-                    && CFE_SB.PipeTbl[PipeTblIdx].SysQueueId == QueueId)
+                    && OS_ObjectIdEqual(CFE_SB.PipeTbl[PipeTblIdx].SysQueueId, QueueId))
                 {
                     /* grab the ID before we release the lock */
                     *PipeIdPtr = CFE_SB.PipeTbl[PipeTblIdx].PipeId;

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.h
@@ -48,7 +48,7 @@
 
 #define CFE_SB_INVALID_ROUTE_IDX        ((CFE_SB_MsgRouteIdx_t){ .RouteIdx = 0 })
 #define CFE_SB_INVALID_MSG_KEY          ((CFE_SB_MsgKey_t){ .KeyIdx = 0 })
-#define CFE_SB_UNUSED_QUEUE             0xFFFF
+#define CFE_SB_UNUSED_QUEUE             OS_OBJECT_ID_UNDEFINED
 #define CFE_SB_INVALID_PIPE             0xFF
 #define CFE_SB_NO_DESTINATION           0xFF
 #define CFE_SB_FAILED                   1
@@ -249,7 +249,7 @@ typedef struct {
      uint8              Opts;
      uint8              Spare;
      uint32             AppId;
-     uint32             SysQueueId;
+     osal_id_t          SysQueueId;
      uint32             LastSender;
      uint16             QueueDepth;
      uint16             SendErrors;
@@ -280,7 +280,7 @@ typedef struct {
 **     This structure contains the SB global variables.
 */
 typedef struct {
-    uint32              SharedDataMutexId;
+    osal_id_t           SharedDataMutexId;
     uint32              SubscriptionReporting;
     uint32              SenderReporting;
     uint32              AppId;

--- a/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
@@ -895,7 +895,7 @@ int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBuffe
     int32                Status = CFE_SUCCESS;
     CFE_FS_Header_t      StdFileHeader;
     CFE_TBL_File_Hdr_t   TblFileHeader;
-    int32                FileDescriptor;
+    osal_id_t            FileDescriptor;
     size_t               FilenameLen = strlen(Filename);
     uint32               NumBytes;
     uint8                ExtraByte;
@@ -912,17 +912,19 @@ int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBuffe
     }
 
     /* Try to open the specified table file */
-    FileDescriptor = OS_open(Filename, OS_READ_ONLY, 0);
+    Status = OS_open(Filename, OS_READ_ONLY, 0);
 
-    if (FileDescriptor < 0)
+    if (Status < 0)
     {
         CFE_EVS_SendEventWithAppID(CFE_TBL_FILE_ACCESS_ERR_EID,
             CFE_EVS_EventType_ERROR, CFE_TBL_TaskData.TableTaskAppId,
             "%s: Unable to open file (FileDescriptor=%d)",
-            AppName, (int)FileDescriptor);
+            AppName, (int)Status);
 
             return CFE_TBL_ERR_ACCESS;
     }
+
+    FileDescriptor = OS_ObjectIdFromInteger(Status);
 
     Status = CFE_TBL_ReadHeaders(FileDescriptor, &StdFileHeader, &TblFileHeader, Filename);
 
@@ -1163,7 +1165,7 @@ void CFE_TBL_NotifyTblUsersOfUpdate(CFE_TBL_RegistryRec_t *RegRecPtr)
 ** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
 ********************************************************************/
 
-int32 CFE_TBL_ReadHeaders( int32 FileDescriptor,
+int32 CFE_TBL_ReadHeaders( osal_id_t FileDescriptor,
                            CFE_FS_Header_t *StdFileHeaderPtr,
                            CFE_TBL_File_Hdr_t *TblFileHeaderPtr,
                            const char *LoadFilename )

--- a/fsw/cfe-core/src/tbl/cfe_tbl_internal.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_internal.h
@@ -455,7 +455,7 @@ void   CFE_TBL_NotifyTblUsersOfUpdate( CFE_TBL_RegistryRec_t *RegRecPtr );
 ** \retval #CFE_TBL_ERR_BAD_PROCESSOR_ID    \copydoc CFE_TBL_ERR_BAD_PROCESSOR_ID
 **                     
 ******************************************************************************/
-int32 CFE_TBL_ReadHeaders( int32 FileDescriptor, 
+int32 CFE_TBL_ReadHeaders( osal_id_t FileDescriptor,
                            CFE_FS_Header_t *StdFileHeaderPtr, 
                            CFE_TBL_File_Hdr_t *TblFileHeaderPtr,
                            const char *LoadFilename );

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task.h
@@ -324,8 +324,8 @@ typedef struct
   /*
   ** Registry Access Mutex and Load Buffer Semaphores
   */
-  uint32                 RegistryMutex;                   /**< \brief Mutex that controls access to Table Registry */
-  uint32                 WorkBufMutex;                    /**< \brief Mutex that controls assignment of Working Buffers */
+  osal_id_t              RegistryMutex;                   /**< \brief Mutex that controls access to Table Registry */
+  osal_id_t              WorkBufMutex;                    /**< \brief Mutex that controls assignment of Working Buffers */
   CFE_ES_CDSHandle_t     CritRegHandle;                   /**< \brief Handle to Critical Table Registry in CDS */
   CFE_TBL_LoadBuff_t     LoadBuffs[CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS];  /**< \brief Working table buffers shared by single buffered tables */
 

--- a/fsw/cfe-core/src/time/cfe_time_task.c
+++ b/fsw/cfe-core/src/time/cfe_time_task.c
@@ -198,8 +198,8 @@ void CFE_TIME_TaskMain(void)
 int32 CFE_TIME_TaskInit(void)
 {
     int32 Status = CFE_SUCCESS;
-    uint32 TimeBaseId;
-    uint32 TimerId;
+    osal_id_t TimeBaseId;
+    osal_id_t TimerId;
 
     Status = CFE_ES_RegisterApp();
     if(Status != CFE_SUCCESS)

--- a/fsw/cfe-core/src/time/cfe_time_tone.c
+++ b/fsw/cfe-core/src/time/cfe_time_tone.c
@@ -1068,7 +1068,7 @@ void CFE_TIME_ToneUpdate(void)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-void CFE_TIME_Local1HzTimerCallback(uint32 TimerId, void *Arg)
+void CFE_TIME_Local1HzTimerCallback(osal_id_t TimerId, void *Arg)
 {
     CFE_TIME_Local1HzISR();
 }

--- a/fsw/cfe-core/src/time/cfe_time_utils.h
+++ b/fsw/cfe-core/src/time/cfe_time_utils.h
@@ -300,8 +300,8 @@ typedef struct
   /*
   ** Interrupt task semaphores...
   */
-  uint32                LocalSemaphore;
-  uint32                ToneSemaphore;
+  osal_id_t             LocalSemaphore;
+  osal_id_t             ToneSemaphore;
   /*
   ** Interrupt task ID's...
   */
@@ -462,7 +462,7 @@ void CFE_TIME_NotifyTimeSynchApps(void);
 */
 void CFE_TIME_Local1HzTask(void);
 void CFE_TIME_Local1HzStateMachine(void);
-void CFE_TIME_Local1HzTimerCallback(uint32 TimerId, void *Arg);
+void CFE_TIME_Local1HzTimerCallback(osal_id_t TimerId, void *Arg);
 
 
 #endif /* _cfe_time_utils_ */

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -216,16 +216,14 @@ uint32 ES_UT_MakeTaskIdForIndex(uint32 ArrayIdx)
 void ES_UT_SetupSingleAppId(CFE_ES_AppType_Enum_t AppType, CFE_ES_AppState_Enum_t AppState,
         const char *AppName, CFE_ES_AppRecord_t **OutAppRec, CFE_ES_TaskRecord_t **OutTaskRec)
 {
-    uint32 UtOsalId;
+    osal_id_t UtOsalId;
     uint32 UtTaskId;
     uint32 UtAppId;
-    uint32 ArrayIdx;
     CFE_ES_AppRecord_t *LocalAppPtr;
     CFE_ES_TaskRecord_t *LocalTaskPtr;
 
     OS_TaskCreate(&UtOsalId, "UT", NULL, NULL, 0, 0, 0);
-    OS_ConvertToArrayIndex(UtOsalId, &ArrayIdx);
-    UtTaskId = UtOsalId;
+    UtTaskId = CFE_ES_ResourceID_FromOSAL(UtOsalId);
     UtAppId = ES_UT_MakeAppIdForIndex(ES_UT_NumApps);
     ++ES_UT_NumApps;
 
@@ -275,19 +273,17 @@ void ES_UT_SetupSingleAppId(CFE_ES_AppType_Enum_t AppType, CFE_ES_AppState_Enum_
  */
 void ES_UT_SetupChildTaskId(const CFE_ES_AppRecord_t *ParentApp, const char *TaskName, CFE_ES_TaskRecord_t **OutTaskRec)
 {
-    uint32 UtOsalId;
+    osal_id_t UtOsalId;
     uint32 UtTaskId;
     uint32 UtAppId;
-    uint32 ArrayIdx;
     CFE_ES_TaskRecord_t *LocalTaskPtr;
 
     UtAppId = CFE_ES_AppRecordGetID(ParentApp);
 
     OS_TaskCreate(&UtOsalId, "C", NULL, NULL, 0, 0, 0);
-    OS_ConvertToArrayIndex(UtOsalId, &ArrayIdx);
-    UtTaskId = UtOsalId;
+    UtTaskId = CFE_ES_ResourceID_FromOSAL(UtOsalId);
 
-    LocalTaskPtr = &CFE_ES_Global.TaskTable[ArrayIdx];
+    LocalTaskPtr = CFE_ES_LocateTaskRecordByID(UtTaskId);
     CFE_ES_TaskRecordSetUsed(LocalTaskPtr, UtTaskId);
     LocalTaskPtr->AppId = UtAppId;
 
@@ -345,7 +341,7 @@ int32 ES_UT_SetupOSCleanupHook(void *UserObj, int32 StubRetcode,
                                uint32 CallCount,
                                const UT_StubContext_t *Context)
 {
-    uint32 ObjList[7];
+    osal_id_t ObjList[7];
 
     /* On the first call, Use the stub functions to generate one object of
      * each type
@@ -358,7 +354,7 @@ int32 ES_UT_SetupOSCleanupHook(void *UserObj, int32 StubRetcode,
         OS_BinSemCreate(&ObjList[3], NULL, 0, 0);
         OS_CountSemCreate(&ObjList[4], NULL, 0, 0);
         OS_TimerCreate(&ObjList[5], NULL, NULL, NULL);
-        ObjList[6] = OS_open(NULL, 0, 0);
+        ObjList[6] = OS_ObjectIdFromInteger(OS_open(NULL, 0, 0));
 
         UT_SetDataBuffer((UT_EntryKey_t)&OS_ForEachObject, ObjList,
                           sizeof(ObjList), true);
@@ -2031,7 +2027,7 @@ void TestTask(void)
 {
     uint32                      ResetType;
     uint32                      UT_ContextData;
-    uint32                   UT_ContextTask;
+    osal_id_t                   UT_ContextTask;
     union
     {
         CFE_SB_Msg_t             Msg;
@@ -2888,7 +2884,7 @@ void TestTask(void)
     ES_ResetUnitTest();
     UT_SetForceFail(UT_KEY(CFE_PSP_Exception_GetCount), 1);
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, &UtTaskRecPtr);
-    UT_ContextTask = CFE_ES_TaskRecordGetID(UtTaskRecPtr);
+    UT_ContextTask = CFE_ES_ResourceID_ToOSAL(CFE_ES_TaskRecordGetID(UtTaskRecPtr));
     UT_SetDataBuffer(UT_KEY(CFE_PSP_Exception_GetSummary), &UT_ContextTask, sizeof(UT_ContextTask), false);
     UtAppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_APP_RUN;
     UtAppRecPtr->StartParams.ExceptionAction = CFE_ES_ExceptionAction_RESTART_APP;
@@ -2909,7 +2905,7 @@ void TestTask(void)
     ES_ResetUnitTest();
     UT_SetForceFail(UT_KEY(CFE_PSP_Exception_GetCount), 1);
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, &UtTaskRecPtr);
-    UT_ContextTask = CFE_ES_TaskRecordGetID(UtTaskRecPtr);
+    UT_ContextTask = CFE_ES_ResourceID_ToOSAL(CFE_ES_TaskRecordGetID(UtTaskRecPtr));
     UT_SetDataBuffer(UT_KEY(CFE_PSP_Exception_GetSummary), &UT_ContextTask, sizeof(UT_ContextTask), false);
     UtAppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_APP_RUN;
     UtAppRecPtr->StartParams.ExceptionAction = CFE_ES_ExceptionAction_RESTART_APP;
@@ -3858,7 +3854,7 @@ void TestPerf(void)
     ES_ResetUnitTest();
     memset(&CFE_ES_TaskData.BackgroundPerfDumpState, 0,
             sizeof(CFE_ES_TaskData.BackgroundPerfDumpState));
-    CFE_ES_TaskData.BackgroundPerfDumpState.FileDesc = OS_creat("UT", OS_WRITE_ONLY);
+    CFE_ES_TaskData.BackgroundPerfDumpState.FileDesc = OS_ObjectIdFromInteger(OS_creat("UT", OS_WRITE_ONLY));
     CFE_ES_TaskData.BackgroundPerfDumpState.CurrentState = CFE_ES_PerfDumpState_WRITE_PERF_ENTRIES;
     CFE_ES_TaskData.BackgroundPerfDumpState.PendingState = CFE_ES_PerfDumpState_WRITE_PERF_ENTRIES;
     CFE_ES_TaskData.BackgroundPerfDumpState.DataPos = CFE_PLATFORM_ES_PERF_DATA_BUFFER_SIZE - 2;
@@ -3879,7 +3875,7 @@ void TestPerf(void)
     ES_ResetUnitTest();
     memset(&CFE_ES_TaskData.BackgroundPerfDumpState, 0,
             sizeof(CFE_ES_TaskData.BackgroundPerfDumpState));
-    CFE_ES_TaskData.BackgroundPerfDumpState.FileDesc = OS_creat("UT", OS_WRITE_ONLY);
+    CFE_ES_TaskData.BackgroundPerfDumpState.FileDesc = OS_ObjectIdFromInteger(OS_creat("UT", OS_WRITE_ONLY));
     CFE_ES_TaskData.BackgroundPerfDumpState.CurrentState = CFE_ES_PerfDumpState_WRITE_PERF_METADATA;
     CFE_ES_TaskData.BackgroundPerfDumpState.StateCounter = 10;
     Perf->MetaData.DataCount = 100;
@@ -3892,7 +3888,7 @@ void TestPerf(void)
 
 void TestAPI(void)
 {
-    uint32 TestObjId;
+    osal_id_t TestObjId;
     char AppName[32];
     uint32 StackBuf[8];
     int32  Return;
@@ -4309,8 +4305,8 @@ void TestAPI(void)
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
     ES_UT_SetupChildTaskId(UtAppRecPtr, NULL, &UtTaskRecPtr);
-    TestObjId = CFE_ES_TaskRecordGetID(UtTaskRecPtr);
-    UT_SetForceFail(UT_KEY(OS_TaskGetId), (unsigned long)TestObjId); /* Set context to that of child */
+    TestObjId = CFE_ES_ResourceID_ToOSAL(CFE_ES_TaskRecordGetID(UtTaskRecPtr));
+    UT_SetForceFail(UT_KEY(OS_TaskGetId), OS_ObjectIdToInteger(TestObjId)); /* Set context to that of child */
     Return = CFE_ES_CreateChildTask(&TaskId,
                                     "TaskName",
                                     TestAPI,
@@ -4398,8 +4394,8 @@ void TestAPI(void)
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
     ES_UT_SetupChildTaskId(UtAppRecPtr, NULL, &UtTaskRecPtr);
-    TestObjId = CFE_ES_TaskRecordGetID(UtTaskRecPtr);
-    UT_SetForceFail(UT_KEY(OS_TaskGetId), (unsigned long)TestObjId); /* Set context to that of child */
+    TestObjId = CFE_ES_ResourceID_ToOSAL(CFE_ES_TaskRecordGetID(UtTaskRecPtr));
+    UT_SetForceFail(UT_KEY(OS_TaskGetId), OS_ObjectIdToInteger(TestObjId)); /* Set context to that of child */
     CFE_ES_ExitChildTask();
     UT_Report(__FILE__, __LINE__,
               UT_GetStubCount(UT_KEY(OS_TaskExit)) == 1,

--- a/fsw/cfe-core/unit-test/fs_UT.c
+++ b/fsw/cfe-core/unit-test/fs_UT.c
@@ -88,7 +88,7 @@ void Test_CFE_FS_InitHeader(void)
 */
 void Test_CFE_FS_ReadHeader(void)
 {
-    int32 FileDes = 0;
+    osal_id_t FileDes = OS_OBJECT_ID_UNDEFINED;
     CFE_FS_Header_t Hdr;
 
 #ifdef UT_VERBOSE
@@ -118,7 +118,7 @@ void Test_CFE_FS_ReadHeader(void)
 */
 void Test_CFE_FS_WriteHeader(void)
 {
-    int32 FileDes = 0;
+    osal_id_t FileDes = OS_OBJECT_ID_UNDEFINED;
     CFE_FS_Header_t Hdr;
 
 #ifdef UT_VERBOSE
@@ -148,7 +148,7 @@ void Test_CFE_FS_WriteHeader(void)
 */
 void Test_CFE_FS_SetTimestamp(void)
 {
-    int32 FileDes = 0;
+    osal_id_t FileDes = OS_OBJECT_ID_UNDEFINED;
     CFE_TIME_SysTime_t NewTimestamp = {0, 0};
 
 #ifdef UT_VERBOSE

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -1833,7 +1833,7 @@ void Test_GetPipeName(void)
     CFE_SB_PipeId_t PipeId = 0;
 
     OS_queue_prop_t queue_info = {
-        "TestPipe1", 0
+        "TestPipe1"
     };
 
     SETUP(CFE_SB_CreatePipe(&PipeId, 4, "TestPipe1"));

--- a/fsw/cfe-core/unit-test/tbl_UT.c
+++ b/fsw/cfe-core/unit-test/tbl_UT.c
@@ -4069,13 +4069,14 @@ void Test_CFE_TBL_Internal(void)
     int32                      i;
     CFE_FS_Header_t            StdFileHeader;
     CFE_TBL_File_Hdr_t         TblFileHeader;
-    int32                      FileDescriptor = 0;
+    osal_id_t                  FileDescriptor;
     void                       *TblPtr;
 
 #ifdef UT_VERBOSE
     UT_Text("Begin Test Internal\n");
 #endif
 
+    FileDescriptor = OS_OBJECT_ID_UNDEFINED;
     StdFileHeader.SpacecraftID = CFE_PLATFORM_TBL_VALID_SCID_1;
     StdFileHeader.ProcessorID = CFE_PLATFORM_TBL_VALID_PRID_1;
 

--- a/fsw/cfe-core/unit-test/time_UT.c
+++ b/fsw/cfe-core/unit-test/time_UT.c
@@ -3198,7 +3198,7 @@ void Test_1Hz(void)
     CFE_TIME_TaskData.OneHzAdjust.Subseconds = 0;
     CFE_TIME_FinishReferenceUpdate(RefState);
     UT_SetBSP_Time(0, 0);
-    CFE_TIME_Local1HzTimerCallback(123, &Arg);
+    CFE_TIME_Local1HzTimerCallback(OS_ObjectIdFromInteger(123), &Arg);
     UT_Report(__FILE__, __LINE__,
               CFE_TIME_TaskData.LocalIntCounter == 2,
               "CFE_TIME_Local1HzTimerCallback",

--- a/fsw/cfe-core/ut-stubs/ut_fs_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_fs_stubs.c
@@ -87,7 +87,7 @@ void CFE_FS_InitHeader(CFE_FS_Header_t *Hdr, const char *Description, uint32 Sub
 **        CFE_FS_Header_t structure in bytes.
 **
 ******************************************************************************/
-int32 CFE_FS_WriteHeader(int32 FileDes, CFE_FS_Header_t *Hdr)
+int32 CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_FS_WriteHeader), FileDes);
     UT_Stub_RegisterContext(UT_KEY(CFE_FS_WriteHeader), Hdr);
@@ -126,7 +126,7 @@ int32 CFE_FS_WriteHeader(int32 FileDes, CFE_FS_Header_t *Hdr)
 **        CFE_FS_Header_t structure in bytes.
 **
 ******************************************************************************/
-int32 CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, int32 FileDes)
+int32 CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, osal_id_t FileDes)
 {
     UT_Stub_RegisterContext(UT_KEY(CFE_FS_ReadHeader), Hdr);
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_FS_ReadHeader), FileDes);
@@ -163,7 +163,7 @@ int32 CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, int32 FileDes)
 **        Returns either a user-defined status flag or OS_SUCCESS.
 **
 ******************************************************************************/
-int32 CFE_FS_SetTimestamp(int32 FileDes, CFE_TIME_SysTime_t NewTimestamp)
+int32 CFE_FS_SetTimestamp(osal_id_t FileDes, CFE_TIME_SysTime_t NewTimestamp)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_FS_SetTimestamp), FileDes);
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_FS_SetTimestamp), NewTimestamp);


### PR DESCRIPTION
**Describe the contribution**
Scrub all CFE references/uses of OSAL IDs to use the proper `osal_id_t` type.

Any place that an OSAL ID is stored in memory or passed in an API call are changed to the `osal_id_t` type, rather than `uint32`.  Conversions between this and other types (e.g. bare integer) is done using the OSAL-supplied conversion helpers.

Fixes #858

**Testing performed**
Build and sanity check CFE
Run all unit tests
Also specifically spot check various CFE commands that save data to file (e.g. perf log, query all tasks, etc) to confirm these files are being properly created - as these previously used the `int32` type to store the file handle and necessitated a bigger change.

**Expected behavior changes**
No impact to behavior.  Since the `osal_id_t` is initially a typedef to `uint32`, this should be effectively no change except to future proof.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Depends on nasa/osal#568 which provides the typedef and conversion helpers (currently in IC)

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.