### PR TITLE
Fix #769, Adds name to struct/union/enum typedefs

### DIFF
--- a/fsw/cfe-core/src/inc/ccsds_hdr.h
+++ b/fsw/cfe-core/src/inc/ccsds_hdr.h
@@ -49,7 +49,7 @@
 /**
  * \brief CCSDS packet primary header
  */
-typedef struct {
+typedef struct CCSDS_PrimaryHeader {
 
    uint8   StreamId[2];  /**< \brief packet identifier word (stream ID) */
       /*  bits  shift   ------------ description ---------------- */
@@ -72,7 +72,7 @@ typedef struct {
 /**
  * \brief CCSDS packet extended header
  */
-typedef struct {
+typedef struct CCSDS_ExtendedHeader {
 
    uint8 Subsystem[2]; /**< \brief subsystem qualifier */
       /*  bits  shift   ------------ description ---------------- */

--- a/fsw/cfe-core/src/inc/cfe_es.h
+++ b/fsw/cfe-core/src/inc/cfe_es.h
@@ -204,7 +204,7 @@ typedef cpuaddr CFE_ES_MemHandle_t;
  * Structure that is used to provide information about an app.
  * It is primarily used for the QueryOne and QueryAll Commands.
  */
-typedef struct
+typedef struct CFE_ES_AppInfo
 {
    uint32   AppId;                          /**< \cfetlmmnemonic \ES_APP_ID
                                                  \brief Application ID for this Application */
@@ -257,7 +257,7 @@ typedef struct
 /**
  * \brief Task Info
  */
-typedef struct
+typedef struct CFE_ES_TaskInfo
 {
    uint32   TaskId;                    /**< \brief Task Id */
    uint32   ExecutionCounter;          /**< \brief Task Execution Counter */
@@ -270,7 +270,7 @@ typedef struct
 /**
  * \brief Block statistics
  */
-typedef struct
+typedef struct CFE_ES_BlockStats
 {
     uint32  BlockSize;               /**< \brief Number of bytes in each of these blocks */
     uint32  NumCreated;              /**< \brief Number of Memory Blocks of this size created */
@@ -280,7 +280,7 @@ typedef struct
 /**
  * \brief Memory Pool Statistics
  */
-typedef struct
+typedef struct CFE_ES_MemPoolStats
 {
     uint32                PoolSize;                /**< \cfetlmmnemonic \ES_POOLSIZE
                                                         \brief  Size of Memory Pool (in bytes) */
@@ -304,7 +304,7 @@ typedef cpuaddr CFE_ES_CDSHandle_t;
 /**
  * \brief CDS Register Dump Record
  */
-typedef struct
+typedef struct CFE_ES_CDSRegDumpRec
 {
     CFE_ES_CDSHandle_t    Handle;          /**< \brief Handle of CDS */
     uint32                Size;            /**< \brief Size, in bytes, of the CDS memory block */
@@ -326,7 +326,7 @@ typedef int32 (*CFE_ES_LibraryEntryFuncPtr_t)(uint32 LibId); /**< \brief Require
  * It contains the longest native data types such that the alignment of this structure
  * should reflect the largest possible alignment requirements for any data on this processor.
  */
-typedef union
+typedef union CFE_ES_PoolAlign
 {
     void *Ptr; /**< \brief Aligned pointer */
     /* note -- native types (int/double) are intentional here */

--- a/fsw/cfe-core/src/inc/cfe_es_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_es_msg.h
@@ -1118,7 +1118,7 @@
 ** -# The No-Op Command (For details, see #CFE_ES_NOOP_CC)
 ** -# The Reset Counters Command (For details, see #CFE_ES_RESET_COUNTERS_CC)
 */
-typedef struct
+typedef struct CFE_ES_NoArgsCmd
 {
   uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];     /**< \brief cFE Software Bus Command Message Header */
 
@@ -1143,13 +1143,13 @@ typedef CFE_ES_NoArgsCmd_t      CFE_ES_ResetPRCount_t;
 ** For command details, see #CFE_ES_RESTART_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_RestartCmd_Payload
 {
   uint16                RestartType;                       /**< \brief #CFE_PSP_RST_TYPE_PROCESSOR=Processor Reset
                                                                 or #CFE_PSP_RST_TYPE_POWERON=Power-On Reset        */
 } CFE_ES_RestartCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_Restart
 {
     uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_RestartCmd_Payload_t Payload;
@@ -1190,13 +1190,13 @@ typedef struct
 ** #CFE_ES_WRITE_SYSLOG_CC, and #CFE_ES_WRITE_ER_LOG_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_FileNameCmd_Payload
 {
   char                  FileName[CFE_MISSION_MAX_PATH_LEN]; /**< \brief ASCII text string containing full path and
                                                                 filename of file in which Application data is to be dumped */
 } CFE_ES_FileNameCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_FileNameCmd
 {
     uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_FileNameCmd_Payload_t Payload;
@@ -1217,14 +1217,14 @@ typedef CFE_ES_FileNameCmd_t CFE_ES_WriteERLog_t;
 ** For command details, see #CFE_ES_OVER_WRITE_SYSLOG_CC
 **
 **/
-typedef struct 
+typedef struct CFE_ES_OverWriteSysLogCmd_Payload
 {
    uint32               Mode;                            /**< \brief #CFE_ES_LogMode_DISCARD=Throw away most recent messages,
                                                                      #CFE_ES_LogMode_OVERWRITE=Overwrite oldest with most recent */
 
 } CFE_ES_OverWriteSysLogCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_OverWriteSyslog
 {
     uint8                               CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_OverWriteSysLogCmd_Payload_t Payload;
@@ -1236,7 +1236,7 @@ typedef struct
 ** For command details, see #CFE_ES_START_APP_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_StartAppCmd_Payload
 {
   char                  Application[CFE_MISSION_MAX_API_LEN];    /**< \brief Name of Application to be started */
   char                  AppEntryPoint[CFE_MISSION_MAX_API_LEN];  /**< \brief Symbolic name of Application's entry point */
@@ -1253,7 +1253,7 @@ typedef struct
 
 } CFE_ES_StartAppCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_StartApp
 {
     uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_StartAppCmd_Payload_t    Payload;
@@ -1265,12 +1265,12 @@ typedef struct
 ** For command details, see #CFE_ES_STOP_APP_CC, #CFE_ES_RESTART_APP_CC, #CFE_ES_QUERY_ONE_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_AppNameCmd_Payload
 {
   char                  Application[CFE_MISSION_MAX_API_LEN];    /**< \brief ASCII text string containing Application Name */
 } CFE_ES_AppNameCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_AppNameCmd
 {
     uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_AppNameCmd_Payload_t Payload;
@@ -1291,14 +1291,14 @@ typedef CFE_ES_AppNameCmd_t CFE_ES_QueryOne_t;
 ** For command details, see #CFE_ES_RELOAD_APP_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_AppReloadCmd_Payload
 {
   char                  Application[CFE_MISSION_MAX_API_LEN];   /**< \brief ASCII text string containing Application Name */
   char                  AppFileName[CFE_MISSION_MAX_PATH_LEN];   /**< \brief Full path and filename of Application's 
                                                                     executable image */
 } CFE_ES_AppReloadCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_ReloadApp
 {
     uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_AppReloadCmd_Payload_t   Payload;
@@ -1310,13 +1310,13 @@ typedef struct
 ** For command details, see #CFE_ES_SET_MAX_PR_COUNT_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_SetMaxPRCountCmd_Payload
 {
   uint16                MaxPRCount;                     /**< \brief New maximum number of Processor Resets before
                                                                     an automatic Power-On Reset is performed */
 } CFE_ES_SetMaxPRCountCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_SetMaxPRCount
 {
     uint8                               CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_SetMaxPRCountCmd_Payload_t   Payload;
@@ -1328,13 +1328,13 @@ typedef struct
 ** For command details, see #CFE_ES_DELETE_CDS_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_DeleteCDSCmd_Payload
 {
   char                  CdsName[CFE_MISSION_ES_CDS_MAX_NAME_LEN]; /**< \brief ASCII text string containing name of CDS to delete */
 
 } CFE_ES_DeleteCDSCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_DeleteCDS
 {
     uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_DeleteCDSCmd_Payload_t   Payload;
@@ -1346,12 +1346,12 @@ typedef struct
 ** For command details, see #CFE_ES_START_PERF_DATA_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_StartPerfCmd_Payload
 {
   uint32                TriggerMode;                    /**< \brief Desired trigger position (Start, Center, End) */
 } CFE_ES_StartPerfCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_StartPerfData
 {
     uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_StartPerfCmd_Payload_t   Payload;
@@ -1363,13 +1363,13 @@ typedef struct
 ** For command details, see #CFE_ES_STOP_PERF_DATA_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_StopPerfCmd_Payload
 {
   char                  DataFileName[CFE_MISSION_MAX_PATH_LEN];  /**< \brief ASCII text string of full path and filename 
                                                                     of file Performance Analyzer data is to be written */
 } CFE_ES_StopPerfCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_StopPerfData
 {
     uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_StopPerfCmd_Payload_t    Payload;
@@ -1382,14 +1382,14 @@ typedef struct
 ** For command details, see #CFE_ES_SET_PERF_FILTER_MASK_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_SetPerfFilterMaskCmd_Payload
 {
   uint32                FilterMaskNum;                   /**< \brief Index into array of Filter Masks */
   uint32                FilterMask;                      /**< \brief New Mask for specified entry in array of Filter Masks */
 
 } CFE_ES_SetPerfFilterMaskCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_SetPerfFilterMask
 {
     uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_SetPerfFilterMaskCmd_Payload_t Payload;
@@ -1401,14 +1401,14 @@ typedef struct
 ** For command details, see #CFE_ES_SET_PERF_TRIGGER_MASK_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_SetPerfTrigMaskCmd_Payload
 {
   uint32                TriggerMaskNum;                 /**< \brief Index into array of Trigger Masks */
   uint32                TriggerMask;                    /**< \brief New Mask for specified entry in array of Trigger Masks */
 
 } CFE_ES_SetPerfTrigMaskCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_SetPerfTriggerMask
 {
     uint8                               CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_SetPerfTrigMaskCmd_Payload_t Payload;
@@ -1420,14 +1420,14 @@ typedef struct
 ** For command details, see #CFE_ES_SEND_MEM_POOL_STATS_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_SendMemPoolStatsCmd_Payload
 {
   char                  Application[CFE_MISSION_MAX_API_LEN];   /**< \brief - RESERVED - should be all zeroes */
   CFE_ES_MemHandle_t    PoolHandle;                     /**< \brief Handle of Pool whose statistics are to be telemetered */
 
 } CFE_ES_SendMemPoolStatsCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_SendMemPoolStats
 {
     uint8                               CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_SendMemPoolStatsCmd_Payload_t    Payload;
@@ -1439,13 +1439,13 @@ typedef struct
 ** For command details, see #CFE_ES_DUMP_CDS_REGISTRY_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_DumpCDSRegistryCmd_Payload
 {
   char                  DumpFilename[CFE_MISSION_MAX_PATH_LEN];  /**< \brief ASCII text string of full path and filename 
                                                                     of file CDS Registry is to be written */
 } CFE_ES_DumpCDSRegistryCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_DumpCDSRegistry
 {
     uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_DumpCDSRegistryCmd_Payload_t  Payload;
@@ -1459,13 +1459,13 @@ typedef struct
 /** 
 **  \cfeestlm Single Application Information Packet
 **/
-typedef struct
+typedef struct CFE_ES_OneAppTlm_Payload
 {
   CFE_ES_AppInfo_t      AppInfo;                        /**< \brief For more information, see #CFE_ES_AppInfo_t */
   
 } CFE_ES_OneAppTlm_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_OneAppTlm
 {
     uint8                       TlmHeader[CFE_SB_TLM_HDR_SIZE]; /**< \brief cFE Software Bus Telemetry Message Header */
     CFE_ES_OneAppTlm_Payload_t  Payload;
@@ -1474,14 +1474,14 @@ typedef struct
 /** 
 **  \cfeestlm Memory Pool Statistics Packet
 **/
-typedef struct
+typedef struct CFE_ES_PoolStatsTlm_Payload
 {
   CFE_ES_MemHandle_t    PoolHandle;                     /**< \cfetlmmnemonic \ES_POOLHANDLE
                                                              \brief Handle of memory pool whose stats are being telemetered */
   CFE_ES_MemPoolStats_t PoolStats;                      /**< \brief For more info, see #CFE_ES_MemPoolStats_t */
 } CFE_ES_PoolStatsTlm_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_MemStatsTlm
 {
     uint8                           TlmHeader[CFE_SB_TLM_HDR_SIZE]; /**< \brief cFE Software Bus Telemetry Message Header */
     CFE_ES_PoolStatsTlm_Payload_t   Payload;
@@ -1492,7 +1492,7 @@ typedef struct
 /** 
 **  \cfeestlm Executive Services Housekeeping Packet
 **/
-typedef struct
+typedef struct CFE_ES_HousekeepingTlm_Payload
 {
   uint8                 CommandCounter;  /**< \cfetlmmnemonic \ES_CMDPC 
                                           \brief The ES Application Command Counter */
@@ -1578,7 +1578,7 @@ typedef struct
                                               \brief Number of bytes in the largest free block */
 } CFE_ES_HousekeepingTlm_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_HousekeepingTlm
 {
     uint8                       TlmHeader[CFE_SB_TLM_HDR_SIZE]; /**< \brief cFE Software Bus Telemetry Message Header */
     CFE_ES_HousekeepingTlm_Payload_t   Payload;

--- a/fsw/cfe-core/src/inc/cfe_evs.h
+++ b/fsw/cfe-core/src/inc/cfe_evs.h
@@ -108,7 +108,7 @@
 /******************  Structure Definitions *********************/
 
 /** \brief Event message filter defintion structure */
-typedef struct {
+typedef struct CFE_EVS_BinFilter {
    uint16 EventID;	/**< \brief Numerical event identifier */
    uint16 Mask;		/**< \brief Binary filter mask value */
 
@@ -145,7 +145,7 @@ typedef struct {
 **          <b> Code: </b> CFE_EVS_EventFilter_BINARY <BR>
 **          <b> Filter Structure: </b> 
 **          \code
-**                     typedef struct {
+**                     typedef struct CFE_EVS_BinFilter {
 **                           uint16  EventID,
 **                           uint16  Mask ;
 **                     } CFE_EVS_BinFilter_t;

--- a/fsw/cfe-core/src/inc/cfe_evs_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_evs_msg.h
@@ -918,7 +918,7 @@
 /**
 ** \brief Command with no additional arguments
 **/
-typedef struct {
+typedef struct CFE_EVS_NoArgsCmd {
    uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];
 } CFE_EVS_NoArgsCmd_t;
 
@@ -937,11 +937,11 @@ typedef CFE_EVS_NoArgsCmd_t CFE_EVS_ClearLog_t;
 ** For command details, see #CFE_EVS_WRITE_LOG_DATA_FILE_CC
 **
 **/
-typedef struct {
+typedef struct CFE_EVS_LogFileCmd_Payload {
     char LogFilename[CFE_MISSION_MAX_PATH_LEN];      /**< \brief Filename where log data is to be written */
 } CFE_EVS_LogFileCmd_Payload_t;
 
-typedef struct {
+typedef struct CFE_EVS_WriteLogDataFile {
    uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];
    CFE_EVS_LogFileCmd_Payload_t Payload;
 } CFE_EVS_WriteLogDataFile_t;
@@ -953,11 +953,11 @@ typedef struct {
 ** For command details, see #CFE_EVS_WRITE_APP_DATA_FILE_CC
 **
 **/
-typedef struct {
+typedef struct CFE_EVS_AppDataCmd_Payload {
    char AppDataFilename[CFE_MISSION_MAX_PATH_LEN];  /**< \brief Filename where applicaton data is to be written */
 } CFE_EVS_AppDataCmd_Payload_t;
 
-typedef struct {
+typedef struct CFE_EVS_WriteAppDataFile {
    uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];
    CFE_EVS_AppDataCmd_Payload_t Payload;
 } CFE_EVS_WriteAppDataFile_t;
@@ -968,12 +968,12 @@ typedef struct {
 ** For command details, see #CFE_EVS_SET_EVENT_FORMAT_MODE_CC and/or #CFE_EVS_SET_LOG_MODE_CC
 **
 **/
-typedef struct {
+typedef struct CFE_EVS_SetLogMode_Payload {
     CFE_EVS_LogMode_Enum_t   LogMode;                           /**< \brief Mode to use in the command*/
    uint8                     Spare;                             /**< \brief Pad to even byte*/
 } CFE_EVS_SetLogMode_Payload_t;
 
-typedef struct {
+typedef struct CFE_EVS_SetLogMode {
    uint8                     CmdHeader[CFE_SB_CMD_HDR_SIZE];
    CFE_EVS_SetLogMode_Payload_t Payload;
 } CFE_EVS_SetLogMode_t;
@@ -984,12 +984,12 @@ typedef struct {
 ** For command details, see #CFE_EVS_SET_EVENT_FORMAT_MODE_CC and/or #CFE_EVS_SET_LOG_MODE_CC
 **
 **/
-typedef struct {
+typedef struct CFE_EVS_SetEventFormatCode_Payload {
     CFE_EVS_MsgFormat_Enum_t MsgFormat;                         /**< \brief Mode to use in the command*/
    uint8                     Spare;                             /**< \brief Pad to even byte*/
 } CFE_EVS_SetEventFormatMode_Payload_t;
 
-typedef struct {
+typedef struct CFE_EVS_SetEventFormatMode {
    uint8                     CmdHeader[CFE_SB_CMD_HDR_SIZE];
    CFE_EVS_SetEventFormatMode_Payload_t Payload;
 } CFE_EVS_SetEventFormatMode_t;
@@ -1001,12 +1001,12 @@ typedef struct {
 **                          #CFE_EVS_ENABLE_PORTS_CC and/or #CFE_EVS_DISABLE_PORTS_CC
 **
 **/
-typedef struct {
+typedef struct CFE_EVS_BitMaskCmd_Payload {
    uint8                     BitMask;           /**< \brief BitMask to use in the command */
    uint8                     Spare;                             /**< \brief Pad to even byte*/
 } CFE_EVS_BitMaskCmd_Payload_t;
 
-typedef struct {
+typedef struct CFE_EVS_BitMaskCmd {
    uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];
    CFE_EVS_BitMaskCmd_Payload_t Payload;
 } CFE_EVS_BitMaskCmd_t;
@@ -1028,11 +1028,11 @@ typedef CFE_EVS_BitMaskCmd_t CFE_EVS_DisableEventType_t;
 **                          #CFE_EVS_RESET_APP_COUNTER_CC and/or #CFE_EVS_RESET_ALL_FILTERS_CC
 **
 **/
-typedef struct {
+typedef struct CFE_EVS_AppNameCmd_Payload {
    char                     AppName[CFE_MISSION_MAX_API_LEN];          /**< \brief Application name to use in the command*/
 } CFE_EVS_AppNameCmd_Payload_t;
 
-typedef struct {
+typedef struct CFE_EVS_AppNameCmd {
    uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];
    CFE_EVS_AppNameCmd_Payload_t Payload;
 } CFE_EVS_AppNameCmd_t;
@@ -1053,12 +1053,12 @@ typedef CFE_EVS_AppNameCmd_t CFE_EVS_ResetAllFilters_t;
 ** For command details, see #CFE_EVS_RESET_FILTER_CC
 **
 **/
-typedef struct {
+typedef struct CFE_EVS_AppNameEventIDCmd_Payload {
    char                      AppName[CFE_MISSION_MAX_API_LEN];          /**< \brief Application name to use in the command*/
    uint16                    EventID;                           /**< \brief Event ID  to use in the command*/
 } CFE_EVS_AppNameEventIDCmd_Payload_t;
 
-typedef struct {
+typedef struct CFE_EVS_AppNameEventIDCmd {
    uint8                                CmdHeader[CFE_SB_CMD_HDR_SIZE];
    CFE_EVS_AppNameEventIDCmd_Payload_t  Payload;
 } CFE_EVS_AppNameEventIDCmd_t;
@@ -1077,13 +1077,13 @@ typedef CFE_EVS_AppNameEventIDCmd_t CFE_EVS_DeleteEventFilter_t;
 ** For command details, see #CFE_EVS_ENABLE_APP_EVENT_TYPE_CC and/or #CFE_EVS_DISABLE_APP_EVENT_TYPE_CC
 **
 **/
-typedef struct {
+typedef struct CFE_EVS_AppNameBitMaskCmd_Payload {
    char                      AppName[CFE_MISSION_MAX_API_LEN];          /**< \brief Application name to use in the command*/
    uint8                     BitMask;                           /**< \brief BitMask to use in the command*/
    uint8                     Spare;                             /**< \brief Pad to even byte*/
 } CFE_EVS_AppNameBitMaskCmd_Payload_t;
 
-typedef struct {
+typedef struct CFE_EVS_AppNameBitMaskCmd {
    uint8                     CmdHeader[CFE_SB_CMD_HDR_SIZE];
    CFE_EVS_AppNameBitMaskCmd_Payload_t Payload;
 } CFE_EVS_AppNameBitMaskCmd_t;
@@ -1103,13 +1103,13 @@ typedef CFE_EVS_AppNameBitMaskCmd_t CFE_EVS_DisableAppEventType_t;
 **                      and/or #CFE_EVS_DELETE_EVENT_FILTER_CC
 **
 **/
-typedef struct {
+typedef struct CFE_EVS_AppNameEventIDMaskCmd_Payload {
    char                      AppName[CFE_MISSION_MAX_API_LEN];          /**< \brief Application name to use in the command*/
    uint16                    EventID;                           /**< \brief Event ID  to use in the command*/
    uint16                    Mask;                              /**< \brief Mask to use in the command */
 } CFE_EVS_AppNameEventIDMaskCmd_Payload_t;
 
-typedef struct {
+typedef struct CFE_EVS_AppNameEventIDMaskCmd {
    uint8                                    CmdHeader[CFE_SB_CMD_HDR_SIZE];
    CFE_EVS_AppNameEventIDMaskCmd_Payload_t  Payload;
 } CFE_EVS_AppNameEventIDMaskCmd_t;
@@ -1126,7 +1126,7 @@ typedef CFE_EVS_AppNameEventIDMaskCmd_t CFE_EVS_SetFilter_t;
 /**********************************/
 /* Telemetry Message Data Formats */
 /**********************************/
-typedef struct {
+typedef struct CFE_EVS_AppTlmData {
    uint32               AppID;                  /**< \cfetlmmnemonic \EVS_APPID
                                                      \brief Numerical application identifier */
    uint16               AppMessageSentCounter;  /**< \cfetlmmnemonic \EVS_APPMSGSENTC
@@ -1142,7 +1142,7 @@ typedef struct {
 /** 
 **  \cfeevstlm Event Services Housekeeping Telemetry Packet
 **/
-typedef struct {
+typedef struct CFE_EVS_HousekeepingTlm_Payload {
    uint8                 CommandCounter;                    /**< \cfetlmmnemonic \EVS_CMDPC
                                                                  \brief EVS Command Counter */
    uint8                 CommandErrorCounter;                 /**< \cfetlmmnemonic \EVS_CMDEC
@@ -1180,14 +1180,14 @@ typedef struct {
 
 } CFE_EVS_HousekeepingTlm_Payload_t;
 
-typedef struct {
+typedef struct CFE_EVS_HousekeepingTlm {
    uint8                    TlmHeader[CFE_SB_TLM_HDR_SIZE];
    CFE_EVS_HousekeepingTlm_Payload_t Payload;
 } CFE_EVS_HousekeepingTlm_t;
 
 /** Telemetry packet structures */
 
-typedef struct {
+typedef struct CFE_EVS_PacketID {
    char    AppName[CFE_MISSION_MAX_API_LEN];  /**< \cfetlmmnemonic \EVS_APPNAME
                                            \brief Application name */
    uint16  EventID;                   /**< \cfetlmmnemonic \EVS_EVENTID
@@ -1205,7 +1205,7 @@ typedef struct {
 /** 
 **  \cfeevstlm Event Message Telemetry Packet (Long format)
 **/
-typedef struct {
+typedef struct CFE_EVS_LongEventTlm_Payload {
    CFE_EVS_PacketID_t        PacketID;                              /**< \brief Event packet information */
    char                      Message[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];   /**< \cfetlmmnemonic \EVS_EVENT
                                                                          \brief Event message string */
@@ -1218,18 +1218,18 @@ typedef struct {
 /**
 **  \cfeevstlm Event Message Telemetry Packet (Short format)
 **/
-typedef struct {
+typedef struct CFE_EVS_ShortEventTlm_Payload {
    CFE_EVS_PacketID_t        PacketID;                              /**< \brief Event packet information */
 
 } CFE_EVS_ShortEventTlm_Payload_t;
 
-typedef struct {
+typedef struct CFE_EVS_LongEventTlm {
    uint8                    TlmHeader[CFE_SB_TLM_HDR_SIZE];
    CFE_EVS_LongEventTlm_Payload_t Payload;
 
 } CFE_EVS_LongEventTlm_t;
 
-typedef struct {
+typedef struct CFE_EVS_ShortEventTlm {
    uint8                    TlmHeader[CFE_SB_TLM_HDR_SIZE];
    CFE_EVS_ShortEventTlm_Payload_t Payload;
 

--- a/fsw/cfe-core/src/inc/cfe_fs_extern_typedefs.h
+++ b/fsw/cfe-core/src/inc/cfe_fs_extern_typedefs.h
@@ -220,7 +220,7 @@ typedef uint32                                           CFE_FS_SubType_Enum_t;
 /**
 ** \brief Standard cFE File header structure definition
 */
-typedef struct
+typedef struct CFE_FS_Header
 {
     uint32  ContentType;           /**< \brief Identifies the content type (='cFE1'=0x63464531)*/
     uint32  SubType;               /**< \brief Type of \c ContentType, if necessary */

--- a/fsw/cfe-core/src/inc/cfe_msg_typedefs.h
+++ b/fsw/cfe-core/src/inc/cfe_msg_typedefs.h
@@ -54,7 +54,7 @@ typedef uint16 CFE_MSG_Subsystem_t;     /**< \brief Message subsystem */
 typedef uint16 CFE_MSG_System_t;        /**< \brief Message system */
 
 /** \brief Message type */
-typedef enum
+typedef enum CFE_MSG_Type
 {
     CFE_MSG_Type_Invalid, /**< \brief Message type invalid, undefined, not implemented */
     CFE_MSG_Type_Cmd,     /**< \brief Command message type */
@@ -62,7 +62,7 @@ typedef enum
 } CFE_MSG_Type_t;
 
 /** \brief Segmentation flags */
-typedef enum
+typedef enum CFE_MSG_SegmentationFlag
 {
     CFE_MSG_SegFlag_Invalid,    /**< \brief Invalid segmentation flag */
     CFE_MSG_SegFlag_Continue,   /**< \brief Continuation segment of User Data */
@@ -72,7 +72,7 @@ typedef enum
 } CFE_MSG_SegmentationFlag_t;
 
 /** \brief Endian flag */
-typedef enum
+typedef enum CFE_MSG_Endian
 {
     CFE_MSG_Endian_Invalid, /**< \brief Invalid endian setting */
     CFE_MSG_Endian_Big,     /**< \brief Big endian */
@@ -80,7 +80,7 @@ typedef enum
 } CFE_MSG_Endian_t;
 
 /** \brief Playback flag */
-typedef enum
+typedef enum CFE_MSG_PlaybackFlag
 {
     CFE_MSG_PlayFlag_Invalid,  /**< \brief Invalid playback setting */
     CFE_MSG_PlayFlag_Original, /**< \brief Original */

--- a/fsw/cfe-core/src/inc/cfe_sb.h
+++ b/fsw/cfe-core/src/inc/cfe_sb.h
@@ -150,13 +150,13 @@
 typedef CFE_MSG_Message_t CFE_SB_Msg_t;
 
 /** \brief Aligned Software Bus command header */
-typedef union {
+typedef union CFE_SB_CmdHdr {
     CFE_MSG_CommandHeader_t Cmd;
     CFE_SB_Msg_t            BaseMsg;
 } CFE_SB_CmdHdr_t;
 
 /** \brief Aligned Software Bus telemetry header */
-typedef union {
+typedef union CFE_SB_TlmHdr {
     CFE_MSG_TelemetryHeader_t Tlm;
     CFE_SB_Msg_t              BaseMsg;
 } CFE_SB_TlmHdr_t;

--- a/fsw/cfe-core/src/inc/cfe_sb_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_sb_msg.h
@@ -491,11 +491,11 @@ typedef CFE_SB_CmdHdr_t  CFE_SB_SendPrevSubs_t;
 **  'Write Pipe Info to File' #CFE_SB_SEND_PIPE_INFO_CC and
 **  'Write Map Info to File' #CFE_SB_SEND_MAP_INFO_CC.
 */
-typedef struct{
+typedef struct CFE_SB_WriteFileInfoCmd_Payload {
    char Filename[CFE_MISSION_MAX_PATH_LEN];/**< \brief Path and Filename of data to be loaded */
 } CFE_SB_WriteFileInfoCmd_Payload_t;
 
-typedef struct{
+typedef struct CFE_SB_WriteFileInfoCmd {
     CFE_SB_CmdHdr_t                     Hdr;/**< \brief cFE Software Bus Command Message Header #CFE_SB_CmdHdr_t */
     CFE_SB_WriteFileInfoCmd_Payload_t   Payload;
 }CFE_SB_WriteFileInfoCmd_t;
@@ -515,14 +515,14 @@ typedef CFE_SB_WriteFileInfoCmd_t CFE_SB_SendMapInfo_t;
 **  A route is the destination pipe for a  particular message and is therefore defined
 **  as a MsgId and PipeId combination.
 */
-typedef struct {
+typedef struct CFE_SB_RouteCmd_Payload {
 
    CFE_SB_MsgId_t       MsgId;/**< \brief Message ID of route to be enabled or disabled #CFE_SB_MsgId_t */
    CFE_SB_PipeId_t      Pipe;/**< \brief Pipe ID of route to be enabled or disabled #CFE_SB_PipeId_t */
    uint8                Spare;/**<\brief Spare byte to make command even number of bytes */
 } CFE_SB_RouteCmd_Payload_t;
 
-typedef struct{
+typedef struct CFE_SB_RouteCmd {
     CFE_SB_CmdHdr_t             Hdr;/**< \brief cFE Software Bus Command Message Header #CFE_SB_CmdHdr_t */
     CFE_SB_RouteCmd_Payload_t  Payload;
 } CFE_SB_RouteCmd_t;
@@ -540,7 +540,7 @@ typedef CFE_SB_RouteCmd_t CFE_SB_DisableRoute_t;
 /**
 **  \cfesbtlm Software Bus task housekeeping Packet
 */
-typedef struct {
+typedef struct CFE_SB_HousekeepingTlm_Payload {
 
     uint8           CommandCounter;/**< \cfetlmmnemonic \SB_CMDPC
                                     \brief Count of valid commands received */
@@ -583,7 +583,7 @@ typedef struct {
                                      \brief cfg param CFE_PLATFORM_SB_BUF_MEMORY_BYTES minus Peak Memory in use */
 } CFE_SB_HousekeepingTlm_Payload_t;
 
-typedef struct{
+typedef struct CFE_SB_HousekeepingTlm {
     CFE_SB_TlmHdr_t         Hdr;/**< \brief cFE Software Bus Telemetry Message Header */
     CFE_SB_HousekeepingTlm_Payload_t  Payload;
 } CFE_SB_HousekeepingTlm_t;
@@ -594,7 +594,7 @@ typedef struct{
 **
 ** Used in SB Statistics Telemetry Packet #CFE_SB_StatsTlm_t
 */
-typedef struct {
+typedef struct CFE_SB_PipeDepthStats {
 
     CFE_SB_PipeId_t     PipeId;/**< \cfetlmmnemonic \SB_PDPIPEID
                                     \brief Pipe Id associated with the stats below */
@@ -614,7 +614,7 @@ typedef struct {
 **
 ** SB Statistics packet sent (via CFE_SB_SendMsg) in response to #CFE_SB_SEND_SB_STATS_CC
 */
-typedef struct {
+typedef struct CFE_SB_StatsTlm_Payload {
 
     uint32              MsgIdsInUse;/**< \cfetlmmnemonic \SB_SMMIDIU
                                          \brief Current number of MsgIds with a destination */
@@ -656,7 +656,7 @@ typedef struct {
                                                                   \brief Pipe Depth Statistics #CFE_SB_PipeDepthStats_t*/
 } CFE_SB_StatsTlm_Payload_t;
 
-typedef struct{
+typedef struct CFE_SB_StatsTlm {
     CFE_SB_TlmHdr_t             Hdr;/**< \brief cFE Software Bus Telemetry Message Header */
     CFE_SB_StatsTlm_Payload_t    Payload;
 } CFE_SB_StatsTlm_t;
@@ -667,7 +667,7 @@ typedef struct{
 **
 ** Structure of one element of the routing information in response to #CFE_SB_SEND_ROUTING_INFO_CC
 */
-typedef struct{
+typedef struct CFE_SB_RoutingFileEntry {
     CFE_SB_MsgId_t      MsgId;/**< \brief Message Id portion of the route */
     CFE_SB_PipeId_t     PipeId;/**< \brief Pipe Id portion of the route */
     uint8               State;/**< \brief Route Enabled or Disabled */
@@ -682,7 +682,7 @@ typedef struct{
 **
 ** Structure of one element of the map information in response to #CFE_SB_SEND_MAP_INFO_CC
 */
-typedef struct{
+typedef struct CFE_SB_MsgMapFileEntry {
     CFE_SB_MsgId_t             MsgId;/**< \brief Message Id which has been subscribed to */
     CFE_SB_MsgRouteIdx_Atom_t  Index;/**< \brief Routing table index where pipe destinations are found */
 }CFE_SB_MsgMapFileEntry_t;
@@ -698,7 +698,7 @@ typedef struct{
 **
 ** \sa #CFE_SB_ENABLE_SUB_REPORTING_CC, #CFE_SB_DISABLE_SUB_REPORTING_CC
 */
-typedef struct {
+typedef struct CFE_SB_SingleSubscriptionTlm_Payload {
 
    uint8                SubType;/**< \brief Subscription or Unsubscription */
    CFE_SB_MsgId_t       MsgId;/**< \brief MsgId subscribed or unsubscribe to */
@@ -707,7 +707,7 @@ typedef struct {
 
 } CFE_SB_SingleSubscriptionTlm_Payload_t;
 
-typedef struct{
+typedef struct CFE_SB_SingleSubscriptionTlm {
     CFE_SB_TlmHdr_t             Hdr;/**< \brief cFE Software Bus Telemetry Message Header */
     CFE_SB_SingleSubscriptionTlm_Payload_t Payload;
 } CFE_SB_SingleSubscriptionTlm_t;
@@ -721,7 +721,7 @@ typedef struct{
 **
 ** Used in structure definition #CFE_SB_AllSubscriptionsTlm_t
 */
-typedef struct {
+typedef struct CFE_SB_SubEntries {
 
    CFE_SB_MsgId_t       MsgId;/**< \brief MsgId portion of the subscription */
    CFE_SB_Qos_t         Qos;/**< \brief Qos portion of the subscription */
@@ -739,7 +739,7 @@ typedef struct {
 ** there are more subscriptions than can fit in one pkt. The complete list of
 ** subscriptions is sent via a series of segmented pkts.
 */
-typedef struct {
+typedef struct CFE_SB_AllSubscriptionsTlm_Payload {
 
    uint32               PktSegment;/**< \brief Pkt number(starts at 1) in the series */
    uint32               TotalSegments;/**< \brief Total number of pkts needed to complete the request */
@@ -747,7 +747,7 @@ typedef struct {
    CFE_SB_SubEntries_t  Entry[CFE_SB_SUB_ENTRIES_PER_PKT];/**< \brief Array of #CFE_SB_SubEntries_t entries */
 } CFE_SB_AllSubscriptionsTlm_Payload_t;
 
-typedef struct{
+typedef struct CFE_SB_AllSubscriptionsTlm {
     CFE_SB_TlmHdr_t             Hdr;/**< \brief cFE Software Bus Telemetry Message Header */
     CFE_SB_AllSubscriptionsTlm_Payload_t Payload;
 } CFE_SB_AllSubscriptionsTlm_t;

--- a/fsw/cfe-core/src/inc/cfe_tbl.h
+++ b/fsw/cfe-core/src/inc/cfe_tbl.h
@@ -110,7 +110,7 @@ typedef int32 (*CFE_TBL_CallbackFuncPtr_t)(void *TblPtr);
 typedef int16 CFE_TBL_Handle_t;
 
 /** \brief Table Source */
-typedef enum 
+typedef enum CFE_TBL_SrcEnum
 {
     CFE_TBL_SRC_FILE = 0, /**< \brief File source
                                When this option is selected, the \c SrcDataPtr 
@@ -129,7 +129,7 @@ typedef enum
 } CFE_TBL_SrcEnum_t;
 
 /** \brief Table Info */
-typedef struct
+typedef struct CFE_TBL_Info
 {
     uint32                Size;                             /**< \brief Size, in bytes, of Table */
     uint32                NumUsers;                         /**< \brief Number of Apps with access to the table */

--- a/fsw/cfe-core/src/inc/cfe_tbl_extern_typedefs.h
+++ b/fsw/cfe-core/src/inc/cfe_tbl_extern_typedefs.h
@@ -66,7 +66,7 @@ typedef uint16                                           CFE_TBL_BufferSelect_En
  *
  * This header follows the CFE_FS header and precedes the the actual table data.
  */
-typedef struct
+typedef struct CFE_TBL_File_Hdr
 {
     uint32                   Reserved;                             /**< Future Use: NumTblSegments in File?   */
     uint32                   Offset;                               /**< Byte Offset at which load should commence */

--- a/fsw/cfe-core/src/inc/cfe_tbl_filedef.h
+++ b/fsw/cfe-core/src/inc/cfe_tbl_filedef.h
@@ -58,7 +58,7 @@
  * The definition of the file definition metadata that can be used by
  * external tools (e.g. elf2cfetbl) to generate CFE table data files.
  */
-typedef struct
+typedef struct CFE_TBL_FileDef
 {
     char        ObjectName[64];                             /**< \brief Name of instantiated variable that contains desired table image */
     char        TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \brief Name of Table as defined onboard */
@@ -78,7 +78,7 @@ typedef struct
  
     #include "cfe_tbl_filedef.h"
 
-   typedef struct
+   typedef struct MyTblStruct
    {
        int     Int1;
        int     Int2;

--- a/fsw/cfe-core/src/inc/cfe_tbl_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_tbl_msg.h
@@ -490,7 +490,7 @@
 ** -# The No-Op Command (For details, see #CFE_TBL_NOOP_CC)
 ** -# The Reset Counters Command (For details, see #CFE_TBL_RESET_COUNTERS_CC)
 */
-typedef struct
+typedef struct CFE_TBL_NoArgsCmd
 {
     uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];   /**< \brief cFE Software Bus Command Message Header */
 
@@ -510,14 +510,14 @@ typedef CFE_TBL_NoArgsCmd_t CFE_TBL_ResetCounters_t;
 ** For command details, see #CFE_TBL_LOAD_CC
 **
 **/
-typedef struct
+typedef struct CFE_TBL_LoadCmd_Payload
 {
     char                  LoadFilename[CFE_MISSION_MAX_PATH_LEN];  /**< \brief Filename (and path) of data to be loaded */
                                                           /**< ASCII Character string containing full path 
                                                                filename for file to be loaded */
 } CFE_TBL_LoadCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TBL_Load
 {
     uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_LoadCmd_Payload_t   Payload;
@@ -528,7 +528,7 @@ typedef struct
 **
 ** For command details, see #CFE_TBL_DUMP_CC
 */
-typedef struct
+typedef struct CFE_TBL_DumpCmd_Payload
 {
     uint16                ActiveTableFlag;                        /**< \brief #CFE_TBL_BufferSelect_INACTIVE=Inactive Table, 
                                                                             #CFE_TBL_BufferSelect_ACTIVE=Active Table */
@@ -544,7 +544,7 @@ typedef struct
                                                                      where data is to be dumped */
 } CFE_TBL_DumpCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TBL_DumpCmd
 {
     uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_DumpCmd_Payload_t   Payload;
@@ -555,7 +555,7 @@ typedef struct
 **
 ** For command details, see #CFE_TBL_VALIDATE_CC
 */
-typedef struct
+typedef struct CFE_TBL_ValidateCmd_Payload
 {
     uint16                ActiveTableFlag;                         /**< \brief #CFE_TBL_BufferSelect_INACTIVE=Inactive Table, 
                                                                              #CFE_TBL_BufferSelect_ACTIVE=Active Table */
@@ -568,7 +568,7 @@ typedef struct
                                                                       identifier of table to be validated */
 } CFE_TBL_ValidateCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TBL_Validate
 {
     uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_ValidateCmd_Payload_t   Payload;
@@ -579,14 +579,14 @@ typedef struct
 **
 ** For command details, see #CFE_TBL_ACTIVATE_CC
 */
-typedef struct
+typedef struct CFE_TBL_ActivateCmd_Payload
 {
     char                  TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN];  /**< \brief Full Name of Table to be activated */
                                                                  /**< ASCII string containing full table name 
                                                                       identifier of table to be activated */
 } CFE_TBL_ActivateCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TBL_Activate
 {
     uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_ActivateCmd_Payload_t   Payload;
@@ -597,7 +597,7 @@ typedef struct
 **
 ** For command details, see #CFE_TBL_DUMP_REGISTRY_CC
 */
-typedef struct
+typedef struct CFE_TBL_DumpRegistryCmd_Payload
 {
     char                  DumpFilename[CFE_MISSION_MAX_PATH_LEN];        /**< \brief Full Filename where dumped data is to be 
                                                                      written */
@@ -605,7 +605,7 @@ typedef struct
                                                                      where registry is to be dumped */
 } CFE_TBL_DumpRegistryCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TBL_DumpRegistry
 {
     uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_DumpRegistryCmd_Payload_t    Payload;
@@ -616,7 +616,7 @@ typedef struct
 **
 ** For command details, see #CFE_TBL_SEND_REGISTRY_CC
 */
-typedef struct
+typedef struct CFE_TBL_SendRegistryCmd_Payload
 {
     char                  TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN];  /**< \brief Full Name of Table whose registry entry
                                                                       is to be telemetered */
@@ -625,7 +625,7 @@ typedef struct
                                                                       to be telemetered via #CFE_TBL_TableRegistryTlm_t */
 } CFE_TBL_SendRegistryCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TBL_SendRegistry
 {
     uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_SendRegistryCmd_Payload_t Payload;
@@ -636,7 +636,7 @@ typedef struct
 **
 ** For command details, see #CFE_TBL_DELETE_CDS_CC
 */
-typedef struct
+typedef struct CFE_TBL_DelCDSCmd_Payload
 {
     char                  TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN];  /**< \brief Full Name of Table whose CDS is
                                                                       to be deleted */
@@ -645,7 +645,7 @@ typedef struct
                                                                       CDS is to be deleted */
 } CFE_TBL_DelCDSCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TBL_DeleteCDS
 {
     uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_DelCDSCmd_Payload_t Payload;
@@ -656,14 +656,14 @@ typedef struct
 **
 ** For command details, see #CFE_TBL_ABORT_LOAD_CC
 */
-typedef struct
+typedef struct CFE_TBL_AbortLoadCmd_Payload
 {
     char                  TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN];  /**< \brief Full Name of Table whose load is to be aborted */
                                                                  /**< ASCII string containing full table name 
                                                                       identifier of a table whose load is to be aborted */
 } CFE_TBL_AbortLoadCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TBL_AbortLoad
 {
     uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_AbortLoadCmd_Payload_t    Payload;
@@ -683,12 +683,12 @@ typedef struct
 **      command message with the application specified message ID, command code and
 **      parameter whenever the table requires management (e.g. - loads and validations).
 */
-typedef struct
+typedef struct CFE_TBL_NotifyCmd_Payload
 {
     uint32                Parameter;                             /**< \brief Application specified command parameter */
 } CFE_TBL_NotifyCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TBL_NotifyCmd
 {
     uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_NotifyCmd_Payload_t Payload;
@@ -701,7 +701,7 @@ typedef struct
 /** 
 **  \cfetbltlm Table Services Housekeeping Packet
 **/
-typedef struct
+typedef struct CFE_TBL_HousekeepingTlm_Payload
 {
     /*
     ** Task command interface counters...
@@ -760,7 +760,7 @@ typedef struct
                                                                           \brief Name of the last table loaded */
 } CFE_TBL_HousekeepingTlm_Payload_t;
 
-typedef struct
+typedef struct CFE_TBL_HousekeepingTlm
 {
     uint8                       TlmHeader[CFE_SB_TLM_HDR_SIZE];       /**< \brief cFE Software Bus Telemetry Message Header */
     CFE_TBL_HousekeepingTlm_Payload_t  Payload;
@@ -770,7 +770,7 @@ typedef struct
 /** 
 **  \cfetbltlm Table Registry Info Packet
 **/
-typedef struct
+typedef struct CFE_TBL_TblRegPacket_Payload
 {
     uint32                      Size;                           /**< \cfetlmmnemonic \TBL_SIZE 
                                                                      \brief Size, in bytes, of Table */
@@ -808,7 +808,7 @@ typedef struct
                                                                      \brief Spare byte to maintain byte alignment */
 } CFE_TBL_TblRegPacket_Payload_t;
 
-typedef struct
+typedef struct CFE_TBL_TableRegistryTlm
 {
     uint8                           TlmHeader[CFE_SB_TLM_HDR_SIZE];       /**< \brief cFE Software Bus Telemetry Message Header */
     CFE_TBL_TblRegPacket_Payload_t  Payload;

--- a/fsw/cfe-core/src/inc/cfe_time.h
+++ b/fsw/cfe-core/src/inc/cfe_time.h
@@ -112,7 +112,7 @@
 **       elapsed since the epoch.
 **
 */
-typedef struct
+typedef struct CFE_TIME_SysTime
 {
   uint32  Seconds;            /**< \brief Number of seconds since epoch */
   uint32  Subseconds;         /**< \brief Number of subseconds since epoch (LSB = 2^(-32) seconds) */
@@ -135,7 +135,7 @@ typedef struct
 **       to be "negative".  This can lead to some confusion about what relationship exists between two time values.
 **       To resolve this confusion, the cFE provides the API #CFE_TIME_Compare which returns these enumerated values.
 */
-typedef enum  
+typedef enum CFE_TIME_Compare
 {
   CFE_TIME_A_LT_B  = -1,      /**< \brief The first specified time is considered to be before the second specified time */
   CFE_TIME_EQUAL   =  0,      /**< \brief The two specified times are considered to be equal */
@@ -150,7 +150,7 @@ typedef enum
 **       in an area of memory that is not cleared during a Processor Reset.  This allows the
 **       cFE Time Service to maintain time to the best of its ability after a Processor Reset.
 */
-typedef struct
+typedef struct CFE_TIME_ResetVars
 {
   uint32 Signature;                     /**< \brief Data validation signature used to verify data structure contents*/
   int16  LeapSeconds;                   /**< \brief Leap seconds value */

--- a/fsw/cfe-core/src/inc/cfe_time_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_time_msg.h
@@ -726,7 +726,7 @@
 /*
 ** Type definition (generic "no arguments" command)...
 */
-typedef struct
+typedef struct CFE_TIME_NoArgsCmd
 {
   uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];
 
@@ -744,12 +744,12 @@ typedef CFE_TIME_NoArgsCmd_t CFE_TIME_SendDiagnosticTlm_t;
 /*
 ** Type definition (leap seconds command)...
 */
-typedef struct
+typedef struct CFE_TIME_LeapsCmd_Payload
 {
     int16                 LeapSeconds;
 } CFE_TIME_LeapsCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TIME_SetLeapSeconds
 {
   uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
   CFE_TIME_LeapsCmd_Payload_t   Payload;
@@ -759,7 +759,7 @@ typedef struct
 /*
 ** Type definition (clock state command)...
 */
-typedef struct
+typedef struct CFE_TIME_StateCmd_Payload
 {
     int16                 ClockState;                    /**< \brief #CFE_TIME_ClockState_INVALID=Spacecraft time has not been accurately set,
                                                                      #CFE_TIME_ClockState_VALID=Spacecraft clock has been accurately set,
@@ -767,7 +767,7 @@ typedef struct
                                                          /**< Selects the current clock state */
 } CFE_TIME_StateCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TIME_SetStateCmd
 {
   uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
   CFE_TIME_StateCmd_Payload_t   Payload;
@@ -777,14 +777,14 @@ typedef struct
 /*
 ** Type definition (time data source command)...
 */
-typedef struct
+typedef struct CFE_TIME_SourceCmd_Payload
 {
     int16                 TimeSource;                    /**< \brief #CFE_TIME_SourceSelect_INTERNAL=Internal Source,
                                                                      #CFE_TIME_SourceSelect_EXTERNAL=External Source   */
                                                          /**< Selects either the "Internal" and "External" clock source */
 } CFE_TIME_SourceCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TIME_SetSource
 {
   uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
   CFE_TIME_SourceCmd_Payload_t  Payload;
@@ -794,14 +794,14 @@ typedef struct
 /*
 ** Type definition (tone signal source command)...
 */
-typedef struct
+typedef struct CFE_TIME_SignalCmd_Payload
 {
     int16                 ToneSource;                    /**< \brief #CFE_TIME_ToneSignalSelect_PRIMARY=Primary Source,
                                                                      #CFE_TIME_ToneSignalSelect_REDUNDANT=Redundant Source   */
                                                          /**< Selects either the "Primary" or "Redundant" tone signal source */
 } CFE_TIME_SignalCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TIME_SetSignal
 {
   uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
   CFE_TIME_SignalCmd_Payload_t  Payload;
@@ -812,13 +812,13 @@ typedef struct
 /*
 ** Type definition (generic "time argument" command)...
 */
-typedef struct
+typedef struct CFE_TIME_TimeCmd_Payload
 {
     uint32                Seconds;
     uint32                MicroSeconds;
 } CFE_TIME_TimeCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TIME_TimeCmd
 {
   uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
   CFE_TIME_TimeCmd_Payload_t    Payload;
@@ -841,14 +841,14 @@ typedef CFE_TIME_TimeCmd_t CFE_TIME_SetTime_t;
 /*
 ** Type definition (1Hz STCF adjustment "time argument" command)...
 */
-typedef struct
+typedef struct CFE_TIME_OneHzAdjustmentCmd_Payload
 {
     uint32                Seconds;
     uint32                Subseconds;
 
 } CFE_TIME_OneHzAdjustmentCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TIME_OneHzAdjustmentCmd
 {
   uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
   CFE_TIME_OneHzAdjustmentCmd_Payload_t  Payload;
@@ -866,7 +866,7 @@ typedef CFE_TIME_OneHzAdjustmentCmd_t CFE_TIME_Sub1HZAdjustment_t;
 /*
 ** Type definition (local 1Hz wake-up command)...
 */
-typedef struct
+typedef struct CFE_TIME_1HzCmd
 {
   uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];
 
@@ -876,7 +876,7 @@ typedef struct
 /*
 ** Type definition (time at the tone signal command)...
 */
-typedef struct
+typedef struct CFE_TIME_ToneSignalCmd
 {
   CFE_SB_CmdHdr_t         CmdHeader;
 
@@ -886,7 +886,7 @@ typedef struct
 /*
 ** Type definition ("fake" time at the tone signal command)...
 */
-typedef struct
+typedef struct CFE_TIME_FakeToneCmd
 {
     CFE_SB_CmdHdr_t       CmdHeader;
 
@@ -896,7 +896,7 @@ typedef struct
 /*
 ** Type definition (time at the tone data command)...
 */
-typedef struct
+typedef struct CFE_TIME_ToneDataCmd_Payload
 {
     CFE_TIME_SysTime_t    AtToneMET;    /**< \brief MET at time of tone */
     CFE_TIME_SysTime_t    AtToneSTCF;   /**< \brief STCF at time of tone */
@@ -904,7 +904,7 @@ typedef struct
     int16                 AtToneState;  /**< \brief Clock state at time of tone */
 } CFE_TIME_ToneDataCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TIME_ToneDataCmd
 {
   uint8                             CmdHeader[CFE_SB_CMD_HDR_SIZE];
   CFE_TIME_ToneDataCmd_Payload_t    Payload;
@@ -916,7 +916,7 @@ typedef struct
 /** 
 **  \cfetimetlm Time Services Housekeeping Packet
 **/
-typedef struct
+typedef struct CFE_TIME_HousekeepingTlm_Payload
 {
     /*
     ** Task command interface counters...
@@ -975,7 +975,7 @@ typedef struct
 
 } CFE_TIME_HousekeepingTlm_Payload_t;
 
-typedef struct
+typedef struct CFE_TIME_HousekeepingTlm
 {
   uint8                         TlmHeader[CFE_SB_TLM_HDR_SIZE];
   CFE_TIME_HousekeepingTlm_Payload_t   Payload;
@@ -987,7 +987,7 @@ typedef struct
 /** 
 **  \cfetimetlm Time Services Diagnostics Packet
 **/
-typedef struct
+typedef struct CFE_TIME_DiagnosticTlm_Payload
 {
     /*
      ** Data values used to compute time (in reference to "tone")...
@@ -1133,7 +1133,7 @@ typedef struct
 	                                               \brief Data Store status (preserved across processor reset) */
 } CFE_TIME_DiagnosticTlm_Payload_t;
 
-typedef struct
+typedef struct CFE_TIME_DiagnosticTlm
 {
   uint8                 		TlmHeader[CFE_SB_TLM_HDR_SIZE];
   CFE_TIME_DiagnosticTlm_Payload_t Payload;


### PR DESCRIPTION
Closes #769 

**Describe the contribution**
This adds names to `typedef struct`, `typedef union`, and `typedef enum` types, some tools find this helpful.

**Testing performed**
make install && make test

**Expected behavior changes**
no behavior change

**System(s) tested on**
Debian 10.5

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov