### PR TITLE
Fix #870, generic counter table management

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_start.c
+++ b/fsw/cfe-core/src/es/cfe_es_start.c
@@ -87,6 +87,7 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const cha
    int32 ReturnCode;
    CFE_ES_AppRecord_t *AppRecPtr;
    CFE_ES_TaskRecord_t *TaskRecPtr;
+   CFE_ES_GenCounterRecord_t *CountRecPtr;
 
    /*
    ** Indicate that the CFE is the earliest initialization state
@@ -200,9 +201,11 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const cha
    ** Initialize the ES Generic Counter Table
    ** to mark all entries as unused.
    */
+   CountRecPtr = CFE_ES_Global.CounterTable;
    for ( i = 0; i < CFE_PLATFORM_ES_MAX_GEN_COUNTERS; i++ )
    {
-      CFE_ES_Global.CounterTable[i].RecordUsed = false;
+       CFE_ES_CounterRecordSetFree(CountRecPtr);
+       ++CountRecPtr;
    }
 
    /*

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -4741,11 +4741,6 @@ void TestGenericCounterAPI(void)
     /* Test registering a generic counter with a null counter name */
     ES_ResetUnitTest();
 
-    for ( i = 0; i < CFE_PLATFORM_ES_MAX_GEN_COUNTERS; i++ )
-    {
-       CFE_ES_Global.CounterTable[i].RecordUsed = false;
-    }
-
     UT_Report(__FILE__, __LINE__,
              CFE_ES_RegisterGenCounter(&CounterId,
                                         NULL) == CFE_ES_BAD_ARGUMENT,
@@ -4761,7 +4756,6 @@ void TestGenericCounterAPI(void)
 
     /* Test setting a generic counter where the record is not in use */
     ES_ResetUnitTest();
-    CFE_ES_Global.CounterTable[CounterId].RecordUsed = false;
     UT_Report(__FILE__, __LINE__,
              CFE_ES_SetGenCount(CounterId, 0) == CFE_ES_BAD_ARGUMENT,
               "CFE_ES_SetGenCount",
@@ -4769,7 +4763,6 @@ void TestGenericCounterAPI(void)
 
     /* Test getting a generic counter where the record is not in use */
     ES_ResetUnitTest();
-    CFE_ES_Global.CounterTable[CounterId].RecordUsed = false;
     UT_Report(__FILE__, __LINE__,
              CFE_ES_GetGenCount(CounterId, &CounterCount)
                 == CFE_ES_BAD_ARGUMENT,
@@ -4778,7 +4771,6 @@ void TestGenericCounterAPI(void)
 
     /* Test getting a generic counter where the count is null */
     ES_ResetUnitTest();
-    CFE_ES_Global.CounterTable[CounterId].RecordUsed = true;
     UT_Report(__FILE__, __LINE__,
              CFE_ES_GetGenCount(CounterId, NULL)
                 == CFE_ES_BAD_ARGUMENT,


### PR DESCRIPTION
**Describe the contribution**
Apply the appid/taskid pattern to Generic Counter resources.

**Testing performed**
Unit tests
Build and sanity test CFE.

**Expected behavior changes**
No real logic change - just putting the repeated logic into inline functions.

However, This does add a `CFE_ES_LockSharedData()` wrapper around counter ID allocation, deletion, and lookup to avoid a possible race condition here.  This was likely a bug, but never noticed perhaps because these aren't a heavily used feature.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.