### PR TITLE
Integration Candidate: 2020-09-09

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ The detailed cFE user's guide can be viewed at <https://github.com/nasa/cFS/blob
 
 ## Version History
 
+### Development Build: 6.8.0-rc1+dev81
+
+- Deconflict CFE_ES_LIB_ALREADY_LOADED and CFE_ES_ERR_SYS_LOG_TRUNCATED EIDs
+- Scrub all CFE references/uses of OSAL IDs to use the proper osal_id_t type. Any place that an OSAL ID is stored in memory or passed in an API call are changed to the osal_id_t type, rather than uint32. Conversions between this and other types (e.g. bare integer) is done using the OSAL-supplied conversion helpers.
+- After the changes implemented in #101, there may be routing table entries with no subscribers (RoutePtr->ListHeadPtr would be NULL.) This could cause a seg-fault. Also, even if there are entries in the routing table, there will be no event generated if the unsubscribe does not find a matching route entry.
+- Adds debug message.
+- Applies the appid/taskid pattern to Generic Counter resources.
+- Adds test for SB subscribe/unusubscribe/unsubscribe.
+- See <https://github.com/nasa/cFE/pull/876>
+
+
 ### Development Build: 6.8.0-rc1+dev65
 
 - In the next major CFE release, this code will be no longer supported at all. It should be removed early in the cycle to avoid needing to maintain this compatibility code.

--- a/fsw/cfe-core/src/es/cfe_es_api.c
+++ b/fsw/cfe-core/src/es/cfe_es_api.c
@@ -926,7 +926,7 @@ int32 CFE_ES_CreateChildTask(uint32 *TaskIdPtr,
    uint32         TaskId;
    uint32         ChildTaskId;
    uint32         ParentTaskId;
-   uint32         OsalId;
+   osal_id_t      OsalId;
 
    /*
    ** Validate some of the arguments
@@ -974,7 +974,8 @@ int32 CFE_ES_CreateChildTask(uint32 *TaskIdPtr,
          ** First, Make sure the Calling Task is a cFE Main task.
          ** TaskID must be the same as the Parent Task ID.
          */
-         TaskId = OS_TaskGetId();
+         OsalId = OS_TaskGetId();
+         TaskId = CFE_ES_ResourceID_FromOSAL(OsalId);
          ParentTaskId = AppRecPtr->TaskInfo.MainTaskId;
          if ( TaskId == ParentTaskId )
          {
@@ -997,7 +998,7 @@ int32 CFE_ES_CreateChildTask(uint32 *TaskIdPtr,
             */
             if ( Result == OS_SUCCESS )
             {
-               ChildTaskId = OsalId;
+               ChildTaskId = CFE_ES_ResourceID_FromOSAL(OsalId);
                TaskRecPtr = CFE_ES_LocateTaskRecordByID(ChildTaskId);
 
                CFE_ES_TaskRecordSetUsed(TaskRecPtr, ChildTaskId);
@@ -1091,7 +1092,7 @@ void CFE_ES_IncrementTaskCounter(void)
      * Because the global data is not locked, only minimal validation
      * is performed.
      */
-    TaskID = OS_TaskGetId();
+    TaskID = CFE_ES_ResourceID_FromOSAL(OS_TaskGetId());
     TaskRecPtr = CFE_ES_LocateTaskRecordByID(TaskID);
     if (TaskRecPtr != NULL)
     {
@@ -1113,6 +1114,7 @@ int32 CFE_ES_DeleteChildTask(uint32 TaskId)
     bool    TaskIsMain = false;
     int32   ReturnCode = CFE_SUCCESS;
     int32   OSReturnCode;
+    osal_id_t   OsalId;
 
     /*
     ** Make sure the task ID is within range
@@ -1154,7 +1156,8 @@ int32 CFE_ES_DeleteChildTask(uint32 TaskId)
              /*
              ** Can delete the Task
              */
-             OSReturnCode = OS_TaskDelete(TaskId);
+             OsalId = CFE_ES_ResourceID_ToOSAL(TaskId);
+             OSReturnCode = OS_TaskDelete(OsalId);
              if ( OSReturnCode == OS_SUCCESS )
              {
                 /*
@@ -1691,7 +1694,10 @@ int32 CFE_ES_AppID_ToIndex(uint32 AppId, uint32 *Idx)
  */
 int32 CFE_ES_TaskID_ToIndex(uint32 TaskID, uint32 *Idx)
 {
-    if (OS_ConvertToArrayIndex(TaskID, Idx) != OS_SUCCESS)
+    osal_id_t OsalID;
+
+    OsalID = CFE_ES_ResourceID_ToOSAL(TaskID);
+    if (OS_ConvertToArrayIndex(OsalID, Idx) != OS_SUCCESS)
     {
         return CFE_ES_ERR_TASKID;
     }
@@ -1721,6 +1727,33 @@ int32 CFE_ES_CounterID_ToIndex(uint32 CounterId, uint32 *Idx)
 /***************************************************************************************
 ** Private API functions
 */
+
+/**
+ * Convert a CFE_ES_ResourceID_t type to an OSAL ID type.
+ *
+ * This should only be used on ES resource IDs that are known to refer to
+ * an OSAL resource (e.g. a task ID).
+ *
+ * Note this may result in an invalid OSAL ID if the CFE_ES_ResourceID_t did
+ * not actually refer to an OSAL resource.
+ */
+osal_id_t CFE_ES_ResourceID_ToOSAL(uint32 id)
+{
+    unsigned long val = (uint32)id; /* type conversion */
+    return OS_ObjectIdFromInteger(val);
+}
+
+/**
+ * Convert an OSAL ID type to a CFE_ES_ResourceID_t type.
+ *
+ * Any OSAL ID can also be represented as a CFE_ES_ResourceID_t
+ */
+uint32 CFE_ES_ResourceID_FromOSAL(osal_id_t id)
+{
+    unsigned long val = OS_ObjectIdToInteger(id);
+    return (uint32)val; /* type conversion */
+}
+
 
 /*
  * Note - this gets the table entry pointer but does not dereference or
@@ -1796,7 +1829,7 @@ CFE_ES_TaskRecord_t *CFE_ES_GetTaskRecordByContext(void)
     /*
     ** Use the OS task ID to get the ES task record
     */
-    TaskID = OS_TaskGetId();
+    TaskID = CFE_ES_ResourceID_FromOSAL(OS_TaskGetId());
     TaskRecPtr = CFE_ES_LocateTaskRecordByID(TaskID);
 
     /*

--- a/fsw/cfe-core/src/es/cfe_es_apps.h
+++ b/fsw/cfe-core/src/es/cfe_es_apps.h
@@ -76,7 +76,7 @@ typedef struct
 
   uint32                StackSize;
   cpuaddr               StartAddress;
-  uint32                ModuleId;
+  osal_id_t             ModuleId;
 
   uint16                ExceptionAction;
   uint16                Priority;

--- a/fsw/cfe-core/src/es/cfe_es_backgroundtask.c
+++ b/fsw/cfe-core/src/es/cfe_es_backgroundtask.c
@@ -246,7 +246,7 @@ void CFE_ES_BackgroundCleanup(void)
     OS_BinSemDelete(CFE_ES_Global.BackgroundTask.WorkSem);
 
     CFE_ES_Global.BackgroundTask.TaskID = 0;
-    CFE_ES_Global.BackgroundTask.WorkSem = 0;
+    CFE_ES_Global.BackgroundTask.WorkSem = OS_OBJECT_ID_UNDEFINED;
 }
 
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */

--- a/fsw/cfe-core/src/es/cfe_es_cds.h
+++ b/fsw/cfe-core/src/es/cfe_es_cds.h
@@ -75,7 +75,7 @@ typedef struct
 
 typedef struct
 {
-    uint32               RegistryMutex;                         /**< \brief Mutex that controls access to CDS Registry */
+    osal_id_t            RegistryMutex;                         /**< \brief Mutex that controls access to CDS Registry */
     uint32               CDSSize;                               /**< \brief Total size of the CDS as reported by BSP */
     uint32               MemPoolSize;
     uint32               MaxNumRegEntries;                      /**< \brief Maximum number of Registry entries */

--- a/fsw/cfe-core/src/es/cfe_es_cds_mempool.h
+++ b/fsw/cfe-core/src/es/cfe_es_cds_mempool.h
@@ -81,7 +81,7 @@ typedef struct {
    int32    SizeIndex;
    uint16   CheckErrCntr;
    uint16   RequestCntr;
-   uint32   MutexId;
+   osal_id_t   MutexId;
    uint32   MinBlockSize;
    CFE_ES_CDSBlockSizeDesc_t SizeDesc[CFE_ES_CDS_NUM_BLOCK_SIZES];
 } CFE_ES_CDSPool_t;

--- a/fsw/cfe-core/src/es/cfe_es_global.h
+++ b/fsw/cfe-core/src/es/cfe_es_global.h
@@ -75,7 +75,7 @@ typedef struct
 typedef struct
 {
     uint32 TaskID;          /**< OSAL ID of the background task */
-    uint32 WorkSem;         /**< Semaphore that is given whenever background work is pending */
+    osal_id_t WorkSem;      /**< Semaphore that is given whenever background work is pending */
     uint32 NumJobsRunning;  /**< Current Number of active jobs (updated by background task) */
 } CFE_ES_BackgroundTaskState_t;
 
@@ -95,12 +95,12 @@ typedef struct
    /*
    ** Shared Data Semaphore
    */
-   uint32 SharedDataMutex;
+   osal_id_t SharedDataMutex;
 
    /*
    ** Performance Data Mutex
    */
-   uint32 PerfDataMutex;
+   osal_id_t PerfDataMutex;
 
    /*
    ** Startup Sync
@@ -467,6 +467,47 @@ extern CFE_ES_AppRecord_t* CFE_ES_GetAppRecordByContext(void);
  * The global data lock should be obtained prior to invoking this function.
  */
 extern CFE_ES_TaskRecord_t* CFE_ES_GetTaskRecordByContext(void);
+
+/**
+ * @brief Convert an ES Task ID to an OSAL task ID
+ *
+ * Task IDs created via CFE ES are also OSAL task IDs, but technically
+ * do refer to a different scope and therefore have a different type
+ * to represent them.
+ *
+ * This function facilitates converting between the types.
+ *
+ * @note Currently the numeric values are the same and can be interchanged
+ * for backward compatibility, however they may diverge in a future version.
+ * New code should not assume equivalence between OSAL and ES task IDs.
+ *
+ * @sa CFE_ES_ResourceID_FromOSAL
+ *
+ * @param[in] id    The ES task ID
+ * @returns         The OSAL task ID
+ */
+osal_id_t CFE_ES_ResourceID_ToOSAL(uint32 id);
+
+/**
+ * @brief Convert an ES Task ID to an OSAL task ID
+ *
+ * Task IDs created via CFE ES are also OSAL task IDs, but technically
+ * do refer to a different scope and therefore have a different type
+ * to represent them.
+ *
+ * This function facilitates converting between the types.
+ *
+ * @note Currently the numeric values are the same and can be interchanged
+ * for backward compatibility, however they may diverge in a future version.
+ * New code should not assume equivalence between OSAL and ES task IDs.
+ *
+ * @sa CFE_ES_ResourceID_ToOSAL
+ *
+ * @param[in] id    The OSAL task ID
+ * @returns         The ES task ID
+ */
+uint32 CFE_ES_ResourceID_FromOSAL(osal_id_t id);
+
 
 /*
 ** Functions used to lock/unlock shared data

--- a/fsw/cfe-core/src/es/cfe_es_perf.h
+++ b/fsw/cfe-core/src/es/cfe_es_perf.h
@@ -110,7 +110,7 @@ typedef struct
     CFE_ES_PerfDumpState_t  PendingState;   /* the pending/next state, if transitioning */
 
     char                DataFileName[OS_MAX_PATH_LEN];  /* output file name from dump command */
-    int32               FileDesc;                       /* file descriptor for writing */
+    osal_id_t           FileDesc;                       /* file descriptor for writing */
     uint32              WorkCredit;                     /* accumulator based on the passage of time */
     uint32              StateCounter;                   /* number of blocks/items left in current state */
     uint32              DataPos;                        /* last position within the Perf Log */

--- a/fsw/cfe-core/src/es/cfe_es_start.c
+++ b/fsw/cfe-core/src/es/cfe_es_start.c
@@ -776,7 +776,7 @@ void  CFE_ES_CreateObjects(void)
     bool      AppSlotFound;
     uint16    i;
     uint16    j;
-    uint32    OsalId;
+    osal_id_t OsalId;
     CFE_ES_AppRecord_t *AppRecPtr;
     CFE_ES_TaskRecord_t *TaskRecPtr;
 
@@ -875,7 +875,7 @@ void  CFE_ES_CreateObjects(void)
                }
                else
                {
-                  AppRecPtr->TaskInfo.MainTaskId = OsalId;
+                  AppRecPtr->TaskInfo.MainTaskId = CFE_ES_ResourceID_FromOSAL(OsalId);
                   TaskRecPtr = CFE_ES_LocateTaskRecordByID(AppRecPtr->TaskInfo.MainTaskId);
 
                   /*

--- a/fsw/cfe-core/src/es/cfe_es_start.c
+++ b/fsw/cfe-core/src/es/cfe_es_start.c
@@ -87,6 +87,7 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const cha
    int32 ReturnCode;
    CFE_ES_AppRecord_t *AppRecPtr;
    CFE_ES_TaskRecord_t *TaskRecPtr;
+   CFE_ES_GenCounterRecord_t *CountRecPtr;
 
    /*
    ** Indicate that the CFE is the earliest initialization state
@@ -200,9 +201,11 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const cha
    ** Initialize the ES Generic Counter Table
    ** to mark all entries as unused.
    */
+   CountRecPtr = CFE_ES_Global.CounterTable;
    for ( i = 0; i < CFE_PLATFORM_ES_MAX_GEN_COUNTERS; i++ )
    {
-      CFE_ES_Global.CounterTable[i].RecordUsed = false;
+       CFE_ES_CounterRecordSetFree(CountRecPtr);
+       ++CountRecPtr;
    }
 
    /*

--- a/fsw/cfe-core/src/es/cfe_es_syslog.c
+++ b/fsw/cfe-core/src/es/cfe_es_syslog.c
@@ -468,7 +468,7 @@ void CFE_ES_SysLog_snprintf(char *Buffer, size_t BufferSize, const char *SpecStr
  */
 int32 CFE_ES_SysLogDump(const char *Filename)
 {
-    int32   fd;
+    osal_id_t   fd;
     int32   Status;
     size_t  WritePos;
     size_t  TotalSize;
@@ -479,14 +479,16 @@ int32 CFE_ES_SysLogDump(const char *Filename)
         CFE_FS_Header_t FileHdr;
     } Buffer;
 
-    fd = OS_creat(Filename, OS_WRITE_ONLY);
-    if(fd < 0)
+    Status = OS_creat(Filename, OS_WRITE_ONLY);
+    if(Status < 0)
     {
         CFE_EVS_SendEvent(CFE_ES_SYSLOG2_ERR_EID,CFE_EVS_EventType_ERROR,
                 "Error creating file %s, RC = 0x%08X",
-                Filename,(unsigned int)fd);
+                Filename,(unsigned int)Status);
         return CFE_ES_FILE_IO_ERR;
     }/* end if */
+
+    fd = OS_ObjectIdFromInteger(Status);
 
     CFE_FS_InitHeader(&Buffer.FileHdr, CFE_ES_SYS_LOG_DESC, CFE_FS_SubType_ES_SYSLOG);
 

--- a/fsw/cfe-core/src/es/cfe_es_task.c
+++ b/fsw/cfe-core/src/es/cfe_es_task.c
@@ -1175,7 +1175,7 @@ int32 CFE_ES_QueryOneCmd(const CFE_ES_QueryOne_t *data)
 int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAll_t *data)
 {
     CFE_FS_Header_t       FileHeader;
-    int32                 FileDescriptor;
+    osal_id_t             FileDescriptor;
     uint32                i;
     uint32                EntryCount = 0;
     uint32                FileSize = 0;
@@ -1194,9 +1194,10 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAll_t *data)
     /*
     ** Check to see if the file already exists
     */
-    FileDescriptor = OS_open(QueryAllFilename, OS_READ_ONLY, 0);
-    if (FileDescriptor >= 0)
+    Result = OS_open(QueryAllFilename, OS_READ_ONLY, 0);
+    if (Result >= 0)
     {
+        FileDescriptor = OS_ObjectIdFromInteger(Result);
         OS_close(FileDescriptor);
         OS_remove(QueryAllFilename);
     }
@@ -1204,9 +1205,10 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAll_t *data)
     /*
     ** Create ES task log data file
     */
-    FileDescriptor = OS_creat(QueryAllFilename, OS_WRITE_ONLY);
-    if (FileDescriptor >= 0)
+    Result = OS_creat(QueryAllFilename, OS_WRITE_ONLY);
+    if (Result >= 0)
     {
+        FileDescriptor = OS_ObjectIdFromInteger(Result);
         /*
         ** Initialize cFE file header
         */
@@ -1290,7 +1292,7 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAll_t *data)
     {
         CFE_ES_TaskData.CommandErrorCounter++;
         CFE_EVS_SendEvent(CFE_ES_OSCREATE_ERR_EID, CFE_EVS_EventType_ERROR,
-                "Failed to write App Info file, OS_creat RC = 0x%08X",(unsigned int)FileDescriptor);
+                "Failed to write App Info file, OS_creat RC = 0x%08X",(unsigned int)Result);
     }
 
     return CFE_SUCCESS;
@@ -1305,7 +1307,7 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAll_t *data)
 int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasks_t *data)
 {
     CFE_FS_Header_t            FileHeader;
-    int32                      FileDescriptor;
+    osal_id_t                  FileDescriptor;
     uint32                     i;
     uint32                     EntryCount = 0;
     uint32                     FileSize = 0;
@@ -1323,9 +1325,10 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasks_t *data)
     /*
     ** Check to see if the file already exists
     */
-    FileDescriptor = OS_open(QueryAllFilename, OS_READ_ONLY, 0);
-    if (FileDescriptor >= 0)
+    Result = OS_open(QueryAllFilename, OS_READ_ONLY, 0);
+    if (Result >= 0)
     {
+        FileDescriptor = OS_ObjectIdFromInteger(Result);
         OS_close(FileDescriptor);
         OS_remove(QueryAllFilename);
     }
@@ -1333,9 +1336,10 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasks_t *data)
     /*
     ** Create ES task log data file
     */
-    FileDescriptor = OS_creat(QueryAllFilename, OS_WRITE_ONLY);
-    if (FileDescriptor >= 0)
+    Result = OS_creat(QueryAllFilename, OS_WRITE_ONLY);
+    if (Result >= 0)
     {
+        FileDescriptor = OS_ObjectIdFromInteger(Result);
         /*
         ** Initialize cFE file header
         */
@@ -1419,7 +1423,7 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasks_t *data)
     {
         CFE_ES_TaskData.CommandErrorCounter++;
         CFE_EVS_SendEvent(CFE_ES_TASKINFO_OSCREATE_ERR_EID, CFE_EVS_EventType_ERROR,
-                "Failed to write Task Info file, OS_creat RC = 0x%08X",(unsigned int)FileDescriptor);
+                "Failed to write Task Info file, OS_creat RC = 0x%08X",(unsigned int)Result);
     }
 
     return CFE_SUCCESS;
@@ -1784,7 +1788,7 @@ int32 CFE_ES_SendMemPoolStatsCmd(const CFE_ES_SendMemPoolStats_t *data)
 int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistry_t *data)
 {
     CFE_FS_Header_t               StdFileHeader;
-    int32                         FileDescriptor;
+    osal_id_t                     FileDescriptor;
     int32                         Status;
     int16                         RegIndex=0;
     const CFE_ES_DumpCDSRegistryCmd_Payload_t *CmdPtr = &data->Payload;
@@ -1799,10 +1803,12 @@ int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistry_t *data)
             OS_MAX_PATH_LEN, sizeof(CmdPtr->DumpFilename));
 
     /* Create a new dump file, overwriting anything that may have existed previously */
-    FileDescriptor = OS_creat(DumpFilename, OS_WRITE_ONLY);
+    Status = OS_creat(DumpFilename, OS_WRITE_ONLY);
 
-    if (FileDescriptor >= OS_SUCCESS)
+    if (Status >= OS_SUCCESS)
     {
+        FileDescriptor = OS_ObjectIdFromInteger(Status);
+
         /* Initialize the standard cFE File Header for the Dump File */
         CFE_FS_InitHeader(&StdFileHeader, "CDS_Registry", CFE_FS_SubType_ES_CDS_REG);
 
@@ -1886,7 +1892,7 @@ int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistry_t *data)
         CFE_EVS_SendEvent(CFE_ES_CREATING_CDS_DUMP_ERR_EID,
                 CFE_EVS_EventType_ERROR,
                 "Error creating CDS dump file '%s', Status=0x%08X",
-                DumpFilename, (unsigned int)FileDescriptor);
+                DumpFilename, (unsigned int)Status);
 
         /* Increment Command Error Counter */
         CFE_ES_TaskData.CommandErrorCounter++;

--- a/fsw/cfe-core/src/es/cfe_esmempool.h
+++ b/fsw/cfe-core/src/es/cfe_esmempool.h
@@ -68,7 +68,7 @@ typedef struct
    BlockSizeDesc_t *SizeDescPtr;
    uint16           CheckErrCntr;
    uint16           RequestCntr;
-   uint32           MutexId;
+   osal_id_t        MutexId;
    uint32           UseMutex;
    BlockSizeDesc_t  SizeDesc[CFE_ES_MAX_MEMPOOL_BLOCK_SIZES];
 } Pool_t;

--- a/fsw/cfe-core/src/evs/cfe_evs_log.c
+++ b/fsw/cfe-core/src/evs/cfe_evs_log.c
@@ -154,7 +154,7 @@ int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFile_t *data)
     int32           Result;
     int32           LogIndex;
     int32           BytesWritten;
-    int32           LogFileHandle;
+    osal_id_t       LogFileHandle;
     uint32          i;
     CFE_FS_Header_t LogFileHdr;
     char            LogFilename[OS_MAX_PATH_LEN];
@@ -172,18 +172,19 @@ int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFile_t *data)
                 OS_MAX_PATH_LEN, sizeof(CmdPtr->LogFilename));
 
         /* Create the log file */
-        LogFileHandle = OS_creat(LogFilename, OS_WRITE_ONLY);
+        Result = OS_creat(LogFilename, OS_WRITE_ONLY);
 
-        if (LogFileHandle < OS_SUCCESS)
+        if (Result < OS_SUCCESS)
         {
             EVS_SendEvent(CFE_EVS_ERR_CRLOGFILE_EID, CFE_EVS_EventType_ERROR,
                     "Write Log File Command Error: OS_creat = 0x%08X, filename = %s",
-                    (unsigned int)LogFileHandle, LogFilename);
+                    (unsigned int)Result, LogFilename);
 
-            Result = LogFileHandle;
         }
         else
         {
+            LogFileHandle = OS_ObjectIdFromInteger(Result);
+
             /* Result will be overridden if everything works */
             Result = CFE_EVS_FILE_WRITE_ERROR;
 

--- a/fsw/cfe-core/src/evs/cfe_evs_task.c
+++ b/fsw/cfe-core/src/evs/cfe_evs_task.c
@@ -1737,7 +1737,7 @@ int32 CFE_EVS_DeleteEventFilterCmd(const CFE_EVS_DeleteEventFilter_t *data)
 int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFile_t *data)
 {
    int32                             Result;
-   int32                             FileHandle;
+   osal_id_t                         FileHandle;
    int32                             BytesWritten;
    uint32                            EntryCount = 0;
    uint32                            i;
@@ -1752,18 +1752,18 @@ int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFile_t *data)
            OS_MAX_PATH_LEN, sizeof(CmdPtr->AppDataFilename));
 
    /* Create Application Data File */
-   FileHandle = OS_creat(LocalName, OS_WRITE_ONLY);
+   Result = OS_creat(LocalName, OS_WRITE_ONLY);
 
-   if (FileHandle < OS_SUCCESS)
+   if (Result < OS_SUCCESS)
    {
       EVS_SendEvent(CFE_EVS_ERR_CRDATFILE_EID, CFE_EVS_EventType_ERROR,
                    "Write App Data Command Error: OS_creat = 0x%08X, filename = %s",
-                    (unsigned int)FileHandle, LocalName);
-
-      Result = FileHandle;
+                    (unsigned int)Result, LocalName);
    }
    else
    {
+      FileHandle = OS_ObjectIdFromInteger(Result);
+
       /* Result will be overridden if everything works */
       Result = CFE_EVS_FILE_WRITE_ERROR;
 

--- a/fsw/cfe-core/src/evs/cfe_evs_task.h
+++ b/fsw/cfe-core/src/evs/cfe_evs_task.h
@@ -122,7 +122,7 @@ typedef struct
    */
    CFE_EVS_HousekeepingTlm_t    EVS_TlmPkt;
    CFE_SB_PipeId_t     EVS_CommandPipe;
-   uint32              EVS_SharedDataMutexID;
+   osal_id_t           EVS_SharedDataMutexID;
    uint32              EVS_AppID;
 
 } CFE_EVS_GlobalData_t;

--- a/fsw/cfe-core/src/fs/cfe_fs_api.c
+++ b/fsw/cfe-core/src/fs/cfe_fs_api.c
@@ -46,7 +46,7 @@
 /*
 ** CFE_FS_ReadHeader() - See API and header file for details
 */
-int32 CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, int32 FileDes)
+int32 CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, osal_id_t FileDes)
 {
     int32   Result;
     int32   EndianCheck = 0x01020304;
@@ -89,7 +89,7 @@ void CFE_FS_InitHeader(CFE_FS_Header_t *Hdr, const char *Description, uint32 Sub
 /*
 ** CFE_FS_WriteHeader() - See API and header file for details
 */
-int32 CFE_FS_WriteHeader(int32 FileDes, CFE_FS_Header_t *Hdr)
+int32 CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr)
 {
     CFE_TIME_SysTime_t Time;
     int32   Result;
@@ -158,7 +158,7 @@ int32 CFE_FS_WriteHeader(int32 FileDes, CFE_FS_Header_t *Hdr)
 /*
 ** CFE_FS_SetTimestamp - See API and header file for details
 */
-int32 CFE_FS_SetTimestamp(int32 FileDes, CFE_TIME_SysTime_t NewTimestamp)
+int32 CFE_FS_SetTimestamp(osal_id_t FileDes, CFE_TIME_SysTime_t NewTimestamp)
 {
     int32              Result;
     CFE_FS_Header_t    TempHdr;

--- a/fsw/cfe-core/src/fs/cfe_fs_priv.h
+++ b/fsw/cfe-core/src/fs/cfe_fs_priv.h
@@ -57,7 +57,7 @@
 */
 typedef struct 
 {
-    uint32              SharedDataMutexId;
+    osal_id_t              SharedDataMutexId;
 
 } CFE_FS_t;
 

--- a/fsw/cfe-core/src/inc/ccsds_hdr.h
+++ b/fsw/cfe-core/src/inc/ccsds_hdr.h
@@ -49,7 +49,7 @@
 /**
  * \brief CCSDS packet primary header
  */
-typedef struct {
+typedef struct CCSDS_PrimaryHeader {
 
    uint8   StreamId[2];  /**< \brief packet identifier word (stream ID) */
       /*  bits  shift   ------------ description ---------------- */
@@ -72,7 +72,7 @@ typedef struct {
 /**
  * \brief CCSDS packet extended header
  */
-typedef struct {
+typedef struct CCSDS_ExtendedHeader {
 
    uint8 Subsystem[2]; /**< \brief subsystem qualifier */
       /*  bits  shift   ------------ description ---------------- */

--- a/fsw/cfe-core/src/inc/cfe_error.h
+++ b/fsw/cfe-core/src/inc/cfe_error.h
@@ -631,7 +631,7 @@
  *  due to insufficient space in the log buffer.
  *
  */
-#define CFE_ES_ERR_SYS_LOG_TRUNCATED  ((int32)0x44000028)
+#define CFE_ES_ERR_SYS_LOG_TRUNCATED  ((int32)0x44000029)
 
 /**
  * @brief Not Implemented

--- a/fsw/cfe-core/src/inc/cfe_es.h
+++ b/fsw/cfe-core/src/inc/cfe_es.h
@@ -208,7 +208,7 @@ int32 CFE_ES_TaskID_ToIndex(uint32 TaskID, uint32 *Idx);
  * Structure that is used to provide information about an app.
  * It is primarily used for the QueryOne and QueryAll Commands.
  */
-typedef struct
+typedef struct CFE_ES_AppInfo
 {
    uint32   AppId;                          /**< \cfetlmmnemonic \ES_APP_ID
                                                  \brief Application ID for this Application */
@@ -261,7 +261,7 @@ typedef struct
 /**
  * \brief Task Info
  */
-typedef struct
+typedef struct CFE_ES_TaskInfo
 {
    uint32   TaskId;                    /**< \brief Task Id */
    uint32   ExecutionCounter;          /**< \brief Task Execution Counter */
@@ -274,7 +274,7 @@ typedef struct
 /**
  * \brief Block statistics
  */
-typedef struct
+typedef struct CFE_ES_BlockStats
 {
     uint32  BlockSize;               /**< \brief Number of bytes in each of these blocks */
     uint32  NumCreated;              /**< \brief Number of Memory Blocks of this size created */
@@ -284,7 +284,7 @@ typedef struct
 /**
  * \brief Memory Pool Statistics
  */
-typedef struct
+typedef struct CFE_ES_MemPoolStats
 {
     uint32                PoolSize;                /**< \cfetlmmnemonic \ES_POOLSIZE
                                                         \brief  Size of Memory Pool (in bytes) */
@@ -308,7 +308,7 @@ typedef cpuaddr CFE_ES_CDSHandle_t;
 /**
  * \brief CDS Register Dump Record
  */
-typedef struct
+typedef struct CFE_ES_CDSRegDumpRec
 {
     CFE_ES_CDSHandle_t    Handle;          /**< \brief Handle of CDS */
     uint32                Size;            /**< \brief Size, in bytes, of the CDS memory block */
@@ -330,7 +330,7 @@ typedef int32 (*CFE_ES_LibraryEntryFuncPtr_t)(uint32 LibId); /**< \brief Require
  * It contains the longest native data types such that the alignment of this structure
  * should reflect the largest possible alignment requirements for any data on this processor.
  */
-typedef union
+typedef union CFE_ES_PoolAlign
 {
     void *Ptr; /**< \brief Aligned pointer */
     /* note -- native types (int/double) are intentional here */

--- a/fsw/cfe-core/src/inc/cfe_es.h
+++ b/fsw/cfe-core/src/inc/cfe_es.h
@@ -224,7 +224,7 @@ typedef struct
 
    uint32   StackSize;                      /**< \cfetlmmnemonic \ES_STACKSIZE
                                                  \brief The Stack Size of the Application */
-   uint32   ModuleId;                       /**< \cfetlmmnemonic \ES_MODULEID
+   osal_id_t   ModuleId;                       /**< \cfetlmmnemonic \ES_MODULEID
                                                  \brief The ID of the Loadable Module for the Application */
    uint32   AddressesAreValid;              /**< \cfetlmmnemonic \ES_ADDRVALID
                                                  \brief Indicates that the Code, Data, and BSS addresses/sizes are valid */

--- a/fsw/cfe-core/src/inc/cfe_es_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_es_msg.h
@@ -1068,7 +1068,7 @@
 ** -# The No-Op Command (For details, see #CFE_ES_NOOP_CC)
 ** -# The Reset Counters Command (For details, see #CFE_ES_RESET_COUNTERS_CC)
 */
-typedef struct
+typedef struct CFE_ES_NoArgsCmd
 {
   uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];     /**< \brief cFE Software Bus Command Message Header */
 
@@ -1093,13 +1093,13 @@ typedef CFE_ES_NoArgsCmd_t      CFE_ES_ResetPRCount_t;
 ** For command details, see #CFE_ES_RESTART_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_RestartCmd_Payload
 {
   uint16                RestartType;                       /**< \brief #CFE_PSP_RST_TYPE_PROCESSOR=Processor Reset
                                                                 or #CFE_PSP_RST_TYPE_POWERON=Power-On Reset        */
 } CFE_ES_RestartCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_Restart
 {
     uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_RestartCmd_Payload_t Payload;
@@ -1114,13 +1114,13 @@ typedef struct
 ** #CFE_ES_WRITE_SYSLOG_CC, and #CFE_ES_WRITE_ER_LOG_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_FileNameCmd_Payload
 {
   char                  FileName[CFE_MISSION_MAX_PATH_LEN]; /**< \brief ASCII text string containing full path and
                                                                 filename of file in which Application data is to be dumped */
 } CFE_ES_FileNameCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_FileNameCmd
 {
     uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_FileNameCmd_Payload_t Payload;
@@ -1141,14 +1141,14 @@ typedef CFE_ES_FileNameCmd_t CFE_ES_WriteERLog_t;
 ** For command details, see #CFE_ES_OVER_WRITE_SYSLOG_CC
 **
 **/
-typedef struct 
+typedef struct CFE_ES_OverWriteSysLogCmd_Payload
 {
    uint32               Mode;                            /**< \brief #CFE_ES_LogMode_DISCARD=Throw away most recent messages,
                                                                      #CFE_ES_LogMode_OVERWRITE=Overwrite oldest with most recent */
 
 } CFE_ES_OverWriteSysLogCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_OverWriteSyslog
 {
     uint8                               CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_OverWriteSysLogCmd_Payload_t Payload;
@@ -1160,7 +1160,7 @@ typedef struct
 ** For command details, see #CFE_ES_START_APP_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_StartAppCmd_Payload
 {
   char                  Application[CFE_MISSION_MAX_API_LEN];    /**< \brief Name of Application to be started */
   char                  AppEntryPoint[CFE_MISSION_MAX_API_LEN];  /**< \brief Symbolic name of Application's entry point */
@@ -1177,7 +1177,7 @@ typedef struct
 
 } CFE_ES_StartAppCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_StartApp
 {
     uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_StartAppCmd_Payload_t    Payload;
@@ -1189,12 +1189,12 @@ typedef struct
 ** For command details, see #CFE_ES_STOP_APP_CC, #CFE_ES_RESTART_APP_CC, #CFE_ES_QUERY_ONE_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_AppNameCmd_Payload
 {
   char                  Application[CFE_MISSION_MAX_API_LEN];    /**< \brief ASCII text string containing Application Name */
 } CFE_ES_AppNameCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_AppNameCmd
 {
     uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_AppNameCmd_Payload_t Payload;
@@ -1215,14 +1215,14 @@ typedef CFE_ES_AppNameCmd_t CFE_ES_QueryOne_t;
 ** For command details, see #CFE_ES_RELOAD_APP_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_AppReloadCmd_Payload
 {
   char                  Application[CFE_MISSION_MAX_API_LEN];   /**< \brief ASCII text string containing Application Name */
   char                  AppFileName[CFE_MISSION_MAX_PATH_LEN];   /**< \brief Full path and filename of Application's 
                                                                     executable image */
 } CFE_ES_AppReloadCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_ReloadApp
 {
     uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_AppReloadCmd_Payload_t   Payload;
@@ -1234,13 +1234,13 @@ typedef struct
 ** For command details, see #CFE_ES_SET_MAX_PR_COUNT_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_SetMaxPRCountCmd_Payload
 {
   uint16                MaxPRCount;                     /**< \brief New maximum number of Processor Resets before
                                                                     an automatic Power-On Reset is performed */
 } CFE_ES_SetMaxPRCountCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_SetMaxPRCount
 {
     uint8                               CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_SetMaxPRCountCmd_Payload_t   Payload;
@@ -1252,13 +1252,13 @@ typedef struct
 ** For command details, see #CFE_ES_DELETE_CDS_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_DeleteCDSCmd_Payload
 {
   char                  CdsName[CFE_MISSION_ES_CDS_MAX_NAME_LEN]; /**< \brief ASCII text string containing name of CDS to delete */
 
 } CFE_ES_DeleteCDSCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_DeleteCDS
 {
     uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_DeleteCDSCmd_Payload_t   Payload;
@@ -1270,12 +1270,12 @@ typedef struct
 ** For command details, see #CFE_ES_START_PERF_DATA_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_StartPerfCmd_Payload
 {
   uint32                TriggerMode;                    /**< \brief Desired trigger position (Start, Center, End) */
 } CFE_ES_StartPerfCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_StartPerfData
 {
     uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_StartPerfCmd_Payload_t   Payload;
@@ -1287,13 +1287,13 @@ typedef struct
 ** For command details, see #CFE_ES_STOP_PERF_DATA_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_StopPerfCmd_Payload
 {
   char                  DataFileName[CFE_MISSION_MAX_PATH_LEN];  /**< \brief ASCII text string of full path and filename 
                                                                     of file Performance Analyzer data is to be written */
 } CFE_ES_StopPerfCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_StopPerfData
 {
     uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_StopPerfCmd_Payload_t    Payload;
@@ -1306,14 +1306,14 @@ typedef struct
 ** For command details, see #CFE_ES_SET_PERF_FILTER_MASK_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_SetPerfFilterMaskCmd_Payload
 {
   uint32                FilterMaskNum;                   /**< \brief Index into array of Filter Masks */
   uint32                FilterMask;                      /**< \brief New Mask for specified entry in array of Filter Masks */
 
 } CFE_ES_SetPerfFilterMaskCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_SetPerfFilterMask
 {
     uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_SetPerfFilterMaskCmd_Payload_t Payload;
@@ -1325,14 +1325,14 @@ typedef struct
 ** For command details, see #CFE_ES_SET_PERF_TRIGGER_MASK_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_SetPerfTrigMaskCmd_Payload
 {
   uint32                TriggerMaskNum;                 /**< \brief Index into array of Trigger Masks */
   uint32                TriggerMask;                    /**< \brief New Mask for specified entry in array of Trigger Masks */
 
 } CFE_ES_SetPerfTrigMaskCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_SetPerfTriggerMask
 {
     uint8                               CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_SetPerfTrigMaskCmd_Payload_t Payload;
@@ -1344,14 +1344,14 @@ typedef struct
 ** For command details, see #CFE_ES_SEND_MEM_POOL_STATS_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_SendMemPoolStatsCmd_Payload
 {
   char                  Application[CFE_MISSION_MAX_API_LEN];   /**< \brief - RESERVED - should be all zeroes */
   CFE_ES_MemHandle_t    PoolHandle;                     /**< \brief Handle of Pool whose statistics are to be telemetered */
 
 } CFE_ES_SendMemPoolStatsCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_SendMemPoolStats
 {
     uint8                               CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_SendMemPoolStatsCmd_Payload_t    Payload;
@@ -1363,13 +1363,13 @@ typedef struct
 ** For command details, see #CFE_ES_DUMP_CDS_REGISTRY_CC
 **
 **/
-typedef struct
+typedef struct CFE_ES_DumpCDSRegistryCmd_Payload
 {
   char                  DumpFilename[CFE_MISSION_MAX_PATH_LEN];  /**< \brief ASCII text string of full path and filename 
                                                                     of file CDS Registry is to be written */
 } CFE_ES_DumpCDSRegistryCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_DumpCDSRegistry
 {
     uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
     CFE_ES_DumpCDSRegistryCmd_Payload_t  Payload;
@@ -1383,13 +1383,13 @@ typedef struct
 /** 
 **  \cfeestlm Single Application Information Packet
 **/
-typedef struct
+typedef struct CFE_ES_OneAppTlm_Payload
 {
   CFE_ES_AppInfo_t      AppInfo;                        /**< \brief For more information, see #CFE_ES_AppInfo_t */
   
 } CFE_ES_OneAppTlm_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_OneAppTlm
 {
     uint8                       TlmHeader[CFE_SB_TLM_HDR_SIZE]; /**< \brief cFE Software Bus Telemetry Message Header */
     CFE_ES_OneAppTlm_Payload_t  Payload;
@@ -1398,14 +1398,14 @@ typedef struct
 /** 
 **  \cfeestlm Memory Pool Statistics Packet
 **/
-typedef struct
+typedef struct CFE_ES_PoolStatsTlm_Payload
 {
   CFE_ES_MemHandle_t    PoolHandle;                     /**< \cfetlmmnemonic \ES_POOLHANDLE
                                                              \brief Handle of memory pool whose stats are being telemetered */
   CFE_ES_MemPoolStats_t PoolStats;                      /**< \brief For more info, see #CFE_ES_MemPoolStats_t */
 } CFE_ES_PoolStatsTlm_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_MemStatsTlm
 {
     uint8                           TlmHeader[CFE_SB_TLM_HDR_SIZE]; /**< \brief cFE Software Bus Telemetry Message Header */
     CFE_ES_PoolStatsTlm_Payload_t   Payload;
@@ -1416,7 +1416,7 @@ typedef struct
 /** 
 **  \cfeestlm Executive Services Housekeeping Packet
 **/
-typedef struct
+typedef struct CFE_ES_HousekeepingTlm_Payload
 {
   uint8                 CommandCounter;  /**< \cfetlmmnemonic \ES_CMDPC 
                                           \brief The ES Application Command Counter */
@@ -1502,7 +1502,7 @@ typedef struct
                                               \brief Number of bytes in the largest free block */
 } CFE_ES_HousekeepingTlm_Payload_t;
 
-typedef struct
+typedef struct CFE_ES_HousekeepingTlm
 {
     uint8                       TlmHeader[CFE_SB_TLM_HDR_SIZE]; /**< \brief cFE Software Bus Telemetry Message Header */
     CFE_ES_HousekeepingTlm_Payload_t   Payload;

--- a/fsw/cfe-core/src/inc/cfe_evs.h
+++ b/fsw/cfe-core/src/inc/cfe_evs.h
@@ -77,7 +77,7 @@
 /******************  Structure Definitions *********************/
 
 /** \brief Event message filter defintion structure */
-typedef struct {
+typedef struct CFE_EVS_BinFilter {
    uint16 EventID;	/**< \brief Numerical event identifier */
    uint16 Mask;		/**< \brief Binary filter mask value */
 
@@ -114,7 +114,7 @@ typedef struct {
 **          <b> Code: </b> CFE_EVS_EventFilter_BINARY <BR>
 **          <b> Filter Structure: </b> 
 **          \code
-**                     typedef struct {
+**                     typedef struct CFE_EVS_BinFilter {
 **                           uint16  EventID,
 **                           uint16  Mask ;
 **                     } CFE_EVS_BinFilter_t;

--- a/fsw/cfe-core/src/inc/cfe_evs_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_evs_msg.h
@@ -918,7 +918,7 @@
 /**
 ** \brief Command with no additional arguments
 **/
-typedef struct {
+typedef struct CFE_EVS_NoArgsCmd {
    uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];
 } CFE_EVS_NoArgsCmd_t;
 
@@ -937,11 +937,11 @@ typedef CFE_EVS_NoArgsCmd_t CFE_EVS_ClearLog_t;
 ** For command details, see #CFE_EVS_WRITE_LOG_DATA_FILE_CC
 **
 **/
-typedef struct {
+typedef struct CFE_EVS_LogFileCmd_Payload {
     char LogFilename[CFE_MISSION_MAX_PATH_LEN];      /**< \brief Filename where log data is to be written */
 } CFE_EVS_LogFileCmd_Payload_t;
 
-typedef struct {
+typedef struct CFE_EVS_WriteLogDataFile {
    uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];
    CFE_EVS_LogFileCmd_Payload_t Payload;
 } CFE_EVS_WriteLogDataFile_t;
@@ -953,11 +953,11 @@ typedef struct {
 ** For command details, see #CFE_EVS_WRITE_APP_DATA_FILE_CC
 **
 **/
-typedef struct {
+typedef struct CFE_EVS_AppDataCmd_Payload {
    char AppDataFilename[CFE_MISSION_MAX_PATH_LEN];  /**< \brief Filename where applicaton data is to be written */
 } CFE_EVS_AppDataCmd_Payload_t;
 
-typedef struct {
+typedef struct CFE_EVS_WriteAppDataFile {
    uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];
    CFE_EVS_AppDataCmd_Payload_t Payload;
 } CFE_EVS_WriteAppDataFile_t;
@@ -968,12 +968,12 @@ typedef struct {
 ** For command details, see #CFE_EVS_SET_EVENT_FORMAT_MODE_CC and/or #CFE_EVS_SET_LOG_MODE_CC
 **
 **/
-typedef struct {
+typedef struct CFE_EVS_SetLogMode_Payload {
     CFE_EVS_LogMode_Enum_t   LogMode;                           /**< \brief Mode to use in the command*/
    uint8                     Spare;                             /**< \brief Pad to even byte*/
 } CFE_EVS_SetLogMode_Payload_t;
 
-typedef struct {
+typedef struct CFE_EVS_SetLogMode {
    uint8                     CmdHeader[CFE_SB_CMD_HDR_SIZE];
    CFE_EVS_SetLogMode_Payload_t Payload;
 } CFE_EVS_SetLogMode_t;
@@ -984,12 +984,12 @@ typedef struct {
 ** For command details, see #CFE_EVS_SET_EVENT_FORMAT_MODE_CC and/or #CFE_EVS_SET_LOG_MODE_CC
 **
 **/
-typedef struct {
+typedef struct CFE_EVS_SetEventFormatCode_Payload {
     CFE_EVS_MsgFormat_Enum_t MsgFormat;                         /**< \brief Mode to use in the command*/
    uint8                     Spare;                             /**< \brief Pad to even byte*/
 } CFE_EVS_SetEventFormatMode_Payload_t;
 
-typedef struct {
+typedef struct CFE_EVS_SetEventFormatMode {
    uint8                     CmdHeader[CFE_SB_CMD_HDR_SIZE];
    CFE_EVS_SetEventFormatMode_Payload_t Payload;
 } CFE_EVS_SetEventFormatMode_t;
@@ -1001,12 +1001,12 @@ typedef struct {
 **                          #CFE_EVS_ENABLE_PORTS_CC and/or #CFE_EVS_DISABLE_PORTS_CC
 **
 **/
-typedef struct {
+typedef struct CFE_EVS_BitMaskCmd_Payload {
    uint8                     BitMask;           /**< \brief BitMask to use in the command */
    uint8                     Spare;                             /**< \brief Pad to even byte*/
 } CFE_EVS_BitMaskCmd_Payload_t;
 
-typedef struct {
+typedef struct CFE_EVS_BitMaskCmd {
    uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];
    CFE_EVS_BitMaskCmd_Payload_t Payload;
 } CFE_EVS_BitMaskCmd_t;
@@ -1028,11 +1028,11 @@ typedef CFE_EVS_BitMaskCmd_t CFE_EVS_DisableEventType_t;
 **                          #CFE_EVS_RESET_APP_COUNTER_CC and/or #CFE_EVS_RESET_ALL_FILTERS_CC
 **
 **/
-typedef struct {
+typedef struct CFE_EVS_AppNameCmd_Payload {
    char                     AppName[CFE_MISSION_MAX_API_LEN];          /**< \brief Application name to use in the command*/
 } CFE_EVS_AppNameCmd_Payload_t;
 
-typedef struct {
+typedef struct CFE_EVS_AppNameCmd {
    uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];
    CFE_EVS_AppNameCmd_Payload_t Payload;
 } CFE_EVS_AppNameCmd_t;
@@ -1053,12 +1053,12 @@ typedef CFE_EVS_AppNameCmd_t CFE_EVS_ResetAllFilters_t;
 ** For command details, see #CFE_EVS_RESET_FILTER_CC
 **
 **/
-typedef struct {
+typedef struct CFE_EVS_AppNameEventIDCmd_Payload {
    char                      AppName[CFE_MISSION_MAX_API_LEN];          /**< \brief Application name to use in the command*/
    uint16                    EventID;                           /**< \brief Event ID  to use in the command*/
 } CFE_EVS_AppNameEventIDCmd_Payload_t;
 
-typedef struct {
+typedef struct CFE_EVS_AppNameEventIDCmd {
    uint8                                CmdHeader[CFE_SB_CMD_HDR_SIZE];
    CFE_EVS_AppNameEventIDCmd_Payload_t  Payload;
 } CFE_EVS_AppNameEventIDCmd_t;
@@ -1077,13 +1077,13 @@ typedef CFE_EVS_AppNameEventIDCmd_t CFE_EVS_DeleteEventFilter_t;
 ** For command details, see #CFE_EVS_ENABLE_APP_EVENT_TYPE_CC and/or #CFE_EVS_DISABLE_APP_EVENT_TYPE_CC
 **
 **/
-typedef struct {
+typedef struct CFE_EVS_AppNameBitMaskCmd_Payload {
    char                      AppName[CFE_MISSION_MAX_API_LEN];          /**< \brief Application name to use in the command*/
    uint8                     BitMask;                           /**< \brief BitMask to use in the command*/
    uint8                     Spare;                             /**< \brief Pad to even byte*/
 } CFE_EVS_AppNameBitMaskCmd_Payload_t;
 
-typedef struct {
+typedef struct CFE_EVS_AppNameBitMaskCmd {
    uint8                     CmdHeader[CFE_SB_CMD_HDR_SIZE];
    CFE_EVS_AppNameBitMaskCmd_Payload_t Payload;
 } CFE_EVS_AppNameBitMaskCmd_t;
@@ -1103,13 +1103,13 @@ typedef CFE_EVS_AppNameBitMaskCmd_t CFE_EVS_DisableAppEventType_t;
 **                      and/or #CFE_EVS_DELETE_EVENT_FILTER_CC
 **
 **/
-typedef struct {
+typedef struct CFE_EVS_AppNameEventIDMaskCmd_Payload {
    char                      AppName[CFE_MISSION_MAX_API_LEN];          /**< \brief Application name to use in the command*/
    uint16                    EventID;                           /**< \brief Event ID  to use in the command*/
    uint16                    Mask;                              /**< \brief Mask to use in the command */
 } CFE_EVS_AppNameEventIDMaskCmd_Payload_t;
 
-typedef struct {
+typedef struct CFE_EVS_AppNameEventIDMaskCmd {
    uint8                                    CmdHeader[CFE_SB_CMD_HDR_SIZE];
    CFE_EVS_AppNameEventIDMaskCmd_Payload_t  Payload;
 } CFE_EVS_AppNameEventIDMaskCmd_t;
@@ -1126,7 +1126,7 @@ typedef CFE_EVS_AppNameEventIDMaskCmd_t CFE_EVS_SetFilter_t;
 /**********************************/
 /* Telemetry Message Data Formats */
 /**********************************/
-typedef struct {
+typedef struct CFE_EVS_AppTlmData {
    uint32               AppID;                  /**< \cfetlmmnemonic \EVS_APPID
                                                      \brief Numerical application identifier */
    uint16               AppMessageSentCounter;  /**< \cfetlmmnemonic \EVS_APPMSGSENTC
@@ -1142,7 +1142,7 @@ typedef struct {
 /** 
 **  \cfeevstlm Event Services Housekeeping Telemetry Packet
 **/
-typedef struct {
+typedef struct CFE_EVS_HousekeepingTlm_Payload {
    uint8                 CommandCounter;                    /**< \cfetlmmnemonic \EVS_CMDPC
                                                                  \brief EVS Command Counter */
    uint8                 CommandErrorCounter;                 /**< \cfetlmmnemonic \EVS_CMDEC
@@ -1180,14 +1180,14 @@ typedef struct {
 
 } CFE_EVS_HousekeepingTlm_Payload_t;
 
-typedef struct {
+typedef struct CFE_EVS_HousekeepingTlm {
    uint8                    TlmHeader[CFE_SB_TLM_HDR_SIZE];
    CFE_EVS_HousekeepingTlm_Payload_t Payload;
 } CFE_EVS_HousekeepingTlm_t;
 
 /** Telemetry packet structures */
 
-typedef struct {
+typedef struct CFE_EVS_PacketID {
    char    AppName[CFE_MISSION_MAX_API_LEN];  /**< \cfetlmmnemonic \EVS_APPNAME
                                            \brief Application name */
    uint16  EventID;                   /**< \cfetlmmnemonic \EVS_EVENTID
@@ -1205,7 +1205,7 @@ typedef struct {
 /** 
 **  \cfeevstlm Event Message Telemetry Packet (Long format)
 **/
-typedef struct {
+typedef struct CFE_EVS_LongEventTlm_Payload {
    CFE_EVS_PacketID_t        PacketID;                              /**< \brief Event packet information */
    char                      Message[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];   /**< \cfetlmmnemonic \EVS_EVENT
                                                                          \brief Event message string */
@@ -1218,18 +1218,18 @@ typedef struct {
 /**
 **  \cfeevstlm Event Message Telemetry Packet (Short format)
 **/
-typedef struct {
+typedef struct CFE_EVS_ShortEventTlm_Payload {
    CFE_EVS_PacketID_t        PacketID;                              /**< \brief Event packet information */
 
 } CFE_EVS_ShortEventTlm_Payload_t;
 
-typedef struct {
+typedef struct CFE_EVS_LongEventTlm {
    uint8                    TlmHeader[CFE_SB_TLM_HDR_SIZE];
    CFE_EVS_LongEventTlm_Payload_t Payload;
 
 } CFE_EVS_LongEventTlm_t;
 
-typedef struct {
+typedef struct CFE_EVS_ShortEventTlm {
    uint8                    TlmHeader[CFE_SB_TLM_HDR_SIZE];
    CFE_EVS_ShortEventTlm_Payload_t Payload;
 

--- a/fsw/cfe-core/src/inc/cfe_fs.h
+++ b/fsw/cfe-core/src/inc/cfe_fs.h
@@ -70,7 +70,7 @@
 ** \sa #CFE_FS_WriteHeader
 **
 ******************************************************************************/
-int32 CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, int32 FileDes);
+int32 CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, osal_id_t FileDes);
 
 /*****************************************************************************/
 /**
@@ -128,7 +128,7 @@ void CFE_FS_InitHeader(CFE_FS_Header_t *Hdr, const char *Description, uint32 Sub
 ** \sa #CFE_FS_ReadHeader
 **
 ******************************************************************************/
-int32 CFE_FS_WriteHeader(int32 FileDes, CFE_FS_Header_t *Hdr);
+int32 CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr);
 
 /*****************************************************************************/
 /**
@@ -153,7 +153,7 @@ int32 CFE_FS_WriteHeader(int32 FileDes, CFE_FS_Header_t *Hdr);
 ** \return Execution status, see \ref CFEReturnCodes
 **               
 ******************************************************************************/
-int32 CFE_FS_SetTimestamp(int32 FileDes, CFE_TIME_SysTime_t NewTimestamp);
+int32 CFE_FS_SetTimestamp(osal_id_t FileDes, CFE_TIME_SysTime_t NewTimestamp);
 /**@}*/
 
 

--- a/fsw/cfe-core/src/inc/cfe_fs_extern_typedefs.h
+++ b/fsw/cfe-core/src/inc/cfe_fs_extern_typedefs.h
@@ -219,7 +219,7 @@ typedef uint32                                           CFE_FS_SubType_Enum_t;
 /**
 ** \brief Standard cFE File header structure definition
 */
-typedef struct
+typedef struct CFE_FS_Header
 {
     uint32  ContentType;           /**< \brief Identifies the content type (='cFE1'=0x63464531)*/
     uint32  SubType;               /**< \brief Type of \c ContentType, if necessary */

--- a/fsw/cfe-core/src/inc/cfe_msg_typedefs.h
+++ b/fsw/cfe-core/src/inc/cfe_msg_typedefs.h
@@ -54,7 +54,7 @@ typedef uint16 CFE_MSG_Subsystem_t;     /**< \brief Message subsystem */
 typedef uint16 CFE_MSG_System_t;        /**< \brief Message system */
 
 /** \brief Message type */
-typedef enum
+typedef enum CFE_MSG_Type
 {
     CFE_MSG_Type_Invalid, /**< \brief Message type invalid, undefined, not implemented */
     CFE_MSG_Type_Cmd,     /**< \brief Command message type */
@@ -62,7 +62,7 @@ typedef enum
 } CFE_MSG_Type_t;
 
 /** \brief Segmentation flags */
-typedef enum
+typedef enum CFE_MSG_SegmentationFlag
 {
     CFE_MSG_SegFlag_Invalid,    /**< \brief Invalid segmentation flag */
     CFE_MSG_SegFlag_Continue,   /**< \brief Continuation segment of User Data */
@@ -72,7 +72,7 @@ typedef enum
 } CFE_MSG_SegmentationFlag_t;
 
 /** \brief Endian flag */
-typedef enum
+typedef enum CFE_MSG_Endian
 {
     CFE_MSG_Endian_Invalid, /**< \brief Invalid endian setting */
     CFE_MSG_Endian_Big,     /**< \brief Big endian */
@@ -80,7 +80,7 @@ typedef enum
 } CFE_MSG_Endian_t;
 
 /** \brief Playback flag */
-typedef enum
+typedef enum CFE_MSG_PlaybackFlag
 {
     CFE_MSG_PlayFlag_Invalid,  /**< \brief Invalid playback setting */
     CFE_MSG_PlayFlag_Original, /**< \brief Original */

--- a/fsw/cfe-core/src/inc/cfe_sb.h
+++ b/fsw/cfe-core/src/inc/cfe_sb.h
@@ -150,13 +150,13 @@
 typedef CFE_MSG_Message_t CFE_SB_Msg_t;
 
 /** \brief Aligned Software Bus command header */
-typedef union {
+typedef union CFE_SB_CmdHdr {
     CFE_MSG_CommandHeader_t Cmd;
     CFE_SB_Msg_t            BaseMsg;
 } CFE_SB_CmdHdr_t;
 
 /** \brief Aligned Software Bus telemetry header */
-typedef union {
+typedef union CFE_SB_TlmHdr {
     CFE_MSG_TelemetryHeader_t Tlm;
     CFE_SB_Msg_t              BaseMsg;
 } CFE_SB_TlmHdr_t;

--- a/fsw/cfe-core/src/inc/cfe_sb_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_sb_msg.h
@@ -491,11 +491,11 @@ typedef CFE_SB_CmdHdr_t  CFE_SB_SendPrevSubs_t;
 **  'Write Pipe Info to File' #CFE_SB_SEND_PIPE_INFO_CC and
 **  'Write Map Info to File' #CFE_SB_SEND_MAP_INFO_CC.
 */
-typedef struct{
+typedef struct CFE_SB_WriteFileInfoCmd_Payload {
    char Filename[CFE_MISSION_MAX_PATH_LEN];/**< \brief Path and Filename of data to be loaded */
 } CFE_SB_WriteFileInfoCmd_Payload_t;
 
-typedef struct{
+typedef struct CFE_SB_WriteFileInfoCmd {
     CFE_SB_CmdHdr_t                     Hdr;/**< \brief cFE Software Bus Command Message Header #CFE_SB_CmdHdr_t */
     CFE_SB_WriteFileInfoCmd_Payload_t   Payload;
 }CFE_SB_WriteFileInfoCmd_t;
@@ -515,14 +515,14 @@ typedef CFE_SB_WriteFileInfoCmd_t CFE_SB_SendMapInfo_t;
 **  A route is the destination pipe for a  particular message and is therefore defined
 **  as a MsgId and PipeId combination.
 */
-typedef struct {
+typedef struct CFE_SB_RouteCmd_Payload {
 
    CFE_SB_MsgId_t       MsgId;/**< \brief Message ID of route to be enabled or disabled #CFE_SB_MsgId_t */
    CFE_SB_PipeId_t      Pipe;/**< \brief Pipe ID of route to be enabled or disabled #CFE_SB_PipeId_t */
    uint8                Spare;/**<\brief Spare byte to make command even number of bytes */
 } CFE_SB_RouteCmd_Payload_t;
 
-typedef struct{
+typedef struct CFE_SB_RouteCmd {
     CFE_SB_CmdHdr_t             Hdr;/**< \brief cFE Software Bus Command Message Header #CFE_SB_CmdHdr_t */
     CFE_SB_RouteCmd_Payload_t  Payload;
 } CFE_SB_RouteCmd_t;
@@ -540,7 +540,7 @@ typedef CFE_SB_RouteCmd_t CFE_SB_DisableRoute_t;
 /**
 **  \cfesbtlm Software Bus task housekeeping Packet
 */
-typedef struct {
+typedef struct CFE_SB_HousekeepingTlm_Payload {
 
     uint8           CommandCounter;/**< \cfetlmmnemonic \SB_CMDPC
                                     \brief Count of valid commands received */
@@ -583,7 +583,7 @@ typedef struct {
                                      \brief cfg param CFE_PLATFORM_SB_BUF_MEMORY_BYTES minus Peak Memory in use */
 } CFE_SB_HousekeepingTlm_Payload_t;
 
-typedef struct{
+typedef struct CFE_SB_HousekeepingTlm {
     CFE_SB_TlmHdr_t         Hdr;/**< \brief cFE Software Bus Telemetry Message Header */
     CFE_SB_HousekeepingTlm_Payload_t  Payload;
 } CFE_SB_HousekeepingTlm_t;
@@ -594,7 +594,7 @@ typedef struct{
 **
 ** Used in SB Statistics Telemetry Packet #CFE_SB_StatsTlm_t
 */
-typedef struct {
+typedef struct CFE_SB_PipeDepthStats {
 
     CFE_SB_PipeId_t     PipeId;/**< \cfetlmmnemonic \SB_PDPIPEID
                                     \brief Pipe Id associated with the stats below */
@@ -614,7 +614,7 @@ typedef struct {
 **
 ** SB Statistics packet sent (via CFE_SB_SendMsg) in response to #CFE_SB_SEND_SB_STATS_CC
 */
-typedef struct {
+typedef struct CFE_SB_StatsTlm_Payload {
 
     uint32              MsgIdsInUse;/**< \cfetlmmnemonic \SB_SMMIDIU
                                          \brief Current number of MsgIds with a destination */
@@ -656,7 +656,7 @@ typedef struct {
                                                                   \brief Pipe Depth Statistics #CFE_SB_PipeDepthStats_t*/
 } CFE_SB_StatsTlm_Payload_t;
 
-typedef struct{
+typedef struct CFE_SB_StatsTlm {
     CFE_SB_TlmHdr_t             Hdr;/**< \brief cFE Software Bus Telemetry Message Header */
     CFE_SB_StatsTlm_Payload_t    Payload;
 } CFE_SB_StatsTlm_t;
@@ -667,7 +667,7 @@ typedef struct{
 **
 ** Structure of one element of the routing information in response to #CFE_SB_SEND_ROUTING_INFO_CC
 */
-typedef struct{
+typedef struct CFE_SB_RoutingFileEntry {
     CFE_SB_MsgId_t      MsgId;/**< \brief Message Id portion of the route */
     CFE_SB_PipeId_t     PipeId;/**< \brief Pipe Id portion of the route */
     uint8               State;/**< \brief Route Enabled or Disabled */
@@ -682,7 +682,7 @@ typedef struct{
 **
 ** Structure of one element of the map information in response to #CFE_SB_SEND_MAP_INFO_CC
 */
-typedef struct{
+typedef struct CFE_SB_MsgMapFileEntry {
     CFE_SB_MsgId_t             MsgId;/**< \brief Message Id which has been subscribed to */
     CFE_SB_MsgRouteIdx_Atom_t  Index;/**< \brief Routing table index where pipe destinations are found */
 }CFE_SB_MsgMapFileEntry_t;
@@ -698,7 +698,7 @@ typedef struct{
 **
 ** \sa #CFE_SB_ENABLE_SUB_REPORTING_CC, #CFE_SB_DISABLE_SUB_REPORTING_CC
 */
-typedef struct {
+typedef struct CFE_SB_SingleSubscriptionTlm_Payload {
 
    uint8                SubType;/**< \brief Subscription or Unsubscription */
    CFE_SB_MsgId_t       MsgId;/**< \brief MsgId subscribed or unsubscribe to */
@@ -707,7 +707,7 @@ typedef struct {
 
 } CFE_SB_SingleSubscriptionTlm_Payload_t;
 
-typedef struct{
+typedef struct CFE_SB_SingleSubscriptionTlm {
     CFE_SB_TlmHdr_t             Hdr;/**< \brief cFE Software Bus Telemetry Message Header */
     CFE_SB_SingleSubscriptionTlm_Payload_t Payload;
 } CFE_SB_SingleSubscriptionTlm_t;
@@ -721,7 +721,7 @@ typedef struct{
 **
 ** Used in structure definition #CFE_SB_AllSubscriptionsTlm_t
 */
-typedef struct {
+typedef struct CFE_SB_SubEntries {
 
    CFE_SB_MsgId_t       MsgId;/**< \brief MsgId portion of the subscription */
    CFE_SB_Qos_t         Qos;/**< \brief Qos portion of the subscription */
@@ -739,7 +739,7 @@ typedef struct {
 ** there are more subscriptions than can fit in one pkt. The complete list of
 ** subscriptions is sent via a series of segmented pkts.
 */
-typedef struct {
+typedef struct CFE_SB_AllSubscriptionsTlm_Payload {
 
    uint32               PktSegment;/**< \brief Pkt number(starts at 1) in the series */
    uint32               TotalSegments;/**< \brief Total number of pkts needed to complete the request */
@@ -747,7 +747,7 @@ typedef struct {
    CFE_SB_SubEntries_t  Entry[CFE_SB_SUB_ENTRIES_PER_PKT];/**< \brief Array of #CFE_SB_SubEntries_t entries */
 } CFE_SB_AllSubscriptionsTlm_Payload_t;
 
-typedef struct{
+typedef struct CFE_SB_AllSubscriptionsTlm {
     CFE_SB_TlmHdr_t             Hdr;/**< \brief cFE Software Bus Telemetry Message Header */
     CFE_SB_AllSubscriptionsTlm_Payload_t Payload;
 } CFE_SB_AllSubscriptionsTlm_t;

--- a/fsw/cfe-core/src/inc/cfe_tbl.h
+++ b/fsw/cfe-core/src/inc/cfe_tbl.h
@@ -94,7 +94,7 @@ typedef int32 (*CFE_TBL_CallbackFuncPtr_t)(void *TblPtr);
 typedef int16 CFE_TBL_Handle_t;
 
 /** \brief Table Source */
-typedef enum 
+typedef enum CFE_TBL_SrcEnum
 {
     CFE_TBL_SRC_FILE = 0, /**< \brief File source
                                When this option is selected, the \c SrcDataPtr 
@@ -113,7 +113,7 @@ typedef enum
 } CFE_TBL_SrcEnum_t;
 
 /** \brief Table Info */
-typedef struct
+typedef struct CFE_TBL_Info
 {
     uint32                Size;                             /**< \brief Size, in bytes, of Table */
     uint32                NumUsers;                         /**< \brief Number of Apps with access to the table */

--- a/fsw/cfe-core/src/inc/cfe_tbl_extern_typedefs.h
+++ b/fsw/cfe-core/src/inc/cfe_tbl_extern_typedefs.h
@@ -66,7 +66,7 @@ typedef uint16                                           CFE_TBL_BufferSelect_En
  *
  * This header follows the CFE_FS header and precedes the the actual table data.
  */
-typedef struct
+typedef struct CFE_TBL_File_Hdr
 {
     uint32                   Reserved;                             /**< Future Use: NumTblSegments in File?   */
     uint32                   Offset;                               /**< Byte Offset at which load should commence */

--- a/fsw/cfe-core/src/inc/cfe_tbl_filedef.h
+++ b/fsw/cfe-core/src/inc/cfe_tbl_filedef.h
@@ -58,7 +58,7 @@
  * The definition of the file definition metadata that can be used by
  * external tools (e.g. elf2cfetbl) to generate CFE table data files.
  */
-typedef struct
+typedef struct CFE_TBL_FileDef
 {
     char        ObjectName[64];                             /**< \brief Name of instantiated variable that contains desired table image */
     char        TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \brief Name of Table as defined onboard */
@@ -78,7 +78,7 @@ typedef struct
  
     #include "cfe_tbl_filedef.h"
 
-   typedef struct
+   typedef struct MyTblStruct
    {
        int     Int1;
        int     Int2;

--- a/fsw/cfe-core/src/inc/cfe_tbl_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_tbl_msg.h
@@ -490,7 +490,7 @@
 ** -# The No-Op Command (For details, see #CFE_TBL_NOOP_CC)
 ** -# The Reset Counters Command (For details, see #CFE_TBL_RESET_COUNTERS_CC)
 */
-typedef struct
+typedef struct CFE_TBL_NoArgsCmd
 {
     uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];   /**< \brief cFE Software Bus Command Message Header */
 
@@ -510,14 +510,14 @@ typedef CFE_TBL_NoArgsCmd_t CFE_TBL_ResetCounters_t;
 ** For command details, see #CFE_TBL_LOAD_CC
 **
 **/
-typedef struct
+typedef struct CFE_TBL_LoadCmd_Payload
 {
     char                  LoadFilename[CFE_MISSION_MAX_PATH_LEN];  /**< \brief Filename (and path) of data to be loaded */
                                                           /**< ASCII Character string containing full path 
                                                                filename for file to be loaded */
 } CFE_TBL_LoadCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TBL_Load
 {
     uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_LoadCmd_Payload_t   Payload;
@@ -528,7 +528,7 @@ typedef struct
 **
 ** For command details, see #CFE_TBL_DUMP_CC
 */
-typedef struct
+typedef struct CFE_TBL_DumpCmd_Payload
 {
     uint16                ActiveTableFlag;                        /**< \brief #CFE_TBL_BufferSelect_INACTIVE=Inactive Table, 
                                                                             #CFE_TBL_BufferSelect_ACTIVE=Active Table */
@@ -544,7 +544,7 @@ typedef struct
                                                                      where data is to be dumped */
 } CFE_TBL_DumpCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TBL_DumpCmd
 {
     uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_DumpCmd_Payload_t   Payload;
@@ -555,7 +555,7 @@ typedef struct
 **
 ** For command details, see #CFE_TBL_VALIDATE_CC
 */
-typedef struct
+typedef struct CFE_TBL_ValidateCmd_Payload
 {
     uint16                ActiveTableFlag;                         /**< \brief #CFE_TBL_BufferSelect_INACTIVE=Inactive Table, 
                                                                              #CFE_TBL_BufferSelect_ACTIVE=Active Table */
@@ -568,7 +568,7 @@ typedef struct
                                                                       identifier of table to be validated */
 } CFE_TBL_ValidateCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TBL_Validate
 {
     uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_ValidateCmd_Payload_t   Payload;
@@ -579,14 +579,14 @@ typedef struct
 **
 ** For command details, see #CFE_TBL_ACTIVATE_CC
 */
-typedef struct
+typedef struct CFE_TBL_ActivateCmd_Payload
 {
     char                  TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN];  /**< \brief Full Name of Table to be activated */
                                                                  /**< ASCII string containing full table name 
                                                                       identifier of table to be activated */
 } CFE_TBL_ActivateCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TBL_Activate
 {
     uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_ActivateCmd_Payload_t   Payload;
@@ -597,7 +597,7 @@ typedef struct
 **
 ** For command details, see #CFE_TBL_DUMP_REGISTRY_CC
 */
-typedef struct
+typedef struct CFE_TBL_DumpRegistryCmd_Payload
 {
     char                  DumpFilename[CFE_MISSION_MAX_PATH_LEN];        /**< \brief Full Filename where dumped data is to be 
                                                                      written */
@@ -605,7 +605,7 @@ typedef struct
                                                                      where registry is to be dumped */
 } CFE_TBL_DumpRegistryCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TBL_DumpRegistry
 {
     uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_DumpRegistryCmd_Payload_t    Payload;
@@ -616,7 +616,7 @@ typedef struct
 **
 ** For command details, see #CFE_TBL_SEND_REGISTRY_CC
 */
-typedef struct
+typedef struct CFE_TBL_SendRegistryCmd_Payload
 {
     char                  TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN];  /**< \brief Full Name of Table whose registry entry
                                                                       is to be telemetered */
@@ -625,7 +625,7 @@ typedef struct
                                                                       to be telemetered via #CFE_TBL_TableRegistryTlm_t */
 } CFE_TBL_SendRegistryCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TBL_SendRegistry
 {
     uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_SendRegistryCmd_Payload_t Payload;
@@ -636,7 +636,7 @@ typedef struct
 **
 ** For command details, see #CFE_TBL_DELETE_CDS_CC
 */
-typedef struct
+typedef struct CFE_TBL_DelCDSCmd_Payload
 {
     char                  TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN];  /**< \brief Full Name of Table whose CDS is
                                                                       to be deleted */
@@ -645,7 +645,7 @@ typedef struct
                                                                       CDS is to be deleted */
 } CFE_TBL_DelCDSCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TBL_DeleteCDS
 {
     uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_DelCDSCmd_Payload_t Payload;
@@ -656,14 +656,14 @@ typedef struct
 **
 ** For command details, see #CFE_TBL_ABORT_LOAD_CC
 */
-typedef struct
+typedef struct CFE_TBL_AbortLoadCmd_Payload
 {
     char                  TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN];  /**< \brief Full Name of Table whose load is to be aborted */
                                                                  /**< ASCII string containing full table name 
                                                                       identifier of a table whose load is to be aborted */
 } CFE_TBL_AbortLoadCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TBL_AbortLoad
 {
     uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_AbortLoadCmd_Payload_t    Payload;
@@ -683,12 +683,12 @@ typedef struct
 **      command message with the application specified message ID, command code and
 **      parameter whenever the table requires management (e.g. - loads and validations).
 */
-typedef struct
+typedef struct CFE_TBL_NotifyCmd_Payload
 {
     uint32                Parameter;                             /**< \brief Application specified command parameter */
 } CFE_TBL_NotifyCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TBL_NotifyCmd
 {
     uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
     CFE_TBL_NotifyCmd_Payload_t Payload;
@@ -701,7 +701,7 @@ typedef struct
 /** 
 **  \cfetbltlm Table Services Housekeeping Packet
 **/
-typedef struct
+typedef struct CFE_TBL_HousekeepingTlm_Payload
 {
     /*
     ** Task command interface counters...
@@ -760,7 +760,7 @@ typedef struct
                                                                           \brief Name of the last table loaded */
 } CFE_TBL_HousekeepingTlm_Payload_t;
 
-typedef struct
+typedef struct CFE_TBL_HousekeepingTlm
 {
     uint8                       TlmHeader[CFE_SB_TLM_HDR_SIZE];       /**< \brief cFE Software Bus Telemetry Message Header */
     CFE_TBL_HousekeepingTlm_Payload_t  Payload;
@@ -770,7 +770,7 @@ typedef struct
 /** 
 **  \cfetbltlm Table Registry Info Packet
 **/
-typedef struct
+typedef struct CFE_TBL_TblRegPacket_Payload
 {
     uint32                      Size;                           /**< \cfetlmmnemonic \TBL_SIZE 
                                                                      \brief Size, in bytes, of Table */
@@ -808,7 +808,7 @@ typedef struct
                                                                      \brief Spare byte to maintain byte alignment */
 } CFE_TBL_TblRegPacket_Payload_t;
 
-typedef struct
+typedef struct CFE_TBL_TableRegistryTlm
 {
     uint8                           TlmHeader[CFE_SB_TLM_HDR_SIZE];       /**< \brief cFE Software Bus Telemetry Message Header */
     CFE_TBL_TblRegPacket_Payload_t  Payload;

--- a/fsw/cfe-core/src/inc/cfe_time.h
+++ b/fsw/cfe-core/src/inc/cfe_time.h
@@ -66,7 +66,7 @@
 **       elapsed since the epoch.
 **
 */
-typedef struct
+typedef struct CFE_TIME_SysTime
 {
   uint32  Seconds;            /**< \brief Number of seconds since epoch */
   uint32  Subseconds;         /**< \brief Number of subseconds since epoch (LSB = 2^(-32) seconds) */
@@ -89,7 +89,7 @@ typedef struct
 **       to be "negative".  This can lead to some confusion about what relationship exists between two time values.
 **       To resolve this confusion, the cFE provides the API #CFE_TIME_Compare which returns these enumerated values.
 */
-typedef enum  
+typedef enum CFE_TIME_Compare
 {
   CFE_TIME_A_LT_B  = -1,      /**< \brief The first specified time is considered to be before the second specified time */
   CFE_TIME_EQUAL   =  0,      /**< \brief The two specified times are considered to be equal */
@@ -104,7 +104,7 @@ typedef enum
 **       in an area of memory that is not cleared during a Processor Reset.  This allows the
 **       cFE Time Service to maintain time to the best of its ability after a Processor Reset.
 */
-typedef struct
+typedef struct CFE_TIME_ResetVars
 {
   uint32 Signature;                     /**< \brief Data validation signature used to verify data structure contents*/
   int16  LeapSeconds;                   /**< \brief Leap seconds value */

--- a/fsw/cfe-core/src/inc/cfe_time_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_time_msg.h
@@ -726,7 +726,7 @@
 /*
 ** Type definition (generic "no arguments" command)...
 */
-typedef struct
+typedef struct CFE_TIME_NoArgsCmd
 {
   uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];
 
@@ -744,12 +744,12 @@ typedef CFE_TIME_NoArgsCmd_t CFE_TIME_SendDiagnosticTlm_t;
 /*
 ** Type definition (leap seconds command)...
 */
-typedef struct
+typedef struct CFE_TIME_LeapsCmd_Payload
 {
     int16                 LeapSeconds;
 } CFE_TIME_LeapsCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TIME_SetLeapSeconds
 {
   uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
   CFE_TIME_LeapsCmd_Payload_t   Payload;
@@ -759,7 +759,7 @@ typedef struct
 /*
 ** Type definition (clock state command)...
 */
-typedef struct
+typedef struct CFE_TIME_StateCmd_Payload
 {
     int16                 ClockState;                    /**< \brief #CFE_TIME_ClockState_INVALID=Spacecraft time has not been accurately set,
                                                                      #CFE_TIME_ClockState_VALID=Spacecraft clock has been accurately set,
@@ -767,7 +767,7 @@ typedef struct
                                                          /**< Selects the current clock state */
 } CFE_TIME_StateCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TIME_SetStateCmd
 {
   uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
   CFE_TIME_StateCmd_Payload_t   Payload;
@@ -777,14 +777,14 @@ typedef struct
 /*
 ** Type definition (time data source command)...
 */
-typedef struct
+typedef struct CFE_TIME_SourceCmd_Payload
 {
     int16                 TimeSource;                    /**< \brief #CFE_TIME_SourceSelect_INTERNAL=Internal Source,
                                                                      #CFE_TIME_SourceSelect_EXTERNAL=External Source   */
                                                          /**< Selects either the "Internal" and "External" clock source */
 } CFE_TIME_SourceCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TIME_SetSource
 {
   uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
   CFE_TIME_SourceCmd_Payload_t  Payload;
@@ -794,14 +794,14 @@ typedef struct
 /*
 ** Type definition (tone signal source command)...
 */
-typedef struct
+typedef struct CFE_TIME_SignalCmd_Payload
 {
     int16                 ToneSource;                    /**< \brief #CFE_TIME_ToneSignalSelect_PRIMARY=Primary Source,
                                                                      #CFE_TIME_ToneSignalSelect_REDUNDANT=Redundant Source   */
                                                          /**< Selects either the "Primary" or "Redundant" tone signal source */
 } CFE_TIME_SignalCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TIME_SetSignal
 {
   uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
   CFE_TIME_SignalCmd_Payload_t  Payload;
@@ -812,13 +812,13 @@ typedef struct
 /*
 ** Type definition (generic "time argument" command)...
 */
-typedef struct
+typedef struct CFE_TIME_TimeCmd_Payload
 {
     uint32                Seconds;
     uint32                MicroSeconds;
 } CFE_TIME_TimeCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TIME_TimeCmd
 {
   uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
   CFE_TIME_TimeCmd_Payload_t    Payload;
@@ -841,14 +841,14 @@ typedef CFE_TIME_TimeCmd_t CFE_TIME_SetTime_t;
 /*
 ** Type definition (1Hz STCF adjustment "time argument" command)...
 */
-typedef struct
+typedef struct CFE_TIME_OneHzAdjustmentCmd_Payload
 {
     uint32                Seconds;
     uint32                Subseconds;
 
 } CFE_TIME_OneHzAdjustmentCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TIME_OneHzAdjustmentCmd
 {
   uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
   CFE_TIME_OneHzAdjustmentCmd_Payload_t  Payload;
@@ -866,7 +866,7 @@ typedef CFE_TIME_OneHzAdjustmentCmd_t CFE_TIME_Sub1HZAdjustment_t;
 /*
 ** Type definition (local 1Hz wake-up command)...
 */
-typedef struct
+typedef struct CFE_TIME_1HzCmd
 {
   uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];
 
@@ -876,7 +876,7 @@ typedef struct
 /*
 ** Type definition (time at the tone signal command)...
 */
-typedef struct
+typedef struct CFE_TIME_ToneSignalCmd
 {
   CFE_SB_CmdHdr_t         CmdHeader;
 
@@ -886,7 +886,7 @@ typedef struct
 /*
 ** Type definition ("fake" time at the tone signal command)...
 */
-typedef struct
+typedef struct CFE_TIME_FakeToneCmd
 {
     CFE_SB_CmdHdr_t       CmdHeader;
 
@@ -896,7 +896,7 @@ typedef struct
 /*
 ** Type definition (time at the tone data command)...
 */
-typedef struct
+typedef struct CFE_TIME_ToneDataCmd_Payload
 {
     CFE_TIME_SysTime_t    AtToneMET;    /**< \brief MET at time of tone */
     CFE_TIME_SysTime_t    AtToneSTCF;   /**< \brief STCF at time of tone */
@@ -904,7 +904,7 @@ typedef struct
     int16                 AtToneState;  /**< \brief Clock state at time of tone */
 } CFE_TIME_ToneDataCmd_Payload_t;
 
-typedef struct
+typedef struct CFE_TIME_ToneDataCmd
 {
   uint8                             CmdHeader[CFE_SB_CMD_HDR_SIZE];
   CFE_TIME_ToneDataCmd_Payload_t    Payload;
@@ -916,7 +916,7 @@ typedef struct
 /** 
 **  \cfetimetlm Time Services Housekeeping Packet
 **/
-typedef struct
+typedef struct CFE_TIME_HousekeepingTlm_Payload
 {
     /*
     ** Task command interface counters...
@@ -975,7 +975,7 @@ typedef struct
 
 } CFE_TIME_HousekeepingTlm_Payload_t;
 
-typedef struct
+typedef struct CFE_TIME_HousekeepingTlm
 {
   uint8                         TlmHeader[CFE_SB_TLM_HDR_SIZE];
   CFE_TIME_HousekeepingTlm_Payload_t   Payload;
@@ -987,7 +987,7 @@ typedef struct
 /** 
 **  \cfetimetlm Time Services Diagnostics Packet
 **/
-typedef struct
+typedef struct CFE_TIME_DiagnosticTlm_Payload
 {
     /*
      ** Data values used to compute time (in reference to "tone")...
@@ -1133,7 +1133,7 @@ typedef struct
 	                                               \brief Data Store status (preserved across processor reset) */
 } CFE_TIME_DiagnosticTlm_Payload_t;
 
-typedef struct
+typedef struct CFE_TIME_DiagnosticTlm
 {
   uint8                 		TlmHeader[CFE_SB_TLM_HDR_SIZE];
   CFE_TIME_DiagnosticTlm_Payload_t Payload;

--- a/fsw/cfe-core/src/inc/cfe_version.h
+++ b/fsw/cfe-core/src/inc/cfe_version.h
@@ -35,7 +35,7 @@
 
 
 /* Development Build Macro Definitions */
-#define CFE_BUILD_NUMBER 65 /*!< Development Build: Number of commits since baseline */
+#define CFE_BUILD_NUMBER 81 /*!< Development Build: Number of commits since baseline */
 #define CFE_BUILD_BASELINE "v6.8.0-rc1" /*!< Development Build: git tag that is the base for the current development */
 
 /* Version Macro Definitions */

--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -82,7 +82,7 @@ int32  CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16  Depth, const char *
 {
     uint32          AppId = 0xFFFFFFFF;
     uint32          TskId = 0;
-    uint32          SysQueueId = 0;
+    osal_id_t       SysQueueId;
     int32           Status;
     CFE_SB_PipeId_t OriginalPipeIdParamValue = (PipeIdPtr == NULL) ? 0 : (*PipeIdPtr);
     CFE_SB_PipeId_t PipeTblIdx;
@@ -561,7 +561,7 @@ int32 CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *PipeName)
     int32         Status = CFE_SUCCESS;
     int32         RtnFromVal = 0;
     uint32        TskId = 0;
-    uint32        QueueId = 0;
+    osal_id_t     QueueId;
     char          FullName[(OS_MAX_API_NAME * 2)];
 
     /* get TaskId of caller for events */
@@ -593,7 +593,7 @@ int32 CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *PipeName)
                 PipeTblIdx++)
             {
                 if(CFE_SB.PipeTbl[PipeTblIdx].InUse != 0
-                    && CFE_SB.PipeTbl[PipeTblIdx].SysQueueId == QueueId)
+                    && OS_ObjectIdEqual(CFE_SB.PipeTbl[PipeTblIdx].SysQueueId, QueueId))
                 {
                     /* grab the ID before we release the lock */
                     *PipeIdPtr = CFE_SB.PipeTbl[PipeTblIdx].PipeId;

--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -1019,7 +1019,6 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId,CFE_SB_PipeId_t PipeId,
     CFE_SB_RouteEntry_t* RoutePtr;
     uint32  PipeIdx;
     uint32  TskId = 0;
-    bool    MatchFound = false;
     CFE_SB_DestinationD_t   *DestPtr = NULL;
     char    FullName[(OS_MAX_API_NAME * 2)];
 
@@ -1067,8 +1066,9 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId,CFE_SB_PipeId_t PipeId,
     MsgKey = CFE_SB_ConvertMsgIdtoMsgKey(MsgId);
     RouteIdx = CFE_SB_GetRoutingTblIdx(MsgKey);
 
-    /* if there are no subscriptions for this message id... */
-    if(!CFE_SB_IsValidRouteIdx(RouteIdx)){
+    /* if there have never been subscriptions for this message id... */
+    if(!CFE_SB_IsValidRouteIdx(RouteIdx))
+    {
         char    PipeName[OS_MAX_API_NAME] = {'\0'};
 
         CFE_SB_UnlockSharedData(__func__,__LINE__);
@@ -1082,42 +1082,43 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId,CFE_SB_PipeId_t PipeId,
         return CFE_SUCCESS;
     }/* end if */
 
-    /* At this point, there must be at least one destination. */
-    /* So the value of 'ListHeadPtr' will not be NULL by design */
     RoutePtr = CFE_SB_GetRoutePtrFromIdx(RouteIdx);
 
     /* search the list for a matching pipe id */
-    DestPtr = RoutePtr->ListHeadPtr;
+    for (DestPtr = RoutePtr->ListHeadPtr; DestPtr != NULL && DestPtr->PipeId != PipeId; DestPtr = DestPtr->Next)
+        ;
 
-    do{
+    if(DestPtr)
+    {
+        /* match found, remove node from list */
+        CFE_SB_RemoveDest(RoutePtr,DestPtr);
 
-        if(DestPtr->PipeId == PipeId){
-            /* match found, remove node from list */
-            CFE_SB_RemoveDest(RoutePtr,DestPtr);
+        /* return node to memory pool */
+        CFE_SB_PutDestinationBlk(DestPtr);
 
-            /* return node to memory pool */
-            CFE_SB_PutDestinationBlk(DestPtr);
+        RoutePtr->Destinations--;
+        CFE_SB.StatTlmMsg.Payload.SubscriptionsInUse--;
 
-            RoutePtr->Destinations--;
-            CFE_SB.StatTlmMsg.Payload.SubscriptionsInUse--;
-
-            MatchFound = true;
-
-        }/* end if */
-
-        DestPtr = DestPtr->Next;
-
-    }while((MatchFound == false)&&(DestPtr != NULL));
-
-    CFE_SB_UnlockSharedData(__func__,__LINE__);
-
-    CFE_EVS_SendEventWithAppID(CFE_SB_SUBSCRIPTION_REMOVED_EID,CFE_EVS_EventType_DEBUG,CFE_SB.AppId,
+        CFE_EVS_SendEventWithAppID(CFE_SB_SUBSCRIPTION_REMOVED_EID,CFE_EVS_EventType_DEBUG,CFE_SB.AppId,
             "Subscription Removed:Msg 0x%x on pipe %d,app %s",
             (unsigned int)CFE_SB_MsgIdToValue(MsgId),
             (int)PipeId,CFE_SB_GetAppTskName(TskId,FullName));
+    }
+    else
+    {
+        char    PipeName[OS_MAX_API_NAME] = {'\0'};
+
+        CFE_SB_GetPipeName(PipeName, sizeof(PipeName), PipeId);
+
+        CFE_EVS_SendEventWithAppID(CFE_SB_UNSUB_NO_SUBS_EID,CFE_EVS_EventType_INFORMATION,CFE_SB.AppId,
+            "Unsubscribe Err:No subs for Msg 0x%x on %s,app %s",
+            (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+            PipeName,CFE_SB_GetAppTskName(TskId,FullName));
+    }/* end if */
+
+    CFE_SB_UnlockSharedData(__func__,__LINE__);
 
     return CFE_SUCCESS;
-
 }/* end CFE_SB_UnsubscribeFull */
 
 /*

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.h
@@ -48,7 +48,7 @@
 
 #define CFE_SB_INVALID_ROUTE_IDX        ((CFE_SB_MsgRouteIdx_t){ .RouteIdx = 0 })
 #define CFE_SB_INVALID_MSG_KEY          ((CFE_SB_MsgKey_t){ .KeyIdx = 0 })
-#define CFE_SB_UNUSED_QUEUE             0xFFFF
+#define CFE_SB_UNUSED_QUEUE             OS_OBJECT_ID_UNDEFINED
 #define CFE_SB_INVALID_PIPE             0xFF
 #define CFE_SB_NO_DESTINATION           0xFF
 #define CFE_SB_FAILED                   1
@@ -249,7 +249,7 @@ typedef struct {
      uint8              Opts;
      uint8              Spare;
      uint32             AppId;
-     uint32             SysQueueId;
+     osal_id_t          SysQueueId;
      uint32             LastSender;
      uint16             QueueDepth;
      uint16             SendErrors;
@@ -280,7 +280,7 @@ typedef struct {
 **     This structure contains the SB global variables.
 */
 typedef struct {
-    uint32              SharedDataMutexId;
+    osal_id_t           SharedDataMutexId;
     uint32              SubscriptionReporting;
     uint32              SenderReporting;
     uint32              AppId;

--- a/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
@@ -895,7 +895,7 @@ int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBuffe
     int32                Status = CFE_SUCCESS;
     CFE_FS_Header_t      StdFileHeader;
     CFE_TBL_File_Hdr_t   TblFileHeader;
-    int32                FileDescriptor;
+    osal_id_t            FileDescriptor;
     size_t               FilenameLen = strlen(Filename);
     uint32               NumBytes;
     uint8                ExtraByte;
@@ -912,17 +912,19 @@ int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBuffe
     }
 
     /* Try to open the specified table file */
-    FileDescriptor = OS_open(Filename, OS_READ_ONLY, 0);
+    Status = OS_open(Filename, OS_READ_ONLY, 0);
 
-    if (FileDescriptor < 0)
+    if (Status < 0)
     {
         CFE_EVS_SendEventWithAppID(CFE_TBL_FILE_ACCESS_ERR_EID,
             CFE_EVS_EventType_ERROR, CFE_TBL_TaskData.TableTaskAppId,
             "%s: Unable to open file (FileDescriptor=%d)",
-            AppName, (int)FileDescriptor);
+            AppName, (int)Status);
 
             return CFE_TBL_ERR_ACCESS;
     }
+
+    FileDescriptor = OS_ObjectIdFromInteger(Status);
 
     Status = CFE_TBL_ReadHeaders(FileDescriptor, &StdFileHeader, &TblFileHeader, Filename);
 
@@ -1163,7 +1165,7 @@ void CFE_TBL_NotifyTblUsersOfUpdate(CFE_TBL_RegistryRec_t *RegRecPtr)
 ** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
 ********************************************************************/
 
-int32 CFE_TBL_ReadHeaders( int32 FileDescriptor,
+int32 CFE_TBL_ReadHeaders( osal_id_t FileDescriptor,
                            CFE_FS_Header_t *StdFileHeaderPtr,
                            CFE_TBL_File_Hdr_t *TblFileHeaderPtr,
                            const char *LoadFilename )

--- a/fsw/cfe-core/src/tbl/cfe_tbl_internal.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_internal.h
@@ -455,7 +455,7 @@ void   CFE_TBL_NotifyTblUsersOfUpdate( CFE_TBL_RegistryRec_t *RegRecPtr );
 ** \retval #CFE_TBL_ERR_BAD_PROCESSOR_ID    \copydoc CFE_TBL_ERR_BAD_PROCESSOR_ID
 **                     
 ******************************************************************************/
-int32 CFE_TBL_ReadHeaders( int32 FileDescriptor, 
+int32 CFE_TBL_ReadHeaders( osal_id_t FileDescriptor,
                            CFE_FS_Header_t *StdFileHeaderPtr, 
                            CFE_TBL_File_Hdr_t *TblFileHeaderPtr,
                            const char *LoadFilename );

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task.h
@@ -324,8 +324,8 @@ typedef struct
   /*
   ** Registry Access Mutex and Load Buffer Semaphores
   */
-  uint32                 RegistryMutex;                   /**< \brief Mutex that controls access to Table Registry */
-  uint32                 WorkBufMutex;                    /**< \brief Mutex that controls assignment of Working Buffers */
+  osal_id_t              RegistryMutex;                   /**< \brief Mutex that controls access to Table Registry */
+  osal_id_t              WorkBufMutex;                    /**< \brief Mutex that controls assignment of Working Buffers */
   CFE_ES_CDSHandle_t     CritRegHandle;                   /**< \brief Handle to Critical Table Registry in CDS */
   CFE_TBL_LoadBuff_t     LoadBuffs[CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS];  /**< \brief Working table buffers shared by single buffered tables */
 

--- a/fsw/cfe-core/src/time/cfe_time_task.c
+++ b/fsw/cfe-core/src/time/cfe_time_task.c
@@ -198,8 +198,8 @@ void CFE_TIME_TaskMain(void)
 int32 CFE_TIME_TaskInit(void)
 {
     int32 Status = CFE_SUCCESS;
-    uint32 TimeBaseId;
-    uint32 TimerId;
+    osal_id_t TimeBaseId;
+    osal_id_t TimerId;
 
     Status = CFE_ES_RegisterApp();
     if(Status != CFE_SUCCESS)

--- a/fsw/cfe-core/src/time/cfe_time_tone.c
+++ b/fsw/cfe-core/src/time/cfe_time_tone.c
@@ -1068,7 +1068,7 @@ void CFE_TIME_ToneUpdate(void)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-void CFE_TIME_Local1HzTimerCallback(uint32 TimerId, void *Arg)
+void CFE_TIME_Local1HzTimerCallback(osal_id_t TimerId, void *Arg)
 {
     CFE_TIME_Local1HzISR();
 }

--- a/fsw/cfe-core/src/time/cfe_time_utils.h
+++ b/fsw/cfe-core/src/time/cfe_time_utils.h
@@ -300,8 +300,8 @@ typedef struct
   /*
   ** Interrupt task semaphores...
   */
-  uint32                LocalSemaphore;
-  uint32                ToneSemaphore;
+  osal_id_t             LocalSemaphore;
+  osal_id_t             ToneSemaphore;
   /*
   ** Interrupt task ID's...
   */
@@ -462,7 +462,7 @@ void CFE_TIME_NotifyTimeSynchApps(void);
 */
 void CFE_TIME_Local1HzTask(void);
 void CFE_TIME_Local1HzStateMachine(void);
-void CFE_TIME_Local1HzTimerCallback(uint32 TimerId, void *Arg);
+void CFE_TIME_Local1HzTimerCallback(osal_id_t TimerId, void *Arg);
 
 
 #endif /* _cfe_time_utils_ */

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -4741,11 +4741,6 @@ void TestGenericCounterAPI(void)
     /* Test registering a generic counter with a null counter name */
     ES_ResetUnitTest();
 
-    for ( i = 0; i < CFE_PLATFORM_ES_MAX_GEN_COUNTERS; i++ )
-    {
-       CFE_ES_Global.CounterTable[i].RecordUsed = false;
-    }
-
     UT_Report(__FILE__, __LINE__,
              CFE_ES_RegisterGenCounter(&CounterId,
                                         NULL) == CFE_ES_BAD_ARGUMENT,
@@ -4761,7 +4756,6 @@ void TestGenericCounterAPI(void)
 
     /* Test setting a generic counter where the record is not in use */
     ES_ResetUnitTest();
-    CFE_ES_Global.CounterTable[CounterId].RecordUsed = false;
     UT_Report(__FILE__, __LINE__,
              CFE_ES_SetGenCount(CounterId, 0) == CFE_ES_BAD_ARGUMENT,
               "CFE_ES_SetGenCount",
@@ -4769,7 +4763,6 @@ void TestGenericCounterAPI(void)
 
     /* Test getting a generic counter where the record is not in use */
     ES_ResetUnitTest();
-    CFE_ES_Global.CounterTable[CounterId].RecordUsed = false;
     UT_Report(__FILE__, __LINE__,
              CFE_ES_GetGenCount(CounterId, &CounterCount)
                 == CFE_ES_BAD_ARGUMENT,
@@ -4778,7 +4771,6 @@ void TestGenericCounterAPI(void)
 
     /* Test getting a generic counter where the count is null */
     ES_ResetUnitTest();
-    CFE_ES_Global.CounterTable[CounterId].RecordUsed = true;
     UT_Report(__FILE__, __LINE__,
              CFE_ES_GetGenCount(CounterId, NULL)
                 == CFE_ES_BAD_ARGUMENT,

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -216,16 +216,14 @@ uint32 ES_UT_MakeTaskIdForIndex(uint32 ArrayIdx)
 void ES_UT_SetupSingleAppId(CFE_ES_AppType_Enum_t AppType, CFE_ES_AppState_Enum_t AppState,
         const char *AppName, CFE_ES_AppRecord_t **OutAppRec, CFE_ES_TaskRecord_t **OutTaskRec)
 {
-    uint32 UtOsalId;
+    osal_id_t UtOsalId;
     uint32 UtTaskId;
     uint32 UtAppId;
-    uint32 ArrayIdx;
     CFE_ES_AppRecord_t *LocalAppPtr;
     CFE_ES_TaskRecord_t *LocalTaskPtr;
 
     OS_TaskCreate(&UtOsalId, "UT", NULL, NULL, 0, 0, 0);
-    OS_ConvertToArrayIndex(UtOsalId, &ArrayIdx);
-    UtTaskId = UtOsalId;
+    UtTaskId = CFE_ES_ResourceID_FromOSAL(UtOsalId);
     UtAppId = ES_UT_MakeAppIdForIndex(ES_UT_NumApps);
     ++ES_UT_NumApps;
 
@@ -275,19 +273,17 @@ void ES_UT_SetupSingleAppId(CFE_ES_AppType_Enum_t AppType, CFE_ES_AppState_Enum_
  */
 void ES_UT_SetupChildTaskId(const CFE_ES_AppRecord_t *ParentApp, const char *TaskName, CFE_ES_TaskRecord_t **OutTaskRec)
 {
-    uint32 UtOsalId;
+    osal_id_t UtOsalId;
     uint32 UtTaskId;
     uint32 UtAppId;
-    uint32 ArrayIdx;
     CFE_ES_TaskRecord_t *LocalTaskPtr;
 
     UtAppId = CFE_ES_AppRecordGetID(ParentApp);
 
     OS_TaskCreate(&UtOsalId, "C", NULL, NULL, 0, 0, 0);
-    OS_ConvertToArrayIndex(UtOsalId, &ArrayIdx);
-    UtTaskId = UtOsalId;
+    UtTaskId = CFE_ES_ResourceID_FromOSAL(UtOsalId);
 
-    LocalTaskPtr = &CFE_ES_Global.TaskTable[ArrayIdx];
+    LocalTaskPtr = CFE_ES_LocateTaskRecordByID(UtTaskId);
     CFE_ES_TaskRecordSetUsed(LocalTaskPtr, UtTaskId);
     LocalTaskPtr->AppId = UtAppId;
 
@@ -345,7 +341,7 @@ int32 ES_UT_SetupOSCleanupHook(void *UserObj, int32 StubRetcode,
                                uint32 CallCount,
                                const UT_StubContext_t *Context)
 {
-    uint32 ObjList[7];
+    osal_id_t ObjList[7];
 
     /* On the first call, Use the stub functions to generate one object of
      * each type
@@ -358,7 +354,7 @@ int32 ES_UT_SetupOSCleanupHook(void *UserObj, int32 StubRetcode,
         OS_BinSemCreate(&ObjList[3], NULL, 0, 0);
         OS_CountSemCreate(&ObjList[4], NULL, 0, 0);
         OS_TimerCreate(&ObjList[5], NULL, NULL, NULL);
-        ObjList[6] = OS_open(NULL, 0, 0);
+        ObjList[6] = OS_ObjectIdFromInteger(OS_open(NULL, 0, 0));
 
         UT_SetDataBuffer((UT_EntryKey_t)&OS_ForEachObject, ObjList,
                           sizeof(ObjList), true);
@@ -2031,7 +2027,7 @@ void TestTask(void)
 {
     uint32                      ResetType;
     uint32                      UT_ContextData;
-    uint32                   UT_ContextTask;
+    osal_id_t                   UT_ContextTask;
     union
     {
         CFE_SB_Msg_t             Msg;
@@ -2888,7 +2884,7 @@ void TestTask(void)
     ES_ResetUnitTest();
     UT_SetForceFail(UT_KEY(CFE_PSP_Exception_GetCount), 1);
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, &UtTaskRecPtr);
-    UT_ContextTask = CFE_ES_TaskRecordGetID(UtTaskRecPtr);
+    UT_ContextTask = CFE_ES_ResourceID_ToOSAL(CFE_ES_TaskRecordGetID(UtTaskRecPtr));
     UT_SetDataBuffer(UT_KEY(CFE_PSP_Exception_GetSummary), &UT_ContextTask, sizeof(UT_ContextTask), false);
     UtAppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_APP_RUN;
     UtAppRecPtr->StartParams.ExceptionAction = CFE_ES_ExceptionAction_RESTART_APP;
@@ -2909,7 +2905,7 @@ void TestTask(void)
     ES_ResetUnitTest();
     UT_SetForceFail(UT_KEY(CFE_PSP_Exception_GetCount), 1);
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, &UtTaskRecPtr);
-    UT_ContextTask = CFE_ES_TaskRecordGetID(UtTaskRecPtr);
+    UT_ContextTask = CFE_ES_ResourceID_ToOSAL(CFE_ES_TaskRecordGetID(UtTaskRecPtr));
     UT_SetDataBuffer(UT_KEY(CFE_PSP_Exception_GetSummary), &UT_ContextTask, sizeof(UT_ContextTask), false);
     UtAppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_APP_RUN;
     UtAppRecPtr->StartParams.ExceptionAction = CFE_ES_ExceptionAction_RESTART_APP;
@@ -3858,7 +3854,7 @@ void TestPerf(void)
     ES_ResetUnitTest();
     memset(&CFE_ES_TaskData.BackgroundPerfDumpState, 0,
             sizeof(CFE_ES_TaskData.BackgroundPerfDumpState));
-    CFE_ES_TaskData.BackgroundPerfDumpState.FileDesc = OS_creat("UT", OS_WRITE_ONLY);
+    CFE_ES_TaskData.BackgroundPerfDumpState.FileDesc = OS_ObjectIdFromInteger(OS_creat("UT", OS_WRITE_ONLY));
     CFE_ES_TaskData.BackgroundPerfDumpState.CurrentState = CFE_ES_PerfDumpState_WRITE_PERF_ENTRIES;
     CFE_ES_TaskData.BackgroundPerfDumpState.PendingState = CFE_ES_PerfDumpState_WRITE_PERF_ENTRIES;
     CFE_ES_TaskData.BackgroundPerfDumpState.DataPos = CFE_PLATFORM_ES_PERF_DATA_BUFFER_SIZE - 2;
@@ -3879,7 +3875,7 @@ void TestPerf(void)
     ES_ResetUnitTest();
     memset(&CFE_ES_TaskData.BackgroundPerfDumpState, 0,
             sizeof(CFE_ES_TaskData.BackgroundPerfDumpState));
-    CFE_ES_TaskData.BackgroundPerfDumpState.FileDesc = OS_creat("UT", OS_WRITE_ONLY);
+    CFE_ES_TaskData.BackgroundPerfDumpState.FileDesc = OS_ObjectIdFromInteger(OS_creat("UT", OS_WRITE_ONLY));
     CFE_ES_TaskData.BackgroundPerfDumpState.CurrentState = CFE_ES_PerfDumpState_WRITE_PERF_METADATA;
     CFE_ES_TaskData.BackgroundPerfDumpState.StateCounter = 10;
     Perf->MetaData.DataCount = 100;
@@ -3892,7 +3888,7 @@ void TestPerf(void)
 
 void TestAPI(void)
 {
-    uint32 TestObjId;
+    osal_id_t TestObjId;
     char AppName[32];
     uint32 StackBuf[8];
     int32  Return;
@@ -4309,8 +4305,8 @@ void TestAPI(void)
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
     ES_UT_SetupChildTaskId(UtAppRecPtr, NULL, &UtTaskRecPtr);
-    TestObjId = CFE_ES_TaskRecordGetID(UtTaskRecPtr);
-    UT_SetForceFail(UT_KEY(OS_TaskGetId), (unsigned long)TestObjId); /* Set context to that of child */
+    TestObjId = CFE_ES_ResourceID_ToOSAL(CFE_ES_TaskRecordGetID(UtTaskRecPtr));
+    UT_SetForceFail(UT_KEY(OS_TaskGetId), OS_ObjectIdToInteger(TestObjId)); /* Set context to that of child */
     Return = CFE_ES_CreateChildTask(&TaskId,
                                     "TaskName",
                                     TestAPI,
@@ -4398,8 +4394,8 @@ void TestAPI(void)
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
     ES_UT_SetupChildTaskId(UtAppRecPtr, NULL, &UtTaskRecPtr);
-    TestObjId = CFE_ES_TaskRecordGetID(UtTaskRecPtr);
-    UT_SetForceFail(UT_KEY(OS_TaskGetId), (unsigned long)TestObjId); /* Set context to that of child */
+    TestObjId = CFE_ES_ResourceID_ToOSAL(CFE_ES_TaskRecordGetID(UtTaskRecPtr));
+    UT_SetForceFail(UT_KEY(OS_TaskGetId), OS_ObjectIdToInteger(TestObjId)); /* Set context to that of child */
     CFE_ES_ExitChildTask();
     UT_Report(__FILE__, __LINE__,
               UT_GetStubCount(UT_KEY(OS_TaskExit)) == 1,

--- a/fsw/cfe-core/unit-test/fs_UT.c
+++ b/fsw/cfe-core/unit-test/fs_UT.c
@@ -88,7 +88,7 @@ void Test_CFE_FS_InitHeader(void)
 */
 void Test_CFE_FS_ReadHeader(void)
 {
-    int32 FileDes = 0;
+    osal_id_t FileDes = OS_OBJECT_ID_UNDEFINED;
     CFE_FS_Header_t Hdr;
 
 #ifdef UT_VERBOSE
@@ -118,7 +118,7 @@ void Test_CFE_FS_ReadHeader(void)
 */
 void Test_CFE_FS_WriteHeader(void)
 {
-    int32 FileDes = 0;
+    osal_id_t FileDes = OS_OBJECT_ID_UNDEFINED;
     CFE_FS_Header_t Hdr;
 
 #ifdef UT_VERBOSE
@@ -148,7 +148,7 @@ void Test_CFE_FS_WriteHeader(void)
 */
 void Test_CFE_FS_SetTimestamp(void)
 {
-    int32 FileDes = 0;
+    osal_id_t FileDes = OS_OBJECT_ID_UNDEFINED;
     CFE_TIME_SysTime_t NewTimestamp = {0, 0};
 
 #ifdef UT_VERBOSE

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -2545,7 +2545,7 @@ void Test_Unsubscribe_NoMatch(void)
     CFE_SB.RoutingTbl[CFE_SB_RouteIdxToValue(Idx)].ListHeadPtr->Next = NULL;
     ASSERT(CFE_SB_Unsubscribe(MsgId, TestPipe));
 
-    EVTCNT(6);
+    EVTCNT(7);
 
     EVTSENT(CFE_SB_UNSUB_NO_SUBS_EID);
 

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -2456,6 +2456,12 @@ void Test_Unsubscribe_Basic(void)
 
     EVTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
+    /* Check unsubscribe after unsubscribe produces event */
+    UT_ClearEventHistory();
+    ASSERT(CFE_SB_Unsubscribe(MsgId, TestPipe));
+    EVTCNT(2);
+    EVTSENT(CFE_SB_UNSUB_NO_SUBS_EID);
+
     TEARDOWN(CFE_SB_DeletePipe(TestPipe));
 
 } /* end Test_Unsubscribe_Basic */

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -1833,7 +1833,7 @@ void Test_GetPipeName(void)
     CFE_SB_PipeId_t PipeId = 0;
 
     OS_queue_prop_t queue_info = {
-        "TestPipe1", 0
+        "TestPipe1"
     };
 
     SETUP(CFE_SB_CreatePipe(&PipeId, 4, "TestPipe1"));

--- a/fsw/cfe-core/unit-test/tbl_UT.c
+++ b/fsw/cfe-core/unit-test/tbl_UT.c
@@ -4069,13 +4069,14 @@ void Test_CFE_TBL_Internal(void)
     int32                      i;
     CFE_FS_Header_t            StdFileHeader;
     CFE_TBL_File_Hdr_t         TblFileHeader;
-    int32                      FileDescriptor = 0;
+    osal_id_t                  FileDescriptor;
     void                       *TblPtr;
 
 #ifdef UT_VERBOSE
     UT_Text("Begin Test Internal\n");
 #endif
 
+    FileDescriptor = OS_OBJECT_ID_UNDEFINED;
     StdFileHeader.SpacecraftID = CFE_PLATFORM_TBL_VALID_SCID_1;
     StdFileHeader.ProcessorID = CFE_PLATFORM_TBL_VALID_PRID_1;
 

--- a/fsw/cfe-core/unit-test/time_UT.c
+++ b/fsw/cfe-core/unit-test/time_UT.c
@@ -3198,7 +3198,7 @@ void Test_1Hz(void)
     CFE_TIME_TaskData.OneHzAdjust.Subseconds = 0;
     CFE_TIME_FinishReferenceUpdate(RefState);
     UT_SetBSP_Time(0, 0);
-    CFE_TIME_Local1HzTimerCallback(123, &Arg);
+    CFE_TIME_Local1HzTimerCallback(OS_ObjectIdFromInteger(123), &Arg);
     UT_Report(__FILE__, __LINE__,
               CFE_TIME_TaskData.LocalIntCounter == 2,
               "CFE_TIME_Local1HzTimerCallback",

--- a/fsw/cfe-core/ut-stubs/ut_evs_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_evs_stubs.c
@@ -35,6 +35,7 @@
 #include <string.h>
 #include "cfe.h"
 #include "utstubs.h"
+#include "uttools.h"
 
 /*
 ** Functions
@@ -112,6 +113,8 @@ int32 CFE_EVS_SendEvent(uint16 EventID,
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_EVS_SendEvent), EventType);
     UT_Stub_RegisterContext(UT_KEY(CFE_EVS_SendEvent), Spec);
 
+    UtDebug("CFE_EVS_SendEvent: %u - %s", EventID, Spec);
+
     int32 status;
     va_list va;
 
@@ -162,6 +165,8 @@ int32 CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time,
 
     int32 status;
     va_list va;
+
+    UtDebug("CFE_EVS_SendTimedEvent: %u - %s", EventID, Spec);
 
     va_start(va, Spec);
     status = UT_DefaultStubImplWithArgs(__func__, UT_KEY(CFE_EVS_SendTimedEvent), CFE_SUCCESS, va);
@@ -246,6 +251,8 @@ int32 CFE_EVS_SendEventWithAppID(uint16 EventID,
 
     int32 status;
     va_list va;
+
+    UtDebug("CFE_EVS_SendEventWithAppID: %u - %s", EventID, Spec);
 
     va_start(va, Spec);
     status = UT_DefaultStubImplWithArgs(__func__, UT_KEY(CFE_EVS_SendEventWithAppID), CFE_SUCCESS, va);

--- a/fsw/cfe-core/ut-stubs/ut_fs_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_fs_stubs.c
@@ -87,7 +87,7 @@ void CFE_FS_InitHeader(CFE_FS_Header_t *Hdr, const char *Description, uint32 Sub
 **        CFE_FS_Header_t structure in bytes.
 **
 ******************************************************************************/
-int32 CFE_FS_WriteHeader(int32 FileDes, CFE_FS_Header_t *Hdr)
+int32 CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_FS_WriteHeader), FileDes);
     UT_Stub_RegisterContext(UT_KEY(CFE_FS_WriteHeader), Hdr);
@@ -126,7 +126,7 @@ int32 CFE_FS_WriteHeader(int32 FileDes, CFE_FS_Header_t *Hdr)
 **        CFE_FS_Header_t structure in bytes.
 **
 ******************************************************************************/
-int32 CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, int32 FileDes)
+int32 CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, osal_id_t FileDes)
 {
     UT_Stub_RegisterContext(UT_KEY(CFE_FS_ReadHeader), Hdr);
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_FS_ReadHeader), FileDes);
@@ -163,7 +163,7 @@ int32 CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, int32 FileDes)
 **        Returns either a user-defined status flag or OS_SUCCESS.
 **
 ******************************************************************************/
-int32 CFE_FS_SetTimestamp(int32 FileDes, CFE_TIME_SysTime_t NewTimestamp)
+int32 CFE_FS_SetTimestamp(osal_id_t FileDes, CFE_TIME_SysTime_t NewTimestamp)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_FS_SetTimestamp), FileDes);
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_FS_SetTimestamp), NewTimestamp);


### PR DESCRIPTION
**Describe the contribution**
Fix #846 
Fix #858
Fix #862 
Fix #863 
Fix #870 
Fix #873 

**Testing performed**
Bundle CI - https://github.com/nasa/cFS/pull/139/checks

**Expected behavior changes**
PR #872 -  Deconflict `CFE_ES_LIB_ALREADY_LOADED` and `CFE_ES_ERR_SYS_LOG_TRUNCATED` EIDs

PR #868 - Scrub all CFE references/uses of OSAL IDs to use the proper `osal_id_t` type. Any place that an OSAL ID is stored in memory or passed in an API call are changed to the `osal_id_t` type, rather than `uint32`. Conversions between this and other types (e.g. bare integer) is done using the OSAL-supplied conversion helpers.

PR #865 - After the changes implemented in #101, there may be routing table entries with no subscribers (RoutePtr->ListHeadPtr would be NULL.) This could cause a seg-fault. Also, even if there are entries in the routing table, there will be no event generated if the unsubscribe does not find a matching route entry.

PR #864 -  Adds debug message.

PR #871 - Applies the appid/taskid pattern to Generic Counter resources.

PR #875 - Adds test for SB subscribe/unusubscribe/unsubscribe.

**System(s) tested on**
Ubuntu - CI

**Additional context**
https://github.com/nasa/cFS/pull/139

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman, NASA-GSFC
Joseph Hickey, Vantage Systems, Inc.
Chris Knight, NASA-ARC