### PR TITLE
Fix #796, Remove dependency on CCSDS version define

### DIFF
--- a/cmake/sample_defs/cpu1_msgids.h
+++ b/cmake/sample_defs/cpu1_msgids.h
@@ -41,53 +41,94 @@
 
 #include "cfe_mission_cfg.h"
 
+/**
+ * \brief Platform command message ID base offset
+ *
+ * Example mechanism for setting default command bits and deconflicting MIDs across multiple
+ * platforms in a mission.  For any sufficiently complex mission this method is
+ * typically replaced by a centralized message ID management scheme.
+ *
+ * 0x1800 - Nominal value for default message ID implementation (V1). This sets the command
+ *          field and the secondary header present field.  Typical V1 command MID range
+ *          is 0x1800-1FFF.  Additional cpus can deconflict message IDs by incrementing
+ *          this value to provide sub-allocations (0x1900 for example).
+ * 0x0080 - Command bit for MISSION_MSGID_V2 message ID implementation (V2).  Although
+ *          this can be used for the value below due to the relatively small set
+ *          of MIDs in the framework it will not scale so an alternative
+ *          method of deconfliction is recommended.
+ */
+#define CFE_PLATFORM_CMD_MID_BASE 0x1800
+
+/**
+ * \brief Platform telemetry message ID base offset
+ *
+ * 0x0800 - Nominal for message ID V1
+ * 0x0000 - Potential value for MISSION_MSGID_V2, but limited to a range of
+ *          0x0000-0x007F since the command bit is 0x0080.  Alternative
+ *          method of deconfliction is recommended.
+ *
+ * See #CFE_PLATFORM_CMD_MID_BASE for more information
+ */
+#define CFE_PLATFORM_TLM_MID_BASE 0x0800
+
+/**
+ * \brief "Global" command message ID base offset
+ *
+ * 0x1860 - Nominal value for message ID V1
+ * 0x00E0 - Potential value for MISSION_MSGID_V2, note command bit is 0x0080.
+ *          Works in limited cases only, alternative method of deconfliction
+ *          is recommended.
+ * See #CFE_PLATFORM_CMD_MID_BASE for more information
+ */
+#define CFE_PLATFORM_CMD_MID_BASE_GLOB 0x1860
+
 /*
 ** cFE Command Message Id's
 */
-#define CFE_EVS_CMD_MID         CFE_MISSION_CMD_MID_BASE1 + CFE_MISSION_EVS_CMD_MSG         /* 0x1801 */
+#define CFE_EVS_CMD_MID         CFE_PLATFORM_CMD_MID_BASE + CFE_MISSION_EVS_CMD_MSG         /* 0x1801 */
                                                        /* Message ID 0x1802 is available  */
-#define CFE_SB_CMD_MID          CFE_MISSION_CMD_MID_BASE1 + CFE_MISSION_SB_CMD_MSG          /* 0x1803 */
-#define CFE_TBL_CMD_MID         CFE_MISSION_CMD_MID_BASE1 + CFE_MISSION_TBL_CMD_MSG         /* 0x1804 */
-#define CFE_TIME_CMD_MID        CFE_MISSION_CMD_MID_BASE1 + CFE_MISSION_TIME_CMD_MSG        /* 0x1805 */
-#define CFE_ES_CMD_MID          CFE_MISSION_CMD_MID_BASE1 + CFE_MISSION_ES_CMD_MSG          /* 0x1806 */
+#define CFE_SB_CMD_MID          CFE_PLATFORM_CMD_MID_BASE + CFE_MISSION_SB_CMD_MSG          /* 0x1803 */
+#define CFE_TBL_CMD_MID         CFE_PLATFORM_CMD_MID_BASE + CFE_MISSION_TBL_CMD_MSG         /* 0x1804 */
+#define CFE_TIME_CMD_MID        CFE_PLATFORM_CMD_MID_BASE + CFE_MISSION_TIME_CMD_MSG        /* 0x1805 */
+#define CFE_ES_CMD_MID          CFE_PLATFORM_CMD_MID_BASE + CFE_MISSION_ES_CMD_MSG          /* 0x1806 */
 
-#define CFE_ES_SEND_HK_MID      CFE_MISSION_CMD_MID_BASE1 + CFE_MISSION_ES_SEND_HK_MSG      /* 0x1808 */
-#define CFE_EVS_SEND_HK_MID     CFE_MISSION_CMD_MID_BASE1 + CFE_MISSION_EVS_SEND_HK_MSG     /* 0x1809 */
+#define CFE_ES_SEND_HK_MID      CFE_PLATFORM_CMD_MID_BASE + CFE_MISSION_ES_SEND_HK_MSG      /* 0x1808 */
+#define CFE_EVS_SEND_HK_MID     CFE_PLATFORM_CMD_MID_BASE + CFE_MISSION_EVS_SEND_HK_MSG     /* 0x1809 */
                                                        /* Message ID 0x180A is available  */
-#define CFE_SB_SEND_HK_MID      CFE_MISSION_CMD_MID_BASE1 + CFE_MISSION_SB_SEND_HK_MSG      /* 0x180B */
-#define CFE_TBL_SEND_HK_MID     CFE_MISSION_CMD_MID_BASE1 + CFE_MISSION_TBL_SEND_HK_MSG     /* 0x180C */
-#define CFE_TIME_SEND_HK_MID    CFE_MISSION_CMD_MID_BASE1 + CFE_MISSION_TIME_SEND_HK_MSG    /* 0x180D */
+#define CFE_SB_SEND_HK_MID      CFE_PLATFORM_CMD_MID_BASE + CFE_MISSION_SB_SEND_HK_MSG      /* 0x180B */
+#define CFE_TBL_SEND_HK_MID     CFE_PLATFORM_CMD_MID_BASE + CFE_MISSION_TBL_SEND_HK_MSG     /* 0x180C */
+#define CFE_TIME_SEND_HK_MID    CFE_PLATFORM_CMD_MID_BASE + CFE_MISSION_TIME_SEND_HK_MSG    /* 0x180D */
 
-#define CFE_SB_SUB_RPT_CTRL_MID CFE_MISSION_CMD_MID_BASE1 + CFE_MISSION_SB_SUB_RPT_CTRL_MSG /* 0x180E */
+#define CFE_SB_SUB_RPT_CTRL_MID CFE_PLATFORM_CMD_MID_BASE + CFE_MISSION_SB_SUB_RPT_CTRL_MSG /* 0x180E */
 
-#define CFE_TIME_TONE_CMD_MID   CFE_MISSION_CMD_MID_BASE1 + CFE_MISSION_TIME_TONE_CMD_MSG   /* 0x1810 */
-#define CFE_TIME_1HZ_CMD_MID    CFE_MISSION_CMD_MID_BASE1 + CFE_MISSION_TIME_1HZ_CMD_MSG    /* 0x1811 */
+#define CFE_TIME_TONE_CMD_MID   CFE_PLATFORM_CMD_MID_BASE + CFE_MISSION_TIME_TONE_CMD_MSG   /* 0x1810 */
+#define CFE_TIME_1HZ_CMD_MID    CFE_PLATFORM_CMD_MID_BASE + CFE_MISSION_TIME_1HZ_CMD_MSG    /* 0x1811 */
 
 
 /*
 ** cFE Global Command Message Id's
 */
-#define CFE_TIME_DATA_CMD_MID   CFE_MISSION_CMD_MID_BASE_GLOB + CFE_MISSION_TIME_DATA_CMD_MSG   /* 0x1860 */
-#define CFE_TIME_SEND_CMD_MID   CFE_MISSION_CMD_MID_BASE_GLOB + CFE_MISSION_TIME_SEND_CMD_MSG   /* 0x1862 */
+#define CFE_TIME_DATA_CMD_MID   CFE_PLATFORM_CMD_MID_BASE_GLOB + CFE_MISSION_TIME_DATA_CMD_MSG   /* 0x1860 */
+#define CFE_TIME_SEND_CMD_MID   CFE_PLATFORM_CMD_MID_BASE_GLOB + CFE_MISSION_TIME_SEND_CMD_MSG   /* 0x1862 */
 
 
 /*
 ** CFE Telemetry Message Id's
 */
-#define CFE_ES_HK_TLM_MID           CFE_MISSION_TLM_MID_BASE1 + CFE_MISSION_ES_HK_TLM_MSG       /* 0x0800 */
-#define CFE_EVS_HK_TLM_MID          CFE_MISSION_TLM_MID_BASE1 + CFE_MISSION_EVS_HK_TLM_MSG      /* 0x0801 */
+#define CFE_ES_HK_TLM_MID           CFE_PLATFORM_TLM_MID_BASE + CFE_MISSION_ES_HK_TLM_MSG       /* 0x0800 */
+#define CFE_EVS_HK_TLM_MID          CFE_PLATFORM_TLM_MID_BASE + CFE_MISSION_EVS_HK_TLM_MSG      /* 0x0801 */
                                                        /* Message ID 0x0802 is available  */
-#define CFE_SB_HK_TLM_MID           CFE_MISSION_TLM_MID_BASE1 + CFE_MISSION_SB_HK_TLM_MSG       /* 0x0803 */
-#define CFE_TBL_HK_TLM_MID          CFE_MISSION_TLM_MID_BASE1 + CFE_MISSION_TBL_HK_TLM_MSG      /* 0x0804 */
-#define CFE_TIME_HK_TLM_MID         CFE_MISSION_TLM_MID_BASE1 + CFE_MISSION_TIME_HK_TLM_MSG     /* 0x0805 */
-#define CFE_TIME_DIAG_TLM_MID       CFE_MISSION_TLM_MID_BASE1 + CFE_MISSION_TIME_DIAG_TLM_MSG   /* 0x0806 */
-#define CFE_EVS_LONG_EVENT_MSG_MID  CFE_MISSION_TLM_MID_BASE1 + CFE_MISSION_EVS_LONG_EVENT_MSG_MSG   /* 0x0808 */
-#define CFE_EVS_SHORT_EVENT_MSG_MID CFE_MISSION_TLM_MID_BASE1 + CFE_MISSION_EVS_SHORT_EVENT_MSG_MSG  /* 0x0809 */
-#define CFE_SB_STATS_TLM_MID        CFE_MISSION_TLM_MID_BASE1 + CFE_MISSION_SB_STATS_TLM_MSG    /* 0x080A */
-#define CFE_ES_APP_TLM_MID          CFE_MISSION_TLM_MID_BASE1 + CFE_MISSION_ES_APP_TLM_MSG      /* 0x080B */
-#define CFE_TBL_REG_TLM_MID         CFE_MISSION_TLM_MID_BASE1 + CFE_MISSION_TBL_REG_TLM_MSG     /* 0x080C */
-#define CFE_SB_ALLSUBS_TLM_MID      CFE_MISSION_TLM_MID_BASE1 + CFE_MISSION_SB_ALLSUBS_TLM_MSG  /* 0x080D */
-#define CFE_SB_ONESUB_TLM_MID       CFE_MISSION_TLM_MID_BASE1 + CFE_MISSION_SB_ONESUB_TLM_MSG   /* 0x080E */
-#define CFE_ES_MEMSTATS_TLM_MID     CFE_MISSION_TLM_MID_BASE1 + CFE_MISSION_ES_MEMSTATS_TLM_MSG /* 0x0810 */
+#define CFE_SB_HK_TLM_MID           CFE_PLATFORM_TLM_MID_BASE + CFE_MISSION_SB_HK_TLM_MSG       /* 0x0803 */
+#define CFE_TBL_HK_TLM_MID          CFE_PLATFORM_TLM_MID_BASE + CFE_MISSION_TBL_HK_TLM_MSG      /* 0x0804 */
+#define CFE_TIME_HK_TLM_MID         CFE_PLATFORM_TLM_MID_BASE + CFE_MISSION_TIME_HK_TLM_MSG     /* 0x0805 */
+#define CFE_TIME_DIAG_TLM_MID       CFE_PLATFORM_TLM_MID_BASE + CFE_MISSION_TIME_DIAG_TLM_MSG   /* 0x0806 */
+#define CFE_EVS_LONG_EVENT_MSG_MID  CFE_PLATFORM_TLM_MID_BASE + CFE_MISSION_EVS_LONG_EVENT_MSG_MSG   /* 0x0808 */
+#define CFE_EVS_SHORT_EVENT_MSG_MID CFE_PLATFORM_TLM_MID_BASE + CFE_MISSION_EVS_SHORT_EVENT_MSG_MSG  /* 0x0809 */
+#define CFE_SB_STATS_TLM_MID        CFE_PLATFORM_TLM_MID_BASE + CFE_MISSION_SB_STATS_TLM_MSG    /* 0x080A */
+#define CFE_ES_APP_TLM_MID          CFE_PLATFORM_TLM_MID_BASE + CFE_MISSION_ES_APP_TLM_MSG      /* 0x080B */
+#define CFE_TBL_REG_TLM_MID         CFE_PLATFORM_TLM_MID_BASE + CFE_MISSION_TBL_REG_TLM_MSG     /* 0x080C */
+#define CFE_SB_ALLSUBS_TLM_MID      CFE_PLATFORM_TLM_MID_BASE + CFE_MISSION_SB_ALLSUBS_TLM_MSG  /* 0x080D */
+#define CFE_SB_ONESUB_TLM_MID       CFE_PLATFORM_TLM_MID_BASE + CFE_MISSION_SB_ONESUB_TLM_MSG   /* 0x080E */
+#define CFE_ES_MEMSTATS_TLM_MID     CFE_PLATFORM_TLM_MID_BASE + CFE_MISSION_ES_MEMSTATS_TLM_MSG /* 0x0810 */
 
 #endif

--- a/cmake/sample_defs/sample_mission_cfg.h
+++ b/cmake/sample_defs/sample_mission_cfg.h
@@ -53,21 +53,6 @@
 
 
 /**
-**  \cfemissioncfg cFE SB message format
-**
-**  \par Description:
-**      Dictates the message format used by the cFE.
-**   
-**  \par Limits
-**      All versions of the cFE currently support only CCSDS as the message format
-**      Defining MESSAGE_FORMAT_IS_CCSDS_VER_2 implements the APID extended header format
-**      MESSAGE_FORMAT_IS_CCSDS_VER_2 is optional
-*/
-/* #define MESSAGE_FORMAT_IS_CCSDS_VER_2 */
-#undef MESSAGE_FORMAT_IS_CCSDS_VER_2
-
-
-/**
 **  \cfesbcfg Maximum SB Message Size
 **
 **  \par Description:
@@ -333,48 +318,6 @@
 **       any possible neighboring fields without implicit padding.
 */
 #define CFE_MISSION_TBL_MAX_NAME_LENGTH         16
-
-
-/**
-**  \cfemissioncfg cFE Message ID Base Numbers
-**
-**  \par Description:
-**      Message Id base numbers for the cFE messages
-**      These will now differ in format when using CCSDS version 2 as they will no longer
-**      include the Secondary Header Flag and CCSDS version bits. 
-**
-**      NOTES: cFE MsgIds are the sum of the base numbers and the portable msg
-**             numbers.
-**
-**             For MESSAGE_FORMAT_IS_CCSDS_VER_2 These base MsgIds values are dependent on the
-**             values returned by the following SB Macros to form a 16 bit message ID (default
-**             macro definitions are in cfe_sb_msg_id_utils.h, default values below are
-**             representative of default macro definitions) :
-**               CFE_SB_CMD_MESSAGE_TYPE, CFE_SB_RD_APID_FROM_MSGID
-**               CFE_SB_RD_SUBSYS_ID_FROM_MSGID and CFE_SB_RD_TYPE_FROM_MSGID
-**
-**  \par Limits
-**      Must be less than CFE_PLATFORM_SB_HIGHEST_VALID_MSGID
-*/
-#ifndef MESSAGE_FORMAT_IS_CCSDS_VER_2
-#define CFE_MISSION_CMD_MID_BASE1   0x1800
-#define CFE_MISSION_TLM_MID_BASE1   0x0800
-#else
-#define CFE_MISSION_CMD_MID_BASE1   0x0080
-#define CFE_MISSION_TLM_MID_BASE1   0x0000
-#endif
-
-#define CFE_MISSION_CMD_APPID_BASE1 1
-#define CFE_MISSION_TLM_APPID_BASE1 0
-
-#ifndef MESSAGE_FORMAT_IS_CCSDS_VER_2
-#define CFE_MISSION_CMD_MID_BASE_GLOB   0x1860
-#define CFE_MISSION_TLM_MID_BASE_GLOB   0x0860
-#else
-#define CFE_MISSION_CMD_MID_BASE_GLOB   0x00E0
-#define CFE_MISSION_TLM_MID_BASE_GLOB   0x0060
-#endif
-
 
 
 /**

--- a/docs/src/cfe_sb.dox
+++ b/docs/src/cfe_sb.dox
@@ -60,32 +60,29 @@
   All commands, telemetry, and other data that are passed between the ground and
   the spacecraft, and between subsystems of the spacecraft, are considered to be
   messages. The most common message format is CCSDS (Consultative Committee for
-  Space Data Systems).
-
-  The cFE software bus was designed with 'hooks' to allow message formats other
-  than CCSDS to be used. The APIs that are used to set and get message header
-  fields are intentionally designed to be decoupled from CCSDS.
+  Space Data Systems) in <a href="https://public.ccsds.org/Pubs/133x0b2.pdf">
+  CCSDS Space Packet Protocol</a>, but can be customized by replacing the message module.
 
   There are two general types of messages - commands (or command packets) and
   telemetry (or telemetry packets).  Command packets are sent to a particular
   software task from the ground (or another task).  Telemetry packets are sent
   from a particular software task to the ground (or other tasks).
 
-  Each packet begins with a header that includes the message identifier, often
-  abbreviated as MsgId or message ID. The MsgId for CCSDS messages is the first
-  16 bits of the packet. The message 'type' indicator (command or telemetry) is
-  embedded in the Message ID. The header also contains a packet length field and a
-  packet sequence field. The packet sequence field is incremented by the software
-  bus for telemetry packets each time a packet is sent. The software bus does not
-  increment the sequence field for command packets. See the section named 'Packet
-  Sequence Values' for more detail.
-
+  The concept of a message identifier is utilized to provide abstraction
+  from header implementation, often abbreviated as message ID, MsgId, or MID.
+  Header and message identifier values should not be accessed directly to
+  avoid implementation specific dependencies.
+ 
   Telemetry packets typically contain a timestamp that indicates when the packet
   was produced.  Command packets typically contain a command code that identifies
   the particular type of command.
 
-  The software bus provides APIs for 'setting' and 'getting' the fields in the
-  header of the message.
+  The message module provides APIs for 'setting' and 'getting' the fields in the
+  header of the message.  The message module was separated from software bus
+  to enable users to customize message headers without requiring clone and
+  own of the entire cfe repository.  To customize, remove the built in msg
+  module from the build and replace with custom implementation.  See sample
+  target definitions folder for examples.
 
   Following the header is the user defined message data.
 

--- a/fsw/cfe-core/src/inc/cfe_sb_extern_typedefs.h
+++ b/fsw/cfe-core/src/inc/cfe_sb_extern_typedefs.h
@@ -94,12 +94,9 @@ typedef uint16  CFE_SB_MsgRouteIdx_Atom_t;
  * @brief  CFE_SB_MsgId_Atom_t primitive type definition
  *
  * This is an integer type capable of holding any Message ID value
+ * Note: This value is limited via #CFE_PLATFORM_SB_HIGHEST_VALID_MSGID
  */
-#ifdef MESSAGE_FORMAT_IS_CCSDS_VER_2
 typedef uint32 CFE_SB_MsgId_Atom_t;
-#else
-typedef uint16 CFE_SB_MsgId_Atom_t;
-#endif
 
 /**
  * @brief  CFE_SB_MsgId_t type definition

--- a/fsw/cfe-core/src/sb/cfe_sb_init.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_init.c
@@ -223,12 +223,6 @@ void CFE_SB_InitMsgMap(void){
         CFE_SB.MsgMap[KeyVal] = CFE_SB_INVALID_ROUTE_IDX;
     }
 
-#ifndef MESSAGE_FORMAT_IS_CCSDS_VER_2  /* Then use the default, version 1 */
-    CFE_ES_WriteToSysLog("SB internal message format: CCSDS Space Packet Protocol version 1\n");
-#else   /* VER_2 is the same now but will change for larger and/or distributed systems */
-    CFE_ES_WriteToSysLog("SB internal message format: Space Packet Protocol version 2 (extended hdr)\n");
-#endif
-
 }/* end CFE_SB_InitMsgMap */
 
 

--- a/fsw/cfe-core/src/sb/cfe_sb_msg_id_util.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_msg_id_util.c
@@ -20,66 +20,8 @@
 
 /******************************************************************************
 ** File: cfe_sb_msg_id_util.c
-**
-** Purpose:
-**      This file contains 'access' macros and functions for reading and
-**      writing message ID header fields.
-**      
-**      The function prototypes are in cfe_sb.h except for ConvertMsgIdToMsgKey
-**      which is in cfe_sb_priv.h
-*
-**      The MsgId is a mission defined message identifier to publish or subscribe to that must be 
-**      unique within the system(s). CFE_SB_MsgId_t is a uint32 that can be created from any 
-**      combination of bits from the primary header SID (StreamId) and the secondary header APID Qualifiers
-**      
-**      Implementation is based on CCSDS Space Packet Protocol 133.0.B-1 with Technical Corrigendum 2, September 2012
-**      Multi-mission Interoperable extended secondary headers should be registered in Space
-**      Assigned Numbers Authority (SANA). The process for SANA registration is documented in
-**      133.0.B-2. Mission specific headers need not be registered
-**
-**      For  MESSAGE_FORMAT_IS_CCSDS_VER_2 the default setup will combine:
-**       1 bit for the command/telemetry flag 
-**       7 bits from the primary header APID
-**       0 bits from the Playback flag
-**       8 bits from the secondary header APID qualifier (Subsystem)
-**       0 bits from the secondary header APID qualifier as the System
-**    = 16 bits total 
-**     
-**
-**     The APID qualifier System field can be populated in the Secondary header but
-**     but will be ignored in the default case for SB/SBN routing purposes. It is suggested 
-**     that the CCSDS Spacecraft ID be used for that field.
-**
-** Notes: The following 4 terms have been or are used in the cFS architecture and implementation
-**         
-**      StreamId - First 16 bits of CCSDS Space Packet Protocol (SPP) 133.0-B.1c2 Blue Book 
-**                 packet primary header. It contains the 3 bit Version Number, 1 bit Packet Type ID,
-**                 1 bit Secondary Header flag, and 11 bit Application Process ID
-**                 It was used in earlier cFS implementaions and defined here for historical reference
-**                 It is NOT exposed to user applications.
-**
-**      MsgId    - Unique numeric message identifier within a mission namespace. It is used by cFS
-**                 applications to the identify messages for publishing and subscribing
-**                 It is used by the SB API and encoded in a mission defended way in the header of 
-**                 all cFS messages.
-**                 It is exposed to all cFS applications
-**
-**      ApId     - CCSDS Application Process Id field in the primary header. 
-**                 It has default bit mask of 0x07FF and is part of the cFS message Id
-**                 It should not be confused with the cFE Executive Services (ES) term appId which
-**                 identifies the software application/component
-**                 It is NOT exposed to user applications.
-**
-**      MsgIdkey - This is a unique numeric key within a mission namespace that is used with  
-**                 cFS software bus internal structures. 
-**                 It is algorithmically created in a mission defined way from the MsgId to support
-**                 efficient lookup and mapping implementations 
-**                 It is NOT exposed to user applications.
-**
-** Author:   J. Wilmot/NASA
-**
-******************************************************************************/
-
+** Purpose: message ID utility functions
+*/
 
 /*
 ** Include Files

--- a/fsw/cfe-core/src/sb/cfe_sb_verify.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_verify.h
@@ -38,16 +38,6 @@
     #error CFE_PLATFORM_SB_MAX_MSG_IDS cannot be less than 1!
 #endif
 
-#ifndef MESSAGE_FORMAT_IS_CCSDS_VER_2
-   #if CFE_PLATFORM_SB_MAX_MSG_IDS > 4096
-       #error CFE_PLATFORM_SB_MAX_MSG_IDS cannot be greater than 2^12 (4096)!
-   #endif
-#else
-   #if CFE_PLATFORM_SB_MAX_MSG_IDS > 65536
-       #error CFE_PLATFORM_SB_MAX_MSG_IDS cannot be greater than 2^16 (65536)!
-   #endif
-#endif
-
 #if CFE_PLATFORM_SB_MAX_PIPES < 1
     #error CFE_PLATFORM_SB_MAX_PIPES cannot be less than 1!
 #endif

--- a/fsw/cfe-core/unit-test/sb_UT.h
+++ b/fsw/cfe-core/unit-test/sb_UT.h
@@ -82,8 +82,8 @@ typedef struct {
      uint16       Tlm16Param2;
 } SB_UT_TstPktWoSecHdr_t;
 
-#define SB_UT_CMD_MID_VALUE_BASE    CFE_MISSION_CMD_MID_BASE1 + 1
-#define SB_UT_TLM_MID_VALUE_BASE    CFE_MISSION_TLM_MID_BASE1 + 1
+#define SB_UT_CMD_MID_VALUE_BASE    CFE_PLATFORM_CMD_MID_BASE + 1
+#define SB_UT_TLM_MID_VALUE_BASE    CFE_PLATFORM_TLM_MID_BASE + 1
 
 /* SB unit test functions */
 /*****************************************************************************/
@@ -3113,7 +3113,6 @@ void Test_CFE_SB_SetGetMsgId(void);
 **
 ** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_SetMsgId,
 ** \sa #CFE_SB_SetUserDataLength, #CFE_SB_GetUserDataLength,
-** \sa #UT_GetActualPktLenField, #UT_Report
 **
 ******************************************************************************/
 void Test_CFE_SB_SetGetUserDataLength(void);
@@ -3133,7 +3132,6 @@ void Test_CFE_SB_SetGetUserDataLength(void);
 **
 ** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_SetMsgId,
 ** \sa #CFE_SB_SetTotalMsgLength, #CFE_SB_GetTotalMsgLength,
-** \sa #UT_GetActualPktLenField, #UT_Report
 **
 ******************************************************************************/
 void Test_CFE_SB_SetGetTotalMsgLength(void);
@@ -3171,8 +3169,7 @@ void Test_CFE_SB_SetGetMsgTime(void);
 **        This function does not return a value.
 **
 ** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_SetMsgId, #CFE_SB_SetCmdCode,
-** \sa #CFE_SB_GetCmdCode, #UT_GetActualCmdCodeField, #UT_DisplayPkt,
-** \sa #UT_Report
+** \sa #CFE_SB_GetCmdCode, #UT_DisplayPkt
 **
 ******************************************************************************/
 void Test_CFE_SB_SetGetCmdCode(void);

--- a/fsw/cfe-core/unit-test/ut_support.c
+++ b/fsw/cfe-core/unit-test/ut_support.c
@@ -467,45 +467,6 @@ void UT_DisplayPkt(CFE_SB_MsgPtr_t ptr, uint32 size)
     UT_Text(DisplayMsg);
 }
 
-/*
-** Return the actual packet length
-*/
-int16 UT_GetActualPktLenField(CFE_SB_MsgPtr_t MsgPtr)
-{
-    return ( ( MsgPtr->CCSDS.Pri.Length[0] << 8) + MsgPtr->CCSDS.Pri.Length[1] );
-}
-
-/*
-** Return the actual command code
-*/
-uint8 UT_GetActualCmdCodeField(CFE_SB_MsgPtr_t MsgPtr)
-{
-    /*
-     * This function is used to "go around" the structure field
-     * definitions and access macro definitions, to look for the
-     * bits of the function code in the exact spot where we are
-     * expecting to find them.
-     *
-     * The CCSDS Command Function Code is defined as living in
-     * the first byte of the command secondary header (mask 0x7F)
-     * NOTE: this definition is endian agnostic
-     *
-     * CCSDS version 1 - cmd sec header is offset 6 bytes
-     * CCSDS Version 2 - cmd sec header is offset 10 bytes
-     */
-
-    uint8 Index; /* Field index (in BYTES) */
-    uint8 *w = (uint8 *)MsgPtr;
-
-#ifndef MESSAGE_FORMAT_IS_CCSDS_VER_2
-    Index = 6;
-#else
-    Index = 10;
-#endif
-    return (w[Index] & 0x7F);
-}
-
-
 
 CFE_ES_ResetData_t *UT_GetResetDataPtr(void)
 {

--- a/fsw/cfe-core/unit-test/ut_support.h
+++ b/fsw/cfe-core/unit-test/ut_support.h
@@ -619,42 +619,6 @@ void UT_DisplayPkt(CFE_SB_MsgPtr_t ptr, uint32 size);
 
 /*****************************************************************************/
 /**
-** \brief Return the actual packet length
-**
-** \par Description
-**        Return the actual packet length field from the specified packet.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \param[in] MsgPtr  Message packet
-**
-** \returns
-**        Returns a pointer to the SB packet length.
-**
-******************************************************************************/
-/*uint16 TODO*/int16 UT_GetActualPktLenField(CFE_SB_MsgPtr_t MsgPtr);
-
-/*****************************************************************************/
-/**
-** \brief Return the actual command code
-**
-** \par Description
-**        Return the actual command code from the specified packet.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \param[in] MsgPtr  Message packet
-**
-** \returns
-**        Returns the actual SB packet command code.
-**
-******************************************************************************/
-/*uint16 TODO*/uint8 UT_GetActualCmdCodeField(CFE_SB_MsgPtr_t MsgPtr);
-
-/*****************************************************************************/
-/**
 ** \brief Report and close any sockets found open
 **
 ** \par Description

--- a/modules/msg/private_inc/cfe_msg_defaults.h
+++ b/modules/msg/private_inc/cfe_msg_defaults.h
@@ -42,11 +42,7 @@
 #endif
 
 #ifndef CFE_MISSION_CCSDSVER
-#ifdef MESSAGE_FORMAT_IS_CCSDS_VER_2
-#define CFE_MISSION_CCSDSVER 1 /**< \brief Default CCSDS Version, cFS Ver 2 historically = 1 */
-#else
-#define CFE_MISSION_CCSDSVER 0 /**< \brief Default CCSDS Version, cFS Ver 1 historically = 0 */
-#endif
+#define CFE_MISSION_CCSDSVER 0 /**< \brief Default CCSDS Version */
 #endif
 
 #ifndef CFE_PLATFORM_DEFAULT_SUBSYS

--- a/modules/msg/src/cfe_msg_ccsdspri.c
+++ b/modules/msg/src/cfe_msg_ccsdspri.c
@@ -49,7 +49,7 @@ void CFE_MSG_SetDefaultCCSDSPri(CFE_MSG_Message_t *MsgPtr)
     /* cFS standard is for secondary header to be present */
     CFE_MSG_SetHasSecondaryHeader(MsgPtr, true);
 
-    /* cFS standard for CCSDS Version is Ver 1 = 0, Ver 2 = 1, but mission may redefine */
+    /* cFS standard for CCSDS Version */
     CFE_MSG_SetHeaderVersion(MsgPtr, CFE_MISSION_CCSDSVER);
 
     /* Default bits of the APID, for whatever isn't set by MsgId */


### PR DESCRIPTION
**Describe the contribution**
Fix #796 
- Removes MESSAGE_FORMAT_IS_CCSDS_VER2 and all references
- Now replaced by MISSION_MSGID_V2 and MISSION_INCLUDE_CCSDS_HEADER
  cmake variables
- Base MIDs localized to cpu1_msgids.h and improved documentation
  indicating example nature of implementation, note issue #732
  may make this obsolete
- Updated cfe_sb.dox for message module concept
- MsgId base type now always uint32 (reduces logic differences)
- Removed system log report of version used, in build and obvious
  from packet sizes
- Cleaned extra documentation from cfe_sb_msg_id_util.c
- Removed verification limits on CFE_PLATFORM_SB_MAX_MSG_IDS
- Removed UT_GetActualPktLenField and UT_GetActualCmdCodeField
  that depended on the define, shouldn't directly access message
  in a unit test since it's implementation dependent
- Default CCSDS version default now always 0 (per the standard)
  but mission configurable

**Testing performed**
Build unit tests, passed except for sample app.  Build usersguide and confirmed no errors or warnings.

**Expected behavior changes**
None, just no longer requires additional configuration flag

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: bundle main + this commit

**Additional context**
#726 

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC