### PR TITLE
Fix #882, Returned processor ID to default to unbreak toolchain

### DIFF
--- a/cmake/sample_defs/targets.cmake
+++ b/cmake/sample_defs/targets.cmake
@@ -100,13 +100,13 @@ SET(FT_INSTALL_SUBDIR "host/functional-test")
 # Each target board can have its own HW arch selection and set of included apps
 SET(MISSION_CPUNAMES cpu1)
 
-SET(cpu1_PROCESSORID 10)
+SET(cpu1_PROCESSORID 1)
 SET(cpu1_APPLIST ci_lab to_lab sch_lab)
 SET(cpu1_FILELIST cfe_es_startup.scr)
 
-# CPU2/3 are duplicates of CPU1.  These are not built by default anymore but are
-# commented out to serve as an example of how one would configure multiple cpus.
-SET(cpu2_PROCESSORID 11)
+# CPU2 example.  This is not built by default anymore but 
+# serves as an example of how one would configure multiple cpus.
+SET(cpu2_PROCESSORID 2)
 SET(cpu2_APPLIST ci_lab to_lab sch_lab)
 SET(cpu2_FILELIST cfe_es_startup.scr)
 


### PR DESCRIPTION
**Describe the contribution**
Fix #882 

CI port selection depends on processor ID, #776 changed the default which broke toolchain.

**Testing performed**
built, ran, confirmed CI is back to listening on default port.

**Expected behavior changes**
Defaults work again in the toolchain

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this change.

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC