### PR TITLE
Fix #881, Install unit test to target directory

### DIFF
--- a/fsw/cfe-core/unit-test/CMakeLists.txt
+++ b/fsw/cfe-core/unit-test/CMakeLists.txt
@@ -74,9 +74,9 @@ foreach(MODULE ${CFE_CORE_MODULES})
         ut_assert)
 
   add_test(${UT_TARGET_NAME}_UT ${UT_TARGET_NAME}_UT)
-  foreach(TGTNAME ${TGTSYS_${SYSVAR}})
+  foreach(TGTNAME ${INSTALL_TARGET_LIST})
       install(TARGETS ${UT_TARGET_NAME}_UT DESTINATION ${TGTNAME}/${UT_INSTALL_SUBDIR})
-  endforeach(TGTNAME ${TGTSYS_${SYSVAR}})
+  endforeach(TGTNAME ${INSTALL_TARGET_LIST})
 endforeach(MODULE ${CFE_CORE_MODULES})
 
 # Generate the FS test input files

--- a/modules/msg/unit-test-coverage/CMakeLists.txt
+++ b/modules/msg/unit-test-coverage/CMakeLists.txt
@@ -60,4 +60,6 @@ target_link_libraries(${DEP}_UT
     ut_assert)
 
 add_test(${DEP}_UT ${DEP}_UT)
-install(TARGETS ${DEP}_UT DESTINATION ${TGTNAME}/${UT_INSTALL_SUBDIR})
+foreach(TGT ${INSTALL_TARGET_LIST})
+    install(TARGETS ${DEP}_UT DESTINATION ${TGT}/${UT_INSTALL_SUBDIR})
+endforeach()


### PR DESCRIPTION
**Describe the contribution**
Fix #881, Install unit test to target directory

**Testing performed**
Make unit tests, install, observe they install in correct directory

**Expected behavior changes**
Correct install directory

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC