### PR TITLE
Fix #827, Remove old name and id defines

### DIFF
--- a/cmake/arch_build.cmake
+++ b/cmake/arch_build.cmake
@@ -155,10 +155,7 @@ function(add_cfe_tables APP_NAME TBL_SRC_FILES)
       # current content of a dependency (rightfully so).
       add_custom_command(
         OUTPUT "${TABLE_DESTDIR}/${TBLWE}.tbl"
-        COMMAND ${CMAKE_C_COMPILER} ${TBL_CFLAGS} 
-            -DCFE_PLATFORM_CPU_ID=${${TGT}_PROCESSORID}
-            -DCFE_PLATFORM_CPU_NAME="${TGT}"
-            -c -o ${TBLWE}.o ${TBL_SRC}
+        COMMAND ${CMAKE_C_COMPILER} ${TBL_CFLAGS} -c -o ${TBLWE}.o ${TBL_SRC}
         COMMAND ${MISSION_BINARY_DIR}/tools/elf2cfetbl/elf2cfetbl ${TBLWE}.o
         DEPENDS ${MISSION_BINARY_DIR}/tools/elf2cfetbl/elf2cfetbl ${TBL_SRC}
         WORKING_DIRECTORY ${TABLE_DESTDIR}

--- a/cmake/sample_defs/cpu1_platform_cfg.h
+++ b/cmake/sample_defs/cpu1_platform_cfg.h
@@ -36,11 +36,6 @@
 #ifndef _cfe_platform_cfg_
 #define _cfe_platform_cfg_
 
-/*
-** Allow reference to CFE_MISSION_SPACECRAFT_ID (see CFE_TBL_VALID_ definitions below)
-*/
-#include "cfe_mission_cfg.h"
-
 /**
 **  \cfesbcfg Maximum Number of Unique Message IDs SB Routing Table can hold
 **
@@ -1742,7 +1737,7 @@
 **  \par Limits
 **       This value can be any 32 bit unsigned integer.
 */
-#define CFE_PLATFORM_TBL_VALID_SCID_1            (CFE_MISSION_SPACECRAFT_ID)
+#define CFE_PLATFORM_TBL_VALID_SCID_1            (0x42)
 #define CFE_PLATFORM_TBL_VALID_SCID_2            (CFE_PLATFORM_TBL_U32FROM4CHARS('a', 'b', 'c', 'd'))
 
 /**
@@ -1776,7 +1771,7 @@
 **  \par Limits
 **       This value can be any 32 bit unsigned integer.
 */
-#define CFE_PLATFORM_TBL_VALID_PRID_1            (10)
+#define CFE_PLATFORM_TBL_VALID_PRID_1            (1)
 #define CFE_PLATFORM_TBL_VALID_PRID_2            (CFE_PLATFORM_TBL_U32FROM4CHARS('a', 'b', 'c', 'd'))
 #define CFE_PLATFORM_TBL_VALID_PRID_3            0
 #define CFE_PLATFORM_TBL_VALID_PRID_4            0

--- a/cmake/sample_defs/sample_mission_cfg.h
+++ b/cmake/sample_defs/sample_mission_cfg.h
@@ -39,20 +39,6 @@
 
 
 /**
-**  \cfemissioncfg Spacecraft ID
-**
-**  \par Description:
-**      This defines the value that is returned by the call to
-**      CFE_PSP_GetSpacecraftId.
-**
-**  \par Limits
-**       The cFE does not place a limit on this configuration paramter.
-**       CCSDS allocates 8 bits for this field in the standard VCDU.
-*/
-#define CFE_MISSION_SPACECRAFT_ID       0x42
-
-
-/**
 **  \cfesbcfg Maximum SB Message Size
 **
 **  \par Description:


### PR DESCRIPTION
**Describe the contribution**
Fix #827, Remove old name and id defines
 CFE_PLATFORM_CPU_ID, CFE_PLATFORM_CPU_NAME, and CFE_MISSION_SPACECRAFT_ID

Use CFE_PSP_GetProcessorId(), CFE_PSP_GetProcessorName(), CFE_PSP_GetSpacecraftId() going forward.

**Testing performed**
Built with unit tests, passed.  Also nominal core-cfe run.

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
#710 

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC