### PR TITLE
Fix #890, CFE_ES_CalculateCRC default stub behavior

### DIFF
--- a/fsw/cfe-core/ut-stubs/ut_es_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_es_stubs.c
@@ -751,7 +751,7 @@ void CFE_ES_PerfLogAdd(uint32 Marker, uint32 EntryExit)
 **        None
 **
 ** \returns
-**        Returns 332424.
+**        Returns either a user-defined status flag or CFE_SUCCESS.
 **
 ******************************************************************************/
 uint32 CFE_ES_CalculateCRC(const void *DataPtr,
@@ -764,16 +764,11 @@ uint32 CFE_ES_CalculateCRC(const void *DataPtr,
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_CalculateCRC), InputCRC);
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_CalculateCRC), TypeCRC);
 
-    uint32 result;
+    uint32 status;
 
-    UT_DEFAULT_IMPL(CFE_ES_CalculateCRC);
+    status = UT_DEFAULT_IMPL(CFE_ES_CalculateCRC);
 
-    if (UT_Stub_CopyToLocal(UT_KEY(CFE_ES_CalculateCRC), (uint8*)&result, sizeof(result)) < sizeof(result))
-    {
-        result = 332424;
-    }
-
-    return result;
+    return status;
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
**Describe the contribution**
Fix #890 - CFE_ES_CalculateCRC updated to default return behavior.

**Testing performed**
Built and ran unit tests, passed.

**Expected behavior changes**
Now setting the return code (and deferred return code) works for CFE_ES_CalculateCRC.

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: bundle main + this commit.

**Additional context**
None.

**Third party code**
None.

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC