### PR TITLE
Fix #893, replace calls to OS_open and OS_creat

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_apps.c
+++ b/fsw/cfe-core/src/es/cfe_es_apps.c
@@ -94,14 +94,13 @@ void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath )
       /*
       ** Open the file in the volatile disk.
       */
-      Status = OS_open( CFE_PLATFORM_ES_VOLATILE_STARTUP_FILE, OS_READ_ONLY, 0);
+      Status = OS_OpenCreate(&AppFile, CFE_PLATFORM_ES_VOLATILE_STARTUP_FILE, OS_FILE_FLAG_NONE, OS_READ_ONLY);
 
       if ( Status >= 0 )
       {
          CFE_ES_WriteToSysLog ("ES Startup: Opened ES App Startup file: %s\n",
                                 CFE_PLATFORM_ES_VOLATILE_STARTUP_FILE);
          FileOpened = true;
-         AppFile = OS_ObjectIdFromInteger(Status);
       }
       else
       {
@@ -120,13 +119,12 @@ void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath )
       /*
       ** Try to Open the file passed in to the cFE start.
       */
-      Status = OS_open( (const char *)StartFilePath, OS_READ_ONLY, 0);
+      Status = OS_OpenCreate(&AppFile, StartFilePath, OS_FILE_FLAG_NONE, OS_READ_ONLY);
 
       if ( Status >= 0 )
       {
          CFE_ES_WriteToSysLog ("ES Startup: Opened ES App Startup file: %s\n",StartFilePath);
          FileOpened = true;
-         AppFile = OS_ObjectIdFromInteger(Status);
       }
       else
       {

--- a/fsw/cfe-core/src/es/cfe_es_erlog.c
+++ b/fsw/cfe-core/src/es/cfe_es_erlog.c
@@ -207,7 +207,7 @@ bool CFE_ES_RunERLogDump(uint32 ElapsedTime, void *Arg)
     }
 
     FileSize = 0;
-    Status = OS_creat(State->DataFileName, OS_WRITE_ONLY);
+    Status = OS_OpenCreate(&fd, State->DataFileName, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
     if(Status < 0)
     {
         CFE_EVS_SendEvent(CFE_ES_ERLOG2_ERR_EID,CFE_EVS_EventType_ERROR,
@@ -216,7 +216,6 @@ bool CFE_ES_RunERLogDump(uint32 ElapsedTime, void *Arg)
     }
     else
     {
-        fd = OS_ObjectIdFromInteger(Status);
         CFE_FS_InitHeader(&FileHdr, CFE_ES_ER_LOG_DESC, CFE_FS_SubType_ES_ERLOG);
 
         /* write the cFE header to the file */

--- a/fsw/cfe-core/src/es/cfe_es_perf.c
+++ b/fsw/cfe-core/src/es/cfe_es_perf.c
@@ -311,12 +311,9 @@ bool CFE_ES_RunPerfLogDump(uint32 ElapsedTime, void *Arg)
             {
             case CFE_ES_PerfDumpState_OPEN_FILE:
                 /* Create the file to dump to */
-                Status = OS_creat(State->DataFileName, OS_WRITE_ONLY);
-                if (Status >= 0)
-                {
-                    State->FileDesc = OS_ObjectIdFromInteger(Status);
-                }
-                else
+                Status = OS_OpenCreate(&State->FileDesc, State->DataFileName,
+                        OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
+                if (Status < 0)
                 {
                     State->FileDesc = OS_OBJECT_ID_UNDEFINED;
                     CFE_EVS_SendEvent(CFE_ES_PERF_LOG_ERR_EID,CFE_EVS_EventType_ERROR,

--- a/fsw/cfe-core/src/es/cfe_es_syslog.c
+++ b/fsw/cfe-core/src/es/cfe_es_syslog.c
@@ -479,7 +479,7 @@ int32 CFE_ES_SysLogDump(const char *Filename)
         CFE_FS_Header_t FileHdr;
     } Buffer;
 
-    Status = OS_creat(Filename, OS_WRITE_ONLY);
+    Status = OS_OpenCreate(&fd, Filename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
     if(Status < 0)
     {
         CFE_EVS_SendEvent(CFE_ES_SYSLOG2_ERR_EID,CFE_EVS_EventType_ERROR,
@@ -487,8 +487,6 @@ int32 CFE_ES_SysLogDump(const char *Filename)
                 Filename,(unsigned int)Status);
         return CFE_ES_FILE_IO_ERR;
     }/* end if */
-
-    fd = OS_ObjectIdFromInteger(Status);
 
     CFE_FS_InitHeader(&Buffer.FileHdr, CFE_ES_SYS_LOG_DESC, CFE_FS_SubType_ES_SYSLOG);
 

--- a/fsw/cfe-core/src/es/cfe_es_task.c
+++ b/fsw/cfe-core/src/es/cfe_es_task.c
@@ -1194,10 +1194,10 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAll_t *data)
     /*
     ** Check to see if the file already exists
     */
-    Result = OS_open(QueryAllFilename, OS_READ_ONLY, 0);
+    Result = OS_OpenCreate(&FileDescriptor, QueryAllFilename,
+            OS_FILE_FLAG_NONE, OS_READ_ONLY);
     if (Result >= 0)
     {
-        FileDescriptor = OS_ObjectIdFromInteger(Result);
         OS_close(FileDescriptor);
         OS_remove(QueryAllFilename);
     }
@@ -1205,10 +1205,10 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAll_t *data)
     /*
     ** Create ES task log data file
     */
-    Result = OS_creat(QueryAllFilename, OS_WRITE_ONLY);
+    Result = OS_OpenCreate(&FileDescriptor, QueryAllFilename,
+            OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
     if (Result >= 0)
     {
-        FileDescriptor = OS_ObjectIdFromInteger(Result);
         /*
         ** Initialize cFE file header
         */
@@ -1292,7 +1292,7 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAll_t *data)
     {
         CFE_ES_TaskData.CommandErrorCounter++;
         CFE_EVS_SendEvent(CFE_ES_OSCREATE_ERR_EID, CFE_EVS_EventType_ERROR,
-                "Failed to write App Info file, OS_creat RC = 0x%08X",(unsigned int)Result);
+                "Failed to write App Info file, OS_OpenCreate RC = 0x%08X",(unsigned int)Result);
     }
 
     return CFE_SUCCESS;
@@ -1325,10 +1325,10 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasks_t *data)
     /*
     ** Check to see if the file already exists
     */
-    Result = OS_open(QueryAllFilename, OS_READ_ONLY, 0);
+    Result = OS_OpenCreate(&FileDescriptor, QueryAllFilename,
+            OS_FILE_FLAG_NONE, OS_READ_ONLY);
     if (Result >= 0)
     {
-        FileDescriptor = OS_ObjectIdFromInteger(Result);
         OS_close(FileDescriptor);
         OS_remove(QueryAllFilename);
     }
@@ -1336,10 +1336,10 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasks_t *data)
     /*
     ** Create ES task log data file
     */
-    Result = OS_creat(QueryAllFilename, OS_WRITE_ONLY);
+    Result = OS_OpenCreate(&FileDescriptor, QueryAllFilename,
+            OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
     if (Result >= 0)
     {
-        FileDescriptor = OS_ObjectIdFromInteger(Result);
         /*
         ** Initialize cFE file header
         */
@@ -1423,7 +1423,7 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasks_t *data)
     {
         CFE_ES_TaskData.CommandErrorCounter++;
         CFE_EVS_SendEvent(CFE_ES_TASKINFO_OSCREATE_ERR_EID, CFE_EVS_EventType_ERROR,
-                "Failed to write Task Info file, OS_creat RC = 0x%08X",(unsigned int)Result);
+                "Failed to write Task Info file, OS_OpenCreate RC = 0x%08X",(unsigned int)Result);
     }
 
     return CFE_SUCCESS;
@@ -1803,12 +1803,11 @@ int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistry_t *data)
             OS_MAX_PATH_LEN, sizeof(CmdPtr->DumpFilename));
 
     /* Create a new dump file, overwriting anything that may have existed previously */
-    Status = OS_creat(DumpFilename, OS_WRITE_ONLY);
+    Status = OS_OpenCreate(&FileDescriptor, DumpFilename,
+            OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
 
     if (Status >= OS_SUCCESS)
     {
-        FileDescriptor = OS_ObjectIdFromInteger(Status);
-
         /* Initialize the standard cFE File Header for the Dump File */
         CFE_FS_InitHeader(&StdFileHeader, "CDS_Registry", CFE_FS_SubType_ES_CDS_REG);
 

--- a/fsw/cfe-core/src/evs/cfe_evs_log.c
+++ b/fsw/cfe-core/src/evs/cfe_evs_log.c
@@ -172,19 +172,17 @@ int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFile_t *data)
                 OS_MAX_PATH_LEN, sizeof(CmdPtr->LogFilename));
 
         /* Create the log file */
-        Result = OS_creat(LogFilename, OS_WRITE_ONLY);
+        Result = OS_OpenCreate(&LogFileHandle, LogFilename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
 
         if (Result < OS_SUCCESS)
         {
             EVS_SendEvent(CFE_EVS_ERR_CRLOGFILE_EID, CFE_EVS_EventType_ERROR,
-                    "Write Log File Command Error: OS_creat = 0x%08X, filename = %s",
+                    "Write Log File Command Error: OS_OpenCreate = 0x%08X, filename = %s",
                     (unsigned int)Result, LogFilename);
 
         }
         else
         {
-            LogFileHandle = OS_ObjectIdFromInteger(Result);
-
             /* Result will be overridden if everything works */
             Result = CFE_EVS_FILE_WRITE_ERROR;
 

--- a/fsw/cfe-core/src/evs/cfe_evs_task.c
+++ b/fsw/cfe-core/src/evs/cfe_evs_task.c
@@ -1752,18 +1752,16 @@ int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFile_t *data)
            OS_MAX_PATH_LEN, sizeof(CmdPtr->AppDataFilename));
 
    /* Create Application Data File */
-   Result = OS_creat(LocalName, OS_WRITE_ONLY);
+   Result = OS_OpenCreate(&FileHandle, LocalName, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
 
    if (Result < OS_SUCCESS)
    {
       EVS_SendEvent(CFE_EVS_ERR_CRDATFILE_EID, CFE_EVS_EventType_ERROR,
-                   "Write App Data Command Error: OS_creat = 0x%08X, filename = %s",
+                   "Write App Data Command Error: OS_OpenCreate = 0x%08X, filename = %s",
                     (unsigned int)Result, LocalName);
    }
    else
    {
-      FileHandle = OS_ObjectIdFromInteger(Result);
-
       /* Result will be overridden if everything works */
       Result = CFE_EVS_FILE_WRITE_ERROR;
 

--- a/fsw/cfe-core/src/inc/cfe_es_events.h
+++ b/fsw/cfe-core/src/inc/cfe_es_events.h
@@ -843,8 +843,8 @@
 #define CFE_ES_ONE_APPID_ERR_EID       50
 
 
-/** \brief <tt> 'Failed to write App Info file, OS_creat returned \%d' </tt>
-**  \event <tt> 'Failed to write App Info file, OS_creat returned \%d' </tt> 
+/** \brief <tt> 'Failed to write App Info file, OS_OpenCreate returned \%d' </tt>
+**  \event <tt> 'Failed to write App Info file, OS_OpenCreate returned \%d' </tt> 
 **
 **  \par Type: ERROR
 **
@@ -853,7 +853,7 @@
 **  This event message is generated when an Executive Services \link #CFE_ES_QUERY_ALL_CC Dump Application
 **  Data Command \endlink fails to create the dump file.
 **
-**  The \c 'd' parameter identifies, in decimal, the error code returned by #OS_creat when the attempt was made
+**  The \c 'd' parameter identifies, in decimal, the error code returned by #OS_OpenCreate when the attempt was made
 **  to create the file.
 **/
 #define CFE_ES_OSCREATE_ERR_EID  51
@@ -900,7 +900,7 @@
 **  Command \endlink fails while attempting to create the specified file.
 **
 **  The \c 's' field identifies the name of the file that was attempted to be created and the \c stat field
-**  specifies, in hex, the error code returned by the #OS_creat API.
+**  specifies, in hex, the error code returned by the #OS_OpenCreate API.
 **/
 #define CFE_ES_SYSLOG2_ERR_EID     55
 
@@ -915,7 +915,7 @@
 **  Command \endlink fails while attempting to create the specified file.
 **
 **  The \c 's' field identifies the name of the file that was attempted to be created and the \c stat field
-**  specifies, in hex, the error code returned by the #OS_creat API.
+**  specifies, in hex, the error code returned by the #OS_OpenCreate API.
 **/
 #define CFE_ES_ERLOG2_ERR_EID    56
 
@@ -1072,7 +1072,7 @@
 **  fails to create the associated logic analyzer dump file.
 **
 **  The \c 's' field identifies the name of the file that was attempted to be created and the \c stat field
-**  specifies, in decimal, the error code returned by the #OS_creat API.
+**  specifies, in decimal, the error code returned by the #OS_OpenCreate API.
 **/
 #define CFE_ES_PERF_LOG_ERR_EID     67
 
@@ -1362,7 +1362,7 @@
 **  is unable to create the specified file on the onboard filesystem. 
 **
 **  The \c 's' field identifies the CDS Registry Dump Filename.
-**  The \c '08X' field identifies error code returned by the API #OS_creat.
+**  The \c '08X' field identifies error code returned by the API #OS_OpenCreate.
 **/
 #define CFE_ES_CREATING_CDS_DUMP_ERR_EID      86
 
@@ -1385,8 +1385,8 @@
 #define CFE_ES_TASKINFO_EID      87
 
 
-/** \brief <tt> 'Failed to write Task Info file, OS_creat returned \%d' </tt>
-**  \event <tt> 'Failed to write Task Info file, OS_creat returned \%d' </tt> 
+/** \brief <tt> 'Failed to write Task Info file, OS_OpenCreate returned \%d' </tt>
+**  \event <tt> 'Failed to write Task Info file, OS_OpenCreate returned \%d' </tt> 
 **
 **  \par Type: ERROR
 **
@@ -1395,7 +1395,7 @@
 **  This event message is generated when an Executive Services \link #CFE_ES_QUERY_ALL_TASKS_CC Dump Task
 **  Data Command \endlink fails to create the dump file.
 **
-**  The \c 'd' parameter identifies, in decimal, the error code returned by #OS_creat when the attempt was made
+**  The \c 'd' parameter identifies, in decimal, the error code returned by #OS_OpenCreate when the attempt was made
 **  to create the file.
 **/
 #define CFE_ES_TASKINFO_OSCREATE_ERR_EID  88

--- a/fsw/cfe-core/src/inc/cfe_evs_events.h
+++ b/fsw/cfe-core/src/inc/cfe_evs_events.h
@@ -87,8 +87,8 @@
 **/
 #define CFE_EVS_ERR_WRLOGFILE_EID          2
 
-/** \brief <tt> 'Write Log File Command Error: OS_creat = 0x\%08X, filename = \%s' </tt>
-**  \event <tt> 'Write Log File Command Error: OS_creat = 0x\%08X, filename = \%s' </tt>
+/** \brief <tt> 'Write Log File Command Error: OS_OpenCreate = 0x\%08X, filename = \%s' </tt>
+**  \event <tt> 'Write Log File Command Error: OS_OpenCreate = 0x\%08X, filename = \%s' </tt>
 **
 **  \par Type: ERROR
 **
@@ -241,8 +241,8 @@
 **/
 #define CFE_EVS_ERR_WRDATFILE_EID         12
 
-/** \brief <tt> 'Write App Data Command Error: OS_creat = 0x\%08X, filename = \%s' </tt>
-**  \event <tt> 'Write App Data Command Error: OS_creat = 0x\%08X, filename = \%s' </tt> 
+/** \brief <tt> 'Write App Data Command Error: OS_OpenCreate = 0x\%08X, filename = \%s' </tt>
+**  \event <tt> 'Write App Data Command Error: OS_OpenCreate = 0x\%08X, filename = \%s' </tt> 
 **
 **  \par Type: ERROR
 **

--- a/fsw/cfe-core/src/inc/cfe_fs.h
+++ b/fsw/cfe-core/src/inc/cfe_fs.h
@@ -56,10 +56,10 @@
 **        the given File Descriptor.
 **
 ** \par Assumptions, External Events, and Notes:
-**        -# The File has already been successfully opened using #OS_open and
+**        -# The File has already been successfully opened using #OS_OpenCreate and
 **           the caller has a legitimate File Descriptor.
 **
-** \param[in] FileDes File Descriptor obtained from a previous call to #OS_open
+** \param[in] FileDes File Descriptor obtained from a previous call to #OS_OpenCreate
 **                    that is associated with the file whose header is to be read.
 **
 ** \param[in, out] Hdr     Pointer to a variable of type #CFE_FS_Header_t that will be
@@ -112,12 +112,12 @@ void CFE_FS_InitHeader(CFE_FS_Header_t *Hdr, const char *Description, uint32 Sub
 **        
 **        
 ** \par Assumptions, External Events, and Notes:
-**        -# The File has already been successfully opened using #OS_open and
+**        -# The File has already been successfully opened using #OS_OpenCreate and
 **           the caller has a legitimate File Descriptor.
 **        -# The \c SubType field has been filled appropriately by the Application.
 **        -# The \c Description field has been filled appropriately by the Application.
 **
-** \param[in] FileDes File Descriptor obtained from a previous call to #OS_open
+** \param[in] FileDes File Descriptor obtained from a previous call to #OS_OpenCreate
 **                    that is associated with the file whose header is to be read.
 **
 ** \param[in, out] Hdr     Pointer to a variable of type #CFE_FS_Header_t that will be
@@ -140,11 +140,11 @@ int32 CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr);
 **        with the time specified by the caller.
 **
 ** \par Assumptions, External Events, and Notes:
-**        -# The File has already been successfully opened using #OS_open and
+**        -# The File has already been successfully opened using #OS_OpenCreate and
 **           the caller has a legitimate File Descriptor.
 **        -# The \c NewTimestamp field has been filled appropriately by the Application.
 **
-** \param[in] FileDes File Descriptor obtained from a previous call to #OS_open
+** \param[in] FileDes File Descriptor obtained from a previous call to #OS_OpenCreate
 **                    that is associated with the file whose header is to be read.
 **
 ** \param[in] NewTimestamp A #CFE_TIME_SysTime_t data structure containing the desired time

--- a/fsw/cfe-core/src/inc/cfe_tbl_events.h
+++ b/fsw/cfe-core/src/inc/cfe_tbl_events.h
@@ -318,7 +318,7 @@
 **  -# The length (including terminator) of the filename and/or path exceeds the 
 **     allowable length (see #OS_MAX_PATH_LEN and #OS_MAX_FILE_NAME, respectively)
 **
-**  The \c Status field in the event message indicates the error code returned by the #OS_open
+**  The \c Status field in the event message indicates the error code returned by the #OS_OpenCreate
 **  API. 
 **/
 #define CFE_TBL_FILE_ACCESS_ERR_EID            53
@@ -468,7 +468,7 @@
 **  This event message is generated when a Table Dump or Table Registry Dump command was 
 **  received and the cFE Table Services is unable to create the specified file.
 **
-**  The \c Status field provides the return status from the #OS_creat function call.
+**  The \c Status field provides the return status from the #OS_OpenCreate function call.
 **/
 #define CFE_TBL_CREATING_DUMP_FILE_ERR_EID     62  
 

--- a/fsw/cfe-core/src/sb/cfe_sb_task.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_task.c
@@ -870,15 +870,14 @@ int32 CFE_SB_SendRtgInfo(const char *Filename)
     CFE_SB_PipeD_t              *pd; 
     CFE_SB_DestinationD_t       *DestPtr;
 
-    Status = OS_creat(Filename, OS_WRITE_ONLY);
+    Status = OS_OpenCreate(&fd, Filename,
+            OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
     if(Status < OS_SUCCESS){
         CFE_EVS_SendEvent(CFE_SB_SND_RTG_ERR1_EID,CFE_EVS_EventType_ERROR,
                       "Error creating file %s, stat=0x%x",
                       Filename,(unsigned int)Status);
         return CFE_SB_FILE_IO_ERR;
     }/* end if */
-
-    fd = OS_ObjectIdFromInteger(Status);
 
     /* clear out the cfe file header fields, then populate description and subtype */
     CFE_FS_InitHeader(&FileHdr, "SB Routing Information", CFE_FS_SubType_SB_ROUTEDATA);
@@ -981,7 +980,7 @@ int32 CFE_SB_SendPipeInfo(const char *Filename)
     uint32 EntryCount = 0;
     CFE_FS_Header_t FileHdr;
 
-    Status = OS_creat(Filename, OS_WRITE_ONLY);
+    Status = OS_OpenCreate(&fd, Filename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
 
     if(Status < OS_SUCCESS){
         CFE_EVS_SendEvent(CFE_SB_SND_RTG_ERR1_EID,CFE_EVS_EventType_ERROR,
@@ -989,8 +988,6 @@ int32 CFE_SB_SendPipeInfo(const char *Filename)
                            Filename,(unsigned int)Status);
         return CFE_SB_FILE_IO_ERR;
     }/* end if */
-
-    fd = OS_ObjectIdFromInteger(Status);
 
     /* clear out the cfe file header fields, then populate description and subtype */
     CFE_FS_InitHeader(&FileHdr, "SB Pipe Information", CFE_FS_SubType_SB_PIPEDATA);
@@ -1058,7 +1055,7 @@ int32 CFE_SB_SendMapInfo(const char *Filename)
     CFE_SB_MsgMapFileEntry_t Entry;
     CFE_FS_Header_t FileHdr;
 
-    Status = OS_creat(Filename, OS_WRITE_ONLY);
+    Status = OS_OpenCreate(&fd, Filename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
 
     if (Status < OS_SUCCESS){
         CFE_EVS_SendEvent(CFE_SB_SND_RTG_ERR1_EID,CFE_EVS_EventType_ERROR,
@@ -1066,8 +1063,6 @@ int32 CFE_SB_SendMapInfo(const char *Filename)
                            Filename,(unsigned int)Status);
         return CFE_SB_FILE_IO_ERR;
     }/* end if */
-
-    fd = OS_ObjectIdFromInteger(Status);
 
     /* clear out the cfe file header fields, then populate description and subtype */
     CFE_FS_InitHeader(&FileHdr, "SB Message Map Information", CFE_FS_SubType_SB_MAPDATA);

--- a/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
@@ -912,7 +912,7 @@ int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBuffe
     }
 
     /* Try to open the specified table file */
-    Status = OS_open(Filename, OS_READ_ONLY, 0);
+    Status = OS_OpenCreate(&FileDescriptor, Filename, OS_FILE_FLAG_NONE, OS_READ_ONLY);
 
     if (Status < 0)
     {
@@ -923,8 +923,6 @@ int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBuffe
 
             return CFE_TBL_ERR_ACCESS;
     }
-
-    FileDescriptor = OS_ObjectIdFromInteger(Status);
 
     Status = CFE_TBL_ReadHeaders(FileDescriptor, &StdFileHeader, &TblFileHeader, Filename);
 

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.c
@@ -113,12 +113,10 @@ int32 CFE_TBL_HousekeepingCmd(const CFE_SB_CmdHdr_t *data)
                 DumpTime.Seconds = DumpCtrlPtr->DumpBufferPtr->FileCreateTimeSecs;
                 DumpTime.Subseconds = DumpCtrlPtr->DumpBufferPtr->FileCreateTimeSubSecs;
             
-                Status = OS_open(DumpCtrlPtr->DumpBufferPtr->DataSource, OS_READ_WRITE, 0);
+                Status = OS_OpenCreate(&FileDescriptor, DumpCtrlPtr->DumpBufferPtr->DataSource, OS_FILE_FLAG_NONE, OS_READ_WRITE);
 
                 if (Status >= 0)
                 {
-                    FileDescriptor = OS_ObjectIdFromInteger(Status);
-
                     Status = CFE_FS_SetTimestamp(FileDescriptor, DumpTime);
                     
                     if (Status != OS_SUCCESS)
@@ -387,12 +385,10 @@ int32 CFE_TBL_LoadCmd(const CFE_TBL_Load_t *data)
             OS_MAX_PATH_LEN, sizeof(CmdPtr->LoadFilename));
 
     /* Try to open the specified table file */
-    Status = OS_open(LoadFilename, OS_READ_ONLY, 0);
+    Status = OS_OpenCreate(&FileDescriptor, LoadFilename, OS_FILE_FLAG_NONE, OS_READ_ONLY);
 
     if (Status >= 0)
     {
-        FileDescriptor = OS_ObjectIdFromInteger(Status);
-
         Status = CFE_TBL_ReadHeaders(FileDescriptor, &StdFileHeader, &TblFileHeader, &LoadFilename[0]);
 
         if (Status == CFE_SUCCESS)
@@ -748,22 +744,20 @@ CFE_TBL_CmdProcRet_t CFE_TBL_DumpToFile( const char *DumpFilename, const char *T
     memset(&TblFileHeader, 0, sizeof(CFE_TBL_File_Hdr_t));
 
     /* Check to see if the dump file already exists */
-    Status = OS_open(DumpFilename, OS_READ_ONLY, 0);
+    Status = OS_OpenCreate(&FileDescriptor, DumpFilename, OS_FILE_FLAG_NONE, OS_READ_ONLY);
 
     if (Status >= 0)
     {
         FileExistedPrev = true;
-        FileDescriptor = OS_ObjectIdFromInteger(Status);
         OS_close(FileDescriptor);
     }
 
     /* Create a new dump file, overwriting anything that may have existed previously */
-    Status = OS_creat(DumpFilename, OS_WRITE_ONLY);
+    Status = OS_OpenCreate(&FileDescriptor, DumpFilename,
+            OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
 
     if (Status >= OS_SUCCESS)
     {
-        FileDescriptor = OS_ObjectIdFromInteger(Status);
-
         /* Initialize the standard cFE File Header for the Dump File */
         CFE_FS_InitHeader(&StdFileHeader, "Table Dump Image", CFE_FS_SubType_TBL_IMG);
 
@@ -1142,22 +1136,20 @@ int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistry_t *data)
             OS_MAX_PATH_LEN, sizeof(CmdPtr->DumpFilename));
 
     /* Check to see if the dump file already exists */
-    Status = OS_open(DumpFilename, OS_READ_ONLY, 0);
+    Status = OS_OpenCreate(&FileDescriptor, DumpFilename, OS_FILE_FLAG_NONE, OS_READ_ONLY);
 
     if (Status >= 0)
     {
         FileExistedPrev = true;
-        FileDescriptor = OS_ObjectIdFromInteger(Status);
         OS_close(FileDescriptor);
     }
 
     /* Create a new dump file, overwriting anything that may have existed previously */
-    Status = OS_creat(DumpFilename, OS_WRITE_ONLY);
+    Status = OS_OpenCreate(&FileDescriptor, DumpFilename,
+            OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
 
     if (Status >= OS_SUCCESS)
     {
-        FileDescriptor = OS_ObjectIdFromInteger(Status);
-
         /* Initialize the standard cFE File Header for the Dump File */
         CFE_FS_InitHeader(&StdFileHeader, "Table Registry", CFE_FS_SubType_TBL_REG);
 

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -354,7 +354,7 @@ int32 ES_UT_SetupOSCleanupHook(void *UserObj, int32 StubRetcode,
         OS_BinSemCreate(&ObjList[3], NULL, 0, 0);
         OS_CountSemCreate(&ObjList[4], NULL, 0, 0);
         OS_TimerCreate(&ObjList[5], NULL, NULL, NULL);
-        ObjList[6] = OS_ObjectIdFromInteger(OS_open(NULL, 0, 0));
+        OS_OpenCreate(&ObjList[6], NULL, 0, 0);
 
         UT_SetDataBuffer((UT_EntryKey_t)&OS_ForEachObject, ObjList,
                           sizeof(ObjList), true);
@@ -512,7 +512,7 @@ void TestStartupErrorPaths(void)
     /* Perform ES main startup with a file open failure */
     ES_ResetUnitTest();
     UT_SetDummyFuncRtn(OS_SUCCESS);
-    UT_SetForceFail(UT_KEY(OS_open), OS_ERROR);
+    UT_SetForceFail(UT_KEY(OS_OpenCreate), OS_ERROR);
     UT_SetHookFunction(UT_KEY(OS_TaskCreate), ES_UT_SetAppStateHook, NULL);
     CFE_ES_Main(CFE_PSP_RST_TYPE_POWERON, 1, 1,
                 (char *) CFE_PLATFORM_ES_NONVOL_STARTUP_FILE);
@@ -1006,7 +1006,7 @@ void TestApps(void)
 
     /* Test starting an application with an open failure */
     ES_ResetUnitTest();
-    UT_SetForceFail(UT_KEY(OS_open), OS_ERROR);
+    UT_SetForceFail(UT_KEY(OS_OpenCreate), OS_ERROR);
     CFE_ES_StartApplications(CFE_PSP_RST_TYPE_PROCESSOR,
                              CFE_PLATFORM_ES_NONVOL_STARTUP_FILE);
     UT_Report(__FILE__, __LINE__,
@@ -2620,7 +2620,7 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
-    UT_SetForceFail(UT_KEY(OS_creat), OS_ERROR);
+    UT_SetForceFail(UT_KEY(OS_OpenCreate), OS_ERROR);
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_QueryAll_t),
             UT_TPID_CFE_ES_CMD_QUERY_ALL_CC);
     UT_Report(__FILE__, __LINE__,
@@ -2667,7 +2667,7 @@ void TestTask(void)
     /* Test write of all task data to a file with an OS create failure */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    UT_SetForceFail(UT_KEY(OS_creat), OS_ERROR);
+    UT_SetForceFail(UT_KEY(OS_OpenCreate), OS_ERROR);
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_QueryAllTasks_t),
             UT_TPID_CFE_ES_CMD_QUERY_ALL_TASKS_CC);
     UT_Report(__FILE__, __LINE__,
@@ -2734,7 +2734,7 @@ void TestTask(void)
     /* Test writing the system log with an OS create failure */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    UT_SetForceFail(UT_KEY(OS_creat), OS_ERROR);
+    UT_SetForceFail(UT_KEY(OS_OpenCreate), OS_ERROR);
     strncpy((char *) CmdBuf.WriteSyslogCmd.Payload.FileName, "",
             sizeof(CmdBuf.WriteSyslogCmd.Payload.FileName));
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_WriteSyslog_t),
@@ -2839,7 +2839,7 @@ void TestTask(void)
     /* Test writing the E&R log with an OS create failure */
     ES_ResetUnitTest();
     CFE_ES_TaskData.BackgroundERLogDumpState.IsPending = true;
-    UT_SetForceFail(UT_KEY(OS_creat), OS_ERROR);
+    UT_SetForceFail(UT_KEY(OS_OpenCreate), OS_ERROR);
     CFE_ES_RunERLogDump(0, &CFE_ES_TaskData.BackgroundERLogDumpState);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_ERLOG2_ERR_EID),
@@ -3056,7 +3056,7 @@ void TestTask(void)
     /* Test dumping of the CDS to a file with an OS create failure */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    UT_SetForceFail(UT_KEY(OS_creat), OS_ERROR);
+    UT_SetForceFail(UT_KEY(OS_OpenCreate), OS_ERROR);
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_DumpCDSRegistry_t),
             UT_TPID_CFE_ES_CMD_DUMP_CDS_REGISTRY_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3257,7 +3257,7 @@ void TestTask(void)
     /* Test write of all app data to file with a file open failure */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    UT_SetForceFail(UT_KEY(OS_open), OS_ERROR);
+    UT_SetDeferredRetcode(UT_KEY(OS_OpenCreate), 1, OS_ERROR);
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_QueryAll_t),
             UT_TPID_CFE_ES_CMD_QUERY_ALL_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3279,7 +3279,7 @@ void TestTask(void)
     /* Test write of all task data to file with a file open failure */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    UT_SetForceFail(UT_KEY(OS_open), OS_ERROR);
+    UT_SetDeferredRetcode(UT_KEY(OS_OpenCreate), 1, OS_ERROR);
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_QueryAllTasks_t),
             UT_TPID_CFE_ES_CMD_QUERY_ALL_TASKS_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3816,7 +3816,7 @@ void TestPerf(void)
     UtAssert_True(CFE_ES_TaskData.BackgroundPerfDumpState.CurrentState == CFE_ES_PerfDumpState_DELAY,
             "CFE_ES_RunPerfLogDump - CFE_ES_TaskData.BackgroundPerfDumpState.CurrentState (%d) == DELAY (%d)",
             (int)CFE_ES_TaskData.BackgroundPerfDumpState.CurrentState, (int)CFE_ES_PerfDumpState_DELAY);
-    UtAssert_True(UT_GetStubCount(UT_KEY(OS_creat)) == 1, "CFE_ES_RunPerfLogDump - OS_creat() called");
+    UtAssert_True(UT_GetStubCount(UT_KEY(OS_OpenCreate)) == 1, "CFE_ES_RunPerfLogDump - OS_OpenCreate() called");
 
     /* Nominal call 2 - should go through up to the remainder of states, back to IDLE */
     CFE_ES_RunPerfLogDump(1000, &CFE_ES_TaskData.BackgroundPerfDumpState);
@@ -3831,7 +3831,7 @@ void TestPerf(void)
     memset(&CFE_ES_TaskData.BackgroundPerfDumpState, 0,
                 sizeof(CFE_ES_TaskData.BackgroundPerfDumpState));
     CFE_ES_TaskData.BackgroundPerfDumpState.PendingState = CFE_ES_PerfDumpState_INIT;
-    UT_SetForceFail(UT_KEY(OS_creat), -10);
+    UT_SetForceFail(UT_KEY(OS_OpenCreate), -10);
     CFE_ES_RunPerfLogDump(1000, &CFE_ES_TaskData.BackgroundPerfDumpState);
     UtAssert_True(CFE_ES_TaskData.BackgroundPerfDumpState.CurrentState == CFE_ES_PerfDumpState_IDLE,
             "CFE_ES_RunPerfLogDump - OS create fail, CFE_ES_TaskData.BackgroundPerfDumpState.CurrentState (%d) == IDLE (%d)",
@@ -3866,7 +3866,7 @@ void TestPerf(void)
     ES_ResetUnitTest();
     memset(&CFE_ES_TaskData.BackgroundPerfDumpState, 0,
             sizeof(CFE_ES_TaskData.BackgroundPerfDumpState));
-    CFE_ES_TaskData.BackgroundPerfDumpState.FileDesc = OS_ObjectIdFromInteger(OS_creat("UT", OS_WRITE_ONLY));
+    OS_OpenCreate(&CFE_ES_TaskData.BackgroundPerfDumpState.FileDesc, "UT", 0, OS_WRITE_ONLY);
     CFE_ES_TaskData.BackgroundPerfDumpState.CurrentState = CFE_ES_PerfDumpState_WRITE_PERF_ENTRIES;
     CFE_ES_TaskData.BackgroundPerfDumpState.PendingState = CFE_ES_PerfDumpState_WRITE_PERF_ENTRIES;
     CFE_ES_TaskData.BackgroundPerfDumpState.DataPos = CFE_PLATFORM_ES_PERF_DATA_BUFFER_SIZE - 2;
@@ -3887,7 +3887,7 @@ void TestPerf(void)
     ES_ResetUnitTest();
     memset(&CFE_ES_TaskData.BackgroundPerfDumpState, 0,
             sizeof(CFE_ES_TaskData.BackgroundPerfDumpState));
-    CFE_ES_TaskData.BackgroundPerfDumpState.FileDesc = OS_ObjectIdFromInteger(OS_creat("UT", OS_WRITE_ONLY));
+    OS_OpenCreate(&CFE_ES_TaskData.BackgroundPerfDumpState.FileDesc, "UT", 0, OS_WRITE_ONLY);
     CFE_ES_TaskData.BackgroundPerfDumpState.CurrentState = CFE_ES_PerfDumpState_WRITE_PERF_METADATA;
     CFE_ES_TaskData.BackgroundPerfDumpState.StateCounter = 10;
     Perf->MetaData.DataCount = 100;

--- a/fsw/cfe-core/unit-test/evs_UT.c
+++ b/fsw/cfe-core/unit-test/evs_UT.c
@@ -1373,7 +1373,7 @@ void Test_Logging(void)
     /* Test writing a log entry with a create failure */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(OS_MutSemCreate), 1, OS_SUCCESS);
-    UT_SetForceFail(UT_KEY(OS_creat), OS_ERROR);
+    UT_SetForceFail(UT_KEY(OS_OpenCreate), OS_ERROR);
     UT_Report(__FILE__, __LINE__,
               CFE_EVS_WriteLogDataFileCmd(&CmdBuf.logfilecmd) != CFE_SUCCESS,
               "CFE_EVS_WriteLogDataFileCmd",
@@ -1471,7 +1471,7 @@ void Test_WriteApp(void)
     UT_InitData();
     strncpy((char *) CmdBuf.AppDataCmd.Payload.AppDataFilename, "ut_cfe_evs",
             sizeof(CmdBuf.AppDataCmd.Payload.AppDataFilename));
-    UT_SetForceFail(UT_KEY(OS_creat), OS_ERROR);
+    UT_SetForceFail(UT_KEY(OS_OpenCreate), OS_ERROR);
     UT_EVS_DoDispatchCheckEvents(&CmdBuf.AppDataCmd, sizeof(CmdBuf.AppDataCmd),
                UT_TPID_CFE_EVS_CMD_WRITE_APP_DATA_FILE_CC,
                &UT_EVS_EventBuf);
@@ -1508,7 +1508,7 @@ void Test_WriteApp(void)
     UT_InitData();
     strncpy((char *) CmdBuf.AppDataCmd.Payload.AppDataFilename, "AppDataFileName",
             sizeof(CmdBuf.AppDataCmd.Payload.AppDataFilename));
-    UT_SetForceFail(UT_KEY(OS_creat), OS_ERROR);
+    UT_SetForceFail(UT_KEY(OS_OpenCreate), OS_ERROR);
     UT_EVS_DoDispatchCheckEvents(&CmdBuf.AppDataCmd, sizeof(CmdBuf.AppDataCmd),
                UT_TPID_CFE_EVS_CMD_WRITE_APP_DATA_FILE_CC,
                &UT_EVS_EventBuf);

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -566,7 +566,7 @@ void Test_SB_Cmds_RoutingInfoCreateFail(void)
     CFE_SB.CmdPipePktPtr = (CFE_SB_MsgPtr_t) &WriteFileCmd;
 
     /* Make function CFE_SB_SendRtgInfo return CFE_SB_FILE_IO_ERR */
-    UT_SetForceFail(UT_KEY(OS_creat), OS_ERROR);
+    UT_SetForceFail(UT_KEY(OS_OpenCreate), OS_ERROR);
 
     CFE_SB_ProcessCmdPipePkt();
 
@@ -686,7 +686,7 @@ void Test_SB_Cmds_PipeInfoSpec(void)
 */
 void Test_SB_Cmds_PipeInfoCreateFail(void)
 {
-    UT_SetForceFail(UT_KEY(OS_creat), OS_ERROR);
+    UT_SetForceFail(UT_KEY(OS_OpenCreate), OS_ERROR);
     ASSERT_EQ(CFE_SB_SendPipeInfo("PipeTstFile"), CFE_SB_FILE_IO_ERR);
 
     EVTCNT(1);
@@ -821,7 +821,7 @@ void Test_SB_Cmds_MapInfoSpec(void)
 */
 void Test_SB_Cmds_MapInfoCreateFail(void)
 {
-    UT_SetForceFail(UT_KEY(OS_creat), OS_ERROR);
+    UT_SetForceFail(UT_KEY(OS_OpenCreate), OS_ERROR);
     ASSERT_EQ(CFE_SB_SendMapInfo("MapTstFile"), CFE_SB_FILE_IO_ERR);
 
     EVTCNT(1);

--- a/fsw/cfe-core/unit-test/tbl_UT.c
+++ b/fsw/cfe-core/unit-test/tbl_UT.c
@@ -752,7 +752,7 @@ void Test_CFE_TBL_DumpToFile(void)
 
     /* Test with an error creating the dump file */
     UT_InitData();
-    UT_SetForceFail(UT_KEY(OS_creat), OS_ERROR);
+    UT_SetForceFail(UT_KEY(OS_OpenCreate), OS_ERROR);
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DumpToFile("filename" ,"tablename" ,"dumpaddress",
                                  TblSizeInBytes) == CFE_TBL_INC_ERR_CTR,
@@ -793,7 +793,7 @@ void Test_CFE_TBL_DumpToFile(void)
 
     /* Test successful file creation and data dumped */
     UT_InitData();
-    UT_SetForceFail(UT_KEY(OS_open), OS_ERROR);
+    UT_SetDeferredRetcode(UT_KEY(OS_OpenCreate), 1, OS_ERROR);
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DumpToFile("filename" ,"tablename" ,"dumpaddress",
                                  TblSizeInBytes) == CFE_TBL_INC_CMD_CTR,
@@ -1167,7 +1167,7 @@ void Test_CFE_TBL_DumpRegCmd(void)
     UT_InitData();
     strncpy((char *)DumpRegCmd.Payload.DumpFilename, "",
             sizeof(DumpRegCmd.Payload.DumpFilename));
-    UT_SetForceFail(UT_KEY(OS_creat), OS_ERROR);
+    UT_SetForceFail(UT_KEY(OS_OpenCreate), OS_ERROR);
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DumpRegistryCmd(&DumpRegCmd) ==
                 CFE_TBL_INC_ERR_CTR,
@@ -1193,7 +1193,7 @@ void Test_CFE_TBL_DumpRegCmd(void)
     CFE_TBL_TaskData.Registry[1].OwnerAppId = CFE_TBL_NOT_OWNED;
     CFE_TBL_TaskData.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
     CFE_TBL_TaskData.Registry[0].DoubleBuffered = true;
-    UT_SetForceFail(UT_KEY(OS_open), OS_ERROR);
+    UT_SetDeferredRetcode(UT_KEY(OS_OpenCreate), 1, OS_ERROR);
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DumpRegistryCmd(&DumpRegCmd) ==
                 CFE_TBL_INC_CMD_CTR,
@@ -1441,7 +1441,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_InitData();
     strncpy((char *)LoadCmd.Payload.LoadFilename, "LoadFileName",
             sizeof(LoadCmd.Payload.LoadFilename));
-    UT_SetForceFail(UT_KEY(OS_open), OS_ERROR);
+    UT_SetForceFail(UT_KEY(OS_OpenCreate), OS_ERROR);
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_LoadCmd(&LoadCmd) ==
                 CFE_TBL_INC_ERR_CTR,
@@ -1759,7 +1759,7 @@ void Test_CFE_TBL_HousekeepingCmd(void)
     UT_InitData();
     CFE_TBL_TaskData.DumpControlBlocks[0].State = CFE_TBL_DUMP_PERFORMED;
     CFE_TBL_TaskData.HkTlmTblRegIndex = CFE_TBL_NOT_FOUND + 1;
-    UT_SetForceFail(UT_KEY(OS_open), OS_ERROR);
+    UT_SetForceFail(UT_KEY(OS_OpenCreate), OS_ERROR);
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_HousekeepingCmd(NULL) == CFE_TBL_DONT_INC_CTR,
               "CFE_TBL_HousekeepingCmd",
@@ -1769,7 +1769,7 @@ void Test_CFE_TBL_HousekeepingCmd(void)
     UT_InitData();
     CFE_TBL_TaskData.HkTlmTblRegIndex = CFE_TBL_NOT_FOUND;
     CFE_TBL_TaskData.DumpControlBlocks[0].State = CFE_TBL_DUMP_PERFORMED;
-    UT_SetForceFail(UT_KEY(OS_creat), OS_ERROR);
+    UT_SetForceFail(UT_KEY(OS_OpenCreate), OS_ERROR);
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_HousekeepingCmd(NULL) == CFE_TBL_DONT_INC_CTR,
               "CFE_TBL_HousekeepingCmd",
@@ -4281,7 +4281,7 @@ void Test_CFE_TBL_Internal(void)
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
-    UT_SetForceFail(UT_KEY(OS_open), OS_ERROR);
+    UT_SetForceFail(UT_KEY(OS_OpenCreate), OS_ERROR);
     RtnCode = CFE_TBL_LoadFromFile("UT", WorkingBufferPtr, RegRecPtr, Filename);
     EventsCorrect = (UT_EventIsInHistory(CFE_TBL_FILE_ACCESS_ERR_EID) == true &&
         UT_GetNumEventsSent() == 1);


### PR DESCRIPTION
**Describe the contribution**

Use `OS_OpenCreate()`, which has an API consistent with the rest of OSAL.  
`OS_open` and `OS_create` will be deprecated in nasa/osal#556.

Fixes #893 

**Testing performed**
Build CFE and run unit tests
Sanity test CFE by sending commands that use files (e.g. `CFE_ES_QUERY_ALL_TASKS_CC`) using cmdUtil and verify functionality is not changed.

**Expected behavior changes**
No impact to behavior.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Note that OS_open and OS_creat were already just backward compatibility wrappers around `OS_OpenCreate` that mimicked the historical API.  This just bypasses the wrapper.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
