### PR TITLE
Fix #705, Use cFE defines to size arrays

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_apps.c
+++ b/fsw/cfe-core/src/es/cfe_es_apps.c
@@ -1531,9 +1531,9 @@ int32 CFE_ES_GetTaskInfoInternal(CFE_ES_TaskRecord_t *TaskRecPtr, CFE_ES_TaskInf
       ** Get the Application ID and Task Name
       */
       TaskInfoPtr->AppId = TaskRecPtr->AppId;
-      strncpy((char *)TaskInfoPtr->TaskName,
-              (char *)TaskRecPtr->TaskName,OS_MAX_API_NAME);
-      TaskInfoPtr->TaskName[OS_MAX_API_NAME - 1] = '\0';
+      strncpy((char*)TaskInfoPtr->TaskName, TaskRecPtr->TaskName,
+              sizeof(TaskInfoPtr->TaskName)-1);
+      TaskInfoPtr->TaskName[sizeof(TaskInfoPtr->TaskName)-1] = '\0';
 
       /*
       ** Store away the Task ID ( for the QueryAllTasks Cmd )
@@ -1551,9 +1551,9 @@ int32 CFE_ES_GetTaskInfoInternal(CFE_ES_TaskRecord_t *TaskRecPtr, CFE_ES_TaskInf
       AppRecPtr = CFE_ES_LocateAppRecordByID(TaskRecPtr->AppId);
       if (CFE_ES_AppRecordIsMatch(AppRecPtr, TaskRecPtr->AppId))
       {
-         strncpy((char*)TaskInfoPtr->AppName,
-                 (char*)AppRecPtr->StartParams.Name,
+         strncpy((char*)TaskInfoPtr->AppName, AppRecPtr->StartParams.Name,
                  sizeof(TaskInfoPtr->AppName)-1);
+         TaskInfoPtr->AppName[sizeof(TaskInfoPtr->AppName)-1] = '\0';
          ReturnCode = CFE_SUCCESS;
       }
       else

--- a/fsw/cfe-core/src/inc/cfe_es.h
+++ b/fsw/cfe-core/src/inc/cfe_es.h
@@ -85,7 +85,7 @@
 /** \{ */
 /** Maximum length allowed for CDS name. <BR>
 ** NOTE: "+2" is for NULL Character and "." (i.e. - "AppName.CDSName") */
-#define CFE_ES_CDS_MAX_FULL_NAME_LEN (CFE_MISSION_ES_CDS_MAX_NAME_LENGTH + OS_MAX_API_NAME + 2)
+#define CFE_ES_CDS_MAX_FULL_NAME_LEN (CFE_MISSION_ES_CDS_MAX_NAME_LENGTH + CFE_MISSION_MAX_API_LEN + 2)
 
 #define CFE_ES_CDS_BAD_HANDLE  (CFE_ES_CDSHandle_t) 0xFFFF
 /** \} */
@@ -306,11 +306,11 @@ typedef struct CFE_ES_AppInfo
    uint32   Type;                           /**< \cfetlmmnemonic \ES_APPTYPE
                                                  \brief The type of App: CORE or EXTERNAL */
 
-   char     Name[OS_MAX_API_NAME];          /**< \cfetlmmnemonic \ES_APPNAME
+   char     Name[CFE_MISSION_MAX_API_LEN];  /**< \cfetlmmnemonic \ES_APPNAME
                                                  \brief The Registered Name of the Application */
-   char     EntryPoint[OS_MAX_API_NAME];    /**< \cfetlmmnemonic \ES_APPENTRYPT
+   char     EntryPoint[CFE_MISSION_MAX_API_LEN];    /**< \cfetlmmnemonic \ES_APPENTRYPT
                                                  \brief The Entry Point label for the Application */
-   char     FileName[OS_MAX_PATH_LEN];      /**< \cfetlmmnemonic \ES_APPFILENAME
+   char     FileName[CFE_MISSION_MAX_PATH_LEN];     /**< \cfetlmmnemonic \ES_APPFILENAME
                                                  \brief The Filename of the file containing the Application */
 
    uint32   StackSize;                      /**< \cfetlmmnemonic \ES_STACKSIZE
@@ -342,7 +342,7 @@ typedef struct CFE_ES_AppInfo
                                                  \brief The Application's Main Task ID */
    uint32   ExecutionCounter;               /**< \cfetlmmnemonic \ES_MAINTASKEXECNT
                                                  \brief The Application's Main Task Execution Counter */
-   char     MainTaskName[OS_MAX_API_NAME];  /**< \cfetlmmnemonic \ES_MAINTASKNAME
+   char     MainTaskName[CFE_MISSION_MAX_API_LEN];  /**< \cfetlmmnemonic \ES_MAINTASKNAME
                                                  \brief The Application's Main Task ID */
    uint32   NumOfChildTasks;                /**< \cfetlmmnemonic \ES_CHILDTASKS
                                                  \brief Number of Child tasks for an App */
@@ -354,12 +354,11 @@ typedef struct CFE_ES_AppInfo
  */
 typedef struct CFE_ES_TaskInfo
 {
-   CFE_ES_ResourceID_t   TaskId;       /**< \brief Task Id */
-   uint32   ExecutionCounter;          /**< \brief Task Execution Counter */
-   char     TaskName[OS_MAX_API_NAME]; /**< \brief Task Name */
-   CFE_ES_ResourceID_t   AppId;        /**< \brief Parent Application ID */
-   char     AppName[OS_MAX_API_NAME];  /**< \brief Parent Application Name */
-
+   CFE_ES_ResourceID_t TaskId;                            /**< \brief Task Id */
+   uint32              ExecutionCounter;                  /**< \brief Task Execution Counter */
+   char                TaskName[CFE_MISSION_MAX_API_LEN]; /**< \brief Task Name */
+   CFE_ES_ResourceID_t AppId;                             /**< \brief Parent Application ID */
+   char                AppName[CFE_MISSION_MAX_API_LEN];  /**< \brief Parent Application Name */
 } CFE_ES_TaskInfo_t;
 
 /**

--- a/fsw/cfe-core/src/inc/cfe_tbl.h
+++ b/fsw/cfe-core/src/inc/cfe_tbl.h
@@ -126,7 +126,7 @@ typedef struct CFE_TBL_Info
     bool                  DoubleBuffered;                      /**< \brief Flag indicating Table has a dedicated inactive buffer */
     bool                  UserDefAddr;                      /**< \brief Flag indicating Table address was defined by Owner Application */
     bool                  Critical;                         /**< \brief Flag indicating Table contents are maintained in a CDS */
-    char                  LastFileLoaded[OS_MAX_PATH_LEN];  /**< \brief Filename of last file loaded into table */
+    char                  LastFileLoaded[CFE_MISSION_MAX_PATH_LEN];  /**< \brief Filename of last file loaded into table */
 } CFE_TBL_Info_t;
 
 /*************************** Function Prototypes ******************************/

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.c
@@ -634,7 +634,7 @@ char *CFE_SB_GetAppTskName(CFE_ES_ResourceID_t TaskId,char *FullName){
       strncpy(FullName,"Unknown",OS_MAX_API_NAME-1);
       FullName[OS_MAX_API_NAME-1] = '\0';
 
-    }else if(strncmp((char *)ptr->AppName,(char *)ptr->TaskName,OS_MAX_API_NAME-1) == 0){
+    }else if(strncmp((char *)ptr->AppName,(char *)ptr->TaskName,sizeof(ptr->AppName)) == 0){
 
       /* if app name and task name are the same */
       strncpy(FullName,(char *)ptr->AppName,OS_MAX_API_NAME-1);

--- a/fsw/cfe-core/src/tbl/cfe_tbl_api.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_api.c
@@ -1401,7 +1401,9 @@ int32 CFE_TBL_GetInfo( CFE_TBL_Info_t *TblInfoPtr, const char *TblName )
         TblInfoPtr->FileCreateTimeSecs = RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].FileCreateTimeSecs;
         TblInfoPtr->FileCreateTimeSubSecs = RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].FileCreateTimeSubSecs;
         TblInfoPtr->Crc = RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].Crc;
-        strncpy(TblInfoPtr->LastFileLoaded, RegRecPtr->LastFileLoaded, OS_MAX_PATH_LEN);
+        strncpy(TblInfoPtr->LastFileLoaded, RegRecPtr->LastFileLoaded,
+                sizeof(TblInfoPtr->LastFileLoaded)-1);
+        TblInfoPtr->LastFileLoaded[sizeof(TblInfoPtr->LastFileLoaded)-1] = 0;
         
         /* Count the number of Access Descriptors to determine the number of users */
         HandleIterator = RegRecPtr->HeadOfAccessList;


### PR DESCRIPTION
**Describe the contribution**
Fixes #705, also a similar issue in TBL
Change from OS_MAX* defines to CFE defines for array sizing

**Testing performed**
Built and ran unit tests, passed.  Visually confirmed sizes matched.

**Expected behavior changes**
No impact as long as the sizes are the same.  Now scoped appropriately such that OS's can be configured differently and won't break cFE (as long as the cFE defines are max of the set)

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC