### PR TITLE
Fix #900, Replace UT_Text with UtPrintf

### DIFF
--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -408,7 +408,7 @@ static int32 ES_UT_SetAppStateHook(void *UserObj, int32 StubRetcode,
 void UtTest_Setup(void)
 {
     UT_Init("es");
-    UT_Text("cFE ES Unit Test Output File\n\n");
+    UtPrintf("cFE ES Unit Test Output File\n\n");
 
     /* Set up the performance logging variable */
     Perf = (CFE_ES_PerfData_t *) &CFE_ES_ResetDataPtr->Perf;
@@ -442,9 +442,7 @@ void ES_ResetUnitTest(void)
 
 void TestInit(void)
 {
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Init\n");
-#endif
+    UtPrintf("Begin Test Init");
 
     UT_SetCDSSize(128 * 1024);
     UT_SetSizeofESResetArea(sizeof(CFE_ES_ResetData_t));
@@ -483,9 +481,7 @@ void TestStartupErrorPaths(void)
     CFE_ES_TaskRecord_t *TaskRecPtr;
     CFE_ES_AppRecord_t *AppRecPtr;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Startup Error Paths\n");
-#endif
+    UtPrintf("Begin Test Startup Error Paths");
 
     /* Set up the startup script for reading */
     strncpy(StartupScript,
@@ -942,9 +938,7 @@ void TestApps(void)
     CFE_ES_TaskRecord_t *UtTaskRecPtr;
     CFE_ES_AppRecord_t *UtAppRecPtr;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Apps\n");
-#endif
+    UtPrintf("Begin Test Apps");
 
     /* Test starting an application where the startup script is too long */
     ES_ResetUnitTest();
@@ -1995,9 +1989,7 @@ void TestERLog(void)
 {
     int Return;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Exception and Reset Log\n");
-#endif
+    UtPrintf("Begin Test Exception and Reset Log");
 
     /* Test initial rolling over log entry,
      * null description,
@@ -2064,9 +2056,8 @@ void TestTask(void)
     CFE_ES_AppRecord_t          *UtAppRecPtr;
     CFE_ES_TaskRecord_t         *UtTaskRecPtr;
     CFE_ES_CDS_RegRec_t         *UtCDSRegRecPtr;
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Task\n");
-#endif
+
+    UtPrintf("Begin Test Task");
 
     /* Reset the log index; CFE_ES_TaskMain() calls CFE_ES_TaskInit() which
      * sets SystemLogMode to DISCARD, which can result in a log overflow
@@ -3413,9 +3404,7 @@ void TestPerf(void)
         CFE_ES_SetPerfTriggerMask_t PerfSetTrigMaskCmd;
     } CmdBuf;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Performance Log\n");
-#endif
+    UtPrintf("Begin Test Performance Log");
 
     /* Test successful performance mask and value initialization */
     ES_ResetUnitTest();
@@ -3915,9 +3904,7 @@ void TestAPI(void)
     CFE_ES_AppRecord_t *UtAppRecPtr;
     CFE_ES_TaskRecord_t *UtTaskRecPtr;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test API\n");
-#endif
+    UtPrintf("Begin Test API");
 
     /* Test resetting the cFE with a processor reset */
     ES_ResetUnitTest();
@@ -4805,10 +4792,7 @@ void TestCDS()
     uint32 i;
     uint32 TempSize;
 
-
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test CDS\n");
-#endif
+    UtPrintf("Begin Test CDS");
 
     /* Set up the PSP stubs for CDS testing */
     UT_SetCDSSize(128 * 1024);
@@ -5185,9 +5169,8 @@ void TestCDSMempool(void)
 
     extern uint32 CFE_ES_CDSMemPoolDefSize[];
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test CDS memory pool\n");
-#endif
+    UtPrintf("Begin Test CDS memory pool");
+
     UT_SetCDSSize(0);
 
     /* Set up the CDS block to read in the following tests */
@@ -5604,9 +5587,7 @@ void TestESMempool(void)
     CFE_ES_MemHandle_t    HandlePtrSave;
     uint32                i;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test ES memory pool\n");
-#endif
+    UtPrintf("Begin Test ES memory pool");
 
     /* Test creating memory pool without using a mutex with the pool size
       * too small
@@ -6137,10 +6118,8 @@ void TestSysLog(void)
     char                      LogString[(CFE_PLATFORM_ES_SYSTEM_LOG_SIZE / 2) + 2];
 
     char          TmpString[CFE_ES_MAX_SYSLOG_MSG_SIZE + 1];
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Sys Log\n");
-#endif
 
+    UtPrintf("Begin Test Sys Log");
 
     /* Test loop in CFE_ES_SysLogReadStart_Unsync that ensures
      * reading at the start of a message */

--- a/fsw/cfe-core/unit-test/es_UT.h
+++ b/fsw/cfe-core/unit-test/es_UT.h
@@ -82,7 +82,7 @@
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Init, #UT_Text, #UT_SetCDSSize, #UT_SetSizeofESResetArea
+** \sa #UT_Init, #UT_SetCDSSize, #UT_SetSizeofESResetArea
 ** \sa #UT_SetStatusBSPResetArea, #UT_SetReadBuffer, #UT_SetRtnCode
 ** \sa #UT_SetDummyFuncRtn, #UT_SetBSPloadAppFileResult, #CFE_ES_Main
 ** \sa #UT_Report
@@ -108,7 +108,7 @@ void TestInit(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_SetRtnCode, #UT_SetOSFail, #CFE_ES_Main, #UT_Report
+** \sa #UT_SetRtnCode, #UT_SetOSFail, #CFE_ES_Main, #UT_Report
 ** \sa #CFE_ES_SetupResetVariables, #UT_SetStatusBSPResetArea
 ** \sa #UT_SetSizeofESResetArea, #CFE_ES_InitializeFileSystems, #UT_SetBSPFail
 ** \sa #CFE_ES_CreateObjects
@@ -132,7 +132,7 @@ void TestStartupErrorPaths(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_SetReadBuffer, #UT_SetRtnCode, #CFE_ES_StartApplications
+** \sa #UT_SetReadBuffer, #UT_SetRtnCode, #CFE_ES_StartApplications
 ** \sa #UT_Report, #UT_SetOSFail, #CFE_ES_ParseFileEntry
 ** \sa #UT_SetBSPloadAppFileResult, #CFE_ES_AppCreate, #UT_SetDummyFuncRtn
 ** \sa #CFE_ES_LoadLibrary, #CFE_ES_ScanAppTable, #CFE_ES_ProcessControlRequest
@@ -158,7 +158,7 @@ void TestApps(void);
 ** \returns
 **        This function does not return a value.  
 **
-** \sa #UT_Text, #CFE_ES_WriteToERLog, #UT_Report
+** \sa #CFE_ES_WriteToERLog, #UT_Report
 **
 ******************************************************************************/
 void TestERLog(void);
@@ -178,7 +178,7 @@ void TestERLog(void);
 ** \returns
 **        This function does not return a value.  
 **
-** \sa #UT_Text, #UT_SetRtnCode, #CFE_ES_TaskMain, #UT_Report, #UT_SetOSFail
+** \sa #UT_SetRtnCode, #CFE_ES_TaskMain, #UT_Report, #UT_SetOSFail
 ** \sa #CFE_ES_TaskInit, #UT_SetSBTotalMsgLen, #UT_SendMsg
 ** \sa #UT_SetBSPloadAppFileResult, #UT_SetStatusBSPResetArea
 ** \sa #CFE_ES_HousekeepingCmd, #CFE_ES_NoopCmd, #CFE_ES_ResetCountersCmd
@@ -224,7 +224,7 @@ void TestBackground(void);
 ** \returns
 **        This function does not return a value.  
 **
-** \sa #UT_Text, #CFE_ES_SetupPerfVariables, #UT_Report, #UT_SetRtnCode
+** \sa #CFE_ES_SetupPerfVariables, #UT_Report, #UT_SetRtnCode
 ** \sa #UT_SetSBTotalMsgLen, #UT_SendMsg, #UT_SetBSPloadAppFileResult
 ** \sa #CFE_ES_PerfLogDump, #CFE_ES_PerfLogAdd, #CFE_ES_StartPerfDataCmd
 ** \sa #CFE_ES_StopPerfDataCmd, #CFE_ES_SetPerfFilterMaskCmd
@@ -246,7 +246,7 @@ void TestPerf(void);
 ** \returns
 **        This function does not return a value.  
 **
-** \sa #UT_Text, #UT_SetRtnCode, #CFE_ES_ResetCFE, #UT_Report
+** \sa #UT_SetRtnCode, #CFE_ES_ResetCFE, #UT_Report
 ** \sa #CFE_ES_GetResetType, #CFE_ES_RestartApp, #CFE_ES_ReloadApp
 ** \sa #CFE_ES_DeleteApp, #CFE_ES_ExitApp, #CFE_ES_RunLoop
 ** \sa #CFE_ES_RegisterApp, #CFE_ES_GetAppID, #CFE_ES_GetAppName
@@ -276,7 +276,7 @@ void TestAPI(void);
 ** \returns
 **        This function does not return a value.  
 **
-** \sa #UT_Text, #UT_InitData, #UT_Report, #CFE_ES_CDS_ValidateAppID
+** \sa #UT_InitData, #UT_Report, #CFE_ES_CDS_ValidateAppID
 ** \sa #UT_SetBSPFail, #CFE_ES_RebuildCDS, #UT_SetRtnCode
 ** \sa #CFE_ES_InitCDSRegistry, #UT_SetCDSSize, #CFE_ES_CDS_EarlyInit
 ** \sa #UT_SetCDSBSPCheckValidity, #CFE_ES_ValidateCDS, #UT_SetCDSReadGoodEnd
@@ -300,7 +300,7 @@ void TestCDS(void);
 ** \returns
 **        This function does not return a value.  
 **
-** \sa #UT_Text, #UT_InitData, #UT_Report, #CFE_ES_CreateCDSPool
+** \sa #UT_InitData, #UT_Report, #CFE_ES_CreateCDSPool
 ** \sa #CFE_ES_RebuildCDSPool, #UT_SetRtnCode, #UT_SetBSPFail
 ** \sa #CFE_ES_GetCDSBlock, #CFE_ES_PutCDSBlock, #CFE_ES_CDSBlockWrite
 ** \sa #CFE_ES_CDSBlockRead
@@ -323,7 +323,7 @@ void TestCDSMempool(void);
 ** \returns
 **        This function does not return a value.  
 **
-** \sa #UT_Text, #UT_InitData, #UT_Report, #CFE_ES_PoolCreateNoSem
+** \sa #UT_InitData, #UT_Report, #CFE_ES_PoolCreateNoSem
 ** \sa #CFE_ES_PoolCreate, #CFE_ES_GetPoolBuf, #CFE_ES_GetPoolBufInfo
 ** \sa #CFE_ES_PutPoolBuf, #CFE_ES_ValidateHandle, #UT_SetRtnCode
 ** \sa #CFE_ES_GetMemPoolStats, #CFE_ES_PoolCreateEx, #CFE_ES_PoolCreateNoSem

--- a/fsw/cfe-core/unit-test/evs_UT.c
+++ b/fsw/cfe-core/unit-test/evs_UT.c
@@ -253,7 +253,7 @@ void UtTest_Setup(void)
 {
     /* Initialize unit test */
     UT_Init("evs");
-    UT_Text("cFE EVS Unit Test Output File\n\n");
+    UtPrintf("cFE EVS Unit Test Output File\n\n");
 
     /* Test_Init is a test but also MUST be called first and only once */
     UT_ADD_TEST(Test_Init);
@@ -280,9 +280,7 @@ void Test_Init(void)
     CFE_EVS_BitMaskCmd_t        bitmaskcmd;
     CFE_EVS_AppNameBitMaskCmd_t appbitcmd;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Init\n");
-#endif
+    UtPrintf("Begin Test Init");
 
     UT_SetAppID(1); /*jphfix*/
 
@@ -494,9 +492,7 @@ void Test_IllegalAppID(void)
 {
     CFE_TIME_SysTime_t time = {0, 0};
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Illegal App ID\n");
-#endif
+    UtPrintf("Begin Test Illegal App ID");
 
     /* Set test up with illegal application ID */
     UT_InitData();
@@ -593,10 +589,7 @@ void Test_UnregisteredApp(void)
     /* Get a local ref to the "current" AppData table entry */
     EVS_GetCurrentContext(&AppDataPtr, &AppID);
 
-
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Unregistered App\n");
-#endif
+    UtPrintf("Begin Test Unregistered App");
 
     UT_InitData();
 
@@ -680,9 +673,7 @@ void Test_FilterRegistration(void)
     /* Get a local ref to the "current" AppData table entry */
     EVS_GetCurrentContext(&AppDataPtr, &AppID);
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Filter Registration\n");
-#endif
+    UtPrintf("Begin Test Filter Registration");
 
     CFE_EVS_GlobalData.EVS_AppID = AppID;
     CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
@@ -836,9 +827,7 @@ void Test_FilterReset(void)
 {
     CFE_EVS_BinFilter_t filter;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Filter Reset\n");
-#endif
+    UtPrintf("Begin Test Filter Reset");
 
     /* Test successful filter registration */
     UT_InitData();
@@ -922,9 +911,7 @@ void Test_Format(void)
     /* Get a local ref to the "current" AppData table entry */
     EVS_GetCurrentContext(&AppDataPtr, &AppID);
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Format\n");
-#endif
+    UtPrintf("Begin Test Format");
 
     CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
 
@@ -1072,9 +1059,7 @@ void Test_Ports(void)
             .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_LONG_EVENT_MSG_MID)
     };
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Ports\n");
-#endif
+    UtPrintf("Begin Test Ports");
 
     CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
 
@@ -1218,9 +1203,7 @@ void Test_Logging(void)
     cpuaddr              TempAddr;
     CFE_ES_ResetData_t   *CFE_EVS_ResetDataPtr;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Logging\n");
-#endif
+    UtPrintf("Begin Test Logging");
 
     CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
 
@@ -1434,9 +1417,7 @@ void Test_WriteApp(void)
         CFE_EVS_AppNameBitMaskCmd_t appbitcmd;
     } CmdBuf;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Write App\n");
-#endif
+    UtPrintf("Begin Test Write App");
 
     CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
 
@@ -1538,9 +1519,7 @@ void Test_BadAppCmd(void)
     CFE_EVS_AppNameEventIDCmd_t     appcmdcmd;
     uint32 TestAppIndex;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Bad App Command\n");
-#endif
+    UtPrintf("Begin Test Bad App Command");
 
     CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
 
@@ -1945,9 +1924,7 @@ void Test_EventCmd(void)
         .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_LONG_EVENT_MSG_MID)
     };
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Event Command\n");
-#endif
+    UtPrintf("Begin Test Event Command");
 
     CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
 
@@ -2188,9 +2165,7 @@ void Test_FilterCmd(void)
     CFE_EVS_AppNameEventIDCmd_t     appcmdcmd;
     CFE_EVS_AppNameBitMaskCmd_t     appbitcmd;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Filter Command\n");
-#endif
+    UtPrintf("Begin Test Filter Command");
 
     CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
 
@@ -2422,9 +2397,7 @@ void Test_InvalidCmd(void)
 {
     CFE_EVS_NoArgsCmd_t cmd;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Invalid Command\n");
-#endif
+    UtPrintf("Begin Test Invalid Command");
 
     /* Test invalid msg id event */
     UT_InitData();
@@ -2688,9 +2661,7 @@ void Test_Misc(void)
 
     EVS_GetCurrentContext(&AppDataPtr, &AppID);
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Miscellaneous\n");
-#endif
+    UtPrintf("Begin Test Miscellaneous");
 
     memset(&PktBuf, 0, sizeof(PktBuf));
     CFE_EVS_GlobalData.EVS_AppID = AppID;

--- a/fsw/cfe-core/unit-test/evs_UT.h
+++ b/fsw/cfe-core/unit-test/evs_UT.h
@@ -71,7 +71,7 @@
 ** \returns
 **        This function does not return a value.  
 **
-** \sa #UT_Text, UT_InitData, #UT_SetSizeofESResetArea, #UT_SetRtnCode
+** \sa UT_InitData, #UT_SetSizeofESResetArea, #UT_SetRtnCode
 ** \sa #CFE_EVS_EarlyInit, #UT_Report, #CFE_EVS_TaskMain
 ** \sa #UT_SetStatusBSPResetArea, #UT_SetAppID, #UT_SendMsg
 ** \sa #UT_SetSBTotalMsgLen
@@ -92,7 +92,7 @@ void Test_Init(void);
 ** \returns
 **        This function does not return a value.  
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetAppID, #UT_Report, #CFE_EVS_Register
+** \sa #UT_InitData, #UT_SetAppID, #UT_Report, #CFE_EVS_Register
 ** \sa #CFE_EVS_SendEvent, #CFE_EVS_SendTimedEvent, #CFE_EVS_SendEventWithAppID
 ** \sa #CFE_EVS_ResetFilter, #CFE_EVS_ResetAllFilters, #CFE_EVS_CleanUpApp
 ** \sa #CFE_EVS_EnableAppEventTypesCmd, #CFE_EVS_DisablePortsCmd
@@ -113,7 +113,7 @@ void Test_IllegalAppID(void);
 ** \returns
 **        This function does not return a value.  
 **
-** \sa #UT_Text, #UT_InitData, #CFE_EVS_Unregister, #UT_Report
+** \sa #UT_InitData, #CFE_EVS_Unregister, #UT_Report
 ** \sa #CFE_EVS_SendEvent, #CFE_EVS_ResetFilter, #CFE_EVS_ResetAllFilters
 ** \sa #CFE_EVS_SendEventWithAppID, #CFE_EVS_SendTimedEvent
 ** \sa #CFE_EVS_CleanUpApp, #CFE_EVS_Register
@@ -134,7 +134,7 @@ void Test_UnregisteredApp(void);
 ** \returns
 **        This function does not return a value.  
 **
-** \sa #UT_Text, #UT_InitData, #UT_Report, #CFE_EVS_Register
+** \sa #UT_InitData, #UT_Report, #CFE_EVS_Register
 ** \sa #UT_SetPutPoolFail, #UT_SetRtnCode, #CFE_EVS_Unregister
 ** \sa #CFE_EVS_SendEvent, #CFE_ES_GetAppID
 **
@@ -154,7 +154,7 @@ void Test_FilterRegistration(void);
 ** \returns
 **        This function does not return a value.  
 **
-** \sa #UT_Text, #UT_InitData, #UT_Report, #CFE_EVS_Register
+** \sa #UT_InitData, #UT_Report, #CFE_EVS_Register
 ** \sa #CFE_EVS_ResetFilter, #CFE_EVS_ResetAllFilters
 **
 ******************************************************************************/
@@ -175,7 +175,7 @@ void Test_FilterReset(void);
 ** \returns
 **        This function does not return a value.  
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetSBTotalMsgLen, #UT_SendMsg, #UT_Report
+** \sa #UT_InitData, #UT_SetSBTotalMsgLen, #UT_SendMsg, #UT_Report
 ** \sa #CFE_EVS_SendEvent, #UT_SetRtnCode, #CFE_EVS_SendTimedEvent
 ** \sa #CFE_EVS_SendEventWithAppID, #CFE_EVS_EnableAppEventTypesCmd
 ** \sa #CFE_EVS_SetEventFormatModeCmd
@@ -196,7 +196,7 @@ void Test_Format(void);
 ** \returns
 **        This function does not return a value.  
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetRtnCode, #UT_SetSBTotalMsgLen
+** \sa #UT_InitData, #UT_SetRtnCode, #UT_SetSBTotalMsgLen
 ** \sa #UT_SendMsg, #UT_Report, #CFE_EVS_SendEvent, #CFE_EVS_EnablePortsCmd
 ** \sa #CFE_EVS_DisablePortsCmd
 **
@@ -216,7 +216,7 @@ void Test_Ports(void);
 ** \returns
 **        This function does not return a value.  
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetSBTotalMsgLen, #UT_SendMsg
+** \sa #UT_InitData, #UT_SetSBTotalMsgLen, #UT_SendMsg
 ** \sa #UT_Report, #UT_SetSizeofESResetArea, #UT_SetRtnCode
 ** \sa #CFE_PSP_GetResetArea, #CFE_EVS_SendEvent, #UT_SetOSFail
 ** \sa #CFE_EVS_SetLogModeCmd, #CFE_EVS_WriteLogDataFileCmd, #EVS_ClearLog
@@ -238,7 +238,7 @@ void Test_Logging(void);
 ** \returns
 **        This function does not return a value.  
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetSBTotalMsgLen, #UT_SendMsg
+** \sa #UT_InitData, #UT_SetSBTotalMsgLen, #UT_SendMsg
 ** \sa #UT_Report, #UT_SetOSFail, #CFE_EVS_EnableAppEventTypesCmd
 ** \sa #CFE_EVS_ResetCountersCmd, #CFE_EVS_WriteAppDataFileCmd
 **
@@ -260,7 +260,7 @@ void Test_WriteApp(void);
 ** \returns
 **        This function does not return a value.  
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetSBTotalMsgLen, #UT_SendMsg
+** \sa #UT_InitData, #UT_SetSBTotalMsgLen, #UT_SendMsg
 ** \sa #UT_Report, #CFE_EVS_DisableAppEventTypesCmd
 ** \sa #CFE_EVS_EnableAppEventTypesCmd, #CFE_EVS_EnableAppEventsCmd
 ** \sa #CFE_EVS_DisableAppEventsCmd, #CFE_EVS_ResetAppEventCounterCmd
@@ -284,7 +284,7 @@ void Test_BadAppCmd(void);
 ** \returns
 **        This function does not return a value.  
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetSBTotalMsgLen, #UT_SendMsg
+** \sa #UT_InitData, #UT_SetSBTotalMsgLen, #UT_SendMsg
 ** \sa #CFE_EVS_SendEvent, #UT_Report, #CFE_EVS_DisableAppEventTypesCmd
 ** \sa #CFE_EVS_EnableAppEventTypesCmd, #CFE_EVS_DisableAppEventsCmd
 ** \sa #CFE_EVS_EnableAppEventsCmd, #CFE_EVS_DisableEventTypesCmd
@@ -306,7 +306,7 @@ void Test_EventCmd(void);
 ** \returns
 **        This function does not return a value.  
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetSBTotalMsgLen, #UT_SendMsg
+** \sa #UT_InitData, #UT_SetSBTotalMsgLen, #UT_SendMsg
 ** \sa #UT_Report, #CFE_EVS_Register, #CFE_EVS_EnableAppEventTypesCmd
 ** \sa #CFE_EVS_DeleteEventFilterCmd, #CFE_EVS_SetFilterMaskCmd
 ** \sa #CFE_EVS_ResetFilterCmd, #CFE_EVS_ResetAllFiltersCmd
@@ -330,7 +330,7 @@ void Test_FilterCmd(void);
 ** \returns
 **        This function does not return a value.  
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetSBTotalMsgLen, #UT_SendMsg
+** \sa #UT_InitData, #UT_SetSBTotalMsgLen, #UT_SendMsg
 ** \sa #UT_Report, #CFE_EVS_ProcessGroundCommand, #CFE_EVS_VerifyCmdLength
 **
 ******************************************************************************/
@@ -349,7 +349,7 @@ void Test_InvalidCmd(void);
 ** \returns
 **        This function does not return a value.  
 **
-** \sa #UT_Text, #UT_InitData, #UT_Report, #EVS_GetApplicationInfo
+** \sa #UT_InitData, #UT_Report, #EVS_GetApplicationInfo
 ** \sa #UT_SetSBTotalMsgLen, #UT_SendMsg, #CFE_EVS_CleanUpApp
 ** \sa #CFE_EVS_Register, #CFE_EVS_WriteLogDataFileCmd, #CFE_EVS_SetLogModeCmd
 ** \sa #CFE_EVS_ReportHousekeepingCmd

--- a/fsw/cfe-core/unit-test/fs_UT.c
+++ b/fsw/cfe-core/unit-test/fs_UT.c
@@ -54,7 +54,7 @@ void UtTest_Setup(void)
 {
     /* Initialize unit test */
     UT_Init("fs");
-    UT_Text("cFE FS Unit Test Output File\n\n");
+    UtPrintf("cFE FS Unit Test Output File\n\n");
 
     /* Perform tests */
     UT_ADD_TEST(Test_CFE_FS_InitHeader);
@@ -91,9 +91,7 @@ void Test_CFE_FS_ReadHeader(void)
     osal_id_t FileDes = OS_OBJECT_ID_UNDEFINED;
     CFE_FS_Header_t Hdr;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Read Header\n");
-#endif
+    UtPrintf("Begin Test Read Header");
 
     /* Test reading the header with a lseek failure */
     UT_InitData();
@@ -121,9 +119,7 @@ void Test_CFE_FS_WriteHeader(void)
     osal_id_t FileDes = OS_OBJECT_ID_UNDEFINED;
     CFE_FS_Header_t Hdr;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Write Header\n");
-#endif
+    UtPrintf("Begin Test Write Header");
 
     /* Test writing the header with a lseek failure */
     UT_InitData();
@@ -151,9 +147,7 @@ void Test_CFE_FS_SetTimestamp(void)
     osal_id_t FileDes = OS_OBJECT_ID_UNDEFINED;
     CFE_TIME_SysTime_t NewTimestamp = {0, 0};
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Set Time Stamp\n");
-#endif
+    UtPrintf("Begin Test Set Time Stamp");
 
     /* Test setting the time stamp with a lseek failure */
     UT_InitData();
@@ -194,9 +188,7 @@ void Test_CFE_FS_ByteSwapCFEHeader(void)
 {
     CFE_FS_Header_t Hdr;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Byte Swap cFE Header\n");
-#endif
+    UtPrintf("Begin Test Byte Swap cFE Header");
 
     UT_InitData();
     Hdr.ContentType = 0x11223344;
@@ -229,9 +221,7 @@ void Test_CFE_FS_ByteSwapUint32(void)
     uint32 test = 0x11223344;
     uint32 *testptr = &test;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Byte Swap uint32\n");
-#endif
+    UtPrintf("Begin Test Byte Swap uint32");
 
     /* Test byte-swapping a uint32 value */
     UT_InitData();
@@ -251,9 +241,7 @@ void Test_CFE_FS_ExtractFileNameFromPath(void)
     char LongFileName[OS_MAX_PATH_LEN + 7];
     int j;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Extract File Name from Path\n");
-#endif
+    UtPrintf("Begin Test Extract File Name from Path");
 
     /* Test extracting the file name from a path/file name that's
      * missing the path
@@ -314,9 +302,7 @@ void Test_CFE_FS_ExtractFileNameFromPath(void)
 */
 void Test_CFE_FS_Private(void)
 {
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Private\n");
-#endif
+    UtPrintf("Begin Test Private");
 
     /* Test successful FS initialization */
     UT_InitData();
@@ -369,8 +355,6 @@ void Test_CFE_FS_Private(void)
               "CFE_FS_UnlockSharedData",
               "SharedData mutex give error");
 
-#ifdef UT_VERBOSE
-    UT_Text("End Test Private\n\n");
-#endif
+    UtPrintf("End Test Private\n");
 }
 

--- a/fsw/cfe-core/unit-test/fs_UT.h
+++ b/fsw/cfe-core/unit-test/fs_UT.h
@@ -64,8 +64,6 @@
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text
-**
 ******************************************************************************/
 void Test_CFE_FS_API(void);
 
@@ -100,7 +98,7 @@ void Test_CFE_FS_InitHeader(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetOSFail, #UT_Report, #CFE_FS_ReadHeader,
+** \sa #UT_InitData, #UT_SetOSFail, #UT_Report, #CFE_FS_ReadHeader,
 ** \sa #UT_SetRtnCode
 **
 ******************************************************************************/
@@ -119,7 +117,7 @@ void Test_CFE_FS_ReadHeader(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetOSFail, #UT_Report, #CFE_FS_WriteHeader,
+** \sa #UT_InitData, #UT_SetOSFail, #UT_Report, #CFE_FS_WriteHeader,
 ** \sa #UT_SetRtnCode
 **
 ******************************************************************************/
@@ -138,7 +136,7 @@ void Test_CFE_FS_WriteHeader(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetOSFail, #UT_Report, #CFE_FS_SetTimestamp,
+** \sa #UT_InitData, #UT_SetOSFail, #UT_Report, #CFE_FS_SetTimestamp,
 ** \sa #UT_SetRtnCode
 **
 ******************************************************************************/
@@ -157,7 +155,7 @@ void Test_CFE_FS_SetTimestamp(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #CFE_FS_ByteSwapCFEHeader, #UT_Report
+** \sa #UT_InitData, #CFE_FS_ByteSwapCFEHeader, #UT_Report
 **
 ******************************************************************************/
 void Test_CFE_FS_ByteSwapCFEHeader(void);
@@ -175,7 +173,7 @@ void Test_CFE_FS_ByteSwapCFEHeader(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #CFE_FS_ByteSwapUint32, #UT_Report
+** \sa #UT_InitData, #CFE_FS_ByteSwapUint32, #UT_Report
 **
 ******************************************************************************/
 void Test_CFE_FS_ByteSwapUint32(void);
@@ -193,7 +191,7 @@ void Test_CFE_FS_ByteSwapUint32(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_Report, #CFE_FS_IsGzFile
+** \sa #UT_InitData, #UT_Report, #CFE_FS_IsGzFile
 **
 ******************************************************************************/
 void Test_CFE_FS_IsGzFile(void);
@@ -211,7 +209,7 @@ void Test_CFE_FS_IsGzFile(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_Report, #CFE_FS_ExtractFilenameFromPath
+** \sa #UT_InitData, #UT_Report, #CFE_FS_ExtractFilenameFromPath
 **
 ******************************************************************************/
 void Test_CFE_FS_ExtractFileNameFromPath(void);
@@ -229,7 +227,7 @@ void Test_CFE_FS_ExtractFileNameFromPath(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_Report, #CFE_FS_EarlyInit,
+** \sa #UT_InitData, #UT_Report, #CFE_FS_EarlyInit,
 ** \sa #CFE_FS_LockSharedData, #UT_SetRtnCode, #CFE_FS_UnlockSharedData
 **
 ******************************************************************************/
@@ -249,7 +247,7 @@ void Test_CFE_FS_Private(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetOSFail, #UT_Report, #CFE_FS_Decompress,
+** \sa #UT_InitData, #UT_SetOSFail, #UT_Report, #CFE_FS_Decompress,
 ** \sa #UT_SetReadBuffer, #FS_gz_inflate_fixed, #FS_gz_inflate_stored,
 ** \sa #FS_gz_fill_inbuf, #FS_gz_flush_window
 **

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -128,7 +128,7 @@ uint32 UT_SB_ResourceID_Modify(uint32 InitialID, int32 Modifier)
 void UtTest_Setup(void)
 {
     UT_Init("sb");
-    UT_Text("cFE SB Unit Test Output File\n\n");
+    UtPrintf("cFE SB Unit Test Output File\n\n");
 
     Test_SB_AppInit();
     Test_SB_MainRoutine();

--- a/fsw/cfe-core/unit-test/sb_UT.h
+++ b/fsw/cfe-core/unit-test/sb_UT.h
@@ -138,7 +138,7 @@ void Test_SB_App(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #Test_SB_AppInit_ESRegFail(), #Test_SB_AppInit_EVSRegFail(),
+** \sa #Test_SB_AppInit_ESRegFail(), #Test_SB_AppInit_EVSRegFail(),
 ** \sa #Test_SB_AppInit_EVSSendEvtFail(), #Test_SB_AppInit_CrPipeFail(),
 ** \sa #Test_SB_AppInit_Sub1Fail(), #Test_SB_AppInit_Sub2Fail(),
 ** \sa #Test_SB_AppInit_GetPoolFail(), #Test_SB_AppInit_PutPoolFail()
@@ -159,7 +159,7 @@ void Test_SB_AppInit(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_AppInit,
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_AppInit,
 ** \sa #UT_GetNumEventsSent, #UT_Report
 **
 ******************************************************************************/
@@ -178,7 +178,7 @@ void Test_SB_AppInit_ESRegFail(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_AppInit,
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_AppInit,
 ** \sa #UT_GetNumEventsSent, #UT_Report
 **
 ******************************************************************************/
@@ -198,7 +198,7 @@ void Test_SB_AppInit_EVSRegFail(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_AppInit,
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_AppInit,
 ** \sa #UT_GetNumEventsSent, #CFE_SB_DeletePipe, #UT_Report
 **
 ******************************************************************************/
@@ -217,7 +217,7 @@ void Test_SB_AppInit_EVSSendEvtFail(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_AppInit, #UT_GetNumEventsSent,
+** \sa #SB_ResetUnitTest, #CFE_SB_AppInit, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #CFE_SB_DeletePipe, #UT_Report
 **
 ******************************************************************************/
@@ -237,7 +237,7 @@ void Test_SB_AppInit_CrPipeFail(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_AppInit,
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_AppInit,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
 **
@@ -258,7 +258,7 @@ void Test_SB_AppInit_Sub1Fail(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_AppInit,
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_AppInit,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
 **
@@ -278,7 +278,7 @@ void Test_SB_AppInit_Sub2Fail(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_AppInit,
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_AppInit,
 ** \sa #UT_GetNumEventsSent, #CFE_SB_DeletePipe, #UT_Report
 **
 ******************************************************************************/
@@ -297,7 +297,7 @@ void Test_SB_AppInit_GetPoolFail(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_AppInit,
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_AppInit,
 ** \sa #UT_GetNumEventsSent, #CFE_SB_DeletePipe, #UT_Report
 **
 ******************************************************************************/
@@ -316,7 +316,7 @@ void Test_SB_AppInit_PutPoolFail(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #Test_SB_Main_RcvErr, #Test_SB_Main_InitErr
+** \sa #Test_SB_Main_RcvErr, #Test_SB_Main_InitErr
 **
 ******************************************************************************/
 void Test_SB_MainRoutine(void);
@@ -334,7 +334,7 @@ void Test_SB_MainRoutine(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_TaskMain,
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_TaskMain,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
 **
@@ -355,7 +355,7 @@ void Test_SB_Main_RcvErr(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_TaskMain,
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_TaskMain,
 ** \sa #UT_GetNumEventsSent, #CFE_SB_DeletePipe, #UT_Report
 **
 ******************************************************************************/
@@ -374,7 +374,7 @@ void Test_SB_Main_InitErr(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #Test_SB_Cmds_Noop(), #Test_SB_Cmds_RstCtrs(),
+** \sa #Test_SB_Cmds_Noop(), #Test_SB_Cmds_RstCtrs(),
 ** \sa #Test_SB_Cmds_Stats(), #Test_SB_Cmds_RoutingInfoDef(),
 ** \sa #Test_SB_Cmds_RoutingInfoSpec(), #Test_SB_Cmds_RoutingInfoCreateFail(),
 ** \sa #Test_SB_Cmds_PipeOpts(),
@@ -412,7 +412,7 @@ void Test_SB_Cmds(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #UT_Report
 **
@@ -432,7 +432,7 @@ void Test_SB_Cmds_Noop(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #UT_Report
 **
@@ -452,7 +452,7 @@ void Test_SB_Cmds_RstCtrs(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #UT_Report
 **
@@ -473,7 +473,7 @@ void Test_SB_Cmds_Stats(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #CFE_SB_AppInit, #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #CFE_SB_DeletePipe, #UT_Report
 **
@@ -494,7 +494,7 @@ void Test_SB_Cmds_RoutingInfoDef(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #UT_Report
 **
@@ -515,7 +515,7 @@ void Test_SB_Cmds_RoutingInfoSpec(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #UT_SetOSFail, #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #UT_Report
 **
@@ -535,7 +535,7 @@ void Test_SB_Cmds_RoutingInfoCreateFail(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #Test_SetPipeOpts_BadID, #Test_SetPipeOpts_NotOwner,
+** \sa #Test_SetPipeOpts_BadID, #Test_SetPipeOpts_NotOwner,
 ** \sa #Test_SetPipeOpts,
 ** \sa #Test_GetPipeOpts_BadID, #Test_GetPipeOpts_BadPtr,
 ** \sa #Test_GetPipeOpts
@@ -557,7 +557,7 @@ void Test_PipeOpts_API(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #UT_SetOSFail, #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #UT_Report
 **
@@ -578,7 +578,7 @@ void Test_SetPipeOpts_BadID(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #UT_SetOSFail, #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #UT_Report
 **
@@ -599,7 +599,7 @@ void Test_SetPipeOpts_NotOwner(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #UT_SetOSFail, #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #UT_Report
 **
@@ -620,7 +620,7 @@ void Test_SetPipeOpts(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #UT_SetOSFail, #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #UT_Report
 **
@@ -641,7 +641,7 @@ void Test_GetPipeOpts_BadID(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #UT_SetOSFail, #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #UT_Report
 **
@@ -662,7 +662,7 @@ void Test_GetPipeOpts_BadPtr(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_SetCmdCode,
 ** \sa #UT_SetOSFail, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #UT_Report
 **
@@ -701,7 +701,7 @@ void Test_GetPipeName_API(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_CreatePipe,
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_CreatePipe,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -721,7 +721,7 @@ void Test_GetPipeName_NullPtr(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_CreatePipe,
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_CreatePipe,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -741,7 +741,7 @@ void Test_GetPipeName_InvalidId(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_SetCmdCode,
 ** \sa #UT_SetOSFail, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #UT_Report
 **
@@ -780,7 +780,7 @@ void Test_GetPipeIdByName_API(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_CreatePipe,
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_CreatePipe,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -800,7 +800,7 @@ void Test_GetPipeIdByName_NullPtrs(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_CreatePipe,
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_CreatePipe,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -820,7 +820,7 @@ void Test_GetPipeIdByName_InvalidName(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_SetCmdCode,
 ** \sa #UT_SetOSFail, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #UT_Report
 **
@@ -842,7 +842,7 @@ void Test_GetPipeIdByName(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_SendRtgInfo,
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_SendRtgInfo,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -863,7 +863,7 @@ void Test_SB_Cmds_RoutingInfoHdrFail(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_AppInit, #UT_SetRtnCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_AppInit, #UT_SetRtnCode,
 ** \sa #CFE_SB_SendRtgInfo, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #CFE_SB_DeletePipe, #UT_Report
 **
@@ -884,7 +884,7 @@ void Test_SB_Cmds_RoutingInfoWriteFail(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #CFE_SB_CreatePipe, #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #CFE_SB_DeletePipe, #UT_Report
 **
@@ -905,7 +905,7 @@ void Test_SB_Cmds_PipeInfoDef(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #UT_Report
 **
@@ -926,7 +926,7 @@ void Test_SB_Cmds_PipeInfoSpec(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetOSFail, #CFE_SB_SendPipeInfo,
+** \sa #SB_ResetUnitTest, #UT_SetOSFail, #CFE_SB_SendPipeInfo,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -947,7 +947,7 @@ void Test_SB_Cmds_PipeInfoCreateFail(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_SendPipeInfo,
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_SendPipeInfo,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -968,7 +968,7 @@ void Test_SB_Cmds_PipeInfoHdrFail(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #UT_SetRtnCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #UT_SetRtnCode,
 ** \sa #CFE_SB_SendPipeInfo, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #CFE_SB_DeletePipe, #UT_Report
 **
@@ -989,7 +989,7 @@ void Test_SB_Cmds_PipeInfoWriteFail(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #CFE_SB_CreatePipe, #CFE_SB_Subscribe, #CFE_SB_ProcessCmdPipePkt,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
@@ -1011,7 +1011,7 @@ void Test_SB_Cmds_MapInfoDef(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #UT_Report
 **
@@ -1032,7 +1032,7 @@ void Test_SB_Cmds_MapInfoSpec(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetOSFail, #CFE_SB_SendMapInfo,
+** \sa #SB_ResetUnitTest, #UT_SetOSFail, #CFE_SB_SendMapInfo,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -1052,7 +1052,7 @@ void Test_SB_Cmds_MapInfoCreateFail(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_SendMapInfo,
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_SendMapInfo,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -1073,7 +1073,7 @@ void Test_SB_Cmds_MapInfoHdrFail(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #UT_SetRtnCode, #CFE_SB_SendMapInfo, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #CFE_SB_DeletePipe, #UT_Report
 **
@@ -1094,7 +1094,7 @@ void Test_SB_Cmds_MapInfoWriteFail(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_InitMsg, #CFE_SB_SetCmdCode, #CFE_SB_ProcessCmdPipePkt,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
@@ -1117,7 +1117,7 @@ void Test_SB_Cmds_EnRouteValParam(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_InitMsg, #CFE_SB_SetCmdCode, #CFE_SB_ProcessCmdPipePkt,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
@@ -1139,7 +1139,7 @@ void Test_SB_Cmds_EnRouteNonExist(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #UT_Report
 **
@@ -1160,7 +1160,7 @@ void Test_SB_Cmds_EnRouteInvParam(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #UT_Report
 **
@@ -1183,7 +1183,7 @@ void Test_SB_Cmds_EnRouteInvParam2(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #UT_Report
 **
@@ -1204,7 +1204,7 @@ void Test_SB_Cmds_EnRouteInvParam3(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_InitMsg, #CFE_SB_SetCmdCode, #CFE_SB_ProcessCmdPipePkt,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
@@ -1226,7 +1226,7 @@ void Test_SB_Cmds_DisRouteValParam(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_InitMsg, #CFE_SB_SetCmdCode, #CFE_SB_ProcessCmdPipePkt,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
@@ -1248,7 +1248,7 @@ void Test_SB_Cmds_DisRouteNonExist(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #UT_Report
 **
@@ -1269,7 +1269,7 @@ void Test_SB_Cmds_DisRouteInvParam(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #UT_Report
 **
@@ -1292,7 +1292,7 @@ void Test_SB_Cmds_DisRouteInvParam2(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #UT_Report
 **
@@ -1312,7 +1312,7 @@ void Test_SB_Cmds_DisRouteInvParam3(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_ProcessCmdPipePkt,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_ProcessCmdPipePkt,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -1333,7 +1333,7 @@ void Test_SB_Cmds_SendHK(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #CFE_SB_CreatePipe, #CFE_SB_Subscribe, #CFE_SB_SubscribeLocal,
 ** \sa #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #CFE_SB_DeletePipe, #UT_Report
@@ -1354,7 +1354,7 @@ void Test_SB_Cmds_SendPrevSubs(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent, #UT_Report
 **
 ******************************************************************************/
@@ -1373,7 +1373,7 @@ void Test_SB_Cmds_SubRptOn(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent, #UT_Report
 **
 ******************************************************************************/
@@ -1393,7 +1393,7 @@ void Test_SB_Cmds_SubRptOff(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #UT_Report
 **
@@ -1414,7 +1414,7 @@ void Test_SB_Cmds_CmdUnexpCmdCode(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #UT_Report
 **
@@ -1435,7 +1435,7 @@ void Test_SB_Cmds_SubRptUnexpCmdCode(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SetCmdCode,
 ** \sa #CFE_SB_ProcessCmdPipePkt, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #UT_Report
 **
@@ -1456,7 +1456,7 @@ void Test_SB_Cmds_BadCmdLength(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_ProcessCmdPipePkt,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_ProcessCmdPipePkt,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -1495,7 +1495,7 @@ void Test_SB_Lib(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #Test_SB_EarlyInit_SemCreateError,
+** \sa #Test_SB_EarlyInit_SemCreateError,
 ** \sa #Test_SB_EarlyInit_PoolCreateError, #Test_SB_EarlyInit_NoErrors
 **
 ******************************************************************************/
@@ -1515,7 +1515,7 @@ void Test_SB_EarlyInit(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #UT_Report
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #UT_Report
 **
 ******************************************************************************/
 void Test_SB_EarlyInit_SemCreateError(void);
@@ -1534,7 +1534,7 @@ void Test_SB_EarlyInit_SemCreateError(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #UT_Report
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #UT_Report
 **
 ******************************************************************************/
 void Test_SB_EarlyInit_PoolCreateError(void);
@@ -1552,7 +1552,7 @@ void Test_SB_EarlyInit_PoolCreateError(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_EarlyInit, #UT_Report
+** \sa #SB_ResetUnitTest, #CFE_SB_EarlyInit, #UT_Report
 **
 ******************************************************************************/
 void Test_SB_EarlyInit_NoErrors(void);
@@ -1590,7 +1590,7 @@ void Test_SB_APIs(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #Test_CreatePipe_NullPtr, #Test_CreatePipe_ValPipeDepth,
+** \sa #Test_CreatePipe_NullPtr, #Test_CreatePipe_ValPipeDepth,
 ** \sa #Test_CreatePipe_InvalPipeDepth, #Test_CreatePipe_EmptyPipeName,
 ** \sa #Test_CreatePipe_LongPipeName, #Test_CreatePipe_SamePipeName,
 ** \sa #Test_CreatePipe_MaxPipes
@@ -1612,7 +1612,7 @@ void Test_CreatePipe_API(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_CreatePipe,
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_CreatePipe,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -1631,7 +1631,7 @@ void Test_CreatePipe_NullPtr(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_CreatePipe,
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_CreatePipe,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -1650,7 +1650,7 @@ void Test_CreatePipe_ValPipeDepth(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_CreatePipe,
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_CreatePipe,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -1669,7 +1669,7 @@ void Test_CreatePipe_InvalPipeDepth(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #UT_GetNumEventsSent,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -1689,7 +1689,7 @@ void Test_CreatePipe_EmptyPipeName(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #UT_GetNumEventsSent,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -1708,7 +1708,7 @@ void Test_CreatePipe_LongPipeName(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #UT_GetNumEventsSent,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -1727,7 +1727,7 @@ void Test_CreatePipe_SamePipeName(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #UT_GetNumEventsSent,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #UT_GetNumEventsSent,
 ** \sa #CFE_SB_DeletePipe, #UT_Report
 **
 ******************************************************************************/
@@ -1746,7 +1746,7 @@ void Test_CreatePipe_MaxPipes(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #Test_DeletePipe_NoSubs, #Test_DeletePipe_WithSubs,
+** \sa #Test_DeletePipe_NoSubs, #Test_DeletePipe_WithSubs,
 ** \sa #Test_DeletePipe_InvalidPipeId, #Test_DeletePipe_InvalidPipeOwner,
 ** \sa #Test_DeletePipe_WithAppid
 **
@@ -1767,7 +1767,7 @@ void Test_DeletePipe_API(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_DeletePipe, #UT_GetNumEventsSent,
+** \sa #SB_ResetUnitTest, #CFE_SB_DeletePipe, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -1787,7 +1787,7 @@ void Test_DeletePipe_NoSubs(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_DeletePipe, #UT_GetNumEventsSent,
+** \sa #SB_ResetUnitTest, #CFE_SB_DeletePipe, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -1806,7 +1806,7 @@ void Test_DeletePipe_WithSubs(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_DeletePipe, #UT_GetNumEventsSent,
+** \sa #SB_ResetUnitTest, #CFE_SB_DeletePipe, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -1826,7 +1826,7 @@ void Test_DeletePipe_InvalidPipeId(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, CFE_SB_CreatePipe, #CFE_SB_DeletePipe,
+** \sa #SB_ResetUnitTest, CFE_SB_CreatePipe, #CFE_SB_DeletePipe,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -1845,7 +1845,7 @@ void Test_DeletePipe_InvalidPipeOwner(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_DeletePipeWithAppId, #UT_GetNumEventsSent, #UT_Report
 **
 ******************************************************************************/
@@ -1864,7 +1864,7 @@ void Test_DeletePipe_WithAppid(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #Test_Subscribe_SubscribeEx, #Test_Subscribe_InvalidPipeId,
+** \sa #Test_Subscribe_SubscribeEx, #Test_Subscribe_InvalidPipeId,
 ** \sa #Test_Subscribe_InvalidMsgId, #Test_Subscribe_MaxMsgLim,
 ** \sa #Test_Subscribe_DuplicateSubscription,
 ** \sa #Test_Subscribe_LocalSubscription, #Test_Subscribe_MaxDestCount,
@@ -1888,7 +1888,7 @@ void Test_Subscribe_API(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_SubscribeEx,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_SubscribeEx,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
 **
@@ -1909,7 +1909,7 @@ void Test_Subscribe_SubscribeEx(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_Subscribe, #UT_GetNumEventsSent,
+** \sa #SB_ResetUnitTest, #CFE_SB_Subscribe, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -1929,7 +1929,7 @@ void Test_Subscribe_InvalidPipeId(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
 **
@@ -1950,7 +1950,7 @@ void Test_Subscribe_InvalidMsgId(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_SubscribeEx,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_SubscribeEx,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
 **
@@ -1971,7 +1971,7 @@ void Test_Subscribe_MaxMsgLim(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
 **
@@ -1991,7 +1991,7 @@ void Test_Subscribe_DuplicateSubscription(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_SubscribeLocal,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_SubscribeLocal,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
 **
@@ -2013,7 +2013,7 @@ void Test_Subscribe_LocalSubscription(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
 **
@@ -2035,7 +2035,7 @@ void Test_Subscribe_MaxDestCount(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #UT_EventIsInHistory, #CFE_SB_DeletePipe, #UT_Report
 **
 ******************************************************************************/
@@ -2055,7 +2055,7 @@ void Test_Subscribe_MaxMsgIdCount(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_SendPrevSubs, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #CFE_SB_DeletePipe, #UT_Report
 **
@@ -2076,7 +2076,7 @@ void Test_Subscribe_SendPrevSubs(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_SubscribeLocal, #CFE_SB_FindGlobalMsgIdCnt,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
@@ -2098,7 +2098,7 @@ void Test_Subscribe_FindGlobalMsgIdCnt(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_Subscribe, UT_GetNumEventsSent,
+** \sa #SB_ResetUnitTest, #CFE_SB_Subscribe, UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -2117,7 +2117,7 @@ void Test_Subscribe_PipeNonexistent(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe,
 ** \sa #CFE_SB_SetSubscriptionReporting, #CFE_SB_Subscribe,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa UT_Report
@@ -2139,7 +2139,7 @@ void Test_Subscribe_SubscriptionReporting(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #UT_EventIsInHistory, #CFE_SB_DeletePipe, #UT_Report
 **
 ******************************************************************************/
@@ -2158,7 +2158,7 @@ void Test_Subscribe_InvalidPipeOwner(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #Test_Unsubscribe_Basic, #Test_Unsubscribe_Local,
+** \sa #Test_Unsubscribe_Basic, #Test_Unsubscribe_Local,
 ** \sa #Test_Unsubscribe_InvalParam, #Test_Unsubscribe_NoMatch,
 ** \sa #Test_Unsubscribe_SubscriptionReporting, #Test_Unsubscribe_InvalidPipe,
 ** \sa #Test_Unsubscribe_InvalidPipeOwner, #Test_Unsubscribe_FirstDestWithMany,
@@ -2180,7 +2180,7 @@ void Test_Unsubscribe_API(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_Unsubscribe, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #CFE_SB_DeletePipe, #UT_Report
 **
@@ -2202,7 +2202,7 @@ void Test_Unsubscribe_Basic(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_UnsubscribeLocal, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #CFE_SB_DeletePipe, #UT_Report
 **
@@ -2223,7 +2223,7 @@ void Test_Unsubscribe_Local(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_UnSubscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_UnSubscribe,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
 **
@@ -2245,7 +2245,7 @@ void Test_Unsubscribe_InvalParam(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_Unsubscribe, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #CFE_SB_DeletePipe, #UT_Report
 **
@@ -2267,7 +2267,7 @@ void Test_Unsubscribe_NoMatch(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_SetSubscriptionReporting, #CFE_SB_Unsubscribe,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
@@ -2289,7 +2289,7 @@ void Test_Unsubscribe_SubscriptionReporting(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_Unsubscribe, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #CFE_SB_DeletePipe, #UT_Report
 **
@@ -2310,7 +2310,7 @@ void Test_Unsubscribe_InvalidPipe(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_Unsubscribe, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #CFE_SB_DeletePipe, #UT_Report
 **
@@ -2332,7 +2332,7 @@ void Test_Unsubscribe_InvalidPipeOwner(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_Unsubscribe, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #CFE_SB_DeletePipe, #UT_Report
 **
@@ -2354,7 +2354,7 @@ void Test_Unsubscribe_FirstDestWithMany(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_Unsubscribe, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #CFE_SB_DeletePipe, #UT_Report
 **
@@ -2376,7 +2376,7 @@ void Test_Unsubscribe_MiddleDestWithMany(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_Unsubscribe, #CFE_SB_GetDestPtr, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #CFE_SB_DeletePipe, #UT_Report
 **
@@ -2396,7 +2396,7 @@ void Test_Unsubscribe_GetDestPtr(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #Test_SendMsg_NullPtr, #Test_SendMsg_InvalidMsgId,
+** \sa #Test_SendMsg_NullPtr, #Test_SendMsg_InvalidMsgId,
 ** \sa #Test_SendMsg_NoSubscribers, #Test_SendMsg_MaxMsgSizePlusOne,
 ** \sa #Test_SendMsg_BasicSend, #Test_SendMsg_SequenceCount,
 ** \sa #Test_SendMsg_QueuePutError, #Test_SendMsg_PipeFull,
@@ -2422,7 +2422,7 @@ void Test_SendMsg_API(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_SendMsg, #UT_GetNumEventsSent,
+** \sa #SB_ResetUnitTest, #CFE_SB_SendMsg, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -2442,7 +2442,7 @@ void Test_SendMsg_NullPtr(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SendMsg,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SendMsg,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -2462,7 +2462,7 @@ void Test_SendMsg_InvalidMsgId(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SendMsg,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SendMsg,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -2483,7 +2483,7 @@ void Test_SendMsg_NoSubscribers(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SendMsg,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SendMsg,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -2503,7 +2503,7 @@ void Test_SendMsg_MaxMsgSizePlusOne(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_InitMsg, #CFE_SB_SendMsg, #UT_GetNumEventsSent,
 ** \sa #CFE_SB_DeletePipe, #UT_Report
 **
@@ -2524,7 +2524,7 @@ void Test_SendMsg_BasicSend(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_InitMsg,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_InitMsg,
 ** \sa #CFE_SB_Subscribe, #CCSDS_WR_SEQ, #CFE_SB_SendMsg, #CFE_SB_RcvMsg,
 ** \sa #CCSDS_RD_SEQ, #CFE_SB_PassMsg, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #CFE_SB_DeletePipe, #UT_Report
@@ -2546,7 +2546,7 @@ void Test_SendMsg_SequenceCount(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_InitMsg, #CFE_SB_SendMsg, #UT_GetNumEventsSent,
 ** \sa #CFE_SB_DeletePipe, #UT_Report
 **
@@ -2567,7 +2567,7 @@ void Test_SendMsg_QueuePutError(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_CreatePipe,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_CreatePipe,
 ** \sa #CFE_SB_Subscribe, #CFE_SB_SendMsg, #UT_GetNumEventsSent,
 ** \sa #CFE_SB_DeletePipe, #UT_Report
 **
@@ -2588,7 +2588,7 @@ void Test_SendMsg_PipeFull(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_CreatePipe,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_CreatePipe,
 ** \sa #CFE_SB_SubscribeEx, #CFE_SB_SendMsg, #UT_GetNumEventsSent,
 ** \sa #CFE_SB_DeletePipe, #UT_Report
 **
@@ -2609,7 +2609,7 @@ void Test_SendMsg_MsgLimitExceeded(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_CreatePipe,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_CreatePipe,
 ** \sa #CFE_SB_Subscribe, #UT_SetRtnCode, #CFE_SB_SendMsg,
 ** \sa #UT_GetNumEventsSent, #CFE_SB_DeletePipe, #UT_Report
 **
@@ -2631,7 +2631,7 @@ void Test_SendMsg_GetPoolBufErr(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_ZeroCopyGetPtr,
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_ZeroCopyGetPtr,
 ** \sa #UT_GetNumEventsSent, #UT_Report
 **
 ******************************************************************************/
@@ -2652,7 +2652,7 @@ void Test_SendMsg_ZeroCopyGetPtr(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_ZeroCopyGetPtr, #CFE_SB_InitMsg, #CCSDS_WR_SEQ,
 ** \sa #CFE_SB_ZeroCopySend, #CFE_SB_RcvMsg, #CCSDS_RD_SEQ,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
@@ -2676,7 +2676,7 @@ void Test_SendMsg_ZeroCopySend(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_ZeroCopyGetPtr, #CFE_SB_InitMsg, #CCSDS_WR_SEQ,
 ** \sa #CFE_SB_ZeroCopyPass, #CFE_SB_RcvMsg, #CCSDS_RD_SEQ,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
@@ -2699,7 +2699,7 @@ void Test_SendMsg_ZeroCopyPass(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_ZeroCopyGetPtr,
+** \sa #SB_ResetUnitTest, #CFE_SB_ZeroCopyGetPtr,
 ** \sa #CFE_SB_ZeroCopyReleasePtr, #UT_SetRtnCode, #UT_GetNumEventsSent,
 ** \sa #UT_Report
 **
@@ -2720,7 +2720,7 @@ void Test_SendMsg_ZeroCopyReleasePtr(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_GetDestPtr, #CFE_SB_InitMsg, #CFE_SB_SendMsg,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
@@ -2741,7 +2741,7 @@ void Test_SendMsg_DisabledDestination(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_InitMsg, #CFE_SB_SendMsgFull, #UT_GetNumEventsSent,
 ** \sa #CFE_SB_DeletePipe, #UT_Report
 **
@@ -2763,7 +2763,7 @@ void Test_SendMsg_SendWithMetadata(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SendMsg,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SendMsg,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -2784,7 +2784,7 @@ void Test_SendMsg_InvalidMsgId_ZeroCopy(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SendMsg,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SendMsg,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -2805,7 +2805,7 @@ void Test_SendMsg_NoSubscribers_ZeroCopy(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SendMsg,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_SendMsg,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -2824,7 +2824,7 @@ void Test_SendMsg_MaxMsgSizePlusOne_ZeroCopy(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #Test_RcvMsg_InvalidPipeId, #Test_RcvMsg_InvalidTimeout,
+** \sa #Test_RcvMsg_InvalidPipeId, #Test_RcvMsg_InvalidTimeout,
 ** \sa #Test_RcvMsg_Poll, #Test_RcvMsg_Timeout,
 ** \sa #Test_RcvMsg_PipeReadError, #Test_RcvMsg_PendForever
 **
@@ -2846,7 +2846,7 @@ void Test_RcvMsg_API(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_RcvMsg, #UT_GetNumEventsSent,
+** \sa #SB_ResetUnitTest, #CFE_SB_RcvMsg, #UT_GetNumEventsSent,
 ** \sa #UT_EventIsInHistory, #UT_Report
 **
 ******************************************************************************/
@@ -2866,7 +2866,7 @@ void Test_RcvMsg_InvalidPipeId(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_RcvMsg,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_RcvMsg,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
 **
@@ -2888,7 +2888,7 @@ void Test_RcvMsg_InvalidTimeout(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_RcvMsg,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_RcvMsg,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
 **
@@ -2908,7 +2908,7 @@ void Test_RcvMsg_Poll(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #UT_SetRtnCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #UT_SetRtnCode,
 ** \sa #CFE_SB_RcvMsg, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #CFE_SB_DeletePipe, #UT_Report
 **
@@ -2929,7 +2929,7 @@ void Test_RcvMsg_Timeout(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_RcvMsg,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_RcvMsg,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
 **
@@ -2950,7 +2950,7 @@ void Test_RcvMsg_PipeReadError(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_InitMsg,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_InitMsg,
 ** \sa #CFE_SB_Subscribe, #CFE_SB_SendMsg, #CFE_SB_RcvMsg,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
@@ -2972,7 +2972,7 @@ void Test_RcvMsg_PendForever(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_RcvMsg,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_RcvMsg,
 ** \sa #UT_GetNumEventsSent, #UT_EventIsInHistory, #CFE_SB_DeletePipe,
 ** \sa #UT_Report
 **
@@ -2994,7 +2994,7 @@ void Test_RcvMsg_InvalidBufferPtr(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_ZeroCopyGetPtr,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_ZeroCopyGetPtr,
 ** \sa #CFE_SB_CleanUpApp, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #UT_Report
 **
@@ -3014,7 +3014,7 @@ void Test_CleanupApp_API(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #Test_CFE_SB_InitMsg, #Test_CFE_SB_MsgHdrSize,
+** \sa #Test_CFE_SB_InitMsg, #Test_CFE_SB_MsgHdrSize,
 ** \sa #Test_CFE_SB_GetUserData, #Test_CFE_SB_SetGetMsgId,
 ** \sa #Test_CFE_SB_SetGetUserDataLength, #Test_CFE_SB_SetGetTotalMsgLength,
 ** \sa #Test_CFE_SB_SetGetMsgTime,
@@ -3053,7 +3053,7 @@ void Test_CFE_SB_InitMsg(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_MsgHdrSize, #UT_Report
+** \sa #SB_ResetUnitTest, #CFE_SB_MsgHdrSize, #UT_Report
 **
 ******************************************************************************/
 void Test_CFE_SB_MsgHdrSize(void);
@@ -3072,7 +3072,7 @@ void Test_CFE_SB_MsgHdrSize(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_SetMsgId, #CFE_SB_GetUserData,
+** \sa #SB_ResetUnitTest, #CFE_SB_SetMsgId, #CFE_SB_GetUserData,
 ** \sa #UT_Report
 **
 ******************************************************************************/
@@ -3091,7 +3091,7 @@ void Test_CFE_SB_GetUserData(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_SetMsgId, #CFE_SB_GetMsgId,
+** \sa #SB_ResetUnitTest, #CFE_SB_SetMsgId, #CFE_SB_GetMsgId,
 ** \sa #UT_Report
 **
 ******************************************************************************/
@@ -3111,7 +3111,7 @@ void Test_CFE_SB_SetGetMsgId(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_SetMsgId,
+** \sa #SB_ResetUnitTest, #CFE_SB_SetMsgId,
 ** \sa #CFE_SB_SetUserDataLength, #CFE_SB_GetUserDataLength,
 **
 ******************************************************************************/
@@ -3130,7 +3130,7 @@ void Test_CFE_SB_SetGetUserDataLength(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_SetMsgId,
+** \sa #SB_ResetUnitTest, #CFE_SB_SetMsgId,
 ** \sa #CFE_SB_SetTotalMsgLength, #CFE_SB_GetTotalMsgLength,
 **
 ******************************************************************************/
@@ -3149,7 +3149,7 @@ void Test_CFE_SB_SetGetTotalMsgLength(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_SetMsgId, #CFE_SB_SetMsgTime,
+** \sa #SB_ResetUnitTest, #CFE_SB_SetMsgId, #CFE_SB_SetMsgTime,
 ** \sa #CFE_SB_GetMsgTime, #UT_DisplayPkt, #UT_Report
 **
 ******************************************************************************/
@@ -3168,7 +3168,7 @@ void Test_CFE_SB_SetGetMsgTime(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_SetMsgId, #CFE_SB_SetCmdCode,
+** \sa #SB_ResetUnitTest, #CFE_SB_SetMsgId, #CFE_SB_SetCmdCode,
 ** \sa #CFE_SB_GetCmdCode, #UT_DisplayPkt
 **
 ******************************************************************************/
@@ -3205,7 +3205,7 @@ void Test_CFE_SB_ChecksumUtils(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest,
+** \sa #SB_ResetUnitTest,
 ** \sa #CFE_SB_ValidateMsgId, #UT_DisplayPkt,
 ** \sa #UT_Report
 **
@@ -3225,7 +3225,7 @@ void Test_CFE_SB_ValidateMsgId(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #Test_OS_MutSem_ErrLogic,
+** \sa #Test_OS_MutSem_ErrLogic,
 ** \sa #Test_ReqToSendEvent_ErrLogic, #Test_PutDestBlk_ErrLogic
 **
 ******************************************************************************/
@@ -3245,7 +3245,7 @@ void Test_SB_SpecialCases(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_CreatePipe,
+** \sa #SB_ResetUnitTest, #UT_SetRtnCode, #CFE_SB_CreatePipe,
 ** \sa #CFE_SB_Subscribe, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #CFE_SB_DeletePipe, #UT_Report
 **
@@ -3265,7 +3265,7 @@ void Test_OS_MutSem_ErrLogic(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_RequestToSendEvent,
+** \sa #SB_ResetUnitTest, #CFE_SB_RequestToSendEvent,
 ** \sa #UT_GetNumEventsSent, #UT_Report
 **
 ******************************************************************************/
@@ -3286,7 +3286,7 @@ void Test_ReqToSendEvent_ErrLogic(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_PutDestinationBlk,
+** \sa #SB_ResetUnitTest, #CFE_SB_PutDestinationBlk,
 ** \sa #UT_GetNumEventsSent, #UT_Report
 **
 ******************************************************************************/
@@ -3307,7 +3307,7 @@ void Test_PutDestBlk_ErrLogic(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_GetPipeIdx, #UT_GetNumEventsSent,
+** \sa #SB_ResetUnitTest, #CFE_SB_GetPipeIdx, #UT_GetNumEventsSent,
 ** \sa #UT_Report
 **
 ******************************************************************************/
@@ -3327,7 +3327,7 @@ void Test_CFE_SB_GetPipeIdx(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_GetBufferFromPool,
+** \sa #SB_ResetUnitTest, #CFE_SB_GetBufferFromPool,
 ** \sa #CFE_SB_ReturnBufferToPool, #CFE_SB_DecrBufUseCnt,
 ** \sa #CFE_SB_PutDestinationBlk, #UT_GetNumEventsSent, #UT_Report
 **
@@ -3347,7 +3347,7 @@ void Test_CFE_SB_Buffers(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_DeletePipeFull,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_DeletePipeFull,
 ** \sa #CFE_SB_SubscribeFull, #UT_GetNumEventsSent, #UT_Report
 **
 ******************************************************************************/
@@ -3366,7 +3366,7 @@ void Test_CFE_SB_BadPipeInfo(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_ProcessCmdPipePkt,
+** \sa #SB_ResetUnitTest, #CFE_SB_InitMsg, #CFE_SB_ProcessCmdPipePkt,
 ** \sa #UT_EventIsInHistory, #CFE_SB_GetMsgId, #UT_SetRtnCode,
 ** \sa #UT_GetNumEventsSent, #CFE_SB_CreatePipe, #CFE_SB_Subscribe,
 ** \sa #CFE_SB_SendMsg, #CFE_SB_DeletePipe, #CFE_SB_SubscribeEx, #UT_Report
@@ -3392,7 +3392,7 @@ void Test_SB_SendMsgPaths_IgnoreOpt(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_InitMsg,
+** \sa #SB_ResetUnitTest, #CFE_SB_CreatePipe, #CFE_SB_InitMsg,
 ** \sa #CFE_SB_Subscribe, #CFE_SB_SendMsg, #CFE_SB_Unsubscribe,
 ** \sa #CFE_SB_RcvMsg, #UT_GetNumEventsSent, #UT_EventIsInHistory,
 ** \sa #CFE_SB_DeletePipe, #UT_Report

--- a/fsw/cfe-core/unit-test/tbl_UT.c
+++ b/fsw/cfe-core/unit-test/tbl_UT.c
@@ -95,7 +95,7 @@ void UtTest_Setup(void)
 {
     /* Initialize unit test */
     UT_Init("tbl");
-    UT_Text("cFE TBL Unit Test Output File\n\n");
+    UtPrintf("cFE TBL Unit Test Output File\n\n");
     UT_InitializeTableRegistryNames();
 
     /* cfe_tbl_task.c functions */
@@ -221,9 +221,7 @@ void Test_CFE_TBL_TaskInit(void)
         CFE_SB_Msg_t Msg;
     } CmdBuf;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Task Init\n");
-#endif
+    UtPrintf("Begin Test Task Init");
 
     memset(&CmdBuf, 0, sizeof(CmdBuf));
 
@@ -371,9 +369,7 @@ void Test_CFE_TBL_TaskInit(void)
 */
 void Test_CFE_TBL_InitData(void)
 {
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Init Data\n");
-#endif
+    UtPrintf("Begin Test Init Data");
 
     /* This function has only one possible path with no return code */
     UT_InitData();
@@ -395,9 +391,7 @@ void Test_CFE_TBL_SearchCmdHndlrTbl(void)
     uint16         CmdCode;
     CFE_SB_MsgId_t MsgID;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Search Command Handler Table\n");
-#endif
+    UtPrintf("Begin Test Search Command Handler Table");
 
     /* Test successfully finding a matching message ID and command code */
     UT_InitData();
@@ -449,9 +443,7 @@ void Test_CFE_TBL_DeleteCDSCmd(void)
     int                 j, k;
     CFE_TBL_DeleteCDS_t DelCDSCmd;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Delete CDS Command\n");
-#endif
+    UtPrintf("Begin Test Delete CDS Command");
 
     /* Test successfully finding the table name in the table registry */
     UT_InitData();
@@ -539,9 +531,7 @@ void Test_CFE_TBL_TlmRegCmd(void)
 {
     CFE_TBL_SendRegistry_t TlmRegCmd;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Telemetry Registry Command\n");
-#endif
+    UtPrintf("Begin Test Telemetry Registry Command");
 
     /* Test when table name does exist */
     UT_InitData();
@@ -577,9 +567,7 @@ void Test_CFE_TBL_AbortLoadCmd(void)
     int load = (int) CFE_TBL_TaskData.Registry[0].LoadInProgress;
     CFE_TBL_AbortLoad_t  AbortLdCmd;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Abort Load Command\n");
-#endif
+    UtPrintf("Begin Test Abort Load Command");
 
     /* Test when table name does exist and a table load is in progress */
     UT_InitData();
@@ -651,9 +639,7 @@ void Test_CFE_TBL_ActivateCmd(void)
     uint8                 dump = CFE_TBL_TaskData.Registry[0].DumpOnly;
     CFE_TBL_Activate_t    ActivateCmd;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Activate Command\n");
-#endif
+    UtPrintf("Begin Test Activate Command");
 
     /* Enter the if statement with a table name that is in the registry */
     strncpy(ActivateCmd.Payload.TableName, CFE_TBL_TaskData.Registry[0].Name,
@@ -746,9 +732,7 @@ void Test_CFE_TBL_DumpToFile(void)
 {
     uint32 TblSizeInBytes = 9;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Dump to File\n");
-#endif
+    UtPrintf("Begin Test Dump to File");
 
     /* Test with an error creating the dump file */
     UT_InitData();
@@ -814,9 +798,7 @@ void Test_CFE_TBL_DumpToFile(void)
 */
 void Test_CFE_TBL_ResetCmd(void)
 {
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Reset Command\n");
-#endif
+    UtPrintf("Begin Test Reset Command");
 
     /* Test run through function (there are no additional paths) */
     UT_InitData();
@@ -839,9 +821,7 @@ void Test_CFE_TBL_ValidateCmd(void)
                                              ((unsigned long )
                                                &UT_InitializeTableRegistryNames);
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Validate Command\n");
-#endif
+    UtPrintf("Begin Test Validate Command");
 
     /* Test when table name is not found in the registry */
     UT_InitData();
@@ -983,9 +963,7 @@ void Test_CFE_TBL_ValidateCmd(void)
 void Test_CFE_TBL_NoopCmd(void)
 {
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test No-Op Command\n");
-#endif
+    UtPrintf("Begin Test No-Op Command");
 
     /* Test run through function (there are no additional paths) */
     UT_InitData();
@@ -1001,9 +979,7 @@ void Test_CFE_TBL_NoopCmd(void)
 */
 void Test_CFE_TBL_GetTblRegData(void)
 {
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Get Table Registry Command\n");
-#endif
+    UtPrintf("Begin Test Get Table Registry Command");
 
     /* Test using a double buffered table */
     UT_InitData();
@@ -1056,9 +1032,7 @@ void Test_CFE_TBL_GetHkData(void)
     /* Get the AppID being used for UT */
     CFE_ES_GetAppID(&AppID);
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Get Housekeeping Data\n");
-#endif
+    UtPrintf("Begin Test Get Housekeeping Data");
 
     for (i = 0; i < CFE_PLATFORM_TBL_MAX_NUM_TABLES; i++)
     {
@@ -1154,9 +1128,7 @@ void Test_CFE_TBL_DumpRegCmd(void)
     CFE_ES_GetAppID(&AppID);
 
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Dump Register Command\n");
-#endif
+    UtPrintf("Begin Test Dump Register Command");
 
     for (q = 0; q < CFE_PLATFORM_TBL_MAX_NUM_TABLES; q++)
     {
@@ -1250,9 +1222,7 @@ void Test_CFE_TBL_DumpCmd(void)
 
     CFE_ES_GetAppID(&AppID);
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Dump Command\n");
-#endif
+    UtPrintf("Begin Test Dump Command");
 
     memset(&DumpCmd, 0, sizeof(DumpCmd));
 
@@ -1430,9 +1400,7 @@ void Test_CFE_TBL_LoadCmd(void)
 
     CFE_ES_GetAppID(&AppID);
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Load Command\n");
-#endif
+    UtPrintf("Begin Test Load Command");
 
     StdFileHeader.SpacecraftID = CFE_PLATFORM_TBL_VALID_SCID_1;
     StdFileHeader.ProcessorID = CFE_PLATFORM_TBL_VALID_PRID_1;
@@ -1710,9 +1678,7 @@ void Test_CFE_TBL_HousekeepingCmd(void)
     uint32                SubSecs = 0;
     int32                 LoadInProg = 0;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Housekeeping Command\n");
-#endif
+    UtPrintf("Begin Test Housekeeping Command");
 
     /* Test response to inability to update timestamp in dump file + inability
      * to send Hk packet
@@ -1813,9 +1779,7 @@ void Test_CFE_TBL_Register(void)
     CFE_TBL_AccessDescriptor_t *AccessDescPtr;
     CFE_TBL_RegistryRec_t      *RegRecPtr;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Register\n");
-#endif
+    UtPrintf("Begin Test Register");
 
     /* Test response to an invalid application ID */
     UT_InitData();
@@ -2520,9 +2484,7 @@ void Test_CFE_TBL_Share(void)
     CFE_FS_Header_t    StdFileHeader;
     CFE_TBL_File_Hdr_t TblFileHeader;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Share\n");
-#endif
+    UtPrintf("Begin Test Share");
 
     StdFileHeader.SpacecraftID = CFE_PLATFORM_TBL_VALID_SCID_1;
     StdFileHeader.ProcessorID = CFE_PLATFORM_TBL_VALID_PRID_1;
@@ -2636,9 +2598,7 @@ void Test_CFE_TBL_Unregister(void)
     int32   RtnCode;
     bool EventsCorrect;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Unregister\n");
-#endif
+    UtPrintf("Begin Test Unregister");
 
     /* Test response to unregistering a table with an invalid handle */
     UT_InitData();
@@ -2682,9 +2642,7 @@ void Test_CFE_TBL_NotifyByMessage(void)
     int32   RtnCode;
     bool EventsCorrect;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Notify by Message\n");
-#endif
+    UtPrintf("Begin Test Notify by Message");
 
     /* Set up notify by message tests */
     UT_InitData();
@@ -2750,9 +2708,7 @@ void Test_CFE_TBL_Load(void)
     CFE_TBL_RegistryRec_t      *RegRecPtr;
     CFE_TBL_AccessDescriptor_t *AccessDescPtr;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Load\n");
-#endif
+    UtPrintf("Begin Test Load");
 
     StdFileHeader.SpacecraftID = CFE_PLATFORM_TBL_VALID_SCID_1;
     StdFileHeader.ProcessorID = CFE_PLATFORM_TBL_VALID_PRID_1;
@@ -3087,9 +3043,7 @@ void Test_CFE_TBL_GetAddress(void)
     UT_Table1_t *App3TblPtr;
     UT_Table1_t *App2TblPtr;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Get Address\n");
-#endif
+    UtPrintf("Begin Test Get Address");
 
     /* Test attempt to get the address of a table for which the application
      * does not have access
@@ -3154,9 +3108,7 @@ void Test_CFE_TBL_ReleaseAddress(void)
     int32   RtnCode;
     bool EventsCorrect;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Release Address\n");
-#endif
+    UtPrintf("Begin Test Release Address");
 
     /* Test address release using an invalid application ID */
     /* a. Test setup - register single buffered table */
@@ -3194,9 +3146,7 @@ void Test_CFE_TBL_GetAddresses(void)
     int32   RtnCode;
     bool EventsCorrect;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Get Addresses\n");
-#endif
+    UtPrintf("Begin Test Get Addresses");
 
     /* Test setup - register a double buffered table */
     UT_InitData();
@@ -3254,9 +3204,7 @@ void Test_CFE_TBL_ReleaseAddresses(void)
     int32   RtnCode;
     bool EventsCorrect;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Release Addresses\n");
-#endif
+    UtPrintf("Begin Test Release Addresses");
 
     /* Test response to releasing two tables that have not been loaded */
     UT_InitData();
@@ -3278,9 +3226,7 @@ void Test_CFE_TBL_Validate(void)
     int32   RtnCode;
     bool EventsCorrect;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Validate\n");
-#endif
+    UtPrintf("Begin Test Validate");
 
     /* Test response to attempt to validate a table that an application is
      * not allowed to see
@@ -3325,9 +3271,7 @@ void Test_CFE_TBL_Manage(void)
     CFE_TBL_AccessDescriptor_t *AccessDescPtr;
     CFE_TBL_Handle_t           AccessIterator;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Manage\n");
-#endif
+    UtPrintf("Begin Test Manage");
 
     /* Test response to attempt to manage a table that doesn't need managing */
     UT_InitData();
@@ -3742,9 +3686,7 @@ void Test_CFE_TBL_Update(void)
     int32   RtnCode;
     bool EventsCorrect;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Update\n");
-#endif
+    UtPrintf("Begin Test Update");
 
     /* Test processing an update on a single buffered table without
      * privileges
@@ -3793,9 +3735,7 @@ void Test_CFE_TBL_GetStatus(void)
     int32   RtnCode;
     bool EventsCorrect;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Get Status\n");
-#endif
+    UtPrintf("Begin Test Get Status");
 
     /* Test response to an attempt to get the status on a table that the
      * application is not allowed to see
@@ -3833,9 +3773,7 @@ void Test_CFE_TBL_GetInfo(void)
     bool        EventsCorrect;
     CFE_TBL_Info_t TblInfo;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Get Info\n");
-#endif
+    UtPrintf("Begin Test Get Info");
 
     /* Test successfully getting information on a table */
     UT_InitData();
@@ -3877,9 +3815,7 @@ void Test_CFE_TBL_TblMod(void)
     CFE_TBL_Handle_t           AccessIterator;
     uint8                       CDS_Data[sizeof(UT_Table1_t)];
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Table Modified\n");
-#endif
+    UtPrintf("Begin Test Table Modified");
 
     FileHeader.SpacecraftID = CFE_PLATFORM_TBL_VALID_SCID_1;
     FileHeader.ProcessorID = CFE_PLATFORM_TBL_VALID_PRID_1;
@@ -4072,9 +4008,7 @@ void Test_CFE_TBL_Internal(void)
     osal_id_t                  FileDescriptor;
     void                       *TblPtr;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Internal\n");
-#endif
+    UtPrintf("Begin Test Internal");
 
     FileDescriptor = OS_OBJECT_ID_UNDEFINED;
     StdFileHeader.SpacecraftID = CFE_PLATFORM_TBL_VALID_SCID_1;

--- a/fsw/cfe-core/unit-test/tbl_UT.h
+++ b/fsw/cfe-core/unit-test/tbl_UT.h
@@ -124,7 +124,7 @@ void UT_ResetTableRegistry(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #CFE_TBL_TaskMain, #UT_Report, #UT_SetRtnCode,
+** \sa #UT_InitData, #CFE_TBL_TaskMain, #UT_Report, #UT_SetRtnCode,
 ** \sa #CFE_TBL_TaskInit, #UT_SetSBTotalMsgLen, #CFE_SB_SetMsgId,
 ** \sa #CFE_SB_SetCmdCode, #CFE_TBL_TaskPipe
 **
@@ -144,7 +144,7 @@ void Test_CFE_TBL_TaskInit(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #CFE_TBL_InitData, #UT_Report
+** \sa #UT_InitData, #CFE_TBL_InitData, #UT_Report
 **
 ******************************************************************************/
 void Test_CFE_TBL_InitData(void);
@@ -164,7 +164,7 @@ void Test_CFE_TBL_InitData(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_Report, #CFE_TBL_SearchCmdHndlrTbl,
+** \sa #UT_InitData, #UT_Report, #CFE_TBL_SearchCmdHndlrTbl,
 **
 ******************************************************************************/
 void Test_CFE_TBL_SearchCmdHndlrTbl(void);
@@ -183,7 +183,7 @@ void Test_CFE_TBL_SearchCmdHndlrTbl(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_Report, #CFE_TBL_DeleteCDSCmd,
+** \sa #UT_InitData, #UT_Report, #CFE_TBL_DeleteCDSCmd,
 ** \sa #UT_SetRtnCode
 **
 ******************************************************************************/
@@ -203,7 +203,7 @@ void Test_CFE_TBL_DeleteCDSCmd(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_Report, #CFE_TBL_SendRegistryCmd
+** \sa #UT_InitData, #UT_Report, #CFE_TBL_SendRegistryCmd
 **
 ******************************************************************************/
 void Test_CFE_TBL_TlmRegCmd(void);
@@ -222,7 +222,7 @@ void Test_CFE_TBL_TlmRegCmd(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_Report, #CFE_TBL_AbortLoadCmd
+** \sa #UT_InitData, #UT_Report, #CFE_TBL_AbortLoadCmd
 **
 ******************************************************************************/
 void Test_CFE_TBL_AbortLoadCmd(void);
@@ -240,7 +240,7 @@ void Test_CFE_TBL_AbortLoadCmd(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_Report, #CFE_TBL_ActivateCmd
+** \sa #UT_InitData, #UT_Report, #CFE_TBL_ActivateCmd
 **
 ******************************************************************************/
 void Test_CFE_TBL_ActivateCmd(void);
@@ -258,7 +258,7 @@ void Test_CFE_TBL_ActivateCmd(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetOSFail, #UT_Report, #CFE_TBL_DumpToFile,
+** \sa #UT_InitData, #UT_SetOSFail, #UT_Report, #CFE_TBL_DumpToFile,
 ** \sa #UT_SetRtnCode
 **
 ******************************************************************************/
@@ -278,7 +278,7 @@ void Test_CFE_TBL_DumpToFile(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_Report, #CFE_TBL_ResetCountersCmd
+** \sa #UT_Report, #CFE_TBL_ResetCountersCmd
 **
 ******************************************************************************/
 void Test_CFE_TBL_ResetCmd(void);
@@ -296,7 +296,7 @@ void Test_CFE_TBL_ResetCmd(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_Report, #CFE_TBL_ValidateCmd
+** \sa #UT_InitData, #UT_Report, #CFE_TBL_ValidateCmd
 **
 ******************************************************************************/
 void Test_CFE_TBL_ValidateCmd(void);
@@ -315,7 +315,7 @@ void Test_CFE_TBL_ValidateCmd(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_Report, #CFE_TBL_NoopCmd
+** \sa #UT_InitData, #UT_Report, #CFE_TBL_NoopCmd
 **
 ******************************************************************************/
 void Test_CFE_TBL_NoopCmd(void);
@@ -335,7 +335,7 @@ void Test_CFE_TBL_NoopCmd(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #CFE_TBL_GetTblRegData, #UT_Report
+** \sa #UT_InitData, #CFE_TBL_GetTblRegData, #UT_Report
 **
 ******************************************************************************/
 void Test_CFE_TBL_GetTblRegData(void);
@@ -355,7 +355,7 @@ void Test_CFE_TBL_GetTblRegData(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #CFE_TBL_GetHkData, #UT_Report
+** \sa #UT_InitData, #CFE_TBL_GetHkData, #UT_Report
 **
 ******************************************************************************/
 void Test_CFE_TBL_GetHkData(void);
@@ -375,7 +375,7 @@ void Test_CFE_TBL_GetHkData(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetOSFail, #UT_Report, #CFE_TBL_DumpRegistryCmd,
+** \sa #UT_InitData, #UT_SetOSFail, #UT_Report, #CFE_TBL_DumpRegistryCmd,
 ** \sa #UT_SetRtnCode
 **
 ******************************************************************************/
@@ -395,7 +395,7 @@ void Test_CFE_TBL_DumpRegCmd(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_Report, #CFE_TBL_DumpCmd, #UT_SetRtnCode
+** \sa #UT_InitData, #UT_Report, #CFE_TBL_DumpCmd, #UT_SetRtnCode
 **
 ******************************************************************************/
 void Test_CFE_TBL_DumpCmd(void);
@@ -415,7 +415,7 @@ void Test_CFE_TBL_DumpCmd(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetOSFail, #UT_Report, #CFE_TBL_LoadCmd,
+** \sa #UT_InitData, #UT_SetOSFail, #UT_Report, #CFE_TBL_LoadCmd,
 ** \sa #UT_SetReadBuffer, #UT_SetReadHeader, #CFE_TBL_ByteSwapUint32,
 ** \sa #UT_SetRtnCode
 **
@@ -436,7 +436,7 @@ void Test_CFE_TBL_LoadCmd(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetRtnCode, #UT_Report,
+** \sa #UT_InitData, #UT_SetRtnCode, #UT_Report,
 ** \sa #CFE_TBL_HousekeepingCmd, #UT_SetOSFail
 **
 ******************************************************************************/
@@ -475,7 +475,7 @@ void Test_CFE_TBL_ApiInit(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetRtnCode, #CFE_TBL_Register,
+** \sa #UT_InitData, #UT_SetRtnCode, #CFE_TBL_Register,
 ** \sa #UT_EventIsInHistory, #UT_GetNumEventsSent, #UT_Report, #UT_SetAppID,
 ** \sa #UT_ResetTableRegistry
 **
@@ -497,7 +497,7 @@ void Test_CFE_TBL_Register(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetRtnCode, #CFE_TBL_Share,
+** \sa #UT_InitData, #UT_SetRtnCode, #CFE_TBL_Share,
 ** \sa #UT_EventIsInHistory, #UT_GetNumEventsSent, #UT_Report, #UT_SetAppID,
 ** \sa #CFE_TBL_Unregister, #UT_SetOSFail, #CFE_TBL_ByteSwapUint32,
 ** \sa #UT_SetReadBuffer, #UT_SetReadHeader
@@ -520,7 +520,7 @@ void Test_CFE_TBL_Share(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetAppID, #CFE_TBL_Unregister,
+** \sa #UT_InitData, #UT_SetAppID, #CFE_TBL_Unregister,
 ** \sa #UT_EventIsInHistory, #UT_GetNumEventsSent, #UT_Report
 **
 ******************************************************************************/
@@ -542,7 +542,7 @@ void Test_CFE_TBL_Unregister(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetAppID, #UT_ResetCDS, #CFE_TBL_EarlyInit,
+** \sa #UT_InitData, #UT_SetAppID, #UT_ResetCDS, #CFE_TBL_EarlyInit,
 ** \sa #UT_ResetPoolBufferIndex, #CFE_TBL_Register, #UT_GetNumEventsSent,
 ** \sa #UT_Report, #CFE_TBL_NotifyByMessage
 **
@@ -564,7 +564,7 @@ void Test_CFE_TBL_NotifyByMessage(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetAppID, #UT_ResetTableRegistry,
+** \sa #UT_InitData, #UT_SetAppID, #UT_ResetTableRegistry,
 ** \sa #CFE_TBL_Register, #UT_EventIsInHistory, #UT_GetNumEventsSent,
 ** \sa #UT_Report, #UT_SetOSFail, #CFE_TBL_ByteSwapUint32, #UT_SetReadBuffer,
 ** \sa #UT_SetReadHeader, #UT_SetRtnCode, #CFE_TBL_Load, #CFE_TBL_Share,
@@ -588,7 +588,7 @@ void Test_CFE_TBL_Load(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetAppID, #CFE_TBL_GetAddress,
+** \sa #UT_InitData, #UT_SetAppID, #CFE_TBL_GetAddress,
 ** \sa #UT_GetNumEventsSent, #UT_Report, #UT_SetRtnCode, #CFE_TBL_Unregister
 **
 ******************************************************************************/
@@ -609,7 +609,7 @@ void Test_CFE_TBL_GetAddress(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetAppID, #UT_ResetTableRegistry,
+** \sa #UT_InitData, #UT_SetAppID, #UT_ResetTableRegistry,
 ** \sa #CFE_TBL_Register, #UT_EventIsInHistory, #UT_GetNumEventsSent,
 ** \sa #UT_Report, #CFE_TBL_ReleaseAddress
 **
@@ -631,7 +631,7 @@ void Test_CFE_TBL_ReleaseAddress(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetAppID, #CFE_TBL_Register,
+** \sa #UT_InitData, #UT_SetAppID, #CFE_TBL_Register,
 ** \sa #UT_EventIsInHistory, #UT_GetNumEventsSent, #UT_Report,
 ** #CFE_TBL_GetAddresses
 **
@@ -653,7 +653,7 @@ void Test_CFE_TBL_GetAddresses(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetAppID, #CFE_TBL_ReleaseAddresses,
+** \sa #UT_InitData, #UT_SetAppID, #CFE_TBL_ReleaseAddresses,
 ** \sa #UT_GetNumEventsSent, #UT_Report
 **
 ******************************************************************************/
@@ -673,7 +673,7 @@ void Test_CFE_TBL_ReleaseAddresses(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetAppID, #CFE_TBL_Validate,
+** \sa #UT_InitData, #UT_SetAppID, #CFE_TBL_Validate,
 ** \sa #UT_GetNumEventsSent, #UT_Report
 **
 ******************************************************************************/
@@ -694,7 +694,7 @@ void Test_CFE_TBL_Validate(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #CFE_TBL_Manage, #UT_GetNumEventsSent,
+** \sa #UT_InitData, #CFE_TBL_Manage, #UT_GetNumEventsSent,
 ** \sa #UT_Report, #CFE_TBL_FindTableInRegistry, #CFE_TBL_GetWorkingBuffer,
 ** \sa #UT_SetAppID, #CFE_TBL_Load, #UT_EventIsInHistory, #UT_SetRtnCode,
 **
@@ -716,7 +716,7 @@ void Test_CFE_TBL_Manage(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetAppID, #CFE_TBL_Update,
+** \sa #UT_InitData, #UT_SetAppID, #CFE_TBL_Update,
 ** \sa #UT_EventIsInHistory, #UT_GetNumEventsSent, #UT_Report
 **
 ******************************************************************************/
@@ -737,7 +737,7 @@ void Test_CFE_TBL_Update(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetAppID, #CFE_TBL_GetStatus,
+** \sa #UT_InitData, #UT_SetAppID, #CFE_TBL_GetStatus,
 ** \sa #UT_GetNumEventsSent, #UT_Report
 **
 ******************************************************************************/
@@ -758,7 +758,7 @@ void Test_CFE_TBL_GetStatus(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #
+** \sa #
 **
 ******************************************************************************/
 void Test_CFE_TBL_GetInfo(void);
@@ -778,7 +778,7 @@ void Test_CFE_TBL_GetInfo(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetAppID, #UT_ResetCDS, #CFE_TBL_EarlyInit,
+** \sa #UT_InitData, #UT_SetAppID, #UT_ResetCDS, #CFE_TBL_EarlyInit,
 ** \sa #UT_ResetPoolBufferIndex, #CFE_TBL_Register, #UT_GetNumEventsSent,
 ** \sa #UT_Report, #CFE_TBL_ByteSwapUint32, #UT_SetReadBuffer,
 ** \sa #UT_SetReadHeader, #CFE_TBL_Load, #UT_EventIsInHistory,
@@ -800,7 +800,7 @@ void Test_CFE_TBL_TblMod(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #CFE_TBL_GetWorkingBuffer, #UT_GetNumEventsSent,
+** \sa #UT_InitData, #CFE_TBL_GetWorkingBuffer, #UT_GetNumEventsSent,
 ** \sa #UT_Report, #UT_SetRtnCode, #CFE_TBL_LoadFromFile,
 ** \sa #CFE_TBL_ByteSwapUint32, #UT_SetReadBuffer, #UT_SetReadHeader,
 ** \sa #UT_EventIsInHistory, #CFE_TBL_ReadHeaders, #CFE_TBL_Unregister,

--- a/fsw/cfe-core/unit-test/time_UT.c
+++ b/fsw/cfe-core/unit-test/time_UT.c
@@ -203,7 +203,7 @@ void UtTest_Setup(void)
 {
     /* Initialize unit test */
     UT_Init("time");
-    UT_Text("cFE TIME Unit Test Output File\n\n");
+    UtPrintf("cFE TIME Unit Test Output File\n\n");
 
     UT_ADD_TEST(Test_Main);
     UT_ADD_TEST(Test_Init);
@@ -229,9 +229,7 @@ void UtTest_Setup(void)
 */
 void Test_Main(void)
 {
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Main\n");
-#endif
+    UtPrintf("Begin Test Main");
 
     /* Test successful run through (a pipe read error is expected) */
     UT_InitData();
@@ -264,9 +262,7 @@ void Test_Init(void)
     int16 SubLocalErrCnt = 0;
 #endif
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Init\n");
-#endif
+    UtPrintf("Begin Test Init");
 
     /* Test successful API initialization */
     UT_InitData();
@@ -525,9 +521,7 @@ void Test_GetTime(void)
     const char *expectedSTCF = "1980-001-01:00:00.00000";
     volatile CFE_TIME_ReferenceState_t *RefState;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Get Time\n");
-#endif
+    UtPrintf("Begin Test Get Time");
 
     CFE_TIME_TaskData.LastVersionCounter = 0x1000;
 
@@ -737,9 +731,7 @@ void Test_TimeOp(void)
 {
     CFE_TIME_SysTime_t time1, time2, result, exp_result;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Time Operations\n");
-#endif
+    UtPrintf("Begin Test Time Operations");
 
     /* Initialize to zero time values */
     time1.Subseconds = 0;
@@ -1038,9 +1030,7 @@ void Test_ConvertTime(void)
     const char *expectedSCTime = "1980-001-02:00:08.00000";
 #endif
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Convert Time\n");
-#endif
+    UtPrintf("Begin Test Convert Time");
 
     /* Test MET to SCTF conversion */
     UT_InitData();
@@ -1158,9 +1148,7 @@ void Test_Print(void)
     char testDesc[1+UT_MAX_MESSAGE_LENGTH];
     CFE_TIME_SysTime_t time;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Print\n");
-#endif
+    UtPrintf("Begin Test Print");
 
     /* Test with zero time value */
     UT_InitData();
@@ -1234,9 +1222,7 @@ void Test_RegisterSyncCallbackTrue(void)
 {
     int32   Result;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Register Synch Callback\n");
-#endif
+    UtPrintf("Begin Test Register Synch Callback");
 
     /*
      * One callback per application is allowed; the first should succeed,
@@ -1305,9 +1291,7 @@ void Test_RegisterSyncCallbackTrue(void)
 */
 void Test_ExternalTone(void)
 {
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test External Tone\n");
-#endif
+    UtPrintf("Begin Test External Tone");
 
     UT_InitData();
     UT_SetBSP_Time(123, 0);
@@ -1333,9 +1317,7 @@ void Test_External(void)
     CFE_TIME_SysTime_t settime = {5, 4};
 #endif
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test External Time Set\n");
-#endif
+    UtPrintf("Begin Test External Time Set");
 
 #if (CFE_PLATFORM_TIME_CFG_SRC_MET == true)
     /* Test setting time data from MET using an external source with the clock
@@ -1783,9 +1765,7 @@ void Test_PipeCmds(void)
     uint32 count;
 #endif
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Pipe Commands\n");
-#endif
+    UtPrintf("Begin Test Pipe Commands");
 
     memset(&CmdBuf, 0, sizeof(CmdBuf));
 
@@ -2396,9 +2376,7 @@ void Test_ResetArea(void)
 {
     CFE_TIME_Reference_t Reference;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Reset Area\n");
-#endif
+    UtPrintf("Begin Test Reset Area");
 
     /* Test successfully updating the reset area */
     UT_InitData();
@@ -2500,9 +2478,7 @@ void Test_State(void)
     CFE_TIME_Reference_t Reference;
     volatile CFE_TIME_ReferenceState_t *RefState;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Time State\n");
-#endif
+    UtPrintf("Begin Test Time State");
 
     /* Test determining if the clock state is valid with the server state
      * in "no flywheel"
@@ -2610,9 +2586,7 @@ void Test_GetReference(void)
     CFE_TIME_Reference_t Reference;
     volatile CFE_TIME_ReferenceState_t *RefState;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Get Reference\n");
-#endif
+    UtPrintf("Begin Test Get Reference");
 
     /* Test with local clock rollover */
     UT_InitData();
@@ -2678,9 +2652,7 @@ void Test_Tone(void)
     uint32 MinElapsed = CFE_TIME_TaskData.MinElapsed;
     uint32 MaxElapsed = CFE_TIME_TaskData.MaxElapsed;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Tone\n");
-#endif
+    UtPrintf("Begin Test Tone");
 
     /* Test time at the tone in flywheel mode */
     UT_InitData();
@@ -3215,9 +3187,7 @@ void Test_UnregisterSynchCallback(void)
 
     ut_time_CallbackCalled = 0;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Unregister Callback\n");
-#endif
+    UtPrintf("Begin Test Unregister Callback");
 
     /* Unregister callback function one too many times to test both valid and
      * invalid cases
@@ -3300,9 +3270,7 @@ void Test_CleanUpApp(void)
     uint32 AppIndex;
     uint32 TestAppId;
 
-#ifdef UT_VERBOSE
-    UT_Text("Begin Test Cleanup App\n");
-#endif
+    UtPrintf("Begin Test Cleanup App");
 
     UT_InitData();
     CFE_ES_GetAppID(&TestAppId);

--- a/fsw/cfe-core/unit-test/time_UT.h
+++ b/fsw/cfe-core/unit-test/time_UT.h
@@ -67,7 +67,7 @@
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, CFE_TIME_TaskMain, #UT_Report, #UT_SetRtnCode
+** \sa #UT_InitData, CFE_TIME_TaskMain, #UT_Report, #UT_SetRtnCode
 **
 ******************************************************************************/
 void Test_Main(void);
@@ -87,7 +87,7 @@ void Test_Main(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #CFE_TIME_EarlyInit, #UT_InitData, #UT_Report,
+** \sa #CFE_TIME_EarlyInit, #UT_InitData, #UT_Report,
 ** \sa #CFE_TIME_TaskInit, #UT_SetRtnCode
 **
 ******************************************************************************/
@@ -106,7 +106,7 @@ void Test_Init(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetBSP_Time, #CFE_TIME_Print,
+** \sa #UT_InitData, #UT_SetBSP_Time, #CFE_TIME_Print,
 ** \sa #CFE_TIME_GetMET, #UT_Report, #CFE_TIME_GetMETseconds,
 ** \sa #CFE_TIME_GetMETsubsecs, #CFE_TIME_Micro2SubSecs,
 ** \sa #CFE_TIME_GetLeapSeconds, #CFE_TIME_GetTAI, #CFE_TIME_GetUTC,
@@ -128,7 +128,7 @@ void Test_GetTime(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #CFE_TIME_Add, #UT_Report, #CFE_TIME_Subtract,
+** \sa #UT_InitData, #CFE_TIME_Add, #UT_Report, #CFE_TIME_Subtract,
 ** \sa #CFE_TIME_Compare
 **
 ******************************************************************************/
@@ -147,7 +147,7 @@ void Test_TimeOp(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #CFE_TIME_Print, #CFE_TIME_MET2SCTime,
+** \sa #UT_InitData, #CFE_TIME_Print, #CFE_TIME_MET2SCTime,
 ** \sa #UT_Report, #CFE_TIME_Sub2MicroSecs, #CFE_TIME_Micro2SubSecs
 **
 ******************************************************************************/
@@ -168,7 +168,7 @@ void Test_ConvertTime(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #CFE_TIME_Print, #UT_Report
+** \sa #UT_InitData, #CFE_TIME_Print, #UT_Report
 **
 ******************************************************************************/
 void Test_Print(void);
@@ -211,7 +211,7 @@ int32 ut_time_MyCallbackFunc(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #CFE_TIME_RegisterSynchCallback, #UT_Report
+** \sa #UT_InitData, #CFE_TIME_RegisterSynchCallback, #UT_Report
 **
 ******************************************************************************/
 void Test_RegisterSyncCallback(bool reportResults);
@@ -248,7 +248,7 @@ void Test_RegisterSyncCallbackTrue(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetBSP_Time, #CFE_TIME_ExternalTone,
+** \sa #UT_InitData, #UT_SetBSP_Time, #CFE_TIME_ExternalTone,
 ** \sa #UT_Report
 **
 ******************************************************************************/
@@ -267,7 +267,7 @@ void Test_ExternalTone(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #CFE_TIME_ExternalMET, #UT_Report,
+** \sa #UT_InitData, #CFE_TIME_ExternalMET, #UT_Report,
 ** \sa #CFE_TIME_ExternalGPS, #CFE_TIME_ExternalTime
 **
 ******************************************************************************/
@@ -286,7 +286,7 @@ void Test_External(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SendMsg, #UT_Report, #UT_SetBSP_Time
+** \sa #UT_InitData, #UT_SendMsg, #UT_Report, #UT_SetBSP_Time
 **
 ******************************************************************************/
 void Test_PipeCmds(void);
@@ -304,7 +304,7 @@ void Test_PipeCmds(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetStatusBSPResetArea,
+** \sa #UT_InitData, #UT_SetStatusBSPResetArea,
 ** \sa #CFE_TIME_QueryResetVars, #CFE_TIME_UpdateResetVars, #UT_Report
 **
 ******************************************************************************/
@@ -323,7 +323,7 @@ void Test_ResetArea(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_Report, #CFE_TIME_CalculateState,
+** \sa #UT_InitData, #UT_Report, #CFE_TIME_CalculateState,
 ** \sa #CFE_TIME_SetState, #CFE_TIME_GetStateFlags
 **
 ******************************************************************************/
@@ -342,7 +342,7 @@ void Test_State(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #UT_SetBSP_Time, #CFE_TIME_GetReference,
+** \sa #UT_InitData, #UT_SetBSP_Time, #CFE_TIME_GetReference,
 ** \sa #UT_Report
 **
 ******************************************************************************/
@@ -362,7 +362,7 @@ void Test_GetReference(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #CFE_TIME_SetState, #UT_SetBSP_Time,
+** \sa #UT_InitData, #CFE_TIME_SetState, #UT_SetBSP_Time,
 ** \sa #UT_Report, #CFE_TIME_ToneSend, #CFE_TIME_ToneVerify, CFE_TIME_SetState,
 **
 ******************************************************************************/
@@ -383,7 +383,7 @@ void Test_Tone(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #CFE_TIME_Set1HzAdj, #CFE_TIME_Local1HzISR,
+** \sa #UT_InitData, #CFE_TIME_Set1HzAdj, #CFE_TIME_Local1HzISR,
 ** \sa #UT_Report, #UT_SetBSP_Time, #UT_SetBinSemFail, #CFE_TIME_Local1HzTask,
 ** \sa #CFE_TIME_Tone1HzTask
 **
@@ -403,7 +403,7 @@ void Test_1Hz(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #CFE_TIME_UnregisterSynchCallback, #UT_Report
+** \sa #UT_InitData, #CFE_TIME_UnregisterSynchCallback, #UT_Report
 **
 ******************************************************************************/
 void Test_UnregisterSynchCallback(void);
@@ -421,7 +421,7 @@ void Test_UnregisterSynchCallback(void);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text, #UT_InitData, #Test_RegisterSyncCallback,
+** \sa #UT_InitData, #Test_RegisterSyncCallback,
 ** \sa #CFE_TIME_CleanUpApp, #CFE_TIME_UnregisterSynchCallback, #UT_Report
 **
 ******************************************************************************/

--- a/fsw/cfe-core/unit-test/ut_support.c
+++ b/fsw/cfe-core/unit-test/ut_support.c
@@ -201,14 +201,6 @@ void UT_ResetPoolBufferIndex(void)
 }
 
 /*
-** Output a text string
-*/
-void UT_Text(const char *text)
-{
-    UtPrintf("%s\n", text);
-}
-
-/*
 ** Output single test's pass/fail status
 */
 void UT_Report(const char *file, uint32 line, bool test, const char *fun_name,
@@ -464,7 +456,7 @@ void UT_DisplayPkt(CFE_SB_MsgPtr_t ptr, uint32 size)
         ++BytePtr;
     }
 
-    UT_Text(DisplayMsg);
+    UtPrintf("%s", DisplayMsg);
 }
 
 

--- a/fsw/cfe-core/unit-test/ut_support.h
+++ b/fsw/cfe-core/unit-test/ut_support.h
@@ -32,19 +32,6 @@
 #ifndef _UT_CFE_SUPPORT_H_
 #define _UT_CFE_SUPPORT_H_
 
-/* Compiler flags:
-   - Define UT_SHOW_PASS to display PASSED (and FAILED) test results;
-     undefine to show only FAILED test results
-   - Define UT_VERBOSE to display stub routine messages in unit test
-     log files
-   - Define SOCKET_QUEUE to use Linux socket queue functions; undefine
-     to use an embedded queue replacement
-   - Define CFE_LINUX if compiling under Linux; undefine when compiling
-     on the GHS target
-   - Define OS_USE_EMBEDDED_PRINTF to use the embedded (replacement) printf
-     functions; undefine to use the standard printf library functions
-*/
-
 /*
 ** Includes
 */
@@ -171,9 +158,6 @@ typedef struct
 **        This function must be called prior to executing any of the cFE unit
 **        tests.
 **
-** \par Assumptions, External Events, and Notes:
-**        A log file is written only if CFE_LINUX is defined.
-**
 ** \param[in] subsys  Pointer to subsystem ID character string
 **
 ** \returns
@@ -240,26 +224,6 @@ void UT_ResetPoolBufferIndex(void);
 
 /*****************************************************************************/
 /**
-** \brief Output text string
-**
-** \par Description
-**        Output a text string to the log file or other target.
-**
-** \par Assumptions, External Events, and Notes:
-**        If CFE_LINUX is not defined then a suitable target function for the
-**        text output must be designated.
-**
-** \param[in] text  Pointer to character string to output
-**
-** \returns
-**        This function does not return a value.
-**
-******************************************************************************/
-/* Output text string to log file */
-void UT_Text(const char *text);
-
-/*****************************************************************************/
-/**
 ** \brief Output single test's pass/fail status
 **
 ** \par Description
@@ -279,8 +243,6 @@ void UT_Text(const char *text);
 ** \returns
 **        This function does not return a value.
 **
-** \sa #UT_Text
-**
 ******************************************************************************/
 void UT_Report(const char *file, uint32 line, bool test, const char *fun_name,
 		       const char *info);
@@ -292,13 +254,8 @@ void UT_Report(const char *file, uint32 line, bool test, const char *fun_name,
 ** \par Description
 **        Output total number of tests passed and failed.
 **
-** \par Assumptions, External Events, and Notes:
-**        If CFE_LINUX is defined then the output is also sent to the console
-**
 ** \returns
 **        This function does not return a value.
-**
-** \sa #UT_Text
 **
 ******************************************************************************/
 void UT_ReportFailures(void);

--- a/modules/msg/unit-test-coverage/msg_UT.c
+++ b/modules/msg/unit-test-coverage/msg_UT.c
@@ -42,7 +42,7 @@
 void UtTest_Setup(void)
 {
     UT_Init("msg");
-    UT_Text("Message header coverage test...");
+    UtPrintf("Message header coverage test...");
 
     UT_ADD_TEST(Test_MSG_Init);
     Test_MSG_CCSDSPri();

--- a/modules/msg/unit-test-coverage/test_cfe_msg_ccsdsext.c
+++ b/modules/msg/unit-test-coverage/test_cfe_msg_ccsdsext.c
@@ -68,7 +68,7 @@ void Test_MSG_Init_Ext(void)
     /* Set up return */
     UT_SetDeferredRetcode(UT_KEY(CFE_PSP_GetSpacecraftId), 1, sc_id);
 
-    UT_Text("Set to all F's, msgid value = 0, and run with clearing");
+    UtPrintf("Set to all F's, msgid value = 0, and run with clearing");
     memset(&msg, 0xFF, sizeof(msg));
     msgidval_exp = 0;
     ASSERT_EQ(CFE_MSG_Init(&msg, CFE_SB_ValueToMsgId(msgidval_exp), sizeof(msg), true), CFE_SUCCESS);
@@ -100,7 +100,7 @@ void Test_MSG_Init_Ext(void)
     /* Confirm the rest of the fields not already explicitly checked */
     ASSERT_EQ(Test_MSG_Ext_NotZero(&msg) & ~(MSG_EDSVER_FLAG | MSG_ENDIAN_FLAG | MSG_SUBSYS_FLAG | MSG_SYSTEM_FLAG), 0);
 
-    UT_Text("Set to all 0, max msgid value, and run without clearing");
+    UtPrintf("Set to all 0, max msgid value, and run without clearing");
     memset(&msg, 0, sizeof(msg));
     msgidval_exp = CFE_PLATFORM_SB_HIGHEST_VALID_MSGID;
     ASSERT_EQ(CFE_MSG_Init(&msg, CFE_SB_ValueToMsgId(msgidval_exp), sizeof(msg), false), CFE_SUCCESS);
@@ -124,7 +124,7 @@ void Test_MSG_EDSVersion(void)
     CFE_MSG_EDSVersion_t actual  = TEST_EDSVER_MAX;
     int                  i;
 
-    UT_Text("Bad parameter tests, Null pointers and invalid (max valid + 1, max)");
+    UtPrintf("Bad parameter tests, Null pointers and invalid (max valid + 1, max)");
     memset(&msg, 0, sizeof(msg));
     ASSERT_EQ(CFE_MSG_GetEDSVersion(NULL, &actual), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(actual, TEST_EDSVER_MAX);
@@ -136,7 +136,7 @@ void Test_MSG_EDSVersion(void)
     ASSERT_EQ(CFE_MSG_SetEDSVersion(&msg, 0xFFFF), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(Test_MSG_NotZero(&msg), 0);
 
-    UT_Text("Set to all F's, various valid inputs");
+    UtPrintf("Set to all F's, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&msg, 0xFF, sizeof(msg));
@@ -156,7 +156,7 @@ void Test_MSG_EDSVersion(void)
         }
     }
 
-    UT_Text("Set to all 0, various valid inputs");
+    UtPrintf("Set to all 0, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&msg, 0, sizeof(msg));
@@ -184,7 +184,7 @@ void Test_MSG_Endian(void)
     CFE_MSG_Endian_t  actual  = 0;
     int               i;
 
-    UT_Text("Bad parameter tests, Null pointers and invalid (CFE_MSG_Endian_Invalid, CFE_MSG_Endian_Little + 1");
+    UtPrintf("Bad parameter tests, Null pointers and invalid (CFE_MSG_Endian_Invalid, CFE_MSG_Endian_Little + 1");
     memset(&msg, 0, sizeof(msg));
     ASSERT_EQ(CFE_MSG_GetEndian(NULL, &actual), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(actual, 0);
@@ -196,7 +196,7 @@ void Test_MSG_Endian(void)
     ASSERT_EQ(CFE_MSG_SetEndian(&msg, CFE_MSG_Endian_Little + 1), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(Test_MSG_NotZero(&msg), 0);
 
-    UT_Text("Set to all F's, various valid inputs");
+    UtPrintf("Set to all F's, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&msg, 0xFF, sizeof(msg));
@@ -216,7 +216,7 @@ void Test_MSG_Endian(void)
         }
     }
 
-    UT_Text("Set to all 0, various valid inputs");
+    UtPrintf("Set to all 0, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&msg, 0, sizeof(msg));
@@ -244,7 +244,7 @@ void Test_MSG_PlaybackFlag(void)
     CFE_MSG_PlaybackFlag_t actual  = 0;
     int                    i;
 
-    UT_Text("Bad parameter tests, Null pointers and invalid (CFE_MSG_PlayFlag_Invalid, CFE_MSG_PlayFlag_Playback + 1");
+    UtPrintf("Bad parameter tests, Null pointers and invalid (CFE_MSG_PlayFlag_Invalid, CFE_MSG_PlayFlag_Playback + 1");
     memset(&msg, 0, sizeof(msg));
     ASSERT_EQ(CFE_MSG_GetPlaybackFlag(NULL, &actual), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(actual, 0);
@@ -256,7 +256,7 @@ void Test_MSG_PlaybackFlag(void)
     ASSERT_EQ(CFE_MSG_SetPlaybackFlag(&msg, CFE_MSG_PlayFlag_Playback + 1), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(Test_MSG_NotZero(&msg), 0);
 
-    UT_Text("Set to all F's, various valid inputs");
+    UtPrintf("Set to all F's, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&msg, 0xFF, sizeof(msg));
@@ -276,7 +276,7 @@ void Test_MSG_PlaybackFlag(void)
         }
     }
 
-    UT_Text("Set to all 0, various valid inputs");
+    UtPrintf("Set to all 0, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&msg, 0, sizeof(msg));
@@ -304,7 +304,7 @@ void Test_MSG_Subsystem(void)
     CFE_MSG_Subsystem_t actual  = TEST_SUBSYS_MAX;
     int                 i;
 
-    UT_Text("Bad parameter tests, Null pointers and invalid (max valid + 1, max)");
+    UtPrintf("Bad parameter tests, Null pointers and invalid (max valid + 1, max)");
     memset(&msg, 0, sizeof(msg));
     ASSERT_EQ(CFE_MSG_GetSubsystem(NULL, &actual), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(actual, TEST_SUBSYS_MAX);
@@ -316,7 +316,7 @@ void Test_MSG_Subsystem(void)
     ASSERT_EQ(CFE_MSG_SetSubsystem(&msg, 0xFFFF), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(Test_MSG_NotZero(&msg), 0);
 
-    UT_Text("Set to all F's, various valid inputs");
+    UtPrintf("Set to all F's, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&msg, 0xFF, sizeof(msg));
@@ -336,7 +336,7 @@ void Test_MSG_Subsystem(void)
         }
     }
 
-    UT_Text("Set to all 0, various valid inputs");
+    UtPrintf("Set to all 0, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&msg, 0, sizeof(msg));
@@ -364,7 +364,7 @@ void Test_MSG_System(void)
     CFE_MSG_ApId_t    actual  = TEST_SYSTEM_MAX;
     int               i;
 
-    UT_Text("Bad parameter tests, Null pointers");
+    UtPrintf("Bad parameter tests, Null pointers");
     memset(&msg, 0, sizeof(msg));
     ASSERT_EQ(CFE_MSG_GetSystem(NULL, &actual), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(actual, TEST_SYSTEM_MAX);
@@ -373,7 +373,7 @@ void Test_MSG_System(void)
     ASSERT_EQ(CFE_MSG_SetSystem(NULL, input[0]), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(Test_MSG_NotZero(&msg), 0);
 
-    UT_Text("Set to all F's, various valid inputs");
+    UtPrintf("Set to all F's, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&msg, 0xFF, sizeof(msg));
@@ -393,7 +393,7 @@ void Test_MSG_System(void)
         }
     }
 
-    UT_Text("Set to all 0, various valid inputs");
+    UtPrintf("Set to all 0, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&msg, 0, sizeof(msg));

--- a/modules/msg/unit-test-coverage/test_cfe_msg_ccsdspri.c
+++ b/modules/msg/unit-test-coverage/test_cfe_msg_ccsdspri.c
@@ -48,7 +48,7 @@ void Test_MSG_Size(void)
     CFE_MSG_Size_t    actual  = 0;
     int               i;
 
-    UT_Text("Bad parameter tests, Null pointers and invalid (0, min valid - 1, max valid + 1, max)");
+    UtPrintf("Bad parameter tests, Null pointers and invalid (0, min valid - 1, max valid + 1, max)");
     memset(&msg, 0, sizeof(msg));
     ASSERT_EQ(CFE_MSG_GetSize(NULL, &actual), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(actual, 0);
@@ -64,7 +64,7 @@ void Test_MSG_Size(void)
     ASSERT_EQ(CFE_MSG_SetSize(&msg, 0xFFFFFFFF), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(Test_MSG_NotZero(&msg), 0);
 
-    UT_Text("Set to all F's, various valid inputs");
+    UtPrintf("Set to all F's, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&msg, 0xFF, sizeof(msg));
@@ -84,7 +84,7 @@ void Test_MSG_Size(void)
         }
     }
 
-    UT_Text("Set to all 0, various valid inputs");
+    UtPrintf("Set to all 0, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&msg, 0, sizeof(msg));
@@ -112,7 +112,7 @@ void Test_MSG_Type(void)
     CFE_MSG_Type_t    actual  = 0;
     int               i;
 
-    UT_Text("Bad parameter tests, Null pointers and invalid (CFE_MSG_Type_Invalid, CFE_MSG_Type_Tlm + 1");
+    UtPrintf("Bad parameter tests, Null pointers and invalid (CFE_MSG_Type_Invalid, CFE_MSG_Type_Tlm + 1");
     memset(&msg, 0, sizeof(msg));
     ASSERT_EQ(CFE_MSG_GetType(NULL, &actual), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(actual, 0);
@@ -124,7 +124,7 @@ void Test_MSG_Type(void)
     ASSERT_EQ(CFE_MSG_SetType(&msg, CFE_MSG_Type_Tlm + 1), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(Test_MSG_NotZero(&msg), 0);
 
-    UT_Text("Set to all F's, various valid inputs");
+    UtPrintf("Set to all F's, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&msg, 0xFF, sizeof(msg));
@@ -144,7 +144,7 @@ void Test_MSG_Type(void)
         }
     }
 
-    UT_Text("Set to all 0, various valid inputs");
+    UtPrintf("Set to all 0, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&msg, 0, sizeof(msg));
@@ -172,7 +172,7 @@ void Test_MSG_HeaderVersion(void)
     CFE_MSG_HeaderVersion_t actual  = TEST_CCSDSVER_MAX;
     int                     i;
 
-    UT_Text("Bad parameter tests, Null pointers and invalid (max valid + 1, max)");
+    UtPrintf("Bad parameter tests, Null pointers and invalid (max valid + 1, max)");
     memset(&msg, 0, sizeof(msg));
     ASSERT_EQ(CFE_MSG_GetHeaderVersion(NULL, &actual), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(actual, TEST_CCSDSVER_MAX);
@@ -184,7 +184,7 @@ void Test_MSG_HeaderVersion(void)
     ASSERT_EQ(CFE_MSG_SetHeaderVersion(&msg, 0xFFFF), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(Test_MSG_NotZero(&msg), 0);
 
-    UT_Text("Set to all F's, various valid inputs");
+    UtPrintf("Set to all F's, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&msg, 0xFF, sizeof(msg));
@@ -204,7 +204,7 @@ void Test_MSG_HeaderVersion(void)
         }
     }
 
-    UT_Text("Set to all 0, various valid inputs");
+    UtPrintf("Set to all 0, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&msg, 0, sizeof(msg));
@@ -230,7 +230,7 @@ void Test_MSG_HasSecondaryHeader(void)
     CFE_MSG_Message_t msg;
     bool              actual = true;
 
-    UT_Text("Bad parameter tests, Null pointers");
+    UtPrintf("Bad parameter tests, Null pointers");
     memset(&msg, 0, sizeof(msg));
     ASSERT_EQ(CFE_MSG_GetHasSecondaryHeader(NULL, &actual), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(actual, true);
@@ -238,7 +238,7 @@ void Test_MSG_HasSecondaryHeader(void)
     ASSERT_EQ(Test_MSG_NotZero(&msg), 0);
     ASSERT_EQ(CFE_MSG_SetHasSecondaryHeader(NULL, false), CFE_MSG_BAD_ARGUMENT);
 
-    UT_Text("Set to all F's, true and false inputs");
+    UtPrintf("Set to all F's, true and false inputs");
     memset(&msg, 0xFF, sizeof(msg));
     ASSERT_EQ(CFE_MSG_GetHasSecondaryHeader(&msg, &actual), CFE_SUCCESS);
     ASSERT_EQ(actual, true);
@@ -255,7 +255,7 @@ void Test_MSG_HasSecondaryHeader(void)
     ASSERT_EQ(actual, false);
     ASSERT_EQ(Test_MSG_NotF(&msg), MSG_HASSEC_FLAG);
 
-    UT_Text("Set to all 0, true and false inputs");
+    UtPrintf("Set to all 0, true and false inputs");
     memset(&msg, 0, sizeof(msg));
     ASSERT_EQ(CFE_MSG_GetHasSecondaryHeader(&msg, &actual), CFE_SUCCESS);
     ASSERT_EQ(actual, false);
@@ -280,7 +280,7 @@ void Test_MSG_ApId(void)
     CFE_MSG_ApId_t    actual  = TEST_APID_MAX;
     int               i;
 
-    UT_Text("Bad parameter tests, Null pointers and invalid (max valid + 1, max)");
+    UtPrintf("Bad parameter tests, Null pointers and invalid (max valid + 1, max)");
     memset(&msg, 0, sizeof(msg));
     ASSERT_EQ(CFE_MSG_GetApId(NULL, &actual), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(actual, TEST_APID_MAX);
@@ -292,7 +292,7 @@ void Test_MSG_ApId(void)
     ASSERT_EQ(CFE_MSG_SetApId(&msg, 0xFFFF), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(Test_MSG_NotZero(&msg), 0);
 
-    UT_Text("Set to all F's, various valid inputs");
+    UtPrintf("Set to all F's, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&msg, 0xFF, sizeof(msg));
@@ -312,7 +312,7 @@ void Test_MSG_ApId(void)
         }
     }
 
-    UT_Text("Set to all 0, various valid inputs");
+    UtPrintf("Set to all 0, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&msg, 0, sizeof(msg));
@@ -341,7 +341,7 @@ void Test_MSG_SegmentationFlag(void)
     CFE_MSG_SegmentationFlag_t actual  = CFE_MSG_SegFlag_Invalid;
     int                        i;
 
-    UT_Text("Bad parameter tests, Null pointers and invalid (*_Invalid, max valid + 1");
+    UtPrintf("Bad parameter tests, Null pointers and invalid (*_Invalid, max valid + 1");
     memset(&msg, 0, sizeof(msg));
     ASSERT_EQ(CFE_MSG_GetSegmentationFlag(NULL, &actual), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(actual, CFE_MSG_SegFlag_Invalid);
@@ -353,7 +353,7 @@ void Test_MSG_SegmentationFlag(void)
     ASSERT_EQ(CFE_MSG_SetSegmentationFlag(&msg, CFE_MSG_SegFlag_Unsegmented + 1), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(Test_MSG_NotZero(&msg), 0);
 
-    UT_Text("Set to all F's, various valid inputs");
+    UtPrintf("Set to all F's, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&msg, 0xFF, sizeof(msg));
@@ -373,7 +373,7 @@ void Test_MSG_SegmentationFlag(void)
         }
     }
 
-    UT_Text("Set to all 0, various valid inputs");
+    UtPrintf("Set to all 0, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&msg, 0, sizeof(msg));
@@ -401,7 +401,7 @@ void Test_MSG_SequenceCount(void)
     CFE_MSG_ApId_t    actual  = TEST_SEQUENCE_MAX;
     int               i;
 
-    UT_Text("Bad parameter tests, Null pointers and invalid (max valid + 1, max)");
+    UtPrintf("Bad parameter tests, Null pointers and invalid (max valid + 1, max)");
     memset(&msg, 0, sizeof(msg));
     ASSERT_EQ(CFE_MSG_GetSequenceCount(NULL, &actual), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(actual, TEST_SEQUENCE_MAX);
@@ -413,7 +413,7 @@ void Test_MSG_SequenceCount(void)
     ASSERT_EQ(CFE_MSG_SetSequenceCount(&msg, 0xFFFF), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(Test_MSG_NotZero(&msg), 0);
 
-    UT_Text("Set to all F's, various valid inputs");
+    UtPrintf("Set to all F's, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&msg, 0xFF, sizeof(msg));
@@ -433,7 +433,7 @@ void Test_MSG_SequenceCount(void)
         }
     }
 
-    UT_Text("Set to all 0, various valid inputs");
+    UtPrintf("Set to all 0, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&msg, 0, sizeof(msg));

--- a/modules/msg/unit-test-coverage/test_cfe_msg_checksum.c
+++ b/modules/msg/unit-test-coverage/test_cfe_msg_checksum.c
@@ -40,7 +40,7 @@ void Test_MSG_Checksum(void)
     CFE_MSG_Message_t *msgptr = (CFE_MSG_Message_t *)&cmd;
     bool               actual;
 
-    UT_Text("Bad parameter tests, Null pointers");
+    UtPrintf("Bad parameter tests, Null pointers");
     memset(&cmd, 0, sizeof(cmd));
     actual = true;
     ASSERT_EQ(CFE_MSG_GenerateChecksum(NULL), CFE_MSG_BAD_ARGUMENT);
@@ -49,14 +49,14 @@ void Test_MSG_Checksum(void)
     ASSERT_EQ(CFE_MSG_ValidateChecksum(msgptr, NULL), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(Test_MSG_NotZero(msgptr), 0);
 
-    UT_Text("Bad message, no secondary header");
+    UtPrintf("Bad message, no secondary header");
     ASSERT_EQ(CFE_MSG_SetType(msgptr, CFE_MSG_Type_Cmd), CFE_SUCCESS);
     ASSERT_EQ(CFE_MSG_ValidateChecksum(msgptr, &actual), CFE_MSG_WRONG_MSG_TYPE);
     ASSERT_EQ(actual, true);
     ASSERT_EQ(CFE_MSG_GenerateChecksum(msgptr), CFE_MSG_WRONG_MSG_TYPE);
     ASSERT_EQ(Test_MSG_NotZero(msgptr), MSG_TYPE_FLAG);
 
-    UT_Text("Bad message, wrong type (telemetry)");
+    UtPrintf("Bad message, wrong type (telemetry)");
     ASSERT_EQ(CFE_MSG_SetType(msgptr, CFE_MSG_Type_Tlm), CFE_SUCCESS);
     ASSERT_EQ(CFE_MSG_SetHasSecondaryHeader(msgptr, true), CFE_SUCCESS);
     ASSERT_EQ(CFE_MSG_ValidateChecksum(msgptr, &actual), CFE_MSG_WRONG_MSG_TYPE);
@@ -64,7 +64,7 @@ void Test_MSG_Checksum(void)
     ASSERT_EQ(CFE_MSG_GenerateChecksum(msgptr), CFE_MSG_WRONG_MSG_TYPE);
     ASSERT_EQ(Test_MSG_NotZero(msgptr), MSG_HASSEC_FLAG);
 
-    UT_Text("Set to all F's, validate/generate/validate");
+    UtPrintf("Set to all F's, validate/generate/validate");
     memset(&cmd, 0xFF, sizeof(cmd));
     ASSERT_EQ(CFE_MSG_SetSize(msgptr, sizeof(cmd)), CFE_SUCCESS);
     ASSERT_EQ(CFE_MSG_ValidateChecksum(msgptr, &actual), CFE_SUCCESS);
@@ -75,7 +75,7 @@ void Test_MSG_Checksum(void)
     ASSERT_EQ(actual, true);
     ASSERT_EQ(Test_MSG_NotF(msgptr), MSG_LENGTH_FLAG);
 
-    UT_Text("Set to all 0 except secheader and type, validate/generate/validate");
+    UtPrintf("Set to all 0 except secheader and type, validate/generate/validate");
     memset(&cmd, 0, sizeof(cmd));
     ASSERT_EQ(CFE_MSG_SetSize(msgptr, sizeof(cmd)), CFE_SUCCESS);
     ASSERT_EQ(CFE_MSG_SetType(msgptr, CFE_MSG_Type_Cmd), CFE_SUCCESS);

--- a/modules/msg/unit-test-coverage/test_cfe_msg_fc.c
+++ b/modules/msg/unit-test-coverage/test_cfe_msg_fc.c
@@ -47,7 +47,7 @@ void Test_MSG_FcnCode(void)
     CFE_MSG_FcnCode_t  actual  = TEST_FCNCODE_MAX;
     int                i;
 
-    UT_Text("Bad parameter tests, Null pointers, invalid (max valid + 1, max)");
+    UtPrintf("Bad parameter tests, Null pointers, invalid (max valid + 1, max)");
     memset(&cmd, 0, sizeof(cmd));
     ASSERT_EQ(CFE_MSG_GetFcnCode(NULL, &actual), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(actual, TEST_FCNCODE_MAX);
@@ -59,14 +59,14 @@ void Test_MSG_FcnCode(void)
     ASSERT_EQ(CFE_MSG_SetFcnCode(msgptr, 0xFFFF), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(Test_MSG_NotZero(msgptr), 0);
 
-    UT_Text("Bad message, no secondary header");
+    UtPrintf("Bad message, no secondary header");
     ASSERT_EQ(CFE_MSG_SetType(msgptr, CFE_MSG_Type_Cmd), CFE_SUCCESS);
     ASSERT_EQ(CFE_MSG_GetFcnCode(msgptr, &actual), CFE_MSG_WRONG_MSG_TYPE);
     ASSERT_EQ(actual, 0);
     ASSERT_EQ(CFE_MSG_SetFcnCode(msgptr, 0), CFE_MSG_WRONG_MSG_TYPE);
     ASSERT_EQ(Test_MSG_NotZero(msgptr), MSG_TYPE_FLAG);
 
-    UT_Text("Bad message, wrong type (telemetry)");
+    UtPrintf("Bad message, wrong type (telemetry)");
     memset(&cmd, 0, sizeof(cmd));
     actual = TEST_FCNCODE_MAX;
     ASSERT_EQ(CFE_MSG_SetHasSecondaryHeader(msgptr, true), CFE_SUCCESS);
@@ -75,7 +75,7 @@ void Test_MSG_FcnCode(void)
     ASSERT_EQ(CFE_MSG_SetFcnCode(msgptr, 0), CFE_MSG_WRONG_MSG_TYPE);
     ASSERT_EQ(Test_MSG_NotZero(msgptr), MSG_HASSEC_FLAG);
 
-    UT_Text("Set to all F's, various valid inputs");
+    UtPrintf("Set to all F's, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&cmd, 0xFF, sizeof(cmd));
@@ -88,7 +88,7 @@ void Test_MSG_FcnCode(void)
         ASSERT_EQ(Test_MSG_NotF(msgptr), 0);
     }
 
-    UT_Text("Set to all 0, various valid inputs");
+    UtPrintf("Set to all 0, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&cmd, 0, sizeof(cmd));

--- a/modules/msg/unit-test-coverage/test_cfe_msg_init.c
+++ b/modules/msg/unit-test-coverage/test_cfe_msg_init.c
@@ -54,7 +54,7 @@ void Test_MSG_Init(void)
     bool                       hassec;
     bool                       is_v1;
 
-    UT_Text("Bad parameter tests, Null pointer, invalid size, invalid msgid");
+    UtPrintf("Bad parameter tests, Null pointer, invalid size, invalid msgid");
     memset(&msg, 0, sizeof(msg));
     ASSERT_EQ(CFE_MSG_Init(NULL, CFE_SB_ValueToMsgId(0), sizeof(msg), false), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(CFE_MSG_Init(&msg, CFE_SB_ValueToMsgId(0), 0, false), CFE_MSG_BAD_ARGUMENT);
@@ -63,7 +63,7 @@ void Test_MSG_Init(void)
     ASSERT_EQ(CFE_MSG_Init(&msg, CFE_SB_ValueToMsgId(-1), sizeof(msg), false), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(Test_MSG_NotZero(&msg), 0);
 
-    UT_Text("Set to all F's, msgid value = 0, and run without clearing");
+    UtPrintf("Set to all F's, msgid value = 0, and run without clearing");
     memset(&msg, 0xFF, sizeof(msg));
     msgidval_exp = 0;
     ASSERT_EQ(CFE_MSG_Init(&msg, CFE_SB_ValueToMsgId(msgidval_exp), sizeof(msg), false), CFE_SUCCESS);
@@ -83,7 +83,7 @@ void Test_MSG_Init(void)
     ASSERT_EQ(CFE_MSG_GetSize(&msg, &size), CFE_SUCCESS);
     ASSERT_EQ(size, sizeof(msg));
 
-    UT_Text("Set to all F's, msgid value = 0, and run with clearing");
+    UtPrintf("Set to all F's, msgid value = 0, and run with clearing");
     memset(&msg, 0xFF, sizeof(msg));
     msgidval_exp = 0;
 
@@ -116,7 +116,7 @@ void Test_MSG_Init(void)
     ASSERT_EQ(Test_MSG_Pri_NotZero(&msg) & ~(MSG_APID_FLAG | MSG_HDRVER_FLAG | MSG_HASSEC_FLAG),
               MSG_LENGTH_FLAG | MSG_SEGMENT_FLAG);
 
-    UT_Text("Set to all 0, max msgid value, and run without clearing");
+    UtPrintf("Set to all 0, max msgid value, and run without clearing");
     memset(&msg, 0, sizeof(msg));
     msgidval_exp = CFE_PLATFORM_SB_HIGHEST_VALID_MSGID;
     ASSERT_EQ(CFE_MSG_Init(&msg, CFE_SB_ValueToMsgId(msgidval_exp), sizeof(msg), false), CFE_SUCCESS);

--- a/modules/msg/unit-test-coverage/test_cfe_msg_msgid_shared.c
+++ b/modules/msg/unit-test-coverage/test_cfe_msg_msgid_shared.c
@@ -40,12 +40,12 @@ void Test_MSG_GetTypeFromMsgId(void)
     CFE_SB_MsgId_t    msgid  = CFE_SB_ValueToMsgId(0);
     CFE_MSG_Type_t    actual = CFE_MSG_Type_Invalid;
 
-    UT_Text("Bad parameter tests, Null pointer");
+    UtPrintf("Bad parameter tests, Null pointer");
     memset(&msg, 0, sizeof(msg));
     ASSERT_EQ(CFE_MSG_GetTypeFromMsgId(msgid, NULL), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(Test_MSG_NotZero(&msg), 0);
 
-    UT_Text("Set to all F's, test cmd and tlm");
+    UtPrintf("Set to all F's, test cmd and tlm");
     memset(&msg, 0xFF, sizeof(msg));
     ASSERT_EQ(CFE_MSG_SetMsgId(&msg, CFE_SB_ValueToMsgId(CFE_PLATFORM_SB_HIGHEST_VALID_MSGID)), CFE_SUCCESS);
     ASSERT_EQ(CFE_MSG_SetType(&msg, CFE_MSG_Type_Tlm), CFE_SUCCESS);
@@ -58,7 +58,7 @@ void Test_MSG_GetTypeFromMsgId(void)
     ASSERT_EQ(CFE_MSG_GetTypeFromMsgId(msgid, &actual), CFE_SUCCESS);
     ASSERT_EQ(actual, CFE_MSG_Type_Cmd);
 
-    UT_Text("Set to all 0, test cmd and tlm");
+    UtPrintf("Set to all 0, test cmd and tlm");
     ASSERT_EQ(CFE_MSG_SetType(&msg, CFE_MSG_Type_Cmd), CFE_SUCCESS);
     ASSERT_EQ(CFE_MSG_GetMsgId(&msg, &msgid), CFE_SUCCESS);
     ASSERT_EQ(CFE_MSG_GetTypeFromMsgId(msgid, &actual), CFE_SUCCESS);

--- a/modules/msg/unit-test-coverage/test_cfe_msg_msgid_v1.c
+++ b/modules/msg/unit-test-coverage/test_cfe_msg_msgid_v1.c
@@ -41,7 +41,7 @@ void Test_MSG_MsgId(void)
     CFE_MSG_ApId_t    apid;
     bool              hassec;
 
-    UT_Text("Bad parameter tests, Null pointers and invalid (max valid + 1)");
+    UtPrintf("Bad parameter tests, Null pointers and invalid (max valid + 1)");
     memset(&msg, 0, sizeof(msg));
     ASSERT_EQ(CFE_MSG_GetMsgId(NULL, &msgid), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(CFE_SB_MsgIdToValue(msgid), 1);
@@ -55,7 +55,7 @@ void Test_MSG_MsgId(void)
     ASSERT_EQ(CFE_MSG_SetMsgId(&msg, 0xFFFF), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(Test_MSG_NotZero(&msg), 0);
 
-    UT_Text("Set msg to all F's, set msgid to 0 and verify");
+    UtPrintf("Set msg to all F's, set msgid to 0 and verify");
     memset(&msg, 0xFF, sizeof(msg));
     ASSERT_EQ(CFE_MSG_GetMsgId(&msg, &msgid), CFE_SUCCESS);
     ASSERT_EQ(CFE_SB_MsgIdToValue(msgid), 0xFFFF);
@@ -65,7 +65,7 @@ void Test_MSG_MsgId(void)
     ASSERT_EQ(CFE_SB_MsgIdToValue(msgid), 0);
     ASSERT_EQ(Test_MSG_NotF(&msg), MSG_HDRVER_FLAG | MSG_APID_FLAG | MSG_TYPE_FLAG | MSG_HASSEC_FLAG);
 
-    UT_Text("Set msg to all 0, set msgid to max and verify");
+    UtPrintf("Set msg to all 0, set msgid to max and verify");
     memset(&msg, 0, sizeof(msg));
     ASSERT_EQ(CFE_MSG_GetMsgId(&msg, &msgid), CFE_SUCCESS);
     ASSERT_EQ(CFE_SB_MsgIdToValue(msgid), 0);
@@ -81,21 +81,21 @@ void Test_MSG_MsgId(void)
     ASSERT_EQ(CFE_MSG_GetHasSecondaryHeader(&msg, &hassec), CFE_SUCCESS);
     ASSERT_EQ(hassec, true);
 
-    UT_Text("Set ApId msgid bits only and verify");
+    UtPrintf("Set ApId msgid bits only and verify");
     ASSERT_EQ(CFE_MSG_SetMsgId(&msg, CFE_SB_ValueToMsgId(TEST_MAX_APID)), CFE_SUCCESS);
     ASSERT_EQ(CFE_MSG_GetMsgId(&msg, &msgid), CFE_SUCCESS);
     ASSERT_EQ(Test_MSG_NotZero(&msg), MSG_APID_FLAG);
     ASSERT_EQ(CFE_MSG_GetApId(&msg, &apid), CFE_SUCCESS);
     ASSERT_EQ(apid, TEST_MAX_APID);
 
-    UT_Text("Set has secondary header bit only and verify");
+    UtPrintf("Set has secondary header bit only and verify");
     ASSERT_EQ(CFE_MSG_SetMsgId(&msg, CFE_SB_ValueToMsgId(0x0800)), CFE_SUCCESS);
     ASSERT_EQ(CFE_MSG_GetMsgId(&msg, &msgid), CFE_SUCCESS);
     ASSERT_EQ(Test_MSG_NotZero(&msg), MSG_HASSEC_FLAG);
     ASSERT_EQ(CFE_MSG_GetHasSecondaryHeader(&msg, &hassec), CFE_SUCCESS);
     ASSERT_EQ(hassec, true);
 
-    UT_Text("Set type msgid bit only and verify");
+    UtPrintf("Set type msgid bit only and verify");
     ASSERT_EQ(CFE_MSG_SetMsgId(&msg, CFE_SB_ValueToMsgId(0x1000)), CFE_SUCCESS);
     ASSERT_EQ(CFE_MSG_GetMsgId(&msg, &msgid), CFE_SUCCESS);
     ASSERT_EQ(Test_MSG_NotZero(&msg), MSG_TYPE_FLAG);

--- a/modules/msg/unit-test-coverage/test_cfe_msg_msgid_v2.c
+++ b/modules/msg/unit-test-coverage/test_cfe_msg_msgid_v2.c
@@ -49,7 +49,7 @@ void Test_MSG_MsgId(void)
         local_subsys_flag = MSG_SUBSYS_FLAG;
     }
 
-    UT_Text("Bad parameter tests, Null pointers and invalid (max valid + 1)");
+    UtPrintf("Bad parameter tests, Null pointers and invalid (max valid + 1)");
     memset(&msg, 0, sizeof(msg));
     ASSERT_EQ(CFE_MSG_GetMsgId(NULL, &msgid), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(CFE_SB_MsgIdToValue(msgid), 1);
@@ -63,7 +63,7 @@ void Test_MSG_MsgId(void)
     ASSERT_EQ(CFE_MSG_SetMsgId(&msg, 0xFFFFFFFF), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(Test_MSG_NotZero(&msg), 0);
 
-    UT_Text("Set msg to all F's, set msgid to 0 and verify");
+    UtPrintf("Set msg to all F's, set msgid to 0 and verify");
     memset(&msg, 0xFF, sizeof(msg));
     ASSERT_EQ(CFE_MSG_GetMsgId(&msg, &msgid), CFE_SUCCESS);
     ASSERT_EQ(CFE_SB_MsgIdToValue(msgid), 0xFFFF);
@@ -73,7 +73,7 @@ void Test_MSG_MsgId(void)
     ASSERT_EQ(CFE_SB_MsgIdToValue(msgid), 0);
     ASSERT_EQ(Test_MSG_NotF(&msg), MSG_APID_FLAG | MSG_TYPE_FLAG | local_subsys_flag);
 
-    UT_Text("Set msg to all 0, set msgid to max and verify");
+    UtPrintf("Set msg to all 0, set msgid to max and verify");
     memset(&msg, 0, sizeof(msg));
     ASSERT_EQ(CFE_MSG_GetMsgId(&msg, &msgid), CFE_SUCCESS);
     ASSERT_EQ(CFE_SB_MsgIdToValue(msgid), 0);
@@ -91,21 +91,21 @@ void Test_MSG_MsgId(void)
         ASSERT_EQ(subsystem, CFE_PLATFORM_SB_HIGHEST_VALID_MSGID >> 8);
     }
 
-    UT_Text("Set ApId msgid bits only and verify");
+    UtPrintf("Set ApId msgid bits only and verify");
     ASSERT_EQ(CFE_MSG_SetMsgId(&msg, CFE_SB_ValueToMsgId(0x007F)), CFE_SUCCESS);
     ASSERT_EQ(CFE_MSG_GetMsgId(&msg, &msgid), CFE_SUCCESS);
     ASSERT_EQ(Test_MSG_NotZero(&msg), MSG_APID_FLAG);
     ASSERT_EQ(CFE_MSG_GetApId(&msg, &apid), CFE_SUCCESS);
     ASSERT_EQ(apid, 0x007F);
 
-    UT_Text("Set type msgid bit only and verify");
+    UtPrintf("Set type msgid bit only and verify");
     ASSERT_EQ(CFE_MSG_SetMsgId(&msg, CFE_SB_ValueToMsgId(0x0080)), CFE_SUCCESS);
     ASSERT_EQ(CFE_MSG_GetMsgId(&msg, &msgid), CFE_SUCCESS);
     ASSERT_EQ(Test_MSG_NotZero(&msg), MSG_TYPE_FLAG);
     ASSERT_EQ(CFE_MSG_GetType(&msg, &type), CFE_SUCCESS);
     ASSERT_EQ(type, CFE_MSG_Type_Cmd);
 
-    UT_Text("Set subsystem msgid bits only and verify");
+    UtPrintf("Set subsystem msgid bits only and verify");
     ASSERT_EQ(CFE_MSG_SetMsgId(&msg, CFE_SB_ValueToMsgId(0xFF00 & CFE_PLATFORM_SB_HIGHEST_VALID_MSGID)), CFE_SUCCESS);
     ASSERT_EQ(CFE_MSG_GetMsgId(&msg, &msgid), CFE_SUCCESS);
     ASSERT_EQ(Test_MSG_NotZero(&msg), local_subsys_flag);

--- a/modules/msg/unit-test-coverage/test_cfe_msg_time.c
+++ b/modules/msg/unit-test-coverage/test_cfe_msg_time.c
@@ -42,7 +42,7 @@ void Test_MSG_Time(void)
     CFE_TIME_SysTime_t actual  = {0xFFFFFFFF, 0xFFFFFFFF};
     int                i;
 
-    UT_Text("Bad parameter tests, Null pointers, no secondary header");
+    UtPrintf("Bad parameter tests, Null pointers, no secondary header");
     memset(&tlm, 0, sizeof(tlm));
     ASSERT_EQ(CFE_MSG_GetMsgTime(NULL, &actual), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(actual.Seconds, 0xFFFFFFFF);
@@ -56,7 +56,7 @@ void Test_MSG_Time(void)
     ASSERT_EQ(actual.Seconds, 0);
     ASSERT_EQ(actual.Subseconds, 0);
 
-    UT_Text("Bad <F2>message, wrong type (command)");
+    UtPrintf("Bad <F2>message, wrong type (command)");
     ASSERT_EQ(CFE_MSG_SetType(msgptr, CFE_MSG_Type_Cmd), CFE_SUCCESS);
     ASSERT_EQ(CFE_MSG_SetMsgTime(msgptr, actual), CFE_MSG_WRONG_MSG_TYPE);
     ASSERT_EQ(Test_MSG_NotZero(msgptr), MSG_TYPE_FLAG);
@@ -64,7 +64,7 @@ void Test_MSG_Time(void)
     ASSERT_EQ(actual.Seconds, 0);
     ASSERT_EQ(actual.Subseconds, 0);
 
-    UT_Text("Set to all F's, various valid inputs");
+    UtPrintf("Set to all F's, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&tlm, 0xFF, sizeof(tlm));
@@ -80,7 +80,7 @@ void Test_MSG_Time(void)
         ASSERT_EQ(Test_MSG_NotF(msgptr), MSG_TYPE_FLAG);
     }
 
-    UT_Text("Set to all 0, various valid inputs");
+    UtPrintf("Set to all 0, various valid inputs");
     for (i = 0; i < sizeof(input) / sizeof(input[0]); i++)
     {
         memset(&tlm, 0, sizeof(tlm));


### PR DESCRIPTION
**Describe the contribution**
Fix #900 - replaces UT_Text with UtPrintf and eliminates UT_VERBOSE ifdef (run time reporting control provided by ut_assert)

**Testing performed**
Built and ran unit tests, passed.  Spot checked reports and it looked good (sb_UT, tbl_UT)

**Expected behavior changes**
Minor text changes in report, but now can be controlled by run time test verbosity levels.  Also reports actual test line number and file (instead of utility function info).

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC