### PR TITLE
Fix #903, Add CFE_SB_GetUserData padding check

### DIFF
--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -3661,9 +3661,49 @@ void Test_CFE_SB_MsgHdrSize(void)
 void Test_CFE_SB_GetUserData(void)
 {
     CFE_MSG_Message_t msg;
-    uint8            *ExpAdrReturned;
+    uint8            *expected;
     bool              hassec;
     CFE_MSG_Type_t    type = CFE_MSG_Type_Invalid;
+    struct
+    {
+        CFE_MSG_CommandHeader_t cmd;
+        uint8                   payload;
+    } cmd_uint8;
+    struct
+    {
+        CFE_MSG_CommandHeader_t cmd;
+        uint16                  payload;
+    } cmd_uint16;
+    struct
+    {
+        CFE_MSG_CommandHeader_t cmd;
+        uint32                  payload;
+    } cmd_uint32;
+    struct
+    {
+        CFE_MSG_CommandHeader_t cmd;
+        uint64                  payload;
+    } cmd_uint64;
+    struct
+    {
+        CFE_MSG_TelemetryHeader_t tlm;
+        uint8           payload;
+    } tlm_uint8;
+    struct
+    {
+        CFE_MSG_TelemetryHeader_t tlm;
+        uint16          payload;
+    } tlm_uint16;
+    struct
+    {
+        CFE_MSG_TelemetryHeader_t tlm;
+        uint32          payload;
+    } tlm_uint32;
+    struct
+    {
+        CFE_MSG_TelemetryHeader_t tlm;
+        uint64          payload;
+    } tlm_uint64;
 
     /* No secondary */
     hassec = false;
@@ -3671,9 +3711,39 @@ void Test_CFE_SB_GetUserData(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
 
     /* Expected return */
-    ExpAdrReturned = (uint8 *)&msg + sizeof(CCSDS_SpacePacket_t);
+    expected = (uint8 *)&msg + sizeof(CCSDS_SpacePacket_t);
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&msg), expected);
 
-    ASSERT_TRUE(CFE_SB_GetUserData(&msg) == ExpAdrReturned);
+    /* Commands */
+    hassec = true;
+    type = CFE_MSG_Type_Cmd;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&cmd_uint8.cmd.Msg), &(cmd_uint8.payload));
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&cmd_uint16.cmd.Msg), &(cmd_uint16.payload));
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&cmd_uint32.cmd.Msg), &(cmd_uint32.payload));
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&cmd_uint64.cmd.Msg), &(cmd_uint64.payload));
+
+    /* Telemetry */
+    type = CFE_MSG_Type_Tlm;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&tlm_uint8.tlm.Msg), &(tlm_uint8.payload));
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&tlm_uint16.tlm.Msg), &(tlm_uint16.payload));
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&tlm_uint32.tlm.Msg), &(tlm_uint32.payload));
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&tlm_uint64.tlm.Msg), &(tlm_uint64.payload));
 
 } /* end Test_CFE_SB_GetUserData */
 


### PR DESCRIPTION
**Describe the contribution**
Fix #903 - this adds checks to see that CFE_SB_GetUserData works with all payload data types.

Illustrates the issue in #488 - As expected it fails for 64 bit payload in a telemetry packet because of implicit padding added between the header (12 bytes) and the 64bit payload (requires 64bit alignment.. so pads to 16 bytes).

Cmds are only OK because the default header is 8 bytes.

Also note - I expect these tests would also throw cast-align errors for an alignment sensitive build, since there's a cast from a structure with 64bit alignment to 32bit alignment.

**Testing performed**
Build and run unit tests... currently failing due to implicit padding.

**Expected behavior changes**
None, except shows the current issue with our header definitions.

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: main bundle + this commit

**Additional context**
Depends on nasa/osal#605 (address equal assert)

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC