### PR TITLE
Fix #906, Update variable checks in read_targetconfig

### DIFF
--- a/cmake/global_functions.cmake
+++ b/cmake/global_functions.cmake
@@ -185,10 +185,10 @@ function(read_targetconfig)
   endwhile()
   
   foreach(CPUNAME ${MISSION_CPUNAMES})
-    if (DEFINED SIMULATION)
+    if (SIMULATION)
       # if simulation use simulation system architecture for all targets
       set(TOOLCHAIN_NAME "${SIMULATION}")
-    elseif (DEFINED ${CPUNAME}_SYSTEM)
+    elseif (${CPUNAME}_SYSTEM)
       # get the target system arch identifier string
       set(TOOLCHAIN_NAME "${${CPUNAME}_SYSTEM}")
     else()


### PR DESCRIPTION
**Describe the contribution**

CMake script was using a "DEFINED" test to check if these variables were set.  Problem discovered is that this is always true because "SIMULATION" is a cache var set from an environment variable, so it ALWAYS defined, it is just empty if not being used.

Fix is to use `if (SIMULATION)` rather than `if (DEFINED SIMULATION)` which should only be true if the string is not empty, as intended.  Also applying this to `${CPUNAME}_SYSTEM` so if someone does e.g. `set(cpu1_SYSTEM)` then it won't try to use that empty string either.

Fixes #906 

**Testing performed**
Build for Vxworks 6.9 using GSFC build machine
Build for native using both SIMULATION=native and without SIMULATION (using toolchain-cpu1.cmake)

**Expected behavior changes**
Builds without SIMULATION directive work as expected

**System(s) tested on**
- Vxworks 6.9 using GSFC build machine
- Native on Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
