### PR TITLE
Integration Candidate: 2020-09-29

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ The detailed cFE user's guide can be viewed at <https://github.com/nasa/cFS/blob
 
 ## Version History
 
+### Development Build: 6.8.0-rc1+dev109
+- Add a new typedef `CFE_ES_ResourceID_t` that can replace `uint32` for all ID storage and manipulation. Initially this is just an alias to `uint32` for backward compatibility.
+- See <https://github.com/nasa/cFE/pull/916>
+
 ### Development Build: 6.8.0-rc1+dev105
 - Removes dependency on CCSDS version define.
 - Removes old name and id defines.

--- a/fsw/cfe-core/src/es/cfe_es_api.c
+++ b/fsw/cfe-core/src/es/cfe_es_api.c
@@ -167,7 +167,7 @@ int32 CFE_ES_ResetCFE(uint32 ResetType)
 /*
 ** Function: CFE_ES_RestartApp - See API and header file for details
 */
-int32 CFE_ES_RestartApp(uint32 AppID)
+int32 CFE_ES_RestartApp(CFE_ES_ResourceID_t AppID)
 {
     int32 ReturnCode = CFE_SUCCESS;
     CFE_ES_AppRecord_t *AppRecPtr;
@@ -218,7 +218,7 @@ int32 CFE_ES_RestartApp(uint32 AppID)
 /*
 ** Function: CFE_ES_ReloadApp - See API and header file for details
 */
-int32 CFE_ES_ReloadApp(uint32 AppID, const char *AppFileName)
+int32 CFE_ES_ReloadApp(CFE_ES_ResourceID_t AppID, const char *AppFileName)
 {
     int32 ReturnCode = CFE_SUCCESS;
     os_fstat_t FileStatus;
@@ -276,7 +276,7 @@ int32 CFE_ES_ReloadApp(uint32 AppID, const char *AppFileName)
 /*
 ** Function: CFE_ES_DeleteApp - See API and header file for details
 */
-int32 CFE_ES_DeleteApp(uint32 AppID)
+int32 CFE_ES_DeleteApp(CFE_ES_ResourceID_t AppID)
 {
     int32 ReturnCode = CFE_SUCCESS;
     CFE_ES_AppRecord_t *AppRecPtr = CFE_ES_LocateAppRecordByID(AppID);
@@ -689,7 +689,7 @@ int32 CFE_ES_RegisterApp(void)
 /*
 ** Function: CFE_ES_GetAppIDByName - See API and header file for details
 */
-int32 CFE_ES_GetAppIDByName(uint32 *AppIdPtr, const char *AppName)
+int32 CFE_ES_GetAppIDByName(CFE_ES_ResourceID_t *AppIdPtr, const char *AppName)
 {
    int32 Result = CFE_ES_ERR_APPNAME;
    CFE_ES_AppRecord_t *AppRecPtr;
@@ -699,7 +699,7 @@ int32 CFE_ES_GetAppIDByName(uint32 *AppIdPtr, const char *AppName)
     * ensure the output value is set to a safe value,
     * in case the does not check the return code.
     */
-   *AppIdPtr = 0;
+   *AppIdPtr = CFE_ES_RESOURCEID_UNDEFINED;
 
    CFE_ES_LockSharedData(__func__,__LINE__);
 
@@ -732,7 +732,7 @@ int32 CFE_ES_GetAppIDByName(uint32 *AppIdPtr, const char *AppName)
 /*
 ** Function: CFE_ES_GetAppID  - See API and header file for details
 */
-int32 CFE_ES_GetAppID(uint32 *AppIdPtr)
+int32 CFE_ES_GetAppID(CFE_ES_ResourceID_t *AppIdPtr)
 {
    int32  Result;
 
@@ -749,7 +749,7 @@ int32 CFE_ES_GetAppID(uint32 *AppIdPtr)
 /*
 ** Function: CFE_ES_GetTaskID  - See API and header file for details
 */
-int32 CFE_ES_GetTaskID(uint32 *TaskIdPtr)
+int32 CFE_ES_GetTaskID(CFE_ES_ResourceID_t *TaskIdPtr)
 {
     int32 Result;
     CFE_ES_TaskRecord_t *TaskRecPtr;
@@ -758,7 +758,7 @@ int32 CFE_ES_GetTaskID(uint32 *TaskIdPtr)
     TaskRecPtr = CFE_ES_GetTaskRecordByContext();
     if (TaskRecPtr == NULL)
     {
-        *TaskIdPtr = 0;
+        *TaskIdPtr = CFE_ES_RESOURCEID_UNDEFINED;
         Result = CFE_ES_ERR_TASKID;
     }
     else
@@ -773,7 +773,7 @@ int32 CFE_ES_GetTaskID(uint32 *TaskIdPtr)
 /*
 ** Function: CFE_ES_GetAppName - See API and header file for details
 */
-int32 CFE_ES_GetAppName(char *AppName, uint32 AppId, uint32 BufferLength)
+int32 CFE_ES_GetAppName(char *AppName, CFE_ES_ResourceID_t AppId, uint32 BufferLength)
 {
    int32 Result;
    CFE_ES_AppRecord_t *AppRecPtr;
@@ -823,7 +823,7 @@ int32 CFE_ES_GetAppName(char *AppName, uint32 AppId, uint32 BufferLength)
 /*
 ** Function: CFE_ES_GetAppInfo - See API and header file for details
 */
-int32 CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, uint32 AppId)
+int32 CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, CFE_ES_ResourceID_t AppId)
 {
    int32  ReturnCode = CFE_SUCCESS;
    CFE_ES_AppRecord_t *AppRecPtr;
@@ -843,7 +843,7 @@ int32 CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, uint32 AppId)
    if ( AppRecPtr == NULL )
    {
        CFE_ES_WriteToSysLog("CFE_ES_GetAppInfo: App ID Invalid: %lu\n",
-               (unsigned long)AppId);
+               CFE_ES_ResourceID_ToInteger(AppId));
        return CFE_ES_ERR_APPID;
     }
 
@@ -866,7 +866,7 @@ int32 CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, uint32 AppId)
 /*
 ** Function: CFE_ES_GetTaskInfo - See API and header file for details
 */
-int32 CFE_ES_GetTaskInfo(CFE_ES_TaskInfo_t *TaskInfo, uint32 TaskId)
+int32 CFE_ES_GetTaskInfo(CFE_ES_TaskInfo_t *TaskInfo, CFE_ES_ResourceID_t TaskId)
 {
    CFE_ES_TaskRecord_t *TaskRecPtr;
    int32  ReturnCode;
@@ -910,7 +910,7 @@ int32 CFE_ES_GetTaskInfo(CFE_ES_TaskInfo_t *TaskInfo, uint32 TaskId)
 /*
 ** Function: CFE_ES_CreateChildTask - See API and header file for details
 */
-int32 CFE_ES_CreateChildTask(uint32 *TaskIdPtr,
+int32 CFE_ES_CreateChildTask(CFE_ES_ResourceID_t *TaskIdPtr,
                         const char   *TaskName,
                         CFE_ES_ChildTaskMainFuncPtr_t   FunctionPtr,
                         uint32 *StackPtr,
@@ -923,9 +923,9 @@ int32 CFE_ES_CreateChildTask(uint32 *TaskIdPtr,
    CFE_ES_AppRecord_t *AppRecPtr;
    CFE_ES_TaskRecord_t *TaskRecPtr;
    int32          ReturnCode;
-   uint32         TaskId;
-   uint32         ChildTaskId;
-   uint32         ParentTaskId;
+   CFE_ES_ResourceID_t  TaskId;
+   CFE_ES_ResourceID_t  ChildTaskId;
+   CFE_ES_ResourceID_t  ParentTaskId;
    osal_id_t      OsalId;
 
    /*
@@ -977,7 +977,7 @@ int32 CFE_ES_CreateChildTask(uint32 *TaskIdPtr,
          OsalId = OS_TaskGetId();
          TaskId = CFE_ES_ResourceID_FromOSAL(OsalId);
          ParentTaskId = AppRecPtr->TaskInfo.MainTaskId;
-         if ( TaskId == ParentTaskId )
+         if ( CFE_ES_ResourceID_Equal(TaskId, ParentTaskId) )
          {
             /*
             ** Truncate the priority if needed
@@ -1079,7 +1079,7 @@ int32 CFE_ES_RegisterChildTask(void)
 void CFE_ES_IncrementTaskCounter(void)
 {
     CFE_ES_TaskRecord_t *TaskRecPtr;
-    uint32 TaskID;
+    CFE_ES_ResourceID_t TaskID;
 
     /*
      * Note this locates a task record but intentionally does _not_
@@ -1106,7 +1106,7 @@ void CFE_ES_IncrementTaskCounter(void)
 /*
 ** Function: CFE_ES_DeleteChildTask - See API and header file for details
 */
-int32 CFE_ES_DeleteChildTask(uint32 TaskId)
+int32 CFE_ES_DeleteChildTask(CFE_ES_ResourceID_t TaskId)
 {
     CFE_ES_TaskRecord_t *TaskRecPtr;
     CFE_ES_AppRecord_t *AppRecPtr;
@@ -1139,7 +1139,7 @@ int32 CFE_ES_DeleteChildTask(uint32 TaskId)
           {
              if ( CFE_ES_AppRecordIsUsed(AppRecPtr) )
              {
-                if ( AppRecPtr->TaskInfo.MainTaskId == TaskId )
+                if ( CFE_ES_ResourceID_Equal(AppRecPtr->TaskInfo.MainTaskId, TaskId) )
                 {
                    /*
                    ** Error, the task Id is an App Main Task ID
@@ -1401,7 +1401,7 @@ int32 CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *CDSHandlePtr, int32 BlockSize, cons
 {
     int32   Status;
     size_t  NameLen = 0;
-    uint32  ThisAppId;
+    CFE_ES_ResourceID_t  ThisAppId;
 
     char    AppName[OS_MAX_API_NAME] = {"UNKNOWN"};
     char    CDSName[CFE_ES_CDS_MAX_FULL_NAME_LEN] = {""};
@@ -1504,10 +1504,10 @@ int32 CFE_ES_RestoreFromCDS(void *RestoreToMemory, CFE_ES_CDSHandle_t Handle)
 /* end of file */
 
 
-int32 CFE_ES_RegisterGenCounter(uint32 *CounterIdPtr, const char *CounterName)
+int32 CFE_ES_RegisterGenCounter(CFE_ES_ResourceID_t *CounterIdPtr, const char *CounterName)
 {
    int32 ReturnCode = CFE_ES_BAD_ARGUMENT;
-   uint32 CheckPtr;
+   CFE_ES_ResourceID_t CheckPtr;
    int32 Status;
    uint32 i;
    CFE_ES_GenCounterRecord_t *CountRecPtr;
@@ -1524,7 +1524,8 @@ int32 CFE_ES_RegisterGenCounter(uint32 *CounterIdPtr, const char *CounterName)
          {
             strncpy(CountRecPtr->CounterName,CounterName,OS_MAX_API_NAME);
             CountRecPtr->Counter = 0;
-            CFE_ES_CounterRecordSetUsed(CountRecPtr, i);
+            CFE_ES_CounterRecordSetUsed(CountRecPtr,
+                    CFE_ES_ResourceID_FromInteger(i + CFE_ES_COUNTID_BASE));
             *CounterIdPtr = CFE_ES_CounterRecordGetID(CountRecPtr);
             break;
          }
@@ -1547,7 +1548,7 @@ int32 CFE_ES_RegisterGenCounter(uint32 *CounterIdPtr, const char *CounterName)
 ** Purpose:  Delete a Generic Counter.
 **
 */
-int32 CFE_ES_DeleteGenCounter(uint32 CounterId)
+int32 CFE_ES_DeleteGenCounter(CFE_ES_ResourceID_t CounterId)
 {
    CFE_ES_GenCounterRecord_t *CountRecPtr;
    int32 Status = CFE_ES_BAD_ARGUMENT;
@@ -1575,7 +1576,7 @@ int32 CFE_ES_DeleteGenCounter(uint32 CounterId)
 ** Purpose:  Increment a Generic Counter.
 **
 */
-int32 CFE_ES_IncrementGenCounter(uint32 CounterId)
+int32 CFE_ES_IncrementGenCounter(CFE_ES_ResourceID_t CounterId)
 {
    int32 Status = CFE_ES_BAD_ARGUMENT;
    CFE_ES_GenCounterRecord_t *CountRecPtr;
@@ -1596,7 +1597,7 @@ int32 CFE_ES_IncrementGenCounter(uint32 CounterId)
 ** Purpose:  Sets a Generic Counter's count.
 **
 */
-int32 CFE_ES_SetGenCount(uint32 CounterId, uint32 Count)
+int32 CFE_ES_SetGenCount(CFE_ES_ResourceID_t CounterId, uint32 Count)
 {
    int32 Status = CFE_ES_BAD_ARGUMENT;
    CFE_ES_GenCounterRecord_t *CountRecPtr;
@@ -1616,7 +1617,7 @@ int32 CFE_ES_SetGenCount(uint32 CounterId, uint32 Count)
 ** Purpose:  Gets the value of a Generic Counter.
 **
 */
-int32 CFE_ES_GetGenCount(uint32 CounterId, uint32 *Count)
+int32 CFE_ES_GetGenCount(CFE_ES_ResourceID_t CounterId, uint32 *Count)
 {
    int32 Status = CFE_ES_BAD_ARGUMENT;
    CFE_ES_GenCounterRecord_t *CountRecPtr;
@@ -1631,7 +1632,7 @@ int32 CFE_ES_GetGenCount(uint32 CounterId, uint32 *Count)
    return Status;
 } /* End of CFE_ES_GetGenCount() */
 
-int32 CFE_ES_GetGenCounterIDByName(uint32 *CounterIdPtr, const char *CounterName)
+int32 CFE_ES_GetGenCounterIDByName(CFE_ES_ResourceID_t *CounterIdPtr, const char *CounterName)
 {
    CFE_ES_GenCounterRecord_t *CountRecPtr;
    int32 Result = CFE_ES_BAD_ARGUMENT;
@@ -1667,41 +1668,42 @@ int32 CFE_ES_GetGenCounterIDByName(uint32 *CounterIdPtr, const char *CounterName
 
 
 /*
+ * A conversion function to obtain an index value correlating to a generic resource ID
+ * This is a zero based value that can be used as an array index.
+ */
+int32 CFE_ES_ResourceID_ToIndex_Internal(uint32 Serial, uint32 TableSize, uint32 *Idx)
+{
+    if (Serial > CFE_ES_RESOURCEID_MAX)
+    {
+        return CFE_ES_RESOURCE_ID_INVALID;
+    }
+
+    *Idx = Serial % TableSize;
+    return CFE_SUCCESS;
+}
+
+/*
  * A conversion function to obtain an index value correlating to an AppID
  * This is a zero based value that can be used for indexing into a table.
  */
-int32 CFE_ES_AppID_ToIndex(uint32 AppId, uint32 *Idx)
+int32 CFE_ES_AppID_ToIndex(CFE_ES_ResourceID_t AppID, uint32 *Idx)
 {
-    if (AppId >= CFE_PLATFORM_ES_MAX_APPLICATIONS)
-    {
-        return CFE_ES_ERR_APPID;
-    }
-
-    /*
-     * Currently this is a direct/simple pass through.
-     * Will evolve in a future rev to make it more safe.
-     */
-    *Idx = AppId;
-    return CFE_SUCCESS;
+    return CFE_ES_ResourceID_ToIndex_Internal(
+            CFE_ES_ResourceID_ToInteger(AppID) - CFE_ES_APPID_BASE,
+            CFE_PLATFORM_ES_MAX_APPLICATIONS,
+            Idx);
 }
 
 /*
  * A conversion function to obtain an index value correlating to a LibID
  * This is a zero based value that can be used for indexing into a table.
  */
-int32 CFE_ES_LibID_ToIndex(uint32 LibId, uint32 *Idx)
+int32 CFE_ES_LibID_ToIndex(CFE_ES_ResourceID_t LibId, uint32 *Idx)
 {
-    if (LibId >= CFE_PLATFORM_ES_MAX_LIBRARIES)
-    {
-        return CFE_ES_BAD_ARGUMENT; /* these do not have a dedicated error */
-    }
-
-    /*
-     * Currently this is a direct/simple pass through.
-     * Will evolve in a future rev to make it more safe.
-     */
-    *Idx = LibId;
-    return CFE_SUCCESS;
+    return CFE_ES_ResourceID_ToIndex_Internal(
+            CFE_ES_ResourceID_ToInteger(LibId) - CFE_ES_LIBID_BASE,
+            CFE_PLATFORM_ES_MAX_LIBRARIES,
+            Idx);
 }
 
 /*
@@ -1711,12 +1713,17 @@ int32 CFE_ES_LibID_ToIndex(uint32 LibId, uint32 *Idx)
  * Task IDs come from OSAL, so this is currently a wrapper around the OSAL converter.
  * This is an alias for consistency with the ES AppID paradigm.
  */
-int32 CFE_ES_TaskID_ToIndex(uint32 TaskID, uint32 *Idx)
+int32 CFE_ES_TaskID_ToIndex(CFE_ES_ResourceID_t TaskID, uint32 *Idx)
 {
     osal_id_t OsalID;
 
+    if (!CFE_ES_ResourceID_IsDefined(TaskID))
+    {
+        return CFE_ES_ERR_TASKID;
+    }
+
     OsalID = CFE_ES_ResourceID_ToOSAL(TaskID);
-    if (OS_ConvertToArrayIndex(OsalID, Idx) != OS_SUCCESS)
+    if (OS_ObjectIdToArrayIndex(OS_OBJECT_TYPE_OS_TASK, OsalID, Idx) != OS_SUCCESS)
     {
         return CFE_ES_ERR_TASKID;
     }
@@ -1728,19 +1735,12 @@ int32 CFE_ES_TaskID_ToIndex(uint32 TaskID, uint32 *Idx)
  * A conversion function to obtain an index value correlating to a CounterID
  * This is a zero based value that can be used for indexing into a table.
  */
-int32 CFE_ES_CounterID_ToIndex(uint32 CounterId, uint32 *Idx)
+int32 CFE_ES_CounterID_ToIndex(CFE_ES_ResourceID_t CounterId, uint32 *Idx)
 {
-    if (CounterId >= CFE_PLATFORM_ES_MAX_GEN_COUNTERS)
-    {
-        return CFE_ES_BAD_ARGUMENT; /* these do not have a dedicated error */
-    }
-
-    /*
-     * Currently this is a direct/simple pass through.
-     * Will evolve in a future rev to make it more safe.
-     */
-    *Idx = CounterId;
-    return CFE_SUCCESS;
+    return CFE_ES_ResourceID_ToIndex_Internal(
+            CFE_ES_ResourceID_ToInteger(CounterId) - CFE_ES_COUNTID_BASE,
+            CFE_PLATFORM_ES_MAX_GEN_COUNTERS,
+            Idx);
 }
 
 /***************************************************************************************
@@ -1756,10 +1756,10 @@ int32 CFE_ES_CounterID_ToIndex(uint32 CounterId, uint32 *Idx)
  * Note this may result in an invalid OSAL ID if the CFE_ES_ResourceID_t did
  * not actually refer to an OSAL resource.
  */
-osal_id_t CFE_ES_ResourceID_ToOSAL(uint32 id)
+osal_id_t CFE_ES_ResourceID_ToOSAL(CFE_ES_ResourceID_t id)
 {
-    unsigned long val = (uint32)id; /* type conversion */
-    return OS_ObjectIdFromInteger(val);
+    unsigned long val = CFE_ES_ResourceID_ToInteger(id);
+    return OS_ObjectIdFromInteger(val ^ CFE_ES_RESOURCEID_MARK);
 }
 
 /**
@@ -1767,10 +1767,10 @@ osal_id_t CFE_ES_ResourceID_ToOSAL(uint32 id)
  *
  * Any OSAL ID can also be represented as a CFE_ES_ResourceID_t
  */
-uint32 CFE_ES_ResourceID_FromOSAL(osal_id_t id)
+CFE_ES_ResourceID_t CFE_ES_ResourceID_FromOSAL(osal_id_t id)
 {
     unsigned long val = OS_ObjectIdToInteger(id);
-    return (uint32)val; /* type conversion */
+    return CFE_ES_ResourceID_FromInteger(val ^ CFE_ES_RESOURCEID_MARK);
 }
 
 
@@ -1779,7 +1779,7 @@ uint32 CFE_ES_ResourceID_FromOSAL(osal_id_t id)
  * otherwise check/validate said pointer, as that would have to be done while
  * locked.
  */
-CFE_ES_AppRecord_t *CFE_ES_LocateAppRecordByID(uint32 AppID)
+CFE_ES_AppRecord_t *CFE_ES_LocateAppRecordByID(CFE_ES_ResourceID_t AppID)
 {
     CFE_ES_AppRecord_t *AppRecPtr;
     uint32 Idx;
@@ -1796,7 +1796,7 @@ CFE_ES_AppRecord_t *CFE_ES_LocateAppRecordByID(uint32 AppID)
     return AppRecPtr;
 }
 
-extern CFE_ES_LibRecord_t* CFE_ES_LocateLibRecordByID(uint32 LibID)
+extern CFE_ES_LibRecord_t* CFE_ES_LocateLibRecordByID(CFE_ES_ResourceID_t LibID)
 {
     CFE_ES_LibRecord_t *LibRecPtr;
     uint32 Idx;
@@ -1819,7 +1819,7 @@ extern CFE_ES_LibRecord_t* CFE_ES_LocateLibRecordByID(uint32 LibID)
  * otherwise check/validate said pointer, as that would have to be done while
  * locked.
  */
-CFE_ES_TaskRecord_t *CFE_ES_LocateTaskRecordByID(uint32 TaskID)
+CFE_ES_TaskRecord_t *CFE_ES_LocateTaskRecordByID(CFE_ES_ResourceID_t TaskID)
 {
     CFE_ES_TaskRecord_t *TaskRecPtr;
     uint32 Idx;
@@ -1836,7 +1836,7 @@ CFE_ES_TaskRecord_t *CFE_ES_LocateTaskRecordByID(uint32 TaskID)
     return TaskRecPtr;
 }
 
-CFE_ES_GenCounterRecord_t* CFE_ES_LocateCounterRecordByID(uint32 CounterID)
+CFE_ES_GenCounterRecord_t* CFE_ES_LocateCounterRecordByID(CFE_ES_ResourceID_t CounterID)
 {
     CFE_ES_GenCounterRecord_t *CounterRecPtr;
     uint32 Idx;
@@ -1861,7 +1861,7 @@ CFE_ES_GenCounterRecord_t* CFE_ES_LocateCounterRecordByID(uint32 CounterID)
 CFE_ES_TaskRecord_t *CFE_ES_GetTaskRecordByContext(void)
 {
     CFE_ES_TaskRecord_t *TaskRecPtr;
-    uint32 TaskID;
+    CFE_ES_ResourceID_t TaskID;
 
     /*
     ** Use the OS task ID to get the ES task record
@@ -1927,7 +1927,7 @@ CFE_ES_AppRecord_t *CFE_ES_GetAppRecordByContext(void)
 **            so there are not nested calls to the ES Shared Data mutex lock.
 **
 */
-int32 CFE_ES_GetAppIDInternal(uint32 *AppIdPtr)
+int32 CFE_ES_GetAppIDInternal(CFE_ES_ResourceID_t *AppIdPtr)
 {
     CFE_ES_AppRecord_t *AppRecPtr;
     int32 Result;
@@ -1941,7 +1941,7 @@ int32 CFE_ES_GetAppIDInternal(uint32 *AppIdPtr)
     }
     else
     {
-        *AppIdPtr = 0;
+        *AppIdPtr = CFE_ES_RESOURCEID_UNDEFINED;
         Result = CFE_ES_ERR_APPID;
     }
 
@@ -1968,7 +1968,7 @@ void CFE_ES_LockSharedData(const char *FunctionName, int32 LineNumber)
 {
 
     int32   Status;
-    uint32  AppId;
+    CFE_ES_ResourceID_t  AppId;
 
     Status = OS_MutSemTake(CFE_ES_Global.SharedDataMutex);
     if (Status != OS_SUCCESS)
@@ -2005,7 +2005,7 @@ void CFE_ES_LockSharedData(const char *FunctionName, int32 LineNumber)
 void CFE_ES_UnlockSharedData(const char *FunctionName, int32 LineNumber)
 {
     int32   Status;
-    uint32  AppId;
+    CFE_ES_ResourceID_t  AppId;
 
     Status = OS_MutSemGive(CFE_ES_Global.SharedDataMutex);
     if (Status != OS_SUCCESS)

--- a/fsw/cfe-core/src/es/cfe_es_apps.h
+++ b/fsw/cfe-core/src/es/cfe_es_apps.h
@@ -90,8 +90,8 @@ typedef struct
 */
 typedef struct
 {
-   uint32   MainTaskId;                     /* The Application's Main Task ID */
-   char     MainTaskName[OS_MAX_API_NAME];  /* The Application's Main Task ID */
+   CFE_ES_ResourceID_t  MainTaskId;                     /* The Application's Main Task ID */
+   char                 MainTaskName[OS_MAX_API_NAME];  /* The Application's Main Task ID */
 } CFE_ES_MainTaskInfo_t;
 
 
@@ -101,6 +101,7 @@ typedef struct
 */
 typedef struct
 {
+   CFE_ES_ResourceID_t     AppId;                       /* The actual AppID of this entry, or undefined */
    CFE_ES_AppState_Enum_t  AppState;                    /* Is the app running, or stopped, or waiting? */
    uint32                  Type;                        /* The type of App: CORE or EXTERNAL */
    CFE_ES_AppStartParams_t StartParams;                 /* The start parameters for an App */
@@ -116,9 +117,8 @@ typedef struct
 */
 typedef struct
 {
-   bool      RecordUsed;                      /* Is the record used(1) or available(0) */
-   uint32    AppId;                           /* The parent Application's App ID */
-   uint32    TaskId;                          /* Task ID */
+   CFE_ES_ResourceID_t     TaskId;            /* The actual TaskID of this entry, or undefined */
+   CFE_ES_ResourceID_t     AppId;             /* The parent Application's App ID */
    uint32    ExecutionCounter;                /* The execution counter for the Child task */
    char      TaskName[OS_MAX_API_NAME];       /* Task Name */
 
@@ -131,7 +131,7 @@ typedef struct
 */
 typedef struct
 {
-   bool      RecordUsed;                      /* Is the record used(1) or available(0) */
+   CFE_ES_ResourceID_t     LibId;             /* The actual LibID of this entry, or undefined */
    char      LibName[OS_MAX_API_NAME];        /* Library Name */
 } CFE_ES_LibRecord_t;
 
@@ -167,7 +167,7 @@ int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens);
 ** Internal function to create/start a new cFE app
 ** based on the parameters passed in
 */
-int32 CFE_ES_AppCreate(uint32 *ApplicationIdPtr,
+int32 CFE_ES_AppCreate(CFE_ES_ResourceID_t *ApplicationIdPtr,
                        const char   *FileName,
                        const void   *EntryPointData,
                        const char   *AppName,
@@ -177,7 +177,7 @@ int32 CFE_ES_AppCreate(uint32 *ApplicationIdPtr,
 /*
 ** Internal function to load a a new cFE shared Library
 */
-int32 CFE_ES_LoadLibrary(uint32 *LibraryIdPtr,
+int32 CFE_ES_LoadLibrary(CFE_ES_ResourceID_t *LibraryIdPtr,
                        const char   *FileName,
                        const void   *EntryPointData,
                        const char   *LibName);
@@ -221,7 +221,7 @@ int32 CFE_ES_CleanUpApp(CFE_ES_AppRecord_t *AppRecPtr);
 /*
 ** Clean up all Task resources and detete the task
 */
-int32 CFE_ES_CleanupTaskResources(uint32 TaskId);
+int32 CFE_ES_CleanupTaskResources(CFE_ES_ResourceID_t TaskId);
 
 /*
 ** Populate the cFE_ES_AppInfo structure with the data for an app

--- a/fsw/cfe-core/src/es/cfe_es_backgroundtask.c
+++ b/fsw/cfe-core/src/es/cfe_es_backgroundtask.c
@@ -245,7 +245,7 @@ void CFE_ES_BackgroundCleanup(void)
     CFE_ES_DeleteChildTask(CFE_ES_Global.BackgroundTask.TaskID);
     OS_BinSemDelete(CFE_ES_Global.BackgroundTask.WorkSem);
 
-    CFE_ES_Global.BackgroundTask.TaskID = 0;
+    CFE_ES_Global.BackgroundTask.TaskID = CFE_ES_RESOURCEID_UNDEFINED;
     CFE_ES_Global.BackgroundTask.WorkSem = OS_OBJECT_ID_UNDEFINED;
 }
 

--- a/fsw/cfe-core/src/es/cfe_es_cds.c
+++ b/fsw/cfe-core/src/es/cfe_es_cds.c
@@ -536,7 +536,7 @@ int32 CFE_ES_UpdateCDSRegistry(void)
 ** NOTE: For complete prolog information, see 'cfe_es_cds.h'
 ********************************************************************/
 
-void CFE_ES_FormCDSName(char *FullCDSName, const char *CDSName, uint32 ThisAppId)
+void CFE_ES_FormCDSName(char *FullCDSName, const char *CDSName, CFE_ES_ResourceID_t ThisAppId)
 {
     char AppName[OS_MAX_API_NAME];
 
@@ -728,7 +728,7 @@ int32 CFE_ES_DeleteCDS(const char *CDSName, bool CalledByTblServices)
     int32                RegIndx;
     CFE_ES_CDS_RegRec_t *RegRecPtr = NULL;
     char                 OwnerName[OS_MAX_API_NAME];
-    uint32               AppId;
+    CFE_ES_ResourceID_t  AppId;
     uint32               i;
     char                 LogMessage[CFE_ES_MAX_SYSLOG_MSG_SIZE];
     

--- a/fsw/cfe-core/src/es/cfe_es_cds.h
+++ b/fsw/cfe-core/src/es/cfe_es_cds.h
@@ -134,7 +134,7 @@ int32 CFE_ES_UpdateCDSRegistry(void);
 **
 **
 ******************************************************************************/
-void CFE_ES_FormCDSName(char *FullCDSName, const char *CDSName, uint32 ThisAppId);
+void CFE_ES_FormCDSName(char *FullCDSName, const char *CDSName, CFE_ES_ResourceID_t ThisAppId);
 
 /*****************************************************************************/
 /**

--- a/fsw/cfe-core/src/es/cfe_es_erlog.c
+++ b/fsw/cfe-core/src/es/cfe_es_erlog.c
@@ -62,7 +62,7 @@
 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 int32 CFE_ES_WriteToERLogWithContext( CFE_ES_LogEntryType_Enum_t EntryType,   uint32  ResetType, uint32 ResetSubtype,
-                           const char  *Description, uint32 AppId, uint32 PspContextId)
+                           const char  *Description, CFE_ES_ResourceID_t AppId, uint32 PspContextId)
 {
    uint32 LogIdx;
    CFE_ES_ERLog_MetaData_t *EntryPtr;
@@ -174,7 +174,7 @@ int32 CFE_ES_WriteToERLog( CFE_ES_LogEntryType_Enum_t EntryType,   uint32  Reset
 {
     /* passing 0xFFFFFFFF as the appid avoids confusion with actual appid 0 */
     return CFE_ES_WriteToERLogWithContext(EntryType, ResetType, ResetSubtype,
-                               Description, 0xFFFFFFFF, CFE_ES_ERLOG_NO_CONTEXT);
+                               Description, CFE_ES_RESOURCEID_UNDEFINED, CFE_ES_ERLOG_NO_CONTEXT);
     
 } /* End of CFE_ES_WriteToERLog() */
 

--- a/fsw/cfe-core/src/es/cfe_es_log.h
+++ b/fsw/cfe-core/src/es/cfe_es_log.h
@@ -365,6 +365,6 @@ int32 CFE_ES_WriteToERLog( CFE_ES_LogEntryType_Enum_t EntryType,   uint32  Reset
  * \param PspContextId Identifier of extended context info stored in the PSP (if available)
  */
 int32 CFE_ES_WriteToERLogWithContext( CFE_ES_LogEntryType_Enum_t EntryType,   uint32  ResetType, uint32 ResetSubtype,
-                           const char  *Description, uint32 AppId, uint32 PspContextId);
+                           const char  *Description, CFE_ES_ResourceID_t AppId, uint32 PspContextId);
 
 #endif  /* _cfe_es_log_ */

--- a/fsw/cfe-core/src/es/cfe_es_start.c
+++ b/fsw/cfe-core/src/es/cfe_es_start.c
@@ -820,7 +820,7 @@ void  CFE_ES_CreateObjects(void)
                ** Core apps still have the notion of an init/running state
                ** Set the state here to mark the record as used.
                */
-               CFE_ES_AppRecordSetUsed(AppRecPtr, j);
+               CFE_ES_AppRecordSetUsed(AppRecPtr, CFE_ES_ResourceID_FromInteger(j + CFE_ES_APPID_BASE));
                
                AppRecPtr->Type = CFE_ES_AppType_CORE;
                

--- a/fsw/cfe-core/src/es/cfe_es_task.c
+++ b/fsw/cfe-core/src/es/cfe_es_task.c
@@ -855,7 +855,7 @@ int32 CFE_ES_RestartCmd(const CFE_ES_Restart_t *data)
 int32 CFE_ES_StartAppCmd(const CFE_ES_StartApp_t *data)
 {
     const CFE_ES_StartAppCmd_Payload_t *cmd = &data->Payload;
-    uint32                AppID          = 0;
+    CFE_ES_ResourceID_t   AppID;
     int32                 Result;
     int32                 FilenameLen;
     int32                 AppEntryLen;
@@ -964,7 +964,7 @@ int32 CFE_ES_StopAppCmd(const CFE_ES_StopApp_t *data)
 {
     const CFE_ES_AppNameCmd_Payload_t *cmd = &data->Payload;
     char LocalApp[OS_MAX_API_NAME];
-    uint32 AppID;
+    CFE_ES_ResourceID_t AppID;
     int32 Result;
 
     CFE_SB_MessageStringGet(LocalApp, (char *)cmd->Application, NULL, OS_MAX_API_NAME, sizeof(cmd->Application));
@@ -1017,7 +1017,7 @@ int32 CFE_ES_RestartAppCmd(const CFE_ES_RestartApp_t *data)
 {
     const CFE_ES_AppNameCmd_Payload_t *cmd = &data->Payload;
     char LocalApp[OS_MAX_API_NAME];
-    uint32 AppID;
+    CFE_ES_ResourceID_t AppID;
     int32 Result;
 
     CFE_SB_MessageStringGet(LocalApp, (char *)cmd->Application, NULL, OS_MAX_API_NAME, sizeof(cmd->Application));
@@ -1067,8 +1067,7 @@ int32 CFE_ES_ReloadAppCmd(const CFE_ES_ReloadApp_t *data)
     const CFE_ES_AppReloadCmd_Payload_t *cmd = &data->Payload;
     char LocalApp[OS_MAX_API_NAME];
     char LocalFileName[OS_MAX_PATH_LEN];
-
-    uint32  AppID;
+    CFE_ES_ResourceID_t  AppID;
     int32   Result;
 
     CFE_SB_MessageStringGet(LocalFileName, (char *)cmd->AppFileName, NULL, sizeof(LocalFileName), sizeof(cmd->AppFileName));
@@ -1119,7 +1118,7 @@ int32 CFE_ES_QueryOneCmd(const CFE_ES_QueryOne_t *data)
 {
     const CFE_ES_AppNameCmd_Payload_t *cmd = &data->Payload;
     char LocalApp[OS_MAX_API_NAME];
-    uint32 AppID;
+    CFE_ES_ResourceID_t AppID;
     int32 Result;
 
     CFE_SB_MessageStringGet(LocalApp, (char *)cmd->Application, NULL, OS_MAX_API_NAME, sizeof(cmd->Application));

--- a/fsw/cfe-core/src/es/cfe_esmempool.c
+++ b/fsw/cfe-core/src/es/cfe_esmempool.c
@@ -311,7 +311,7 @@ int32 CFE_ES_GetPoolBuf(uint32             **BufPtr,
    Pool_t  * PoolPtr = (Pool_t *)Handle;
    uint32   BlockSize;
    MemPoolAddr_t BlockAddr;
-   uint32    AppId= 0xFFFFFFFF;
+   CFE_ES_ResourceID_t    AppId;
 
    if (PoolPtr != NULL)
    {
@@ -629,7 +629,7 @@ uint32 CFE_ES_GetBlockSize(Pool_t  *PoolPtr, uint32 Size)
 int32 CFE_ES_GetMemPoolStats(CFE_ES_MemPoolStats_t *BufPtr,
                              CFE_ES_MemHandle_t  Handle)
 {
-    uint32    AppId = 0xFFFFFFFF;
+    CFE_ES_ResourceID_t    AppId;
     Pool_t   *PoolPtr;
     uint32    i;
     

--- a/fsw/cfe-core/src/evs/cfe_evs.c
+++ b/fsw/cfe-core/src/evs/cfe_evs.c
@@ -55,7 +55,7 @@ int32 CFE_EVS_Register (void *Filters, uint16 NumEventFilters, uint16 FilterSche
    uint16 FilterLimit;
    uint16 i;
    int32  Status;
-   uint32 AppID = CFE_EVS_UNDEF_APPID;
+   CFE_ES_ResourceID_t    AppID;
    CFE_EVS_BinFilter_t   *AppFilters;
    EVS_AppData_t         *AppDataPtr;
 
@@ -126,7 +126,7 @@ int32 CFE_EVS_Register (void *Filters, uint16 NumEventFilters, uint16 FilterSche
 int32 CFE_EVS_Unregister(void)
 {
    int32 Status;
-   uint32 AppID = CFE_EVS_UNDEF_APPID;
+   CFE_ES_ResourceID_t AppID;
    EVS_AppData_t *AppDataPtr;
 
    /* Query and verify the caller's AppID */
@@ -147,7 +147,7 @@ int32 CFE_EVS_Unregister(void)
 int32 CFE_EVS_SendEvent (uint16 EventID, uint16 EventType, const char *Spec, ... )
 {
    int32              Status;
-   uint32             AppID = CFE_EVS_UNDEF_APPID;
+   CFE_ES_ResourceID_t AppID;
    CFE_TIME_SysTime_t Time;
    va_list            Ptr;
    EVS_AppData_t     *AppDataPtr;
@@ -181,7 +181,7 @@ int32 CFE_EVS_SendEvent (uint16 EventID, uint16 EventType, const char *Spec, ...
 /*
 ** Function: CFE_EVS_SendEventWithAppID - See API and header file for details
 */
-int32 CFE_EVS_SendEventWithAppID (uint16 EventID, uint16 EventType, uint32 AppID, const char *Spec, ... )
+int32 CFE_EVS_SendEventWithAppID (uint16 EventID, uint16 EventType, CFE_ES_ResourceID_t AppID, const char *Spec, ... )
 {
    int32              Status = CFE_SUCCESS;
    CFE_TIME_SysTime_t Time;
@@ -219,7 +219,7 @@ int32 CFE_EVS_SendEventWithAppID (uint16 EventID, uint16 EventType, uint32 AppID
 int32 CFE_EVS_SendTimedEvent (CFE_TIME_SysTime_t Time, uint16 EventID, uint16 EventType, const char *Spec, ... )
 {
    int32              Status;
-   uint32             AppID = CFE_EVS_UNDEF_APPID;
+   CFE_ES_ResourceID_t AppID;
    va_list            Ptr;
    EVS_AppData_t     *AppDataPtr;
 
@@ -252,7 +252,7 @@ int32 CFE_EVS_ResetFilter (int16 EventID)
 {
    int32            Status;
    EVS_BinFilter_t *FilterPtr = NULL;
-   uint32           AppID = CFE_EVS_UNDEF_APPID;
+   CFE_ES_ResourceID_t AppID;
    EVS_AppData_t   *AppDataPtr;
 
    /* Query and verify the caller's AppID */
@@ -289,7 +289,7 @@ int32 CFE_EVS_ResetFilter (int16 EventID)
 int32 CFE_EVS_ResetAllFilters ( void )
 {
    int32    Status;
-   uint32   AppID = CFE_EVS_UNDEF_APPID;
+   CFE_ES_ResourceID_t AppID;
    uint32   i;
    EVS_AppData_t *AppDataPtr;
 

--- a/fsw/cfe-core/src/evs/cfe_evs_task.c
+++ b/fsw/cfe-core/src/evs/cfe_evs_task.c
@@ -85,8 +85,6 @@ int32 CFE_EVS_EarlyInit ( void )
 
    memset(&CFE_EVS_GlobalData, 0, sizeof(CFE_EVS_GlobalData_t));
 
-   CFE_EVS_GlobalData.EVS_AppID = CFE_EVS_UNDEF_APPID;
-
    /* Initialize housekeeping packet */
    CFE_SB_InitMsg(&CFE_EVS_GlobalData.EVS_TlmPkt, CFE_SB_ValueToMsgId(CFE_EVS_HK_TLM_MID),
            sizeof(CFE_EVS_GlobalData.EVS_TlmPkt), false);
@@ -181,7 +179,7 @@ int32 CFE_EVS_EarlyInit ( void )
 **
 ** Assumptions and Notes:
 */
-int32 CFE_EVS_CleanUpApp(uint32 AppID)
+int32 CFE_EVS_CleanUpApp(CFE_ES_ResourceID_t AppID)
 {
    int32  Status = CFE_SUCCESS;
    EVS_AppData_t *AppDataPtr;
@@ -282,7 +280,7 @@ void CFE_EVS_TaskMain(void)
 int32 CFE_EVS_TaskInit ( void )
 {
    int32 Status;
-   uint32 AppID;
+   CFE_ES_ResourceID_t AppID;
  
    /* Register EVS application */
    Status = CFE_ES_RegisterApp();
@@ -722,7 +720,7 @@ int32 CFE_EVS_ReportHousekeepingCmd (const CFE_SB_CmdHdr_t *data)
    /* Clear unused portion of event state data in telemetry packet */
    for (i = j; i < CFE_MISSION_ES_MAX_APPLICATIONS; i++)
    {
-       AppTlmDataPtr->AppID = 0;
+       AppTlmDataPtr->AppID = CFE_ES_RESOURCEID_UNDEFINED;
        AppTlmDataPtr->AppEnableStatus = false;
        AppTlmDataPtr->AppMessageSentCounter = 0;
    }

--- a/fsw/cfe-core/src/evs/cfe_evs_task.h
+++ b/fsw/cfe-core/src/evs/cfe_evs_task.h
@@ -63,7 +63,6 @@
 #define CFE_EVS_MAX_EVENT_SEND_COUNT    65535
 #define CFE_EVS_MAX_FILTER_COUNT        65535
 #define CFE_EVS_PIPE_NAME               "EVS_CMD_PIPE"
-#define CFE_EVS_UNDEF_APPID             0xFFFFFFFF
 #define CFE_EVS_MAX_PORT_MSG_LENGTH     (CFE_MISSION_EVS_MAX_MESSAGE_LENGTH+OS_MAX_API_NAME+30)
 
 /* Since CFE_EVS_MAX_PORT_MSG_LENGTH is the size of the buffer that is sent to 
@@ -89,12 +88,12 @@ typedef struct
 
 typedef struct
 {
+    CFE_ES_ResourceID_t AppID;
     EVS_BinFilter_t    BinFilters[CFE_PLATFORM_EVS_MAX_EVENT_FILTERS];  /* Array of binary filters */
 
     uint8              ActiveFlag;             /* Application event service active flag */
     uint8              EventTypesActiveFlag;   /* Application event types active flag */
     uint16             EventCount;             /* Application event counter */
-    uint16             RegisterFlag;           /* Application has registered flag */
 
 } EVS_AppData_t;
 
@@ -123,7 +122,7 @@ typedef struct
    CFE_EVS_HousekeepingTlm_t    EVS_TlmPkt;
    CFE_SB_PipeId_t     EVS_CommandPipe;
    osal_id_t           EVS_SharedDataMutexID;
-   uint32              EVS_AppID;
+   CFE_ES_ResourceID_t EVS_AppID;
 
 } CFE_EVS_GlobalData_t;
 

--- a/fsw/cfe-core/src/evs/cfe_evs_utils.c
+++ b/fsw/cfe-core/src/evs/cfe_evs_utils.c
@@ -64,7 +64,7 @@ void EVS_OutputPort4 (char *Message);
 ** Assumptions and Notes:
 **
 */
-EVS_AppData_t *EVS_GetAppDataByID (uint32 AppID)
+EVS_AppData_t *EVS_GetAppDataByID (CFE_ES_ResourceID_t AppID)
 {
    uint32 AppIndex;
    EVS_AppData_t *AppDataPtr;
@@ -83,9 +83,9 @@ EVS_AppData_t *EVS_GetAppDataByID (uint32 AppID)
 
 } /* End EVS_GetAppDataByID */
 
-int32 EVS_GetCurrentContext (EVS_AppData_t **AppDataOut, uint32 *AppIDOut)
+int32 EVS_GetCurrentContext (EVS_AppData_t **AppDataOut, CFE_ES_ResourceID_t *AppIDOut)
 {
-   uint32 AppID;
+   CFE_ES_ResourceID_t AppID;
    EVS_AppData_t *AppDataPtr;
    int32 Status;
 
@@ -134,7 +134,7 @@ int32 EVS_GetCurrentContext (EVS_AppData_t **AppDataOut, uint32 *AppIDOut)
 int32 EVS_GetApplicationInfo (EVS_AppData_t **AppDataOut, const char *pAppName)
 {
    int32 Status;
-   uint32 AppID;
+   CFE_ES_ResourceID_t AppID;
    EVS_AppData_t *AppDataPtr;
 
    Status = CFE_ES_GetAppIDByName(&AppID, pAppName);
@@ -180,7 +180,7 @@ int32 EVS_GetApplicationInfo (EVS_AppData_t **AppDataOut, const char *pAppName)
 ** Assumptions and Notes:
 **
 */
-int32 EVS_NotRegistered (EVS_AppData_t *AppDataPtr, uint32 AppID)
+int32 EVS_NotRegistered (EVS_AppData_t *AppDataPtr, CFE_ES_ResourceID_t CallerID)
 {
    char AppName[OS_MAX_API_NAME];
 
@@ -194,7 +194,7 @@ int32 EVS_NotRegistered (EVS_AppData_t *AppDataPtr, uint32 AppID)
       AppDataPtr->EventCount++;
 
       /* Get the name of the "not registered" app */
-      CFE_ES_GetAppName(AppName, AppID, OS_MAX_API_NAME);
+      CFE_ES_GetAppName(AppName, CallerID, OS_MAX_API_NAME);
 
       /* Send the "not registered" event */
       EVS_SendEvent(CFE_EVS_ERR_UNREGISTERED_EVS_APP, CFE_EVS_EventType_ERROR,

--- a/fsw/cfe-core/src/evs/cfe_evs_utils.h
+++ b/fsw/cfe-core/src/evs/cfe_evs_utils.h
@@ -63,7 +63,7 @@
  * @param[in]   AppID   AppID to find
  * @returns Pointer to app table entry, or NULL if ID is invalid.
  */
-EVS_AppData_t *EVS_GetAppDataByID (uint32 AppID);
+EVS_AppData_t *EVS_GetAppDataByID (CFE_ES_ResourceID_t AppID);
 
 /**
  * @brief Obtain the context information for the currently running app
@@ -74,7 +74,7 @@ EVS_AppData_t *EVS_GetAppDataByID (uint32 AppID);
  * @param[out]   AppIDOut       Location to store AppID
  * @returns CFE_SUCCESS if successful, or relevant error code.
  */
-int32 EVS_GetCurrentContext (EVS_AppData_t **AppDataOut, uint32 *AppIDOut);
+int32 EVS_GetCurrentContext (EVS_AppData_t **AppDataOut, CFE_ES_ResourceID_t *AppIDOut);
 
 
 /**
@@ -90,7 +90,7 @@ int32 EVS_GetCurrentContext (EVS_AppData_t **AppDataOut, uint32 *AppIDOut);
  */
 static inline bool EVS_AppDataIsUsed(EVS_AppData_t *AppDataPtr)
 {
-    return (AppDataPtr->RegisterFlag);
+    return CFE_ES_ResourceID_IsDefined(AppDataPtr->AppID);
 }
 
 /**
@@ -101,13 +101,13 @@ static inline bool EVS_AppDataIsUsed(EVS_AppData_t *AppDataPtr)
  * @param[in]   AppDataPtr   pointer to app table entry
  * @returns AppID of entry
  */
-static inline uint32 EVS_AppDataGetID(EVS_AppData_t *AppDataPtr)
+static inline CFE_ES_ResourceID_t EVS_AppDataGetID(EVS_AppData_t *AppDataPtr)
 {
     /*
      * The initial implementation does not store the ID in the entry;
      * the ID is simply the zero-based index into the table.
      */
-    return (AppDataPtr - CFE_EVS_GlobalData.AppData);
+    return (AppDataPtr->AppID);
 }
 
 /**
@@ -122,9 +122,9 @@ static inline uint32 EVS_AppDataGetID(EVS_AppData_t *AppDataPtr)
  * @param[in]   AppDataPtr   pointer to app table entry
  * @param[in]   AppID       the app ID of this entry
  */
-static inline void EVS_AppDataSetUsed(EVS_AppData_t *AppDataPtr, uint32 AppID)
+static inline void EVS_AppDataSetUsed(EVS_AppData_t *AppDataPtr, CFE_ES_ResourceID_t AppID)
 {
-    AppDataPtr->RegisterFlag = true;
+    AppDataPtr->AppID = AppID;
 }
 
 /**
@@ -137,7 +137,7 @@ static inline void EVS_AppDataSetUsed(EVS_AppData_t *AppDataPtr, uint32 AppID)
  */
 static inline void EVS_AppDataSetFree(EVS_AppData_t *AppDataPtr)
 {
-    AppDataPtr->RegisterFlag = false;
+    AppDataPtr->AppID = CFE_ES_RESOURCEID_UNDEFINED;
 }
 
 /**
@@ -150,17 +150,16 @@ static inline void EVS_AppDataSetFree(EVS_AppData_t *AppDataPtr)
  * @param[in]   AppID       expected app ID
  * @returns true if the entry matches the given app ID
  */
-static inline bool EVS_AppDataIsMatch(EVS_AppData_t *AppDataPtr, uint32 AppID)
+static inline bool EVS_AppDataIsMatch(EVS_AppData_t *AppDataPtr, CFE_ES_ResourceID_t AppID)
 {
-    return (AppDataPtr != NULL && EVS_AppDataIsUsed(AppDataPtr) &&
-            EVS_AppDataGetID(AppDataPtr) == AppID);
+    return (AppDataPtr != NULL && CFE_ES_ResourceID_Equal(AppDataPtr->AppID, AppID));
 }
 
 
 
 int32 EVS_GetApplicationInfo(EVS_AppData_t **AppDataOut, const char *pAppName);
 
-int32 EVS_NotRegistered (EVS_AppData_t *AppDataPtr, uint32 AppID);
+int32 EVS_NotRegistered (EVS_AppData_t *AppDataPtr, CFE_ES_ResourceID_t CallerID);
 
 bool EVS_IsFiltered(EVS_AppData_t *AppDataPtr, uint16 EventID, uint16 EventType);
 

--- a/fsw/cfe-core/src/fs/cfe_fs_api.c
+++ b/fsw/cfe-core/src/fs/cfe_fs_api.c
@@ -94,6 +94,7 @@ int32 CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr)
     CFE_TIME_SysTime_t Time;
     int32   Result;
     int32   EndianCheck = 0x01020304;
+    CFE_ES_ResourceID_t AppID;
 
     /*
     ** Ensure that we are at the start of the file...
@@ -107,7 +108,8 @@ int32 CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr)
         */
           Hdr->SpacecraftID  = CFE_PSP_GetSpacecraftId();
           Hdr->ProcessorID   = CFE_PSP_GetProcessorId();
-          CFE_ES_GetAppID((uint32 *)&(Hdr->ApplicationID));
+          CFE_ES_GetAppID(&AppID);
+          Hdr->ApplicationID = CFE_ES_ResourceID_ToInteger(AppID);
 
           /* Fill in length field */
 

--- a/fsw/cfe-core/src/fs/cfe_fs_priv.c
+++ b/fsw/cfe-core/src/fs/cfe_fs_priv.c
@@ -92,7 +92,7 @@ int32 CFE_FS_EarlyInit (void)
 void CFE_FS_LockSharedData(const char *FunctionName)
 {
     int32   Status;
-    uint32  AppId = 0;
+    CFE_ES_ResourceID_t  AppId;
 
     Status = OS_MutSemTake(CFE_FS.SharedDataMutexId);
     if (Status != OS_SUCCESS) 
@@ -124,7 +124,7 @@ void CFE_FS_LockSharedData(const char *FunctionName)
 void CFE_FS_UnlockSharedData(const char *FunctionName)
 {
    int32   Status;
-   uint32  AppId = 0;
+   CFE_ES_ResourceID_t  AppId;
 
    Status = OS_MutSemGive(CFE_FS.SharedDataMutexId);
    if (Status != OS_SUCCESS) 

--- a/fsw/cfe-core/src/inc/cfe_error.h
+++ b/fsw/cfe-core/src/inc/cfe_error.h
@@ -449,7 +449,7 @@
 /**
  * @brief Task ID Error
  *
- *  Occurs when the Task ID passed into #CFE_ES_GetTaskInfo is invalid.
+ *  Occurs when the Task ID passed into a task-related API is invalid.
  *
  */
 #define CFE_ES_ERR_TASKID  ((int32)0xc4000016)
@@ -632,6 +632,27 @@
  *
  */
 #define CFE_ES_ERR_SYS_LOG_TRUNCATED  ((int32)0x44000029)
+
+
+/**
+ * @brief Resource ID is not valid
+ *
+ *  This error indicates that the passed in resource identifier
+ *  (App ID, Lib ID, Counter ID, etc) did not validate.
+ *
+ */
+#define CFE_ES_RESOURCE_ID_INVALID     ((int32)0xc400002A)
+
+/**
+ * @brief Resource ID is not available
+ *
+ *  This error indicates that the maximum resource identifiers
+ *  (App ID, Lib ID, Counter ID, etc) has already been reached
+ *  and a new ID cannot be allocated.
+ *
+ */
+#define CFE_ES_NO_RESOURCE_IDS_AVAILABLE     ((int32)0xc400002B)
+
 
 /**
  * @brief Not Implemented

--- a/fsw/cfe-core/src/inc/cfe_evs.h
+++ b/fsw/cfe-core/src/inc/cfe_evs.h
@@ -265,7 +265,7 @@ int32 CFE_EVS_SendEvent (uint16 EventID,
 **/
 int32 CFE_EVS_SendEventWithAppID (uint16 EventID,
                                   uint16 EventType,
-                                  uint32 AppID, 
+                                  CFE_ES_ResourceID_t AppID,
                                   const char *Spec, ... ) OS_PRINTF(4,5);
 
 

--- a/fsw/cfe-core/src/inc/cfe_evs_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_evs_msg.h
@@ -1127,7 +1127,7 @@ typedef CFE_EVS_AppNameEventIDMaskCmd_t CFE_EVS_SetFilter_t;
 /* Telemetry Message Data Formats */
 /**********************************/
 typedef struct CFE_EVS_AppTlmData {
-   uint32               AppID;                  /**< \cfetlmmnemonic \EVS_APPID
+   CFE_ES_ResourceID_t  AppID;                  /**< \cfetlmmnemonic \EVS_APPID
                                                      \brief Numerical application identifier */
    uint16               AppMessageSentCounter;  /**< \cfetlmmnemonic \EVS_APPMSGSENTC
                                                      \brief Application message sent counter */

--- a/fsw/cfe-core/src/inc/cfe_version.h
+++ b/fsw/cfe-core/src/inc/cfe_version.h
@@ -35,7 +35,7 @@
 
 
 /* Development Build Macro Definitions */
-#define CFE_BUILD_NUMBER 105 /*!< Development Build: Number of commits since baseline */
+#define CFE_BUILD_NUMBER 109 /*!< Development Build: Number of commits since baseline */
 #define CFE_BUILD_BASELINE "v6.8.0-rc1" /*!< Development Build: git tag that is the base for the current development */
 
 /* Version Macro Definitions */

--- a/fsw/cfe-core/src/inc/private/cfe_es_erlog_typedef.h
+++ b/fsw/cfe-core/src/inc/private/cfe_es_erlog_typedef.h
@@ -93,7 +93,7 @@ typedef struct
 typedef struct
 {
     CFE_ES_ERLog_BaseInfo_t BaseInfo;       /**< Core Log Data */
-    uint32                  AppID;          /* The application ID */
+    CFE_ES_ResourceID_t     AppID;          /* The application ID */
     uint32                  PspContextId;   /**< Reference to context information stored in PSP */
 } CFE_ES_ERLog_MetaData_t;
 

--- a/fsw/cfe-core/src/inc/private/cfe_private.h
+++ b/fsw/cfe-core/src/inc/private/cfe_private.h
@@ -226,7 +226,7 @@ extern int32 CFE_FS_EarlyInit(void);
 **           the specified application from the Critical Data Store.
 **
 ******************************************************************************/
-extern int32 CFE_TBL_CleanUpApp(uint32 AppId);
+extern int32 CFE_TBL_CleanUpApp(CFE_ES_ResourceID_t AppId);
 
 /*****************************************************************************/
 /**
@@ -238,7 +238,7 @@ extern int32 CFE_TBL_CleanUpApp(uint32 AppId);
 **        that have been allocated to the specified Application.
 **
 ******************************************************************************/
-extern int32 CFE_SB_CleanUpApp(uint32 AppId);
+extern int32 CFE_SB_CleanUpApp(CFE_ES_ResourceID_t AppId);
 
 /*****************************************************************************/
 /**
@@ -250,7 +250,7 @@ extern int32 CFE_SB_CleanUpApp(uint32 AppId);
 **        that have been allocated to the specified Application.
 **
 ******************************************************************************/
-extern int32 CFE_EVS_CleanUpApp(uint32 AppId);
+extern int32 CFE_EVS_CleanUpApp(CFE_ES_ResourceID_t AppId);
 
 /*****************************************************************************/
 /**
@@ -262,7 +262,7 @@ extern int32 CFE_EVS_CleanUpApp(uint32 AppId);
 **        that have been allocated to the specified Application.
 **
 ******************************************************************************/
-extern int32 CFE_TIME_CleanUpApp(uint32 AppId);
+extern int32 CFE_TIME_CleanUpApp(CFE_ES_ResourceID_t AppId);
 
 
 /*****************************************************************************/

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.c
@@ -122,14 +122,14 @@ void CFE_SB_InitIdxStack(void)
 **  Return:
 **    None
 */
-int32 CFE_SB_CleanUpApp(uint32 AppId){
+int32 CFE_SB_CleanUpApp(CFE_ES_ResourceID_t AppId){
 
   uint32 i;
 
   /* loop through the pipe table looking for pipes owned by AppId */
   for(i=0;i<CFE_PLATFORM_SB_MAX_PIPES;i++){
     if((CFE_SB.PipeTbl[i].InUse == CFE_SB_IN_USE)&&
-       (CFE_SB.PipeTbl[i].AppId == AppId))
+       CFE_ES_ResourceID_Equal(CFE_SB.PipeTbl[i].AppId, AppId))
     {
       CFE_SB_DeletePipeWithAppId(CFE_SB.PipeTbl[i].PipeId,AppId);
     }/* end if */
@@ -281,7 +281,7 @@ uint8 CFE_SB_GetPipeIdx(CFE_SB_PipeId_t PipeId){
 void CFE_SB_LockSharedData(const char *FuncName, int32 LineNumber){
 
     int32   Status;
-    uint32  AppId = 0xFFFFFFFF;
+    CFE_ES_ResourceID_t AppId;
 
     Status = OS_MutSemTake(CFE_SB.SharedDataMutexId);
     if (Status != OS_SUCCESS) {
@@ -316,7 +316,7 @@ void CFE_SB_LockSharedData(const char *FuncName, int32 LineNumber){
 void CFE_SB_UnlockSharedData(const char *FuncName, int32 LineNumber){
 
    int32   Status;
-   uint32  AppId = 0xFFFFFFFF;
+   CFE_ES_ResourceID_t AppId;
 
     Status = OS_MutSemGive(CFE_SB.SharedDataMutexId);
     if (Status != OS_SUCCESS) {
@@ -621,7 +621,7 @@ int32 CFE_SB_ValidatePipeId(CFE_SB_PipeId_t PipeId){
 **  Note: With taskId, Parent App name and Child Task name can be queried from ES
 **
 */
-char *CFE_SB_GetAppTskName(uint32 TaskId,char *FullName){
+char *CFE_SB_GetAppTskName(CFE_ES_ResourceID_t TaskId,char *FullName){
 
     CFE_ES_TaskInfo_t  TaskInfo;
     CFE_ES_TaskInfo_t  *ptr = &TaskInfo;
@@ -671,7 +671,7 @@ char *CFE_SB_GetAppTskName(uint32 TaskId,char *FullName){
 **    If the bit is set this function will return CFE_SB_DENIED.
 **    If bit is not set, this function set the bit and return CFE_SB_GRANTED.
 */
-uint32 CFE_SB_RequestToSendEvent(uint32 TaskId, uint32 Bit){
+uint32 CFE_SB_RequestToSendEvent(CFE_ES_ResourceID_t TaskId, uint32 Bit){
 
     uint32 Indx;
 
@@ -708,7 +708,7 @@ uint32 CFE_SB_RequestToSendEvent(uint32 TaskId, uint32 Bit){
 **    If the bit is set this function will return CFE_SB_DENIED.
 **    If bit is not set, this function set the bit and return CFE_SB_GRANTED.
 */
-void CFE_SB_FinishSendEvent(uint32 TaskId, uint32 Bit){
+void CFE_SB_FinishSendEvent(CFE_ES_ResourceID_t TaskId, uint32 Bit){
 
     uint32 Indx;
 
@@ -854,14 +854,15 @@ int32 CFE_SB_RemoveDest(CFE_SB_RouteEntry_t *RouteEntry, CFE_SB_DestinationD_t *
 **          Status
 **
 ******************************************************************************/
-int32 CFE_SB_ZeroCopyReleaseAppId(uint32         AppId)
+int32 CFE_SB_ZeroCopyReleaseAppId(CFE_ES_ResourceID_t         AppId)
 {
     CFE_SB_ZeroCopyD_t *prev = NULL;
     CFE_SB_ZeroCopyD_t *zcd = (CFE_SB_ZeroCopyD_t *) (CFE_SB.ZeroCopyTail);
 
     while(zcd != NULL){
         prev = (CFE_SB_ZeroCopyD_t *) (zcd->Prev);
-        if(zcd->AppID == AppId){
+        if( CFE_ES_ResourceID_Equal(zcd->AppID, AppId) )
+        {
             CFE_SB_ZeroCopyReleasePtr((CFE_SB_Msg_t *) zcd->Buffer, (CFE_SB_ZeroCopyHandle_t) zcd);
         }
         zcd = prev;

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.h
@@ -211,7 +211,7 @@ typedef struct {
 */
 
 typedef struct {
-     uint32            AppID;
+     CFE_ES_ResourceID_t AppID;
      uint32            Size;
      void              *Buffer;
      void              *Next;
@@ -248,7 +248,7 @@ typedef struct {
      char               AppName[OS_MAX_API_NAME];
      uint8              Opts;
      uint8              Spare;
-     uint32             AppId;
+     CFE_ES_ResourceID_t AppId;
      osal_id_t          SysQueueId;
      uint32             LastSender;
      uint16             QueueDepth;
@@ -283,8 +283,8 @@ typedef struct {
     osal_id_t           SharedDataMutexId;
     uint32              SubscriptionReporting;
     uint32              SenderReporting;
-    uint32              AppId;
-    uint32              StopRecurseFlags[CFE_PLATFORM_ES_MAX_APPLICATIONS];
+    CFE_ES_ResourceID_t AppId;
+    uint32              StopRecurseFlags[OS_MAX_TASKS];
     void               *ZeroCopyTail;
     CFE_SB_PipeD_t      PipeTbl[CFE_PLATFORM_SB_MAX_PIPES];
     CFE_SB_HousekeepingTlm_t        HKTlmMsg;
@@ -346,7 +346,7 @@ CFE_SB_MsgKey_t CFE_SB_ConvertMsgIdtoMsgKey(CFE_SB_MsgId_t MsgId);
 void   CFE_SB_LockSharedData(const char *FuncName, int32 LineNumber);
 void   CFE_SB_UnlockSharedData(const char *FuncName, int32 LineNumber);
 void   CFE_SB_ReleaseBuffer (CFE_SB_BufferD_t *bd, CFE_SB_DestinationD_t *dest);
-int32  CFE_SB_ReadQueue(CFE_SB_PipeD_t *PipeDscPtr,uint32 TskId,
+int32  CFE_SB_ReadQueue(CFE_SB_PipeD_t *PipeDscPtr,CFE_ES_ResourceID_t TskId,
                         CFE_SB_TimeOut_t Time_Out,CFE_SB_BufferD_t **Message );
 int32  CFE_SB_WriteQueue(CFE_SB_PipeD_t *pd,uint32 TskId,
                          const CFE_SB_BufferD_t *bd,CFE_SB_MsgId_t MsgId );
@@ -359,14 +359,14 @@ void   CFE_SB_SetRoutingTblIdx(CFE_SB_MsgKey_t MsgKey, CFE_SB_MsgRouteIdx_t Valu
 CFE_SB_RouteEntry_t* CFE_SB_GetRoutePtrFromIdx(CFE_SB_MsgRouteIdx_t RouteIdx);
 void   CFE_SB_ResetCounters(void);
 void   CFE_SB_SetMsgSeqCnt(CFE_SB_MsgPtr_t MsgPtr,uint32 Count);
-char   *CFE_SB_GetAppTskName(uint32 TaskId, char* FullName);
+char   *CFE_SB_GetAppTskName(CFE_ES_ResourceID_t TaskId, char* FullName);
 CFE_SB_BufferD_t *CFE_SB_GetBufferFromPool(CFE_SB_MsgId_t MsgId, uint16 Size);
 CFE_SB_BufferD_t *CFE_SB_GetBufferFromCaller(CFE_SB_MsgId_t MsgId, void *Address);
 CFE_SB_PipeD_t   *CFE_SB_GetPipePtr(CFE_SB_PipeId_t PipeId);
 CFE_SB_PipeId_t  CFE_SB_GetAvailPipeIdx(void);
 CFE_SB_DestinationD_t *CFE_SB_GetDestPtr (CFE_SB_MsgKey_t MsgKey, CFE_SB_PipeId_t PipeId);
-int32 CFE_SB_DeletePipeWithAppId(CFE_SB_PipeId_t PipeId,uint32 AppId);
-int32 CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId,uint32 AppId);
+int32 CFE_SB_DeletePipeWithAppId(CFE_SB_PipeId_t PipeId,CFE_ES_ResourceID_t AppId);
+int32 CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId,CFE_ES_ResourceID_t AppId);
 int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
                            CFE_SB_PipeId_t  PipeId,
                            CFE_SB_Qos_t     Quality,
@@ -374,16 +374,16 @@ int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
                            uint8            Scope);
 
 int32 CFE_SB_UnsubscribeWithAppId(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId,
-                                   uint32 AppId);
+        CFE_ES_ResourceID_t AppId);
 
 int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId,
-                              uint8 Scope, uint32 AppId);
+                              uint8 Scope, CFE_ES_ResourceID_t AppId);
 int32  CFE_SB_SendMsgFull(CFE_SB_Msg_t   *MsgPtr, uint32 TlmCntIncrements, uint32 CopyMode);
 int32 CFE_SB_SendRtgInfo(const char *Filename);
 int32 CFE_SB_SendPipeInfo(const char *Filename);
 int32 CFE_SB_SendMapInfo(const char *Filename);
 int32 CFE_SB_ZeroCopyReleaseDesc(CFE_SB_Msg_t *Ptr2Release, CFE_SB_ZeroCopyHandle_t BufferHandle);
-int32 CFE_SB_ZeroCopyReleaseAppId(uint32         AppId);
+int32 CFE_SB_ZeroCopyReleaseAppId(CFE_ES_ResourceID_t         AppId);
 int32 CFE_SB_DecrBufUseCnt(CFE_SB_BufferD_t *bd);
 int32 CFE_SB_ValidateMsgId(CFE_SB_MsgId_t MsgId);
 int32 CFE_SB_ValidatePipeId(CFE_SB_PipeId_t PipeId);
@@ -391,8 +391,8 @@ void CFE_SB_IncrCmdCtr(int32 status);
 void CFE_SB_FileWriteByteCntErr(const char *Filename,uint32 Requested,uint32 Actual);
 void CFE_SB_SetSubscriptionReporting(uint32 state);
 uint32 CFE_SB_FindGlobalMsgIdCnt(void);
-uint32 CFE_SB_RequestToSendEvent(uint32 TaskId, uint32 Bit);
-void CFE_SB_FinishSendEvent(uint32 TaskId, uint32 Bit);
+uint32 CFE_SB_RequestToSendEvent(CFE_ES_ResourceID_t TaskId, uint32 Bit);
+void CFE_SB_FinishSendEvent(CFE_ES_ResourceID_t TaskId, uint32 Bit);
 CFE_SB_DestinationD_t *CFE_SB_GetDestinationBlk(void);
 int32 CFE_SB_PutDestinationBlk(CFE_SB_DestinationD_t *Dest);
 int32 CFE_SB_AddDest(CFE_SB_RouteEntry_t *RouteEntry, CFE_SB_DestinationD_t *NewNode);

--- a/fsw/cfe-core/src/tbl/cfe_tbl_api.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_api.c
@@ -61,7 +61,7 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
     int32                       Status;
     size_t                      NameLen = 0;
     int16                       RegIndx = -1;
-    uint32                      ThisAppId;
+    CFE_ES_ResourceID_t         ThisAppId;
     char                        AppName[OS_MAX_API_NAME] = {"UNKNOWN"};
     char                        TblName[CFE_TBL_MAX_FULL_NAME_LEN] = {""};
     CFE_TBL_Handle_t            AccessIndex;
@@ -168,7 +168,7 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
             RegRecPtr = &CFE_TBL_TaskData.Registry[RegIndx];
 
             /* If this app previously owned the table, then allow them to re-register */
-            if (RegRecPtr->OwnerAppId == ThisAppId)
+            if ( CFE_ES_ResourceID_Equal(RegRecPtr->OwnerAppId, ThisAppId) )
             {
                 /* If the new table is the same size as the old, then no need to reallocate memory */
                 if (Size != RegRecPtr->Size)
@@ -193,7 +193,7 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
                     while ((AccessIndex != CFE_TBL_END_OF_LIST) && (*TblHandlePtr == CFE_TBL_BAD_TABLE_HANDLE))
                     {
                         if ((CFE_TBL_TaskData.Handles[AccessIndex].UsedFlag == true) &&
-                            (CFE_TBL_TaskData.Handles[AccessIndex].AppId == ThisAppId) &&
+                            CFE_ES_ResourceID_Equal(CFE_TBL_TaskData.Handles[AccessIndex].AppId, ThisAppId) &&
                             (CFE_TBL_TaskData.Handles[AccessIndex].RegIndex == RegIndx))
                         {
                             *TblHandlePtr = AccessIndex;
@@ -510,7 +510,7 @@ int32 CFE_TBL_Share( CFE_TBL_Handle_t *TblHandlePtr,
                      const char *TblName )
 {
     int32   Status;
-    uint32  ThisAppId;
+    CFE_ES_ResourceID_t  ThisAppId;
     int16   RegIndx = CFE_TBL_NOT_FOUND;
     CFE_TBL_AccessDescriptor_t *AccessDescPtr = NULL;
     CFE_TBL_RegistryRec_t      *RegRecPtr = NULL;
@@ -608,7 +608,7 @@ int32 CFE_TBL_Share( CFE_TBL_Handle_t *TblHandlePtr,
 int32 CFE_TBL_Unregister ( CFE_TBL_Handle_t TblHandle )
 {
     int32   Status;
-    uint32  ThisAppId;
+    CFE_ES_ResourceID_t  ThisAppId;
     CFE_TBL_RegistryRec_t *RegRecPtr = NULL;
     CFE_TBL_AccessDescriptor_t *AccessDescPtr = NULL;
     char    AppName[OS_MAX_API_NAME] = {"UNKNOWN"};
@@ -625,7 +625,7 @@ int32 CFE_TBL_Unregister ( CFE_TBL_Handle_t TblHandle )
         RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
 
         /* Verify that the application unregistering the table owns the table */
-        if (RegRecPtr->OwnerAppId == ThisAppId)
+        if (CFE_ES_ResourceID_Equal(RegRecPtr->OwnerAppId, ThisAppId))
         {
             /* Mark table as free, although, technically, it isn't free until the */
             /* linked list of Access Descriptors has no links in it.              */
@@ -679,7 +679,7 @@ int32 CFE_TBL_Load( CFE_TBL_Handle_t TblHandle,
                     const void *SrcDataPtr )
 {
     int32                       Status;
-    uint32                      ThisAppId;
+    CFE_ES_ResourceID_t         ThisAppId;
     CFE_TBL_LoadBuff_t         *WorkingBufferPtr;
     CFE_TBL_AccessDescriptor_t *AccessDescPtr;
     CFE_TBL_RegistryRec_t      *RegRecPtr;
@@ -910,7 +910,7 @@ int32 CFE_TBL_Load( CFE_TBL_Handle_t TblHandle,
 int32 CFE_TBL_Update( CFE_TBL_Handle_t TblHandle )
 {
     int32                       Status;
-    uint32                      ThisAppId;
+    CFE_ES_ResourceID_t         ThisAppId;
     CFE_TBL_RegistryRec_t      *RegRecPtr=NULL;
     CFE_TBL_AccessDescriptor_t *AccessDescPtr=NULL;
     char                        AppName[OS_MAX_API_NAME]={"UNKNOWN"};
@@ -991,7 +991,7 @@ int32 CFE_TBL_GetAddress( void **TblPtr,
                           CFE_TBL_Handle_t TblHandle )
 {
     int32   Status;
-    uint32  ThisAppId;
+    CFE_ES_ResourceID_t  ThisAppId;
 
     /* Assume failure at returning the table address */
     *TblPtr = NULL;
@@ -1022,7 +1022,7 @@ int32 CFE_TBL_GetAddress( void **TblPtr,
 int32 CFE_TBL_ReleaseAddress( CFE_TBL_Handle_t TblHandle )
 {
     int32   Status;
-    uint32  ThisAppId;
+    CFE_ES_ResourceID_t   ThisAppId;
 
     /* Verify that this application has the right to perform operation */
     Status = CFE_TBL_ValidateAccess(TblHandle, &ThisAppId);
@@ -1057,7 +1057,7 @@ int32 CFE_TBL_GetAddresses( void **TblPtrs[],
 {
     uint16  i;
     int32   Status;
-    uint32  ThisAppId;
+    CFE_ES_ResourceID_t   ThisAppId;
 
     /* Assume failure at returning the table addresses */
     for (i=0; i<NumTables; i++)
@@ -1128,7 +1128,7 @@ int32 CFE_TBL_ReleaseAddresses( uint16 NumTables,
 int32 CFE_TBL_Validate( CFE_TBL_Handle_t TblHandle )
 {
     int32                       Status;
-    uint32                      ThisAppId;
+    CFE_ES_ResourceID_t         ThisAppId;
     CFE_TBL_RegistryRec_t      *RegRecPtr;
     CFE_TBL_AccessDescriptor_t *AccessDescPtr;
     char                        AppName[OS_MAX_API_NAME]={"UNKNWON"};
@@ -1332,7 +1332,7 @@ int32 CFE_TBL_Manage( CFE_TBL_Handle_t TblHandle )
 int32 CFE_TBL_GetStatus( CFE_TBL_Handle_t TblHandle )
 {
     int32                       Status ;
-    uint32                      ThisAppId;
+    CFE_ES_ResourceID_t         ThisAppId;
     CFE_TBL_RegistryRec_t      *RegRecPtr;
     CFE_TBL_AccessDescriptor_t *AccessDescPtr;
 
@@ -1472,7 +1472,7 @@ int32 CFE_TBL_Modified( CFE_TBL_Handle_t TblHandle )
     CFE_TBL_AccessDescriptor_t *AccessDescPtr = NULL;
     CFE_TBL_RegistryRec_t      *RegRecPtr = NULL;
     CFE_TBL_Handle_t            AccessIterator;
-    uint32                      ThisAppId;
+    CFE_ES_ResourceID_t         ThisAppId;
     size_t                      FilenameLen = 0;
 
     /* Verify that this application has the right to perform operation */
@@ -1515,7 +1515,7 @@ int32 CFE_TBL_Modified( CFE_TBL_Handle_t TblHandle )
         while (AccessIterator != CFE_TBL_END_OF_LIST)
         {
             /* Only notify *OTHER* applications that the contents have changed */
-            if (CFE_TBL_TaskData.Handles[AccessIterator].AppId != ThisAppId)
+            if (!CFE_ES_ResourceID_Equal(CFE_TBL_TaskData.Handles[AccessIterator].AppId, ThisAppId))
             {
                 CFE_TBL_TaskData.Handles[AccessIterator].Updated = true;
             }
@@ -1542,7 +1542,7 @@ int32 CFE_TBL_NotifyByMessage(CFE_TBL_Handle_t TblHandle, CFE_SB_MsgId_t MsgId, 
     int32                       Status;
     CFE_TBL_AccessDescriptor_t *AccessDescPtr = NULL;
     CFE_TBL_RegistryRec_t      *RegRecPtr = NULL;
-    uint32                      ThisAppId;
+    CFE_ES_ResourceID_t         ThisAppId;
 
     /* Verify that this application has the right to perform operation */
     Status = CFE_TBL_ValidateAccess(TblHandle, &ThisAppId);
@@ -1554,7 +1554,7 @@ int32 CFE_TBL_NotifyByMessage(CFE_TBL_Handle_t TblHandle, CFE_SB_MsgId_t MsgId, 
         RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
         
         /* Verify that the calling application is the table owner */
-        if (RegRecPtr->OwnerAppId == ThisAppId)
+        if (CFE_ES_ResourceID_Equal(RegRecPtr->OwnerAppId, ThisAppId))
         {
             RegRecPtr->NotificationMsgId = MsgId;
             RegRecPtr->NotificationCC = CommandCode;

--- a/fsw/cfe-core/src/tbl/cfe_tbl_internal.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_internal.h
@@ -41,7 +41,7 @@
 
 /*********************  Macro and Constant Type Definitions   ***************************/
 
-#define CFE_TBL_NOT_OWNED               0xFFFFFFFF
+#define CFE_TBL_NOT_OWNED               CFE_ES_RESOURCEID_UNDEFINED
 #define CFE_TBL_NOT_FOUND               (-1)
 #define CFE_TBL_END_OF_LIST             (CFE_TBL_Handle_t)0xFFFF
 
@@ -93,7 +93,7 @@ int32   CFE_TBL_ValidateHandle(CFE_TBL_Handle_t TblHandle);
 ** \retval #CFE_TBL_ERR_NO_ACCESS           \copydoc CFE_TBL_ERR_NO_ACCESS
 **                     
 ******************************************************************************/
-int32   CFE_TBL_ValidateAccess(CFE_TBL_Handle_t TblHandle, uint32 *AppIdPtr);
+int32   CFE_TBL_ValidateAccess(CFE_TBL_Handle_t TblHandle, CFE_ES_ResourceID_t *AppIdPtr);
 
 /*****************************************************************************/
 /**
@@ -116,7 +116,7 @@ int32   CFE_TBL_ValidateAccess(CFE_TBL_Handle_t TblHandle, uint32 *AppIdPtr);
 ** \retval #CFE_TBL_ERR_NO_ACCESS           \copydoc CFE_TBL_ERR_NO_ACCESS
 **                     
 ******************************************************************************/
-int32   CFE_TBL_CheckAccessRights(CFE_TBL_Handle_t TblHandle, uint32 ThisAppId);
+int32   CFE_TBL_CheckAccessRights(CFE_TBL_Handle_t TblHandle, CFE_ES_ResourceID_t ThisAppId);
 
 
 /*****************************************************************************/
@@ -167,7 +167,7 @@ int32   CFE_TBL_RemoveAccessLink(CFE_TBL_Handle_t TblHandle);
 ** \retval #CFE_TBL_ERR_UNREGISTERED        \copydoc CFE_TBL_ERR_UNREGISTERED
 **                
 ******************************************************************************/
-int32   CFE_TBL_GetAddressInternal(void **TblPtr, CFE_TBL_Handle_t TblHandle, uint32 ThisAppId);
+int32   CFE_TBL_GetAddressInternal(void **TblPtr, CFE_TBL_Handle_t TblHandle, CFE_ES_ResourceID_t ThisAppId);
 
 
 /*****************************************************************************/
@@ -262,7 +262,7 @@ CFE_TBL_Handle_t CFE_TBL_FindFreeHandle(void);
 **
 **                      
 ******************************************************************************/
-void CFE_TBL_FormTableName(char *FullTblName, const char *TblName, uint32 ThisAppId);
+void CFE_TBL_FormTableName(char *FullTblName, const char *TblName, CFE_ES_ResourceID_t ThisAppId);
 
 
 /*****************************************************************************/

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task.h
@@ -165,7 +165,7 @@ typedef struct
 */
 typedef struct 
 {
-    uint32                AppId;            /**< \brief Application ID to verify access */
+    CFE_ES_ResourceID_t   AppId;            /**< \brief Application ID to verify access */
     int16                 RegIndex;         /**< \brief Index into Table Registry (a.k.a. - Global Table #) */
     CFE_TBL_Handle_t      PrevLink;         /**< \brief Index of previous access descriptor in linked list */
     CFE_TBL_Handle_t      NextLink;         /**< \brief Index of next access descriptor in linked list */
@@ -184,7 +184,7 @@ typedef struct
 */
 typedef struct 
 {
-    uint32                      OwnerAppId;         /**< \brief Application ID of App that Registered Table */
+    CFE_ES_ResourceID_t         OwnerAppId;         /**< \brief Application ID of App that Registered Table */
     uint32                      Size;               /**< \brief Size, in bytes, of Table */
     CFE_SB_MsgId_t              NotificationMsgId;  /**< \brief Message ID of an associated management notification message */
     uint32                      NotificationParam;  /**< \brief Parameter of an associated management notification message */
@@ -316,7 +316,7 @@ typedef struct
   */
   char                   PipeName[16];                    /**< \brief Contains name of Table Task command pipe */
   uint16                 PipeDepth;                       /**< \brief Contains depth of Table Task command pipe */
-  uint32                 TableTaskAppId;                  /**< \brief Contains Table Task Application ID as assigned by OS AL */
+  CFE_ES_ResourceID_t    TableTaskAppId;                  /**< \brief Contains Table Task Application ID as assigned by OS AL */
 
   int16                  HkTlmTblRegIndex;                /**< \brief Index of table registry entry to be telemetered with Housekeeping */
   uint16                 ValidationCounter;

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.c
@@ -172,7 +172,7 @@ void CFE_TBL_GetHkData(void)
     Count = 0;
     for (i=0; i<CFE_PLATFORM_TBL_MAX_NUM_TABLES; i++)
     {
-        if (CFE_TBL_TaskData.Registry[i].OwnerAppId != CFE_TBL_NOT_OWNED)
+        if (!CFE_ES_ResourceID_Equal(CFE_TBL_TaskData.Registry[i].OwnerAppId, CFE_TBL_NOT_OWNED))
         {
             Count++;
 
@@ -246,7 +246,7 @@ void CFE_TBL_GetHkData(void)
         (CFE_TBL_TaskData.LastTblUpdated < CFE_PLATFORM_TBL_MAX_NUM_TABLES))
     {
         /* Check to make sure the Registry Entry is still valid */
-        if (CFE_TBL_TaskData.Registry[CFE_TBL_TaskData.LastTblUpdated].OwnerAppId != CFE_TBL_NOT_OWNED)
+        if (!CFE_ES_ResourceID_Equal(CFE_TBL_TaskData.Registry[CFE_TBL_TaskData.LastTblUpdated].OwnerAppId, CFE_TBL_NOT_OWNED))
         {
             /* Get the time at the last table update */
             CFE_TBL_TaskData.HkPacket.Payload.LastUpdateTime =
@@ -1168,7 +1168,7 @@ int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistry_t *data)
                 RegRecPtr = &CFE_TBL_TaskData.Registry[RegIndex];
 
                 /* Check to see if the Registry entry is empty */
-                if ((RegRecPtr->OwnerAppId != CFE_TBL_NOT_OWNED) ||
+                if (!CFE_ES_ResourceID_Equal(RegRecPtr->OwnerAppId, CFE_TBL_NOT_OWNED) ||
                     (RegRecPtr->HeadOfAccessList != CFE_TBL_END_OF_LIST))
                 {
                     /* Fill Registry Dump Record with relevant information */
@@ -1220,7 +1220,7 @@ int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistry_t *data)
                     }
 
                     /* Determine the name of the owning application */
-                    if (RegRecPtr->OwnerAppId != CFE_TBL_NOT_OWNED)
+                    if (!CFE_ES_ResourceID_Equal(RegRecPtr->OwnerAppId, CFE_TBL_NOT_OWNED))
                     {
                         CFE_ES_GetAppName(DumpRecord.OwnerAppName, RegRecPtr->OwnerAppId, sizeof(DumpRecord.OwnerAppName));
                     }

--- a/fsw/cfe-core/src/time/cfe_time_api.c
+++ b/fsw/cfe-core/src/time/cfe_time_api.c
@@ -758,7 +758,7 @@ void CFE_TIME_ExternalTone(void)
 int32  CFE_TIME_RegisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPtr)   
 {
     int32  Status;
-    uint32 AppId;
+    CFE_ES_ResourceID_t AppId;
     uint32 AppIndex;
 
     Status = CFE_ES_GetAppID(&AppId);
@@ -792,7 +792,7 @@ int32  CFE_TIME_RegisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPt
 int32  CFE_TIME_UnregisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPtr)   
 {
     int32  Status;
-    uint32 AppId;
+    CFE_ES_ResourceID_t AppId;
     uint32 AppIndex;
 
     Status = CFE_ES_GetAppID(&AppId);

--- a/fsw/cfe-core/src/time/cfe_time_utils.c
+++ b/fsw/cfe-core/src/time/cfe_time_utils.c
@@ -1136,7 +1136,7 @@ void CFE_TIME_Set1HzAdj(CFE_TIME_SysTime_t NewAdjust, int16 Direction)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-int32 CFE_TIME_CleanUpApp(uint32 AppId)
+int32 CFE_TIME_CleanUpApp(CFE_ES_ResourceID_t AppId)
 {
     int32 Status;
     uint32 AppIndex;

--- a/fsw/cfe-core/src/time/cfe_time_utils.h
+++ b/fsw/cfe-core/src/time/cfe_time_utils.h
@@ -305,8 +305,8 @@ typedef struct
   /*
   ** Interrupt task ID's...
   */
-  uint32                LocalTaskID;
-  uint32                ToneTaskID;
+  CFE_ES_ResourceID_t   LocalTaskID;
+  CFE_ES_ResourceID_t   ToneTaskID;
 
   /*
   ** Maximum difference from expected for external time sources...

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -195,19 +195,27 @@ static const UT_TaskPipeDispatchId_t  UT_TPID_CFE_ES_SEND_HK =
 /*
 ** Functions
 */
-uint32 ES_UT_MakeAppIdForIndex(uint32 ArrayIdx)
+CFE_ES_ResourceID_t ES_UT_MakeAppIdForIndex(uint32 ArrayIdx)
 {
     /* UT hack - make up AppID values in a manner similar to FSW.
      * Real apps should never do this. */
-    return ArrayIdx;
+    return CFE_ES_ResourceID_FromInteger(ArrayIdx + CFE_ES_APPID_BASE);
 }
 
-uint32 ES_UT_MakeTaskIdForIndex(uint32 ArrayIdx)
+CFE_ES_ResourceID_t ES_UT_MakeTaskIdForIndex(uint32 ArrayIdx)
 {
     /* UT hack - make up TaskID values in a manner similar to FSW.
      * Real apps should never do this. */
-    return (ArrayIdx + 0x40010000);
+    return CFE_ES_ResourceID_FromInteger(ArrayIdx + 0x40010000);
 }
+
+CFE_ES_ResourceID_t ES_UT_MakeLibIdForIndex(uint32 ArrayIdx)
+{
+    /* UT hack - make up LibID values in a manner similar to FSW.
+     * Real apps should never do this. */
+    return CFE_ES_ResourceID_FromInteger(ArrayIdx + CFE_ES_LIBID_BASE);
+}
+
 /*
  * Helper function to setup a single app ID in the given state, along with
  * a main task ID.  A pointer to the App and Task record is output so the
@@ -217,8 +225,8 @@ void ES_UT_SetupSingleAppId(CFE_ES_AppType_Enum_t AppType, CFE_ES_AppState_Enum_
         const char *AppName, CFE_ES_AppRecord_t **OutAppRec, CFE_ES_TaskRecord_t **OutTaskRec)
 {
     osal_id_t UtOsalId;
-    uint32 UtTaskId;
-    uint32 UtAppId;
+    CFE_ES_ResourceID_t UtTaskId;
+    CFE_ES_ResourceID_t UtAppId;
     CFE_ES_AppRecord_t *LocalAppPtr;
     CFE_ES_TaskRecord_t *LocalTaskPtr;
 
@@ -274,8 +282,8 @@ void ES_UT_SetupSingleAppId(CFE_ES_AppType_Enum_t AppType, CFE_ES_AppState_Enum_
 void ES_UT_SetupChildTaskId(const CFE_ES_AppRecord_t *ParentApp, const char *TaskName, CFE_ES_TaskRecord_t **OutTaskRec)
 {
     osal_id_t UtOsalId;
-    uint32 UtTaskId;
-    uint32 UtAppId;
+    CFE_ES_ResourceID_t UtTaskId;
+    CFE_ES_ResourceID_t UtAppId;
     CFE_ES_TaskRecord_t *LocalTaskPtr;
 
     UtAppId = CFE_ES_AppRecordGetID(ParentApp);
@@ -934,7 +942,7 @@ void TestApps(void)
     int Return;
     int j;
     CFE_ES_AppInfo_t AppInfo;
-    uint32 Id;
+    CFE_ES_ResourceID_t Id;
     CFE_ES_TaskRecord_t *UtTaskRecPtr;
     CFE_ES_AppRecord_t *UtAppRecPtr;
 
@@ -1860,7 +1868,7 @@ void TestLibs(void)
 {
     CFE_ES_LibRecord_t *UtLibRecPtr;
     char LongLibraryName[sizeof(UtLibRecPtr->LibName)+1];
-    uint32 Id;
+    CFE_ES_ResourceID_t Id;
     uint32 j;
     int32 Return;
 
@@ -1917,7 +1925,8 @@ void TestLibs(void)
               Return == CFE_ES_LIB_ALREADY_LOADED,
               "CFE_ES_LoadLibrary",
               "Duplicate");
-    UtAssert_True(Id == CFE_ES_LibRecordGetID(UtLibRecPtr), "CFE_ES_LoadLibrary() returned previous ID");
+    UtAssert_True(CFE_ES_ResourceID_Equal(Id, CFE_ES_LibRecordGetID(UtLibRecPtr)),
+            "CFE_ES_LoadLibrary() returned previous ID");
 
     /* Test shared library loading and initialization where the library
      * fails to load
@@ -1969,7 +1978,8 @@ void TestLibs(void)
     UtLibRecPtr = CFE_ES_Global.LibTable;
     for (j = 0; j < CFE_PLATFORM_ES_MAX_LIBRARIES; j++)
     {
-        CFE_ES_LibRecordSetUsed(UtLibRecPtr, j);
+        CFE_ES_LibRecordSetUsed(UtLibRecPtr,
+                ES_UT_MakeLibIdForIndex(j));
         ++UtLibRecPtr;
     }
 
@@ -3896,8 +3906,8 @@ void TestAPI(void)
     uint8  Data[12];
     uint32 ResetType;
     uint32 *ResetTypePtr;
-    uint32 AppId;
-    uint32 TaskId;
+    CFE_ES_ResourceID_t AppId;
+    CFE_ES_ResourceID_t TaskId;
     uint32 RunStatus;
     CFE_ES_TaskInfo_t TaskInfo;
     CFE_ES_AppInfo_t AppInfo;
@@ -4170,7 +4180,7 @@ void TestAPI(void)
               "Get task info by ID; NULL buffer");
 
     /* Test getting task information using the task ID - bad task ID  */
-    UT_SetForceFail(UT_KEY(OS_ConvertToArrayIndex), OS_ERROR);
+    UT_SetForceFail(UT_KEY(OS_ObjectIdToArrayIndex), OS_ERROR);
     UT_Report(__FILE__, __LINE__,
               CFE_ES_GetTaskInfo(&TaskInfo, TaskId) == CFE_ES_ERR_TASKID,
               "CFE_ES_GetTaskInfo",
@@ -4208,7 +4218,7 @@ void TestAPI(void)
 
     /* Test getting task information using the task ID with invalid task ID */
     ES_ResetUnitTest();
-    TaskId = ES_UT_MakeTaskIdForIndex(99999);
+    TaskId = CFE_ES_RESOURCEID_UNDEFINED;
     UT_Report(__FILE__, __LINE__,
               CFE_ES_GetTaskInfo(&TaskInfo, TaskId) == CFE_ES_ERR_TASKID,
               "CFE_ES_GetTaskInfo",
@@ -4343,7 +4353,7 @@ void TestAPI(void)
               "Task ID belongs to a main task");
 
     /* Test deleting a child task with an invalid task ID */
-    UT_SetForceFail(UT_KEY(OS_ConvertToArrayIndex), OS_ERROR);
+    UT_SetForceFail(UT_KEY(OS_ObjectIdToArrayIndex), OS_ERROR);
     UT_Report(__FILE__, __LINE__,
               CFE_ES_DeleteChildTask(TaskId) == CFE_ES_ERR_TASKID,
               "CFE_ES_DeleteChildTask",
@@ -4383,7 +4393,7 @@ void TestAPI(void)
 
     /* Test deleting a child task with the task ID out of range */
     ES_ResetUnitTest();
-    TaskId = ES_UT_MakeTaskIdForIndex(99999);
+    TaskId = CFE_ES_RESOURCEID_UNDEFINED;
     UT_Report(__FILE__, __LINE__,
               CFE_ES_DeleteChildTask(TaskId) == CFE_ES_ERR_TASKID,
               "CFE_ES_DeleteChildTask",
@@ -4605,7 +4615,7 @@ void TestAPI(void)
 void TestGenericCounterAPI(void)
 {
     char CounterName[11];
-    uint32 CounterId;
+    CFE_ES_ResourceID_t CounterId;
     uint32 CounterCount;
     int i;
 
@@ -4663,7 +4673,7 @@ void TestGenericCounterAPI(void)
 
     /* Test deleting a registered generic counter that doesn't exist */
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_DeleteGenCounter(123456) == CFE_ES_BAD_ARGUMENT,
+              CFE_ES_DeleteGenCounter(CFE_ES_RESOURCEID_UNDEFINED) == CFE_ES_BAD_ARGUMENT,
               "CFE_ES_DeleteGenCounter",
               "Cannot delete counter that does not exist");
 
@@ -4683,7 +4693,7 @@ void TestGenericCounterAPI(void)
 
     /* Test incrementing a generic counter that doesn't exist */
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_IncrementGenCounter(CFE_PLATFORM_ES_MAX_GEN_COUNTERS)
+              CFE_ES_IncrementGenCounter(CFE_ES_RESOURCEID_UNDEFINED)
                 == CFE_ES_BAD_ARGUMENT,
               "CFE_ES_IncrementGenCounter",
               "Bad counter ID");
@@ -4696,7 +4706,7 @@ void TestGenericCounterAPI(void)
 
     /* Test getting a generic counter value for a counter that doesn't exist */
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_GetGenCount(123456, &CounterCount) == CFE_ES_BAD_ARGUMENT,
+              CFE_ES_GetGenCount(CFE_ES_RESOURCEID_UNDEFINED, &CounterCount) == CFE_ES_BAD_ARGUMENT,
               "CFE_ES_GetGenCount",
               "Bad counter ID");
 
@@ -4709,7 +4719,7 @@ void TestGenericCounterAPI(void)
 
     /* Test setting a generic counter value for a counter that doesn't exist */
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_SetGenCount(123456, 5) == CFE_ES_BAD_ARGUMENT,
+              CFE_ES_SetGenCount(CFE_ES_RESOURCEID_UNDEFINED, 5) == CFE_ES_BAD_ARGUMENT,
               "CFE_ES_SetGenCount",
               "Bad counter ID");
 

--- a/fsw/cfe-core/unit-test/evs_UT.c
+++ b/fsw/cfe-core/unit-test/evs_UT.c
@@ -282,8 +282,6 @@ void Test_Init(void)
 
     UtPrintf("Begin Test Init");
 
-    UT_SetAppID(1); /*jphfix*/
-
     strncpy((char *) appbitcmd.Payload.AppName, "ut_cfe_evs",
             sizeof(appbitcmd.Payload.AppName));
 
@@ -545,7 +543,7 @@ void Test_IllegalAppID(void)
     UT_Report(__FILE__, __LINE__,
               CFE_EVS_SendEventWithAppID(0,
                                          0,
-                                         0,
+                                         CFE_ES_RESOURCEID_UNDEFINED,
                                          "NULL") == CFE_EVS_APP_ILLEGAL_APP_ID,
               "CFE_EVS_SendEventWithAppID",
               "Illegal app ID");
@@ -570,7 +568,7 @@ void Test_IllegalAppID(void)
     UT_InitData();
     UT_SetForceFail(UT_KEY(CFE_ES_AppID_ToIndex), CFE_ES_ERR_APPID);
     UT_Report(__FILE__, __LINE__,
-              CFE_EVS_CleanUpApp(0) ==
+              CFE_EVS_CleanUpApp(CFE_ES_RESOURCEID_UNDEFINED) ==
                   CFE_EVS_APP_ILLEGAL_APP_ID,
               "CFE_EVS_CleanUpApp",
               "Illegal app ID");
@@ -584,7 +582,7 @@ void Test_UnregisteredApp(void)
 {
     CFE_TIME_SysTime_t time = {0, 0};
     EVS_AppData_t       *AppDataPtr;
-    uint32 AppID;
+    CFE_ES_ResourceID_t AppID;
 
     /* Get a local ref to the "current" AppData table entry */
     EVS_GetCurrentContext(&AppDataPtr, &AppID);
@@ -667,7 +665,7 @@ void Test_FilterRegistration(void)
     CFE_EVS_BinFilter_t filter[CFE_PLATFORM_EVS_MAX_EVENT_FILTERS + 1];
     EVS_BinFilter_t     *FilterPtr = NULL;
     EVS_AppData_t       *AppDataPtr;
-    uint32 AppID;
+    CFE_ES_ResourceID_t AppID;
     CFE_TIME_SysTime_t  time = {0, 0};
 
     /* Get a local ref to the "current" AppData table entry */
@@ -799,6 +797,7 @@ void Test_FilterRegistration(void)
      * application
      */
     UT_InitData();
+    AppDataPtr->AppID = AppID;
     AppDataPtr->ActiveFlag = false;
     UT_Report(__FILE__, __LINE__,
               CFE_EVS_SendEventWithAppID(0,
@@ -810,6 +809,7 @@ void Test_FilterRegistration(void)
 
     /* Test sending a timed event to a registered, filtered application */
     UT_InitData();
+    AppDataPtr->AppID = AppID;
     AppDataPtr->ActiveFlag = false;
     UT_Report(__FILE__, __LINE__,
               CFE_EVS_SendTimedEvent(time,
@@ -906,7 +906,7 @@ void Test_Format(void)
             .SnapshotSize = sizeof(CapturedMsg)
     };
     EVS_AppData_t       *AppDataPtr;
-    uint32 AppID;
+    CFE_ES_ResourceID_t AppID;
 
     /* Get a local ref to the "current" AppData table entry */
     EVS_GetCurrentContext(&AppDataPtr, &AppID);
@@ -2650,7 +2650,7 @@ void Test_Misc(void)
         CFE_EVS_WriteLogDataFile_t writelogdatacmd;
     } PktBuf;
 
-    uint32 AppID;
+    CFE_ES_ResourceID_t AppID;
     EVS_AppData_t       *AppDataPtr;
     int                i;
     char               msg[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH + 2];
@@ -2704,7 +2704,7 @@ void Test_Misc(void)
     /* Test successful application cleanup */
     UT_InitData();
     UT_Report(__FILE__, __LINE__,
-              CFE_EVS_CleanUpApp(0) == CFE_SUCCESS,
+              CFE_EVS_CleanUpApp(CFE_ES_RESOURCEID_UNDEFINED) == CFE_SUCCESS,
               "CFE_EVS_CleanUpApp",
               "Application cleanup - successful");
 
@@ -2757,7 +2757,7 @@ void Test_Misc(void)
 
     msg[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH] = '\0';
     CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageTruncCounter = 0;
-    AppDataPtr->RegisterFlag = true;
+    EVS_AppDataSetUsed(AppDataPtr, AppID);
     AppDataPtr->ActiveFlag = true;
     AppDataPtr->EventTypesActiveFlag |=
         CFE_EVS_INFORMATION_BIT;

--- a/fsw/cfe-core/unit-test/tbl_UT.c
+++ b/fsw/cfe-core/unit-test/tbl_UT.c
@@ -55,9 +55,10 @@ CFE_TBL_Handle_t App2TblHandle1;
 CFE_TBL_Handle_t App2TblHandle2;
 CFE_TBL_Handle_t ArrayOfHandles[2];
 
-static const uint32 UT_TBL_APPID_1 =  1;
-static const uint32 UT_TBL_APPID_2 =  2;
-static const uint32 UT_TBL_APPID_10 = 10;
+static const CFE_ES_ResourceID_t UT_TBL_APPID_1 =  { 0x02010001 };
+static const CFE_ES_ResourceID_t UT_TBL_APPID_2 =  { 0x02010002 };
+static const CFE_ES_ResourceID_t UT_TBL_APPID_3 =  { 0x02010003 };
+static const CFE_ES_ResourceID_t UT_TBL_APPID_10 = { 0x0201000A };
 
 void *Tbl1Ptr = NULL;
 void *Tbl2Ptr = NULL;
@@ -1027,7 +1028,7 @@ void Test_CFE_TBL_GetHkData(void)
     int32 NumLoadPendingIndex = CFE_PLATFORM_TBL_MAX_NUM_TABLES - 1;
     int32 FreeSharedBuffIndex = CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS - 1;
     int32 ValTableIndex = CFE_PLATFORM_TBL_MAX_NUM_VALIDATIONS - 1;
-    uint32 AppID;
+    CFE_ES_ResourceID_t AppID;
 
     /* Get the AppID being used for UT */
     CFE_ES_GetAppID(&AppID);
@@ -1122,7 +1123,7 @@ void Test_CFE_TBL_DumpRegCmd(void)
 {
     int                  q;
     CFE_TBL_DumpRegistry_t DumpRegCmd;
-    uint32 AppID;
+    CFE_ES_ResourceID_t AppID;
 
     /* Get the AppID being used for UT */
     CFE_ES_GetAppID(&AppID);
@@ -1218,7 +1219,7 @@ void Test_CFE_TBL_DumpCmd(void)
     uint8              *BuffPtr = &Buff;
     CFE_TBL_LoadBuff_t Load = {0};
     CFE_TBL_Dump_t     DumpCmd;
-    uint32 AppID;
+    CFE_ES_ResourceID_t AppID;
 
     CFE_ES_GetAppID(&AppID);
 
@@ -1396,7 +1397,7 @@ void Test_CFE_TBL_LoadCmd(void)
     CFE_FS_Header_t    StdFileHeader;
     CFE_TBL_LoadBuff_t BufferPtr = CFE_TBL_TaskData.LoadBuffs[0];
     CFE_TBL_Load_t     LoadCmd;
-    uint32 AppID;
+    CFE_ES_ResourceID_t AppID;
 
     CFE_ES_GetAppID(&AppID);
 
@@ -1756,7 +1757,6 @@ void Test_CFE_TBL_HousekeepingCmd(void)
 */
 void Test_CFE_TBL_ApiInit(void)
 {
-    UT_SetAppID(1);
     UT_ResetCDS();
     CFE_TBL_EarlyInit();
     CFE_TBL_TaskData.TableTaskAppId = UT_TBL_APPID_10;
@@ -1804,7 +1804,6 @@ void Test_CFE_TBL_Register(void)
     }
 
     TblName[i] = '\0';
-    UT_SetAppID(1);
     RtnCode = CFE_TBL_Register(&TblHandle1, TblName,
                                sizeof(UT_Table1_t),
                                CFE_TBL_OPT_DEFAULT, NULL);
@@ -1982,7 +1981,7 @@ void Test_CFE_TBL_Register(void)
 
     /* Test attempt to register table owned by another application */
     UT_InitData();
-    UT_SetAppID(2);
+    UT_SetAppID(UT_TBL_APPID_2);
     RtnCode = CFE_TBL_Register(&TblHandle3, "UT_Table1",
                                sizeof(UT_Table1_t),
                                CFE_TBL_OPT_DBL_BUFFER, NULL);
@@ -1995,7 +1994,7 @@ void Test_CFE_TBL_Register(void)
 
     /* Test attempt to register existing table with a different size */
     UT_InitData();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
     RtnCode = CFE_TBL_Register(&TblHandle3, "UT_Table1",
                                sizeof(UT_Table2_t),
                                CFE_TBL_OPT_DBL_BUFFER, NULL);
@@ -2009,7 +2008,7 @@ void Test_CFE_TBL_Register(void)
     /* Test attempt to register a table with the same size and name */
     /* a. Test setup */
     UT_InitData();
-    UT_SetAppID(2);
+    UT_SetAppID(UT_TBL_APPID_2);
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     RtnCode = CFE_TBL_Share(&TblHandle3, "ut_cfe_tbl.UT_Table1");
     UT_Report(__FILE__, __LINE__,
@@ -2019,7 +2018,7 @@ void Test_CFE_TBL_Register(void)
 
     /* b. Perform test */
     UT_InitData();
-    UT_SetAppID(1); /* Restore AppID to proper value */
+    UT_SetAppID(UT_TBL_APPID_1); /* Restore AppID to proper value */
     RtnCode = CFE_TBL_Register(&TblHandle2, "UT_Table1",
                                sizeof(UT_Table1_t),
                                CFE_TBL_OPT_DBL_BUFFER, NULL);
@@ -2032,9 +2031,9 @@ void Test_CFE_TBL_Register(void)
 
     /* c. Test cleanup: unregister tables */
     UT_ClearEventHistory();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
     RtnCode = CFE_TBL_Unregister(TblHandle2);
-    UT_SetAppID(2);
+    UT_SetAppID(UT_TBL_APPID_2);
     RtnCode2 = CFE_TBL_Unregister(TblHandle3);
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     UT_Report(__FILE__, __LINE__,
@@ -2046,7 +2045,7 @@ void Test_CFE_TBL_Register(void)
     /* Test registering a single buffered table */
     /* a. Perform test */
     UT_InitData();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
     RtnCode = CFE_TBL_Register(&TblHandle1, "UT_Table1",
                                sizeof(UT_Table1_t),
                                CFE_TBL_OPT_DEFAULT, NULL);
@@ -2454,7 +2453,7 @@ void Test_CFE_TBL_Register(void)
    /* Test attempt to register a double buffered table with a pool buffer
     * error */
    UT_InitData();
-   UT_SetAppID(1);
+   UT_SetAppID(UT_TBL_APPID_1);
    UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetPoolBuf), 1, CFE_SEVERITY_ERROR);
    snprintf(TblName, CFE_MISSION_TBL_MAX_NAME_LENGTH, "UT_Table%d",
             CFE_PLATFORM_TBL_MAX_NUM_TABLES);
@@ -2502,7 +2501,7 @@ void Test_CFE_TBL_Share(void)
 
     /* Test response when table name is not in the registry */
     UT_InitData();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
     RtnCode = CFE_TBL_Share(&App1TblHandle1, "ut_cfe_tbl.NOT_Table2");
     EventsCorrect = (UT_EventIsInHistory(CFE_TBL_SHARE_ERR_EID) == true &&
                      UT_GetNumEventsSent() == 1);
@@ -2571,7 +2570,7 @@ void Test_CFE_TBL_Share(void)
 
     /* Test successful share of a table that has not been loaded once */
     UT_InitData();
-    UT_SetAppID(2);
+    UT_SetAppID(UT_TBL_APPID_2);
     RtnCode = CFE_TBL_Share(&App2TblHandle1, "ut_cfe_tbl.UT_Table3");
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     UT_Report(__FILE__, __LINE__,
@@ -2602,7 +2601,7 @@ void Test_CFE_TBL_Unregister(void)
 
     /* Test response to unregistering a table with an invalid handle */
     UT_InitData();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
     RtnCode = CFE_TBL_Unregister(CFE_PLATFORM_TBL_MAX_NUM_HANDLES);
     EventsCorrect = (UT_EventIsInHistory(CFE_TBL_UNREGISTER_ERR_EID) == true &&
                      UT_GetNumEventsSent() == 1);
@@ -2622,13 +2621,13 @@ void Test_CFE_TBL_Unregister(void)
 
     /* Test response to unregistering an unowned table */
     UT_InitData();
-    UT_SetAppID(2);
+    UT_SetAppID(UT_TBL_APPID_2);
     RtnCode = CFE_TBL_Unregister(App2TblHandle2);
     EventsCorrect =
-        (UT_EventIsInHistory(CFE_TBL_UNREGISTER_ERR_EID) == false &&
-         UT_GetNumEventsSent() == 0);
+        (UT_EventIsInHistory(CFE_TBL_UNREGISTER_ERR_EID) == true &&
+         UT_GetNumEventsSent() == 1);
     UT_Report(__FILE__, __LINE__,
-              RtnCode == CFE_SUCCESS && EventsCorrect,
+              RtnCode == CFE_TBL_ERR_NO_ACCESS && EventsCorrect,
               "CFE_TBL_Unregister",
               "Unregister unowned table");
 }
@@ -2646,7 +2645,7 @@ void Test_CFE_TBL_NotifyByMessage(void)
 
     /* Set up notify by message tests */
     UT_InitData();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
     CFE_TBL_EarlyInit();
     UT_ResetPoolBufferIndex();
 
@@ -2715,7 +2714,7 @@ void Test_CFE_TBL_Load(void)
 
     /* Set up for table load test */
     UT_InitData();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
     UT_ResetTableRegistry();
     RtnCode = CFE_TBL_Register(&App1TblHandle1, "UT_Table1",
                                sizeof(UT_Table1_t),
@@ -2814,7 +2813,7 @@ void Test_CFE_TBL_Load(void)
     /* Set up for double buffer table load test */
     /* Test setup - register a double buffered table */
     UT_InitData();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
     RtnCode = CFE_TBL_Register(&App1TblHandle2,
                                "UT_Table2x",
                                sizeof(UT_Table1_t),
@@ -2994,7 +2993,7 @@ void Test_CFE_TBL_Load(void)
     /* Test attempt to load a locked shared table */
     /* a. Test setup part 1 */
     UT_InitData();
-    UT_SetAppID(2);
+    UT_SetAppID(UT_TBL_APPID_2);
     RtnCode = CFE_TBL_Share(&App2TblHandle1, "ut_cfe_tbl.UT_Table1");
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     UT_Report(__FILE__, __LINE__,
@@ -3003,7 +3002,6 @@ void Test_CFE_TBL_Load(void)
               "Attempt to load locked shared table (setup part 1)");
 
     /* a. Test setup part 2 */
-    UT_InitData();
     RtnCode = CFE_TBL_GetAddress((void **) &App2TblPtr, App2TblHandle1);
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     UT_Report(__FILE__, __LINE__,
@@ -3013,7 +3011,7 @@ void Test_CFE_TBL_Load(void)
 
     /* c. Perform test */
     UT_InitData();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
     RtnCode = CFE_TBL_Load(App1TblHandle1, CFE_TBL_SRC_ADDRESS, &TestTable1);
     EventsCorrect = (UT_GetNumEventsSent() == 1);
     UT_Report(__FILE__, __LINE__,
@@ -3023,7 +3021,7 @@ void Test_CFE_TBL_Load(void)
 
     /* d. Test cleanup */
     UT_InitData();
-    UT_SetAppID(2);
+    UT_SetAppID(UT_TBL_APPID_2);
     RtnCode = CFE_TBL_ReleaseAddress(App2TblHandle1);
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     UT_Report(__FILE__, __LINE__,
@@ -3049,7 +3047,7 @@ void Test_CFE_TBL_GetAddress(void)
      * does not have access
      */
     UT_InitData();
-    UT_SetAppID(3);
+    UT_SetAppID(UT_TBL_APPID_3);
     RtnCode = CFE_TBL_GetAddress((void **) &App3TblPtr, App2TblHandle1);
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     UT_Report(__FILE__, __LINE__,
@@ -3080,7 +3078,7 @@ void Test_CFE_TBL_GetAddress(void)
     /* Attempt to get the address of an unregistered (unowned) table */
     /* a. Test setup */
     UT_InitData();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
     RtnCode = CFE_TBL_Unregister(App1TblHandle1);
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     UT_Report(__FILE__, __LINE__,
@@ -3090,7 +3088,7 @@ void Test_CFE_TBL_GetAddress(void)
 
     /* b. Perform test */
     UT_InitData();
-    UT_SetAppID(2);
+    UT_SetAppID(UT_TBL_APPID_2);
     RtnCode = CFE_TBL_GetAddress((void **) &App2TblPtr, App2TblHandle1);
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     UT_Report(__FILE__, __LINE__,
@@ -3113,7 +3111,7 @@ void Test_CFE_TBL_ReleaseAddress(void)
     /* Test address release using an invalid application ID */
     /* a. Test setup - register single buffered table */
     UT_InitData();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
     UT_ResetTableRegistry();
     RtnCode = CFE_TBL_Register(&App1TblHandle1, "UT_Table1",
                                sizeof(UT_Table1_t),
@@ -3150,7 +3148,7 @@ void Test_CFE_TBL_GetAddresses(void)
 
     /* Test setup - register a double buffered table */
     UT_InitData();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
     RtnCode = CFE_TBL_Register(&App1TblHandle2,
                                "UT_Table2",
                                sizeof(UT_Table1_t),
@@ -3185,7 +3183,7 @@ void Test_CFE_TBL_GetAddresses(void)
      * allowed to see
      */
     UT_InitData();
-    UT_SetAppID(CFE_PLATFORM_ES_MAX_APPLICATIONS);
+    UT_SetAppID(CFE_ES_RESOURCEID_UNDEFINED);
     RtnCode = CFE_TBL_GetAddresses(ArrayOfPtrsToTblPtrs, 2, ArrayOfHandles);
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     UT_Report(__FILE__, __LINE__,
@@ -3208,7 +3206,7 @@ void Test_CFE_TBL_ReleaseAddresses(void)
 
     /* Test response to releasing two tables that have not been loaded */
     UT_InitData();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
     RtnCode = CFE_TBL_ReleaseAddresses(2, ArrayOfHandles);
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     UT_Report(__FILE__, __LINE__,
@@ -3232,7 +3230,7 @@ void Test_CFE_TBL_Validate(void)
      * not allowed to see
      */
     UT_InitData();
-    UT_SetAppID(CFE_PLATFORM_ES_MAX_APPLICATIONS);
+    UT_SetAppID(CFE_ES_RESOURCEID_UNDEFINED);
     RtnCode = CFE_TBL_Validate(App1TblHandle1);
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     UT_Report(__FILE__, __LINE__,
@@ -3245,7 +3243,7 @@ void Test_CFE_TBL_Validate(void)
      * pending
      */
     UT_InitData();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
     RtnCode = CFE_TBL_Validate(App1TblHandle1);
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     UT_Report(__FILE__, __LINE__,
@@ -3289,7 +3287,7 @@ void Test_CFE_TBL_Manage(void)
     RegIndex = CFE_TBL_FindTableInRegistry("ut_cfe_tbl.UT_Table1");
     RegRecPtr = &CFE_TBL_TaskData.Registry[RegIndex];
     RtnCode = CFE_TBL_GetWorkingBuffer(&WorkingBufferPtr, RegRecPtr, false);
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
     RtnCode = CFE_TBL_Load(App1TblHandle1, CFE_TBL_SRC_ADDRESS, &TestTable1);
     EventsCorrect = (UT_EventIsInHistory(CFE_TBL_LOAD_IN_PROGRESS_ERR_EID) == true &&
                      UT_GetNumEventsSent() == 1);
@@ -3457,7 +3455,7 @@ void Test_CFE_TBL_Manage(void)
     /* Test response to processing an update request on a locked table */
     /* a. Test setup - part 1 */
     UT_InitData();
-    UT_SetAppID(2);
+    UT_SetAppID(UT_TBL_APPID_2);
     RtnCode = CFE_TBL_Share(&App2TblHandle1, "ut_cfe_tbl.UT_Table1");
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     UT_Report(__FILE__, __LINE__,
@@ -3466,7 +3464,6 @@ void Test_CFE_TBL_Manage(void)
               "Process an update request on a locked table (setup - part 1)");
 
     /* a. Test setup - part 2 */
-    UT_InitData();
     RtnCode = CFE_TBL_GetAddress((void **) &App2TblPtr, App2TblHandle1);
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     UT_Report(__FILE__, __LINE__,
@@ -3476,7 +3473,7 @@ void Test_CFE_TBL_Manage(void)
 
     /* c. Perform test */
     UT_InitData();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
 
     /* Configure table for update */
     RegRecPtr->LoadPending = true;
@@ -3494,7 +3491,7 @@ void Test_CFE_TBL_Manage(void)
 
     /* Test unlocking a table by releasing the address */
     UT_InitData();
-    UT_SetAppID(2);
+    UT_SetAppID(UT_TBL_APPID_2);
     RtnCode = CFE_TBL_ReleaseAddress(App2TblHandle1);
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     UT_Report(__FILE__, __LINE__,
@@ -3506,7 +3503,7 @@ void Test_CFE_TBL_Manage(void)
      * buffered table
      */
     UT_InitData();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
 
     /* Configure table for Update */
     RegRecPtr->LoadPending = true;
@@ -3692,7 +3689,7 @@ void Test_CFE_TBL_Update(void)
      * privileges
      */
     UT_InitData();
-    UT_SetAppID(2);
+    UT_SetAppID(UT_TBL_APPID_2);
     RtnCode = CFE_TBL_Update(App1TblHandle1);
     EventsCorrect = (UT_EventIsInHistory(CFE_TBL_UPDATE_ERR_EID) == true &&
                      UT_GetNumEventsSent() == 1);
@@ -3706,7 +3703,7 @@ void Test_CFE_TBL_Update(void)
      * is pending
      */
     UT_InitData();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
     RtnCode = CFE_TBL_Update(App1TblHandle1);
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     UT_Report(__FILE__, __LINE__,
@@ -3718,7 +3715,7 @@ void Test_CFE_TBL_Update(void)
     /* Test processing an update on an application with a bad ID
      */
     UT_InitData();
-    UT_SetAppID(CFE_PLATFORM_ES_MAX_APPLICATIONS);
+    UT_SetAppID(CFE_ES_RESOURCEID_UNDEFINED);
     RtnCode = CFE_TBL_Update(App1TblHandle1);
     EventsCorrect = (UT_GetNumEventsSent() == 1);
     UT_Report(__FILE__, __LINE__,
@@ -3741,7 +3738,7 @@ void Test_CFE_TBL_GetStatus(void)
      * application is not allowed to see
      */
     UT_InitData();
-    UT_SetAppID(CFE_PLATFORM_ES_MAX_APPLICATIONS);
+    UT_SetAppID(CFE_ES_RESOURCEID_UNDEFINED);
     RtnCode = CFE_TBL_GetStatus(App1TblHandle1);
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     UT_Report(__FILE__, __LINE__,
@@ -3754,7 +3751,7 @@ void Test_CFE_TBL_GetStatus(void)
      * application is not allowed to see
      */
     UT_InitData();
-    UT_SetAppID(CFE_PLATFORM_ES_MAX_APPLICATIONS);
+    UT_SetAppID(CFE_ES_RESOURCEID_UNDEFINED);
     RtnCode = CFE_TBL_DumpToBuffer(App1TblHandle1);
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     UT_Report(__FILE__, __LINE__,
@@ -3777,7 +3774,7 @@ void Test_CFE_TBL_GetInfo(void)
 
     /* Test successfully getting information on a table */
     UT_InitData();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
     RtnCode = CFE_TBL_GetInfo(&TblInfo, "ut_cfe_tbl.UT_Table1");
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     UT_Report(__FILE__, __LINE__,
@@ -3825,7 +3822,7 @@ void Test_CFE_TBL_TblMod(void)
      */
     /* a. Test setup */
     UT_InitData();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
     CFE_TBL_EarlyInit();
     UT_ResetPoolBufferIndex();
 
@@ -4016,7 +4013,7 @@ void Test_CFE_TBL_Internal(void)
 
     /* Test setup - register a double buffered table */
     UT_InitData();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
     RtnCode = CFE_TBL_Register(&App1TblHandle2,
                                "UT_Table3",
                                sizeof(UT_Table1_t),
@@ -4461,7 +4458,7 @@ void Test_CFE_TBL_Internal(void)
     /* Reset, then register tables for subsequent tests */
     /* a. Reset tables */
     UT_InitData();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
     RtnCode = CFE_TBL_EarlyInit();
     UT_Report(__FILE__, __LINE__,
               (RtnCode == CFE_SUCCESS),
@@ -4794,7 +4791,7 @@ void Test_CFE_TBL_Internal(void)
     /* a. Share table */
     UT_InitData();
     CFE_TBL_TaskData.CritReg[0].CDSHandle = RegRecPtr->CDSHandle;
-    UT_SetAppID(2);
+    UT_SetAppID(UT_TBL_APPID_2);
     RtnCode = CFE_TBL_Share(&App2TblHandle1, "ut_cfe_tbl.UT_Table1");
     UT_Report(__FILE__, __LINE__,
               RtnCode == CFE_SUCCESS,
@@ -4812,7 +4809,7 @@ void Test_CFE_TBL_Internal(void)
 
     /* Test successful application cleanup */
     UT_InitData();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
     UT_SetForceFail(UT_KEY(CFE_ES_PutPoolBuf), -1);
     AccessDescPtr = &CFE_TBL_TaskData.Handles[App1TblHandle1];
     RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
@@ -4824,7 +4821,7 @@ void Test_CFE_TBL_Internal(void)
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_TaskData.DumpControlBlocks[3].State ==
                   CFE_TBL_DUMP_FREE &&
-              RegRecPtr->OwnerAppId ==  CFE_TBL_NOT_OWNED &&
+              CFE_ES_ResourceID_Equal(RegRecPtr->OwnerAppId, CFE_TBL_NOT_OWNED) &&
               CFE_TBL_TaskData.LoadBuffs[RegRecPtr->LoadInProgress].Taken ==
                   false &&
               RegRecPtr->LoadInProgress == CFE_TBL_NO_LOAD_IN_PROGRESS,
@@ -4983,7 +4980,7 @@ void Test_CFE_TBL_Internal(void)
      * the application doesn't own the table
      */
     UT_InitData();
-    UT_SetAppID(1);
+    UT_SetAppID(UT_TBL_APPID_1);
     UT_SetForceFail(UT_KEY(CFE_ES_PutPoolBuf), -1);
     CFE_TBL_TaskData.Handles[0].AppId = UT_TBL_APPID_1;
     AccessDescPtr = &CFE_TBL_TaskData.Handles[App1TblHandle2];
@@ -4995,7 +4992,7 @@ void Test_CFE_TBL_Internal(void)
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_TaskData.DumpControlBlocks[3].State ==
             CFE_TBL_DUMP_PENDING &&
-              RegRecPtr->OwnerAppId ==  CFE_TBL_NOT_OWNED,
+              CFE_ES_ResourceID_Equal(RegRecPtr->OwnerAppId, CFE_TBL_NOT_OWNED),
               "CFE_TBL_CleanUpApp",
               "Execute clean up - no dumped tables to delete, application "
                   "doesn't own table");

--- a/fsw/cfe-core/unit-test/time_UT.c
+++ b/fsw/cfe-core/unit-test/time_UT.c
@@ -43,8 +43,6 @@
 /*
 ** External global variables
 */
-extern uint32              UT_AppID;
-
 const char *TIME_SYSLOG_MSGS[] =
 {
         NULL,
@@ -1221,6 +1219,7 @@ int32 ut_time_MyCallbackFunc(void)
 void Test_RegisterSyncCallbackTrue(void)
 {
     int32   Result;
+    uint32  AppIndex;
 
     UtPrintf("Begin Test Register Synch Callback");
 
@@ -1245,8 +1244,6 @@ void Test_RegisterSyncCallbackTrue(void)
      */
     UT_InitData();
 
-    UT_SetAppID(1);
-
     /*
      * One callback per application is allowed; the first should succeed,
      * the second should fail.
@@ -1264,7 +1261,8 @@ void Test_RegisterSyncCallbackTrue(void)
               "CFE_TIME_RegisterSynchCallback",
               "Too Many registered callbacks");
 
-    UT_SetAppID(2);
+    AppIndex = 2;
+    UT_SetDataBuffer(UT_KEY(CFE_ES_AppID_ToIndex), &AppIndex, sizeof(AppIndex), false);
 
     Result = CFE_TIME_RegisterSynchCallback(&ut_time_MyCallbackFunc);
     UT_Report(__FILE__, __LINE__,
@@ -1277,7 +1275,8 @@ void Test_RegisterSyncCallbackTrue(void)
      * return "success" with an appid out of range, but nonetheless
      * we need to make sure we do not overwrite our own memory here.
      */
-    UT_SetAppID(CFE_PLATFORM_ES_MAX_APPLICATIONS);
+    AppIndex = 99999;
+    UT_SetDataBuffer(UT_KEY(CFE_ES_AppID_ToIndex), &AppIndex, sizeof(AppIndex), false);
     Result = CFE_TIME_RegisterSynchCallback(&ut_time_MyCallbackFunc);
     UT_Report(__FILE__, __LINE__,
             Result == CFE_TIME_TOO_MANY_SYNCH_CALLBACKS,
@@ -3184,6 +3183,7 @@ void Test_UnregisterSynchCallback(void)
 {
     uint32  i = 0;
     int32   Result;
+    uint32  AppIndex;
 
     ut_time_CallbackCalled = 0;
 
@@ -3209,7 +3209,8 @@ void Test_UnregisterSynchCallback(void)
     }
 
     /* App ID 4 should not have a callback */
-    UT_SetAppID(4);
+    AppIndex = 4;
+    UT_SetDataBuffer(UT_KEY(CFE_ES_AppID_ToIndex), &AppIndex, sizeof(AppIndex), false);
 
     Result = CFE_TIME_UnregisterSynchCallback(&ut_time_MyCallbackFunc);
     UT_Report(__FILE__, __LINE__,
@@ -3222,7 +3223,8 @@ void Test_UnregisterSynchCallback(void)
      * the second should fail.
      */
     /* App ID 2 should have a callback */
-    UT_SetAppID(2);
+    AppIndex = 2;
+    UT_SetDataBuffer(UT_KEY(CFE_ES_AppID_ToIndex), &AppIndex, sizeof(AppIndex), false);
 
     Result = CFE_TIME_UnregisterSynchCallback(&ut_time_MyCallbackFunc);
     UT_Report(__FILE__, __LINE__,
@@ -3230,6 +3232,7 @@ void Test_UnregisterSynchCallback(void)
               "CFE_TIME_UnregisterSynchCallback",
               "Successfully unregister callback");
 
+    UT_SetDataBuffer(UT_KEY(CFE_ES_AppID_ToIndex), &AppIndex, sizeof(AppIndex), false);
     Result = CFE_TIME_UnregisterSynchCallback(&ut_time_MyCallbackFunc);
     UT_Report(__FILE__, __LINE__,
               Result == CFE_TIME_CALLBACK_NOT_REGISTERED,
@@ -3268,7 +3271,7 @@ void Test_CleanUpApp(void)
     uint16 Count;
     int32  Status = CFE_SUCCESS;
     uint32 AppIndex;
-    uint32 TestAppId;
+    CFE_ES_ResourceID_t TestAppId;
 
     UtPrintf("Begin Test Cleanup App");
 
@@ -3342,7 +3345,9 @@ void Test_CleanUpApp(void)
 
     /* Test response to a bad application ID -
      * This is effectively a no-op but here for coverage */
-    Status = CFE_TIME_CleanUpApp(99999);
+    AppIndex = 99999;
+    UT_SetDataBuffer(UT_KEY(CFE_ES_AppID_ToIndex), &AppIndex, sizeof(AppIndex), false);
+    Status = CFE_TIME_CleanUpApp(CFE_ES_RESOURCEID_UNDEFINED);
     UT_Report(__FILE__, __LINE__,
               Status == CFE_TIME_CALLBACK_NOT_REGISTERED,
               "CFE_TIME_CleanUpApp",

--- a/fsw/cfe-core/unit-test/ut_support.c
+++ b/fsw/cfe-core/unit-test/ut_support.c
@@ -43,7 +43,7 @@ uint8  UT_Endianess;
 
 static char    UT_appname[80];
 static char    UT_subsys[5];
-static uint32  UT_AppID;
+static CFE_ES_ResourceID_t  UT_AppID;
 static uint32  UT_LastCDSSize = 0;
 
 typedef union
@@ -170,7 +170,6 @@ void UT_InitData(void)
      * This should return the UT_appname
      */
     UT_SetDataBuffer(UT_KEY(CFE_ES_GetAppName), (uint8*)UT_appname, sizeof(UT_appname), false);
-    UT_SetDataBuffer(UT_KEY(CFE_ES_GetAppID), (uint8*)&UT_AppID, sizeof(UT_AppID), false);
 
     /*
      * Reset the OSAL stubs to the default state
@@ -266,9 +265,10 @@ int32 UT_SoftwareBusSnapshotHook(void *UserObj, int32 StubRetcode, uint32 CallCo
 /*
 ** Set the application ID returned by unit test stubs
 */
-void UT_SetAppID(int32 AppID_in)
+void UT_SetAppID(CFE_ES_ResourceID_t AppID_in)
 {
     UT_AppID = AppID_in;
+    UT_SetDataBuffer(UT_KEY(CFE_ES_GetAppID), (uint8*)&UT_AppID, sizeof(UT_AppID), false);
 }
 
 /*

--- a/fsw/cfe-core/unit-test/ut_support.h
+++ b/fsw/cfe-core/unit-test/ut_support.h
@@ -320,7 +320,7 @@ int32 UT_SoftwareBusSnapshotHook(void *UserObj, int32 StubRetcode, uint32 CallCo
 **        This function does not return a value.
 **
 ******************************************************************************/
-void UT_SetAppID(int32 AppID_in);
+void UT_SetAppID(CFE_ES_ResourceID_t AppID_in);
 
 /*****************************************************************************/
 /**

--- a/fsw/cfe-core/ut-stubs/ut_es_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_es_stubs.c
@@ -63,20 +63,20 @@
  * Default value to return from calls that output an App ID, if the
  * test case does not provide a value
  */
-#define CFE_UT_ES_DEFAULT_APPID     ((uint32)1)
+#define CFE_UT_ES_DEFAULT_APPID     ((CFE_ES_ResourceID_t){0x02010001})
 
 /*
  * Default value to return from calls that output a Task ID, if the
  * test case does not provide a value
  */
-#define CFE_UT_ES_DEFAULT_TASKID    ((uint32)1)
+#define CFE_UT_ES_DEFAULT_TASKID    ((CFE_ES_ResourceID_t){0x02020001})
 
 /*
  * Invalid value to output from calls as resource ID for the
  * calls that return failure.  If subsequently used by application code,
  * it will likely induce a segfault or other noticeably bad behavior.
  */
-#define CFE_UT_ES_ID_INVALID        ((uint32)0xDEADBEEF)
+#define CFE_UT_ES_ID_INVALID        ((CFE_ES_ResourceID_t){0xDEADBEEF})
 
 /*
 ** Functions
@@ -101,7 +101,7 @@
 **        Returns either a user-defined status flag or CFE_SUCCESS.
 **
 ******************************************************************************/
-int32 CFE_ES_CreateChildTask(uint32 *TaskIdPtr,
+int32 CFE_ES_CreateChildTask(CFE_ES_ResourceID_t *TaskIdPtr,
                              const char *TaskName,
                              CFE_ES_ChildTaskMainFuncPtr_t FunctionPtr,
                              uint32 *StackPtr,
@@ -144,12 +144,12 @@ int32 CFE_ES_CreateChildTask(uint32 *TaskIdPtr,
 **        Returns either a user-defined status flag or CFE_SUCCESS.
 **
 ******************************************************************************/
-int32 CFE_ES_GetAppID(uint32 *AppIdPtr)
+int32 CFE_ES_GetAppID(CFE_ES_ResourceID_t *AppIdPtr)
 {
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_GetAppID), AppIdPtr);
 
     int32 status;
-    uint32 *IdBuff;
+    CFE_ES_ResourceID_t *IdBuff;
     uint32 BuffSize;
     uint32 Position;
 
@@ -176,12 +176,12 @@ int32 CFE_ES_GetAppID(uint32 *AppIdPtr)
     return status;
 }
 
-int32 CFE_ES_GetTaskID(uint32 *TaskIdPtr)
+int32 CFE_ES_GetTaskID(CFE_ES_ResourceID_t *TaskIdPtr)
 {
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_GetTaskID), TaskIdPtr);
 
     int32 status;
-    uint32 *IdBuff;
+    CFE_ES_ResourceID_t *IdBuff;
     uint32 BuffSize;
     uint32 Position;
 
@@ -229,7 +229,7 @@ int32 CFE_ES_GetTaskID(uint32 *TaskIdPtr)
 **        Returns either CFE_ES_ERR_APPNAME or CFE_SUCCESS.
 **
 ******************************************************************************/
-int32 CFE_ES_GetAppIDByName(uint32 *AppIdPtr, const char *AppName)
+int32 CFE_ES_GetAppIDByName(CFE_ES_ResourceID_t *AppIdPtr, const char *AppName)
 {
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_GetAppIDByName), AppIdPtr);
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_GetAppIDByName), AppName);
@@ -237,7 +237,7 @@ int32 CFE_ES_GetAppIDByName(uint32 *AppIdPtr, const char *AppName)
     uint32 UserBuffSize;
     uint32 BuffPosition;
     const char *NameBuff;
-    uint32 *IdBuff;
+    CFE_ES_ResourceID_t *IdBuff;
     int32 status;
 
     status = UT_DEFAULT_IMPL(CFE_ES_GetAppIDByName);
@@ -290,7 +290,7 @@ int32 CFE_ES_GetAppIDByName(uint32 *AppIdPtr, const char *AppName)
 **        Returns CFE_SUCCESS.
 **
 ******************************************************************************/
-int32 CFE_ES_GetAppName(char *AppName, uint32 AppId, uint32 BufferLength)
+int32 CFE_ES_GetAppName(char *AppName, CFE_ES_ResourceID_t AppId, uint32 BufferLength)
 {
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_GetAppName), AppName);
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_GetAppName), AppId);
@@ -793,7 +793,7 @@ uint32 CFE_ES_CalculateCRC(const void *DataPtr,
 **        Returns CFE_SUCCESS.
 **
 ******************************************************************************/
-int32 CFE_ES_GetTaskInfo(CFE_ES_TaskInfo_t *TaskInfo, uint32 TaskId)
+int32 CFE_ES_GetTaskInfo(CFE_ES_TaskInfo_t *TaskInfo, CFE_ES_ResourceID_t TaskId)
 {
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_GetTaskInfo), TaskInfo);
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_GetTaskInfo), TaskId);
@@ -1107,7 +1107,7 @@ void CFE_ES_ExitChildTask(void)
     UT_DEFAULT_IMPL(CFE_ES_ExitChildTask);
 }
 
-int32 CFE_ES_DeleteApp(uint32 AppID)
+int32 CFE_ES_DeleteApp(CFE_ES_ResourceID_t AppID)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_DeleteApp), AppID);
 
@@ -1118,7 +1118,7 @@ int32 CFE_ES_DeleteApp(uint32 AppID)
     return status;
 }
 
-int32 CFE_ES_DeleteChildTask(uint32 TaskId)
+int32 CFE_ES_DeleteChildTask(CFE_ES_ResourceID_t TaskId)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_DeleteChildTask), TaskId);
 
@@ -1129,7 +1129,7 @@ int32 CFE_ES_DeleteChildTask(uint32 TaskId)
     return status;
 }
 
-int32 CFE_ES_DeleteGenCounter(uint32 CounterId)
+int32 CFE_ES_DeleteGenCounter(CFE_ES_ResourceID_t CounterId)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_DeleteGenCounter), CounterId);
 
@@ -1140,7 +1140,7 @@ int32 CFE_ES_DeleteGenCounter(uint32 CounterId)
     return status;
 }
 
-int32 CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, uint32 AppId)
+int32 CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, CFE_ES_ResourceID_t AppId)
 {
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_GetAppInfo), AppInfo);
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_GetAppInfo), AppId);
@@ -1152,7 +1152,7 @@ int32 CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, uint32 AppId)
     return status;
 }
 
-int32 CFE_ES_GetGenCount(uint32 CounterId, uint32 *Count)
+int32 CFE_ES_GetGenCount(CFE_ES_ResourceID_t CounterId, uint32 *Count)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_GetGenCount), CounterId);
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_GetGenCount), Count);
@@ -1164,7 +1164,7 @@ int32 CFE_ES_GetGenCount(uint32 CounterId, uint32 *Count)
     return status;
 }
 
-int32 CFE_ES_GetGenCounterIDByName(uint32 *CounterIdPtr, const char *CounterName)
+int32 CFE_ES_GetGenCounterIDByName(CFE_ES_ResourceID_t *CounterIdPtr, const char *CounterName)
 {
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_GetGenCounterIDByName), CounterIdPtr);
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_GetGenCounterIDByName), CounterName);
@@ -1188,7 +1188,7 @@ int32 CFE_ES_GetMemPoolStats(CFE_ES_MemPoolStats_t *BufPtr, CFE_ES_MemHandle_t H
     return status;
 }
 
-int32 CFE_ES_IncrementGenCounter(uint32 CounterId)
+int32 CFE_ES_IncrementGenCounter(CFE_ES_ResourceID_t CounterId)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_IncrementGenCounter), CounterId);
 
@@ -1199,7 +1199,7 @@ int32 CFE_ES_IncrementGenCounter(uint32 CounterId)
     return status;
 }
 
-int32 CFE_ES_RegisterGenCounter(uint32 *CounterIdPtr, const char *CounterName)
+int32 CFE_ES_RegisterGenCounter(CFE_ES_ResourceID_t *CounterIdPtr, const char *CounterName)
 {
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_RegisterGenCounter), CounterIdPtr);
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_RegisterGenCounter), CounterName);
@@ -1211,7 +1211,7 @@ int32 CFE_ES_RegisterGenCounter(uint32 *CounterIdPtr, const char *CounterName)
     return status;
 }
 
-int32 CFE_ES_ReloadApp(uint32 AppID, const char *AppFileName)
+int32 CFE_ES_ReloadApp(CFE_ES_ResourceID_t AppID, const char *AppFileName)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_ReloadApp), AppID);
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_ReloadApp), AppFileName);
@@ -1234,7 +1234,7 @@ int32 CFE_ES_ResetCFE(uint32 ResetType)
     return status;
 }
 
-int32 CFE_ES_RestartApp(uint32 AppID)
+int32 CFE_ES_RestartApp(CFE_ES_ResourceID_t AppID)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_RestartApp), AppID);
 
@@ -1245,7 +1245,7 @@ int32 CFE_ES_RestartApp(uint32 AppID)
     return status;
 }
 
-int32 CFE_ES_SetGenCount(uint32 CounterId, uint32 Count)
+int32 CFE_ES_SetGenCount(CFE_ES_ResourceID_t CounterId, uint32 Count)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_SetGenCount), CounterId);
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_SetGenCount), Count);
@@ -1257,14 +1257,14 @@ int32 CFE_ES_SetGenCount(uint32 CounterId, uint32 Count)
     return status;
 }
 
-int32 CFE_ES_AppID_ToIndex(uint32 AppID, uint32 *Idx)
+int32 CFE_ES_AppID_ToIndex(CFE_ES_ResourceID_t AppID, uint32 *Idx)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_AppID_ToIndex), AppID);
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_AppID_ToIndex), Idx);
 
     int32 return_code;
 
-    *Idx = AppID & 0xFFFF;
+    *Idx = CFE_ES_ResourceID_ToInteger(AppID) & 0xFFFF;
     return_code = UT_DEFAULT_IMPL_RC(CFE_ES_AppID_ToIndex, 1);
 
     if (return_code == 1)
@@ -1281,14 +1281,14 @@ int32 CFE_ES_AppID_ToIndex(uint32 AppID, uint32 *Idx)
     return return_code;
 }
 
-int32 CFE_ES_TaskID_ToIndex(uint32 TaskID, uint32 *Idx)
+int32 CFE_ES_TaskID_ToIndex(CFE_ES_ResourceID_t TaskID, uint32 *Idx)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_TaskID_ToIndex), TaskID);
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_TaskID_ToIndex), Idx);
 
     int32 return_code;
 
-    *Idx = TaskID & 0xFFFF;
+    *Idx = CFE_ES_ResourceID_ToInteger(TaskID) & 0xFFFF;
     return_code = UT_DEFAULT_IMPL_RC(CFE_ES_TaskID_ToIndex, 1);
 
     if (return_code == 1)

--- a/fsw/cfe-core/ut-stubs/ut_evs_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_evs_stubs.c
@@ -240,7 +240,7 @@ int32 CFE_EVS_Register(void *Filters,
 ******************************************************************************/
 int32 CFE_EVS_SendEventWithAppID(uint16 EventID,
                                  uint16 EventType,
-                                 uint32 AppID,
+                                 CFE_ES_ResourceID_t AppID,
                                  const char *Spec,
                                  ...)
 {

--- a/modules/cfe_testcase/src/es_test.c
+++ b/modules/cfe_testcase/src/es_test.c
@@ -35,7 +35,7 @@
 
 void ES_Test_AppId(void)
 {
-    uint32 AppId;
+    CFE_ES_ResourceID_t AppId;
     char   AppNameBuf[OS_MAX_API_NAME + 4];
 
     UtAssert_INT32_EQ(CFE_ES_GetAppID(&AppId), CFE_SUCCESS);


### PR DESCRIPTION
**Describe the contribution**
Fix #894 

**Testing performed**
Bundle CI - https://github.com/nasa/cFS/pull/144/checks

**Expected behavior changes**
PR #896 - Add a new `typedef CFE_ES_ResourceID_t` that can replace `uint32` for all ID storage and manipulation. Initially this is just an alias to `uint32` for backward compatibility.

**System(s) tested on**
Ubuntu - CI

**Additional context**
https://github.com/nasa/cFS/pull/144

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
