### PR TITLE
Fix #888, Add typedef for function return status codes

### DIFF
--- a/fsw/cfe-core/src/inc/cfe_error.h
+++ b/fsw/cfe-core/src/inc/cfe_error.h
@@ -43,6 +43,12 @@
 #include "osapi.h"
 
 /*
+ * Define a type for readability.
+ */
+
+typedef int32 CFE_Status_t;
+
+/*
 **  Status Codes are 32 bit values formatted as follows:
 **
 **   3 3 2 2 2 2 2 2 2 2 2 2 1 1 1 1 1 1 1 1 1 1

--- a/fsw/cfe-core/src/inc/cfe_es.h
+++ b/fsw/cfe-core/src/inc/cfe_es.h
@@ -41,6 +41,7 @@
 #include "cfe_es_extern_typedefs.h"
 #include "cfe_mission_cfg.h"
 #include "cfe_perfids.h"
+#include "cfe_error.h"
 
 /*****************************************************************************/
 
@@ -258,7 +259,7 @@ static inline bool CFE_ES_ResourceID_IsDefined(CFE_ES_ResourceID_t id)
  * @return Execution status, see @ref CFEReturnCodes
  * @retval #CFE_SUCCESS                 @copybrief CFE_SUCCESS
  */
-int32 CFE_ES_AppID_ToIndex(CFE_ES_ResourceID_t AppID, uint32 *Idx);
+CFE_Status_t CFE_ES_AppID_ToIndex(CFE_ES_ResourceID_t AppID, uint32 *Idx);
 
 /**
  * @brief Obtain an index value correlating to an ES Library ID
@@ -306,7 +307,7 @@ int32 CFE_ES_LibID_ToIndex(CFE_ES_ResourceID_t LibID, uint32 *Idx);
  * @return Execution status, see @ref CFEReturnCodes
  * @retval #CFE_SUCCESS                 @copybrief CFE_SUCCESS
  */
-int32 CFE_ES_TaskID_ToIndex(CFE_ES_ResourceID_t TaskID, uint32 *Idx);
+CFE_Status_t CFE_ES_TaskID_ToIndex(CFE_ES_ResourceID_t TaskID, uint32 *Idx);
 
 /**
  * \brief Application Information
@@ -512,7 +513,7 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId , const ch
 ** \sa #CFE_ES_Main
 **
 ******************************************************************************/
-int32  CFE_ES_ResetCFE(uint32 ResetType);
+CFE_Status_t  CFE_ES_ResetCFE(uint32 ResetType);
 /**@}*/
 
 /** @defgroup CFEAPIESAppControl cFE Application Control APIs
@@ -536,7 +537,7 @@ int32  CFE_ES_ResetCFE(uint32 ResetType);
 ** \sa #CFE_ES_ReloadApp, #CFE_ES_DeleteApp
 **
 ******************************************************************************/
-int32 CFE_ES_RestartApp(CFE_ES_ResourceID_t AppID);
+CFE_Status_t CFE_ES_RestartApp(CFE_ES_ResourceID_t AppID);
 
 /*****************************************************************************/
 /**
@@ -563,7 +564,7 @@ int32 CFE_ES_RestartApp(CFE_ES_ResourceID_t AppID);
 ** \sa #CFE_ES_RestartApp, #CFE_ES_DeleteApp, #CFE_ES_START_APP_CC
 **
 ******************************************************************************/
-int32 CFE_ES_ReloadApp(CFE_ES_ResourceID_t AppID, const char *AppFileName);
+CFE_Status_t CFE_ES_ReloadApp(CFE_ES_ResourceID_t AppID, const char *AppFileName);
 
 /*****************************************************************************/
 /**
@@ -582,7 +583,7 @@ int32 CFE_ES_ReloadApp(CFE_ES_ResourceID_t AppID, const char *AppFileName);
 ** \sa #CFE_ES_RestartApp, #CFE_ES_ReloadApp
 **
 ******************************************************************************/
-int32 CFE_ES_DeleteApp(CFE_ES_ResourceID_t AppID);
+CFE_Status_t CFE_ES_DeleteApp(CFE_ES_ResourceID_t AppID);
 /**@}*/
 
 /** @defgroup CFEAPIESAppBehavior cFE Application Behavior APIs
@@ -667,7 +668,7 @@ bool CFE_ES_RunLoop(uint32 *ExitStatus);
 ** \sa #CFE_ES_RunLoop
 **
 ******************************************************************************/
-int32 CFE_ES_WaitForSystemState(uint32 MinSystemState, uint32 TimeOutMilliseconds);
+CFE_Status_t CFE_ES_WaitForSystemState(uint32 MinSystemState, uint32 TimeOutMilliseconds);
 
 /*****************************************************************************/
 /**
@@ -716,7 +717,7 @@ void CFE_ES_WaitForStartupSync(uint32 TimeOutMilliseconds);
 ** \sa #CFE_ES_ExitApp, #CFE_ES_RunLoop
 **
 ******************************************************************************/
-int32 CFE_ES_RegisterApp(void);
+CFE_Status_t CFE_ES_RegisterApp(void);
 
 /*****************************************************************************/
 /**
@@ -792,7 +793,7 @@ int32 CFE_ES_GetResetType(uint32 *ResetSubtypePtr);
 ** \sa #CFE_ES_GetResetType, #CFE_ES_GetAppIDByName, #CFE_ES_GetAppName, #CFE_ES_GetTaskInfo
 **
 ******************************************************************************/
-int32 CFE_ES_GetAppID(CFE_ES_ResourceID_t *AppIdPtr);
+CFE_Status_t CFE_ES_GetAppID(CFE_ES_ResourceID_t *AppIdPtr);
 
 /*****************************************************************************/
 /**
@@ -814,7 +815,7 @@ int32 CFE_ES_GetAppID(CFE_ES_ResourceID_t *AppIdPtr);
 ** \retval #CFE_ES_ERR_TASKID    \copybrief CFE_ES_ERR_TASKID
 **
 ******************************************************************************/
-int32 CFE_ES_GetTaskID(CFE_ES_ResourceID_t *TaskIdPtr);
+CFE_Status_t CFE_ES_GetTaskID(CFE_ES_ResourceID_t *TaskIdPtr);
 
 /*****************************************************************************/
 /**
@@ -839,7 +840,7 @@ int32 CFE_ES_GetTaskID(CFE_ES_ResourceID_t *TaskIdPtr);
 ** \sa #CFE_ES_GetResetType, #CFE_ES_GetAppID, #CFE_ES_GetAppName, #CFE_ES_GetTaskInfo
 **
 ******************************************************************************/
-int32 CFE_ES_GetAppIDByName(CFE_ES_ResourceID_t *AppIdPtr, const char *AppName);
+CFE_Status_t CFE_ES_GetAppIDByName(CFE_ES_ResourceID_t *AppIdPtr, const char *AppName);
 
 /*****************************************************************************/
 /**
@@ -871,7 +872,7 @@ int32 CFE_ES_GetAppIDByName(CFE_ES_ResourceID_t *AppIdPtr, const char *AppName);
 ** \sa #CFE_ES_GetResetType, #CFE_ES_GetAppID, #CFE_ES_GetAppIDByName, #CFE_ES_GetTaskInfo
 **
 ******************************************************************************/
-int32 CFE_ES_GetAppName(char *AppName, CFE_ES_ResourceID_t AppId, uint32 BufferLength);
+CFE_Status_t CFE_ES_GetAppName(char *AppName, CFE_ES_ResourceID_t AppId, uint32 BufferLength);
 
 /*****************************************************************************/
 /**
@@ -900,7 +901,7 @@ int32 CFE_ES_GetAppName(char *AppName, CFE_ES_ResourceID_t AppId, uint32 BufferL
 ** \sa #CFE_ES_GetResetType, #CFE_ES_GetAppID, #CFE_ES_GetAppIDByName, #CFE_ES_GetAppName
 **
 ******************************************************************************/
-int32 CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, CFE_ES_ResourceID_t AppId);
+CFE_Status_t CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, CFE_ES_ResourceID_t AppId);
 
 /*****************************************************************************/
 /**
@@ -929,7 +930,7 @@ int32 CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, CFE_ES_ResourceID_t AppId);
 ** \sa #CFE_ES_GetResetType, #CFE_ES_GetAppID, #CFE_ES_GetAppIDByName, #CFE_ES_GetAppName
 **
 ******************************************************************************/
-int32 CFE_ES_GetTaskInfo(CFE_ES_TaskInfo_t *TaskInfo, CFE_ES_ResourceID_t TaskId);
+CFE_Status_t CFE_ES_GetTaskInfo(CFE_ES_TaskInfo_t *TaskInfo, CFE_ES_ResourceID_t TaskId);
 /**@}*/
 
 /** @defgroup CFEAPIESChildTask cFE Child Task APIs
@@ -954,7 +955,7 @@ int32 CFE_ES_GetTaskInfo(CFE_ES_TaskInfo_t *TaskInfo, CFE_ES_ResourceID_t TaskId
 ** \sa #CFE_ES_CreateChildTask, #CFE_ES_DeleteChildTask, #CFE_ES_ExitChildTask
 **
 ******************************************************************************/
-int32  CFE_ES_RegisterChildTask(void);
+CFE_Status_t  CFE_ES_RegisterChildTask(void);
 
 /*****************************************************************************/
 /**
@@ -993,13 +994,13 @@ int32  CFE_ES_RegisterChildTask(void);
 ** \sa #CFE_ES_RegisterChildTask, #CFE_ES_DeleteChildTask, #CFE_ES_ExitChildTask
 **
 ******************************************************************************/
-int32  CFE_ES_CreateChildTask(CFE_ES_ResourceID_t             *TaskIdPtr,
-                              const char                      *TaskName,
-                              CFE_ES_ChildTaskMainFuncPtr_t    FunctionPtr,
-                              uint32                          *StackPtr,
-                              uint32                           StackSize,
-                              uint32                           Priority,
-                              uint32                           Flags);
+CFE_Status_t  CFE_ES_CreateChildTask(CFE_ES_ResourceID_t             *TaskIdPtr,
+                                     const char                      *TaskName,
+                                     CFE_ES_ChildTaskMainFuncPtr_t    FunctionPtr,
+                                     uint32                          *StackPtr,
+                                     uint32                           StackSize,
+                                     uint32                           Priority,
+                                     uint32                           Flags);
 
 /*****************************************************************************/
 /**
@@ -1021,7 +1022,7 @@ int32  CFE_ES_CreateChildTask(CFE_ES_ResourceID_t             *TaskIdPtr,
 ** \sa #CFE_ES_RegisterChildTask, #CFE_ES_CreateChildTask, #CFE_ES_ExitChildTask
 **
 ******************************************************************************/
-int32 CFE_ES_DeleteChildTask(CFE_ES_ResourceID_t TaskId);
+CFE_Status_t CFE_ES_DeleteChildTask(CFE_ES_ResourceID_t TaskId);
 
 /*****************************************************************************/
 /**
@@ -1070,7 +1071,7 @@ void CFE_ES_ExitChildTask(void);
 ** \retval #CFE_ES_ERR_SYS_LOG_FULL \copybrief CFE_ES_ERR_SYS_LOG_FULL
 **
 ******************************************************************************/
-int32 CFE_ES_WriteToSysLog(const char *SpecStringPtr, ...) OS_PRINTF(1,2);
+CFE_Status_t CFE_ES_WriteToSysLog(const char *SpecStringPtr, ...) OS_PRINTF(1,2);
 
 /*****************************************************************************/
 /**
@@ -1156,7 +1157,7 @@ void CFE_ES_ProcessAsyncEvent(void);
 ** \sa #CFE_ES_CopyToCDS, #CFE_ES_RestoreFromCDS
 **
 ******************************************************************************/
-int32 CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *HandlePtr, int32 BlockSize, const char *Name);
+CFE_Status_t CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *HandlePtr, int32 BlockSize, const char *Name);
 
 /*****************************************************************************/
 /**
@@ -1182,7 +1183,7 @@ int32 CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *HandlePtr, int32 BlockSize, const c
 ** \sa #CFE_ES_RegisterCDS, #CFE_ES_RestoreFromCDS
 **
 */
-int32 CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, void *DataToCopy);
+CFE_Status_t CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, void *DataToCopy);
 
 /*****************************************************************************/
 /**
@@ -1211,7 +1212,7 @@ int32 CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, void *DataToCopy);
 ** \sa #CFE_ES_RegisterCDS, #CFE_ES_CopyToCDS
 **
 */
-int32 CFE_ES_RestoreFromCDS(void *RestoreToMemory, CFE_ES_CDSHandle_t Handle);
+CFE_Status_t CFE_ES_RestoreFromCDS(void *RestoreToMemory, CFE_ES_CDSHandle_t Handle);
 /**@}*/
 
 /** @defgroup CFEAPIESMemManage cFE Memory Manager APIs
@@ -1245,7 +1246,7 @@ int32 CFE_ES_RestoreFromCDS(void *RestoreToMemory, CFE_ES_CDSHandle_t Handle);
 ** \sa #CFE_ES_PoolCreate, #CFE_ES_PoolCreateEx, #CFE_ES_GetPoolBuf, #CFE_ES_PutPoolBuf, #CFE_ES_GetMemPoolStats
 **
 ******************************************************************************/
-int32 CFE_ES_PoolCreateNoSem(CFE_ES_MemHandle_t *PoolID, uint8 *MemPtr, CFE_ES_MemOffset_t Size);
+CFE_Status_t CFE_ES_PoolCreateNoSem(CFE_ES_MemHandle_t *PoolID, uint8 *MemPtr, CFE_ES_MemOffset_t Size);
 
 /*****************************************************************************/
 /**
@@ -1274,7 +1275,7 @@ int32 CFE_ES_PoolCreateNoSem(CFE_ES_MemHandle_t *PoolID, uint8 *MemPtr, CFE_ES_M
 ** \sa #CFE_ES_PoolCreateNoSem, #CFE_ES_PoolCreateEx, #CFE_ES_GetPoolBuf, #CFE_ES_PutPoolBuf, #CFE_ES_GetMemPoolStats
 **
 ******************************************************************************/
-int32 CFE_ES_PoolCreate(CFE_ES_MemHandle_t *PoolID, uint8 *MemPtr, CFE_ES_MemOffset_t Size);
+CFE_Status_t CFE_ES_PoolCreate(CFE_ES_MemHandle_t *PoolID, uint8 *MemPtr, CFE_ES_MemOffset_t Size);
 
 /*****************************************************************************/
 /**
@@ -1312,12 +1313,12 @@ int32 CFE_ES_PoolCreate(CFE_ES_MemHandle_t *PoolID, uint8 *MemPtr, CFE_ES_MemOff
 ** \sa #CFE_ES_PoolCreate, #CFE_ES_PoolCreateNoSem, #CFE_ES_GetPoolBuf, #CFE_ES_PutPoolBuf, #CFE_ES_GetMemPoolStats
 **
 ******************************************************************************/
-int32 CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t        *PoolID,
-                          uint8                     *MemPtr,
-                          CFE_ES_MemOffset_t         Size,
-                          uint16                     NumBlockSizes,
-                          const CFE_ES_MemOffset_t  *BlockSizes,
-                          uint16                     UseMutex );
+CFE_Status_t CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t        *PoolID,
+                                 uint8                     *MemPtr,
+                                 CFE_ES_MemOffset_t         Size,
+                                 uint16                     NumBlockSizes,
+                                 const CFE_ES_MemOffset_t  *BlockSizes,
+                                 uint16                     UseMutex );
 
 
 /*****************************************************************************/
@@ -1343,7 +1344,6 @@ int32 CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t        *PoolID,
 **
 ******************************************************************************/
 int32 CFE_ES_PoolDelete(CFE_ES_MemHandle_t PoolID);
-
 
 
 /*****************************************************************************/
@@ -1393,7 +1393,7 @@ int32 CFE_ES_GetPoolBuf(uint32 **BufPtr, CFE_ES_MemHandle_t PoolID, CFE_ES_MemOf
 ** \sa #CFE_ES_PoolCreate, #CFE_ES_PoolCreateNoSem, #CFE_ES_PoolCreateEx, #CFE_ES_GetPoolBuf, #CFE_ES_GetMemPoolStats, #CFE_ES_PutPoolBuf
 **
 ******************************************************************************/
-int32 CFE_ES_GetPoolBufInfo(CFE_ES_MemHandle_t PoolID, uint32 *BufPtr);
+CFE_Status_t CFE_ES_GetPoolBufInfo(CFE_ES_MemHandle_t PoolID, uint32 *BufPtr);
 
 /*****************************************************************************/
 /**
@@ -1442,7 +1442,7 @@ int32 CFE_ES_PutPoolBuf(CFE_ES_MemHandle_t PoolID, uint32 *BufPtr);
 ** \sa #CFE_ES_PoolCreate, #CFE_ES_PoolCreateNoSem, #CFE_ES_PoolCreateEx, #CFE_ES_GetPoolBuf, #CFE_ES_PutPoolBuf
 **
 ******************************************************************************/
-int32 CFE_ES_GetMemPoolStats(CFE_ES_MemPoolStats_t *BufPtr, CFE_ES_MemHandle_t  Handle);
+CFE_Status_t CFE_ES_GetMemPoolStats(CFE_ES_MemPoolStats_t *BufPtr, CFE_ES_MemHandle_t  Handle);
 /**@}*/
 
 /** @defgroup CFEAPIESPerfMon cFE Performance Monitor APIs
@@ -1534,7 +1534,7 @@ void CFE_ES_PerfLogAdd(uint32 Marker, uint32 EntryExit);
 ** \sa #CFE_ES_IncrementGenCounter, #CFE_ES_DeleteGenCounter, #CFE_ES_SetGenCount, #CFE_ES_GetGenCount, #CFE_ES_GetGenCounterIDByName
 **
 ******************************************************************************/
-int32 CFE_ES_RegisterGenCounter(CFE_ES_ResourceID_t *CounterIdPtr, const char *CounterName);
+CFE_Status_t CFE_ES_RegisterGenCounter(CFE_ES_ResourceID_t *CounterIdPtr, const char *CounterName);
 
 /*****************************************************************************/
 /**
@@ -1555,7 +1555,7 @@ int32 CFE_ES_RegisterGenCounter(CFE_ES_ResourceID_t *CounterIdPtr, const char *C
 ** \sa #CFE_ES_IncrementGenCounter, #CFE_ES_RegisterGenCounter, #CFE_ES_SetGenCount, #CFE_ES_GetGenCount, #CFE_ES_GetGenCounterIDByName
 **
 ******************************************************************************/
-int32 CFE_ES_DeleteGenCounter(CFE_ES_ResourceID_t CounterId);
+CFE_Status_t CFE_ES_DeleteGenCounter(CFE_ES_ResourceID_t CounterId);
 
 /*****************************************************************************/
 /**
@@ -1576,7 +1576,7 @@ int32 CFE_ES_DeleteGenCounter(CFE_ES_ResourceID_t CounterId);
 ** \sa #CFE_ES_RegisterGenCounter, #CFE_ES_DeleteGenCounter, #CFE_ES_SetGenCount, #CFE_ES_GetGenCount, #CFE_ES_GetGenCounterIDByName
 **
 ******************************************************************************/
-int32 CFE_ES_IncrementGenCounter(CFE_ES_ResourceID_t CounterId);
+CFE_Status_t CFE_ES_IncrementGenCounter(CFE_ES_ResourceID_t CounterId);
 
 /*****************************************************************************/
 /**
@@ -1599,7 +1599,7 @@ int32 CFE_ES_IncrementGenCounter(CFE_ES_ResourceID_t CounterId);
 ** \sa #CFE_ES_RegisterGenCounter, #CFE_ES_DeleteGenCounter, #CFE_ES_IncrementGenCounter, #CFE_ES_GetGenCount, #CFE_ES_GetGenCounterIDByName
 **
 ******************************************************************************/
-int32 CFE_ES_SetGenCount(CFE_ES_ResourceID_t CounterId, uint32 Count);
+CFE_Status_t CFE_ES_SetGenCount(CFE_ES_ResourceID_t CounterId, uint32 Count);
 
 /*****************************************************************************/
 /**
@@ -1622,7 +1622,7 @@ int32 CFE_ES_SetGenCount(CFE_ES_ResourceID_t CounterId, uint32 Count);
 ** \sa #CFE_ES_RegisterGenCounter, #CFE_ES_DeleteGenCounter, #CFE_ES_SetGenCount, #CFE_ES_IncrementGenCounter, #CFE_ES_GetGenCounterIDByName
 **
 ******************************************************************************/
-int32 CFE_ES_GetGenCount(CFE_ES_ResourceID_t CounterId, uint32 *Count);
+CFE_Status_t CFE_ES_GetGenCount(CFE_ES_ResourceID_t CounterId, uint32 *Count);
 
 
 /*****************************************************************************/
@@ -1645,7 +1645,7 @@ int32 CFE_ES_GetGenCount(CFE_ES_ResourceID_t CounterId, uint32 *Count);
 **
 ** \sa #CFE_ES_RegisterGenCounter, #CFE_ES_DeleteGenCounter, #CFE_ES_SetGenCount, #CFE_ES_IncrementGenCounter, #CFE_ES_GetGenCount
 ******************************************************************************/
-int32 CFE_ES_GetGenCounterIDByName(CFE_ES_ResourceID_t *CounterIdPtr, const char *CounterName);
+CFE_Status_t CFE_ES_GetGenCounterIDByName(CFE_ES_ResourceID_t *CounterIdPtr, const char *CounterName);
 /**@}*/
 
 #endif  /* _cfe_es_ */

--- a/fsw/cfe-core/src/inc/cfe_evs.h
+++ b/fsw/cfe-core/src/inc/cfe_evs.h
@@ -37,6 +37,7 @@
 
 /********************************** Include Files  ************************************/
 #include "cfe_evs_extern_typedefs.h"
+#include "cfe_error.h"
 #include "common_types.h"    /* Basic data types */
 #include "cfe_time.h"        /* Time library function definitions */
 #include "cfe_evs_msg.h"        /* EVS command codes and data structures*/
@@ -139,7 +140,7 @@ typedef struct CFE_EVS_BinFilter {
 ** \sa #CFE_EVS_Unregister
 **
 **/
-int32 CFE_EVS_Register (void                 *Filters,           /* Pointer to an array of filters */
+CFE_Status_t CFE_EVS_Register (void              *Filters,           /* Pointer to an array of filters */
                         uint16               NumFilteredEvents,  /* How many elements in the array? */
                         uint16               FilterScheme);      /* Filtering Algorithm to be implemented */
 
@@ -163,7 +164,7 @@ int32 CFE_EVS_Register (void                 *Filters,           /* Pointer to a
 ** \sa #CFE_EVS_Register
 **
 **/
-int32 CFE_EVS_Unregister( void );
+CFE_Status_t CFE_EVS_Unregister( void );
 /**@}*/
 
 /** @defgroup CFEAPIEVSSend cFE Send Event APIs
@@ -212,9 +213,9 @@ int32 CFE_EVS_Unregister( void );
 ** \sa #CFE_EVS_SendEventWithAppID, #CFE_EVS_SendTimedEvent
 **
 **/
-int32 CFE_EVS_SendEvent (uint16 EventID,
-                         uint16 EventType,
-                         const char *Spec, ... )  OS_PRINTF(3,4);
+CFE_Status_t CFE_EVS_SendEvent (uint16 EventID,
+                            uint16 EventType,
+                            const char *Spec, ... )  OS_PRINTF(3,4);
 
 
 /** 
@@ -263,10 +264,10 @@ int32 CFE_EVS_SendEvent (uint16 EventID,
 ** \sa #CFE_EVS_SendEvent, #CFE_EVS_SendTimedEvent
 **
 **/
-int32 CFE_EVS_SendEventWithAppID (uint16 EventID,
-                                  uint16 EventType,
-                                  CFE_ES_ResourceID_t AppID,
-                                  const char *Spec, ... ) OS_PRINTF(4,5);
+CFE_Status_t CFE_EVS_SendEventWithAppID (uint16 EventID,
+                                         uint16 EventType,
+                                         CFE_ES_ResourceID_t AppID,
+                                         const char *Spec, ... ) OS_PRINTF(4,5);
 
 
 /** 
@@ -315,10 +316,10 @@ int32 CFE_EVS_SendEventWithAppID (uint16 EventID,
 ** \sa #CFE_EVS_SendEvent, #CFE_EVS_SendEventWithAppID
 **
 **/
-int32 CFE_EVS_SendTimedEvent (CFE_TIME_SysTime_t Time,
-                              uint16 EventID,
-                              uint16 EventType,
-                              const char *Spec, ... ) OS_PRINTF(4,5);
+CFE_Status_t CFE_EVS_SendTimedEvent (CFE_TIME_SysTime_t Time,
+                                 uint16 EventID,
+                                 uint16 EventType,
+                                 const char *Spec, ... ) OS_PRINTF(4,5);
 /**@}*/
 
 /** @defgroup CFEAPIEVSResetFilter cFE Reset Event Filter APIs
@@ -346,7 +347,7 @@ int32 CFE_EVS_SendTimedEvent (CFE_TIME_SysTime_t Time,
 ** \sa #CFE_EVS_ResetAllFilters
 **
 **/
-int32 CFE_EVS_ResetFilter (int16 EventID);
+CFE_Status_t CFE_EVS_ResetFilter (int16 EventID);
 
 
 /** 
@@ -367,7 +368,7 @@ int32 CFE_EVS_ResetFilter (int16 EventID);
 ** \sa #CFE_EVS_ResetFilter
 **
 **/
-int32 CFE_EVS_ResetAllFilters ( void );
+CFE_Status_t CFE_EVS_ResetAllFilters ( void );
 /**@}*/
 
 

--- a/fsw/cfe-core/src/inc/cfe_fs.h
+++ b/fsw/cfe-core/src/inc/cfe_fs.h
@@ -38,6 +38,7 @@
 ** Required header files...
 */
 #include "cfe_fs_extern_typedefs.h"
+#include "cfe_error.h"
 #include "common_types.h"
 #include "cfe_time.h"
 
@@ -70,7 +71,7 @@
 ** \sa #CFE_FS_WriteHeader
 **
 ******************************************************************************/
-int32 CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, osal_id_t FileDes);
+CFE_Status_t CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, osal_id_t FileDes);
 
 /*****************************************************************************/
 /**
@@ -128,7 +129,7 @@ void CFE_FS_InitHeader(CFE_FS_Header_t *Hdr, const char *Description, uint32 Sub
 ** \sa #CFE_FS_ReadHeader
 **
 ******************************************************************************/
-int32 CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr);
+CFE_Status_t CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr);
 
 /*****************************************************************************/
 /**
@@ -153,7 +154,7 @@ int32 CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr);
 ** \return Execution status, see \ref CFEReturnCodes
 **               
 ******************************************************************************/
-int32 CFE_FS_SetTimestamp(osal_id_t FileDes, CFE_TIME_SysTime_t NewTimestamp);
+CFE_Status_t CFE_FS_SetTimestamp(osal_id_t FileDes, CFE_TIME_SysTime_t NewTimestamp);
 /**@}*/
 
 
@@ -181,7 +182,7 @@ int32 CFE_FS_SetTimestamp(osal_id_t FileDes, CFE_TIME_SysTime_t NewTimestamp);
 ** \return Execution status, see \ref CFEReturnCodes
 **
 ******************************************************************************/
-int32 CFE_FS_ExtractFilenameFromPath(const char *OriginalPath, char *FileNameOnly);
+CFE_Status_t CFE_FS_ExtractFilenameFromPath(const char *OriginalPath, char *FileNameOnly);
 /**@}*/
 
 #endif /* _cfe_fs_ */

--- a/fsw/cfe-core/src/inc/cfe_msg_api.h
+++ b/fsw/cfe-core/src/inc/cfe_msg_api.h
@@ -29,6 +29,7 @@
  * Includes
  */
 #include "common_types.h"
+#include "cfe_error.h"
 #include "cfe_msg_hdr.h"
 #include "cfe_msg_typedefs.h"
 #include "cfe_time.h"
@@ -56,7 +57,7 @@
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_MSG_Size_t Size, bool Clear);
+CFE_Status_t CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_MSG_Size_t Size, bool Clear);
 
 /*****************************************************************************/
 /**
@@ -72,7 +73,7 @@ int32 CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_MSG_Size
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_GetSize(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t *Size);
+CFE_Status_t CFE_MSG_GetSize(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t *Size);
 
 /*****************************************************************************/
 /**
@@ -88,7 +89,7 @@ int32 CFE_MSG_GetSize(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t *Size);
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_SetSize(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t Size);
+CFE_Status_t CFE_MSG_SetSize(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t Size);
 
 /*****************************************************************************/
 /**
@@ -104,7 +105,7 @@ int32 CFE_MSG_SetSize(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t Size);
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_GetType(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t *Type);
+CFE_Status_t CFE_MSG_GetType(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t *Type);
 
 /*****************************************************************************/
 /**
@@ -120,7 +121,7 @@ int32 CFE_MSG_GetType(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t *Type);
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_SetType(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t Type);
+CFE_Status_t CFE_MSG_SetType(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t Type);
 
 /*****************************************************************************/
 /**
@@ -136,7 +137,7 @@ int32 CFE_MSG_SetType(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t Type);
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_GetHeaderVersion(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_HeaderVersion_t *Version);
+CFE_Status_t CFE_MSG_GetHeaderVersion(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_HeaderVersion_t *Version);
 
 /*****************************************************************************/
 /**
@@ -153,7 +154,7 @@ int32 CFE_MSG_GetHeaderVersion(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_HeaderVe
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_SetHeaderVersion(CFE_MSG_Message_t *MsgPtr, CFE_MSG_HeaderVersion_t Version);
+CFE_Status_t CFE_MSG_SetHeaderVersion(CFE_MSG_Message_t *MsgPtr, CFE_MSG_HeaderVersion_t Version);
 
 /*****************************************************************************/
 /**
@@ -169,7 +170,7 @@ int32 CFE_MSG_SetHeaderVersion(CFE_MSG_Message_t *MsgPtr, CFE_MSG_HeaderVersion_
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_GetHasSecondaryHeader(const CFE_MSG_Message_t *MsgPtr, bool *HasSecondary);
+CFE_Status_t CFE_MSG_GetHasSecondaryHeader(const CFE_MSG_Message_t *MsgPtr, bool *HasSecondary);
 
 /*****************************************************************************/
 /**
@@ -186,7 +187,7 @@ int32 CFE_MSG_GetHasSecondaryHeader(const CFE_MSG_Message_t *MsgPtr, bool *HasSe
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_SetHasSecondaryHeader(CFE_MSG_Message_t *MsgPtr, bool HasSecondary);
+CFE_Status_t CFE_MSG_SetHasSecondaryHeader(CFE_MSG_Message_t *MsgPtr, bool HasSecondary);
 
 /*****************************************************************************/
 /**
@@ -202,7 +203,7 @@ int32 CFE_MSG_SetHasSecondaryHeader(CFE_MSG_Message_t *MsgPtr, bool HasSecondary
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_GetApId(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t *ApId);
+CFE_Status_t CFE_MSG_GetApId(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t *ApId);
 
 /*****************************************************************************/
 /**
@@ -220,7 +221,7 @@ int32 CFE_MSG_GetApId(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t *ApId);
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_SetApId(CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t ApId);
+CFE_Status_t CFE_MSG_SetApId(CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t ApId);
 
 /*****************************************************************************/
 /**
@@ -236,7 +237,7 @@ int32 CFE_MSG_SetApId(CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t ApId);
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_GetSegmentationFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_SegmentationFlag_t *SegFlag);
+CFE_Status_t CFE_MSG_GetSegmentationFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_SegmentationFlag_t *SegFlag);
 
 /*****************************************************************************/
 /**
@@ -252,7 +253,7 @@ int32 CFE_MSG_GetSegmentationFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Segme
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_SetSegmentationFlag(CFE_MSG_Message_t *MsgPtr, CFE_MSG_SegmentationFlag_t SegFlag);
+CFE_Status_t CFE_MSG_SetSegmentationFlag(CFE_MSG_Message_t *MsgPtr, CFE_MSG_SegmentationFlag_t SegFlag);
 
 /*****************************************************************************/
 /**
@@ -268,7 +269,7 @@ int32 CFE_MSG_SetSegmentationFlag(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Segmentatio
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_GetSequenceCount(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_SequenceCount_t *SeqCnt);
+CFE_Status_t CFE_MSG_GetSequenceCount(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_SequenceCount_t *SeqCnt);
 
 /*****************************************************************************/
 /**
@@ -284,7 +285,7 @@ int32 CFE_MSG_GetSequenceCount(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Sequence
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_SetSequenceCount(CFE_MSG_Message_t *MsgPtr, CFE_MSG_SequenceCount_t SeqCnt);
+CFE_Status_t CFE_MSG_SetSequenceCount(CFE_MSG_Message_t *MsgPtr, CFE_MSG_SequenceCount_t SeqCnt);
 
 /*****************************************************************************/
 /**
@@ -300,7 +301,7 @@ int32 CFE_MSG_SetSequenceCount(CFE_MSG_Message_t *MsgPtr, CFE_MSG_SequenceCount_
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_GetEDSVersion(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_EDSVersion_t *Version);
+CFE_Status_t CFE_MSG_GetEDSVersion(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_EDSVersion_t *Version);
 
 /*****************************************************************************/
 /**
@@ -316,7 +317,7 @@ int32 CFE_MSG_GetEDSVersion(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_EDSVersion_
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_SetEDSVersion(CFE_MSG_Message_t *MsgPtr, CFE_MSG_EDSVersion_t Version);
+CFE_Status_t CFE_MSG_SetEDSVersion(CFE_MSG_Message_t *MsgPtr, CFE_MSG_EDSVersion_t Version);
 
 /*****************************************************************************/
 /**
@@ -332,7 +333,7 @@ int32 CFE_MSG_SetEDSVersion(CFE_MSG_Message_t *MsgPtr, CFE_MSG_EDSVersion_t Vers
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_GetEndian(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Endian_t *Endian);
+CFE_Status_t CFE_MSG_GetEndian(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Endian_t *Endian);
 
 /*****************************************************************************/
 /**
@@ -349,7 +350,7 @@ int32 CFE_MSG_GetEndian(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Endian_t *Endia
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_SetEndian(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Endian_t Endian);
+CFE_Status_t CFE_MSG_SetEndian(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Endian_t Endian);
 
 /*****************************************************************************/
 /**
@@ -365,7 +366,7 @@ int32 CFE_MSG_SetEndian(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Endian_t Endian);
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_GetPlaybackFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_PlaybackFlag_t *PlayFlag);
+CFE_Status_t CFE_MSG_GetPlaybackFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_PlaybackFlag_t *PlayFlag);
 
 /*****************************************************************************/
 /**
@@ -381,7 +382,7 @@ int32 CFE_MSG_GetPlaybackFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_PlaybackF
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_SetPlaybackFlag(CFE_MSG_Message_t *MsgPtr, CFE_MSG_PlaybackFlag_t PlayFlag);
+CFE_Status_t CFE_MSG_SetPlaybackFlag(CFE_MSG_Message_t *MsgPtr, CFE_MSG_PlaybackFlag_t PlayFlag);
 
 /*****************************************************************************/
 /**
@@ -397,7 +398,7 @@ int32 CFE_MSG_SetPlaybackFlag(CFE_MSG_Message_t *MsgPtr, CFE_MSG_PlaybackFlag_t 
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_GetSubsystem(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Subsystem_t *Subsystem);
+CFE_Status_t CFE_MSG_GetSubsystem(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Subsystem_t *Subsystem);
 
 /*****************************************************************************/
 /**
@@ -415,7 +416,7 @@ int32 CFE_MSG_GetSubsystem(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Subsystem_t 
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_SetSubsystem(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Subsystem_t Subsystem);
+CFE_Status_t CFE_MSG_SetSubsystem(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Subsystem_t Subsystem);
 
 /*****************************************************************************/
 /**
@@ -431,7 +432,7 @@ int32 CFE_MSG_SetSubsystem(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Subsystem_t Subsys
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_GetSystem(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_System_t *System);
+CFE_Status_t CFE_MSG_GetSystem(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_System_t *System);
 
 /*****************************************************************************/
 /**
@@ -449,7 +450,7 @@ int32 CFE_MSG_GetSystem(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_System_t *Syste
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_SetSystem(CFE_MSG_Message_t *MsgPtr, CFE_MSG_System_t System);
+CFE_Status_t CFE_MSG_SetSystem(CFE_MSG_Message_t *MsgPtr, CFE_MSG_System_t System);
 
 /*****************************************************************************/
 /**
@@ -474,7 +475,7 @@ int32 CFE_MSG_SetSystem(CFE_MSG_Message_t *MsgPtr, CFE_MSG_System_t System);
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  * \retval #CFE_MSG_WRONG_MSG_TYPE  \copybrief CFE_MSG_WRONG_MSG_TYPE
  */
-int32 CFE_MSG_GenerateChecksum(CFE_MSG_Message_t *MsgPtr);
+CFE_Status_t CFE_MSG_GenerateChecksum(CFE_MSG_Message_t *MsgPtr);
 
 /*****************************************************************************/
 /**
@@ -500,7 +501,7 @@ int32 CFE_MSG_GenerateChecksum(CFE_MSG_Message_t *MsgPtr);
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  * \retval #CFE_MSG_WRONG_MSG_TYPE  \copybrief CFE_MSG_WRONG_MSG_TYPE
  */
-int32 CFE_MSG_ValidateChecksum(const CFE_MSG_Message_t *MsgPtr, bool *IsValid);
+CFE_Status_t CFE_MSG_ValidateChecksum(const CFE_MSG_Message_t *MsgPtr, bool *IsValid);
 
 /*****************************************************************************/
 /**
@@ -523,7 +524,7 @@ int32 CFE_MSG_ValidateChecksum(const CFE_MSG_Message_t *MsgPtr, bool *IsValid);
  * \retval #CFE_MSG_WRONG_MSG_TYPE  \copybrief CFE_MSG_WRONG_MSG_TYPE
  *
  */
-int32 CFE_MSG_SetFcnCode(CFE_MSG_Message_t *MsgPtr, CFE_MSG_FcnCode_t FcnCode);
+CFE_Status_t CFE_MSG_SetFcnCode(CFE_MSG_Message_t *MsgPtr, CFE_MSG_FcnCode_t FcnCode);
 
 /*****************************************************************************/
 /**
@@ -545,7 +546,7 @@ int32 CFE_MSG_SetFcnCode(CFE_MSG_Message_t *MsgPtr, CFE_MSG_FcnCode_t FcnCode);
  * \retval #CFE_MSG_BAD_ARGUMENT   \copybrief CFE_MSG_BAD_ARGUMENT
  * \retval #CFE_MSG_WRONG_MSG_TYPE \copybrief CFE_MSG_WRONG_MSG_TYPE
  */
-int32 CFE_MSG_GetFcnCode(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_FcnCode_t *FcnCode);
+CFE_Status_t CFE_MSG_GetFcnCode(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_FcnCode_t *FcnCode);
 
 /*****************************************************************************/
 /**
@@ -568,7 +569,7 @@ int32 CFE_MSG_GetFcnCode(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_FcnCode_t *Fcn
  * \retval #CFE_MSG_BAD_ARGUMENT   \copybrief CFE_MSG_BAD_ARGUMENT
  * \retval #CFE_MSG_WRONG_MSG_TYPE \copybrief CFE_MSG_WRONG_MSG_TYPE
  */
-int32 CFE_MSG_GetMsgTime(const CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t *Time);
+CFE_Status_t CFE_MSG_GetMsgTime(const CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t *Time);
 
 /*****************************************************************************/
 /**
@@ -595,7 +596,7 @@ int32 CFE_MSG_GetMsgTime(const CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t *Ti
  * \retval #CFE_MSG_BAD_ARGUMENT   \copybrief CFE_MSG_BAD_ARGUMENT
  * \retval #CFE_MSG_WRONG_MSG_TYPE \copybrief CFE_MSG_WRONG_MSG_TYPE
  */
-int32 CFE_MSG_SetMsgTime(CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t Time);
+CFE_Status_t CFE_MSG_SetMsgTime(CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t Time);
 
 /**\}*/
 
@@ -620,7 +621,7 @@ int32 CFE_MSG_SetMsgTime(CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t Time);
  * \retval #CFE_SUCCESS            \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT   \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_GetMsgId(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgId);
+CFE_Status_t CFE_MSG_GetMsgId(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgId);
 
 /*****************************************************************************/
 /**
@@ -642,7 +643,7 @@ int32 CFE_MSG_GetMsgId(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgId);
  * \retval #CFE_SUCCESS            \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT   \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_SetMsgId(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId);
+CFE_Status_t CFE_MSG_SetMsgId(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId);
 
 /*****************************************************************************/
 /**
@@ -658,7 +659,7 @@ int32 CFE_MSG_SetMsgId(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId);
  * \retval #CFE_SUCCESS            \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT   \copybrief CFE_MSG_BAD_ARGUMENT
  */
-int32 CFE_MSG_GetTypeFromMsgId(CFE_SB_MsgId_t MsgId, CFE_MSG_Type_t *Type);
+CFE_Status_t CFE_MSG_GetTypeFromMsgId(CFE_SB_MsgId_t MsgId, CFE_MSG_Type_t *Type);
 
 /**\}*/
 

--- a/fsw/cfe-core/src/inc/cfe_sb.h
+++ b/fsw/cfe-core/src/inc/cfe_sb.h
@@ -36,6 +36,7 @@
 ** Includes
 */
 #include "cfe_sb_extern_typedefs.h"
+#include "cfe_error.h"
 #include "osconfig.h"
 #include "cfe_psp.h"
 #include "common_types.h"
@@ -243,9 +244,7 @@ extern CFE_SB_Qos_t CFE_SB_Default_Qos;/**< \brief  Defines a default priority a
 **
 ** \sa #CFE_SB_DeletePipe #CFE_SB_GetPipeOpts #CFE_SB_SetPipeOpts #CFE_SB_GetPipeIdByName
 **/
-int32  CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr,
-                         uint16  Depth,
-                         const char *PipeName);
+CFE_Status_t  CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16 Depth, const char *PipeName);
 
 /*****************************************************************************/
 /**
@@ -274,7 +273,7 @@ int32  CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr,
 **
 ** \sa #CFE_SB_CreatePipe #CFE_SB_GetPipeOpts #CFE_SB_SetPipeOpts #CFE_SB_GetPipeIdByName
 **/
-int32  CFE_SB_DeletePipe(CFE_SB_PipeId_t PipeId);
+CFE_Status_t  CFE_SB_DeletePipe(CFE_SB_PipeId_t PipeId);
 
 /*****************************************************************************/
 /**
@@ -294,8 +293,7 @@ int32  CFE_SB_DeletePipe(CFE_SB_PipeId_t PipeId);
 **
 ** \sa #CFE_SB_CreatePipe #CFE_SB_DeletePipe #CFE_SB_GetPipeOpts #CFE_SB_GetPipeIdByName #CFE_SB_PIPEOPTS_IGNOREMINE
 **/
-int32  CFE_SB_SetPipeOpts(CFE_SB_PipeId_t     PipeId,
-                          uint8               Opts);
+CFE_Status_t  CFE_SB_SetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 Opts);
 
 /*****************************************************************************/
 /**
@@ -314,8 +312,7 @@ int32  CFE_SB_SetPipeOpts(CFE_SB_PipeId_t     PipeId,
 **
 ** \sa #CFE_SB_CreatePipe #CFE_SB_DeletePipe #CFE_SB_SetPipeOpts #CFE_SB_GetPipeIdByName #CFE_SB_PIPEOPTS_IGNOREMINE
 **/
-int32  CFE_SB_GetPipeOpts(CFE_SB_PipeId_t     PipeId,
-                          uint8               *OptPtr);
+CFE_Status_t  CFE_SB_GetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 *OptPtr);
 
 /*****************************************************************************/
 /**
@@ -336,7 +333,7 @@ int32  CFE_SB_GetPipeOpts(CFE_SB_PipeId_t     PipeId,
 **
 ** \sa #CFE_SB_CreatePipe #CFE_SB_DeletePipe #CFE_SB_SetPipeOpts #CFE_SB_GetPipeIdByName
 **/
-int32 CFE_SB_GetPipeName(char *PipeNameBuf, size_t PipeNameSize, CFE_SB_PipeId_t PipeId);
+CFE_Status_t CFE_SB_GetPipeName(char *PipeNameBuf, size_t PipeNameSize, CFE_SB_PipeId_t PipeId);
 
 /*****************************************************************************/
 /**
@@ -355,7 +352,7 @@ int32 CFE_SB_GetPipeName(char *PipeNameBuf, size_t PipeNameSize, CFE_SB_PipeId_t
 **
 ** \sa #CFE_SB_CreatePipe #CFE_SB_DeletePipe #CFE_SB_SetPipeOpts #CFE_SB_PIPEOPTS_IGNOREMINE
 **/
-int32  CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *PipeName);
+CFE_Status_t  CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *PipeName);
 /**@}*/
 
 /** @defgroup CFEAPISBSubscription cFE Message Subscription Control APIs
@@ -400,10 +397,7 @@ int32  CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *PipeName);
 **
 ** \sa #CFE_SB_Subscribe, #CFE_SB_SubscribeLocal, #CFE_SB_Unsubscribe, #CFE_SB_UnsubscribeLocal
 **/
-int32  CFE_SB_SubscribeEx(CFE_SB_MsgId_t      MsgId,
-                          CFE_SB_PipeId_t     PipeId,
-                          CFE_SB_Qos_t        Quality,
-                          uint16              MsgLim);
+CFE_Status_t  CFE_SB_SubscribeEx(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_Qos_t Quality, uint16 MsgLim);
 
 /*****************************************************************************/
 /**
@@ -438,7 +432,7 @@ int32  CFE_SB_SubscribeEx(CFE_SB_MsgId_t      MsgId,
 **
 ** \sa #CFE_SB_SubscribeEx, #CFE_SB_SubscribeLocal, #CFE_SB_Unsubscribe, #CFE_SB_UnsubscribeLocal
 **/
-int32 CFE_SB_Subscribe(CFE_SB_MsgId_t  MsgId, CFE_SB_PipeId_t PipeId);
+CFE_Status_t CFE_SB_Subscribe(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId);
 
 /*****************************************************************************/
 /**
@@ -472,9 +466,7 @@ int32 CFE_SB_Subscribe(CFE_SB_MsgId_t  MsgId, CFE_SB_PipeId_t PipeId);
 **
 ** \sa #CFE_SB_Subscribe, #CFE_SB_SubscribeEx, #CFE_SB_Unsubscribe, #CFE_SB_UnsubscribeLocal
 **/
-int32 CFE_SB_SubscribeLocal(CFE_SB_MsgId_t MsgId,
-                            CFE_SB_PipeId_t PipeId,
-                            uint16 MsgLim);
+CFE_Status_t CFE_SB_SubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint16 MsgLim);
 
 /*****************************************************************************/
 /**
@@ -499,7 +491,7 @@ int32 CFE_SB_SubscribeLocal(CFE_SB_MsgId_t MsgId,
 **
 ** \sa #CFE_SB_Subscribe, #CFE_SB_SubscribeEx, #CFE_SB_SubscribeLocal, #CFE_SB_UnsubscribeLocal
 **/
-int32  CFE_SB_Unsubscribe(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId);
+CFE_Status_t  CFE_SB_Unsubscribe(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId);
 
 /*****************************************************************************/
 /**
@@ -524,7 +516,7 @@ int32  CFE_SB_Unsubscribe(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId);
 **
 ** \sa #CFE_SB_Subscribe, #CFE_SB_SubscribeEx, #CFE_SB_SubscribeLocal, #CFE_SB_Unsubscribe
 **/
-int32 CFE_SB_UnsubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId);
+CFE_Status_t CFE_SB_UnsubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId);
 /**@}*/
 
 /** @defgroup CFEAPISBMessage cFE Send/Receive Message APIs
@@ -561,7 +553,7 @@ int32 CFE_SB_UnsubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId);
 **
 ** \sa #CFE_SB_RcvMsg, #CFE_SB_ZeroCopySend, #CFE_SB_PassMsg
 **/
-int32  CFE_SB_SendMsg(CFE_SB_Msg_t   *MsgPtr);
+CFE_Status_t  CFE_SB_SendMsg(CFE_SB_Msg_t *MsgPtr);
 
 /*****************************************************************************/
 /**
@@ -594,7 +586,7 @@ int32  CFE_SB_SendMsg(CFE_SB_Msg_t   *MsgPtr);
 **
 ** \sa #CFE_SB_RcvMsg, #CFE_SB_ZeroCopySend, #CFE_SB_SendMsg
 **/
-int32  CFE_SB_PassMsg(CFE_SB_Msg_t   *MsgPtr);
+CFE_Status_t  CFE_SB_PassMsg(CFE_SB_Msg_t *MsgPtr);
 
 /*****************************************************************************/
 /**
@@ -638,9 +630,7 @@ int32  CFE_SB_PassMsg(CFE_SB_Msg_t   *MsgPtr);
 **
 ** \sa #CFE_SB_SendMsg, #CFE_SB_ZeroCopySend
 **/
-int32  CFE_SB_RcvMsg(CFE_SB_MsgPtr_t  *BufPtr,
-                     CFE_SB_PipeId_t  PipeId,
-                     int32            TimeOut);
+CFE_Status_t  CFE_SB_RcvMsg(CFE_SB_MsgPtr_t *BufPtr, CFE_SB_PipeId_t PipeId, int32 TimeOut);
 /**@}*/
 
 /** @defgroup CFEAPISBZeroCopy cFE Zero Copy Message APIs
@@ -711,8 +701,7 @@ CFE_SB_Msg_t  *CFE_SB_ZeroCopyGetPtr(uint16  MsgSize,
 **
 ** \sa #CFE_SB_ZeroCopyGetPtr, #CFE_SB_ZeroCopySend
 **/
-int32 CFE_SB_ZeroCopyReleasePtr(CFE_SB_Msg_t  *Ptr2Release,
-                                CFE_SB_ZeroCopyHandle_t         BufferHandle);
+CFE_Status_t CFE_SB_ZeroCopyReleasePtr(CFE_SB_Msg_t *Ptr2Release, CFE_SB_ZeroCopyHandle_t BufferHandle);
 
 /*****************************************************************************/
 /**
@@ -752,8 +741,7 @@ int32 CFE_SB_ZeroCopyReleasePtr(CFE_SB_Msg_t  *Ptr2Release,
 **
 ** \sa #CFE_SB_SendMsg, #CFE_SB_RcvMsg, #CFE_SB_ZeroCopyReleasePtr, #CFE_SB_ZeroCopyGetPtr
 **/
-int32 CFE_SB_ZeroCopySend(CFE_SB_Msg_t   *MsgPtr,
-                          CFE_SB_ZeroCopyHandle_t          BufferHandle);
+CFE_Status_t CFE_SB_ZeroCopySend(CFE_SB_Msg_t *MsgPtr, CFE_SB_ZeroCopyHandle_t BufferHandle);
 
 /*****************************************************************************/
 /**
@@ -795,8 +783,7 @@ int32 CFE_SB_ZeroCopySend(CFE_SB_Msg_t   *MsgPtr,
 **
 ** \sa #CFE_SB_PassMsg, #CFE_SB_ZeroCopySend, #CFE_SB_ZeroCopyReleasePtr, #CFE_SB_ZeroCopyGetPtr
 **/
-int32 CFE_SB_ZeroCopyPass(CFE_SB_Msg_t   *MsgPtr,
-                          CFE_SB_ZeroCopyHandle_t          BufferHandle);
+CFE_Status_t CFE_SB_ZeroCopyPass(CFE_SB_Msg_t *MsgPtr, CFE_SB_ZeroCopyHandle_t BufferHandle);
 /**@}*/
 
 /** @defgroup CFEAPISBSetMessage cFE Setting Message Characteristics APIs
@@ -938,8 +925,7 @@ void CFE_SB_SetTotalMsgLength(CFE_SB_MsgPtr_t MsgPtr,uint16 TotalLength);
 ** \sa #CFE_SB_SetMsgId, #CFE_SB_SetUserDataLength, #CFE_SB_SetTotalMsgLength,
 **     #CFE_SB_GetMsgTime, #CFE_SB_TimeStampMsg, #CFE_SB_SetCmdCode, #CFE_SB_InitMsg
 **/
-int32 CFE_SB_SetMsgTime(CFE_SB_MsgPtr_t MsgPtr,
-                       CFE_TIME_SysTime_t Time);
+CFE_Status_t CFE_SB_SetMsgTime(CFE_SB_MsgPtr_t MsgPtr, CFE_TIME_SysTime_t Time);
 
 /*****************************************************************************/
 /**
@@ -987,8 +973,7 @@ void CFE_SB_TimeStampMsg(CFE_SB_MsgPtr_t MsgPtr);
 ** \sa #CFE_SB_SetMsgId, #CFE_SB_SetUserDataLength, #CFE_SB_SetTotalMsgLength,
 **     #CFE_SB_SetMsgTime, #CFE_SB_TimeStampMsg, #CFE_SB_GetCmdCode, #CFE_SB_InitMsg
 **/
-int32 CFE_SB_SetCmdCode(CFE_SB_MsgPtr_t MsgPtr,
-                        uint16 CmdCode);
+CFE_Status_t CFE_SB_SetCmdCode(CFE_SB_MsgPtr_t MsgPtr, uint16 CmdCode);
 
 /******************************************************************************/
 /**

--- a/fsw/cfe-core/src/inc/cfe_tbl.h
+++ b/fsw/cfe-core/src/inc/cfe_tbl.h
@@ -41,6 +41,7 @@
 /********************* Include Files  ************************/
 #include "cfe_tbl_extern_typedefs.h"
 #include "cfe_sb_extern_typedefs.h"
+#include "cfe_error.h"
 #include "common_types.h"  /* Basic Data Types */
 #include "cfe_time.h"
 #include "osconfig.h"
@@ -264,11 +265,11 @@ typedef struct CFE_TBL_Info
 **
 ** \sa #CFE_TBL_Unregister, #CFE_TBL_Share
 **/
-int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,                   /* Returned Handle */
-                        const char   *Name,                               /* Application specific name  */
-                        uint32  Size,                                     /* Size, in bytes, of table   */
-                        uint16  TblOptionFlags,                           /* Tbl Options Settings     */
-                        CFE_TBL_CallbackFuncPtr_t TblValidationFuncPtr ); /* Ptr to func that validates tbl */
+CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr,                  /* Returned Handle */
+                          const char   *Name,                              /* Application specific name  */
+                          uint32  Size,                                    /* Size, in bytes, of table   */
+                          uint16  TblOptionFlags,                          /* Tbl Options Settings     */
+                          CFE_TBL_CallbackFuncPtr_t TblValidationFuncPtr); /* Ptr to func that validates tbl */
 
 /*****************************************************************************/
 /**
@@ -308,8 +309,7 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,                   /* Ret
 ** \sa #CFE_TBL_Unregister, #CFE_TBL_Register
 **
 ******************************************************************************/
-int32 CFE_TBL_Share( CFE_TBL_Handle_t *TblHandlePtr,      /* Returned Handle */
-                     const char *TblName );
+CFE_Status_t CFE_TBL_Share(CFE_TBL_Handle_t *TblHandlePtr, const char *TblName);
 
 /*****************************************************************************/
 /**
@@ -339,7 +339,7 @@ int32 CFE_TBL_Share( CFE_TBL_Handle_t *TblHandlePtr,      /* Returned Handle */
 ** \sa #CFE_TBL_Share, #CFE_TBL_Register
 ** 
 ******************************************************************************/
-int32 CFE_TBL_Unregister ( CFE_TBL_Handle_t TblHandle );
+CFE_Status_t CFE_TBL_Unregister (CFE_TBL_Handle_t TblHandle);
 /**@}*/
 
 /** @defgroup CFEAPITBLManage cFE Manage Table Content APIs
@@ -396,9 +396,7 @@ int32 CFE_TBL_Unregister ( CFE_TBL_Handle_t TblHandle );
 ** \sa #CFE_TBL_Update, #CFE_TBL_Validate, #CFE_TBL_Manage 
 **
 ******************************************************************************/
-int32 CFE_TBL_Load( CFE_TBL_Handle_t TblHandle,
-                    CFE_TBL_SrcEnum_t SrcType,
-                    const void *SrcDataPtr );
+CFE_Status_t CFE_TBL_Load(CFE_TBL_Handle_t TblHandle, CFE_TBL_SrcEnum_t SrcType, const void *SrcDataPtr);
 
 /*****************************************************************************/
 /**
@@ -431,7 +429,7 @@ int32 CFE_TBL_Load( CFE_TBL_Handle_t TblHandle,
 ** \sa #CFE_TBL_Load, #CFE_TBL_Validate, #CFE_TBL_Manage
 **
 ******************************************************************************/
-int32 CFE_TBL_Update( CFE_TBL_Handle_t TblHandle );
+CFE_Status_t CFE_TBL_Update(CFE_TBL_Handle_t TblHandle);
 
 /*****************************************************************************/
 /**
@@ -464,7 +462,7 @@ int32 CFE_TBL_Update( CFE_TBL_Handle_t TblHandle );
 ** \sa #CFE_TBL_Update, #CFE_TBL_Manage, #CFE_TBL_Load
 **
 ******************************************************************************/
-int32 CFE_TBL_Validate( CFE_TBL_Handle_t TblHandle );
+CFE_Status_t CFE_TBL_Validate(CFE_TBL_Handle_t TblHandle);
 
 /*****************************************************************************/
 /**
@@ -496,7 +494,7 @@ int32 CFE_TBL_Validate( CFE_TBL_Handle_t TblHandle );
 ** \sa #CFE_TBL_Update, #CFE_TBL_Validate, #CFE_TBL_Load, #CFE_TBL_DumpToBuffer
 **
 ******************************************************************************/
-int32 CFE_TBL_Manage( CFE_TBL_Handle_t TblHandle );
+CFE_Status_t CFE_TBL_Manage(CFE_TBL_Handle_t TblHandle);
 
 /*****************************************************************************/
 /**
@@ -525,7 +523,7 @@ int32 CFE_TBL_Manage( CFE_TBL_Handle_t TblHandle );
 ** \sa #CFE_TBL_Manage
 **
 ******************************************************************************/
-int32   CFE_TBL_DumpToBuffer( CFE_TBL_Handle_t TblHandle );
+CFE_Status_t   CFE_TBL_DumpToBuffer(CFE_TBL_Handle_t TblHandle);
 
 /*****************************************************************************/
 /**
@@ -553,7 +551,7 @@ int32   CFE_TBL_DumpToBuffer( CFE_TBL_Handle_t TblHandle );
 ** \sa #CFE_TBL_Manage
 **
 ******************************************************************************/
-int32   CFE_TBL_Modified( CFE_TBL_Handle_t TblHandle );
+CFE_Status_t   CFE_TBL_Modified(CFE_TBL_Handle_t TblHandle);
 /**@}*/
 
 /** @defgroup CFEAPITBLAccess cFE Access Table Content APIs
@@ -608,8 +606,7 @@ int32   CFE_TBL_Modified( CFE_TBL_Handle_t TblHandle );
 ** \sa #CFE_TBL_ReleaseAddress, #CFE_TBL_GetAddresses, #CFE_TBL_ReleaseAddresses
 **
 ******************************************************************************/
-int32 CFE_TBL_GetAddress( void **TblPtr,
-                          CFE_TBL_Handle_t TblHandle );
+CFE_Status_t CFE_TBL_GetAddress(void **TblPtr, CFE_TBL_Handle_t TblHandle);
 
 /*****************************************************************************/
 /**
@@ -641,7 +638,7 @@ int32 CFE_TBL_GetAddress( void **TblPtr,
 ** \sa #CFE_TBL_GetAddress, #CFE_TBL_GetAddresses, #CFE_TBL_ReleaseAddresses
 **
 ******************************************************************************/
-int32 CFE_TBL_ReleaseAddress( CFE_TBL_Handle_t TblHandle );
+CFE_Status_t CFE_TBL_ReleaseAddress(CFE_TBL_Handle_t TblHandle);
 
 /*****************************************************************************/
 /**
@@ -693,9 +690,7 @@ int32 CFE_TBL_ReleaseAddress( CFE_TBL_Handle_t TblHandle );
 ** \sa #CFE_TBL_GetAddress, #CFE_TBL_ReleaseAddress, #CFE_TBL_ReleaseAddresses
 **
 ******************************************************************************/
-int32 CFE_TBL_GetAddresses( void **TblPtrs[],
-                            uint16 NumTables,
-                            const CFE_TBL_Handle_t TblHandles[] );
+CFE_Status_t CFE_TBL_GetAddresses(void **TblPtrs[], uint16 NumTables, const CFE_TBL_Handle_t TblHandles[]);
 
 /*****************************************************************************/
 /**
@@ -729,8 +724,7 @@ int32 CFE_TBL_GetAddresses( void **TblPtrs[],
 ** \sa #CFE_TBL_GetAddress, #CFE_TBL_ReleaseAddress, #CFE_TBL_GetAddresses
 **
 ******************************************************************************/
-int32 CFE_TBL_ReleaseAddresses( uint16 NumTables,
-                                const CFE_TBL_Handle_t TblHandles[] );
+CFE_Status_t CFE_TBL_ReleaseAddresses(uint16 NumTables, const CFE_TBL_Handle_t TblHandles[]);
 /**@}*/
 
 /** @defgroup CFEAPITBLInfo cFE Get Table Information APIs
@@ -766,10 +760,13 @@ int32 CFE_TBL_ReleaseAddresses( uint16 NumTables,
 ** \retval #CFE_TBL_ERR_NO_ACCESS           \copybrief CFE_TBL_ERR_NO_ACCESS
 ** \retval #CFE_TBL_ERR_INVALID_HANDLE      \copybrief CFE_TBL_ERR_INVALID_HANDLE
 **
+** \note Some status return codes are "success" while being non-zero. This
+**       behavior will change in the future.
+**
 ** \sa #CFE_TBL_Manage, #CFE_TBL_Update, #CFE_TBL_Validate, #CFE_TBL_GetInfo
 **
 ******************************************************************************/
-int32 CFE_TBL_GetStatus( CFE_TBL_Handle_t TblHandle );
+CFE_Status_t CFE_TBL_GetStatus(CFE_TBL_Handle_t TblHandle);
 
 /*****************************************************************************/
 /**
@@ -802,7 +799,7 @@ int32 CFE_TBL_GetStatus( CFE_TBL_Handle_t TblHandle );
 ** \sa #CFE_TBL_GetStatus
 **
 ******************************************************************************/
-int32 CFE_TBL_GetInfo( CFE_TBL_Info_t *TblInfoPtr, const char *TblName );
+CFE_Status_t CFE_TBL_GetInfo(CFE_TBL_Info_t *TblInfoPtr, const char *TblName);
 
 /*****************************************************************************/
 /**
@@ -845,7 +842,7 @@ int32 CFE_TBL_GetInfo( CFE_TBL_Info_t *TblInfoPtr, const char *TblName );
 ** \sa #CFE_TBL_Register
 **
 ******************************************************************************/
-int32 CFE_TBL_NotifyByMessage(CFE_TBL_Handle_t TblHandle, CFE_SB_MsgId_t MsgId, uint16 CommandCode, uint32 Parameter);
+CFE_Status_t CFE_TBL_NotifyByMessage(CFE_TBL_Handle_t TblHandle, CFE_SB_MsgId_t MsgId, uint16 CommandCode, uint32 Parameter);
 /**@}*/
 
 #endif  /* _cfe_tbl_ */

--- a/fsw/cfe-core/src/inc/cfe_time.h
+++ b/fsw/cfe-core/src/inc/cfe_time.h
@@ -40,6 +40,7 @@
 ** Includes
 */
 #include "cfe_time_extern_typedefs.h"
+#include "cfe_error.h"
 #include "common_types.h"
 
 /*****************************************************************************/
@@ -713,7 +714,7 @@ void CFE_TIME_ExternalTime(CFE_TIME_SysTime_t NewTime);
 ** \sa #CFE_TIME_UnregisterSynchCallback
 **
 ******************************************************************************/
-int32  CFE_TIME_RegisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPtr);   
+CFE_Status_t  CFE_TIME_RegisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPtr);   
 
 
 /*****************************************************************************/
@@ -737,7 +738,7 @@ int32  CFE_TIME_RegisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPt
 ** \sa #CFE_TIME_RegisterSynchCallback
 **
 ******************************************************************************/
-int32  CFE_TIME_UnregisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPtr);   
+CFE_Status_t  CFE_TIME_UnregisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPtr);   
 /**@}*/
 
 /** @defgroup CFEAPITIMEMisc cFE Miscellaneous Time APIs


### PR DESCRIPTION
Closes #888 

**Describe the contribution**
This adds a typedef for return status codes for functions. I've also added a brief comment to CFE_TBL_GetStatus as it's behavior will likely change in the future in the hopes of not having a non-zero "info" status.

**Testing performed**
make install

**Expected behavior changes**
no impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov