### PR TITLE
"SenderReporting" from SB private "global" - removed

### DIFF
--- a/fsw/cfe-core/src/sb/cfe_sb_priv.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.h
@@ -282,7 +282,6 @@ typedef struct {
 typedef struct {
     osal_id_t           SharedDataMutexId;
     uint32              SubscriptionReporting;
-    uint32              SenderReporting;
     CFE_ES_ResourceID_t AppId;
     uint32              StopRecurseFlags[OS_MAX_TASKS];
     void               *ZeroCopyTail;


### PR DESCRIPTION
The global variable removed because is only set once and never used.