### PR TITLE
Fix #56, Refactor CDS to use generic pool implementation

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_cds.h
+++ b/fsw/cfe-core/src/es/cfe_es_cds.h
@@ -46,7 +46,7 @@
 #include "cfe_es_apps.h"
 #include "cfe_platform_cfg.h"
 #include "cfe_es.h"
-#include "cfe_es_cds_mempool.h"
+#include "cfe_es_generic_pool.h"
 
 /*
 ** Macro Definitions
@@ -54,45 +54,412 @@
 
 /** \name Registry Mutex Definitions */
 /**  \{ */
-#define CFE_ES_CDS_MUT_REG_NAME       "CDS_REG_MUT"  /**< \brief Name of Mutex controlling CDS Registry Access */
-#define CFE_ES_CDS_MUT_REG_VALUE       0             /**< \brief Initial Value of CDS Registry Access Mutex */
-
-#define CFE_ES_CDS_NOT_FOUND          (uint32)(0xffffffff)
+#define CFE_ES_CDS_MUT_REG_NAME       "CDS_MUTEX"   /**< \brief Name of Mutex controlling CDS Access */
+#define CFE_ES_CDS_MUT_REG_VALUE       0            /**< \brief Initial Value of CDS Access Mutex */
 /** \} */
+
+/** \name Registry Signature Definitions */
+/**  \{ */
+#define CFE_ES_CDS_SIGNATURE_LEN       8            /**< \brief Length of CDS signature field. */
+#define CFE_ES_CDS_SIGNATURE_BEGIN     "_CDSBeg_"   /**< \brief Fixed signature at beginning of CDS */
+#define CFE_ES_CDS_SIGNATURE_END       "_CDSEnd_"   /**< \brief Fixed signature at end of CDS */
+/** \} */
+
+
+/*
+ * Space in CDS should be aligned to a multiple of uint32
+ * These helper macros round up to a whole number of words
+ */
+#define CDS_SIZE_TO_U32WORDS(x)         (((x) + 3) / sizeof(uint32))
+#define CDS_RESERVE_SPACE(name,size)    uint32 name[CDS_SIZE_TO_U32WORDS(size)]
+
+/* Define offset addresses for CDS data segments */
+#define CDS_SIG_BEGIN_OFFSET    offsetof(CFE_ES_CDS_PersistentHeader_t, SignatureBegin)
+#define CDS_REG_SIZE_OFFSET     offsetof(CFE_ES_CDS_PersistentHeader_t, RegistrySize)
+#define CDS_REG_OFFSET          offsetof(CFE_ES_CDS_PersistentHeader_t, RegistryContent)
+#define CDS_POOL_OFFSET         sizeof(CFE_ES_CDS_PersistentHeader_t)
+
+/*
+ * Absolute Minimum CDS size conceivably supportable by the implementation.
+ * This is the space required for the basic signatures and registry information.
+ * It is not possible to create a CDS with a storage area smaller than this.
+ */
+#define CDS_RESERVED_MIN_SIZE   sizeof(CFE_ES_CDS_PersistentHeader_t) + sizeof(CFE_ES_CDS_PersistentTrailer_t)
+
+/*
+ * Absolute Maximum Block size conceivably supportable by the implementation.
+ * User-defined platform limits (in cfe_platform_cfg.h) may be lower,
+ * but this is a hard limit to avoid overflow of CFE_ES_CDS_Offset_t.
+ */
+#define CDS_ABS_MAX_BLOCK_SIZE  ((1 << ((8 * sizeof(CFE_ES_CDS_Offset_t))-2)) - sizeof(CFE_ES_CDS_BlockHeader_t))
+
+
 
 /*
 ** Type Definitions
 */
 
+
+/**
+ * The structure cached in RAM for each block within the CDS non-volatile memory
+ * This has the basic runtime info without having to go to CDS.
+ */
 typedef struct
 {
+    /*
+     * Note that the block size and offset stored here are for the
+     * total block size.  The CDS code adds is own extra metadata
+     * which has a CRC, and therefore the actual user data size is
+     * less than this.
+     */
+    CFE_ES_ResourceID_t       BlockID;      /**< Abstract ID associated with this CDS block */
+    CFE_ES_CDS_Offset_t       BlockOffset;  /**< Start offset of the block in CDS memory */
+    CFE_ES_CDS_Offset_t       BlockSize;    /**< Size, in bytes, of the CDS memory block */
     char                      Name[CFE_ES_CDS_MAX_FULL_NAME_LEN];
-    CFE_ES_CDSBlockHandle_t   MemHandle;
-    uint32                    Size;           /**< \brief Size, in bytes, of the CDS memory block */
-    bool                      Taken;          /**< \brief Flag that indicates whether the registry record is in use */
-    bool                      Table;          /**< \brief Flag that indicates whether CDS contains a Critical Table */
+    bool                      Table;        /**< \brief Flag that indicates whether CDS contains a Critical Table */
 } CFE_ES_CDS_RegRec_t;
 
+typedef struct CFE_ES_CDSBlockHeader
+{
+    uint32              Crc;        /**< CRC of content */
+} CFE_ES_CDS_BlockHeader_t;
+
+/*
+ * A generic buffer to hold the various objects that need
+ * to be cached in RAM from the CDS non-volatile storage.
+ */
+typedef union CFE_ES_CDS_AccessCacheData
+{
+    char                     Sig[CFE_ES_CDS_SIGNATURE_LEN];  /**< A signature field (beginning or end) */
+    uint32                   RegistrySize;           /**< Registry Size Field */
+    uint32                   Zero[4];                /**< Used when clearing CDS content */
+    CFE_ES_GenPoolBD_t       Desc;                   /**< A generic block descriptor */
+    CFE_ES_CDS_BlockHeader_t BlockHeader;            /**< A user block header */
+    CFE_ES_CDS_RegRec_t      RegEntry;               /**< A registry entry */
+} CFE_ES_CDS_AccessCacheData_t;
+
+typedef struct CFE_ES_CDS_AccessCache
+{
+    CFE_ES_CDS_AccessCacheData_t Data;  /**< Cached data (varies in size) */
+    CFE_ES_CDS_Offset_t   Offset;  /**< The offset where Data is cached from */
+    CFE_ES_CDS_Offset_t   Size;    /**< The size of cached Data */
+    int32                 AccessStatus; /**< The PSP status of the last read/write from CDS memory */
+} CFE_ES_CDS_AccessCache_t;
+
+/**
+ * Instance data associated with a CDS
+ *
+ * Currently there is just one global CDS instance (i.e. a singleton)
+ * stored in the CFE_ES_Global structure.
+ */
 typedef struct
 {
-    osal_id_t            RegistryMutex;                         /**< \brief Mutex that controls access to CDS Registry */
-    uint32               CDSSize;                               /**< \brief Total size of the CDS as reported by BSP */
-    uint32               MemPoolSize;
-    uint32               MaxNumRegEntries;                      /**< \brief Maximum number of Registry entries */
+    /*
+     * The generic pool structure
+     * This must be the first entry in this structure.
+     */
+    CFE_ES_GenPoolRecord_t Pool;
+
+    /*
+     * Cache of last accessed data block
+     * Because CDS memory is not memory mapped, this serves
+     * as temporary holding location for data being actively accessed.
+     */
+    CFE_ES_CDS_AccessCache_t Cache;
+
+    osal_id_t            GenMutex;                           /**< \brief Mutex that controls access to CDS and registry */
+    CFE_ES_CDS_Offset_t  TotalSize;                          /**< \brief Total size of the CDS as reported by BSP */
+    CFE_ES_CDS_Offset_t  DataSize;                           /**< \brief Size of actual user data pool */
     CFE_ES_CDS_RegRec_t  Registry[CFE_PLATFORM_ES_CDS_MAX_NUM_ENTRIES];  /**< \brief CDS Registry (Local Copy) */
-    char                 ValidityField[8];
-} CFE_ES_CDSVariables_t;
+} CFE_ES_CDS_Instance_t;
+
+
+/*
+ * structs representing the intended layout of data
+ * in the actual CDS/PSP-provided non-volatile memory
+ *
+ * All blocks should be multiples of uint32
+ *
+ * NOTE: these aren't necessarily instantiated in RAM,
+ * just in CDS.  Mainly interested in the size of these
+ * elements, and offset of the various members within.
+ */
+typedef struct CFE_ES_CDS_PersistentHeader
+{
+    CDS_RESERVE_SPACE(SignatureBegin, CFE_ES_CDS_SIGNATURE_LEN);
+    CDS_RESERVE_SPACE(RegistrySize, sizeof(uint32));
+    CDS_RESERVE_SPACE(RegistryContent, CFE_PLATFORM_ES_CDS_MAX_NUM_ENTRIES * sizeof(CFE_ES_CDS_RegRec_t));
+} CFE_ES_CDS_PersistentHeader_t;
+
+typedef struct CFE_ES_CDS_PersistentTrailer
+{
+    CDS_RESERVE_SPACE(SignatureEnd, CFE_ES_CDS_SIGNATURE_LEN);
+} CFE_ES_CDS_PersistentTrailer_t;
+
+
+
 
 /*****************************************************************************/
 /*
 ** Function prototypes
 */
 
-/*
-** CFE_ES_CDS_EarlyInit
-*/
+/**
+ * @brief Fetch data from the non-volatile storage and store in RAM cache
+ *
+ * This fetches a data segment from the PSP and loads it into the
+ * local CDS cache buffer.  The content can be accessed via the
+ * "Data" member inside the cache structure.
+ *
+ * Only one thread can use CDS cache at a given time, so the CDS access
+ * control mutex must be obtained before calling this function.
+ *
+ * @param[inout] Cache  the global CDS cache buffer
+ * @param[in]    Offset the CDS offset to fetch
+ * @param[in]    Size   the CDS data size to fetch
+ * @returns #CFE_SUCCESS on success, or appropriate error code.
+ */
+int32 CFE_ES_CDS_CacheFetch(CFE_ES_CDS_AccessCache_t *Cache,
+        CFE_ES_CDS_Offset_t Offset, CFE_ES_CDS_Offset_t Size);
 
+
+/**
+ * @brief Write data from the RAM cache back to non-volatile storage
+ *
+ * This stores a data segment from the cache into the PSP for
+ * permanent storage.  Data should be loaded into the cache
+ * prior to invoking this function, either via CFE_ES_CDS_CacheFetch()
+ * or CFE_ES_CDS_CachePreload().
+ *
+ * Only one thread can use CDS cache at a given time, so the CDS access
+ * control mutex must be obtained before calling this function.
+ *
+ * @param[inout] Cache  the global CDS cache buffer
+ * @returns #CFE_SUCCESS on success, or appropriate error code.
+ */
+int32 CFE_ES_CDS_CacheFlush(CFE_ES_CDS_AccessCache_t *Cache);
+
+/**
+ * @brief Preload the cache data from a local buffer
+ *
+ * This loads the CDS cache directly from a provided object/buffer to
+ * prepare for writing to PSP.  The data can then be committed to PSP
+ * at a later time using CFE_ES_CDS_CacheFlush().
+ *
+ * If Source is NULL, then the cache data will be initialized to zero.
+ *
+ * If Source refers to the cache buffer, then no copying will take place, because
+ * source and destination are the same.  No copy is performed, and the data will be
+ * unchanged.  In this mode only the size and offset are updated.
+ *
+ * Only one thread can use CDS cache at a given time, so the CDS access
+ * control mutex must be obtained before calling this function.
+ *
+ *
+ * @param[inout] Cache  the global CDS cache buffer
+ * @param[in]    Source the local object to load into cache
+ * @param[in]    Offset the CDS offset to fetch
+ * @param[in]    Size   the CDS data size to fetch
+ * @returns #CFE_SUCCESS on success, or appropriate error code.
+ */
+int32 CFE_ES_CDS_CachePreload(CFE_ES_CDS_AccessCache_t *Cache, const void *Source,
+        CFE_ES_CDS_Offset_t Offset, CFE_ES_CDS_Offset_t Size);
+
+/**
+ * @brief Get the registry array index correlating with a CDS block ID
+ *
+ * Calculates the array position/index of the CDS registry entry for
+ * the given block ID.
+ *
+ * @param[in]  BlockID the ID/handle of the CDS block to retrieve
+ * @param[out] Idx     Output buffer to store the index
+ * @returns    #CFE_SUCCESS if conversion successful. @copydoc CFE_SUCCESS
+ *             #CFE_ES_RESOURCE_ID_INVALID if block ID is outside valid range
+ */
+int32 CFE_ES_CDSBlockID_ToIndex(CFE_ES_ResourceID_t BlockID, uint32 *Idx);
+
+/**
+ * @brief Get a registry record within the CDS, given a block ID/handle
+ *
+ * Retrieves a pointer to the registry record associated with a CDS block ID/handle
+ * Returns NULL if the handle is outside the valid range
+ *
+ * @note This only does the lookup, it does not validate that the handle
+ * actually matches the returned record.  The caller should lock the CDS and
+ * confirm that the record is a match to the expected ID before using it.
+ *
+ * @param[in] BlockID the ID/handle of the CDS block to retrieve
+ * @returns   Pointer to registry record, or NULL if ID/handle invalid.
+ */
+CFE_ES_CDS_RegRec_t* CFE_ES_LocateCDSBlockRecordByID(CFE_ES_ResourceID_t BlockID);
+
+/**
+ * @brief Check if a Memory Pool record is in use or free/empty
+ *
+ * This routine checks if the Pool table entry is in use or if it is free
+ *
+ * As this dereferences fields within the record, global data must be
+ * locked prior to invoking this function.
+ *
+ * @param[in]   CDSBlockRecPtr   pointer to Pool table entry
+ * @returns true if the entry is in use/configured, or false if it is free/empty
+ */
+static inline bool CFE_ES_CDSBlockRecordIsUsed(const CFE_ES_CDS_RegRec_t *CDSBlockRecPtr)
+{
+    return CFE_ES_ResourceID_IsDefined(CDSBlockRecPtr->BlockID);
+}
+
+/**
+ * @brief Get the ID value from a Memory Pool table entry
+ *
+ * This routine converts the table entry back to an abstract ID.
+ *
+ * @param[in]   CDSBlockRecPtr   pointer to Pool table entry
+ * @returns BlockID of entry
+ */
+static inline CFE_ES_ResourceID_t CFE_ES_CDSBlockRecordGetID(const CFE_ES_CDS_RegRec_t *CDSBlockRecPtr)
+{
+    return (CDSBlockRecPtr->BlockID);
+}
+
+/**
+ * @brief Marks a Memory Pool table entry as used (not free)
+ *
+ * This sets the internal field(s) within this entry, and marks
+ * it as being associated with the given Pool ID.
+ *
+ * @param[in]   CDSBlockRecPtr   pointer to Pool table entry
+ * @param[in]   BlockID       the Pool ID of this entry
+ */
+static inline void CFE_ES_CDSBlockRecordSetUsed(CFE_ES_CDS_RegRec_t *CDSBlockRecPtr, CFE_ES_ResourceID_t BlockID)
+{
+    CDSBlockRecPtr->BlockID = BlockID;
+}
+
+/**
+ * @brief Set a Memory Pool record table entry free (not used)
+ *
+ * This clears the internal field(s) within this entry, and allows the
+ * memory to be re-used in the future.
+ *
+ * @param[in]   CDSBlockRecPtr   pointer to Pool table entry
+ */
+static inline void CFE_ES_CDSBlockRecordSetFree(CFE_ES_CDS_RegRec_t *CDSBlockRecPtr)
+{
+    CDSBlockRecPtr->BlockID = CFE_ES_RESOURCEID_UNDEFINED;
+}
+
+/**
+ * @brief Check if a CDS block record is a match for the given BlockID
+ *
+ * This routine confirms that the previously-located record is valid
+ * and matches the expected block ID.
+ *
+ * As this dereferences fields within the record, CDS access mutex must be
+ * locked prior to invoking this function.
+ *
+ * @param[in]   CDSBlockRecPtr   pointer to registry table entry
+ * @param[in]   BlockID          expected block ID
+ * @returns true if the entry matches the given block ID
+ */
+static inline bool CFE_ES_CDSBlockRecordIsMatch(const CFE_ES_CDS_RegRec_t *CDSBlockRecPtr, CFE_ES_ResourceID_t BlockID)
+{
+    return (CDSBlockRecPtr != NULL && CFE_ES_ResourceID_Equal(CDSBlockRecPtr->BlockID, BlockID));
+}
+
+/**
+ * @brief Gets the data size from a given registry record
+ *
+ * This computes the usable data size of the CDS registry entry
+ *
+ * As this dereferences fields within the record, CDS access mutex must be
+ * locked prior to invoking this function.
+ *
+ * @note CDS entries include an extra header in addition to the data,
+ * which contains error checking information.  Therefore the usable data
+ * size is less than the raw block size.
+ *
+ * @param[in]   CDSBlockRecPtr   pointer to registry table entry
+ * @returns     Usable size of the CDS
+ */
+static inline CFE_ES_MemOffset_t CFE_ES_CDSBlockRecordGetUserSize(const CFE_ES_CDS_RegRec_t *CDSBlockRecPtr)
+{
+    return (CDSBlockRecPtr->BlockSize - sizeof(CFE_ES_CDS_BlockHeader_t));
+}
+
+
+/*****************************************************************************/
+/**
+** \brief Initializes CDS data constructs
+**
+** \par Description
+**        Locates and validates any pre-existing CDS memory or initializes the
+**        memory as a fresh CDS.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \par SysLog Messages
+**
+**
+** \return None
+**
+******************************************************************************/
 int32 CFE_ES_CDS_EarlyInit(void);
+
+
+/*****************************************************************************/
+/**
+** \brief Determines whether a CDS currently exists
+**
+** \par Description
+**        Reads a set of bytes from the beginning and end of the CDS memory
+**        area and determines if a fixed pattern is present, thus determining
+**        whether the CDS still likely contains valid data or not.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \return #CFE_SUCCESS         \copydoc CFE_SUCCESS
+** \return #CFE_ES_CDS_INVALID  \copydoc CFE_ES_CDS_INVALID
+** \return Any of the return values from #CFE_PSP_ReadFromCDS
+**
+******************************************************************************/
+int32 CFE_ES_ValidateCDS(void);
+
+/*****************************************************************************/
+/**
+** \brief Initializes the CDS Registry
+**
+** \par Description
+**        Initializes the data structure used to keep track of CDS blocks and
+**        who they belong to.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \retval #CFE_SUCCESS         \copydoc CFE_SUCCESS
+**
+******************************************************************************/
+int32 CFE_ES_InitCDSRegistry(void);
+
+
+/*****************************************************************************/
+/**
+** \brief Rebuilds memory pool for CDS and recovers existing registry
+**
+** \par Description
+**        Scans memory for existing CDS and initializes memory pool and registry
+**        settings accordingly
+**
+** \par Assumptions, External Events, and Notes:
+**        -# Assumes the validity of the CDS has already been determined
+**
+** \return #CFE_SUCCESS         \copydoc CFE_SUCCESS
+** \return Any of the return values from #CFE_PSP_ReadFromCDS
+**
+******************************************************************************/
+int32 CFE_ES_RebuildCDS(void);
 
 /*****************************************************************************/
 /**
@@ -150,47 +517,50 @@ void CFE_ES_FormCDSName(char *FullCDSName, const char *CDSName, CFE_ES_ResourceI
 ** \param[in]  CDSName - Pointer to character string containing complete
 **                       CDS Name (of the format "AppName.CDSName").
 ** 
-** \retval #CFE_ES_CDS_NOT_FOUND or the Index into Registry for Table with specified name
+** \retval NULL if not found, Non null entry pointer on success
 **
 ******************************************************************************/
-int32  CFE_ES_FindCDSInRegistry(const char *CDSName);
+CFE_ES_CDS_RegRec_t *CFE_ES_FindCDSInRegistry(const char *CDSName);
 
 /*****************************************************************************/
 /**
-** \brief Locates a free slot in the CDS Registry.
+** \brief Locates a free slot in the CDS Registry and configures it for new use.
 **
 ** \par Description
-**        Locates a free slot in the CDS Registry.
+**        Locates a free slot in the CDS Registry, assigns an ID,
+**        and marks the entry as used.
 **
 ** \par Assumptions, External Events, and Notes:
 **        Note: This function assumes the registry has been locked.
 **
-** \retval #CFE_ES_CDS_NOT_FOUND or Index into CDS Registry of unused entry                     
+** \retval NULL if registry full, Non null entry pointer on success
 ******************************************************************************/
-int32  CFE_ES_FindFreeCDSRegistryEntry(void);
+CFE_ES_CDS_RegRec_t *CFE_ES_AllocateNewCDSRegistryEntry(void);
 
 /*****************************************************************************/
 /**
-** \brief Locks access to the CDS Registry
+** \brief Locks access to the CDS
 **
 ** \par Description
-**        Locks the CDS Registry to prevent multiple tasks/threads
+**        Locks the CDS to prevent multiple tasks/threads
 **        from modifying it at once.
+**
+**        This lock covers both the registry and the data access.
 **
 ** \par Assumptions, External Events, and Notes:
 **          None
 **
 ** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS                     
 ******************************************************************************/
-int32   CFE_ES_LockCDSRegistry(void);
+int32   CFE_ES_LockCDS(void);
 
 /*****************************************************************************/
 /**
-** \brief Unlocks access to the CDS Registry
+** \brief Unlocks access to the CDS
 **
 ** \par Description
-**        Unlocks CDS Registry to allow other tasks/threads to
-**        modify the CDS Registry contents.
+**        Unlocks CDS to allow other tasks/threads to
+**        modify the CDS contents.
 **
 ** \par Assumptions, External Events, and Notes:
 **          None
@@ -198,7 +568,7 @@ int32   CFE_ES_LockCDSRegistry(void);
 ** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
 **                     
 ******************************************************************************/
-int32   CFE_ES_UnlockCDSRegistry(void);
+int32   CFE_ES_UnlockCDS(void);
 
 /*****************************************************************************/
 /**
@@ -254,7 +624,26 @@ int32 CFE_ES_ValidateCDS(void);
 
 /*****************************************************************************/
 /**
-** \brief Initializes the contents of the CDS
+** \brief Clears the contents of the CDS
+**
+** \par Description
+**        Writes zeros to the entire CDS storage area
+**
+**        This prevents any stale data that may exist in the
+**        memory area from being potentially interpreted as valid
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \return #CFE_SUCCESS          \copydoc CFE_SUCCESS
+** \return Any of the return values from #CFE_ES_CDS_CacheFlush
+**
+******************************************************************************/
+int32 CFE_ES_ClearCDS(void);
+
+/*****************************************************************************/
+/**
+** \brief Initializes the signatures of the CDS area
 **
 ** \par Description
 **        Stores a fixed pattern at the beginning and end of the CDS memory
@@ -263,15 +652,11 @@ int32 CFE_ES_ValidateCDS(void);
 ** \par Assumptions, External Events, and Notes:
 **          None
 **
-** \param[in]  CDSSize Total size of CDS memory area (in bytes)
-**
-** \return #OS_SUCCESS          \copydoc OS_SUCCESS
-** \return Any of the return values from #CFE_PSP_WriteToCDS
-** \return Any of the return values from #CFE_ES_CreateCDSPool
+** \return #CFE_SUCCESS          \copydoc CFE_SUCCESS
+** \return Any of the return values from #CFE_ES_CDS_CacheFlush
 **
 ******************************************************************************/
-int32 CFE_ES_InitializeCDS(uint32 CDSSize);
-
+int32 CFE_ES_InitCDSSignatures(void);
 
 
 

--- a/fsw/cfe-core/src/es/cfe_es_cds_mempool.c
+++ b/fsw/cfe-core/src/es/cfe_es_cds_mempool.c
@@ -34,21 +34,17 @@
 /*
 ** Includes
 */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
 #include "private/cfe_private.h"
 #include "cfe_es.h"
 #include "cfe_psp.h"
+#include "cfe_es_generic_pool.h"
 #include "cfe_es_cds_mempool.h"
 #include "cfe_es_global.h"
 #include "cfe_es_log.h"
-#include <stdio.h>
-
-/*****************************************************************************/
-/*
-** Local Macro Definitions
-*/
-#define CFE_ES_CDS_CHECK_PATTERN   0x5a5a
-#define CFE_ES_CDS_BLOCK_USED      0xaaaa
-#define CFE_ES_CDS_BLOCK_UNUSED    0xdddd
 
 /*****************************************************************************/
 /*
@@ -60,10 +56,9 @@
 ** File Global Data
 */
 
-CFE_ES_CDSPool_t      CFE_ES_CDSMemPool;
-CFE_ES_CDSBlockDesc_t CFE_ES_CDSBlockDesc;
 
-uint32 CFE_ES_CDSMemPoolDefSize[CFE_ES_CDS_NUM_BLOCK_SIZES] = 
+
+const CFE_ES_MemOffset_t CFE_ES_CDSMemPoolDefSize[CFE_ES_CDS_NUM_BLOCK_SIZES] =
 {
     CFE_PLATFORM_ES_CDS_MAX_BLOCK_SIZE,
     CFE_PLATFORM_ES_CDS_MEM_BLOCK_SIZE_16,
@@ -86,14 +81,47 @@ uint32 CFE_ES_CDSMemPoolDefSize[CFE_ES_CDS_NUM_BLOCK_SIZES] =
 
 /*****************************************************************************/
 /*
-** Local Function Prototypes
-*/
-int32 CFE_ES_CDSGetBinIndex(uint32 DesiredSize);
-
-/*****************************************************************************/
-/*
 ** Functions
 */
+
+/*
+** CFE_ES_CDS_PoolRetrieve will obtain a block descriptor from CDS storage.
+**
+** This is a bridge between the generic pool implementation and the CDS cache.
+*/
+int32 CFE_ES_CDS_PoolRetrieve(CFE_ES_GenPoolRecord_t *GenPoolRecPtr,
+        CFE_ES_MemOffset_t Offset,
+        CFE_ES_GenPoolBD_t **BdPtr)
+{
+    CFE_ES_CDS_Instance_t *CDS = (CFE_ES_CDS_Instance_t *)GenPoolRecPtr;
+    CFE_ES_CDS_Offset_t CDSOffset;
+    CFE_ES_CDS_Offset_t CDSSize;
+
+    /* Type conversions */
+    CDSOffset = Offset;
+    CDSSize = sizeof(CFE_ES_GenPoolBD_t);
+    *BdPtr = &CDS->Cache.Data.Desc;
+
+    return CFE_ES_CDS_CacheFetch(&CDS->Cache, CDSOffset, CDSSize);
+}
+
+/*
+** CFE_ES_CDS_PoolCommit will write a block descriptor to CDS storage.
+**
+** This is a bridge between the generic pool implementation and the CDS cache.
+*/
+int32 CFE_ES_CDS_PoolCommit(CFE_ES_GenPoolRecord_t *GenPoolRecPtr,
+        CFE_ES_MemOffset_t Offset,
+        const CFE_ES_GenPoolBD_t *BdPtr)
+{
+    CFE_ES_CDS_Instance_t *CDS = (CFE_ES_CDS_Instance_t *)GenPoolRecPtr;
+
+    CFE_ES_CDS_CachePreload(&CDS->Cache, BdPtr, Offset,
+            sizeof(CFE_ES_GenPoolBD_t));
+
+    return CFE_ES_CDS_CacheFlush(&CDS->Cache);
+}
+
 
 /*
 ** CFE_ES_CreateCDSPool will initialize a pre-allocated memory pool.
@@ -103,49 +131,34 @@ int32 CFE_ES_CDSGetBinIndex(uint32 DesiredSize);
 **  where it is not possible to have contention writing into the syslog.
 **  Therefore the use of CFE_ES_SysLogWrite_Unsync() is acceptable
 */
-int32 CFE_ES_CreateCDSPool(uint32  CDSPoolSize, uint32  StartOffset)
+int32 CFE_ES_CreateCDSPool(CFE_ES_CDS_Offset_t  CDSPoolSize, CFE_ES_CDS_Offset_t  StartOffset)
 {
-    char MutexName[10] = {"CDS_POOL"};
-    uint32  i = 0;
-    uint32  Size = (CDSPoolSize & 0xfffffffc);
+    CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
+    int32 Status;
+    CFE_ES_MemOffset_t  SizeCheck;
+    CFE_ES_MemOffset_t  ActualSize;
 
-    /* create a semphore to protect this memory pool */
-    OS_MutSemCreate(&(CFE_ES_CDSMemPool.MutexId), MutexName, 0);
+    SizeCheck = CFE_ES_GenPoolCalcMinSize(CFE_ES_CDS_NUM_BLOCK_SIZES, CFE_ES_CDSMemPoolDefSize, 1);
+    ActualSize = CDSPoolSize;
 
-    /* Take the semaphore to ensure the mem pool is not being used during it's creation */
-    OS_MutSemTake(CFE_ES_CDSMemPool.MutexId);
-
-    CFE_ES_CDSMemPool.Start        = StartOffset;
-    CFE_ES_CDSMemPool.End          = StartOffset + Size;
-    CFE_ES_CDSMemPool.Size         = Size;
-    CFE_ES_CDSMemPool.Current      = StartOffset;
-    CFE_ES_CDSMemPool.SizeIndex    = -1;
-
-    CFE_ES_CDSMemPool.CheckErrCntr = 0;
-    CFE_ES_CDSMemPool.RequestCntr  = 0;
-
-    for (i=0; i<CFE_ES_CDS_NUM_BLOCK_SIZES; i++)
-    {
-        CFE_ES_CDSMemPool.SizeDesc[i].Top = 0;
-        CFE_ES_CDSMemPool.SizeDesc[i].NumCreated = 0;
-        CFE_ES_CDSMemPool.SizeDesc[i].MaxSize = CFE_ES_CDSMemPoolDefSize[i];
-    }
-
-    if (CDSPoolSize < (CFE_ES_CDSMemPool.MinBlockSize + sizeof(CFE_ES_CDSBlockDesc_t)))
+    if (ActualSize < SizeCheck)
     {
         /* Must be able make Pool verification, block descriptor and at least one of the smallest blocks  */
-        CFE_ES_SysLogWrite_Unsync("CFE_ES:CreateCDSPool-Pool size(%u) too small for one CDS Block, need >=%u\n",
-                             (unsigned int)CDSPoolSize, (unsigned int)(CFE_ES_CDSMemPool.MinBlockSize + sizeof(CFE_ES_CDSBlockDesc_t)));
-                        
-        /* Give and delete semaphore since CDS Pool creation failed */     
-        OS_MutSemGive(CFE_ES_CDSMemPool.MutexId);
-        OS_MutSemDelete(CFE_ES_CDSMemPool.MutexId);
-        return(CFE_ES_BAD_ARGUMENT);
+        CFE_ES_SysLogWrite_Unsync("CFE_ES:CreateCDSPool-Pool size(%lu) too small for one CDS Block, need >=%lu\n",
+                             (unsigned long)ActualSize, (unsigned long)SizeCheck);
+        return CFE_ES_CDS_INVALID_SIZE;
     }
-    
-    OS_MutSemGive(CFE_ES_CDSMemPool.MutexId);
 
-    return(CFE_SUCCESS);
+    Status = CFE_ES_GenPoolInitialize(&CDS->Pool,
+            StartOffset,                  /* starting offset */
+            ActualSize,                     /* total size */
+            4,                              /* alignment */
+            CFE_ES_CDS_NUM_BLOCK_SIZES,
+            CFE_ES_CDSMemPoolDefSize,
+            CFE_ES_CDS_PoolRetrieve,
+            CFE_ES_CDS_PoolCommit);
+
+    return Status;
 }
 
 
@@ -160,313 +173,30 @@ int32 CFE_ES_CreateCDSPool(uint32  CDSPoolSize, uint32  StartOffset)
 **  where it is not possible to have contention writing into the syslog.
 **  Therefore the use of CFE_ES_SysLogWrite_Unsync() is acceptable
 */
-int32 CFE_ES_RebuildCDSPool(uint32 CDSPoolSize, uint32 StartOffset)
+int32 CFE_ES_RebuildCDSPool(CFE_ES_CDS_Offset_t CDSPoolSize, CFE_ES_CDS_Offset_t StartOffset)
 {
-    char MutexName[10] = {"CDS_POOL"};
-    uint32 i = 0;
-    uint32 Size = (CDSPoolSize & 0xfffffffc);
-    int32  Status = OS_SUCCESS;
-    uint32 Offset = StartOffset;
-    int32  BinIndex = 0;
-
-    /* create a semphore to protect this memory pool */
-    OS_MutSemCreate(&(CFE_ES_CDSMemPool.MutexId), MutexName, 0);
-
-    /* Take the semaphore to ensure the mem pool is not being used during it's creation */
-    OS_MutSemTake(CFE_ES_CDSMemPool.MutexId);
-
-    CFE_ES_CDSMemPool.Start        = StartOffset;
-    CFE_ES_CDSMemPool.End          = StartOffset + Size;
-    CFE_ES_CDSMemPool.Size         = Size;
-    CFE_ES_CDSMemPool.Current      = 0;
-    CFE_ES_CDSMemPool.SizeIndex    = -1;
-
-    CFE_ES_CDSMemPool.CheckErrCntr = 0;
-    CFE_ES_CDSMemPool.RequestCntr  = 0;
-
-    for (i=0; i<CFE_ES_CDS_NUM_BLOCK_SIZES; i++)
-    {
-        CFE_ES_CDSMemPool.SizeDesc[i].Top = 0;
-        CFE_ES_CDSMemPool.SizeDesc[i].NumCreated = 0;
-        CFE_ES_CDSMemPool.SizeDesc[i].MaxSize = CFE_ES_CDSMemPoolDefSize[i];
-    }
-    
-    if (CDSPoolSize < (CFE_ES_CDSMemPool.MinBlockSize + sizeof(CFE_ES_CDSBlockDesc_t)))
-    {
-        /* Must be able make Pool verification, block descriptor and at least one of the smallest blocks  */
-        CFE_ES_SysLogWrite_Unsync("CFE_ES:RebuildCDSPool-Pool size(%u) too small for one CDS Block, need >=%u\n",
-                             (unsigned int)CDSPoolSize, (unsigned int)(CFE_ES_CDSMemPool.MinBlockSize + sizeof(CFE_ES_CDSBlockDesc_t)));
-
-        /* Give and delete semaphore since CDS Pool rebuild failed */     
-        OS_MutSemGive(CFE_ES_CDSMemPool.MutexId);
-        OS_MutSemDelete(CFE_ES_CDSMemPool.MutexId);
-        return(CFE_ES_BAD_ARGUMENT);
-    }
-
-    /* Scan the CDS memory trying to find blocks that were created but are now free */
-    while ((Status == OS_SUCCESS) && 
-           (Offset < (CFE_ES_CDSMemPool.End - sizeof(CFE_ES_CDSBlockDesc_t))) &&
-           (CFE_ES_CDSMemPool.Current == 0))
-    {
-        /* Read the block descriptor for the first block in the memory pool */
-        Status = CFE_PSP_ReadFromCDS(&CFE_ES_CDSBlockDesc, Offset, sizeof(CFE_ES_CDSBlockDesc_t));
-        
-        if (Status == CFE_PSP_SUCCESS)
-        {
-            /* First, determine if the block is being or has been used */
-            if (CFE_ES_CDSBlockDesc.CheckBits == CFE_ES_CDS_CHECK_PATTERN)
-            {
-                /* See if the block is currently being used */
-                if (CFE_ES_CDSBlockDesc.AllocatedFlag != CFE_ES_CDS_BLOCK_USED)
-                {
-                    /* If the block is not currently being used, */
-                    /* then add it to the appropriate linked list in the memory pool */
-                    BinIndex = CFE_ES_CDSGetBinIndex(CFE_ES_CDSBlockDesc.SizeUsed);
-                    
-                    /* Sanity-check the block descriptor */
-                    if (BinIndex >= 0)
-                    {
-                        CFE_ES_CDSBlockDesc.Next = CFE_ES_CDSMemPool.SizeDesc[BinIndex].Top;
-                        CFE_ES_CDSBlockDesc.AllocatedFlag = CFE_ES_CDS_BLOCK_UNUSED;
-                        CFE_ES_CDSMemPool.SizeDesc[BinIndex].Top = Offset;
-
-                        /* Store the new CDS Block Descriptor in the CDS */
-                        Status = CFE_PSP_WriteToCDS(&CFE_ES_CDSBlockDesc, Offset, sizeof(CFE_ES_CDSBlockDesc_t));
-
-                        if (Status != CFE_PSP_SUCCESS)
-                        {
-                            CFE_ES_SysLogWrite_Unsync("CFE_ES:RebuildCDS-Err writing to CDS (Stat=0x%08x)\n", (unsigned int)Status);
-                            Status = CFE_ES_CDS_ACCESS_ERROR;
-                        }
-                    }
-                    else
-                    {
-                        CFE_ES_CDSMemPool.CheckErrCntr++;
-                        CFE_ES_SysLogWrite_Unsync("CFE_ES:RebuildCDS-Invalid Block Descriptor \n");
-                        Status = CFE_ES_CDS_ACCESS_ERROR;
-                    }
-                }
-                
-                /* Skip to the next block of memory */
-                Offset = Offset + CFE_ES_CDSBlockDesc.ActualSize + sizeof(CFE_ES_CDSBlockDesc_t);
-            }
-            else
-            {
-                /* If the block has never been used, then we should save the offset as the current offset */
-                /* which in turn will finish the scan of the CDS memory */
-                CFE_ES_CDSMemPool.Current = Offset;
-            }
-        }
-        else
-        {
-            CFE_ES_SysLogWrite_Unsync("CFE_ES:RebuildCDS-Err reading from CDS (Stat=0x%08x)\n", (unsigned int)Status);
-            Status = CFE_ES_CDS_ACCESS_ERROR;
-        }
-    }  /* end while */
-    
-    OS_MutSemGive(CFE_ES_CDSMemPool.MutexId);
-
-    return Status;
-}
-
-
-/*
-** Function:
-**   CFE_ES_GetCDSBlock
-**
-** Purpose:
-**   CFE_ES_GetCDSBlock allocates a block from the CDS memory pool.
-*/
-int32 CFE_ES_GetCDSBlock(CFE_ES_CDSBlockHandle_t *BlockHandle,
-                         uint32  BlockSize )
-{
-    int32                   BinIndex;
-    int32                   Status;
-
-    OS_MutSemTake(CFE_ES_CDSMemPool.MutexId);
-
-    BinIndex = CFE_ES_CDSGetBinIndex(BlockSize);
-    if (BinIndex < 0)
-    {
-        OS_MutSemGive(CFE_ES_CDSMemPool.MutexId);
-        CFE_ES_WriteToSysLog("CFE_ES:GetCDSBlock-err:size(%d) > max(%d).\n", (int)BlockSize, CFE_PLATFORM_ES_CDS_MAX_BLOCK_SIZE);
-        return(CFE_ES_ERR_MEM_BLOCK_SIZE);
-    }
-
-   /*
-   ** Check if any of the requested size are available
-   */
-   if (CFE_ES_CDSMemPool.SizeDesc[BinIndex].Top != 0)
-   {
-         /*
-         ** Get it off the top on the list
-         */
-         Status = CFE_PSP_ReadFromCDS(&CFE_ES_CDSBlockDesc, 
-                                    CFE_ES_CDSMemPool.SizeDesc[BinIndex].Top, 
-                                    sizeof(CFE_ES_CDSBlockDesc_t));
-                    
-         if (Status != CFE_PSP_SUCCESS)
-         {
-            OS_MutSemGive(CFE_ES_CDSMemPool.MutexId);
-            CFE_ES_WriteToSysLog("CFE_ES:GetCDSBlock-Err reading from CDS (Stat=0x%08x)\n", (unsigned int)Status);
-            return(CFE_ES_CDS_ACCESS_ERROR);
-         }
-                 
-         /* The handle returned is the byte offset of the block in the CDS */
-         *BlockHandle                             = CFE_ES_CDSMemPool.SizeDesc[BinIndex].Top;
-         
-         /* A local version of the block descriptor is initialized */
-         CFE_ES_CDSBlockDesc.CheckBits            = CFE_ES_CDS_CHECK_PATTERN;
-         CFE_ES_CDSBlockDesc.AllocatedFlag        = CFE_ES_CDS_BLOCK_USED;
-         CFE_ES_CDSBlockDesc.SizeUsed             = BlockSize;
-         CFE_ES_CDSBlockDesc.ActualSize           = CFE_ES_CDSMemPool.SizeDesc[BinIndex].MaxSize;
-         CFE_ES_CDSMemPool.SizeDesc[BinIndex].Top = CFE_ES_CDSBlockDesc.Next;
-         CFE_ES_CDSBlockDesc.CRC                  = 0;
-         CFE_ES_CDSBlockDesc.Next                 = 0;
-    }
-    else /* Create a new block */
-    {
-         if ( (CFE_ES_CDSMemPool.Current == 0) ||
-              (((uint32)CFE_ES_CDSMemPool.Current + 
-                sizeof(CFE_ES_CDSBlockDesc_t) + 
-                CFE_ES_CDSMemPool.SizeDesc[BinIndex].MaxSize ) >= CFE_ES_CDSMemPool.End) )
-         {
-            OS_MutSemGive(CFE_ES_CDSMemPool.MutexId);
-            CFE_ES_WriteToSysLog("CFE_ES:GetCDSBlock-err:Request for %d bytes won't fit in remaining memory\n", (int)BlockSize);
-            return(CFE_ES_ERR_MEM_BLOCK_SIZE);
-         }
-
-         *BlockHandle = (CFE_ES_CDSBlockHandle_t)CFE_ES_CDSMemPool.Current;
-
-         CFE_ES_CDSMemPool.SizeDesc[BinIndex].NumCreated++;
-         CFE_ES_CDSMemPool.RequestCntr++;
-
-         /*
-         ** Initialize the buffer descriptor that will be kept in front of the CDS Block
-         */
-         CFE_ES_CDSBlockDesc.CheckBits     = CFE_ES_CDS_CHECK_PATTERN;
-         CFE_ES_CDSBlockDesc.AllocatedFlag = CFE_ES_CDS_BLOCK_USED;
-         CFE_ES_CDSBlockDesc.SizeUsed      = BlockSize;
-         CFE_ES_CDSBlockDesc.ActualSize    = CFE_ES_CDSMemPool.SizeDesc[BinIndex].MaxSize;
-         CFE_ES_CDSBlockDesc.CRC           = 0;
-         CFE_ES_CDSBlockDesc.Next          = 0;
-
-         /*
-         ** Adjust pool current pointer to first unallocated byte in CDS
-         */
-         CFE_ES_CDSMemPool.Current = CFE_ES_CDSMemPool.Current 
-                                     + CFE_ES_CDSBlockDesc.ActualSize
-                                     + sizeof(CFE_ES_CDSBlockDesc_t);
-     }
-     
-     /* Store the new CDS Block Descriptor in the CDS */
-     Status = CFE_PSP_WriteToCDS(&CFE_ES_CDSBlockDesc, *BlockHandle, sizeof(CFE_ES_CDSBlockDesc_t));
-
-     if (Status != CFE_PSP_SUCCESS)
-     {
-        OS_MutSemGive(CFE_ES_CDSMemPool.MutexId);
-        CFE_ES_WriteToSysLog("CFE_ES:GetCDSBlock-Err writing to CDS (Stat=0x%08x)\n", (unsigned int)Status);
-        return(CFE_ES_CDS_ACCESS_ERROR);
-     }
-     
-     OS_MutSemGive(CFE_ES_CDSMemPool.MutexId);
-     
-     return Status;
-}
-
-/*
-** CFE_ES_PutCDSBlock returns a block back to the CDS memory pool.
-*/
-int32 CFE_ES_PutCDSBlock(CFE_ES_CDSBlockHandle_t BlockHandle)
-{
-    int32 BinIndex;
+    CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
     int32 Status;
 
-    /* Perform some sanity checks on the BlockHandle */
-    /* First check, is the handle within an acceptable range of CDS offsets */
-    if ((BlockHandle < sizeof(CFE_ES_Global.CDSVars.ValidityField)) || 
-        (BlockHandle > (CFE_ES_CDSMemPool.End - sizeof(CFE_ES_CDSBlockDesc_t) - 
-                        CFE_ES_CDSMemPool.MinBlockSize - sizeof(CFE_ES_Global.CDSVars.ValidityField))))
+    /*
+     * Start by creating the pool in a clean state, as it would be in a non-rebuild.
+     */
+    Status = CFE_ES_CreateCDSPool(CDSPoolSize, StartOffset);
+    if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("CFE_ES:PutCDSBlock-Invalid Memory Handle.\n");
-        return(CFE_ES_ERR_MEM_HANDLE);
+        return Status;
     }
 
-    OS_MutSemTake(CFE_ES_CDSMemPool.MutexId);
+    /* Now walk through the CDS memory and attempt to recover existing CDS blocks */
+    Status = CFE_ES_GenPoolRebuild(&CDS->Pool);
 
-    /* Read a copy of the contents of the block descriptor being freed */
-    Status = CFE_PSP_ReadFromCDS(&CFE_ES_CDSBlockDesc, BlockHandle, sizeof(CFE_ES_CDSBlockDesc_t));
-
-    if (Status != CFE_PSP_SUCCESS)
+    if (Status != CFE_SUCCESS)
     {
-        OS_MutSemGive(CFE_ES_CDSMemPool.MutexId);
-        CFE_ES_WriteToSysLog("CFE_ES:PutCDSBlock-Err reading from CDS (Stat=0x%08x)\n", (unsigned int)Status);
-        return(CFE_ES_CDS_ACCESS_ERROR);
+        CFE_ES_SysLogWrite_Unsync("CFE_ES:RebuildCDS-Err rebuilding CDS (Stat=0x%08x)\n", (unsigned int)Status);
+        Status = CFE_ES_CDS_ACCESS_ERROR;
     }
-     
-    /* Make sure the contents of the Block Descriptor look reasonable */
-    if ((CFE_ES_CDSBlockDesc.CheckBits != CFE_ES_CDS_CHECK_PATTERN) ||
-        (CFE_ES_CDSBlockDesc.AllocatedFlag != CFE_ES_CDS_BLOCK_USED))
-    {
-        OS_MutSemGive(CFE_ES_CDSMemPool.MutexId);
-        CFE_ES_WriteToSysLog("CFE_ES:PutCDSBlock-Invalid Handle or Block Descriptor.\n");
-        return(CFE_ES_ERR_MEM_HANDLE);
-    }
-
-    BinIndex = CFE_ES_CDSGetBinIndex(CFE_ES_CDSBlockDesc.ActualSize);
-
-    /* Final sanity check on block descriptor, is the Actual size reasonable */
-    if (BinIndex < 0)
-    {
-        CFE_ES_CDSMemPool.CheckErrCntr++;
-        OS_MutSemGive(CFE_ES_CDSMemPool.MutexId);
-        CFE_ES_WriteToSysLog("CFE_ES:PutCDSBlock-Invalid Block Descriptor\n");
-        return(CFE_ES_ERR_MEM_HANDLE);
-    }
-
-    CFE_ES_CDSBlockDesc.Next = CFE_ES_CDSMemPool.SizeDesc[BinIndex].Top;
-    CFE_ES_CDSBlockDesc.AllocatedFlag = CFE_ES_CDS_BLOCK_UNUSED;
-    CFE_ES_CDSMemPool.SizeDesc[BinIndex].Top = BlockHandle;
-
-    /* Store the new CDS Block Descriptor in the CDS */
-    Status = CFE_PSP_WriteToCDS(&CFE_ES_CDSBlockDesc, BlockHandle, sizeof(CFE_ES_CDSBlockDesc_t));
-
-    if (Status != CFE_PSP_SUCCESS)
-    {
-        OS_MutSemGive(CFE_ES_CDSMemPool.MutexId);
-        CFE_ES_WriteToSysLog("CFE_ES:PutCDSBlock-Err writing to CDS (Stat=0x%08x)\n", (unsigned int)Status);
-        return(CFE_ES_CDS_ACCESS_ERROR);
-    }
-     
-    OS_MutSemGive(CFE_ES_CDSMemPool.MutexId);
 
     return Status;
-}
-
-/*
-** Function:
-**   CFE_ES_CDSGetBinIndex
-**
-** Purpose:
-**
-*/
-int32 CFE_ES_CDSGetBinIndex(uint32 DesiredSize)
-{
-    int32 i=0;
-    
-    if (DesiredSize > CFE_ES_CDSMemPool.SizeDesc[0].MaxSize)
-    {
-        return(-1);
-    }
-    
-    /* Look ahead to see if the next bin has a size too small */
-    while ((i < (CFE_ES_CDS_NUM_BLOCK_SIZES-1)) &&
-           (DesiredSize <= CFE_ES_CDSMemPool.SizeDesc[i+1].MaxSize))
-    {
-        i++;
-    }
-    
-    return(i);
 }
 
 
@@ -477,89 +207,86 @@ int32 CFE_ES_CDSGetBinIndex(uint32 DesiredSize)
 ** Purpose:
 **
 */
-int32 CFE_ES_CDSBlockWrite(CFE_ES_CDSBlockHandle_t BlockHandle, void *DataToWrite)
+int32 CFE_ES_CDSBlockWrite(CFE_ES_CDSHandle_t Handle, const void *DataToWrite)
 {
+    CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
     char  LogMessage[CFE_ES_MAX_SYSLOG_MSG_SIZE];
-    int32 Status = CFE_SUCCESS;
-    int32 BinIndex = 0;
-    
+    int32 Status;
+    CFE_ES_MemOffset_t       BlockSize;
+    CFE_ES_CDS_Offset_t      UserDataSize;
+    CFE_ES_CDS_Offset_t      UserDataOffset;
+    CFE_ES_CDS_RegRec_t     *CDSRegRecPtr;
+
     /* Ensure the the log message is an empty string in case it is never written to */
     LogMessage[0] = 0;
 
-    /* Validate the handle before doing anything */
-    if ((BlockHandle < sizeof(CFE_ES_Global.CDSVars.ValidityField)) || 
-        (BlockHandle > (CFE_ES_CDSMemPool.End - sizeof(CFE_ES_CDSBlockDesc_t) - 
-                        CFE_ES_CDSMemPool.MinBlockSize - sizeof(CFE_ES_Global.CDSVars.ValidityField))))
-    {
-        CFE_ES_SysLog_snprintf(LogMessage, sizeof(LogMessage),
-                "CFE_ES:CDSBlkWrite-Invalid Memory Handle.\n");
-        Status = CFE_ES_ERR_MEM_HANDLE;
-    }
-    else
-    {
-        OS_MutSemTake(CFE_ES_CDSMemPool.MutexId);
+    CDSRegRecPtr = CFE_ES_LocateCDSBlockRecordByID(Handle);
 
-        /* Get a copy of the block descriptor associated with the specified handle */
-        /* Read the block descriptor for the first block in the memory pool */
-        Status = CFE_PSP_ReadFromCDS(&CFE_ES_CDSBlockDesc, BlockHandle, sizeof(CFE_ES_CDSBlockDesc_t));
+    /*
+     * A CDS block ID must be accessed by only one thread at a time.
+     * Checking the validity of the block requires access to the registry.
+     */
+    CFE_ES_LockCDS();
 
-        if (Status != CFE_PSP_SUCCESS)
-        {
-            CFE_ES_SysLog_snprintf(LogMessage, sizeof(LogMessage),
-                    "CFE_ES:CDSBlkWrite-Err reading from CDS (Stat=0x%08x)\n", (unsigned int)Status);
-        }
-        /* Validate the block to make sure it is still active and not corrupted */
-        else if ((CFE_ES_CDSBlockDesc.CheckBits != CFE_ES_CDS_CHECK_PATTERN) ||
-                (CFE_ES_CDSBlockDesc.AllocatedFlag != CFE_ES_CDS_BLOCK_USED))
+    if (CFE_ES_CDSBlockRecordIsMatch(CDSRegRecPtr, Handle))
+    {
+        /*
+         * Getting the buffer size via this function retrieves it from the
+         * internal descriptor, and validates the descriptor as part of the operation.
+         * This should always agree with the size in the registry for this block.
+         */
+        Status = CFE_ES_GenPoolGetBlockSize(&CDS->Pool, &BlockSize, CDSRegRecPtr->BlockOffset);
+        if (Status != CFE_SUCCESS)
         {
             CFE_ES_SysLog_snprintf(LogMessage, sizeof(LogMessage),
                     "CFE_ES:CDSBlkWrite-Invalid Handle or Block Descriptor.\n");
-            Status = CFE_ES_ERR_MEM_HANDLE;
+        }
+        else if (BlockSize <= sizeof(CFE_ES_CDS_BlockHeader_t) ||
+                BlockSize != CDSRegRecPtr->BlockSize)
+        {
+            CFE_ES_SysLog_snprintf(LogMessage, sizeof(LogMessage),
+                    "CFE_ES:CDSBlkWrite-Block size %lu invalid, expected %lu\n",
+                    (unsigned long)BlockSize, (unsigned long)CDSRegRecPtr->BlockSize);
+            Status = CFE_ES_CDS_INVALID_SIZE;
         }
         else
         {
-            BinIndex = CFE_ES_CDSGetBinIndex(CFE_ES_CDSBlockDesc.ActualSize);
+            UserDataSize = CDSRegRecPtr->BlockSize;
+            UserDataSize -= sizeof(CFE_ES_CDS_BlockHeader_t);
+            UserDataOffset = CDSRegRecPtr->BlockOffset;
+            UserDataOffset += sizeof(CFE_ES_CDS_BlockHeader_t);
 
-            /* Final sanity check on block descriptor, is the Actual size reasonable */
-            if (BinIndex < 0)
+            CDS->Cache.Data.BlockHeader.Crc = CFE_ES_CalculateCRC(
+                    DataToWrite, UserDataSize, 0, CFE_MISSION_ES_DEFAULT_CRC);
+            CDS->Cache.Offset = CDSRegRecPtr->BlockOffset;
+            CDS->Cache.Size = sizeof(CFE_ES_CDS_BlockHeader_t);
+
+            /* Write the new block descriptor for the data coming from the Application */
+            Status = CFE_ES_CDS_CacheFlush(&CDS->Cache);
+            if (Status != CFE_SUCCESS)
             {
-                CFE_ES_CDSMemPool.CheckErrCntr++;
                 CFE_ES_SysLog_snprintf(LogMessage, sizeof(LogMessage),
-                        "CFE_ES:CDSBlkWrite-Invalid Block Descriptor\n");
-                Status = CFE_ES_ERR_MEM_HANDLE;
+                        "CFE_ES:CDSBlkWrite-Err writing header data to CDS (Stat=0x%08x) @Offset=0x%08lx\n",
+                        (unsigned int)CDS->Cache.AccessStatus, (unsigned long)CDSRegRecPtr->BlockOffset);
             }
             else
             {
-
-                /* Use the size specified when the CDS was created to compute the CRC */
-                CFE_ES_CDSBlockDesc.CRC = CFE_ES_CalculateCRC(DataToWrite, CFE_ES_CDSBlockDesc.SizeUsed, 0, CFE_MISSION_ES_DEFAULT_CRC);
-
-                /* Write the new block descriptor for the data coming from the Application */
-                Status = CFE_PSP_WriteToCDS(&CFE_ES_CDSBlockDesc, BlockHandle, sizeof(CFE_ES_CDSBlockDesc_t));
-
-                if (Status == CFE_PSP_SUCCESS)
-                {
-                    /* Write the new data coming from the Application to the CDS */
-                    Status = CFE_PSP_WriteToCDS(DataToWrite, (BlockHandle + sizeof(CFE_ES_CDSBlockDesc_t)), CFE_ES_CDSBlockDesc.SizeUsed);
-
-                    if (Status != CFE_PSP_SUCCESS)
-                    {
-                        CFE_ES_SysLog_snprintf(LogMessage, sizeof(LogMessage),
-                                "CFE_ES:CDSBlkWrite-Err writing data to CDS (Stat=0x%08x) @Offset=0x%08x\n",
-                                (unsigned int)Status, (unsigned int)(BlockHandle + sizeof(CFE_ES_CDSBlockDesc_t)));
-                    }
-                }
-                else
+                Status = CFE_PSP_WriteToCDS(DataToWrite, UserDataOffset, UserDataSize);
+                if (Status != CFE_PSP_SUCCESS)
                 {
                     CFE_ES_SysLog_snprintf(LogMessage, sizeof(LogMessage),
-                            "CFE_ES:CDSBlkWrite-Err writing BlockDesc to CDS (Stat=0x%08x) @Offset=0x%08x\n",
-                            (unsigned int)Status, (unsigned int)BlockHandle);
+                            "CFE_ES:CDSBlkWrite-Err writing user data to CDS (Stat=0x%08x) @Offset=0x%08lx\n",
+                            (unsigned int)Status, (unsigned long)UserDataOffset);
                 }
             }
         }
-
-        OS_MutSemGive(CFE_ES_CDSMemPool.MutexId);
     }
+    else
+    {
+        Status = CFE_ES_RESOURCE_ID_INVALID;
+    }
+
+    CFE_ES_UnlockCDS();
 
     /* Do the actual syslog if something went wrong */
     if (LogMessage[0] != 0)
@@ -578,88 +305,84 @@ int32 CFE_ES_CDSBlockWrite(CFE_ES_CDSBlockHandle_t BlockHandle, void *DataToWrit
 ** Purpose:
 **
 */
-int32 CFE_ES_CDSBlockRead(void *DataRead, CFE_ES_CDSBlockHandle_t BlockHandle)
+int32 CFE_ES_CDSBlockRead(void *DataRead, CFE_ES_CDSHandle_t Handle)
 {
+    CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
     char   LogMessage[CFE_ES_MAX_SYSLOG_MSG_SIZE];
-    int32  Status = CFE_SUCCESS;
+    int32 Status;
     uint32 CrcOfCDSData;
-    int32  BinIndex;
-    
+    CFE_ES_MemOffset_t       BlockSize;
+    CFE_ES_CDS_Offset_t      UserDataSize;
+    CFE_ES_CDS_Offset_t      UserDataOffset;
+    CFE_ES_CDS_RegRec_t     *CDSRegRecPtr;
+
     /* Validate the handle before doing anything */
     LogMessage[0] = 0;
-    if ((BlockHandle < sizeof(CFE_ES_Global.CDSVars.ValidityField)) || 
-        (BlockHandle > (CFE_ES_CDSMemPool.End - sizeof(CFE_ES_CDSBlockDesc_t) - 
-                        CFE_ES_CDSMemPool.MinBlockSize - sizeof(CFE_ES_Global.CDSVars.ValidityField))))
+
+
+    CDSRegRecPtr = CFE_ES_LocateCDSBlockRecordByID(Handle);
+
+    /*
+     * A CDS block ID must be accessed by only one thread at a time.
+     * Checking the validity of the block requires access to the registry.
+     */
+    CFE_ES_LockCDS();
+
+    if (CFE_ES_CDSBlockRecordIsMatch(CDSRegRecPtr, Handle))
     {
-        CFE_ES_SysLog_snprintf(LogMessage, sizeof(LogMessage),
-                "CFE_ES:CDSBlkRd-Invalid Memory Handle.\n");
-        Status = CFE_ES_ERR_MEM_HANDLE;
-    }
-    else
-    {
-        OS_MutSemTake(CFE_ES_CDSMemPool.MutexId);
-
-        /* Get a copy of the block descriptor associated with the specified handle */
-        /* Read the block descriptor for the first block in the memory pool */
-        Status = CFE_PSP_ReadFromCDS(&CFE_ES_CDSBlockDesc, BlockHandle, sizeof(CFE_ES_CDSBlockDesc_t));
-
-        if (Status != CFE_PSP_SUCCESS)
+        /*
+         * Getting the buffer size via this function retrieves it from the
+         * internal descriptor, and validates the descriptor as part of the operation.
+         * This should always agree with the size in the registry for this block.
+         */
+        Status = CFE_ES_GenPoolGetBlockSize(&CDS->Pool, &BlockSize, CDSRegRecPtr->BlockOffset);
+        if (Status == CFE_SUCCESS)
         {
-            CFE_ES_SysLog_snprintf(LogMessage, sizeof(LogMessage),
-                            "CFE_ES:CDSBlkRd-Err reading from CDS (Stat=0x%08x)\n",
-                            (unsigned int)Status);
-        }
-        /* Validate the block to make sure it is still active and not corrupted */
-        else if ((CFE_ES_CDSBlockDesc.CheckBits != CFE_ES_CDS_CHECK_PATTERN) ||
-                (CFE_ES_CDSBlockDesc.AllocatedFlag != CFE_ES_CDS_BLOCK_USED))
-        {
-            CFE_ES_SysLog_snprintf(LogMessage, sizeof(LogMessage),
-                            "CFE_ES:CDSBlkRd-Invalid Handle or Block Descriptor.\n");
-            Status = CFE_ES_ERR_MEM_HANDLE;
-        }
-        else
-        {
-            BinIndex = CFE_ES_CDSGetBinIndex(CFE_ES_CDSBlockDesc.ActualSize);
-
-            /* Final sanity check on block descriptor, is the Actual size reasonable */
-            if (BinIndex < 0)
+            if (BlockSize <= sizeof(CFE_ES_CDS_BlockHeader_t) ||
+                    BlockSize != CDSRegRecPtr->BlockSize)
             {
-                CFE_ES_CDSMemPool.CheckErrCntr++;
-                CFE_ES_SysLog_snprintf(LogMessage, sizeof(LogMessage),
-                                "CFE_ES:CDSBlkRd-Invalid Block Descriptor\n");
-                Status = CFE_ES_ERR_MEM_HANDLE;
+                Status = CFE_ES_CDS_INVALID_SIZE;
             }
             else
             {
-                /* Read the old data block */
-                Status = CFE_PSP_ReadFromCDS(DataRead, (BlockHandle + sizeof(CFE_ES_CDSBlockDesc_t)), CFE_ES_CDSBlockDesc.SizeUsed);
+                UserDataSize = CDSRegRecPtr->BlockSize;
+                UserDataSize -= sizeof(CFE_ES_CDS_BlockHeader_t);
+                UserDataOffset = CDSRegRecPtr->BlockOffset;
+                UserDataOffset += sizeof(CFE_ES_CDS_BlockHeader_t);
 
-                if (Status == CFE_PSP_SUCCESS)
-                {
-                    /* Compute the CRC for the data read from the CDS and determine if the data is still valid */
-                    CrcOfCDSData = CFE_ES_CalculateCRC(DataRead, CFE_ES_CDSBlockDesc.SizeUsed, 0, CFE_MISSION_ES_DEFAULT_CRC);
+                /* Read the header */
+                Status = CFE_ES_CDS_CacheFetch(&CDS->Cache, CDSRegRecPtr->BlockOffset,
+                        (CFE_ES_CDS_Offset_t){sizeof(CFE_ES_CDS_BlockHeader_t)} );
 
-                    /* If the CRCs do not match, report an error */
-                    if (CrcOfCDSData != CFE_ES_CDSBlockDesc.CRC)
-                    {
-                        Status = CFE_ES_CDS_BLOCK_CRC_ERR;
-                    }
-                    else
-                    {
-                        Status = CFE_SUCCESS;
-                    }
-                }
-                else
+                if (Status == CFE_SUCCESS)
                 {
-                    CFE_ES_SysLog_snprintf(LogMessage, sizeof(LogMessage),
-                                    "CFE_ES:CDSBlkRd-Err reading block from CDS (Stat=0x%08x) @Offset=0x%08x\n",
-                                    (unsigned int)Status, (unsigned int)BlockHandle);
+                    /* Read the data block */
+                    Status = CFE_PSP_ReadFromCDS(DataRead, UserDataOffset, UserDataSize);
+                    if (Status == CFE_PSP_SUCCESS)
+                    {
+                        /* Compute the CRC for the data read from the CDS and determine if the data is still valid */
+                        CrcOfCDSData = CFE_ES_CalculateCRC(DataRead, UserDataSize, 0, CFE_MISSION_ES_DEFAULT_CRC);
+
+                        /* If the CRCs do not match, report an error */
+                        if (CrcOfCDSData != CDS->Cache.Data.BlockHeader.Crc)
+                        {
+                            Status = CFE_ES_CDS_BLOCK_CRC_ERR;
+                        }
+                        else
+                        {
+                            Status = CFE_SUCCESS;
+                        }
+                    }
                 }
             }
         }
-
-        OS_MutSemGive(CFE_ES_CDSMemPool.MutexId);
     }
+    else
+    {
+        Status = CFE_ES_RESOURCE_ID_INVALID;
+    }
+
+    CFE_ES_UnlockCDS();
 
     /* Do the actual syslog if something went wrong */
     if (LogMessage[0] != 0)
@@ -679,17 +402,8 @@ int32 CFE_ES_CDSBlockRead(void *DataRead, CFE_ES_CDSBlockHandle_t BlockHandle)
 */
 uint32 CFE_ES_CDSReqdMinSize(uint32 MaxNumBlocksToSupport)
 {
-    uint32 i;
-
-    for (i=0; i<CFE_ES_CDS_NUM_BLOCK_SIZES; i++)
-    {
-        /* Assume the last non-zero block size is the minimum block size */
-        if (CFE_ES_CDSMemPoolDefSize[i] > 0)
-        {
-            CFE_ES_CDSMemPool.MinBlockSize = CFE_ES_CDSMemPoolDefSize[i];
-        }
-    }
-    
-     return (MaxNumBlocksToSupport * (sizeof(CFE_ES_CDSBlockDesc_t)+CFE_ES_CDSMemPool.MinBlockSize));
+    return CFE_ES_GenPoolCalcMinSize(CFE_ES_CDS_NUM_BLOCK_SIZES,
+            CFE_ES_CDSMemPoolDefSize,
+            MaxNumBlocksToSupport);
 }
 

--- a/fsw/cfe-core/src/es/cfe_es_cds_mempool.h
+++ b/fsw/cfe-core/src/es/cfe_es_cds_mempool.h
@@ -42,58 +42,12 @@
 ** Include Files
 */
 #include "private/cfe_private.h"
+#include "cfe_es_cds.h"
 
 /*
 ** Macro Definitions
 */
 #define CFE_ES_CDS_NUM_BLOCK_SIZES     17
-
-/*
-** Type Definitions
-*/
-
-typedef uint32 CFE_ES_CDSBlockHandle_t;
-
-typedef struct
-{
-  uint16    CheckBits;
-  uint16    AllocatedFlag;
-  uint32    SizeUsed;
-  uint32    ActualSize;
-  uint32    CRC;
-  uint32    Next;
-} CFE_ES_CDSBlockDesc_t;
-
-typedef struct
-{
-   uint32   Top;
-   uint32   NumCreated;
-   uint32   MaxSize;
-} CFE_ES_CDSBlockSizeDesc_t;
-/*
-** Memory Pool Type
-*/
-typedef struct {
-   uint32   Start;
-   uint32   Size;
-   uint32   End;
-   uint32   Current;
-   int32    SizeIndex;
-   uint16   CheckErrCntr;
-   uint16   RequestCntr;
-   osal_id_t   MutexId;
-   uint32   MinBlockSize;
-   CFE_ES_CDSBlockSizeDesc_t SizeDesc[CFE_ES_CDS_NUM_BLOCK_SIZES];
-} CFE_ES_CDSPool_t;
-
-/*
- * External variables
- *
- * Note - these globals should not be modified outside of this module,
- * however the unit test code does tweak them directly in order to test specific code paths
- */
-extern CFE_ES_CDSPool_t      CFE_ES_CDSMemPool;
-extern CFE_ES_CDSBlockDesc_t CFE_ES_CDSBlockDesc;
 
 
 /*****************************************************************************/
@@ -115,18 +69,14 @@ extern CFE_ES_CDSBlockDesc_t CFE_ES_CDSBlockDesc;
 ** \return #CFE_SUCCESS                     \copydoc CFE_SUCCESS
 **                     
 ******************************************************************************/
-int32 CFE_ES_CreateCDSPool(uint32 CDSPoolSize, uint32 StartOffset);
+int32 CFE_ES_CreateCDSPool(CFE_ES_CDS_Offset_t CDSPoolSize, CFE_ES_CDS_Offset_t StartOffset);
 
 
-int32 CFE_ES_RebuildCDSPool(uint32 CDSPoolSize, uint32 StartOffset);
+int32 CFE_ES_RebuildCDSPool(CFE_ES_CDS_Offset_t CDSPoolSize, CFE_ES_CDS_Offset_t StartOffset);
 
-int32 CFE_ES_GetCDSBlock(CFE_ES_CDSBlockHandle_t *BlockHandle, uint32  BlockSize);
+int32 CFE_ES_CDSBlockWrite(CFE_ES_CDSHandle_t Handle, const void *DataToWrite);
 
-int32 CFE_ES_PutCDSBlock(CFE_ES_CDSBlockHandle_t BlockHandle);
-
-int32 CFE_ES_CDSBlockWrite(CFE_ES_CDSBlockHandle_t BlockHandle, void *DataToWrite);
-
-int32 CFE_ES_CDSBlockRead(void *DataRead, CFE_ES_CDSBlockHandle_t BlockHandle);
+int32 CFE_ES_CDSBlockRead(void *DataRead, CFE_ES_CDSHandle_t Handle);
 
 uint32 CFE_ES_CDSReqdMinSize(uint32 MaxNumBlocksToSupport);
 

--- a/fsw/cfe-core/src/es/cfe_es_global.h
+++ b/fsw/cfe-core/src/es/cfe_es_global.h
@@ -46,6 +46,7 @@
 #include "cfe_es_perf.h"
 #include "cfe_es_generic_pool.h"
 #include "cfe_es_mempool.h"
+#include "cfe_es_cds_mempool.h"
 #include "cfe_time.h"
 #include "cfe_platform_cfg.h"
 #include "cfe_evs.h"
@@ -75,6 +76,7 @@
 #define CFE_ES_LIBID_BASE       (CFE_ES_RESOURCEID_MARK | ((OS_OBJECT_TYPE_USER+2) << CFE_ES_RESOURCEID_SHIFT))
 #define CFE_ES_COUNTID_BASE     (CFE_ES_RESOURCEID_MARK | ((OS_OBJECT_TYPE_USER+3) << CFE_ES_RESOURCEID_SHIFT))
 #define CFE_ES_POOLID_BASE      (CFE_ES_RESOURCEID_MARK | ((OS_OBJECT_TYPE_USER+4) << CFE_ES_RESOURCEID_SHIFT))
+#define CFE_ES_CDSBLOCKID_BASE  (CFE_ES_RESOURCEID_MARK | ((OS_OBJECT_TYPE_USER+5) << CFE_ES_RESOURCEID_SHIFT))
 
 /*
 ** Typedefs
@@ -156,7 +158,8 @@ typedef struct
    /*
    ** Critical Data Store Management Variables
    */
-   CFE_ES_CDSVariables_t CDSVars;
+   CFE_ES_CDS_Instance_t CDSVars;
+   bool                  CDSIsAvailable;        /**< \brief Whether or not the CDS service is active/valid */
 
    /*
     * Background task for handling long-running, non real time tasks

--- a/fsw/cfe-core/src/es/cfe_es_task.c
+++ b/fsw/cfe-core/src/es/cfe_es_task.c
@@ -1820,17 +1820,15 @@ int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistry_t *data)
         if (Status == sizeof(CFE_FS_Header_t))
         {
             Status = sizeof(CFE_ES_CDSRegDumpRec_t);
+            RegRecPtr = CFE_ES_Global.CDSVars.Registry;
             while ((RegIndex < CFE_PLATFORM_ES_CDS_MAX_NUM_ENTRIES) && (Status == sizeof(CFE_ES_CDSRegDumpRec_t)))
             {
-                /* Make a pointer to simplify code look and to remove redundant indexing into registry */
-                RegRecPtr = &CFE_ES_Global.CDSVars.Registry[RegIndex];
-
                 /* Check to see if the Registry entry is empty */
-                if (RegRecPtr->Taken == true)
+                if ( CFE_ES_CDSBlockRecordIsUsed(RegRecPtr) )
                 {
                     /* Fill CDS Registry Dump Record with relevant information */
-                    DumpRecord.Size             = RegRecPtr->Size;
-                    DumpRecord.Handle           = RegRecPtr->MemHandle;
+                    DumpRecord.Size             = CFE_ES_CDSBlockRecordGetUserSize(RegRecPtr);
+                    DumpRecord.Handle           = CFE_ES_CDSBlockRecordGetID(RegRecPtr);
                     DumpRecord.Table            = RegRecPtr->Table;
                     DumpRecord.ByteAlignSpare1  = 0;
 
@@ -1848,7 +1846,8 @@ int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistry_t *data)
                 }
 
                 /* Look at the next entry in the Registry */
-                RegIndex++;
+                ++RegIndex;
+                ++RegRecPtr;
             }
 
             if (Status == sizeof(CFE_ES_CDSRegDumpRec_t))

--- a/fsw/cfe-core/src/inc/cfe_error.h
+++ b/fsw/cfe-core/src/inc/cfe_error.h
@@ -412,7 +412,8 @@ typedef int32 CFE_Status_t;
 /**
  * @brief CDS Invalid Size
  *
- *  The Application is requesting a CDS Block with a size of zero.
+ *  The Application is requesting a CDS Block or Pool with a size
+ *  beyond the applicable limits, either too large or too small/zero.
  *
  */
 #define CFE_ES_CDS_INVALID_SIZE  ((int32)0xc4000010)

--- a/fsw/cfe-core/src/inc/cfe_es.h
+++ b/fsw/cfe-core/src/inc/cfe_es.h
@@ -89,7 +89,7 @@
 ** NOTE: "+2" is for NULL Character and "." (i.e. - "AppName.CDSName") */
 #define CFE_ES_CDS_MAX_FULL_NAME_LEN (CFE_MISSION_ES_CDS_MAX_NAME_LENGTH + CFE_MISSION_MAX_API_LEN + 2)
 
-#define CFE_ES_CDS_BAD_HANDLE  (CFE_ES_CDSHandle_t) 0xFFFF
+#define CFE_ES_CDS_BAD_HANDLE  CFE_ES_RESOURCEID_UNDEFINED
 /** \} */
 
 #define CFE_ES_NO_MUTEX                 0 /**< \brief Indicates that the memory pool selection will not use a semaphore */
@@ -409,7 +409,22 @@ typedef struct CFE_ES_MemPoolStats
  *
  * Data type used to hold Handles of Critical Data Stores. See #CFE_ES_RegisterCDS
  */
-typedef cpuaddr CFE_ES_CDSHandle_t;
+typedef CFE_ES_ResourceID_t CFE_ES_CDSHandle_t;
+
+/**
+ * Type used for CDS sizes and offsets.
+ *
+ * This must match the type used in the PSP CDS API, e.g.:
+ * CFE_PSP_GetCDSSize()
+ * CFE_PSP_WriteToCDS()
+ * CFE_PSP_ReadFromCDS()
+ *
+ * It is defined separately from the CFE_ES_MemOffset_t as the type used in
+ * the PSP CDS access API may be different than the ES Pool API.
+ *
+ * In either case this _must_ be an unsigned type.
+ */
+typedef uint32 CFE_ES_CDS_Offset_t;
 
 /**
  * \brief CDS Register Dump Record
@@ -1157,7 +1172,7 @@ void CFE_ES_ProcessAsyncEvent(void);
 ** \sa #CFE_ES_CopyToCDS, #CFE_ES_RestoreFromCDS
 **
 ******************************************************************************/
-CFE_Status_t CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *HandlePtr, int32 BlockSize, const char *Name);
+CFE_Status_t CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *HandlePtr, CFE_ES_CDS_Offset_t BlockSize, const char *Name);
 
 /*****************************************************************************/
 /**

--- a/fsw/cfe-core/src/inc/private/cfe_private.h
+++ b/fsw/cfe-core/src/inc/private/cfe_private.h
@@ -292,7 +292,7 @@ extern int32 CFE_TIME_CleanUpApp(CFE_ES_ResourceID_t AppId);
 **
 ** \param[in, out]   HandlePtr   Pointer Application's variable that will contain the CDS Memory Block Handle. *HandlePtr is the handle of the CDS block that can be used in #CFE_ES_CopyToCDS and #CFE_ES_RestoreFromCDS.
 **
-** \param[in]   BlockSize   The number of bytes needed in the CDS.
+** \param[in]   UserBlockSize   The number of bytes needed in the CDS.
 **
 ** \param[in]   Name        Pointer to character string containing the Application's local name for
 **                          the CDS.
@@ -303,7 +303,7 @@ extern int32 CFE_TIME_CleanUpApp(CFE_ES_ResourceID_t AppId);
 ** \return See return codes for #CFE_ES_RegisterCDS
 **
 ******************************************************************************/
-int32 CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr, int32 BlockSize, const char *Name, bool CriticalTbl);
+int32 CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr, CFE_ES_CDS_Offset_t UserBlockSize, const char *Name, bool CriticalTbl);
 
 /*****************************************************************************/
 /**

--- a/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
@@ -1431,7 +1431,7 @@ void CFE_TBL_FindCriticalTblInfo(CFE_TBL_CritRegRec_t **CritRegRecPtr, CFE_ES_CD
     
     for (i=0; i<CFE_PLATFORM_TBL_MAX_CRITICAL_TABLES; i++)
     {
-        if (CFE_TBL_TaskData.CritReg[i].CDSHandle == CDSHandleToFind)
+        if ( CFE_ES_ResourceID_Equal(CFE_TBL_TaskData.CritReg[i].CDSHandle, CDSHandleToFind) )
         {
             *CritRegRecPtr = &CFE_TBL_TaskData.CritReg[i];
             break;

--- a/fsw/cfe-core/unit-test/es_UT.h
+++ b/fsw/cfe-core/unit-test/es_UT.h
@@ -280,7 +280,7 @@ void TestAPI(void);
 ** \sa #UT_SetBSPFail, #CFE_ES_RebuildCDS, #UT_SetRtnCode
 ** \sa #CFE_ES_InitCDSRegistry, #UT_SetCDSSize, #CFE_ES_CDS_EarlyInit
 ** \sa #UT_SetCDSBSPCheckValidity, #CFE_ES_ValidateCDS, #UT_SetCDSReadGoodEnd
-** \sa #CFE_ES_InitializeCDS, #CFE_ES_RebuildCDS, #CFE_ES_DeleteCDS
+** \sa #CFE_ES_InitCDSSignatures, #CFE_ES_RebuildCDS, #CFE_ES_DeleteCDS
 **
 ******************************************************************************/
 void TestCDS(void);

--- a/fsw/cfe-core/unit-test/tbl_UT.c
+++ b/fsw/cfe-core/unit-test/tbl_UT.c
@@ -2257,7 +2257,7 @@ void Test_CFE_TBL_Register(void)
     /* a. Perform test */
     for (i = 0; i < CFE_PLATFORM_TBL_MAX_CRITICAL_TABLES; i++)
     {
-        CFE_TBL_TaskData.CritReg[i].CDSHandle = 1;
+        CFE_TBL_TaskData.CritReg[i].CDSHandle = CFE_ES_RESOURCEID_UNDEFINED;
     }
 
     RtnCode = CFE_TBL_Register(&TblHandle1, "UT_Table1",
@@ -4771,9 +4771,9 @@ void Test_CFE_TBL_Internal(void)
 
     for (i = 0; i < CFE_PLATFORM_TBL_MAX_CRITICAL_TABLES; i++)
     {
-        if (CFE_TBL_TaskData.CritReg[i].CDSHandle == RegRecPtr->CDSHandle)
+        if ( CFE_ES_ResourceID_Equal(CFE_TBL_TaskData.CritReg[i].CDSHandle, RegRecPtr->CDSHandle) )
         {
-            CFE_TBL_TaskData.CritReg[i].CDSHandle = CFE_ES_CDS_BAD_HANDLE - 1;
+            CFE_TBL_TaskData.CritReg[i].CDSHandle = CFE_ES_RESOURCEID_RESERVED;
         }
     }
 

--- a/fsw/cfe-core/ut-stubs/ut_es_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_es_stubs.c
@@ -72,6 +72,12 @@
 #define CFE_UT_ES_DEFAULT_TASKID    ((CFE_ES_ResourceID_t){0x02020001})
 
 /*
+ * Default value to return from calls that output a CDS ID, if the
+ * test case does not provide a value
+ */
+#define CFE_UT_ES_DEFAULT_CDSID     ((CFE_ES_ResourceID_t){0x02050001})
+
+/*
  * Invalid value to output from calls as resource ID for the
  * calls that return failure.  If subsequently used by application code,
  * it will likely induce a segfault or other noticeably bad behavior.
@@ -884,7 +890,7 @@ int32 CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, void *DataToCopy)
     int32   status;
     uint32  CdsBufferSize;
 
-    UT_Stub_RegisterContext(UT_KEY(CFE_ES_CopyToCDS), (void*)Handle);
+    UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_CopyToCDS), Handle);
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_CopyToCDS), DataToCopy);
     status = UT_DEFAULT_IMPL(CFE_ES_CopyToCDS);
 
@@ -927,7 +933,7 @@ int32 CFE_ES_RestoreFromCDS(void *RestoreToMemory, CFE_ES_CDSHandle_t Handle)
     uint32  CdsBufferSize;
 
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_RestoreFromCDS), RestoreToMemory);
-    UT_Stub_RegisterContext(UT_KEY(CFE_ES_RestoreFromCDS), (void*)Handle);
+    UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_RestoreFromCDS), Handle);
     status = UT_DEFAULT_IMPL(CFE_ES_RestoreFromCDS);
 
     if (status >= 0)
@@ -976,7 +982,7 @@ int32 CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr,
     {
         if (UT_Stub_CopyToLocal(UT_KEY(CFE_ES_RegisterCDSEx), (uint8*)HandlePtr, sizeof(*HandlePtr)) < sizeof(*HandlePtr))
         {
-            *HandlePtr = 1;
+            *HandlePtr = CFE_UT_ES_DEFAULT_CDSID;
         }
     }
 
@@ -1105,7 +1111,7 @@ bool CFE_ES_RunLoop(uint32 *ExitStatus)
     return UT_DEFAULT_IMPL(CFE_ES_RunLoop) != 0;
 }
 
-int32 CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *HandlePtr, int32 BlockSize, const char *Name)
+int32 CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *HandlePtr, CFE_ES_CDS_Offset_t BlockSize, const char *Name)
 {
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_RegisterCDS), HandlePtr);
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_RegisterCDS), BlockSize);


### PR DESCRIPTION
**Describe the contribution**

Rather than having a second pool implementation only for CDS, use the generic pool implementation.  This also uses the abstract resource identifiers to identify CDS blocks, rather than a direct reference.

Fixes #56 

**Testing performed**
Build and sanity test CFE
Confirm all unit tests working
Also tested/Confirmed that the CFE TBL critical table registry is correctly restored when booting in a processor reset mode.  In this case the data is successfully restored from CDS.

**Expected behavior changes**
No impact to behavior.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
This consolidates and simplifies a bunch of code in the CDS access area.
Note that previously there was a separate mutex for the CDS pool and CDS registry.  However almost all accesses needed both, because pool access and registry access go together.  So this is simplified to one mutex now.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
