### PR TITLE
Fix #928 and #929 - Modularize software bus routing, add msg map hash

### DIFF
--- a/cmake/mission_defaults.cmake
+++ b/cmake/mission_defaults.cmake
@@ -15,6 +15,7 @@ set(MISSION_CORE_MODULES
     "osal"
     "psp"
     "msg"
+    "sbr"
 )
 
 # The "MISSION_GLOBAL_APPLIST" is a set of apps/libs that will be built

--- a/cmake/sample_defs/cpu1_platform_cfg.h
+++ b/cmake/sample_defs/cpu1_platform_cfg.h
@@ -47,7 +47,11 @@
 **       regarding this parameter, send an SB command to 'Send Statistics Pkt'.
 **
 **  \par Limits
-**       This parameter has a lower limit of 1 and an upper limit of 1024.
+**       This must be a power of two if software bus message routing hash implementation
+**       is being used.  Lower than 64 will cause unit test failures, and
+**       telemetry reporting is impacted below 32.  There is no hard
+**       upper limit, but impacts memory footprint.  For software bus message routing
+**       search implementation the number of msg ids subscribed to impacts performance.
 **
 */
 #define CFE_PLATFORM_SB_MAX_MSG_IDS              256

--- a/fsw/cfe-core/src/inc/cfe_sb_events.h
+++ b/fsw/cfe-core/src/inc/cfe_sb_events.h
@@ -497,6 +497,21 @@
 **/
 #define CFE_SB_SUBSCRIPTION_RPT_EID     22
 
+/** \brief <tt> 'Msg hash collision: MsgId = 0x\%x, collisions = \%u' </tt>
+**  \event <tt> 'Msg hash collision: MsgId = 0x\%x, collisions = \%u' </tt>
+**
+**  \par Type: DEBUG
+**
+**  \par Cause:
+**
+**  This event message is generated when a message id hash collision occurs when subscribing
+**  to a message.  Collisions indicate how many slots were incremented to find an opening.
+**
+**  Number of collisions will directly impact software bus performance.  These can be resolved
+**  by adjusting MsgId values or increasing CFE_PLATFORM_SB_MAX_MSG_IDS.
+**/
+#define CFE_SB_HASHCOLLISION_EID        23
+
 /** \brief <tt> 'Pipe Overflow,MsgId 0x\%x,pipe \%s,stat 0x\%x,app \%s' </tt>
 **  \event <tt> 'Pipe Overflow,MsgId 0x\%x,pipe \%s,stat 0x\%x,app \%s' </tt>
 **

--- a/fsw/cfe-core/src/inc/cfe_sb_extern_typedefs.h
+++ b/fsw/cfe-core/src/inc/cfe_sb_extern_typedefs.h
@@ -88,7 +88,7 @@ typedef uint8                                            CFE_SB_QosReliability_E
 /**
  * @brief An integer type that should be used for indexing into the Routing Table
  */
-typedef uint16  CFE_SB_MsgRouteIdx_Atom_t;
+typedef uint16  CFE_SB_RouteId_Atom_t;
 
 /**
  * @brief  CFE_SB_MsgId_Atom_t primitive type definition

--- a/fsw/cfe-core/src/inc/cfe_sb_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_sb_msg.h
@@ -683,8 +683,8 @@ typedef struct CFE_SB_RoutingFileEntry {
 ** Structure of one element of the map information in response to #CFE_SB_SEND_MAP_INFO_CC
 */
 typedef struct CFE_SB_MsgMapFileEntry {
-    CFE_SB_MsgId_t             MsgId;/**< \brief Message Id which has been subscribed to */
-    CFE_SB_MsgRouteIdx_Atom_t  Index;/**< \brief Routing table index where pipe destinations are found */
+    CFE_SB_MsgId_t        MsgId;/**< \brief Message Id which has been subscribed to */
+    CFE_SB_RouteId_Atom_t Index;/**< \brief Routing raw index value (0 based, not Route ID) */
 }CFE_SB_MsgMapFileEntry_t;
 
 

--- a/fsw/cfe-core/src/inc/private/cfe_sb_destination_typedef.h
+++ b/fsw/cfe-core/src/inc/private/cfe_sb_destination_typedef.h
@@ -1,0 +1,52 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * Definition of the CFE_SB_DestinationD_t type.
+ * This was moved into its own header file since it is referenced by multiple CFE modules.
+ */
+
+#ifndef CFE_SB_DESTINATION_TYPEDEF_H_
+#define CFE_SB_DESTINATION_TYPEDEF_H_
+
+#include "common_types.h"
+#include "cfe_sb.h"  /* Required for CFE_SB_PipeId_t definition */
+
+/******************************************************************************
+ * This structure defines a DESTINATION DESCRIPTOR used to specify
+ * each destination pipe for a message.
+ *
+ * Note: Changing the size of this structure may require the memory pool
+ * block sizes to change.
+ */
+typedef struct
+{
+     CFE_SB_PipeId_t PipeId;
+     uint8           Active;
+     uint16          MsgId2PipeLim;
+     uint16          BuffCount;
+     uint16          DestCnt;
+     uint8           Scope;
+     uint8           Spare[3];
+     void            *Prev;
+     void            *Next;
+} CFE_SB_DestinationD_t;
+
+#endif /* CFE_SB_DESTINATION_TYPEDEF_H_ */

--- a/fsw/cfe-core/src/inc/private/cfe_sbr.h
+++ b/fsw/cfe-core/src/inc/private/cfe_sbr.h
@@ -1,0 +1,205 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/******************************************************************************
+ * File: cfe_sbr.h
+ *
+ * Purpose:
+ *      Prototypes for private functions and type definitions for SB
+ *      routing internal use.
+ *****************************************************************************/
+
+#ifndef CFE_SBR_H_
+#define CFE_SBR_H_
+
+/*
+ * Includes
+ */
+#include "common_types.h"
+#include "private/cfe_sb_destination_typedef.h"
+#include "cfe_sb.h"
+#include "cfe_msg_typedefs.h"
+#include "cfe_platform_cfg.h"
+
+/******************************************************************************
+ * Type Definitions
+ */
+
+/**
+ * \brief Routing table id
+ *
+ * This is intended as a form of "strong typedef" where direct assignments should
+ * be restricted.  Software bus uses numeric indexes into multiple tables to perform
+ * its duties, and it is important that these index values are distinct and separate
+ * and not mixed together.
+ *
+ * Using this holding structure prevents assignment directly into a different index
+ * or direct usage as numeric value.
+ */
+typedef struct
+{
+    CFE_SB_RouteId_Atom_t RouteId; /**< \brief Holding value, do not use directly in code */
+} CFE_SBR_RouteId_t;
+
+/** \brief Callback throttling structure */
+typedef struct
+{
+    uint32 StartIndex; /**< /brief 0 based index to start at */
+    uint32 MaxLoop;    /**< /brief Max number to process */
+    uint32 NextIndex;  /**< /brief Next start index (output), 0 if completed */
+} CFE_SBR_Throttle_t;
+
+/** \brief For each id callback function prototype */
+typedef void (*CFE_SBR_CallbackPtr_t)(CFE_SBR_RouteId_t RouteId, void *ArgPtr);
+
+/******************************************************************************
+ * Function prototypes
+ */
+
+/**
+ *  \brief Initialize software bus routing module
+ */
+void CFE_SBR_Init(void);
+
+/**
+ *  \brief Add a route for the given a message id
+ *
+ *  Called for the first subscription to a message ID, uses up one
+ *  element in the routing table.  Assumes check for existing
+ *  route was already performed or routes could leak
+ *
+ *  \param[in]  MsgId         Message ID of the route to add
+ *  \param[out] CollisionsPtr Number of collisions (if not null)
+ *
+ *  \returns Route ID, will be invalid if route can not be added
+ */
+CFE_SBR_RouteId_t CFE_SBR_AddRoute(CFE_SB_MsgId_t MsgId, uint32 *CollisionsPtr);
+
+/**
+ *  \brief Obtain the route id given a message id
+ *
+ *  \param[in] MsgId Message ID of the route to get
+ *
+ *  \returns Route ID, will be invalid if can't be returned
+ */
+CFE_SBR_RouteId_t CFE_SBR_GetRouteId(CFE_SB_MsgId_t MsgId);
+
+/**
+ *  \brief Obtain the message id given a route id
+ *
+ *  \param[in] RouteId Route ID of the message id to get
+ *
+ *  \returns Message ID, will be invalid if cant be returned
+ */
+CFE_SB_MsgId_t CFE_SBR_GetMsgId(CFE_SBR_RouteId_t RouteId);
+
+/**
+ *  \brief Obtain the destination list head pointer given a route id
+ *
+ *  \param[in] RouteId Route ID
+ *
+ *  \returns Destination list head pointer for the given route id.
+ *           Will be null if route doesn't exist or no subscribers.
+ */
+CFE_SB_DestinationD_t *CFE_SBR_GetDestListHeadPtr(CFE_SBR_RouteId_t RouteId);
+
+/**
+ * \brief Set the destination list head pointer for given route id
+ *
+ * \param[in] RouteId Route Id
+ * \param[in] DestPtr Destination list head pointer
+ */
+void CFE_SBR_SetDestListHeadPtr(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *DestPtr);
+
+/**
+ * \brief Increment the sequence counter associated with the supplied route ID
+ *
+ * \param[in] RouteId Route ID
+ */
+void CFE_SBR_IncrementSequenceCounter(CFE_SBR_RouteId_t RouteId);
+
+/**
+ * \brief Get the sequence counter associated with the supplied route ID
+ *
+ * \param[in] RouteId Route ID
+ *
+ * \returns the sequence counter
+ */
+CFE_MSG_SequenceCount_t CFE_SBR_GetSequenceCounter(CFE_SBR_RouteId_t RouteId);
+
+/**
+ * \brief Call the supplied callback function for all routes
+ *
+ * Invokes callback for each route in the table.  Message ID order
+ * depends on the routing table implementation.  Possiblities include
+ * in subscription order and in order if incrementing message ids.
+ *
+ * \param[in]     CallbackPtr Function to invoke for each matching ID
+ * \param[in]     ArgPtr      Opaque argument to pass to callback function
+ * \param[in,out] ThrottlePtr Throttling structure, NULL for no throttle
+ */
+void CFE_SBR_ForEachRouteId(CFE_SBR_CallbackPtr_t CallbackPtr, void *ArgPtr, CFE_SBR_Throttle_t *ThrottlePtr);
+
+/******************************************************************************
+** Inline functions
+*/
+
+/**
+ * \brief Identifies whether a given CFE_SBR_RouteId_t is valid
+ *
+ * Implements a basic sanity check on the value provided
+ *
+ * \returns true if sanity checks passed, false otherwise.
+ */
+static inline bool CFE_SBR_IsValidRouteId(CFE_SBR_RouteId_t RouteId)
+{
+    return (RouteId.RouteId != 0 && RouteId.RouteId <= CFE_PLATFORM_SB_MAX_MSG_IDS);
+}
+
+/**
+ * \brief Converts from raw value to CFE_SBR_RouteId_t
+ *
+ * Converts the supplied "bare number" into a type-safe CFE_SBR_RouteId_t value
+ *
+ * \returns A CFE_SBR_RouteId_t
+ */
+static inline CFE_SBR_RouteId_t CFE_SBR_ValueToRouteId(CFE_SB_RouteId_Atom_t Value)
+{
+    return ((CFE_SBR_RouteId_t) {.RouteId = 1 + Value});
+}
+
+/**
+ * \brief Converts from CFE_SBR_RouteId_t to raw value
+ *
+ * Converts the supplied route id into a "bare number" suitable for performing
+ * array lookups or other tasks for which the holding structure cannot be used directly.
+ *
+ * Use with caution, as this removes the type safety information from the value.
+ *
+ * \note It is assumed the value has already been validated using CFE_SB_IsValidRouteId()
+ *
+ * \returns The underlying value
+ */
+static inline CFE_SB_RouteId_Atom_t CFE_SBR_RouteIdToValue(CFE_SBR_RouteId_t RouteId)
+{
+    return (RouteId.RouteId - 1);
+}
+
+#endif /* CFE_SBR_H_ */

--- a/fsw/cfe-core/src/sb/cfe_sb_init.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_init.c
@@ -112,15 +112,9 @@ int32 CFE_SB_EarlyInit (void) {
     /* Initialize the pipe table. */
     CFE_SB_InitPipeTbl();
 
-    /* Initialize the routing index look up table */
-    CFE_SB_InitMsgMap();
+    /* Initialize the routing module */
+    CFE_SBR_Init();
 
-    /* Initialize the routing table. */
-    CFE_SB_InitRoutingTbl();
-
-    /* Initialize the APID to routing index map table */
-    CFE_SB_InitIdxStack();
-    
     /* Initialize the SB Statistics Pkt */
     CFE_SB_InitMsg(&CFE_SB.StatTlmMsg,
                    CFE_SB_ValueToMsgId(CFE_SB_STATS_TLM_MID),
@@ -197,64 +191,5 @@ void CFE_SB_InitPipeTbl(void){
     }/* end for */
 
 }/* end CFE_SB_InitPipeTbl */
-
-
-
-/******************************************************************************
-**  Function:  CFE_SB_InitMsgMap()
-**
-**  Purpose:
-**    Initialize the Software Bus Message Map.
-**
-**  Arguments:
-**
-**  Notes:
-**    This function MUST be called before any SB API's are called.
-**
-**  Return:
-**    none
-*/
-void CFE_SB_InitMsgMap(void){
-
-    CFE_SB_MsgKey_Atom_t   KeyVal;
-
-    for (KeyVal=0; KeyVal < CFE_SB_MAX_NUMBER_OF_MSG_KEYS; KeyVal++)
-    {
-        CFE_SB.MsgMap[KeyVal] = CFE_SB_INVALID_ROUTE_IDX;
-    }
-
-}/* end CFE_SB_InitMsgMap */
-
-
-
-/******************************************************************************
-**  Function:  CFE_SB_InitRoutingTbl()
-**
-**  Purpose:
-**    Initialize the Software Bus Routing Table.
-**
-**  Arguments:
-**
-**  Notes:
-**    This function MUST be called before any SB API's are called.
-**
-**  Return:
-**    none
-*/
-void CFE_SB_InitRoutingTbl(void){
-
-    uint32  i;
-
-    /* Initialize routing table */
-    for(i=0;i<CFE_PLATFORM_SB_MAX_MSG_IDS;i++){
-
-        CFE_SB.RoutingTbl[i].MsgId = CFE_SB_INVALID_MSG_ID;
-        CFE_SB.RoutingTbl[i].SeqCnt = 0;
-        CFE_SB.RoutingTbl[i].Destinations = 0;
-        CFE_SB.RoutingTbl[i].ListHeadPtr = NULL;
-
-    }/* end for */
-
-}/* end CFE_SB_InitRoutingTbl */
 
 /*****************************************************************************/

--- a/fsw/cfe-core/src/sb/cfe_sb_msg_id_util.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_msg_id_util.c
@@ -34,29 +34,6 @@
 #include "cfe_sb_priv.h"
 #include "cfe_msg_api.h"
 
-
-/******************************************************************************
-**  Function:  CFE_SB_ConvertMsgIdtoMsgKey
-**
-**  Purpose:
-**    Convert the full message Id to the mission defined MsgKey format
-**    No conversion is needed for the default implementation as it
-**    is limited to less than 16 bits by CFE_PLATFORM_SB_HIGHEST_VALID_MSGID
-**     If CFE_PLATFORM_SB_HIGHEST_VALID_MSGID is greater than 16 bits this function
-**    may need modification to ensure SB internal data structures are a
-**    reasonable size.
-**
-**  Arguments:
-**    Message ID 
-**
-**  Return:
-**    Converted MsgKey in SB internal format
-*/
-CFE_SB_MsgKey_t CFE_SB_ConvertMsgIdtoMsgKey( CFE_SB_MsgId_t MsgId)
-{
-    return CFE_SB_ValueToMsgKey(CFE_SB_MsgIdToValue(MsgId));
-}/* CFE_SB_ConvertMsgIdtoMsgKey */
-
 /*
  * Function: CFE_SB_GetMsgId - See API and header file for details
  */

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.h
@@ -37,17 +37,17 @@
 */
 #include "common_types.h"
 #include "private/cfe_private.h"
+#include "private/cfe_sb_destination_typedef.h"
 #include "cfe_sb.h"
 #include "cfe_sb_msg.h"
 #include "cfe_time.h"
 #include "cfe_es.h"
+#include "private/cfe_sbr.h"
 
 /*
 ** Macro Definitions
 */
 
-#define CFE_SB_INVALID_ROUTE_IDX        ((CFE_SB_MsgRouteIdx_t){ .RouteIdx = 0 })
-#define CFE_SB_INVALID_MSG_KEY          ((CFE_SB_MsgKey_t){ .KeyIdx = 0 })
 #define CFE_SB_UNUSED_QUEUE             OS_OBJECT_ID_UNDEFINED
 #define CFE_SB_INVALID_PIPE             0xFF
 #define CFE_SB_NO_DESTINATION           0xFF
@@ -99,62 +99,8 @@
 #define CFE_SB_Q_WR_ERR_EID_BIT         4
 
 /*
- * Using the default configuration where there is a 1:1 mapping between MsgID
- * and message key values, the number of keys is equal to the number of MsgIDs.
- *
- * If using an alternative key function / hash, this may change.
- */
-#define CFE_SB_MAX_NUMBER_OF_MSG_KEYS   (1+CFE_PLATFORM_SB_HIGHEST_VALID_MSGID)
-/*
 ** Type Definitions
 */
-
-
-/******************************************************************************
-**  Typedef:  CFE_SB_MsgKey_Atom_t
-**
-**  Purpose:
-**           Defines the an integer type for the numeric key that is used for routing
-**           table lookups.  This is the "raw value" type and typically should not
-**           be used directly, except by internal table lookups.
-**
-*/
-typedef uint32  CFE_SB_MsgKey_Atom_t;
-
-/******************************************************************************
-**  Typedef:  CFE_SB_MsgKey_t
-**
-**  Purpose:
-**           This is a "holding structure" for the related integer CFE_SB_MsgKey_Atom_t values.
-**           This defines the data type that is stored in other structures and/or passed between
-**           software bus functions.
-**
-**           It is implemented this way to improve type safety and help ensure that "MsgKey"
-**           values are not inadvertently exchanged with MsgId or Routing Index values.
-**
-*/
-typedef struct
-{
-    CFE_SB_MsgKey_Atom_t KeyIdx;    /**< Holding value, do not use directly */
-} CFE_SB_MsgKey_t;
-
-/******************************************************************************/
-/**
- * @brief An wrapper for holding a routing table index
- *
- * This is intended as a form of "strong typedef" where direct assignments should
- * be restricted.  Software bus uses numeric indexes into multiple tables to perform
- * its duties, and it is important that these index values are distinct and separate
- * and not mixed together.
- *
- * Using this holding structure prevents assignment directly into a different index
- * or direct usage as numeric value.
- */
-typedef struct
-{
-    CFE_SB_MsgRouteIdx_Atom_t RouteIdx;     /**< Holding value, do not use directly in code */
-} CFE_SB_MsgRouteIdx_t;
-
 
 /******************************************************************************
 **  Typedef:  CFE_SB_BufferD_t
@@ -174,31 +120,6 @@ typedef struct {
      void              *Buffer;
 } CFE_SB_BufferD_t;
 
-
-/******************************************************************************
-**  Typedef:  CFE_SB_DestinationD_t
-**
-**  Purpose:
-**     This structure defines a DESTINATION DESCRIPTOR used to specify
-**     each destination pipe for a message.
-**
-**     Note: Changing the size of this structure may require the memory pool
-**     block sizes to change.
-*/
-
-typedef struct {
-     CFE_SB_PipeId_t PipeId;
-     uint8           Active;
-     uint16          MsgId2PipeLim;
-     uint16          BuffCount;
-     uint16          DestCnt;
-     uint8           Scope;
-     uint8           Spare[3];
-     void            *Prev;
-     void            *Next;
-} CFE_SB_DestinationD_t;
-
-
 /******************************************************************************
 **  Typedef:  CFE_SB_ZeroCopyD_t
 **
@@ -217,22 +138,6 @@ typedef struct {
      void              *Next;
      void              *Prev;
 } CFE_SB_ZeroCopyD_t;
-
-
-/******************************************************************************
-**  Typedef:  CFE_SB_RouteEntry_t
-**
-**  Purpose:
-**     This structure defines an entry in the routing table
-*/
-
-typedef struct {
-     CFE_SB_MsgId_t        MsgId;    /**< Original Message Id when the subscription was created */
-     uint16                Destinations;
-     uint32                SeqCnt;
-     CFE_SB_DestinationD_t *ListHeadPtr;
-} CFE_SB_RouteEntry_t;
-
 
 /******************************************************************************
 **  Typedef:  CFE_SB_PipeD_t
@@ -257,8 +162,6 @@ typedef struct {
      CFE_SB_BufferD_t  *ToTrashBuff;
 } CFE_SB_PipeD_t;
 
-
-
 /******************************************************************************
 **  Typedef:  CFE_SB_BufParams_t
 **
@@ -279,29 +182,24 @@ typedef struct {
 **  Purpose:
 **     This structure contains the SB global variables.
 */
-typedef struct {
-    osal_id_t           SharedDataMutexId;
-    uint32              SubscriptionReporting;
-    uint32              SenderReporting;
-    CFE_ES_ResourceID_t AppId;
-    uint32              StopRecurseFlags[OS_MAX_TASKS];
-    void               *ZeroCopyTail;
-    CFE_SB_PipeD_t      PipeTbl[CFE_PLATFORM_SB_MAX_PIPES];
-    CFE_SB_HousekeepingTlm_t        HKTlmMsg;
-    CFE_SB_StatsTlm_t               StatTlmMsg;
-    CFE_SB_PipeId_t     CmdPipe;
-    CFE_SB_Msg_t        *CmdPipePktPtr;
-    CFE_SB_MemParams_t  Mem;
-    CFE_SB_MsgRouteIdx_t      MsgMap[CFE_SB_MAX_NUMBER_OF_MSG_KEYS];
-    CFE_SB_RouteEntry_t RoutingTbl[CFE_PLATFORM_SB_MAX_MSG_IDS];
-    CFE_SB_AllSubscriptionsTlm_t    PrevSubMsg;
-    CFE_SB_SingleSubscriptionTlm_t  SubRprtMsg;
-    CFE_EVS_BinFilter_t EventFilters[CFE_SB_MAX_CFG_FILE_EVENTS_TO_FILTER];
-
-    uint16 RouteIdxTop;
-    CFE_SB_MsgRouteIdx_t RouteIdxStack[CFE_PLATFORM_SB_MAX_MSG_IDS];
-
-}cfe_sb_t;
+typedef struct
+{
+    osal_id_t                      SharedDataMutexId;
+    uint32                         SubscriptionReporting;
+    uint32                         SenderReporting;
+    CFE_ES_ResourceID_t            AppId;
+    uint32                         StopRecurseFlags[OS_MAX_TASKS];
+    void                          *ZeroCopyTail;
+    CFE_SB_PipeD_t                 PipeTbl[CFE_PLATFORM_SB_MAX_PIPES];
+    CFE_SB_HousekeepingTlm_t       HKTlmMsg;
+    CFE_SB_StatsTlm_t              StatTlmMsg;
+    CFE_SB_PipeId_t                CmdPipe;
+    CFE_SB_Msg_t                  *CmdPipePktPtr;
+    CFE_SB_MemParams_t             Mem;
+    CFE_SB_AllSubscriptionsTlm_t   PrevSubMsg;
+    CFE_SB_SingleSubscriptionTlm_t SubRprtMsg;
+    CFE_EVS_BinFilter_t            EventFilters[CFE_SB_MAX_CFG_FILE_EVENTS_TO_FILTER];
+} cfe_sb_t;
 
 
 /******************************************************************************
@@ -336,13 +234,8 @@ typedef struct{
 int32  CFE_SB_AppInit(void);
 int32  CFE_SB_InitBuffers(void);
 void   CFE_SB_InitPipeTbl(void);
-void   CFE_SB_InitMsgMap(void);
-void   CFE_SB_InitRoutingTbl(void);
 void   CFE_SB_InitIdxStack(void);
 void   CFE_SB_ResetCounts(void);
-void  CFE_SB_RouteIdxPush_Unsync(CFE_SB_MsgRouteIdx_t idx);
-CFE_SB_MsgRouteIdx_t  CFE_SB_RouteIdxPop_Unsync(void);
-CFE_SB_MsgKey_t CFE_SB_ConvertMsgIdtoMsgKey(CFE_SB_MsgId_t MsgId);
 void   CFE_SB_LockSharedData(const char *FuncName, int32 LineNumber);
 void   CFE_SB_UnlockSharedData(const char *FuncName, int32 LineNumber);
 void   CFE_SB_ReleaseBuffer (CFE_SB_BufferD_t *bd, CFE_SB_DestinationD_t *dest);
@@ -350,13 +243,9 @@ int32  CFE_SB_ReadQueue(CFE_SB_PipeD_t *PipeDscPtr,CFE_ES_ResourceID_t TskId,
                         CFE_SB_TimeOut_t Time_Out,CFE_SB_BufferD_t **Message );
 int32  CFE_SB_WriteQueue(CFE_SB_PipeD_t *pd,uint32 TskId,
                          const CFE_SB_BufferD_t *bd,CFE_SB_MsgId_t MsgId );
-CFE_SB_MsgRouteIdx_t CFE_SB_GetRoutingTblIdx(CFE_SB_MsgKey_t MsgKey);
 uint8  CFE_SB_GetPipeIdx(CFE_SB_PipeId_t PipeId);
 int32  CFE_SB_ReturnBufferToPool(CFE_SB_BufferD_t *bd);
 void   CFE_SB_ProcessCmdPipePkt(void);
-int32  CFE_SB_DuplicateSubscribeCheck(CFE_SB_MsgKey_t MsgKey,CFE_SB_PipeId_t PipeId);
-void   CFE_SB_SetRoutingTblIdx(CFE_SB_MsgKey_t MsgKey, CFE_SB_MsgRouteIdx_t Value);
-CFE_SB_RouteEntry_t* CFE_SB_GetRoutePtrFromIdx(CFE_SB_MsgRouteIdx_t RouteIdx);
 void   CFE_SB_ResetCounters(void);
 void   CFE_SB_SetMsgSeqCnt(CFE_SB_MsgPtr_t MsgPtr,uint32 Count);
 char   *CFE_SB_GetAppTskName(CFE_ES_ResourceID_t TaskId, char* FullName);
@@ -364,7 +253,6 @@ CFE_SB_BufferD_t *CFE_SB_GetBufferFromPool(CFE_SB_MsgId_t MsgId, uint16 Size);
 CFE_SB_BufferD_t *CFE_SB_GetBufferFromCaller(CFE_SB_MsgId_t MsgId, void *Address);
 CFE_SB_PipeD_t   *CFE_SB_GetPipePtr(CFE_SB_PipeId_t PipeId);
 CFE_SB_PipeId_t  CFE_SB_GetAvailPipeIdx(void);
-CFE_SB_DestinationD_t *CFE_SB_GetDestPtr (CFE_SB_MsgKey_t MsgKey, CFE_SB_PipeId_t PipeId);
 int32 CFE_SB_DeletePipeWithAppId(CFE_SB_PipeId_t PipeId,CFE_ES_ResourceID_t AppId);
 int32 CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId,CFE_ES_ResourceID_t AppId);
 int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
@@ -390,14 +278,60 @@ int32 CFE_SB_ValidatePipeId(CFE_SB_PipeId_t PipeId);
 void CFE_SB_IncrCmdCtr(int32 status);
 void CFE_SB_FileWriteByteCntErr(const char *Filename,uint32 Requested,uint32 Actual);
 void CFE_SB_SetSubscriptionReporting(uint32 state);
-uint32 CFE_SB_FindGlobalMsgIdCnt(void);
 uint32 CFE_SB_RequestToSendEvent(CFE_ES_ResourceID_t TaskId, uint32 Bit);
 void CFE_SB_FinishSendEvent(CFE_ES_ResourceID_t TaskId, uint32 Bit);
 CFE_SB_DestinationD_t *CFE_SB_GetDestinationBlk(void);
 int32 CFE_SB_PutDestinationBlk(CFE_SB_DestinationD_t *Dest);
-int32 CFE_SB_AddDest(CFE_SB_RouteEntry_t *RouteEntry, CFE_SB_DestinationD_t *NewNode);
-int32 CFE_SB_RemoveDest(CFE_SB_RouteEntry_t *RouteEntry, CFE_SB_DestinationD_t *NodeToRemove);
 
+/**
+ * \brief Add a destination node
+ *
+ * Private function that will add a destination node to the linked list
+ *
+ * \note Assumes destination pointer is valid
+ *
+ * \param[in] RouteId The route ID to add destination node to
+ * \param[in] DestPtr Pointer to the destination to add
+ */
+int32 CFE_SB_AddDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *NewNode);
+
+/**
+ * \brief Remove a destination node
+ *
+ * Private function that will remove a destination node from the linked list
+ *
+ * \note Assumes destination pointer is valid and in route
+ *
+ * \param[in] RouteId The route ID to remove destination node from
+ * \param[in] DestPtr Pointer to the destination to remove
+ */
+void CFE_SB_RemoveDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *NodeToRemove);
+
+/**
+ * \brief Remove a destination
+ *
+ * Private function that will remove a destination by removing the node,
+ * returning the block, and decrementing counters
+ *
+ * \note Assumes destination pointer is valid and in route
+ *
+ * \param[in] RouteId The route ID to remove destination from
+ * \param[in] DestPtr Pointer to the destination to remove
+ */
+void CFE_SB_RemoveDest(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *DestPtr);
+
+/**
+ * \brief Get destination pointer for PipeId from RouteId
+ *
+ * Private function that will return the destination pointer related to the
+ * given PipeId and RouteId if it exists
+ *
+ * \param[in] RouteId The route ID to search
+ * \param[in] PipeId  The pipe ID to search for
+ *
+ * \returns Then destination pointer for a match, NULL otherwise
+ */
+CFE_SB_DestinationD_t *CFE_SB_GetDestPtr(CFE_SBR_RouteId_t RouteId, CFE_SB_PipeId_t PipeId);
 
 /*****************************************************************************/
 /**
@@ -451,102 +385,6 @@ int32 CFE_SB_SendPrevSubsCmd(const CFE_SB_SendPrevSubs_t *data);
  */
 
 extern cfe_sb_t CFE_SB;
-
-
-
-/* ---------------------------------------------------------
- * HELPER FUNCTIONS FOR TYPE-SAFE WRAPPERS / HOLDING STRUCTS
- *
- * These functions implement the type conversions between "bare numbers" and
- * the holding structures, as well as sanity tests for the holding structures.
- *
- * The data within the holding structures should never be directly in the app,
- * one of these helpers should be used once it is verified that the conversion
- * or use case is legitimate.
- * --------------------------------------------------------- */
-
-/**
- * @brief Identifies whether a given CFE_SB_MsgKey_t is valid
- *
- * Implements a basic sanity check on the value provided
- *
- * @returns true if sanity checks passed, false otherwise.
- */
-static inline bool CFE_SB_IsValidMsgKey(CFE_SB_MsgKey_t MsgKey)
-{
-    return (MsgKey.KeyIdx != 0 && MsgKey.KeyIdx <= CFE_SB_MAX_NUMBER_OF_MSG_KEYS);
-}
-
-/**
- * @brief Identifies whether a given CFE_SB_MsgRouteIdx_t is valid
- *
- * Implements a basic sanity check on the value provided
- *
- * @returns true if sanity checks passed, false otherwise.
- */
-static inline bool CFE_SB_IsValidRouteIdx(CFE_SB_MsgRouteIdx_t RouteIdx)
-{
-    return (RouteIdx.RouteIdx != 0 && RouteIdx.RouteIdx <= CFE_PLATFORM_SB_MAX_MSG_IDS);
-}
-
-/**
- * @brief Converts between a CFE_SB_MsgKey_t and a raw value
- *
- * Converts the supplied value into a "bare number" suitable for performing
- * array lookups or other tasks for which the holding structure cannot be used directly.
- *
- * Use with caution, as this removes the type safety information from the value.
- *
- * @note It is assumed the value has already been validated using CFE_SB_IsValidMsgKey()
- *
- * @returns The underlying index value
- */
-static inline CFE_SB_MsgKey_Atom_t CFE_SB_MsgKeyToValue(CFE_SB_MsgKey_t MsgKey)
-{
-    return (MsgKey.KeyIdx - 1);
-}
-
-/**
- * @brief Converts between a CFE_SB_MsgKey_t and a raw value
- *
- * Converts the supplied "bare number" into a type-safe CFE_SB_MsgKey_t value
- *
- * @returns A CFE_SB_MsgKey_t value
- */
-static inline CFE_SB_MsgKey_t CFE_SB_ValueToMsgKey(CFE_SB_MsgKey_Atom_t KeyIdx)
-{
-    return ((CFE_SB_MsgKey_t){ .KeyIdx = 1 + KeyIdx });
-}
-
-/**
- * @brief Converts between a CFE_SB_MsgRouteIdx_t and a raw value
- *
- * Converts the supplied "bare number" into a type-safe CFE_SB_MsgRouteIdx_t value
- *
- * @returns A CFE_SB_MsgRouteIdx_t value
- */
-static inline CFE_SB_MsgRouteIdx_t CFE_SB_ValueToRouteIdx(CFE_SB_MsgRouteIdx_Atom_t TableIdx)
-{
-    return ((CFE_SB_MsgRouteIdx_t){ .RouteIdx = 1 + TableIdx });
-}
-
-/**
- * @brief Converts between a CFE_SB_MsgRouteIdx_t and a raw value
- *
- * Converts the supplied value into a "bare number" suitable for performing
- * array lookups or other tasks for which the holding structure cannot be used directly.
- *
- * Use with caution, as this removes the type safety information from the value.
- *
- * @note It is assumed the value has already been validated using CFE_SB_IsValidRouteIdx()
- *
- * @returns The underlying index value
- */
-static inline CFE_SB_MsgRouteIdx_Atom_t CFE_SB_RouteIdxToValue(CFE_SB_MsgRouteIdx_t RouteIdx)
-{
-    return (RouteIdx.RouteIdx - 1);
-}
-
 
 #endif /* _cfe_sb_priv_ */
 /*****************************************************************************/

--- a/fsw/cfe-core/unit-test/CMakeLists.txt
+++ b/fsw/cfe-core/unit-test/CMakeLists.txt
@@ -71,6 +71,7 @@ foreach(MODULE ${CFE_CORE_MODULES})
         ${UT_COVERAGE_LINK_FLAGS}
         ut_cfe-core_support
         ut_cfe-core_stubs
+        sbr  # TODO remove this
         ut_assert)
 
   add_test(${UT_TARGET_NAME}_UT ${UT_TARGET_NAME}_UT)

--- a/modules/sbr/CMakeLists.txt
+++ b/modules/sbr/CMakeLists.txt
@@ -1,0 +1,43 @@
+##################################################################
+#
+# cFE software bus routing module CMake build recipe
+#
+# This CMakeLists.txt adds source files for the
+# SBR module included in the cFE distribution.  Selected
+# files are built into a static library that in turn
+# is linked into the final executable.
+#
+# Note this is different than applications which are dynamically
+# linked to support runtime loading.  The core applications all
+# use static linkage.
+#
+##################################################################
+
+if (NOT MISSION_MSGMAP_IMPLEMENTATION)
+    set(MISSION_MSGMAP_IMPLEMENTATION "DIRECT")
+endif (NOT MISSION_MSGMAP_IMPLEMENTATION)
+
+if (MISSION_MSGMAP_IMPLEMENTATION STREQUAL "DIRECT")
+    message(STATUS "Using direct map software bus routing implementation")
+    set(${DEP}_SRC
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cfe_sbr_map_direct.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cfe_sbr_route_unsorted.c)
+elseif (MISSION_MSGMAP_IMPLEMENTATION STREQUAL "HASH")
+    message(STATUS "Using hashed map software bus routing implementation")
+    set(${DEP}_SRC
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cfe_sbr_map_hash.c
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/cfe_sbr_route_unsorted.c)
+else()
+    message(ERROR "Invalid software bush routing implementation selected:" MISSION_MSGMAP_IMPLEMENTATION)
+endif()
+
+# Module library
+add_library(${DEP} STATIC ${${DEP}_SRC})
+
+# Add private include
+target_include_directories(${DEP} PRIVATE private_inc)
+
+# Add unit test coverage subdirectory
+if(ENABLE_UNIT_TESTS)
+    add_subdirectory(unit-test-coverage)
+endif(ENABLE_UNIT_TESTS)

--- a/modules/sbr/private_inc/cfe_sbr_priv.h
+++ b/modules/sbr/private_inc/cfe_sbr_priv.h
@@ -1,0 +1,66 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/******************************************************************************
+ * Prototypes for private functions and type definitions for SB
+ * routing internal use.
+ *****************************************************************************/
+
+#ifndef CFE_SBR_PRIV_H_
+#define CFE_SBR_PRIV_H_
+
+/*
+ * Includes
+ */
+#include "private/cfe_sbr.h"
+
+/*
+ * Macro Definitions
+ */
+
+/** \brief Invalid route id */
+#define CFE_SBR_INVALID_ROUTE_ID ((CFE_SBR_RouteId_t) {.RouteId = 0})
+
+/******************************************************************************
+ * Function prototypes
+ */
+
+/**
+ *  \brief Routing map initialization
+ */
+void CFE_SBR_Init_Map(void);
+
+/**
+ * \brief Associates the given route ID with the given message ID
+ *
+ * Used for implementations that use a mapping table (typically hash or direct)
+ * and need this information to later get the route id from the message id.
+ *
+ * \note Typically not needed for a search implementation.  Assumes
+ *       message ID is valid
+ *
+ * \param[in] MsgId   Message id to associate with route id
+ * \param[in] RouteId Route id to associate with message id
+ *
+ * \returns Number of collisions
+ */
+uint32 CFE_SBR_SetRouteId(CFE_SB_MsgId_t MsgId, CFE_SBR_RouteId_t RouteId);
+
+#endif /* CFE_SBR_PRIV_H_ */

--- a/modules/sbr/src/cfe_sbr_map_direct.c
+++ b/modules/sbr/src/cfe_sbr_map_direct.c
@@ -1,0 +1,93 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/******************************************************************************
+ * Direct routing map implementation
+ *
+ * Notes:
+ *   These functions manipulate/access global variables and need
+ *   to be protected by the SB Shared data lock.
+ *
+ */
+
+/*
+ * Include Files
+ */
+
+#include "common_types.h"
+#include "private/cfe_sbr.h"
+#include "cfe_sbr_priv.h"
+#include <string.h>
+
+/*
+ * Macro Definitions
+ */
+
+/**
+ * \brief Message map size
+ *
+ * For direct mapping, map size is maximum valid MsgId value + 1 (since MsgId 0 is valid)
+ */
+#define CFE_SBR_MSG_MAP_SIZE (CFE_PLATFORM_SB_HIGHEST_VALID_MSGID + 1)
+
+/******************************************************************************
+ * Shared data
+ */
+
+/** \brief Message map shared data */
+CFE_SBR_RouteId_t CFE_SBR_MSGMAP[CFE_SBR_MSG_MAP_SIZE];
+
+/******************************************************************************
+ *  Interface function - see header for description
+ */
+void CFE_SBR_Init_Map(void)
+{
+    /* Clear the shared data */
+    memset(&CFE_SBR_MSGMAP, 0, sizeof(CFE_SBR_MSGMAP));
+}
+
+/******************************************************************************
+ *  Interface function - see header for description
+ */
+uint32 CFE_SBR_SetRouteId(CFE_SB_MsgId_t MsgId, CFE_SBR_RouteId_t RouteId)
+{
+    if (CFE_SB_IsValidMsgId(MsgId))
+    {
+        CFE_SBR_MSGMAP[CFE_SB_MsgIdToValue(MsgId)] = RouteId;
+    }
+
+    /* Direct lookup never collides, always return 0 */
+    return 0;
+}
+
+/******************************************************************************
+ *  Interface function - see API for description
+ */
+CFE_SBR_RouteId_t CFE_SBR_GetRouteId(CFE_SB_MsgId_t MsgId)
+{
+    CFE_SBR_RouteId_t routeid = CFE_SBR_INVALID_ROUTE_ID;
+
+    if (CFE_SB_IsValidMsgId(MsgId))
+    {
+        routeid = CFE_SBR_MSGMAP[CFE_SB_MsgIdToValue(MsgId)];
+    }
+
+    return routeid;
+}

--- a/modules/sbr/src/cfe_sbr_map_hash.c
+++ b/modules/sbr/src/cfe_sbr_map_hash.c
@@ -1,0 +1,163 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/******************************************************************************
+ * Hash routing map implementation
+ *
+ * Notes:
+ *   These functions manipulate/access global variables and need
+ *   to be protected by the SB Shared data lock.
+ *
+ */
+
+/*
+ * Include Files
+ */
+
+#include "common_types.h"
+#include "private/cfe_sbr.h"
+#include "cfe_sbr_priv.h"
+#include <string.h>
+#include <limits.h>
+
+/*
+ * Macro Definitions
+ */
+
+/**
+ * \brief Message map size
+ *
+ * For hash mapping, map size is a multiple of maximum number of routes.
+ * The multiple impacts the number of collisions when the routes fill up.
+ * 4 was initially chosen to provide for plenty of holes in the map, while
+ * still remaining much smaller than the routing table.  Note the
+ * multiple must be a factor of 2 to use the efficient shift logic, and
+ * can't be bigger than what can be indexed by CFE_SB_MsgId_Atom_t
+ */
+#define CFE_SBR_MSG_MAP_SIZE (4 * CFE_PLATFORM_SB_MAX_MSG_IDS)
+
+/* Verify power of two */
+#if ((CFE_SBR_MSG_MAP_SIZE & (CFE_SBR_MSG_MAP_SIZE - 1)) != 0)
+#error CFE_SBR_MSG_MAP_SIZE must be a power of 2 for hash algorithm to work
+#endif
+
+/** \brief Hash algorithm magic number
+ *
+ * Ref:
+ * https://stackoverflow.com/questions/664014/what-integer-hash-function-are-good-that-accepts-an-integer-hash-key/12996028#12996028
+ */
+#define CFE_SBR_HASH_MAGIC (0x45d9f3b)
+
+/******************************************************************************
+ * Shared data
+ */
+
+/** \brief Message map shared data */
+CFE_SBR_RouteId_t CFE_SBR_MSGMAP[CFE_SBR_MSG_MAP_SIZE];
+
+/******************************************************************************
+ * Internal helper function to hash the message id
+ *
+ * Note: algorithm designed for a 32 bit int, changing the size of
+ * CFE_SB_MsgId_Atom_t may require an update to this impelementation
+ */
+CFE_SB_MsgId_Atom_t CFE_SBR_MsgIdHash(CFE_SB_MsgId_t MsgId)
+{
+    CFE_SB_MsgId_Atom_t hash;
+
+    hash = CFE_SB_MsgIdToValue(MsgId);
+
+    hash = ((hash >> 16) ^ hash) * CFE_SBR_HASH_MAGIC;
+    hash = ((hash >> 16) ^ hash) * CFE_SBR_HASH_MAGIC;
+    hash = (hash >> 16) ^ hash;
+
+    /* Reduce to fit in map */
+    hash &= CFE_SBR_MSG_MAP_SIZE - 1;
+
+    return hash;
+}
+
+/******************************************************************************
+ *  Interface function - see header for description
+ */
+void CFE_SBR_Init_Map(void)
+{
+    /* Clear the shared data */
+    memset(&CFE_SBR_MSGMAP, 0, sizeof(CFE_SBR_MSGMAP));
+}
+
+/******************************************************************************
+ *  Interface function - see header for description
+ */
+uint32 CFE_SBR_SetRouteId(CFE_SB_MsgId_t MsgId, CFE_SBR_RouteId_t RouteId)
+{
+    CFE_SB_MsgId_Atom_t hash;
+    uint32              collisions = 0;
+
+    if (CFE_SB_IsValidMsgId(MsgId))
+    {
+        hash = CFE_SBR_MsgIdHash(MsgId);
+
+        /*
+         * Increment from original hash to find the next open slot.
+         * Since map is larger than possible routes this will
+         * never deadlock
+         */
+        while (CFE_SBR_IsValidRouteId(CFE_SBR_MSGMAP[hash]))
+        {
+            /* Increment or loop to start of array */
+            hash = (hash + 1) & (CFE_SBR_MSG_MAP_SIZE - 1);
+            collisions++;
+        }
+
+        CFE_SBR_MSGMAP[hash] = RouteId;
+    }
+
+    return collisions;
+}
+
+/******************************************************************************
+ *  Interface function - see API for description
+ */
+CFE_SBR_RouteId_t CFE_SBR_GetRouteId(CFE_SB_MsgId_t MsgId)
+{
+    CFE_SB_MsgId_Atom_t hash;
+    CFE_SBR_RouteId_t   routeid = CFE_SBR_INVALID_ROUTE_ID;
+
+    if (CFE_SB_IsValidMsgId(MsgId))
+    {
+        hash    = CFE_SBR_MsgIdHash(MsgId);
+        routeid = CFE_SBR_MSGMAP[hash];
+
+        /*
+         * Increment from original hash to find matching route.
+         * Since map is larger than possible routes this will
+         * never deadlock
+         */
+        while (CFE_SBR_IsValidRouteId(routeid) && !CFE_SB_MsgId_Equal(CFE_SBR_GetMsgId(routeid), MsgId))
+        {
+            /* Increment or loop to start of array */
+            hash    = (hash + 1) & (CFE_SBR_MSG_MAP_SIZE - 1);
+            routeid = CFE_SBR_MSGMAP[hash];
+        }
+    }
+
+    return routeid;
+}

--- a/modules/sbr/src/cfe_sbr_route_unsorted.c
+++ b/modules/sbr/src/cfe_sbr_route_unsorted.c
@@ -1,0 +1,219 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/******************************************************************************
+ * Purpose:
+ *   Unsorted routing implemenation
+ *   Used with route map implementations where order of routes doesn't matter
+ *
+ * Notes:
+ *   These functions manipulate/access global variables and need
+ *   to be protected by the SB Shared data lock.
+ */
+
+/*
+ * Include Files
+ */
+
+#include "common_types.h"
+#include "private/cfe_sbr.h"
+#include "cfe_sbr_priv.h"
+#include <string.h>
+
+/******************************************************************************
+ * Type Definitions
+ */
+
+/** \brief Routing table entry */
+typedef struct
+{
+    CFE_SB_DestinationD_t * ListHeadPtr; /**< \brief Destination list head */
+    CFE_SB_MsgId_t          MsgId;       /**< \brief Message ID associated with route */
+    CFE_MSG_SequenceCount_t SeqCnt;      /**< \brief Message sequence counter */
+} CFE_SBR_RouteEntry_t;
+
+/** \brief Module data */
+typedef struct
+{
+    CFE_SBR_RouteEntry_t  RoutingTbl[CFE_PLATFORM_SB_MAX_MSG_IDS]; /**< \brief Routing table */
+    CFE_SB_RouteId_Atom_t RouteIdxTop;                             /**< \brief First unused entry in RoutingTbl */
+} cfe_sbr_route_data_t;
+
+/******************************************************************************
+ * Shared data
+ */
+
+/** \brief Routing module shared data */
+cfe_sbr_route_data_t CFE_SBR_RDATA;
+
+/******************************************************************************
+ *  Interface function - see API for description
+ */
+void CFE_SBR_Init(void)
+{
+    CFE_SB_RouteId_Atom_t routeidx;
+
+    /* Clear the shared data */
+    memset(&CFE_SBR_RDATA, 0, sizeof(CFE_SBR_RDATA));
+
+    /* Only non-zero value for shared data initialization is the invalid MsgId */
+    for (routeidx = 0; routeidx < CFE_PLATFORM_SB_MAX_MSG_IDS; routeidx++)
+    {
+        CFE_SBR_RDATA.RoutingTbl[routeidx].MsgId = CFE_SB_INVALID_MSG_ID;
+    }
+
+    /* Initialize map */
+    CFE_SBR_Init_Map();
+}
+
+/******************************************************************************
+ *  Interface function - see API for description
+ */
+CFE_SBR_RouteId_t CFE_SBR_AddRoute(CFE_SB_MsgId_t MsgId, uint32 *CollisionsPtr)
+{
+    CFE_SBR_RouteId_t routeid    = CFE_SBR_INVALID_ROUTE_ID;
+    uint32            collisions = 0;
+
+    if (CFE_SB_IsValidMsgId(MsgId) && (CFE_SBR_RDATA.RouteIdxTop < CFE_PLATFORM_SB_MAX_MSG_IDS))
+    {
+        routeid    = CFE_SBR_ValueToRouteId(CFE_SBR_RDATA.RouteIdxTop);
+        collisions = CFE_SBR_SetRouteId(MsgId, routeid);
+
+        CFE_SBR_RDATA.RoutingTbl[CFE_SBR_RDATA.RouteIdxTop].MsgId = MsgId;
+        CFE_SBR_RDATA.RouteIdxTop++;
+    }
+
+    if (CollisionsPtr != NULL)
+    {
+        *CollisionsPtr = collisions;
+    }
+
+    return routeid;
+}
+
+/******************************************************************************
+ *  Interface function - see API for description
+ */
+CFE_SB_MsgId_t CFE_SBR_GetMsgId(CFE_SBR_RouteId_t RouteId)
+{
+    CFE_SB_MsgId_t msgid = CFE_SB_INVALID_MSG_ID;
+
+    if (CFE_SBR_IsValidRouteId(RouteId))
+    {
+        msgid = CFE_SBR_RDATA.RoutingTbl[CFE_SBR_RouteIdToValue(RouteId)].MsgId;
+    }
+
+    return msgid;
+}
+
+/******************************************************************************
+ *  Interface function - see API for description
+ */
+CFE_SB_DestinationD_t *CFE_SBR_GetDestListHeadPtr(CFE_SBR_RouteId_t RouteId)
+{
+
+    CFE_SB_DestinationD_t *destptr = NULL;
+
+    if (CFE_SBR_IsValidRouteId(RouteId))
+    {
+        destptr = CFE_SBR_RDATA.RoutingTbl[CFE_SBR_RouteIdToValue(RouteId)].ListHeadPtr;
+    }
+
+    return destptr;
+}
+
+/******************************************************************************
+ *  Interface function - see API for description
+ */
+void CFE_SBR_SetDestListHeadPtr(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *DestPtr)
+{
+
+    if (CFE_SBR_IsValidRouteId(RouteId))
+    {
+        CFE_SBR_RDATA.RoutingTbl[CFE_SBR_RouteIdToValue(RouteId)].ListHeadPtr = DestPtr;
+    }
+}
+
+/******************************************************************************
+ *  Interface function - see API for description
+ */
+void CFE_SBR_IncrementSequenceCounter(CFE_SBR_RouteId_t RouteId)
+{
+    if (CFE_SBR_IsValidRouteId(RouteId))
+    {
+        CFE_SBR_RDATA.RoutingTbl[CFE_SBR_RouteIdToValue(RouteId)].SeqCnt++;
+    }
+}
+
+/******************************************************************************
+ *  Interface function - see API for description
+ */
+CFE_MSG_SequenceCount_t CFE_SBR_GetSequenceCounter(CFE_SBR_RouteId_t RouteId)
+{
+    uint32 seqcnt = 0;
+
+    if (CFE_SBR_IsValidRouteId(RouteId))
+    {
+        seqcnt = CFE_SBR_RDATA.RoutingTbl[CFE_SBR_RouteIdToValue(RouteId)].SeqCnt;
+    }
+
+    return seqcnt;
+}
+
+/******************************************************************************
+ * Local helper function for throttling foreach routines
+ *
+ * Updates StartIdxPtr, EndIdxPtr and ThrottlePtr.NextIndex.  Note EndIdxPtr
+ * must be set to maximum prior to calling.
+ */
+void CFE_SBR_Throttle(uint32 *StartIdxPtr, uint32 *EndIdxPtr, CFE_SBR_Throttle_t *ThrottlePtr)
+{
+    if (ThrottlePtr != NULL)
+    {
+        *StartIdxPtr = ThrottlePtr->StartIndex;
+
+        /* Return next index of zero if full range is processed */
+        ThrottlePtr->NextIndex = 0;
+
+        if ((*StartIdxPtr + ThrottlePtr->MaxLoop) < *EndIdxPtr)
+        {
+            *EndIdxPtr             = *StartIdxPtr + ThrottlePtr->MaxLoop;
+            ThrottlePtr->NextIndex = *EndIdxPtr;
+        }
+    }
+}
+
+/******************************************************************************
+ *  Interface function - see API for description
+ */
+void CFE_SBR_ForEachRouteId(CFE_SBR_CallbackPtr_t CallbackPtr, void *ArgPtr, CFE_SBR_Throttle_t *ThrottlePtr)
+{
+    CFE_SB_RouteId_Atom_t routeidx;
+    CFE_SB_MsgId_Atom_t   startidx = 0;
+    CFE_SB_MsgId_Atom_t   endidx   = CFE_SBR_RDATA.RouteIdxTop;
+
+    /* Update throttle settings if needed */
+    CFE_SBR_Throttle(&startidx, &endidx, ThrottlePtr);
+
+    for (routeidx = startidx; routeidx < endidx; routeidx++)
+    {
+        (*CallbackPtr)(CFE_SBR_ValueToRouteId(routeidx), ArgPtr);
+    }
+}

--- a/modules/sbr/unit-test-coverage/CMakeLists.txt
+++ b/modules/sbr/unit-test-coverage/CMakeLists.txt
@@ -1,0 +1,59 @@
+##################################################################
+#
+# cFE unit test build recipe
+#
+# This CMake file contains the recipe for building the cFE unit tests.
+# It is invoked from the parent directory when unit tests are enabled.
+#
+##################################################################
+
+# Set tests once so name changes are in one location
+set(SBR_TEST_MAP_DIRECT "sbr_map_direct")
+set(SBR_TEST_MAP_HASH "sbr_map_hash")
+set(SBR_TEST_ROUTE_UNSORTED "sbr_route_unsorted")
+
+# All coverage tests always built
+set(SBR_TEST_SET ${SBR_TEST_MAP_DIRECT} ${SBR_TEST_MAP_HASH} ${SBR_TEST_ROUTE_UNSORTED})
+
+# Add configured map implementation to routing test source
+if (MISSION_MSGMAP_IMPLEMENTATION STREQUAL "DIRECT")
+    set(${SBR_TEST_ROUTE_UNSORTED}_SRC ../src/cfe_sbr_map_direct.c)
+elseif (MISSION_MSGMAP_IMPLEMENTATION STREQUAL "HASH")
+    set(${SBR_TEST_ROUTE_UNSORTED}_SRC ../src/cfe_sbr_map_hash.c)
+endif()
+
+# Add route implementation to map hash
+set(${SBR_TEST_MAP_HASH}_SRC ../src/cfe_sbr_route_unsorted.c)
+
+foreach(SBR_TEST ${SBR_TEST_SET})
+
+    # Unit test object library sources, options, and includes
+    add_library(ut_${SBR_TEST}_objs OBJECT ${${SBR_TEST}_SRC} ../src/cfe_${SBR_TEST}.c)
+    target_compile_options(ut_${SBR_TEST}_objs PRIVATE ${UT_COVERAGE_COMPILE_FLAGS})
+    target_include_directories(ut_${SBR_TEST}_objs PRIVATE
+         $<TARGET_PROPERTY:${DEP},INCLUDE_DIRECTORIES>)
+
+    set (ut_${SBR_TEST}_tests
+        test_cfe_${SBR_TEST}.c
+        $<TARGET_OBJECTS:ut_${SBR_TEST}_objs>)
+
+    # Add executable
+    add_executable(${SBR_TEST}_UT ${ut_${SBR_TEST}_tests})
+
+    # Add include to get private defaults
+    target_include_directories(${SBR_TEST}_UT PRIVATE ../private_inc)
+
+    # Also add the UT_COVERAGE_LINK_FLAGS to the link command    
+    # This should enable coverage analysis on platforms that support this
+    target_link_libraries(${SBR_TEST}_UT
+        ${UT_COVERAGE_LINK_FLAGS}
+        ut_cfe-core_support
+        ut_cfe-core_stubs
+        ut_assert)
+
+    add_test(${SBR_TEST}_UT ${SBR_TEST}_UT)
+    foreach(TGT ${INSTALL_TARGET_LIST})
+        install(TARGETS ${SBR_TEST}_UT DESTINATION ${TGT}/${UT_INSTALL_SUBDIR})
+    endforeach()
+
+endforeach(SBR_TEST ${SBR_TEST_SET})

--- a/modules/sbr/unit-test-coverage/test_cfe_sbr_map_direct.c
+++ b/modules/sbr/unit-test-coverage/test_cfe_sbr_map_direct.c
@@ -1,0 +1,112 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/*
+ * Test SBR direct message map implementation
+ */
+
+/*
+ * Includes
+ */
+#include "utassert.h"
+#include "ut_support.h"
+#include "private/cfe_sbr.h"
+#include "cfe_sbr_priv.h"
+#include <stdlib.h>
+
+void Test_SBR_Map_Direct(void)
+{
+
+    CFE_SB_MsgId_Atom_t msgidx;
+    CFE_SBR_RouteId_t   routeid;
+    CFE_SB_MsgId_t      msgid;
+    uint32              count;
+    uint32              i;
+
+    UtPrintf("Invalid msg checks");
+    ASSERT_EQ(CFE_SBR_SetRouteId(CFE_SB_ValueToMsgId(0), CFE_SBR_ValueToRouteId(0)), 0);
+    ASSERT_EQ(CFE_SBR_IsValidRouteId(CFE_SBR_GetRouteId(CFE_SB_ValueToMsgId(0))), false);
+
+    UtPrintf("Initialize map");
+    CFE_SBR_Init_Map();
+
+    /* Force valid msgid responses */
+    UT_SetForceFail(UT_KEY(CFE_SB_IsValidMsgId), true);
+
+    UtPrintf("Check that all entries are set invalid");
+    count = 0;
+    for (msgidx = 0; msgidx <= CFE_PLATFORM_SB_HIGHEST_VALID_MSGID; msgidx++)
+    {
+        if (!CFE_SBR_IsValidRouteId(CFE_SBR_GetRouteId(CFE_SB_ValueToMsgId(msgidx))))
+        {
+            count++;
+        }
+    }
+    ASSERT_EQ(count, CFE_PLATFORM_SB_HIGHEST_VALID_MSGID + 1);
+
+    UtPrintf("Set/Get a range of ids ");
+    routeid = CFE_SBR_ValueToRouteId(CFE_PLATFORM_SB_MAX_MSG_IDS + 1);
+    msgid   = CFE_SB_ValueToMsgId(0);
+    ASSERT_EQ(CFE_SBR_SetRouteId(msgid, routeid), 0);
+    ASSERT_EQ(CFE_SBR_GetRouteId(msgid).RouteId, routeid.RouteId);
+
+    routeid = CFE_SBR_ValueToRouteId(0);
+    msgid   = CFE_SB_ValueToMsgId(CFE_PLATFORM_SB_HIGHEST_VALID_MSGID);
+    ASSERT_EQ(CFE_SBR_SetRouteId(msgid, routeid), 0);
+    ASSERT_EQ(CFE_SBR_GetRouteId(msgid).RouteId, routeid.RouteId);
+
+    UtPrintf("Check there is now 1 valid entry in map");
+    count = 0;
+    for (msgidx = 0; msgidx <= CFE_PLATFORM_SB_HIGHEST_VALID_MSGID; msgidx++)
+    {
+        if (!CFE_SBR_IsValidRouteId(CFE_SBR_GetRouteId(CFE_SB_ValueToMsgId(msgidx))))
+        {
+            count++;
+        }
+    }
+    ASSERT_EQ(count, CFE_PLATFORM_SB_HIGHEST_VALID_MSGID);
+
+    UtPrintf("Set back to invalid and check again");
+    routeid = CFE_SBR_INVALID_ROUTE_ID;
+    ASSERT_EQ(CFE_SBR_SetRouteId(msgid, routeid), 0);
+    ASSERT_EQ(CFE_SBR_GetRouteId(msgid).RouteId, routeid.RouteId);
+    ASSERT_EQ(CFE_SBR_IsValidRouteId(CFE_SBR_GetRouteId(msgid)), false);
+
+    /* Performance check, 0xFFFFFF on 3.2GHz linux box is around 8-9 seconds */
+    count = 0;
+    for (i = 0; i <= 0xFFFF; i++)
+    {
+        msgidx = rand() % CFE_PLATFORM_SB_HIGHEST_VALID_MSGID;
+        if (CFE_SBR_IsValidRouteId(CFE_SBR_GetRouteId(CFE_SB_ValueToMsgId(msgidx))))
+        {
+            count++;
+        }
+    }
+    UtPrintf("Valid route id's encountered in performance loop: %u", count);
+}
+
+/* Main unit test routine */
+void UtTest_Setup(void)
+{
+    UT_Init("map_direct");
+    UtPrintf("Software Bus Routing direct map coverage test...");
+
+    UT_ADD_TEST(Test_SBR_Map_Direct);
+}

--- a/modules/sbr/unit-test-coverage/test_cfe_sbr_map_hash.c
+++ b/modules/sbr/unit-test-coverage/test_cfe_sbr_map_hash.c
@@ -1,0 +1,118 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/*
+ * Test SBR direct message map implementation
+ */
+
+/*
+ * Includes
+ */
+#include "utassert.h"
+#include "ut_support.h"
+#include "private/cfe_sbr.h"
+#include "cfe_sbr_priv.h"
+
+/*
+ * Defines
+ */
+
+/* Unhash magic number */
+#define CFE_SBR_UNHASH_MAGIC (0x119de1f3)
+
+/******************************************************************************
+ * Local helper to unhash
+ */
+CFE_SB_MsgId_t Test_SBR_Unhash(CFE_SB_MsgId_Atom_t Hash)
+{
+
+    Hash = ((Hash >> 16) ^ Hash) * CFE_SBR_UNHASH_MAGIC;
+    Hash = ((Hash >> 16) ^ Hash) * CFE_SBR_UNHASH_MAGIC;
+    Hash = (Hash >> 16) ^ Hash;
+
+    return CFE_SB_ValueToMsgId(Hash);
+}
+
+void Test_SBR_Map_Hash(void)
+{
+
+    CFE_SB_MsgId_Atom_t msgidx;
+    CFE_SBR_RouteId_t   routeid[3];
+    CFE_SB_MsgId_t      msgid[3];
+    uint32              count;
+    uint32              collisions;
+
+    UtPrintf("Invalid msg checks");
+    ASSERT_EQ(CFE_SBR_SetRouteId(CFE_SB_ValueToMsgId(0), CFE_SBR_ValueToRouteId(0)), 0);
+    ASSERT_EQ(CFE_SBR_IsValidRouteId(CFE_SBR_GetRouteId(CFE_SB_ValueToMsgId(0))), false);
+
+    UtPrintf("Initialize routing and map");
+    CFE_SBR_Init();
+
+    /* Force valid msgid responses */
+    UT_SetForceFail(UT_KEY(CFE_SB_IsValidMsgId), true);
+
+    UtPrintf("Check that all entries are set invalid");
+    count = 0;
+    for (msgidx = 0; msgidx <= CFE_PLATFORM_SB_HIGHEST_VALID_MSGID; msgidx++)
+    {
+        if (!CFE_SBR_IsValidRouteId(CFE_SBR_GetRouteId(CFE_SB_ValueToMsgId(msgidx))))
+        {
+            count++;
+        }
+    }
+    ASSERT_EQ(count, CFE_PLATFORM_SB_HIGHEST_VALID_MSGID + 1);
+
+    /* Note AddRoute required for hash logic to work since it depends on MsgId in routing table */
+    UtPrintf("Add routes and check with a rollover and a skip");
+    msgid[0]   = CFE_SB_ValueToMsgId(0);
+    msgid[1]   = Test_SBR_Unhash(0xFFFFFFFF);
+    msgid[2]   = Test_SBR_Unhash(0x7FFFFFFF);
+    routeid[0] = CFE_SBR_AddRoute(msgid[0], &collisions);
+    ASSERT_EQ(collisions, 0);
+    routeid[1] = CFE_SBR_AddRoute(msgid[1], &collisions);
+    ASSERT_EQ(collisions, 0);
+    routeid[2] = CFE_SBR_AddRoute(msgid[2], &collisions);
+    ASSERT_EQ(collisions, 2);
+
+    ASSERT_EQ(CFE_SBR_RouteIdToValue(CFE_SBR_GetRouteId(msgid[0])), CFE_SBR_RouteIdToValue(routeid[0]));
+    ASSERT_EQ(CFE_SBR_RouteIdToValue(CFE_SBR_GetRouteId(msgid[1])), CFE_SBR_RouteIdToValue(routeid[1]));
+    ASSERT_EQ(CFE_SBR_RouteIdToValue(CFE_SBR_GetRouteId(msgid[2])), CFE_SBR_RouteIdToValue(routeid[2]));
+
+    /* Performance check, 0xFFFFFF on 3.2GHz linux box is around 8-9 seconds */
+    count = 0;
+    for (msgidx = 0; msgidx <= 0xFFFF; msgidx++)
+    {
+        if (CFE_SBR_IsValidRouteId(CFE_SBR_GetRouteId(CFE_SB_ValueToMsgId(msgidx))))
+        {
+            count++;
+        }
+    }
+    UtPrintf("Valid route id's encountered in performance loop: %u", count);
+}
+
+/* Main unit test routine */
+void UtTest_Setup(void)
+{
+    UT_Init("map_hash");
+    UtPrintf("Software Bus Routing hash map coverage test...");
+
+    UT_ADD_TEST(Test_SBR_Map_Hash);
+}

--- a/modules/sbr/unit-test-coverage/test_cfe_sbr_route_unsorted.c
+++ b/modules/sbr/unit-test-coverage/test_cfe_sbr_route_unsorted.c
@@ -1,0 +1,198 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/*
+ * Test SBR unsorted route implementation
+ */
+
+/*
+ * Includes
+ */
+#include "utassert.h"
+#include "ut_support.h"
+#include "private/cfe_sbr.h"
+#include "cfe_sbr_priv.h"
+
+/* Callback function for testing */
+void Test_SBR_Callback(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
+{
+    uint32 *count = ArgPtr;
+
+    (*count)++;
+}
+
+void Test_SBR_Route_Unsort_General(void)
+{
+
+    CFE_SBR_RouteId_t  routeid;
+    CFE_SB_MsgId_t     msgid;
+    uint32             collisions;
+    uint32             count;
+    CFE_SBR_Throttle_t throttle;
+
+    UtPrintf("Initialize map and route");
+    CFE_SBR_Init();
+
+    UtPrintf("Invalid msg checks");
+    ASSERT_TRUE(!CFE_SBR_IsValidRouteId(CFE_SBR_AddRoute(CFE_SB_ValueToMsgId(0), NULL)));
+    ASSERT_TRUE(!CFE_SBR_IsValidRouteId(CFE_SBR_AddRoute(CFE_SB_ValueToMsgId(0), &collisions)));
+    ASSERT_EQ(collisions, 0);
+
+    /*
+     * Force valid msgid responses
+     * Note from here on msgids must be in the valid range since validation is forced true
+     * and if the underlying map implentation is direct it needs to be a valid array index
+     */
+    UT_SetForceFail(UT_KEY(CFE_SB_IsValidMsgId), true);
+
+    UtPrintf("Callback test with no routes");
+    count = 0;
+    CFE_SBR_ForEachRouteId(Test_SBR_Callback, &count, NULL);
+    ASSERT_EQ(count, 0);
+
+    UtPrintf("Add maximum mesage id value");
+    msgid   = CFE_SB_ValueToMsgId(CFE_PLATFORM_SB_HIGHEST_VALID_MSGID);
+    routeid = CFE_SBR_AddRoute(msgid, &collisions);
+    ASSERT_EQ(collisions, 0);
+    ASSERT_TRUE(CFE_SBR_IsValidRouteId(routeid));
+
+    UtPrintf("Callback test with one route");
+    count = 0;
+    CFE_SBR_ForEachRouteId(Test_SBR_Callback, &count, NULL);
+    ASSERT_EQ(count, 1);
+
+    UtPrintf("Fill routing table");
+    count = 0;
+    while (CFE_SBR_IsValidRouteId(CFE_SBR_AddRoute(CFE_SB_ValueToMsgId(count), NULL)))
+    {
+        count++;
+    }
+
+    /* Check for expected count indicating full routing table */
+    ASSERT_EQ(count + 1, CFE_PLATFORM_SB_MAX_MSG_IDS);
+
+    /* Try one more for good luck */
+    ASSERT_TRUE(!CFE_SBR_IsValidRouteId(CFE_SBR_AddRoute(CFE_SB_ValueToMsgId(count), NULL)));
+
+    /* Check that maximum msgid is still in the table */
+    ASSERT_EQ(CFE_SB_MsgIdToValue(CFE_SBR_GetMsgId(routeid)), CFE_PLATFORM_SB_HIGHEST_VALID_MSGID);
+    ASSERT_EQ(CFE_SBR_GetRouteId(msgid).RouteId, routeid.RouteId);
+
+    UtPrintf("Callback test with full route");
+    count = 0;
+    CFE_SBR_ForEachRouteId(Test_SBR_Callback, &count, NULL);
+    ASSERT_EQ(count, CFE_PLATFORM_SB_MAX_MSG_IDS);
+
+    UtPrintf("Callback test throttled");
+    throttle.MaxLoop    = CFE_PLATFORM_SB_MAX_MSG_IDS - 1;
+    throttle.StartIndex = 0;
+    count               = 0;
+    CFE_SBR_ForEachRouteId(Test_SBR_Callback, &count, &throttle);
+    ASSERT_EQ(count, CFE_PLATFORM_SB_MAX_MSG_IDS - 1);
+    count               = 0;
+    throttle.StartIndex = throttle.NextIndex;
+    CFE_SBR_ForEachRouteId(Test_SBR_Callback, &count, &throttle);
+    ASSERT_EQ(count, 1);
+}
+
+void Test_SBR_Route_Unsort_GetSet(void)
+{
+
+    CFE_SB_RouteId_Atom_t routeidx;
+    CFE_SB_MsgId_t        msgid[3];
+    CFE_SBR_RouteId_t     routeid[3];
+    CFE_SB_DestinationD_t dest[2];
+    uint32                count;
+    uint32                i;
+
+    UtPrintf("Invalid route ID checks");
+    routeid[0] = CFE_SBR_INVALID_ROUTE_ID;
+    routeid[1] = CFE_SBR_ValueToRouteId(CFE_PLATFORM_SB_MAX_MSG_IDS);
+    for (i = 0; i < 2; i++)
+    {
+        ASSERT_TRUE(CFE_SB_MsgId_Equal(CFE_SBR_GetMsgId(routeid[i]), CFE_SB_INVALID_MSG_ID));
+        UtAssert_ADDRESS_EQ(CFE_SBR_GetDestListHeadPtr(routeid[i]), NULL);
+        ASSERT_EQ(CFE_SBR_GetSequenceCounter(routeid[i]), 0);
+    }
+
+    /*
+     * Force valid msgid responses
+     * Note from here on msgids must be in the valid range since validation is forced true
+     * and if the underlying map implentation is direct it needs to be a valid array index
+     */
+    UT_SetForceFail(UT_KEY(CFE_SB_IsValidMsgId), true);
+
+    UtPrintf("Initialize map and route");
+    CFE_SBR_Init();
+
+    UtPrintf("Confirm values initialized for all routes");
+    count = 0;
+    for (routeidx = 0; routeidx < CFE_PLATFORM_SB_MAX_MSG_IDS; routeidx++)
+    {
+        routeid[0] = CFE_SBR_ValueToRouteId(routeidx);
+        if (!CFE_SB_MsgId_Equal(CFE_SBR_GetMsgId(routeid[0]), CFE_SB_INVALID_MSG_ID) ||
+            (CFE_SBR_GetDestListHeadPtr(routeid[0]) != NULL) || (CFE_SBR_GetSequenceCounter(routeid[0]) != 0))
+        {
+            count++;
+        }
+    }
+    ASSERT_EQ(count, 0);
+
+    UtPrintf("Add routes and initialize values for testing");
+    msgid[0] = CFE_SB_ValueToMsgId(0);
+    msgid[1] = CFE_SB_ValueToMsgId(1);
+    msgid[2] = CFE_SB_ValueToMsgId(CFE_PLATFORM_SB_HIGHEST_VALID_MSGID);
+
+    /* Add routes */
+    for (i = 0; i < 3; i++)
+    {
+        routeid[i] = CFE_SBR_AddRoute(msgid[i], NULL);
+    }
+
+    /* Check the msgid matches and increment a sequence counter */
+    for (i = 0; i < 3; i++)
+    {
+        ASSERT_TRUE(CFE_SB_MsgId_Equal(msgid[i], CFE_SBR_GetMsgId(routeid[i])));
+        CFE_SBR_IncrementSequenceCounter(routeid[0]);
+    }
+
+    /* Increment route 1 once and set dest pointers */
+    CFE_SBR_IncrementSequenceCounter(routeid[1]);
+    CFE_SBR_SetDestListHeadPtr(routeid[1], &dest[1]);
+    CFE_SBR_SetDestListHeadPtr(routeid[2], &dest[0]);
+
+    UtPrintf("Verify remaining set values");
+    ASSERT_EQ(CFE_SBR_GetSequenceCounter(routeid[0]), 3);
+    ASSERT_EQ(CFE_SBR_GetSequenceCounter(routeid[1]), 1);
+    ASSERT_EQ(CFE_SBR_GetSequenceCounter(routeid[2]), 0);
+    UtAssert_ADDRESS_EQ(CFE_SBR_GetDestListHeadPtr(routeid[0]), NULL);
+    UtAssert_ADDRESS_EQ(CFE_SBR_GetDestListHeadPtr(routeid[1]), &dest[1]);
+    UtAssert_ADDRESS_EQ(CFE_SBR_GetDestListHeadPtr(routeid[2]), &dest[0]);
+}
+
+/* Main unit test routine */
+void UtTest_Setup(void)
+{
+    UT_Init("route_unsort");
+    UtPrintf("Software Bus Routing unsorted coverage test...");
+
+    UT_ADD_TEST(Test_SBR_Route_Unsort_General);
+    UT_ADD_TEST(Test_SBR_Route_Unsort_GetSet);
+}


### PR DESCRIPTION
**Describe the contribution**
Fix #928 - refactor SB and move routing to a module
Fix #929 - adds message map hash implementation
Partial #948 - fixed double lock potential

Key concepts:
 - added SBR module
 - Message map and routing table are in SBR, access APIs on SB side
 - SB still owns destination logic
 - no more route index or pointers being passed around, all route id and message id based
 - hash message map "oversized" (4x) to minimize collisions (only ~10% single collisions on the real system with a full routing table)
    - added debug event for collisions during add
 - dropped routing push/pop, dropped "key" in direct implementation
 - around a 10-20% performance hit to hash via rough comparison on a linux box, no memory impact from message id "space", just based on needed routes (with overhead)
 - hash designed for 32 bit, a change in CFE_SB_MsgId_Atom_t size may require implementation updates

Remaining work:
- Unit test stubs (could split into new PR), 2 related TODOs in code

Also 
- Deletes unused code CFE_SB_FindGlobalMsgIdCnt
- Note writes to file not protected by lock (before or after refactor)
- CFE_SB_SendPrevSubs isn't really protected by the lock... might be worth removing the locks completely (they don't really solve anything, double lock potential eliminated
  - could just use the private CFE_SBR_ForEachRouteId without a lock instead of messages and reduce all the extra logic
- Whitespace/alignment is very difficult to work with
- Excessive comments (in my opinion)
- violates declare variables at the start of function coding standard, all observed violations fixed

**Testing performed**
 - All unit tests pass, rough performance testing, spot checked routing table size impacts on core with nominal (256), 64, and 32.  32 causes dropped subscriptions/full table and was useful for observing collisions (~10% one level seen) on a realistic set of message ids.  Everything performed as expected. 
- Passed bundle CI at https://travis-ci.com/github/skliper/cFS/builds/191437587

**Expected behavior changes**
- Individual events for deleting destinations when deleting a pipe removed to avoid a race condition
- It's resource intensive to try to report message ID map in message ID order (either search or brute force) for any significantly sized map on an unsorted routing table, allowing out of order makes this reasonable again and gets rid of the need for ForEachMsgId API. Need to trade out of order vs implementing a search.

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: bundle + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC