### PR TITLE
Fix #967, Update startup script names

### DIFF
--- a/cmake/sample_defs/cpu1_cfe_es_startup.scr
+++ b/cmake/sample_defs/cpu1_cfe_es_startup.scr
@@ -1,5 +1,5 @@
-CFE_LIB, /cf/sample_lib.so,  SAMPLE_LibInit,  SAMPLE_LIB,    0,   0,     0x0, 0;
-CFE_APP, /cf/sample_app.so,  SAMPLE_AppMain,  SAMPLE_APP,   50,   16384, 0x0, 0;
+CFE_LIB, /cf/sample_lib.so,  SAMPLE_LIB_Init, SAMPLE_LIB,    0,   0,     0x0, 0;
+CFE_APP, /cf/sample_app.so,  SAMPLE_APP_Main, SAMPLE_APP,   50,   16384, 0x0, 0;
 CFE_APP, /cf/ci_lab.so,      CI_Lab_AppMain,  CI_LAB_APP,   60,   16384, 0x0, 0;
 CFE_APP, /cf/to_lab.so,      TO_Lab_AppMain,  TO_LAB_APP,   70,   16384, 0x0, 0;
 CFE_APP, /cf/sch_lab.so,     SCH_Lab_AppMain, SCH_LAB_APP,  80,   16384, 0x0, 0;


### PR DESCRIPTION
**Describe the contribution**

Startup script reflects names fixed in SAMPLE_APP and SAMPLE_LIB.

Fixes #967.

**Testing performed**
Boot CFE and verify startup works correctly with new names.

**Expected behavior changes**
N/A.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Need this at the same time as nasa/sample_app#100 and nasa/sample_lib#34.  Must be merged in same cycle as the those two.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
