### PR TITLE
Fix #976, short background task name

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_backgroundtask.c
+++ b/fsw/cfe-core/src/es/cfe_es_backgroundtask.c
@@ -41,8 +41,8 @@
 #include "cfe_es_global.h"
 #include "cfe_es_task.h"
 
-#define CFE_ES_BACKGROUND_SEM_NAME             "ES_BackgroundSem"
-#define CFE_ES_BACKGROUND_CHILD_NAME           "ES_BackgroundTask"
+#define CFE_ES_BACKGROUND_SEM_NAME             "ES_BG_SEM"
+#define CFE_ES_BACKGROUND_CHILD_NAME           "ES_BG_TASK"
 #define CFE_ES_BACKGROUND_CHILD_STACK_PTR      NULL
 #define CFE_ES_BACKGROUND_CHILD_STACK_SIZE     CFE_PLATFORM_ES_PERF_CHILD_STACK_SIZE
 #define CFE_ES_BACKGROUND_CHILD_PRIORITY       CFE_PLATFORM_ES_PERF_CHILD_PRIORITY


### PR DESCRIPTION
**Describe the contribution**
Keep names under 16 chars to make more debugger friendly, regardless
of the OSAL limit.

Fixes #976 

**Testing performed**
Run CFE in debugger

**Expected behavior changes**
Confirm task name shows up as "ES_BG_TASK"
No other impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.