### PR TITLE
Fix #973, CFE_MSG_Init clear option removed

### DIFF
--- a/fsw/cfe-core/src/inc/cfe_msg_api.h
+++ b/fsw/cfe-core/src/inc/cfe_msg_api.h
@@ -44,20 +44,19 @@
  * \brief Initialize a message
  *
  * \par Description
- *          This routine initialize a message.  If Clear is true the
- *          message is cleard and constant header defaults are set.
- *          The bits from MsgId and message size are always set.
+ *          This routine initialize a message.  The entire message is
+ *          set to zero (based on size), defaults are set, then the
+ *          size and bits from MsgId are set.
  *
  * \param[in, out]  MsgPtr      A pointer to the buffer that contains the message.
  * \param[in]       MsgId       MsgId that corresponds to message
  * \param[in]       Size        Total size of the mesage (used to set length field)
- * \param[in]       Clear       Boolean to clear and set defaults
  *
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
-CFE_Status_t CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_MSG_Size_t Size, bool Clear);
+CFE_Status_t CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_MSG_Size_t Size);
 
 /*****************************************************************************/
 /**

--- a/fsw/cfe-core/src/sb/cfe_sb_util.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_util.c
@@ -51,7 +51,7 @@ void CFE_SB_InitMsg(void           *MsgPtr,
                     bool        Clear )
 {
 
-   CFE_MSG_Init((CFE_MSG_Message_t *)MsgPtr, MsgId, Length, Clear);
+   CFE_MSG_Init((CFE_MSG_Message_t *)MsgPtr, MsgId, Length);
 
 } /* end CFE_SB_InitMsg */
 

--- a/fsw/cfe-core/ut-stubs/ut_msg_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_msg_stubs.c
@@ -414,12 +414,11 @@ int32 CFE_MSG_GetTypeFromMsgId(CFE_SB_MsgId_t MsgId, CFE_MSG_Type_t *Type)
  * Stub implementation of CFE_MSG_Init
  * -----------------------------------------------------------
  */
-int32 CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_MSG_Size_t Size, bool Clear)
+int32 CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_MSG_Size_t Size)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_MSG_Init), MsgPtr);
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_MSG_Init), MsgId);
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_MSG_Init), Size);
-    UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_MSG_Init), Clear);
 
     int32 status;
 

--- a/modules/msg/src/cfe_msg_init.c
+++ b/modules/msg/src/cfe_msg_init.c
@@ -29,7 +29,7 @@
 /******************************************************************************
  * Top level message initialization - See API and header file for details
  */
-int32 CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_MSG_Size_t Size, bool Clear)
+int32 CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_MSG_Size_t Size)
 {
 
     int32 status;
@@ -39,12 +39,9 @@ int32 CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_MSG_Size
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    /* Clear and set defaults if request */
-    if (Clear)
-    {
-        memset(MsgPtr, 0, Size);
-        CFE_MSG_InitDefaultHdr(MsgPtr);
-    }
+    /* Clear and set defaults */
+    memset(MsgPtr, 0, Size);
+    CFE_MSG_InitDefaultHdr(MsgPtr);
 
     /* Set values input */
     status = CFE_MSG_SetMsgId(MsgPtr, MsgId);


### PR DESCRIPTION
**Describe the contribution**
Fix #973 - removed the clear=false logic (and clear parameter)

**Testing performed**
Built and ran test cases with no extended header, extended header with msgid v1, and extended header with msgid v2.  All passed

**Expected behavior changes**
Always zeroes entire message and sets defaults.

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC