### PR TITLE
Fix #988, add casts on printf calls

### DIFF
--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -896,7 +896,7 @@ int32  CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
     {
         CFE_EVS_SendEventWithAppID(CFE_SB_HASHCOLLISION_EID, CFE_EVS_EventType_DEBUG, CFE_SB.AppId,
         "Msg hash collision: MsgId = 0x%x, collisions = %u",
-        (unsigned int)CFE_SB_MsgIdToValue(MsgId), Collisions);
+        (unsigned int)CFE_SB_MsgIdToValue(MsgId), (unsigned int)Collisions);
     }
 
     return CFE_SUCCESS;

--- a/modules/sbr/unit-test-coverage/test_cfe_sbr_map_direct.c
+++ b/modules/sbr/unit-test-coverage/test_cfe_sbr_map_direct.c
@@ -99,7 +99,7 @@ void Test_SBR_Map_Direct(void)
             count++;
         }
     }
-    UtPrintf("Valid route id's encountered in performance loop: %u", count);
+    UtPrintf("Valid route id's encountered in performance loop: %u", (unsigned int)count);
 }
 
 /* Main unit test routine */

--- a/modules/sbr/unit-test-coverage/test_cfe_sbr_map_hash.c
+++ b/modules/sbr/unit-test-coverage/test_cfe_sbr_map_hash.c
@@ -105,7 +105,7 @@ void Test_SBR_Map_Hash(void)
             count++;
         }
     }
-    UtPrintf("Valid route id's encountered in performance loop: %u", count);
+    UtPrintf("Valid route id's encountered in performance loop: %u", (unsigned int)count);
 }
 
 /* Main unit test routine */


### PR DESCRIPTION
**Describe the contribution**
Cast fixed width types to the type used in the printf call.

Fixes #988 

**Testing performed**
Build and sanity test on RTEMS target

**Expected behavior changes**
No warnings related to printf

**System(s) tested on**
Ubuntu 20.04 host for i686-rtems4.11 target

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
