### PR TITLE
Fix# 1009, Apply consistent alignment pattern

### DIFF
--- a/docs/src/cfe_api.dox
+++ b/docs/src/cfe_api.dox
@@ -133,16 +133,14 @@
     </UL>
     <LI> \ref CFEAPISBMessage
     <UL>
-      <LI> #CFE_SB_SendMsg - \copybrief CFE_SB_SendMsg
-      <LI> #CFE_SB_PassMsg - \copybrief CFE_SB_PassMsg
-      <LI> #CFE_SB_RcvMsg - \copybrief CFE_SB_RcvMsg
+      <LI> #CFE_SB_TransmitMsg - \copybrief CFE_SB_TransmitMsg
+      <LI> #CFE_SB_ReceiveBuffer - \copybrief CFE_SB_ReceiveBuffer
     </UL>
     <LI> \ref CFEAPISBZeroCopy
     <UL>
       <LI> #CFE_SB_ZeroCopyGetPtr - \copybrief CFE_SB_ZeroCopyGetPtr
       <LI> #CFE_SB_ZeroCopyReleasePtr - \copybrief CFE_SB_ZeroCopyReleasePtr
-      <LI> #CFE_SB_ZeroCopySend - \copybrief CFE_SB_ZeroCopySend
-      <LI> #CFE_SB_ZeroCopyPass - \copybrief CFE_SB_ZeroCopyPass
+      <LI> #CFE_SB_TransmitBuffer - \copybrief CFE_SB_TransmitBuffer
     </UL>
     <LI> \ref CFEAPISBSetMessage
     <UL>

--- a/docs/src/cfe_es.dox
+++ b/docs/src/cfe_es.dox
@@ -304,7 +304,7 @@
   the startup script. 
 
   The format of the Start Application command, is defined in the 
-  structure #CFE_ES_StartApp_t. The members of the structure 
+  structure #CFE_ES_StartAppCmd_t. The members of the structure
   include, application name, entry point, filename, stack size, 
   load address, exception action and priority.
 

--- a/docs/src/cfe_sb.dox
+++ b/docs/src/cfe_sb.dox
@@ -166,7 +166,7 @@
   buffer descriptor (CFE_SB_BufferD_t) and one for the size of the packet. Both buffers
   are returned to the pool when the message has been received by all recipients. More
   precisely, if there is one recipient for a message, the message buffers will be released
-  on the following call to cFE_SB_RcvMsg for the pipe that received the message.
+  on the following call to CFE_SB_ReceiveBuffer for the pipe that received the buffer.
 
   Also when subscriptions are received through the subscribe API's, the software bus
   allocates a subscription block (CFE_SB_DestinationD_t) from the pool. The subscription
@@ -292,20 +292,21 @@
 
   The sequence counter for command messages is not altered by the software bus.
 
-  For telemetry messages sent with the #CFE_SB_SendMsg API, the software bus populates the packet sequence
-  header field for all messages. The first time a telemetry message is sent with a new Message ID,
-  the sequence counter field in the header is set to a value of one. For subsequent
-  sends of a message, the sequence counter is incremented by one regardless of the number of
-  destinations for the packet. After a rollover condition the sequence counter will be a
-  value of zero for one instance. The sequence counter is incremented in the #CFE_SB_SendMsg
-  API after all the checks have passed prior to the actual sending of the message. This
-  includes the parameter checks and the memory allocation check.
-  Note: The count is incremented regardless of whether there are any subscribers.
+  For a telemetry message, the behavior is controlled via input parameters or API selection
+  when sending the command.  When enabled, the software bus will populate the packet sequence
+  counter using an internal counter that gets intialized upon the first subscription to the
+  message (first message will have a packet sequence counter value of 1).  From that point on
+  each send request will increment the counter by one, regardless of the number of destinations
+  or if there is an active subscription.
 
-  For telemetry messages sent with the #CFE_SB_PassMsg API the sequence counter is not incremented.
-  This method of message delivery is recommended for situations
-  where the sender did not generate the packet, such as a network interface application
-  passing a packet from a remote system to the local software bus.
+  After a rollover condition the sequence counter will be a value of zero for one instance.
+  The sequence counter is incremented after all the checks have passed prior to the actual
+  sending of the message. This includes the parameter checks and the memory allocation check.
+
+  When disabled, the original message will not be altered.  This method of message delivery
+  is recommended for situations where the sender did not generate the packet,
+  such as a network interface application passing a packet from a remote system to the local
+  software bus.
 
   Next: \ref cfesbugmsgpipeerr <BR>
   Prev: \ref cfesbugrouting <BR>
@@ -369,15 +370,14 @@
 
   There is one case in which events are filtered by the software bus instead of event services.
   This occurs when the software bus needs to suppress events so that a fatal recursive event
-  condition does not transpire. Because the #CFE_SB_SendMsg API is a library function that
-  calls #CFE_EVS_SendEvent, and #CFE_EVS_SendEvent is a library function that calls #CFE_SB_SendMsg,
+  condition does not transpire. Because error cases encountered when sending a message generate
+  an event, and events cause a message to be sent
   a calling sequence could cause a stack overflow if the recursion is not properly terminated.
   The cFE software bus detects this condition and properly terminates the recursion. This is
   done by using a set of flags (one flag per event in the Send API) which determine whether
-  an API has relinquished its stack. If the #CFE_SB_SendMsg needs to send an event that may
-  cause recursion, the flag is set and the event is sent. #CFE_EVS_SendEvent then calls #CFE_SB_SendMsg
-  in the same thread. If the second call to #CFE_SB_SendMsg needs to send that same event again,
-  it finds that the flag is set and the #CFE_EVS_SendEvent call is bypassed, terminating the
+  an API has relinquished its stack. If the software bus needs to send an event that may
+  cause recursion, the flag is set and the event is sent. If sending the event would cause
+  the same event again, the event call will be bypassed, terminating the
   recursion. The result is that the user will see only one event instead of the many events
   that would normally occur without the protection. The heritage software bus did not have
   this condition because it stored events in the software bus event log and another thread
@@ -508,31 +508,29 @@
            How many copies of the message are performed in a typical message delivery?
         </B><TR><TD WIDTH="5%"> &nbsp; <TD WIDTH="95%">
            There is a single copy of the message performed during a typical delivery.
-           During the #CFE_SB_SendMsg API, the software bus copies the message from the
-           callers memory space to the software bus memory space. The #CFE_SB_RcvMsg API
-           gives the user a pointer to the message in the software bus memory space. This
+           When transmitting a message, the software bus copies the message from the
+           callers memory space into a buffer in the software bus memory space.
+           The #CFE_SB_ReceiveBuffer API gives the user back a pointer to the buffer. This
            is equivalent to the copy mode send and pointer mode receive in the heritage
            software bus used on WMAP, ST5, SDO etc.
         <TR><TD COLSPAN=2 WIDTH="100%"> <B>(Q)
-           When does the software bus free the message buffer during a typical message
-           delivery process? Or how long is the message, and the pointer to the message
-           in the #CFE_SB_RcvMsg valid?
+           When does the software bus free the buffer during a typical message
+           delivery process? Or how long is the message, and the pointer to the buffer
+           in the #CFE_SB_ReceiveBuffer valid?
         </B><TR><TD WIDTH="5%"> &nbsp; <TD WIDTH="95%">
-           After receiving a message by calling #CFE_SB_RcvMsg, the message received stays
-           in the software bus memory until the next call to #CFE_SB_RcvMsg with the same
-           Pipe Id. This means that the message pointer given by the software bus to the
-           caller of #CFE_SB_RcvMsg is valid until the next call to #CFE_SB_RcvMsg with the
-           same pipe id. If the caller needs the message longer than the next call to
-           #CFE_SB_RcvMsg, the caller must copy the message to its memory space.
+           After receiving a buffer by calling #CFE_SB_ReceiveBuffer, the buffer received is valid
+           until the next call to #CFE_SB_ReceiveBuffer with the same Pipe Id.
+           If the caller needs the message longer than the next call to
+           #CFE_SB_ReceiveBuffer, the caller must copy the message to its memory space.
         <TR><TD COLSPAN=2 WIDTH="100%"> <B>(Q)
-           The first parameter in the #CFE_SB_RcvMsg API is a pointer to a pointer which
+           The first parameter in the #CFE_SB_ReceiveBuffer API is a pointer to a pointer which
            can get confusing. How can I be sure that the correct address is given for this
            parameter.
         </B><TR><TD WIDTH="5%"> &nbsp; <TD WIDTH="95%">
-           Typically a caller declares a ptr of type CFE_MSG_Message_t (i.e. CFE_MSG_Message_t *Ptr)
+           Typically a caller declares a ptr of type CFE_SB_Buffer_t (i.e. CFE_SB_Buffer_t *Ptr)
            then gives the address of that pointer (&Ptr) as this parameter. After a successful
-           call to #CFE_SB_RcvMsg, Ptr will point to the first byte of the software bus message
-           header. This should be used as a read-only pointer. In systems with an MMU, writes
+           call to #CFE_SB_ReceiveBuffer, Ptr will point to the first byte of the software bus
+           buffer. This should be used as a read-only pointer. In systems with an MMU, writes
            to this pointer may cause a memory protection fault.
         <TR><TD COLSPAN=2 WIDTH="100%"> <B>(Q)
            Why am I not seeing expected Message Limit error events or Pipe Overflow events?
@@ -569,7 +567,7 @@
            will ensure seamless integration when the software bus is expanded to support
            inter-processor communication.
         <TR><TD COLSPAN=2 WIDTH="100%"> <B>(Q)
-           Can I confirm my software bus message was delivered?
+           Can I confirm my software bus buffer was delivered?
         </B><TR><TD WIDTH="5%"> &nbsp; <TD WIDTH="95%">
            There is no built in mechanism for confirming delivery (it could span systems).
            This could be accomplished by generating a response message from the receiver.

--- a/docs/src/cfe_sb.dox
+++ b/docs/src/cfe_sb.dox
@@ -292,8 +292,8 @@
 
   The sequence counter for command messages is not altered by the software bus.
 
-  For a telemetry message, the behavior is controlled via input parameters or API selection
-  when sending the command.  When enabled, the software bus will populate the packet sequence
+  For a telemetry message, the behavior is controlled via API input parameters when sending.
+  When enabled, the software bus will populate the packet sequence
   counter using an internal counter that gets intialized upon the first subscription to the
   message (first message will have a packet sequence counter value of 1).  From that point on
   each send request will increment the counter by one, regardless of the number of destinations
@@ -507,12 +507,18 @@
         <TR><TD COLSPAN=2 WIDTH="100%"> <B>(Q)
            How many copies of the message are performed in a typical message delivery?
         </B><TR><TD WIDTH="5%"> &nbsp; <TD WIDTH="95%">
-           There is a single copy of the message performed during a typical delivery.
-           When transmitting a message, the software bus copies the message from the
-           callers memory space into a buffer in the software bus memory space.
-           The #CFE_SB_ReceiveBuffer API gives the user back a pointer to the buffer. This
-           is equivalent to the copy mode send and pointer mode receive in the heritage
-           software bus used on WMAP, ST5, SDO etc.
+           There is a single copy of the message performed when sending a message
+           (from the callers memory space) using CFE_SB_TransmitMsg. 
+           When transmitting the message, the software bus copies the message from the
+           callers memory space into a buffer in the software bus memory space. There
+           is also the option to request a buffer from SB, write directly to the buffer
+           and send via CFE_SB_TransmitBuffer.  This is equivalent to the previous zero
+           copy implementation.
+           The #CFE_SB_ReceiveBuffer API gives the user back a pointer to the buffer. When
+           working with the buffers, the additional complexity to be aware of is the
+           buffer is only available to the app from the request to send (on the sending side),
+           or from the receive until the next receive on the same pipe on the receiving side.
+           If the data is required outside that scope, the app needs a local copy.
         <TR><TD COLSPAN=2 WIDTH="100%"> <B>(Q)
            When does the software bus free the buffer during a typical message
            delivery process? Or how long is the message, and the pointer to the buffer

--- a/fsw/cfe-core/src/es/cfe_es_log.h
+++ b/fsw/cfe-core/src/es/cfe_es_log.h
@@ -75,7 +75,7 @@
  * first significantly decreases the amount of time that the syslog is locked after
  * a file dump is requested.
  *
- * This buffer also reflects the Syslog "burst size" that is guaranteed to be
+ * This buffer also reflects the SysLog "burst size" that is guaranteed to be
  * safe for concurrent writes and reads/dump operations.  If applications Log more than
  * this amount of data in less time than it takes to write this amount of data to disk,
  * then some log messages may be corrupt or lost in the output file.
@@ -121,7 +121,7 @@
 */
 
 /**
- * \brief Buffer structure for reading data out of the Syslog
+ * \brief Buffer structure for reading data out of the SysLog
  *
  * Access to the syslog must be synchronized, so it is not possible to
  * directly access the contents.  This structure keeps the state of
@@ -309,7 +309,7 @@ void CFE_ES_SysLog_snprintf(char *Buffer, size_t BufferSize, const char *SpecStr
  *
  * A snapshot of the log indices is taken at the beginning of the writing
  * process.  Additional log entries added after this (e.g. from applications
- * calling CFE_ES_WriteToSyslog() after starting a syslog dump) will not be
+ * calling CFE_ES_WriteToSysLog() after starting a syslog dump) will not be
  * included in the dump file.
  *
  * Note that preference is given to the realtime application threads over

--- a/fsw/cfe-core/src/es/cfe_es_perf.c
+++ b/fsw/cfe-core/src/es/cfe_es_perf.c
@@ -158,7 +158,7 @@ uint32 CFE_ES_GetPerfLogDumpRemaining(void)
 /* CFE_ES_StartPerfDataCmd() --                                                  */
 /*                                                                               */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfData_t *data)
+int32 CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfDataCmd_t *data)
 {
     const CFE_ES_StartPerfCmd_Payload_t *CmdPtr = &data->Payload;
     CFE_ES_PerfDumpGlobal_t *PerfDumpState = &CFE_ES_TaskData.BackgroundPerfDumpState;
@@ -214,7 +214,7 @@ int32 CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfData_t *data)
 /* CFE_ES_StopPerfDataCmd() --                                                   */
 /*                                                                               */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 CFE_ES_StopPerfDataCmd(const CFE_ES_StopPerfData_t *data)
+int32 CFE_ES_StopPerfDataCmd(const CFE_ES_StopPerfDataCmd_t *data)
 {
     const CFE_ES_StopPerfCmd_Payload_t *CmdPtr = &data->Payload;
     CFE_ES_PerfDumpGlobal_t *PerfDumpState = &CFE_ES_TaskData.BackgroundPerfDumpState;
@@ -496,7 +496,7 @@ bool CFE_ES_RunPerfLogDump(uint32 ElapsedTime, void *Arg)
 /* CFE_ES_SetPerfFilterMaskCmd() --                                              */
 /*                                                                               */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMask_t *data)
+int32 CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMaskCmd_t *data)
 {
     const CFE_ES_SetPerfFilterMaskCmd_Payload_t *cmd = &data->Payload;
 
@@ -526,7 +526,7 @@ int32 CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMask_t *data)
 /* CFE_ES_SetPerfTriggerMaskCmd() --                                             */
 /*                                                                               */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-int32 CFE_ES_SetPerfTriggerMaskCmd(const CFE_ES_SetPerfTriggerMask_t *data)
+int32 CFE_ES_SetPerfTriggerMaskCmd(const CFE_ES_SetPerfTriggerMaskCmd_t *data)
 {
     const CFE_ES_SetPerfTrigMaskCmd_Payload_t *cmd = &data->Payload;
 

--- a/fsw/cfe-core/src/es/cfe_es_syslog.c
+++ b/fsw/cfe-core/src/es/cfe_es_syslog.c
@@ -33,7 +33,7 @@
 **
 **     Some functions have EXTERNAL SYNC REQUIREMENTS
 **
-**     Syslog functions marked with "Unsync" in their name are designated
+**     SysLog functions marked with "Unsync" in their name are designated
 **     as functions which are _not_ safe to be called concurrently by multiple
 **     threads, and also do _not_ implement any locking or protection.  These
 **     functions expect the caller to perform all thread synchronization before

--- a/fsw/cfe-core/src/es/cfe_es_task.h
+++ b/fsw/cfe-core/src/es/cfe_es_task.h
@@ -89,8 +89,6 @@ typedef struct
     char            DataFileName[OS_MAX_PATH_LEN];
 } CFE_ES_BackgroundLogDumpGlobal_t;
 
-
-
 /*
 ** Type definition (ES task global data)
 */
@@ -103,24 +101,23 @@ typedef struct
   uint8                 CommandErrorCounter;
 
   /*
-  ** ES Task housekeeping telemetry packet
+  ** ES Task housekeeping telemetry
   */
-  CFE_ES_HousekeepingTlm_t     HkPacket;
+  CFE_ES_HousekeepingTlm_t HkPacket;
 
   /*
-  ** Single application telemetry packet
+  ** Single application telemetry
   */
-  CFE_ES_OneAppTlm_t    OneAppPacket;
+  CFE_ES_OneAppTlm_t OneAppPacket;
 
   /*
-  ** Single application telemetry packet
+  ** Memory statistics telemetry
   */
   CFE_ES_MemStatsTlm_t MemStatsPacket;
 
   /*
   ** ES Task operational data (not reported in housekeeping)
   */
-  CFE_MSG_Message_t *MsgPtr;
   CFE_SB_PipeId_t    CmdPipe;
 
   /*
@@ -160,7 +157,7 @@ extern CFE_ES_TaskData_t CFE_ES_TaskData;
 */
 void  CFE_ES_TaskMain(void);
 int32 CFE_ES_TaskInit(void);
-void  CFE_ES_TaskPipe(CFE_MSG_Message_t *MsgPtr);
+void  CFE_ES_TaskPipe(CFE_SB_Buffer_t *SBBufPtr);
 
 
 /*
@@ -174,31 +171,31 @@ void  CFE_ES_BackgroundCleanup(void);
 /*
 ** ES Task message dispatch functions
 */
-int32 CFE_ES_HousekeepingCmd(const CFE_SB_CmdHdr_t *data);
-int32 CFE_ES_NoopCmd(const CFE_ES_Noop_t *Cmd);
-int32 CFE_ES_ResetCountersCmd(const CFE_ES_ResetCounters_t *data);
-int32 CFE_ES_RestartCmd(const CFE_ES_Restart_t *data);
-int32 CFE_ES_StartAppCmd(const CFE_ES_StartApp_t *data);
-int32 CFE_ES_StopAppCmd(const CFE_ES_StopApp_t *data);
-int32 CFE_ES_RestartAppCmd(const CFE_ES_RestartApp_t *data);
-int32 CFE_ES_ReloadAppCmd(const CFE_ES_ReloadApp_t *data);
-int32 CFE_ES_QueryOneCmd(const CFE_ES_QueryOne_t *data);
-int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAll_t *data);
-int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasks_t *data);
-int32 CFE_ES_ClearSyslogCmd(const CFE_ES_ClearSyslog_t *data);
-int32 CFE_ES_OverWriteSyslogCmd(const CFE_ES_OverWriteSyslog_t *data);
-int32 CFE_ES_WriteSyslogCmd(const CFE_ES_WriteSyslog_t *data);
-int32 CFE_ES_ClearERLogCmd(const CFE_ES_ClearERLog_t *data);
-int32 CFE_ES_WriteERLogCmd(const CFE_ES_WriteERLog_t *data);
-int32 CFE_ES_ResetPRCountCmd(const CFE_ES_ResetPRCount_t *data);
-int32 CFE_ES_SetMaxPRCountCmd(const CFE_ES_SetMaxPRCount_t *data);
-int32 CFE_ES_DeleteCDSCmd(const CFE_ES_DeleteCDS_t *data);
-int32 CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfData_t *data);
-int32 CFE_ES_StopPerfDataCmd(const CFE_ES_StopPerfData_t *data);
-int32 CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMask_t *data);
-int32 CFE_ES_SetPerfTriggerMaskCmd(const CFE_ES_SetPerfTriggerMask_t *data);
-int32 CFE_ES_SendMemPoolStatsCmd(const CFE_ES_SendMemPoolStats_t *data);
-int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistry_t *data);
+int32 CFE_ES_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data);
+int32 CFE_ES_NoopCmd(const CFE_ES_NoopCmd_t *Cmd);
+int32 CFE_ES_ResetCountersCmd(const CFE_ES_ResetCountersCmd_t *data);
+int32 CFE_ES_RestartCmd(const CFE_ES_RestartCmd_t *data);
+int32 CFE_ES_StartAppCmd(const CFE_ES_StartAppCmd_t *data);
+int32 CFE_ES_StopAppCmd(const CFE_ES_StopAppCmd_t *data);
+int32 CFE_ES_RestartAppCmd(const CFE_ES_RestartAppCmd_t *data);
+int32 CFE_ES_ReloadAppCmd(const CFE_ES_ReloadAppCmd_t *data);
+int32 CFE_ES_QueryOneCmd(const CFE_ES_QueryOneCmd_t *data);
+int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAllCmd_t *data);
+int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasksCmd_t *data);
+int32 CFE_ES_ClearSysLogCmd(const CFE_ES_ClearSysLogCmd_t *data);
+int32 CFE_ES_OverWriteSysLogCmd(const CFE_ES_OverWriteSysLogCmd_t *data);
+int32 CFE_ES_WriteSysLogCmd(const CFE_ES_WriteSysLogCmd_t *data);
+int32 CFE_ES_ClearERLogCmd(const CFE_ES_ClearERLogCmd_t *data);
+int32 CFE_ES_WriteERLogCmd(const CFE_ES_WriteERLogCmd_t *data);
+int32 CFE_ES_ResetPRCountCmd(const CFE_ES_ResetPRCountCmd_t *data);
+int32 CFE_ES_SetMaxPRCountCmd(const CFE_ES_SetMaxPRCountCmd_t *data);
+int32 CFE_ES_DeleteCDSCmd(const CFE_ES_DeleteCDSCmd_t *data);
+int32 CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfDataCmd_t *data);
+int32 CFE_ES_StopPerfDataCmd(const CFE_ES_StopPerfDataCmd_t *data);
+int32 CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMaskCmd_t *data);
+int32 CFE_ES_SetPerfTriggerMaskCmd(const CFE_ES_SetPerfTriggerMaskCmd_t *data);
+int32 CFE_ES_SendMemPoolStatsCmd(const CFE_ES_SendMemPoolStatsCmd_t *data);
+int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistryCmd_t *data);
 
 /*
 ** Message Handler Helper Functions

--- a/fsw/cfe-core/src/es/cfe_es_verify.h
+++ b/fsw/cfe-core/src/es/cfe_es_verify.h
@@ -145,7 +145,7 @@
 #endif
 
 /* 
-** Syslog mode 
+** SysLog mode
 */
 #if CFE_PLATFORM_ES_DEFAULT_SYSLOG_MODE  <  0
     #error CFE_PLATFORM_ES_DEFAULT_SYSLOG_MODE cannot be less than 0!

--- a/fsw/cfe-core/src/evs/cfe_evs_log.c
+++ b/fsw/cfe-core/src/evs/cfe_evs_log.c
@@ -148,7 +148,7 @@ void EVS_ClearLog ( void )
 ** Assumptions and Notes:
 **
 */
-int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFile_t *data)
+int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFileCmd_t *data)
 {
     const CFE_EVS_LogFileCmd_Payload_t *CmdPtr = &data->Payload;
     int32           Result;
@@ -269,7 +269,7 @@ int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFile_t *data)
 ** Assumptions and Notes:
 **
 */
-int32 CFE_EVS_SetLogModeCmd(const CFE_EVS_SetLogMode_t *data)
+int32 CFE_EVS_SetLogModeCmd(const CFE_EVS_SetLogModeCmd_t *data)
 {
     const CFE_EVS_SetLogMode_Payload_t *CmdPtr = &data->Payload;
     int32 Status;

--- a/fsw/cfe-core/src/evs/cfe_evs_log.h
+++ b/fsw/cfe-core/src/evs/cfe_evs_log.h
@@ -55,7 +55,7 @@
 
 void    EVS_AddLog ( CFE_EVS_LongEventTlm_t *EVS_PktPtr );
 void    EVS_ClearLog ( void );
-int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFile_t *data);
-int32 CFE_EVS_SetLogModeCmd(const CFE_EVS_SetLogMode_t *data);
+int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFileCmd_t *data);
+int32 CFE_EVS_SetLogModeCmd(const CFE_EVS_SetLogModeCmd_t *data);
 
 #endif  /* _cfe_evs_log_ */

--- a/fsw/cfe-core/src/evs/cfe_evs_task.h
+++ b/fsw/cfe-core/src/evs/cfe_evs_task.h
@@ -140,31 +140,31 @@ extern CFE_EVS_GlobalData_t   CFE_EVS_GlobalData;
 * Functions used within this module and by the unit test
 */
 extern int32 CFE_EVS_TaskInit (void);
-extern void  CFE_EVS_ProcessCommandPacket(CFE_MSG_Message_t *MsgPtr);
+extern void  CFE_EVS_ProcessCommandPacket(CFE_SB_Buffer_t *SBBufPtr);
 
 /*
  * EVS Message Handler Functions
  */
-int32 CFE_EVS_ReportHousekeepingCmd (const CFE_SB_CmdHdr_t *data);
-int32 CFE_EVS_NoopCmd(const CFE_EVS_Noop_t *data);
-int32 CFE_EVS_ClearLogCmd(const CFE_EVS_ClearLog_t *data);
-int32 CFE_EVS_ResetCountersCmd(const CFE_EVS_ResetCounters_t *data);
-int32 CFE_EVS_SetFilterCmd(const CFE_EVS_SetFilter_t *data);
-int32 CFE_EVS_EnablePortsCmd(const CFE_EVS_EnablePorts_t *data);
-int32 CFE_EVS_DisablePortsCmd(const CFE_EVS_DisablePorts_t *data);
-int32 CFE_EVS_EnableEventTypeCmd(const CFE_EVS_EnableEventType_t *data);
-int32 CFE_EVS_DisableEventTypeCmd(const CFE_EVS_DisableEventType_t *data);
-int32 CFE_EVS_SetEventFormatModeCmd(const CFE_EVS_SetEventFormatMode_t *data);
-int32 CFE_EVS_EnableAppEventTypeCmd(const CFE_EVS_EnableAppEventType_t *data);
-int32 CFE_EVS_DisableAppEventTypeCmd(const CFE_EVS_DisableAppEventType_t *data);
-int32 CFE_EVS_EnableAppEventsCmd(const CFE_EVS_EnableAppEvents_t *data);
-int32 CFE_EVS_DisableAppEventsCmd(const CFE_EVS_DisableAppEvents_t *data);
-int32 CFE_EVS_ResetAppCounterCmd(const CFE_EVS_ResetAppCounter_t *data);
-int32 CFE_EVS_ResetFilterCmd(const CFE_EVS_ResetFilter_t *data);
-int32 CFE_EVS_AddEventFilterCmd(const CFE_EVS_AddEventFilter_t *data);
-int32 CFE_EVS_DeleteEventFilterCmd(const CFE_EVS_DeleteEventFilter_t *data);
-int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFile_t *data);
-int32 CFE_EVS_ResetAllFiltersCmd(const CFE_EVS_ResetAllFilters_t *data);
+int32 CFE_EVS_ReportHousekeepingCmd(const CFE_MSG_CommandHeader_t *data);
+int32 CFE_EVS_NoopCmd(const CFE_EVS_NoopCmd_t *data);
+int32 CFE_EVS_ClearLogCmd(const CFE_EVS_ClearLogCmd_t *data);
+int32 CFE_EVS_ResetCountersCmd(const CFE_EVS_ResetCountersCmd_t *data);
+int32 CFE_EVS_SetFilterCmd(const CFE_EVS_SetFilterCmd_t *data);
+int32 CFE_EVS_EnablePortsCmd(const CFE_EVS_EnablePortsCmd_t *data);
+int32 CFE_EVS_DisablePortsCmd(const CFE_EVS_DisablePortsCmd_t *data);
+int32 CFE_EVS_EnableEventTypeCmd(const CFE_EVS_EnableEventTypeCmd_t *data);
+int32 CFE_EVS_DisableEventTypeCmd(const CFE_EVS_DisableEventTypeCmd_t *data);
+int32 CFE_EVS_SetEventFormatModeCmd(const CFE_EVS_SetEventFormatModeCmd_t *data);
+int32 CFE_EVS_EnableAppEventTypeCmd(const CFE_EVS_EnableAppEventTypeCmd_t *data);
+int32 CFE_EVS_DisableAppEventTypeCmd(const CFE_EVS_DisableAppEventTypeCmd_t *data);
+int32 CFE_EVS_EnableAppEventsCmd(const CFE_EVS_EnableAppEventsCmd_t *data);
+int32 CFE_EVS_DisableAppEventsCmd(const CFE_EVS_DisableAppEventsCmd_t *data);
+int32 CFE_EVS_ResetAppCounterCmd(const CFE_EVS_ResetAppCounterCmd_t *data);
+int32 CFE_EVS_ResetFilterCmd(const CFE_EVS_ResetFilterCmd_t *data);
+int32 CFE_EVS_AddEventFilterCmd(const CFE_EVS_AddEventFilterCmd_t *data);
+int32 CFE_EVS_DeleteEventFilterCmd(const CFE_EVS_DeleteEventFilterCmd_t *data);
+int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFileCmd_t *data);
+int32 CFE_EVS_ResetAllFiltersCmd(const CFE_EVS_ResetAllFiltersCmd_t *data);
 
 
 #endif  /* _cfe_evs_task_ */

--- a/fsw/cfe-core/src/evs/cfe_evs_utils.c
+++ b/fsw/cfe-core/src/evs/cfe_evs_utils.c
@@ -404,7 +404,7 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint1
     int                      ExpandedLength;
 
     /* Initialize EVS event packets */
-    CFE_MSG_Init(&LongEventTlm.TlmHeader.BaseMsg, CFE_SB_ValueToMsgId(CFE_EVS_LONG_EVENT_MSG_MID),
+    CFE_MSG_Init(&LongEventTlm.TlmHeader.Msg, CFE_SB_ValueToMsgId(CFE_EVS_LONG_EVENT_MSG_MID),
                  sizeof(LongEventTlm));
     LongEventTlm.Payload.PacketID.EventID   = EventID;
     LongEventTlm.Payload.PacketID.EventType = EventType;
@@ -428,7 +428,7 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint1
     LongEventTlm.Payload.PacketID.ProcessorID  = CFE_PSP_GetProcessorId();
 
     /* Set the packet timestamp */
-    CFE_MSG_SetMsgTime((CFE_MSG_Message_t *) &LongEventTlm, *TimeStamp);
+    CFE_MSG_SetMsgTime(&LongEventTlm.TlmHeader.Msg, *TimeStamp);
 
     /* Write event to the event log */
     EVS_AddLog(&LongEventTlm);
@@ -439,7 +439,7 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint1
     if (CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode == CFE_EVS_MsgFormat_LONG)
     {
         /* Send long event via SoftwareBus */
-        CFE_SB_SendMsg((CFE_MSG_Message_t *) &LongEventTlm);
+        CFE_SB_TransmitMsg(&LongEventTlm.TlmHeader.Msg, true);
     }
     else if (CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode == CFE_EVS_MsgFormat_SHORT)
     {
@@ -449,11 +449,11 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint1
          *
          * This goes out on a separate message ID.
          */
-        CFE_MSG_Init(&ShortEventTlm.TlmHeader.BaseMsg, CFE_SB_ValueToMsgId(CFE_EVS_SHORT_EVENT_MSG_MID),
+        CFE_MSG_Init(&ShortEventTlm.TlmHeader.Msg, CFE_SB_ValueToMsgId(CFE_EVS_SHORT_EVENT_MSG_MID),
                      sizeof(ShortEventTlm));
-        CFE_MSG_SetMsgTime((CFE_MSG_Message_t *) &ShortEventTlm, *TimeStamp);
+        CFE_MSG_SetMsgTime(&ShortEventTlm.TlmHeader.Msg, *TimeStamp);
         ShortEventTlm.Payload.PacketID = LongEventTlm.Payload.PacketID;
-        CFE_SB_SendMsg((CFE_MSG_Message_t *) &ShortEventTlm);
+        CFE_SB_TransmitMsg(&ShortEventTlm.TlmHeader.Msg, true);
     }
 
     /* Increment message send counters (prevent rollover) */

--- a/fsw/cfe-core/src/inc/cfe_error.h
+++ b/fsw/cfe-core/src/inc/cfe_error.h
@@ -717,7 +717,7 @@ typedef int32 CFE_Status_t;
 /**
  * @brief Time Out
  *
- *  In #CFE_SB_RcvMsg, this return value indicates that a packet has not 
+ *  In #CFE_SB_ReceiveBuffer, this return value indicates that a packet has not
  *  been received in the time given in the "timeout" parameter.
  *
  */
@@ -727,7 +727,7 @@ typedef int32 CFE_Status_t;
 /**
  * @brief No Message
  *
- *  When "Polling" a pipe for a message in #CFE_SB_RcvMsg, this return 
+ *  When "Polling" a pipe for a message in #CFE_SB_ReceiveBuffer, this return
  *  value indicates that there was not a message on the pipe.
  *
  */
@@ -796,9 +796,8 @@ typedef int32 CFE_Status_t;
 /**
  * @brief Buffer Allocation Error
  *
- *  This error code will be returned from #CFE_SB_SendMsg when the memory 
- *  in the SB message buffer pool has been depleted. The amount of memory  
- *  in the pool is dictated by the configuration parameter 
+ *  Returned when the memory in the SB message buffer pool has been depleted.
+ *  The amount of memory in the pool is dictated by the configuration parameter
  *  #CFE_PLATFORM_SB_BUF_MEMORY_BYTES specified in the cfe_platform_cfg.h file. Also 
  *  the memory statistics, including current utilization figures and high 
  *  water marks for the SB Buffer memory pool can be monitored by sending 

--- a/fsw/cfe-core/src/inc/cfe_es_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_es_msg.h
@@ -39,8 +39,6 @@
 ** Includes
 */
 #include "cfe_es_extern_typedefs.h"
-
-/* The CFE_SB_CMD_HDR_SIZE and CFE_SB_TLM_HDR_SIZE are defined by cfe_sb.h */
 #include "cfe_sb.h"
 
 /*
@@ -58,7 +56,7 @@
 **  \cfecmdmnemonic \ES_NOOP
 **
 **  \par Command Structure
-**       #CFE_ES_NoArgsCmd_t
+**       #CFE_ES_NoopCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -94,7 +92,7 @@
 **  \cfecmdmnemonic \ES_RESETCTRS
 **
 **  \par Command Structure
-**       #CFE_ES_NoArgsCmd_t
+**       #CFE_ES_ResetCountersCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -138,7 +136,7 @@
 **  \cfecmdmnemonic \ES_RESET
 **
 **  \par Command Structure
-**       #CFE_ES_RestartCmd_Payload_t
+**       #CFE_ES_RestartCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command (as a Processor Reset)  
@@ -182,7 +180,7 @@
 **  \cfecmdmnemonic \ES_STARTAPP
 **
 **  \par Command Structure
-**       #CFE_ES_StartApp_t
+**       #CFE_ES_StartAppCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -232,7 +230,7 @@
 **  \cfecmdmnemonic \ES_STOPAPP
 **
 **  \par Command Structure
-**       #CFE_ES_AppNameCmd_t
+**       #CFE_ES_StopAppCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -279,7 +277,7 @@
 **  \cfecmdmnemonic \ES_RESTARTAPP
 **
 **  \par Command Structure
-**       #CFE_ES_AppNameCmd_t
+**       #CFE_ES_RestartAppCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -325,7 +323,7 @@
 **  \cfecmdmnemonic \ES_RELOADAPP
 **
 **  \par Command Structure
-**       #CFE_ES_ReloadApp_t
+**       #CFE_ES_ReloadAppCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -367,7 +365,7 @@
 **  \cfecmdmnemonic \ES_QUERYAPP
 **
 **  \par Command Structure
-**       #CFE_ES_AppNameCmd_t
+**       #CFE_ES_QueryOneCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -405,7 +403,7 @@
 **  \cfecmdmnemonic \ES_WRITEAPPINFO2FILE
 **
 **  \par Command Structure
-**       #CFE_ES_FileNameCmd_t
+**       #CFE_ES_QueryAllCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -446,7 +444,7 @@
 **  \cfecmdmnemonic \ES_CLEARSYSLOG
 **
 **  \par Command Structure
-**       #CFE_ES_NoArgsCmd_t
+**       #CFE_ES_ClearSysLogCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -485,7 +483,7 @@
 **  \cfecmdmnemonic \ES_WRITESYSLOG2FILE
 **
 **  \par Command Structure
-**       #CFE_ES_FileNameCmd_t
+**       #CFE_ES_WriteSysLogCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -528,7 +526,7 @@
 **  \cfecmdmnemonic \ES_CLEARERLOG
 **
 **  \par Command Structure
-**       #CFE_ES_NoArgsCmd_t
+**       #CFE_ES_ClearERLogCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -565,7 +563,7 @@
 **  \cfecmdmnemonic \ES_WRITEERLOG2FILE
 **
 **  \par Command Structure
-**       #CFE_ES_FileNameCmd_t
+**       #CFE_ES_WriteERLogCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -606,7 +604,7 @@
 **  \cfecmdmnemonic \ES_STARTLADATA
 **
 **  \par Command Structure
-**       #CFE_ES_StartPerfData_t
+**       #CFE_ES_StartPerfDataCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -652,7 +650,7 @@
 **  \cfecmdmnemonic \ES_STOPLADATA
 **
 **  \par Command Structure
-**       #CFE_ES_StopPerfData_t
+**       #CFE_ES_StopPerfDataCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -695,7 +693,7 @@
 **  \cfecmdmnemonic \ES_LAFILTERMASK
 **
 **  \par Command Structure
-**       #CFE_ES_SetPerfFilterMask_t
+**       #CFE_ES_SetPerfFilterMaskCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -733,7 +731,7 @@
 **  \cfecmdmnemonic \ES_LATRIGGERMASK
 **
 **  \par Command Structure
-**       #CFE_ES_SetPerfTriggerMask_t
+**       #CFE_ES_SetPerfTriggerMaskCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -773,7 +771,7 @@
 **  \cfecmdmnemonic \ES_OVERWRITESYSLOGMODE
 **
 **  \par Command Structure
-**       #CFE_ES_OverWriteSyslog_t
+**       #CFE_ES_OverWriteSysLogCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -815,7 +813,7 @@
 **  \cfecmdmnemonic \ES_RESETPRCNT
 **
 **  \par Command Structure
-**       #CFE_ES_NoArgsCmd_t
+**       #CFE_ES_ResetPRCountCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -853,7 +851,7 @@
 **  \cfecmdmnemonic \ES_SETMAXPRCNT
 **
 **  \par Command Structure
-**       #CFE_ES_SetMaxPRCount_t
+**       #CFE_ES_SetMaxPRCountCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -894,7 +892,7 @@
 **  \cfecmdmnemonic \ES_DELETECDS
 **
 **  \par Command Structure
-**       #CFE_ES_DeleteCDS_t
+**       #CFE_ES_DeleteCDSCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -937,7 +935,7 @@
 **  \cfecmdmnemonic \ES_TLMPOOLSTATS
 **
 **  \par Command Structure
-**       #CFE_ES_SendMemPoolStats_t
+**       #CFE_ES_SendMemPoolStatsCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -979,7 +977,7 @@
 **  \cfecmdmnemonic \ES_DUMPCDSREG
 **
 **  \par Command Structure
-**       #CFE_ES_DumpCDSRegistry_t
+**       #CFE_ES_DumpCDSRegistryCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -1020,7 +1018,7 @@
 **  \cfecmdmnemonic \ES_WRITETASKINFO2FILE
 **
 **  \par Command Structure
-**       #CFE_ES_FileNameCmd_t
+**       #CFE_ES_QueryAllTasksCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -1072,8 +1070,7 @@
 */
 typedef struct CFE_ES_NoArgsCmd
 {
-  uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];     /**< \brief cFE Software Bus Command Message Header */
-
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 } CFE_ES_NoArgsCmd_t;
 
 /*
@@ -1083,14 +1080,14 @@ typedef struct CFE_ES_NoArgsCmd
  * allows them to change independently in the future without changing the prototype
  * of the handler function.
  */
-typedef CFE_ES_NoArgsCmd_t      CFE_ES_Noop_t;
-typedef CFE_ES_NoArgsCmd_t      CFE_ES_ResetCounters_t;
-typedef CFE_ES_NoArgsCmd_t      CFE_ES_ClearSyslog_t;
-typedef CFE_ES_NoArgsCmd_t      CFE_ES_ClearERLog_t;
-typedef CFE_ES_NoArgsCmd_t      CFE_ES_ResetPRCount_t;
+typedef CFE_ES_NoArgsCmd_t CFE_ES_NoopCmd_t;
+typedef CFE_ES_NoArgsCmd_t CFE_ES_ResetCountersCmd_t;
+typedef CFE_ES_NoArgsCmd_t CFE_ES_ClearSysLogCmd_t;
+typedef CFE_ES_NoArgsCmd_t CFE_ES_ClearERLogCmd_t;
+typedef CFE_ES_NoArgsCmd_t CFE_ES_ResetPRCountCmd_t;
 
 /**
-** \brief Restart cFE Command
+** \brief Restart cFE Command Payload
 **
 ** For command details, see #CFE_ES_RESTART_CC
 **
@@ -1101,15 +1098,17 @@ typedef struct CFE_ES_RestartCmd_Payload
                                                                 or #CFE_PSP_RST_TYPE_POWERON=Power-On Reset        */
 } CFE_ES_RestartCmd_Payload_t;
 
-typedef struct CFE_ES_Restart
+/**
+ * \brief Restart cFE Command
+ */
+typedef struct CFE_ES_RestartCmd
 {
-    uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
-    CFE_ES_RestartCmd_Payload_t Payload;
-} CFE_ES_Restart_t;
-
+    CFE_MSG_CommandHeader_t     CmdHeader; /**< \brief Command header */
+    CFE_ES_RestartCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_ES_RestartCmd_t;
 
 /**
-** \brief Payload format for commands which accept a single file name
+** \brief Generic file name command payload
 **
 ** This format is shared by several executive services commands.
 ** For command details, see #CFE_ES_QUERY_ALL_CC, #CFE_ES_QUERY_ALL_TASKS_CC,
@@ -1122,23 +1121,26 @@ typedef struct CFE_ES_FileNameCmd_Payload
                                                                 filename of file in which Application data is to be dumped */
 } CFE_ES_FileNameCmd_Payload_t;
 
+/**
+ * \brief Generic file name command
+ */
 typedef struct CFE_ES_FileNameCmd
 {
-    uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
-    CFE_ES_FileNameCmd_Payload_t Payload;
+    CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
+    CFE_ES_FileNameCmd_Payload_t Payload;   /**< \brief Command payload */
 } CFE_ES_FileNameCmd_t;
 
 /*
  * Unique typedefs for each of the commands that utilize the FileNameCmd 
  * packet format
  */
-typedef CFE_ES_FileNameCmd_t CFE_ES_QueryAll_t;
-typedef CFE_ES_FileNameCmd_t CFE_ES_QueryAllTasks_t;
-typedef CFE_ES_FileNameCmd_t CFE_ES_WriteSyslog_t;
-typedef CFE_ES_FileNameCmd_t CFE_ES_WriteERLog_t;
+typedef CFE_ES_FileNameCmd_t CFE_ES_QueryAllCmd_t;
+typedef CFE_ES_FileNameCmd_t CFE_ES_QueryAllTasksCmd_t;
+typedef CFE_ES_FileNameCmd_t CFE_ES_WriteSysLogCmd_t;
+typedef CFE_ES_FileNameCmd_t CFE_ES_WriteERLogCmd_t;
 
 /**
-** \brief Overwrite/Discard System Log Configuration Command
+** \brief Overwrite/Discard System Log Configuration Command Payload
 **
 ** For command details, see #CFE_ES_OVER_WRITE_SYSLOG_CC
 **
@@ -1150,14 +1152,17 @@ typedef struct CFE_ES_OverWriteSysLogCmd_Payload
 
 } CFE_ES_OverWriteSysLogCmd_Payload_t;
 
-typedef struct CFE_ES_OverWriteSyslog
+/**
+ * \brief Overwrite/Discard System Log Configuration Command Payload
+ */
+typedef struct CFE_ES_OverWriteSysLogCmd
 {
-    uint8                               CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
-    CFE_ES_OverWriteSysLogCmd_Payload_t Payload;
-} CFE_ES_OverWriteSyslog_t;
+    CFE_MSG_CommandHeader_t             CmdHeader; /**< \brief Command header */
+    CFE_ES_OverWriteSysLogCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_ES_OverWriteSysLogCmd_t;
 
 /**
-** \brief Start Application Command
+** \brief Start Application Command Payload
 **
 ** For command details, see #CFE_ES_START_APP_CC
 **
@@ -1179,14 +1184,17 @@ typedef struct CFE_ES_StartAppCmd_Payload
 
 } CFE_ES_StartAppCmd_Payload_t;
 
+/**
+ * \brief Start Application Command
+ */
 typedef struct CFE_ES_StartApp
 {
-    uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
-    CFE_ES_StartAppCmd_Payload_t    Payload;
-} CFE_ES_StartApp_t;
+    CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
+    CFE_ES_StartAppCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_ES_StartAppCmd_t;
 
 /**
-** \brief Command Structure for Commands requiring just an Application Name
+** \brief Generic application name command payload
 **
 ** For command details, see #CFE_ES_STOP_APP_CC, #CFE_ES_RESTART_APP_CC, #CFE_ES_QUERY_ONE_CC
 **
@@ -1196,10 +1204,13 @@ typedef struct CFE_ES_AppNameCmd_Payload
   char                  Application[CFE_MISSION_MAX_API_LEN];    /**< \brief ASCII text string containing Application Name */
 } CFE_ES_AppNameCmd_Payload_t;
 
+/**
+ * \brief Generic application name command
+ */
 typedef struct CFE_ES_AppNameCmd
 {
-    uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
-    CFE_ES_AppNameCmd_Payload_t Payload;
+    CFE_MSG_CommandHeader_t     CmdHeader; /**< \brief Command header */
+    CFE_ES_AppNameCmd_Payload_t Payload;   /**< \brief Command payload */
 } CFE_ES_AppNameCmd_t;
 
 /*
@@ -1207,12 +1218,12 @@ typedef struct CFE_ES_AppNameCmd
  * Create a separate typedef for each one so they can all evolve independently
  * without affecting the prototype.
  */
-typedef CFE_ES_AppNameCmd_t CFE_ES_StopApp_t;
-typedef CFE_ES_AppNameCmd_t CFE_ES_RestartApp_t;
-typedef CFE_ES_AppNameCmd_t CFE_ES_QueryOne_t;
+typedef CFE_ES_AppNameCmd_t CFE_ES_StopAppCmd_t;
+typedef CFE_ES_AppNameCmd_t CFE_ES_RestartAppCmd_t;
+typedef CFE_ES_AppNameCmd_t CFE_ES_QueryOneCmd_t;
 
 /**
-** \brief Reload Application Command
+** \brief Reload Application Command Payload
 **
 ** For command details, see #CFE_ES_RELOAD_APP_CC
 **
@@ -1224,14 +1235,17 @@ typedef struct CFE_ES_AppReloadCmd_Payload
                                                                     executable image */
 } CFE_ES_AppReloadCmd_Payload_t;
 
-typedef struct CFE_ES_ReloadApp
+/**
+ * \brief Reload Application Command
+ */
+typedef struct CFE_ES_ReloadAppCmd
 {
-    uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
-    CFE_ES_AppReloadCmd_Payload_t   Payload;
-} CFE_ES_ReloadApp_t;
+    CFE_MSG_CommandHeader_t       CmdHeader; /**< \brief Command header */
+    CFE_ES_AppReloadCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_ES_ReloadAppCmd_t;
 
 /**
-** \brief Set Maximum Processor Reset Count Command
+** \brief Set Maximum Processor Reset Count Command Payload
 **
 ** For command details, see #CFE_ES_SET_MAX_PR_COUNT_CC
 **
@@ -1242,14 +1256,17 @@ typedef struct CFE_ES_SetMaxPRCountCmd_Payload
                                                                     an automatic Power-On Reset is performed */
 } CFE_ES_SetMaxPRCountCmd_Payload_t;
 
-typedef struct CFE_ES_SetMaxPRCount
+/**
+ * \brief Set Maximum Processor Reset Count Command
+ */
+typedef struct CFE_ES_SetMaxPRCountCmd
 {
-    uint8                               CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
-    CFE_ES_SetMaxPRCountCmd_Payload_t   Payload;
-} CFE_ES_SetMaxPRCount_t;
+    CFE_MSG_CommandHeader_t           CmdHeader; /**< \brief Command header */
+    CFE_ES_SetMaxPRCountCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_ES_SetMaxPRCountCmd_t;
 
 /**
-** \brief Delete Critical Data Store Command
+** \brief Delete Critical Data Store Command Payload
 **
 ** For command details, see #CFE_ES_DELETE_CDS_CC
 **
@@ -1260,14 +1277,17 @@ typedef struct CFE_ES_DeleteCDSCmd_Payload
 
 } CFE_ES_DeleteCDSCmd_Payload_t;
 
-typedef struct CFE_ES_DeleteCDS
+/**
+ * \brief Delete Critical Data Store Command
+ */
+typedef struct CFE_ES_DeleteCDSCmd
 {
-    uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
-    CFE_ES_DeleteCDSCmd_Payload_t   Payload;
-} CFE_ES_DeleteCDS_t;
+    CFE_MSG_CommandHeader_t       CmdHeader; /**< \brief Command header */
+    CFE_ES_DeleteCDSCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_ES_DeleteCDSCmd_t;
 
 /**
-** \brief Start Performance Analyzer Command
+** \brief Start Performance Analyzer Command Payload
 **
 ** For command details, see #CFE_ES_START_PERF_DATA_CC
 **
@@ -1277,14 +1297,17 @@ typedef struct CFE_ES_StartPerfCmd_Payload
   uint32                TriggerMode;                    /**< \brief Desired trigger position (Start, Center, End) */
 } CFE_ES_StartPerfCmd_Payload_t;
 
-typedef struct CFE_ES_StartPerfData
+/**
+ * \brief Start Performance Analyzer Command
+ */
+typedef struct CFE_ES_StartPerfDataCmd
 {
-    uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
-    CFE_ES_StartPerfCmd_Payload_t   Payload;
-} CFE_ES_StartPerfData_t;
+    CFE_MSG_CommandHeader_t       CmdHeader; /**< \brief Command header */
+    CFE_ES_StartPerfCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_ES_StartPerfDataCmd_t;
 
 /**
-** \brief Stop Performance Analyzer Command
+** \brief Stop Performance Analyzer Command Payload
 **
 ** For command details, see #CFE_ES_STOP_PERF_DATA_CC
 **
@@ -1295,15 +1318,18 @@ typedef struct CFE_ES_StopPerfCmd_Payload
                                                                     of file Performance Analyzer data is to be written */
 } CFE_ES_StopPerfCmd_Payload_t;
 
-typedef struct CFE_ES_StopPerfData
+/**
+ * \brief Stop Performance Analyzer Command
+ */
+typedef struct CFE_ES_StopPerfDataCmd
 {
-    uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
-    CFE_ES_StopPerfCmd_Payload_t    Payload;
-} CFE_ES_StopPerfData_t;
+    CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
+    CFE_ES_StopPerfCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_ES_StopPerfDataCmd_t;
 
 
 /**
-** \brief Set Performance Analyzer Filter Mask Command
+** \brief Set Performance Analyzer Filter Mask Command Payload
 **
 ** For command details, see #CFE_ES_SET_PERF_FILTER_MASK_CC
 **
@@ -1315,14 +1341,17 @@ typedef struct CFE_ES_SetPerfFilterMaskCmd_Payload
 
 } CFE_ES_SetPerfFilterMaskCmd_Payload_t;
 
-typedef struct CFE_ES_SetPerfFilterMask
+/**
+ * \brief Set Performance Analyzer Filter Mask Command
+ */
+typedef struct CFE_ES_SetPerfFilterMaskCmd
 {
-    uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
-    CFE_ES_SetPerfFilterMaskCmd_Payload_t Payload;
-} CFE_ES_SetPerfFilterMask_t;
+    CFE_MSG_CommandHeader_t               CmdHeader; /**< \brief Command header */
+    CFE_ES_SetPerfFilterMaskCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_ES_SetPerfFilterMaskCmd_t;
 
 /**
-** \brief Set Performance Analyzer Trigger Mask Command
+** \brief Set Performance Analyzer Trigger Mask Command Payload
 **
 ** For command details, see #CFE_ES_SET_PERF_TRIGGER_MASK_CC
 **
@@ -1334,14 +1363,17 @@ typedef struct CFE_ES_SetPerfTrigMaskCmd_Payload
 
 } CFE_ES_SetPerfTrigMaskCmd_Payload_t;
 
-typedef struct CFE_ES_SetPerfTriggerMask
+/**
+ * \brief Set Performance Analyzer Trigger Mask Command
+ */
+typedef struct CFE_ES_SetPerfTriggerMaskCmd
 {
-    uint8                               CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
-    CFE_ES_SetPerfTrigMaskCmd_Payload_t Payload;
-} CFE_ES_SetPerfTriggerMask_t;
+    CFE_MSG_CommandHeader_t             CmdHeader; /**< \brief Command header */
+    CFE_ES_SetPerfTrigMaskCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_ES_SetPerfTriggerMaskCmd_t;
 
 /**
-** \brief Telemeter Memory Pool Statistics Command
+** \brief Send Memory Pool Statistics Command Payload
 **
 ** For command details, see #CFE_ES_SEND_MEM_POOL_STATS_CC
 **
@@ -1353,14 +1385,17 @@ typedef struct CFE_ES_SendMemPoolStatsCmd_Payload
 
 } CFE_ES_SendMemPoolStatsCmd_Payload_t;
 
-typedef struct CFE_ES_SendMemPoolStats
+/**
+ * \brief Send Memory Pool Statistics Command
+ */
+typedef struct CFE_ES_SendMemPoolStatsCmd
 {
-    uint8                               CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
-    CFE_ES_SendMemPoolStatsCmd_Payload_t    Payload;
-} CFE_ES_SendMemPoolStats_t;
+    CFE_MSG_CommandHeader_t              CmdHeader; /**< \brief Command header */
+    CFE_ES_SendMemPoolStatsCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_ES_SendMemPoolStatsCmd_t;
 
 /**
-** \brief Dump CDS Registry Command
+** \brief Dump CDS Registry Command Payload
 **
 ** For command details, see #CFE_ES_DUMP_CDS_REGISTRY_CC
 **
@@ -1371,12 +1406,14 @@ typedef struct CFE_ES_DumpCDSRegistryCmd_Payload
                                                                     of file CDS Registry is to be written */
 } CFE_ES_DumpCDSRegistryCmd_Payload_t;
 
-typedef struct CFE_ES_DumpCDSRegistry
+/**
+ * \brief Dump CDS Registry Command
+ */
+typedef struct CFE_ES_DumpCDSRegistryCmd
 {
-    uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE];    /**< \brief cFE Software Bus Command Message Header */
-    CFE_ES_DumpCDSRegistryCmd_Payload_t  Payload;
-
-} CFE_ES_DumpCDSRegistry_t;
+    CFE_MSG_CommandHeader_t             CmdHeader; /**< \brief Command header */
+    CFE_ES_DumpCDSRegistryCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_ES_DumpCDSRegistryCmd_t;
 
 /*************************************************************************/
 
@@ -1529,8 +1566,8 @@ typedef struct CFE_ES_OneAppTlm_Payload
 
 typedef struct CFE_ES_OneAppTlm
 {
-    CFE_SB_TlmHdr_t             TlmHeader; /**< \brief cFE Software Bus Telemetry Message Header */
-    CFE_ES_OneAppTlm_Payload_t  Payload;
+    CFE_MSG_TelemetryHeader_t  TlmHeader; /**< \brief Telemetry header */
+    CFE_ES_OneAppTlm_Payload_t Payload;   /**< \brief Telemetry payload */
 } CFE_ES_OneAppTlm_t;
 
 /** 
@@ -1545,8 +1582,8 @@ typedef struct CFE_ES_PoolStatsTlm_Payload
 
 typedef struct CFE_ES_MemStatsTlm
 {
-    CFE_SB_TlmHdr_t                 TlmHeader; /**< \brief cFE Software Bus Telemetry Message Header */
-    CFE_ES_PoolStatsTlm_Payload_t   Payload;
+    CFE_MSG_TelemetryHeader_t     TlmHeader; /**< \brief Telemetry header */
+    CFE_ES_PoolStatsTlm_Payload_t Payload;   /**< \brief Telemetry payload */
 } CFE_ES_MemStatsTlm_t;
 
 /*************************************************************************/
@@ -1642,8 +1679,8 @@ typedef struct CFE_ES_HousekeepingTlm_Payload
 
 typedef struct CFE_ES_HousekeepingTlm
 {
-    CFE_SB_TlmHdr_t                  TlmHeader; /**< \brief cFE Software Bus Telemetry Message Header */
-    CFE_ES_HousekeepingTlm_Payload_t Payload;
+    CFE_MSG_TelemetryHeader_t        TlmHeader; /**< \brief Telemetry header */
+    CFE_ES_HousekeepingTlm_Payload_t Payload;   /**< \brief Telemetry payload */
   
 } CFE_ES_HousekeepingTlm_t;
 

--- a/fsw/cfe-core/src/inc/cfe_evs.h
+++ b/fsw/cfe-core/src/inc/cfe_evs.h
@@ -214,7 +214,7 @@ CFE_Status_t CFE_EVS_Unregister( void );
 **                               in the format string; they will mess up the formatting when the events are 
 **                               displayed on the ground system.
 **
-** \return Execution status below or from #CFE_ES_GetAppID/#CFE_SB_SendMsg, see \ref CFEReturnCodes
+** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                \copybrief CFE_SUCCESS
 ** \retval #CFE_EVS_APP_NOT_REGISTERED \copybrief CFE_EVS_APP_NOT_REGISTERED
 ** \retval #CFE_EVS_APP_ILLEGAL_APP_ID \copybrief CFE_EVS_APP_ILLEGAL_APP_ID
@@ -265,7 +265,7 @@ CFE_Status_t CFE_EVS_SendEvent (uint16 EventID,
 **                               in the format string; they will mess up the formatting when the events are 
 **                               displayed on the ground system.
 **
-** \return Execution status below or from #CFE_ES_GetAppID/#CFE_SB_SendMsg, see \ref CFEReturnCodes
+** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                \copybrief CFE_SUCCESS
 ** \retval #CFE_EVS_APP_NOT_REGISTERED \copybrief CFE_EVS_APP_NOT_REGISTERED
 ** \retval #CFE_EVS_APP_ILLEGAL_APP_ID \copybrief CFE_EVS_APP_ILLEGAL_APP_ID
@@ -317,7 +317,7 @@ CFE_Status_t CFE_EVS_SendEventWithAppID (uint16 EventID,
 **                               in the format string; they will mess up the formatting when the events are 
 **                               displayed on the ground system.
 **
-** \return Execution status below or from #CFE_ES_GetAppID/#CFE_SB_SendMsg, see \ref CFEReturnCodes
+** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                \copybrief CFE_SUCCESS
 ** \retval #CFE_EVS_APP_NOT_REGISTERED \copybrief CFE_EVS_APP_NOT_REGISTERED
 ** \retval #CFE_EVS_APP_ILLEGAL_APP_ID \copybrief CFE_EVS_APP_ILLEGAL_APP_ID

--- a/fsw/cfe-core/src/inc/cfe_evs_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_evs_msg.h
@@ -56,7 +56,7 @@
 **  \cfecmdmnemonic \EVS_NOOP
 **
 **  \par Command Structure
-**       #CFE_TBL_NoArgsCmd_t
+**       #CFE_EVS_NoopCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -90,7 +90,7 @@
 **  \cfecmdmnemonic \EVS_RESETCTRS
 **
 **  \par Command Structure
-**       #CFE_TBL_NoArgsCmd_t
+**       #CFE_EVS_ResetCountersCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -128,7 +128,7 @@
 **  \cfecmdmnemonic \EVS_ENAEVENTTYPE
 **
 **  \par Command Structure
-**       #CFE_EVS_BitMaskCmd_t
+**       #CFE_EVS_EnableEventTypeCmd_t
 **        The following bit positions apply to structure member named 'BitMask'.
 **            Bit 0 - Debug
 **            Bit 1 - Informational
@@ -177,7 +177,7 @@
 **  \cfecmdmnemonic \EVS_DISEVENTTYPE
 **
 **  \par Command Structure
-**       #CFE_EVS_BitMaskCmd_t
+**       #CFE_EVS_DisableEventTypeCmd_t
 **        The following bit positions apply to structure member named 'BitMask'.
 **            Bit 0 - Debug
 **            Bit 1 - Informational
@@ -235,7 +235,7 @@
 **  \cfecmdmnemonic \EVS_SETEVTFMT
 **
 **  \par Command Structure
-**       #CFE_EVS_SetLogMode_t
+**       #CFE_EVS_SetEventFormatModeCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -278,7 +278,7 @@
 **  \cfecmdmnemonic \EVS_ENAAPPEVTTYPE
 **
 **  \par Command Structure
-**       #CFE_EVS_AppNameBitMaskCmd_t
+**       #CFE_EVS_EnableAppEventTypeCmd_t
 **        The following bit positions apply to structure member named 'BitMask'.
 **            Bit 0 - Debug
 **            Bit 1 - Informational
@@ -330,7 +330,7 @@
 **  \cfecmdmnemonic \EVS_DISAPPEVTTYPE
 **
 **  \par Command Structure
-**       #CFE_EVS_AppNameBitMaskCmd_t
+**       #CFE_EVS_DisableAppEventTypeCmd_t
 **        The following bit positions apply to structure member named 'BitMask'.
 **            Bit 0 - Debug
 **            Bit 1 - Informational
@@ -379,7 +379,7 @@
 **  \cfecmdmnemonic \EVS_ENAAPPEVGEN
 **
 **  \par Command Structure
-**       #CFE_EVS_AppNameCmd_t
+**       #CFE_EVS_EnableAppEventsCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -420,7 +420,7 @@
 **  \cfecmdmnemonic \EVS_DISAPPEVGEN
 **
 **  \par Command Structure
-**       #CFE_EVS_AppNameCmd_t
+**       #CFE_EVS_DisableAppEventsCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -461,7 +461,7 @@
 **  \cfecmdmnemonic \EVS_RSTAPPCTRS
 **
 **  \par Command Structure
-**       #CFE_EVS_AppNameCmd_t
+**       #CFE_EVS_ResetAppCounterCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -500,7 +500,7 @@
 **  \cfecmdmnemonic \EVS_SETBINFLTRMASK
 **
 **  \par Command Structure
-**       #CFE_EVS_AppNameEventIDMaskCmd_t
+**       #CFE_EVS_SetFilterCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -539,7 +539,7 @@
 **  \cfecmdmnemonic \EVS_ENAPORT
 **
 **  \par Command Structure
-**       #CFE_EVS_BitMaskCmd_t
+**       #CFE_EVS_EnablePortsCmd_t
 **        The following bit positions apply to structure member named 'BitMask'.
 **            Bit 0 - Port 1
 **            Bit 1 - Port 2
@@ -579,7 +579,7 @@
 **  \cfecmdmnemonic \EVS_DISPORT
 **
 **  \par Command Structure
-**       #CFE_EVS_BitMaskCmd_t
+**       #CFE_EVS_DisablePortsCmd_t
 **        The following bit positions apply to structure member named 'BitMask'.
 **            Bit 0 - Port 1
 **            Bit 1 - Port 2
@@ -621,7 +621,7 @@
 **  \cfecmdmnemonic \EVS_RSTBINFLTRCTR
 **
 **  \par Command Structure
-**       #CFE_EVS_AppNameEventIDCmd_t
+**       #CFE_EVS_ResetFilterCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -657,7 +657,7 @@
 **  \cfecmdmnemonic \EVS_RSTALLFLTRS
 **
 **  \par Command Structure
-**       #CFE_EVS_AppNameCmd_t
+**       #CFE_EVS_ResetAllFiltersCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -693,7 +693,7 @@
 **  \cfecmdmnemonic \EVS_ADDEVTFLTR
 **
 **  \par Command Structure
-**       #CFE_EVS_AppNameEventIDMaskCmd_t
+**       #CFE_EVS_AddEventFilterCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -729,7 +729,7 @@
 **  \cfecmdmnemonic \EVS_DELEVTFLTR
 **
 **  \par Command Structure
-**       #CFE_EVS_AppNameEventIDCmd_t
+**       #CFE_EVS_DeleteEventFilterCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -765,7 +765,7 @@
 **  \cfecmdmnemonic \EVS_WRITEAPPDATA2FILE
 **
 **  \par Command Structure
-**       #CFE_EVS_WriteAppDataFile_t
+**       #CFE_EVS_WriteAppDataFileCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -800,7 +800,7 @@
 **  \cfecmdmnemonic \EVS_WRITELOG2FILE
 **
 **  \par Command Structure
-**       #CFE_EVS_WriteLogDataFile_t
+**       #CFE_EVS_WriteLogDataFileCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -833,7 +833,7 @@
 **  \cfecmdmnemonic \EVS_SETLOGMODE
 **
 **  \par Command Structure
-**       #CFE_EVS_SetLogMode_t
+**       #CFE_EVS_SetLogModeCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -869,7 +869,7 @@
 **  \cfecmdmnemonic \EVS_CLRLOG
 **
 **  \par Command Structure
-**       #CFE_TBL_NoArgsCmd_t
+**       #CFE_EVS_ClearLogCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -919,7 +919,7 @@
 ** \brief Command with no additional arguments
 **/
 typedef struct CFE_EVS_NoArgsCmd {
-   uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 } CFE_EVS_NoArgsCmd_t;
 
 /*
@@ -927,28 +927,31 @@ typedef struct CFE_EVS_NoArgsCmd {
  * Create a unique type for each one so the prototypes will follow the naming pattern,
  * allowing each command to evolve independently.
  */
-typedef CFE_EVS_NoArgsCmd_t CFE_EVS_Noop_t;
-typedef CFE_EVS_NoArgsCmd_t CFE_EVS_ResetCounters_t;
-typedef CFE_EVS_NoArgsCmd_t CFE_EVS_ClearLog_t;
+typedef CFE_EVS_NoArgsCmd_t CFE_EVS_NoopCmd_t;
+typedef CFE_EVS_NoArgsCmd_t CFE_EVS_ResetCountersCmd_t;
+typedef CFE_EVS_NoArgsCmd_t CFE_EVS_ClearLogCmd_t;
 
 /**
-** \brief Write Event Log to File Command
+** \brief Write Event Log to File Command Payload
 **
 ** For command details, see #CFE_EVS_WRITE_LOG_DATA_FILE_CC
 **
 **/
 typedef struct CFE_EVS_LogFileCmd_Payload {
-    char LogFilename[CFE_MISSION_MAX_PATH_LEN];      /**< \brief Filename where log data is to be written */
+    char LogFilename[CFE_MISSION_MAX_PATH_LEN]; /**< \brief Filename where log data is to be written */
 } CFE_EVS_LogFileCmd_Payload_t;
 
-typedef struct CFE_EVS_WriteLogDataFile {
-   uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];
-   CFE_EVS_LogFileCmd_Payload_t Payload;
-} CFE_EVS_WriteLogDataFile_t;
+/**
+ * \brief Write Event Log to File Command
+ */
+typedef struct CFE_EVS_WriteLogDataFileCmd {
+    CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
+    CFE_EVS_LogFileCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_EVS_WriteLogDataFileCmd_t;
 
 
 /**
-** \brief Write Event Services Application Information to File Command
+** \brief Write Event Services Application Information to File Command Payload
 **
 ** For command details, see #CFE_EVS_WRITE_APP_DATA_FILE_CC
 **
@@ -957,31 +960,37 @@ typedef struct CFE_EVS_AppDataCmd_Payload {
    char AppDataFilename[CFE_MISSION_MAX_PATH_LEN];  /**< \brief Filename where applicaton data is to be written */
 } CFE_EVS_AppDataCmd_Payload_t;
 
-typedef struct CFE_EVS_WriteAppDataFile {
-   uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];
-   CFE_EVS_AppDataCmd_Payload_t Payload;
-} CFE_EVS_WriteAppDataFile_t;
+/**
+ * \brief Write Event Services Application Information to File Command
+ */
+typedef struct CFE_EVS_WriteAppDataFileCmd {
+    CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
+    CFE_EVS_AppDataCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_EVS_WriteAppDataFileCmd_t;
 
 /**
-** \brief Set Event Format Mode or Set Log Mode Commands
+** \brief Set Log Mode Command Payload
 **
-** For command details, see #CFE_EVS_SET_EVENT_FORMAT_MODE_CC and/or #CFE_EVS_SET_LOG_MODE_CC
+** For command details, see #CFE_EVS_SET_LOG_MODE_CC
 **
 **/
 typedef struct CFE_EVS_SetLogMode_Payload {
     CFE_EVS_LogMode_Enum_t   LogMode;                           /**< \brief Mode to use in the command*/
-   uint8                     Spare;                             /**< \brief Pad to even byte*/
+    uint8                    Spare;                             /**< \brief Pad to even byte*/
 } CFE_EVS_SetLogMode_Payload_t;
 
-typedef struct CFE_EVS_SetLogMode {
-   uint8                     CmdHeader[CFE_SB_CMD_HDR_SIZE];
-   CFE_EVS_SetLogMode_Payload_t Payload;
-} CFE_EVS_SetLogMode_t;
+/**
+ * \brief Set Log Mode Command
+ */
+typedef struct CFE_EVS_SetLogModeCmd {
+    CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
+    CFE_EVS_SetLogMode_Payload_t Payload;   /**< \brief Command payload */
+} CFE_EVS_SetLogModeCmd_t;
 
 /**
-** \brief Set Event Format Mode or Set Log Mode Commands
+** \brief Set Event Format Mode Command Payload
 **
-** For command details, see #CFE_EVS_SET_EVENT_FORMAT_MODE_CC and/or #CFE_EVS_SET_LOG_MODE_CC
+** For command details, see #CFE_EVS_SET_EVENT_FORMAT_MODE_CC
 **
 **/
 typedef struct CFE_EVS_SetEventFormatCode_Payload {
@@ -989,13 +998,16 @@ typedef struct CFE_EVS_SetEventFormatCode_Payload {
    uint8                     Spare;                             /**< \brief Pad to even byte*/
 } CFE_EVS_SetEventFormatMode_Payload_t;
 
-typedef struct CFE_EVS_SetEventFormatMode {
-   uint8                     CmdHeader[CFE_SB_CMD_HDR_SIZE];
-   CFE_EVS_SetEventFormatMode_Payload_t Payload;
-} CFE_EVS_SetEventFormatMode_t;
+/**
+ * \brief Set Event Format Mode Command
+ */
+typedef struct CFE_EVS_SetEventFormatModeCmd {
+    CFE_MSG_CommandHeader_t              CmdHeader; /**< \brief Command header */
+    CFE_EVS_SetEventFormatMode_Payload_t Payload;   /**< \brief Command payload */
+} CFE_EVS_SetEventFormatModeCmd_t;
 
 /**
-** \brief Enable/Disable Events or Ports Commands
+** \brief Generic Bitmask Command Payload
 **
 ** For command details, see #CFE_EVS_ENABLE_EVENT_TYPE_CC, #CFE_EVS_DISABLE_EVENT_TYPE_CC,
 **                          #CFE_EVS_ENABLE_PORTS_CC and/or #CFE_EVS_DISABLE_PORTS_CC
@@ -1006,9 +1018,12 @@ typedef struct CFE_EVS_BitMaskCmd_Payload {
    uint8                     Spare;                             /**< \brief Pad to even byte*/
 } CFE_EVS_BitMaskCmd_Payload_t;
 
+/**
+ * \brief Generic Bitmask Command
+ */
 typedef struct CFE_EVS_BitMaskCmd {
-   uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];
-   CFE_EVS_BitMaskCmd_Payload_t Payload;
+    CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
+    CFE_EVS_BitMaskCmd_Payload_t Payload;   /**< \brief Command payload */
 } CFE_EVS_BitMaskCmd_t;
 
 /*
@@ -1016,13 +1031,13 @@ typedef struct CFE_EVS_BitMaskCmd {
  * Create a unique type for each one so the prototypes will follow the naming pattern,
  * allowing each command to evolve independently.
  */
-typedef CFE_EVS_BitMaskCmd_t CFE_EVS_EnablePorts_t;
-typedef CFE_EVS_BitMaskCmd_t CFE_EVS_DisablePorts_t;
-typedef CFE_EVS_BitMaskCmd_t CFE_EVS_EnableEventType_t;
-typedef CFE_EVS_BitMaskCmd_t CFE_EVS_DisableEventType_t;
+typedef CFE_EVS_BitMaskCmd_t CFE_EVS_EnablePortsCmd_t;
+typedef CFE_EVS_BitMaskCmd_t CFE_EVS_DisablePortsCmd_t;
+typedef CFE_EVS_BitMaskCmd_t CFE_EVS_EnableEventTypeCmd_t;
+typedef CFE_EVS_BitMaskCmd_t CFE_EVS_DisableEventTypeCmd_t;
 
 /**
-** \brief Enable/Disable Application Events or Reset One or All Filter Counters
+** \brief Generic App Name Command Payload
 **
 ** For command details, see #CFE_EVS_ENABLE_APP_EVENTS_CC, #CFE_EVS_DISABLE_APP_EVENTS_CC,
 **                          #CFE_EVS_RESET_APP_COUNTER_CC and/or #CFE_EVS_RESET_ALL_FILTERS_CC
@@ -1032,9 +1047,12 @@ typedef struct CFE_EVS_AppNameCmd_Payload {
    char                     AppName[CFE_MISSION_MAX_API_LEN];          /**< \brief Application name to use in the command*/
 } CFE_EVS_AppNameCmd_Payload_t;
 
+/**
+ * \brief Generic App Name Command
+ */
 typedef struct CFE_EVS_AppNameCmd {
-   uint8                        CmdHeader[CFE_SB_CMD_HDR_SIZE];
-   CFE_EVS_AppNameCmd_Payload_t Payload;
+    CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
+    CFE_EVS_AppNameCmd_Payload_t Payload;   /**< \brief Command payload */
 } CFE_EVS_AppNameCmd_t;
 
 /*
@@ -1042,15 +1060,15 @@ typedef struct CFE_EVS_AppNameCmd {
  * Create a unique type for each one so the prototypes will follow the naming pattern,
  * allowing each command to evolve independently.
  */
-typedef CFE_EVS_AppNameCmd_t CFE_EVS_EnableAppEvents_t;
-typedef CFE_EVS_AppNameCmd_t CFE_EVS_DisableAppEvents_t;
-typedef CFE_EVS_AppNameCmd_t CFE_EVS_ResetAppCounter_t;
-typedef CFE_EVS_AppNameCmd_t CFE_EVS_ResetAllFilters_t;
+typedef CFE_EVS_AppNameCmd_t CFE_EVS_EnableAppEventsCmd_t;
+typedef CFE_EVS_AppNameCmd_t CFE_EVS_DisableAppEventsCmd_t;
+typedef CFE_EVS_AppNameCmd_t CFE_EVS_ResetAppCounterCmd_t;
+typedef CFE_EVS_AppNameCmd_t CFE_EVS_ResetAllFiltersCmd_t;
 
 /**
-** \brief Reset an Event Filter for an Application
+** \brief Generic App Name and Event ID Command Payload
 **
-** For command details, see #CFE_EVS_RESET_FILTER_CC
+** For command details, see #CFE_EVS_RESET_FILTER_CC and #CFE_EVS_DELETE_EVENT_FILTER_CC
 **
 **/
 typedef struct CFE_EVS_AppNameEventIDCmd_Payload {
@@ -1058,9 +1076,12 @@ typedef struct CFE_EVS_AppNameEventIDCmd_Payload {
    uint16                    EventID;                           /**< \brief Event ID  to use in the command*/
 } CFE_EVS_AppNameEventIDCmd_Payload_t;
 
+/**
+ * \brief Generic App Name and Event ID Command
+ */
 typedef struct CFE_EVS_AppNameEventIDCmd {
-   uint8                                CmdHeader[CFE_SB_CMD_HDR_SIZE];
-   CFE_EVS_AppNameEventIDCmd_Payload_t  Payload;
+    CFE_MSG_CommandHeader_t              CmdHeader; /**< \brief Command header */
+    CFE_EVS_AppNameEventIDCmd_Payload_t  Payload;   /**< \brief Command payload */
 } CFE_EVS_AppNameEventIDCmd_t;
 
 /*
@@ -1068,11 +1089,11 @@ typedef struct CFE_EVS_AppNameEventIDCmd {
  * Create a unique type for each one so the prototypes will follow the naming pattern,
  * allowing each command to evolve independently.
  */
-typedef CFE_EVS_AppNameEventIDCmd_t CFE_EVS_ResetFilter_t;
-typedef CFE_EVS_AppNameEventIDCmd_t CFE_EVS_DeleteEventFilter_t;
+typedef CFE_EVS_AppNameEventIDCmd_t CFE_EVS_ResetFilterCmd_t;
+typedef CFE_EVS_AppNameEventIDCmd_t CFE_EVS_DeleteEventFilterCmd_t;
 
 /**
-** \brief Enable/Disable an Event Type for an Application
+** \brief Generic App Name and Bitmask Command Payload
 **
 ** For command details, see #CFE_EVS_ENABLE_APP_EVENT_TYPE_CC and/or #CFE_EVS_DISABLE_APP_EVENT_TYPE_CC
 **
@@ -1083,9 +1104,12 @@ typedef struct CFE_EVS_AppNameBitMaskCmd_Payload {
    uint8                     Spare;                             /**< \brief Pad to even byte*/
 } CFE_EVS_AppNameBitMaskCmd_Payload_t;
 
+/**
+ * \brief Generic App Name and Bitmask Command
+ */
 typedef struct CFE_EVS_AppNameBitMaskCmd {
-   uint8                     CmdHeader[CFE_SB_CMD_HDR_SIZE];
-   CFE_EVS_AppNameBitMaskCmd_Payload_t Payload;
+    CFE_MSG_CommandHeader_t             CmdHeader; /**< \brief Command header */
+    CFE_EVS_AppNameBitMaskCmd_Payload_t Payload;   /**< \brief Command payload */
 } CFE_EVS_AppNameBitMaskCmd_t;
 
 /*
@@ -1093,11 +1117,11 @@ typedef struct CFE_EVS_AppNameBitMaskCmd {
  * Create a unique type for each one so the prototypes will follow the naming pattern,
  * allowing each command to evolve independently.
  */
-typedef CFE_EVS_AppNameBitMaskCmd_t CFE_EVS_EnableAppEventType_t;
-typedef CFE_EVS_AppNameBitMaskCmd_t CFE_EVS_DisableAppEventType_t;
+typedef CFE_EVS_AppNameBitMaskCmd_t CFE_EVS_EnableAppEventTypeCmd_t;
+typedef CFE_EVS_AppNameBitMaskCmd_t CFE_EVS_DisableAppEventTypeCmd_t;
 
 /**
-** \brief Set, Add or Delete an Event Filter for an Application
+** \brief Generic App Name, Event ID, Mask Command Payload
 **
 ** For command details, see #CFE_EVS_SET_FILTER_CC, #CFE_EVS_ADD_EVENT_FILTER_CC 
 **                      and/or #CFE_EVS_DELETE_EVENT_FILTER_CC
@@ -1109,9 +1133,12 @@ typedef struct CFE_EVS_AppNameEventIDMaskCmd_Payload {
    uint16                    Mask;                              /**< \brief Mask to use in the command */
 } CFE_EVS_AppNameEventIDMaskCmd_Payload_t;
 
+/**
+ * \brief Generic App Name, Event ID, Mask Command
+ */
 typedef struct CFE_EVS_AppNameEventIDMaskCmd {
-   uint8                                    CmdHeader[CFE_SB_CMD_HDR_SIZE];
-   CFE_EVS_AppNameEventIDMaskCmd_Payload_t  Payload;
+    CFE_MSG_CommandHeader_t                 CmdHeader; /**< \brief Command header */
+    CFE_EVS_AppNameEventIDMaskCmd_Payload_t Payload;   /**< \brief Command payload */
 } CFE_EVS_AppNameEventIDMaskCmd_t;
 
 /*
@@ -1119,8 +1146,8 @@ typedef struct CFE_EVS_AppNameEventIDMaskCmd {
  * Create a unique type for each one so the prototypes will follow the naming pattern,
  * allowing each command to evolve independently.
  */
-typedef CFE_EVS_AppNameEventIDMaskCmd_t CFE_EVS_AddEventFilter_t;
-typedef CFE_EVS_AppNameEventIDMaskCmd_t CFE_EVS_SetFilter_t;
+typedef CFE_EVS_AppNameEventIDMaskCmd_t CFE_EVS_AddEventFilterCmd_t;
+typedef CFE_EVS_AppNameEventIDMaskCmd_t CFE_EVS_SetFilterCmd_t;
 
 /*************************************************************************/
 /**********************************/
@@ -1181,8 +1208,8 @@ typedef struct CFE_EVS_HousekeepingTlm_Payload {
 } CFE_EVS_HousekeepingTlm_Payload_t;
 
 typedef struct CFE_EVS_HousekeepingTlm {
-   CFE_SB_TlmHdr_t                   TlmHeader;
-   CFE_EVS_HousekeepingTlm_Payload_t Payload;
+   CFE_MSG_TelemetryHeader_t         TlmHeader; /**< \brief Telemetry header */
+   CFE_EVS_HousekeepingTlm_Payload_t Payload;   /**< \brief Telemetry payload */
 } CFE_EVS_HousekeepingTlm_t;
 
 /** Telemetry packet structures */
@@ -1224,14 +1251,14 @@ typedef struct CFE_EVS_ShortEventTlm_Payload {
 } CFE_EVS_ShortEventTlm_Payload_t;
 
 typedef struct CFE_EVS_LongEventTlm {
-   CFE_SB_TlmHdr_t                TlmHeader;
-   CFE_EVS_LongEventTlm_Payload_t Payload;
+   CFE_MSG_TelemetryHeader_t      TlmHeader; /**< \brief Telemetry header */
+   CFE_EVS_LongEventTlm_Payload_t Payload;   /**< \brief Telemetry payload */
 
 } CFE_EVS_LongEventTlm_t;
 
 typedef struct CFE_EVS_ShortEventTlm {
-   CFE_SB_TlmHdr_t                 TlmHeader;
-   CFE_EVS_ShortEventTlm_Payload_t Payload;
+   CFE_MSG_TelemetryHeader_t       TlmHeader; /**< \brief Telemetry header */
+   CFE_EVS_ShortEventTlm_Payload_t Payload;   /**< \brief Telemetry payload */
 
 } CFE_EVS_ShortEventTlm_t;
 

--- a/fsw/cfe-core/src/inc/cfe_msg_typedefs.h
+++ b/fsw/cfe-core/src/inc/cfe_msg_typedefs.h
@@ -43,7 +43,7 @@
 /*
  * Types
  */
-typedef uint32 CFE_MSG_Size_t;          /**< \brief Message size (CCSDS needs uint32 for max size) */
+typedef size_t CFE_MSG_Size_t;          /**< \brief Message size (CCSDS needs uint32 for max size) */
 typedef uint32 CFE_MSG_Checksum_t;      /**< \brief Message checksum (Oversized to avoid redefine) */
 typedef uint16 CFE_MSG_FcnCode_t;       /**< \brief Message function code */
 typedef uint16 CFE_MSG_HeaderVersion_t; /**< \brief Message header version */

--- a/fsw/cfe-core/src/inc/cfe_sb_events.h
+++ b/fsw/cfe-core/src/inc/cfe_sb_events.h
@@ -361,7 +361,7 @@
 **
 **  \par Cause:
 **
-**  This error event message is issued when the #CFE_SB_SendMsg API receives an
+**  This error event message is issued when a transmit API receives an
 **  invalid (possibly NULL) ptr as an argument.
 **/
 #define CFE_SB_SEND_BAD_ARG_EID         13
@@ -373,7 +373,7 @@
 **
 **  \par Cause:
 **
-**  This info event message is issued when the #CFE_SB_SendMsg API is called and there
+**  This info event message is issued when a transmit API is called and there
 **  are no subscribers (therefore no destinations) for the message to be sent. Each
 **  time the SB detects this situation, the corresponding SB telemetry point is
 **  incremented..
@@ -391,7 +391,7 @@
 **
 **  \par Cause:
 **
-**  This error event message is issued when the #CFE_SB_SendMsg API is called and the
+**  This error event message is issued when a transmit API is called and the
 **  packet length field in the message header implies that the message size exceeds
 **  the max size defined by mission cfg param #CFE_MISSION_SB_MAX_SB_MSG_SIZE. The request to
 **  send the message is denied, there is no partial packet sent.
@@ -405,7 +405,7 @@
 **
 **  \par Cause:
 **
-**  This error event message is issued when the #CFE_SB_SendMsg API fails to receive
+**  This error event message is issued when a transmit API fails to receive
 **  the necessary buffer memory from the ES memory pool. This could be an indication
 **  that the cfg param #CFE_PLATFORM_SB_BUF_MEMORY_BYTES is set too low. To check this, send SB
 **  cmd to dump the SB statistics pkt and view the buffer memory parameters.
@@ -419,7 +419,7 @@
 **
 **  \par Cause:
 **
-**  This error event message is issued when the #CFE_SB_SendMsg API cannot route the
+**  This error event message is issued when a transmit API cannot route the
 **  MsgId (displayed in event) to the pipe (displayed in the event) because the pipe
 **  currently contains the maximum number of messages of this type (MsgId). This is
 **  typically an indication that the receiver is not reading its pipe fast enough, or
@@ -439,7 +439,7 @@
 **  \par Cause:
 **
 **  This error event message is issued when an invalid paramter is passed into the
-**  #CFE_SB_RcvMsg API. Two possibile problems would be the first parameter (*BufPtr)
+**  #CFE_SB_ReceiveBuffer API. Two possibile problems would be the first parameter (*BufPtr)
 **  being NULL or the third paramter (TimeOut) being less than -1.
 **/
 #define CFE_SB_RCV_BAD_ARG_EID          18
@@ -452,7 +452,7 @@
 **  \par Cause:
 **
 **  This error event message is issued when an invalid PipeId is passed into the
-**  #CFE_SB_RcvMsg API. The SB Pipe Table shows all valid PipeIds and may be viewed
+**  #CFE_SB_ReceiveBuffer API. The SB Pipe Table shows all valid PipeIds and may be viewed
 **  for verification.
 **/
 #define CFE_SB_BAD_PIPEID_EID           19
@@ -479,7 +479,7 @@
 **
 **  \par Cause:
 **
-**  This error event message is issued when the #CFE_SB_SendMsg API is called and
+**  This error event message is issued when a transmit API is called and
 **  the SB discovers that the message to send has a msg id that is invalid. It may be
 **  due to a msg id  that is greater than cfg parameter #CFE_PLATFORM_SB_HIGHEST_VALID_MSGID
 **/
@@ -519,7 +519,7 @@
 **
 **  \par Cause:
 **
-**  This error event message is issued when the #CFE_SB_SendMsg API is called and
+**  This error event message is issued when a transmit API is called and
 **  encounters an error when attempting to write the msg to the destination pipe
 **  (which is an underlying queue). This could indicate that the owner of the pipe is
 **  not readings its messages fast enough or at all. It may also mean that the
@@ -535,7 +535,7 @@
 **
 **  \par Cause:
 **
-**  This error event message is issued when the #CFE_SB_SendMsg API is called and
+**  This error event message is issued when a transmit API is called and
 **  encounters an error when attempting to write the msg to the destination pipe
 **  (which is an underlying queue). More precisely, the OS API #OS_QueuePut has
 **  returned an unexpected error. The return code is displayed in the event. For
@@ -551,7 +551,7 @@
 **
 **  \par Cause:
 **
-**  This error event message is issued when the #CFE_SB_SendMsg API is called and
+**  This error event message is issued when a transmit API is called and
 **  encounters an error when attempting to read the msg from the destination pipe
 **  (which is an underlying queue). More precisely, the OS API #OS_QueueGet has
 **  returned an unexpected error. The return code is displayed in the event. For

--- a/fsw/cfe-core/src/inc/cfe_sb_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_sb_msg.h
@@ -54,7 +54,7 @@
 **  \cfecmdmnemonic \SB_NOOP
 **
 **  \par Command Structure
-**       #CFE_SB_CmdHdr_t
+**       #CFE_SB_NoopCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the
@@ -88,7 +88,7 @@
 **  \cfecmdmnemonic \SB_RESETCTRS
 **
 **  \par Command Structure
-**       #CFE_SB_CmdHdr_t
+**       #CFE_SB_ResetCountersCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the
@@ -125,7 +125,7 @@
 **  \cfecmdmnemonic \SB_DUMPSTATS
 **
 **  \par Command Structure
-**       #CFE_SB_CmdHdr_t
+**       #CFE_SB_SendSbStatsCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the
@@ -164,7 +164,7 @@
 **  \cfecmdmnemonic \SB_WRITEROUTING2FILE
 **
 **  \par Command Structure
-**       #CFE_SB_WriteFileInfoCmd_t
+**       #CFE_SB_SendRoutingInfoCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the
@@ -205,7 +205,7 @@
 **  \cfecmdmnemonic \SB_ENAROUTE
 **
 **  \par Command Structure
-**       #CFE_SB_RouteCmd_t
+**       #CFE_SB_EnableRouteCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the
@@ -243,7 +243,7 @@
 **  \cfecmdmnemonic \SB_DISROUTE
 **
 **  \par Command Structure
-**       #CFE_SB_RouteCmd_t
+**       #CFE_SB_DisableRouteCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the
@@ -291,7 +291,7 @@
 **  \cfecmdmnemonic \SB_WRITEPIPE2FILE
 **
 **  \par Command Structure
-**       #CFE_SB_WriteFileInfoCmd_t
+**       #CFE_SB_SendPipeInfoCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the
@@ -336,7 +336,7 @@
 **  \cfecmdmnemonic \SB_WRITEMAP2FILE
 **
 **  \par Command Structure
-**       #CFE_SB_WriteFileInfoCmd_t
+**       #CFE_SB_SendMapInfoCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the
@@ -380,7 +380,7 @@
 **  \cfecmdmnemonic \SB_ENASUBRPTG
 **
 **  \par Command Structure
-**       #CFE_SB_CmdHdr_t
+**       #CFE_SB_EnableSubReportingCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command will result in the sending
@@ -413,7 +413,7 @@
 **  \cfecmdmnemonic \SB_DISSUBRPTG
 **
 **  \par Command Structure
-**       #CFE_SB_CmdHdr_t
+**       #CFE_SB_DisableSubReportingCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command will result in the suppression
@@ -445,7 +445,7 @@
 **  \cfecmdmnemonic \SB_SENDPREVSUBS
 **
 **  \par Command Structure
-**       #CFE_SB_CmdHdr_t
+**       #CFE_SB_SendPrevSubsCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command will result in a series
@@ -472,19 +472,19 @@
  * SB Messages which have no payload are each
  * given unique typedefs to follow the command handler convention
  *
- * For the SB application these is mapped to the CFE_SB_CmdHdr_t type,
+ * For the SB application these is mapped to the CFE_MSG_CommandHeader_t type,
  * as they contain only a primary + command header.
  */
-typedef CFE_SB_CmdHdr_t  CFE_SB_Noop_t;
-typedef CFE_SB_CmdHdr_t  CFE_SB_ResetCounters_t;
-typedef CFE_SB_CmdHdr_t  CFE_SB_EnableSubReporting_t;
-typedef CFE_SB_CmdHdr_t  CFE_SB_DisableSubReporting_t;
-typedef CFE_SB_CmdHdr_t  CFE_SB_SendSbStats_t;
-typedef CFE_SB_CmdHdr_t  CFE_SB_SendPrevSubs_t;
+typedef CFE_MSG_CommandHeader_t CFE_SB_NoopCmd_t;
+typedef CFE_MSG_CommandHeader_t CFE_SB_ResetCountersCmd_t;
+typedef CFE_MSG_CommandHeader_t CFE_SB_EnableSubReportingCmd_t;
+typedef CFE_MSG_CommandHeader_t CFE_SB_DisableSubReportingCmd_t;
+typedef CFE_MSG_CommandHeader_t CFE_SB_SendSbStatsCmd_t;
+typedef CFE_MSG_CommandHeader_t CFE_SB_SendPrevSubsCmd_t;
 
 
 /**
-**  \brief Write File Info Commands
+**  \brief Write File Info Command Payload
 **
 **  This structure contains a generic definition used by three SB commands,
 **  'Write Routing Info to File' #CFE_SB_SEND_ROUTING_INFO_CC,
@@ -495,20 +495,23 @@ typedef struct CFE_SB_WriteFileInfoCmd_Payload {
    char Filename[CFE_MISSION_MAX_PATH_LEN];/**< \brief Path and Filename of data to be loaded */
 } CFE_SB_WriteFileInfoCmd_Payload_t;
 
+/**
+ * \brief Write File Info Command
+ */
 typedef struct CFE_SB_WriteFileInfoCmd {
-    CFE_SB_CmdHdr_t                     Hdr;/**< \brief cFE Software Bus Command Message Header #CFE_SB_CmdHdr_t */
-    CFE_SB_WriteFileInfoCmd_Payload_t   Payload;
+    CFE_MSG_CommandHeader_t           Hdr;     /**< \brief Command header */
+    CFE_SB_WriteFileInfoCmd_Payload_t Payload; /**< \brief Command payload */
 }CFE_SB_WriteFileInfoCmd_t;
 
 /*
  * Create a unique typedef for each of the commands that share this format.
  */
-typedef CFE_SB_WriteFileInfoCmd_t CFE_SB_SendRoutingInfo_t;
-typedef CFE_SB_WriteFileInfoCmd_t CFE_SB_SendPipeInfo_t;
-typedef CFE_SB_WriteFileInfoCmd_t CFE_SB_SendMapInfo_t;
+typedef CFE_SB_WriteFileInfoCmd_t CFE_SB_SendRoutingInfoCmd_t;
+typedef CFE_SB_WriteFileInfoCmd_t CFE_SB_SendPipeInfoCmd_t;
+typedef CFE_SB_WriteFileInfoCmd_t CFE_SB_SendMapInfoCmd_t;
 
 /**
-**  \brief Enable/Disable Route Commands
+**  \brief Enable/Disable Route Command Payload
 **
 **  This structure contains a definition used by two SB commands,
 **  'Enable Route' #CFE_SB_ENABLE_ROUTE_CC and 'Disable Route' #CFE_SB_DISABLE_ROUTE_CC.
@@ -522,16 +525,19 @@ typedef struct CFE_SB_RouteCmd_Payload {
    uint8                Spare;/**<\brief Spare byte to make command even number of bytes */
 } CFE_SB_RouteCmd_Payload_t;
 
+/**
+ * \brief Enable/Disable Route Command
+ */
 typedef struct CFE_SB_RouteCmd {
-    CFE_SB_CmdHdr_t             Hdr;/**< \brief cFE Software Bus Command Message Header #CFE_SB_CmdHdr_t */
-    CFE_SB_RouteCmd_Payload_t  Payload;
+    CFE_MSG_CommandHeader_t   Hdr;     /**< \brief Command header */
+    CFE_SB_RouteCmd_Payload_t Payload; /**< \brief Command payload */
 } CFE_SB_RouteCmd_t;
 
 /*
  * Create a unique typedef for each of the commands that share this format.
  */
-typedef CFE_SB_RouteCmd_t CFE_SB_EnableRoute_t;
-typedef CFE_SB_RouteCmd_t CFE_SB_DisableRoute_t;
+typedef CFE_SB_RouteCmd_t CFE_SB_EnableRouteCmd_t;
+typedef CFE_SB_RouteCmd_t CFE_SB_DisableRouteCmd_t;
 
 /****************************
 **  SB Telemetry Formats   **
@@ -584,8 +590,8 @@ typedef struct CFE_SB_HousekeepingTlm_Payload {
 } CFE_SB_HousekeepingTlm_Payload_t;
 
 typedef struct CFE_SB_HousekeepingTlm {
-    CFE_SB_TlmHdr_t         Hdr;/**< \brief cFE Software Bus Telemetry Message Header */
-    CFE_SB_HousekeepingTlm_Payload_t  Payload;
+    CFE_MSG_TelemetryHeader_t        Hdr;     /**< \brief Telemetry header */
+    CFE_SB_HousekeepingTlm_Payload_t Payload; /**< \brief Telemetry payload */
 } CFE_SB_HousekeepingTlm_t;
 
 
@@ -612,7 +618,7 @@ typedef struct CFE_SB_PipeDepthStats {
 /**
 ** \cfesbtlm SB Statistics Telemetry Packet
 **
-** SB Statistics packet sent (via CFE_SB_SendMsg) in response to #CFE_SB_SEND_SB_STATS_CC
+** SB Statistics packet sent in response to #CFE_SB_SEND_SB_STATS_CC
 */
 typedef struct CFE_SB_StatsTlm_Payload {
 
@@ -657,8 +663,8 @@ typedef struct CFE_SB_StatsTlm_Payload {
 } CFE_SB_StatsTlm_Payload_t;
 
 typedef struct CFE_SB_StatsTlm {
-    CFE_SB_TlmHdr_t             Hdr;/**< \brief cFE Software Bus Telemetry Message Header */
-    CFE_SB_StatsTlm_Payload_t    Payload;
+    CFE_MSG_TelemetryHeader_t Hdr;     /**< \brief Telemetry header */
+    CFE_SB_StatsTlm_Payload_t Payload; /**< \brief Telemetry payload */
 } CFE_SB_StatsTlm_t;
 
 
@@ -708,8 +714,8 @@ typedef struct CFE_SB_SingleSubscriptionTlm_Payload {
 } CFE_SB_SingleSubscriptionTlm_Payload_t;
 
 typedef struct CFE_SB_SingleSubscriptionTlm {
-    CFE_SB_TlmHdr_t             Hdr;/**< \brief cFE Software Bus Telemetry Message Header */
-    CFE_SB_SingleSubscriptionTlm_Payload_t Payload;
+    CFE_MSG_TelemetryHeader_t              Hdr;     /**< \brief Telemetry header */
+    CFE_SB_SingleSubscriptionTlm_Payload_t Payload; /**< \brief Telemetry payload */
 } CFE_SB_SingleSubscriptionTlm_t;
 
 
@@ -748,8 +754,8 @@ typedef struct CFE_SB_AllSubscriptionsTlm_Payload {
 } CFE_SB_AllSubscriptionsTlm_Payload_t;
 
 typedef struct CFE_SB_AllSubscriptionsTlm {
-    CFE_SB_TlmHdr_t             Hdr;/**< \brief cFE Software Bus Telemetry Message Header */
-    CFE_SB_AllSubscriptionsTlm_Payload_t Payload;
+    CFE_MSG_TelemetryHeader_t            Hdr;     /**< \brief Telemetry header */
+    CFE_SB_AllSubscriptionsTlm_Payload_t Payload; /**< \brief Telemetry payload */
 } CFE_SB_AllSubscriptionsTlm_t;
 
 

--- a/fsw/cfe-core/src/inc/cfe_tbl_events.h
+++ b/fsw/cfe-core/src/inc/cfe_tbl_events.h
@@ -365,7 +365,7 @@
 **  This event message is generated when failure occurs while attempting to send the
 **  Housekeeping Message over the Software Bus.
 **
-**  The \c Status field of the event message contains the error code returned by #CFE_SB_SendMsg. 
+**  The \c Status field of the event message contains the error code.
 **/
 #define CFE_TBL_FAIL_HK_SEND_ERR_EID           56  
 
@@ -838,7 +838,7 @@
 **
 **  The \c MsgId is the message ID of the table management notification message that was attempted to be sent,
 **  the \c CC is the command code, the \c Param is the application specified command parameter and the \c Status
-**  is the error code returned by the #CFE_SB_SendMsg API call. 
+**  is the error code returned.
 **/
 #define CFE_TBL_FAIL_NOTIFY_SEND_ERR_EID       89
 /** \} */

--- a/fsw/cfe-core/src/inc/cfe_tbl_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_tbl_msg.h
@@ -58,7 +58,7 @@
 **  \cfecmdmnemonic \TBL_NOOP
 **
 **  \par Command Structure
-**       #CFE_TBL_NoArgsCmd_t
+**       #CFE_TBL_NoopCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -95,7 +95,7 @@
 **  \cfecmdmnemonic \TBL_RESETCTRS
 **
 **  \par Command Structure
-**       #CFE_TBL_NoArgsCmd_t
+**       #CFE_TBL_ResetCountersCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -130,7 +130,7 @@
 **  \cfecmdmnemonic \TBL_LOAD
 **
 **  \par Command Structure
-**       #CFE_TBL_Load_t
+**       #CFE_TBL_LoadCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with 
@@ -184,7 +184,7 @@
 **  \cfecmdmnemonic \TBL_DUMP
 **
 **  \par Command Structure
-**       #CFE_TBL_Dump_t
+**       #CFE_TBL_DumpCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -230,7 +230,7 @@
 **  \cfecmdmnemonic \TBL_VALIDATE
 **
 **  \par Command Structure
-**       #CFE_TBL_Validate_t
+**       #CFE_TBL_ValidateCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the following 
@@ -286,7 +286,7 @@
 **  \cfecmdmnemonic \TBL_ACTIVATE
 **
 **  \par Command Structure
-**       #CFE_TBL_Activate_t
+**       #CFE_TBL_ActivateCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -326,7 +326,7 @@
 **  \cfecmdmnemonic \TBL_WRITEREG2FILE
 **
 **  \par Command Structure
-**       #CFE_TBL_DumpRegistry_t
+**       #CFE_TBL_DumpRegistryCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -366,7 +366,7 @@
 **  \cfecmdmnemonic \TBL_TLMREG
 **
 **  \par Command Structure
-**       #CFE_TBL_DumpRegistry_t
+**       #CFE_TBL_SendRegistryCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -405,7 +405,7 @@
 **  \cfecmdmnemonic \TBL_DELETECDS
 **
 **  \par Command Structure
-**       #CFE_TBL_DeleteCDS_t
+**       #CFE_TBL_DeleteCDSCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -448,7 +448,7 @@
 **  \cfecmdmnemonic \TBL_LOADABORT
 **
 **  \par Command Structure
-**       #CFE_TBL_AbortLoad_t
+**       #CFE_TBL_AbortLoadCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -492,8 +492,7 @@
 */
 typedef struct CFE_TBL_NoArgsCmd
 {
-    uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];   /**< \brief cFE Software Bus Command Message Header */
-
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 } CFE_TBL_NoArgsCmd_t;
 
 /*
@@ -501,30 +500,31 @@ typedef struct CFE_TBL_NoArgsCmd
  * Allows each command to evolve independently, while following the command
  * handler prototype convention
  */
-typedef CFE_TBL_NoArgsCmd_t CFE_TBL_Noop_t;
-typedef CFE_TBL_NoArgsCmd_t CFE_TBL_ResetCounters_t;
+typedef CFE_TBL_NoArgsCmd_t CFE_TBL_NoopCmd_t;
+typedef CFE_TBL_NoArgsCmd_t CFE_TBL_ResetCountersCmd_t;
 
 /**
-** \brief Load Table Command
+** \brief Load Table Command Payload
 **
 ** For command details, see #CFE_TBL_LOAD_CC
 **
 **/
 typedef struct CFE_TBL_LoadCmd_Payload
 {
-    char                  LoadFilename[CFE_MISSION_MAX_PATH_LEN];  /**< \brief Filename (and path) of data to be loaded */
-                                                          /**< ASCII Character string containing full path 
-                                                               filename for file to be loaded */
+    char LoadFilename[CFE_MISSION_MAX_PATH_LEN];  /**< \brief Filename (and path) of data to be loaded */
 } CFE_TBL_LoadCmd_Payload_t;
 
-typedef struct CFE_TBL_Load
+/**
+ * \brief Load Table Command
+ */
+typedef struct CFE_TBL_LoadCmd
 {
-    uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
-    CFE_TBL_LoadCmd_Payload_t   Payload;
-} CFE_TBL_Load_t;
+    CFE_MSG_CommandHeader_t   CmdHeader; /**< \brief Command header */
+    CFE_TBL_LoadCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TBL_LoadCmd_t;
 
 /**
-** \brief Dump Table Command
+** \brief Dump Table Command Payload
 **
 ** For command details, see #CFE_TBL_DUMP_CC
 */
@@ -544,14 +544,17 @@ typedef struct CFE_TBL_DumpCmd_Payload
                                                                      where data is to be dumped */
 } CFE_TBL_DumpCmd_Payload_t;
 
+/**
+ * /brief Dump Table Command
+ */
 typedef struct CFE_TBL_DumpCmd
 {
-    uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
-    CFE_TBL_DumpCmd_Payload_t   Payload;
-} CFE_TBL_Dump_t;
+    CFE_MSG_CommandHeader_t   CmdHeader; /**< \brief Command header */
+    CFE_TBL_DumpCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TBL_DumpCmd_t;
 
 /**
-** \brief Validate Table Command
+** \brief Validate Table Command Payload
 **
 ** For command details, see #CFE_TBL_VALIDATE_CC
 */
@@ -568,14 +571,17 @@ typedef struct CFE_TBL_ValidateCmd_Payload
                                                                       identifier of table to be validated */
 } CFE_TBL_ValidateCmd_Payload_t;
 
-typedef struct CFE_TBL_Validate
+/**
+ * \brief Validate Table Command
+ */
+typedef struct CFE_TBL_ValidateCmd
 {
-    uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
-    CFE_TBL_ValidateCmd_Payload_t   Payload;
-} CFE_TBL_Validate_t;
+    CFE_MSG_CommandHeader_t       CmdHeader; /**< \brief Command header */
+    CFE_TBL_ValidateCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TBL_ValidateCmd_t;
 
 /**
-** \brief Activate Table Command
+** \brief Activate Table Command Payload
 **
 ** For command details, see #CFE_TBL_ACTIVATE_CC
 */
@@ -586,14 +592,17 @@ typedef struct CFE_TBL_ActivateCmd_Payload
                                                                       identifier of table to be activated */
 } CFE_TBL_ActivateCmd_Payload_t;
 
-typedef struct CFE_TBL_Activate
+/**
+ * \brief Activate Table Command
+ */
+typedef struct CFE_TBL_ActivateCmd
 {
-    uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
-    CFE_TBL_ActivateCmd_Payload_t   Payload;
-} CFE_TBL_Activate_t;
+    CFE_MSG_CommandHeader_t       CmdHeader; /**< \brief Command header */
+    CFE_TBL_ActivateCmd_Payload_t Payload;   /**< \brief Command paylod */
+} CFE_TBL_ActivateCmd_t;
 
 /**
-** \brief Dump Registry Command
+** \brief Dump Registry Command Payload
 **
 ** For command details, see #CFE_TBL_DUMP_REGISTRY_CC
 */
@@ -605,14 +614,17 @@ typedef struct CFE_TBL_DumpRegistryCmd_Payload
                                                                      where registry is to be dumped */
 } CFE_TBL_DumpRegistryCmd_Payload_t;
 
-typedef struct CFE_TBL_DumpRegistry
+/**
+ * \brief Dump Registry Command
+ */
+typedef struct CFE_TBL_DumpRegistryCmd
 {
-    uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
-    CFE_TBL_DumpRegistryCmd_Payload_t    Payload;
-} CFE_TBL_DumpRegistry_t;
+    CFE_MSG_CommandHeader_t           CmdHeader; /**< \brief Command header */
+    CFE_TBL_DumpRegistryCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TBL_DumpRegistryCmd_t;
 
 /**
-** \brief Telemeter Table Registry Entry Command
+** \brief Send Table Registry Command Payload
 **
 ** For command details, see #CFE_TBL_SEND_REGISTRY_CC
 */
@@ -625,14 +637,17 @@ typedef struct CFE_TBL_SendRegistryCmd_Payload
                                                                       to be telemetered via #CFE_TBL_TableRegistryTlm_t */
 } CFE_TBL_SendRegistryCmd_Payload_t;
 
-typedef struct CFE_TBL_SendRegistry
+/**
+ * \brief Send Table Registry Command
+ */
+typedef struct CFE_TBL_SendRegistryCmd
 {
-    uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
-    CFE_TBL_SendRegistryCmd_Payload_t Payload;
-} CFE_TBL_SendRegistry_t;
+    CFE_MSG_CommandHeader_t           CmdHeader; /**< \brief Command header */
+    CFE_TBL_SendRegistryCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TBL_SendRegistryCmd_t;
 
 /**
-** \brief Delete Critical Table CDS Command
+** \brief Delete Critical Table CDS Command Payload
 **
 ** For command details, see #CFE_TBL_DELETE_CDS_CC
 */
@@ -645,14 +660,17 @@ typedef struct CFE_TBL_DelCDSCmd_Payload
                                                                       CDS is to be deleted */
 } CFE_TBL_DelCDSCmd_Payload_t;
 
-typedef struct CFE_TBL_DeleteCDS
+/**
+ * \brief Delete Critical Table CDS Command
+ */
+typedef struct CFE_TBL_DeleteCDSCmd
 {
-    uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
-    CFE_TBL_DelCDSCmd_Payload_t Payload;
-} CFE_TBL_DeleteCDS_t;
+    CFE_MSG_CommandHeader_t     CmdHeader; /**< \brief Command header */
+    CFE_TBL_DelCDSCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TBL_DeleteCDSCmd_t;
 
 /**
-** \brief Abort Load Command
+** \brief Abort Load Command Payload
 **
 ** For command details, see #CFE_TBL_ABORT_LOAD_CC
 */
@@ -663,11 +681,14 @@ typedef struct CFE_TBL_AbortLoadCmd_Payload
                                                                       identifier of a table whose load is to be aborted */
 } CFE_TBL_AbortLoadCmd_Payload_t;
 
-typedef struct CFE_TBL_AbortLoad
+/**
+ * \brief Abort Load Command
+ */
+typedef struct CFE_TBL_AbortLoadCmd
 {
-    uint8                           CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
-    CFE_TBL_AbortLoadCmd_Payload_t    Payload;
-} CFE_TBL_AbortLoad_t;
+    CFE_MSG_CommandHeader_t        CmdHeader; /**< \brief Command header */
+    CFE_TBL_AbortLoadCmd_Payload_t Payload;   /**< \brief Command paylod */
+} CFE_TBL_AbortLoadCmd_t;
 
 
 /*************************************************************************/
@@ -675,7 +696,7 @@ typedef struct CFE_TBL_AbortLoad
 /* Generated Command Message Data Formats */
 /******************************************/
 /**
-** \brief Table Management Notification Message
+** \brief Table Management Notification Command Payload
 **
 ** \par Description
 **      Whenever an application that owns a table calls the #CFE_TBL_NotifyByMessage API
@@ -688,10 +709,13 @@ typedef struct CFE_TBL_NotifyCmd_Payload
     uint32                Parameter;                             /**< \brief Application specified command parameter */
 } CFE_TBL_NotifyCmd_Payload_t;
 
+/**
+ * /brief Table Management Notification Command
+ */
 typedef struct CFE_TBL_NotifyCmd
 {
-    uint8                       CmdHeader[CFE_SB_CMD_HDR_SIZE]; /**< \brief cFE Software Bus Command Message Header */
-    CFE_TBL_NotifyCmd_Payload_t Payload;
+    CFE_MSG_CommandHeader_t     CmdHeader; /**< \brief Command header */
+    CFE_TBL_NotifyCmd_Payload_t Payload;   /**< \brief Command payload */
 } CFE_TBL_NotifyCmd_t;
 
 /*************************************************************************/
@@ -762,8 +786,8 @@ typedef struct CFE_TBL_HousekeepingTlm_Payload
 
 typedef struct CFE_TBL_HousekeepingTlm
 {
-    CFE_SB_TlmHdr_t                   TlmHeader;       /**< \brief cFE Software Bus Telemetry Message Header */
-    CFE_TBL_HousekeepingTlm_Payload_t Payload;
+    CFE_MSG_TelemetryHeader_t         TlmHeader; /**< \brief Telemetry header */
+    CFE_TBL_HousekeepingTlm_Payload_t Payload;   /**< \brief Telemetry payload */
 } CFE_TBL_HousekeepingTlm_t;
 
 
@@ -810,8 +834,8 @@ typedef struct CFE_TBL_TblRegPacket_Payload
 
 typedef struct CFE_TBL_TableRegistryTlm
 {
-    CFE_SB_TlmHdr_t                TlmHeader;       /**< \brief cFE Software Bus Telemetry Message Header */
-    CFE_TBL_TblRegPacket_Payload_t Payload;
+    CFE_MSG_TelemetryHeader_t      TlmHeader; /**< \brief Telemetry header */
+    CFE_TBL_TblRegPacket_Payload_t Payload;   /**< \brief Telemetry payload */
 } CFE_TBL_TableRegistryTlm_t;
 
 

--- a/fsw/cfe-core/src/inc/cfe_time_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_time_msg.h
@@ -58,7 +58,7 @@
 **  \cfecmdmnemonic \TIME_NOOP
 **
 **  \par Command Structure
-**       #CFE_TIME_NoArgsCmd_t
+**       #CFE_TIME_NoopCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -102,7 +102,7 @@
 **  \cfecmdmnemonic \TIME_RESETCTRS
 **
 **  \par Command Structure
-**       #CFE_TIME_NoArgsCmd_t
+**       #CFE_TIME_ResetCountersCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -135,7 +135,7 @@
 **  \cfecmdmnemonic \TIME_REQUESTDIAG
 **
 **  \par Command Structure
-**       #CFE_TIME_NoArgsCmd_t
+**       #CFE_TIME_SendDiagnosticCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -182,7 +182,7 @@
 **  \cfecmdmnemonic \TIME_SETSOURCE
 **
 **  \par Command Structure
-**       #CFE_TIME_SetSource_t
+**       #CFE_TIME_SetSourceCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -233,7 +233,7 @@
 **  \cfecmdmnemonic \TIME_SETSTATE
 **
 **  \par Command Structure
-**       #CFE_TIME_SetState_t
+**       #CFE_TIME_SetStateCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -276,7 +276,7 @@
 **  \cfecmdmnemonic \TIME_ADDCLOCKLAT
 **
 **  \par Command Structure
-**       #CFE_TIME_TimeCmd_t
+**       #CFE_TIME_AddDelayCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -314,7 +314,7 @@
 **  \cfecmdmnemonic \TIME_SUBCLOCKLAT
 **
 **  \par Command Structure
-**       #CFE_TIME_TimeCmd_t
+**       #CFE_TIME_SubDelayCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -359,7 +359,7 @@
 **  \cfecmdmnemonic \TIME_SETCLOCK
 **
 **  \par Command Structure
-**       #CFE_TIME_TimeCmd_t
+**       #CFE_TIME_SetTimeCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -399,7 +399,7 @@
 **  \cfecmdmnemonic \TIME_SETCLOCKMET
 **
 **  \par Command Structure
-**       #CFE_TIME_TimeCmd_t
+**       #CFE_TIME_SetMETCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -436,7 +436,7 @@
 **  \cfecmdmnemonic \TIME_SETCLOCKSTCF
 **
 **  \par Command Structure
-**       #CFE_TIME_TimeCmd_t
+**       #CFE_TIME_SetSTCFCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -473,7 +473,7 @@
 **  \cfecmdmnemonic \TIME_SETCLOCKLEAP
 **
 **  \par Command Structure
-**       #CFE_TIME_TimeCmd_t
+**       #CFE_TIME_SetLeapSecondsCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -506,7 +506,7 @@
 **  \cfecmdmnemonic \TIME_ADDSTCFADJ
 **
 **  \par Command Structure
-**       #CFE_TIME_TimeCmd_t
+**       #CFE_TIME_AddAdjustCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -540,7 +540,7 @@
 **  \cfecmdmnemonic \TIME_SUBSTCFADJ
 **
 **  \par Command Structure
-**       #CFE_TIME_TimeCmd_t
+**       #CFE_TIME_SubAdjustCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -587,7 +587,7 @@
 **  \cfecmdmnemonic \TIME_ADD1HZSTCF
 **
 **  \par Command Structure
-**       #CFE_TIME_Add1HZAdjustment_t
+**       #CFE_TIME_Add1HZAdjustmentCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -633,7 +633,7 @@
 **  \cfecmdmnemonic \TIME_SUB1HZSTCF
 **
 **  \par Command Structure
-**       #CFE_TIME_Sub1HZAdjustment_t
+**       #CFE_TIME_Sub1HZAdjustmentCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -675,7 +675,7 @@
 **  \cfecmdmnemonic \TIME_SETSIGNAL
 **
 **  \par Command Structure
-**       #CFE_TIME_SetSignal_t
+**       #CFE_TIME_SetSignalCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the 
@@ -723,12 +723,12 @@
 
 /*************************************************************************/
 
-/*
-** Type definition (generic "no arguments" command)...
-*/
+/**
+ * \brief Generic no argument command
+ */
 typedef struct CFE_TIME_NoArgsCmd
 {
-  uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];
+  CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
 
 } CFE_TIME_NoArgsCmd_t;
 
@@ -737,28 +737,33 @@ typedef struct CFE_TIME_NoArgsCmd
  * This follows the convention for command handler prototypes and allows
  * each one to independently evolve as necessary.
  */
-typedef CFE_TIME_NoArgsCmd_t CFE_TIME_Noop_t;
-typedef CFE_TIME_NoArgsCmd_t CFE_TIME_ResetCounters_t;
-typedef CFE_TIME_NoArgsCmd_t CFE_TIME_SendDiagnosticTlm_t;
+typedef CFE_TIME_NoArgsCmd_t CFE_TIME_NoopCmd_t;
+typedef CFE_TIME_NoArgsCmd_t CFE_TIME_ResetCountersCmd_t;
+typedef CFE_TIME_NoArgsCmd_t CFE_TIME_SendDiagnosticCmd_t;
+typedef CFE_TIME_NoArgsCmd_t CFE_TIME_1HzCmd_t;
+typedef CFE_TIME_NoArgsCmd_t CFE_TIME_ToneSignalCmd_t;
+typedef CFE_TIME_NoArgsCmd_t CFE_TIME_FakeToneCmd_t;
 
-/*
-** Type definition (leap seconds command)...
-*/
+/**
+ * \brief Set leap seconds command payload
+ */
 typedef struct CFE_TIME_LeapsCmd_Payload
 {
     int16                 LeapSeconds;
 } CFE_TIME_LeapsCmd_Payload_t;
 
-typedef struct CFE_TIME_SetLeapSeconds
+/**
+ * \brief Set leap seconds command
+ */
+typedef struct CFE_TIME_SetLeapSecondsCmd
 {
-  uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
-  CFE_TIME_LeapsCmd_Payload_t   Payload;
-} CFE_TIME_SetLeapSeconds_t;
+    CFE_MSG_CommandHeader_t     CmdHeader; /**< \brief Command header */
+    CFE_TIME_LeapsCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TIME_SetLeapSecondsCmd_t;
 
-
-/*
-** Type definition (clock state command)...
-*/
+/**
+ * \brief Set clock state command payload
+ */
 typedef struct CFE_TIME_StateCmd_Payload
 {
     int16                 ClockState;                    /**< \brief #CFE_TIME_ClockState_INVALID=Spacecraft time has not been accurately set,
@@ -767,16 +772,19 @@ typedef struct CFE_TIME_StateCmd_Payload
                                                          /**< Selects the current clock state */
 } CFE_TIME_StateCmd_Payload_t;
 
+/**
+ * \brief Set clock state command
+ */
 typedef struct CFE_TIME_SetStateCmd
 {
-  uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
-  CFE_TIME_StateCmd_Payload_t   Payload;
-} CFE_TIME_SetState_t;
+  CFE_MSG_CommandHeader_t     CmdHeader; /**< \brief Command header */
+  CFE_TIME_StateCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TIME_SetStateCmd_t;
 
 
-/*
-** Type definition (time data source command)...
-*/
+/**
+ * \brief Set time data source command payload
+ */
 typedef struct CFE_TIME_SourceCmd_Payload
 {
     int16                 TimeSource;                    /**< \brief #CFE_TIME_SourceSelect_INTERNAL=Internal Source,
@@ -784,16 +792,18 @@ typedef struct CFE_TIME_SourceCmd_Payload
                                                          /**< Selects either the "Internal" and "External" clock source */
 } CFE_TIME_SourceCmd_Payload_t;
 
-typedef struct CFE_TIME_SetSource
+/**
+ * \brief Set time data source command
+ */
+typedef struct CFE_TIME_SetSourceCmd
 {
-  uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
-  CFE_TIME_SourceCmd_Payload_t  Payload;
-} CFE_TIME_SetSource_t;
+  CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
+  CFE_TIME_SourceCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TIME_SetSourceCmd_t;
 
-
-/*
-** Type definition (tone signal source command)...
-*/
+/**
+ * \brief Set tone signal source command payload
+ */
 typedef struct CFE_TIME_SignalCmd_Payload
 {
     int16                 ToneSource;                    /**< \brief #CFE_TIME_ToneSignalSelect_PRIMARY=Primary Source,
@@ -801,27 +811,32 @@ typedef struct CFE_TIME_SignalCmd_Payload
                                                          /**< Selects either the "Primary" or "Redundant" tone signal source */
 } CFE_TIME_SignalCmd_Payload_t;
 
-typedef struct CFE_TIME_SetSignal
+/**
+ * \brief Set tone signal source command
+ */
+typedef struct CFE_TIME_SetSignalCmd
 {
-  uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
-  CFE_TIME_SignalCmd_Payload_t  Payload;
+  CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
+  CFE_TIME_SignalCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TIME_SetSignalCmd_t;
 
-} CFE_TIME_SetSignal_t;
 
-
-/*
-** Type definition (generic "time argument" command)...
-*/
+/**
+ * \brief Generic seconds, microseconds command payload
+ */
 typedef struct CFE_TIME_TimeCmd_Payload
 {
     uint32                Seconds;
     uint32                MicroSeconds;
 } CFE_TIME_TimeCmd_Payload_t;
 
+/**
+ * \brief Generic seconds, microseconds argument command
+ */
 typedef struct CFE_TIME_TimeCmd
 {
-  uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
-  CFE_TIME_TimeCmd_Payload_t    Payload;
+  CFE_MSG_CommandHeader_t    CmdHeader; /**< \brief Command header */
+  CFE_TIME_TimeCmd_Payload_t Payload;   /**< \brief Command payload */
 } CFE_TIME_TimeCmd_t;
 
 /*
@@ -829,18 +844,18 @@ typedef struct CFE_TIME_TimeCmd
  * This follows the convention for command handler prototypes and allows
  * each one to independently evolve as necessary.
  */
-typedef CFE_TIME_TimeCmd_t CFE_TIME_AddDelay_t;
-typedef CFE_TIME_TimeCmd_t CFE_TIME_SubDelay_t;
-typedef CFE_TIME_TimeCmd_t CFE_TIME_SetMET_t;
-typedef CFE_TIME_TimeCmd_t CFE_TIME_SetSTCF_t;
-typedef CFE_TIME_TimeCmd_t CFE_TIME_AddAdjust_t;
-typedef CFE_TIME_TimeCmd_t CFE_TIME_SubAdjust_t;
-typedef CFE_TIME_TimeCmd_t CFE_TIME_SetTime_t;
+typedef CFE_TIME_TimeCmd_t CFE_TIME_AddDelayCmd_t;
+typedef CFE_TIME_TimeCmd_t CFE_TIME_SubDelayCmd_t;
+typedef CFE_TIME_TimeCmd_t CFE_TIME_SetMETCmd_t;
+typedef CFE_TIME_TimeCmd_t CFE_TIME_SetSTCFCmd_t;
+typedef CFE_TIME_TimeCmd_t CFE_TIME_AddAdjustCmd_t;
+typedef CFE_TIME_TimeCmd_t CFE_TIME_SubAdjustCmd_t;
+typedef CFE_TIME_TimeCmd_t CFE_TIME_SetTimeCmd_t;
 
 
-/*
-** Type definition (1Hz STCF adjustment "time argument" command)...
-*/
+/**
+ * \brief Generic seconds, subseconds command payload
+ */
 typedef struct CFE_TIME_OneHzAdjustmentCmd_Payload
 {
     uint32                Seconds;
@@ -848,11 +863,13 @@ typedef struct CFE_TIME_OneHzAdjustmentCmd_Payload
 
 } CFE_TIME_OneHzAdjustmentCmd_Payload_t;
 
+/**
+ * \brief Generic seconds, subseconds adjustment command
+ */
 typedef struct CFE_TIME_OneHzAdjustmentCmd
 {
-  uint8                         CmdHeader[CFE_SB_CMD_HDR_SIZE];
-  CFE_TIME_OneHzAdjustmentCmd_Payload_t  Payload;
-
+  CFE_MSG_CommandHeader_t               CmdHeader; /**< \brief Command header */
+  CFE_TIME_OneHzAdjustmentCmd_Payload_t Payload;   /**< \brief Command payload */
 } CFE_TIME_OneHzAdjustmentCmd_t;
 
 /*
@@ -860,42 +877,12 @@ typedef struct CFE_TIME_OneHzAdjustmentCmd
  * This follows the convention for command handler prototypes and allows
  * each one to independently evolve as necessary.
  */
-typedef CFE_TIME_OneHzAdjustmentCmd_t CFE_TIME_Add1HZAdjustment_t;
-typedef CFE_TIME_OneHzAdjustmentCmd_t CFE_TIME_Sub1HZAdjustment_t;
+typedef CFE_TIME_OneHzAdjustmentCmd_t CFE_TIME_Add1HZAdjustmentCmd_t;
+typedef CFE_TIME_OneHzAdjustmentCmd_t CFE_TIME_Sub1HZAdjustmentCmd_t;
 
-/*
-** Type definition (local 1Hz wake-up command)...
-*/
-typedef struct CFE_TIME_1HzCmd
-{
-  uint8                 CmdHeader[CFE_SB_CMD_HDR_SIZE];
-
-} CFE_TIME_1HzCmd_t;
-
-
-/*
-** Type definition (time at the tone signal command)...
-*/
-typedef struct CFE_TIME_ToneSignalCmd
-{
-  CFE_SB_CmdHdr_t         CmdHeader;
-
-} CFE_TIME_ToneSignalCmd_t;
-
-
-/*
-** Type definition ("fake" time at the tone signal command)...
-*/
-typedef struct CFE_TIME_FakeToneCmd
-{
-    CFE_SB_CmdHdr_t       CmdHeader;
-
-} CFE_TIME_FakeToneCmd_t;
-
-
-/*
-** Type definition (time at the tone data command)...
-*/
+/**
+ * \brief Time at tone data command payload
+ */
 typedef struct CFE_TIME_ToneDataCmd_Payload
 {
     CFE_TIME_SysTime_t    AtToneMET;    /**< \brief MET at time of tone */
@@ -904,10 +891,13 @@ typedef struct CFE_TIME_ToneDataCmd_Payload
     int16                 AtToneState;  /**< \brief Clock state at time of tone */
 } CFE_TIME_ToneDataCmd_Payload_t;
 
+/**
+ * \brief Time at tone data command
+ */
 typedef struct CFE_TIME_ToneDataCmd
 {
-  uint8                             CmdHeader[CFE_SB_CMD_HDR_SIZE];
-  CFE_TIME_ToneDataCmd_Payload_t    Payload;
+  CFE_MSG_CommandHeader_t        CmdHeader; /**< \brief Command header */
+  CFE_TIME_ToneDataCmd_Payload_t Payload;   /**< \brief Command payload */
 } CFE_TIME_ToneDataCmd_t;
 
 
@@ -977,8 +967,8 @@ typedef struct CFE_TIME_HousekeepingTlm_Payload
 
 typedef struct CFE_TIME_HousekeepingTlm
 {
-  CFE_SB_TlmHdr_t                    TlmHeader;
-  CFE_TIME_HousekeepingTlm_Payload_t Payload;
+  CFE_MSG_TelemetryHeader_t          TlmHeader; /**< \brief Telemetry header */
+  CFE_TIME_HousekeepingTlm_Payload_t Payload;   /**< \brief Telemetry payload */
 } CFE_TIME_HousekeepingTlm_t;
 
 
@@ -1135,8 +1125,8 @@ typedef struct CFE_TIME_DiagnosticTlm_Payload
 
 typedef struct CFE_TIME_DiagnosticTlm
 {
-  CFE_SB_TlmHdr_t                  TlmHeader;
-  CFE_TIME_DiagnosticTlm_Payload_t Payload;
+  CFE_MSG_TelemetryHeader_t        TlmHeader; /**< \brief Telemetry header */
+  CFE_TIME_DiagnosticTlm_Payload_t Payload;   /**< \brief Telemetry payload */
 } CFE_TIME_DiagnosticTlm_t;
 
 

--- a/fsw/cfe-core/src/sb/cfe_sb_init.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_init.c
@@ -116,7 +116,7 @@ int32 CFE_SB_EarlyInit (void) {
     CFE_SBR_Init();
 
     /* Initialize the SB Statistics Pkt */
-    CFE_MSG_Init(&CFE_SB.StatTlmMsg.Hdr.BaseMsg,
+    CFE_MSG_Init(&CFE_SB.StatTlmMsg.Hdr.Msg,
                  CFE_SB_ValueToMsgId(CFE_SB_STATS_TLM_MID),
                  sizeof(CFE_SB.StatTlmMsg));
 

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.c
@@ -608,7 +608,7 @@ int32 CFE_SB_ZeroCopyReleaseAppId(CFE_ES_ResourceID_t         AppId)
         prev = (CFE_SB_ZeroCopyD_t *) (zcd->Prev);
         if( CFE_ES_ResourceID_Equal(zcd->AppID, AppId) )
         {
-            CFE_SB_ZeroCopyReleasePtr((CFE_MSG_Message_t *) zcd->Buffer, (CFE_SB_ZeroCopyHandle_t) zcd);
+            CFE_SB_ZeroCopyReleasePtr((CFE_SB_Buffer_t *) zcd->Buffer, (CFE_SB_ZeroCopyHandle_t) zcd);
         }
         zcd = prev;
     }

--- a/fsw/cfe-core/src/sb/cfe_sb_task.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_task.c
@@ -72,7 +72,8 @@ typedef struct
 */
 void CFE_SB_TaskMain(void)
 {
-    int32  Status;
+    int32            Status;
+    CFE_SB_Buffer_t *SBBufPtr;
 
     CFE_ES_PerfLogEntry(CFE_MISSION_SB_MAIN_PERF_ID);
 
@@ -103,7 +104,7 @@ void CFE_SB_TaskMain(void)
         CFE_ES_PerfLogExit(CFE_MISSION_SB_MAIN_PERF_ID);
 
         /* Pend on receipt of packet */
-        Status = CFE_SB_RcvMsg(&CFE_SB.CmdPipePktPtr,
+        Status = CFE_SB_ReceiveBuffer(&SBBufPtr,
                                 CFE_SB.CmdPipe,
                                 CFE_SB_PEND_FOREVER);
 
@@ -112,14 +113,14 @@ void CFE_SB_TaskMain(void)
         if(Status == CFE_SUCCESS)
         {
             /* Process cmd pipe msg */
-            CFE_SB_ProcessCmdPipePkt();
+            CFE_SB_ProcessCmdPipePkt(SBBufPtr);
         }else{
             CFE_ES_WriteToSysLog("SB:Error reading cmd pipe,RC=0x%08X\n",(unsigned int)Status);
         }/* end if */
 
     }/* end while */
 
-    /* while loop exits only if CFE_SB_RcvMsg returns error */
+    /* while loop exits only if CFE_SB_ReceiveBuffer returns error */
     CFE_ES_ExitApp(CFE_ES_RunStatus_CORE_APP_RUNTIME_ERROR);
 
 }/* end CFE_SB_TaskMain */
@@ -224,15 +225,15 @@ int32 CFE_SB_AppInit(void){
     
     CFE_ES_WriteToSysLog("SB:Registered %d events for filtering\n",(int)CfgFileEventsToFilter);
 
-    CFE_MSG_Init(&CFE_SB.HKTlmMsg.Hdr.BaseMsg,
+    CFE_MSG_Init(&CFE_SB.HKTlmMsg.Hdr.Msg,
                  CFE_SB_ValueToMsgId(CFE_SB_HK_TLM_MID),
                  sizeof(CFE_SB.HKTlmMsg));
 
-    CFE_MSG_Init(&CFE_SB.PrevSubMsg.Hdr.BaseMsg,
+    CFE_MSG_Init(&CFE_SB.PrevSubMsg.Hdr.Msg,
                  CFE_SB_ValueToMsgId(CFE_SB_ALLSUBS_TLM_MID),
                  sizeof(CFE_SB.PrevSubMsg));
 
-    CFE_MSG_Init(&CFE_SB.SubRprtMsg.Hdr.BaseMsg,
+    CFE_MSG_Init(&CFE_SB.SubRprtMsg.Hdr.Msg,
                  CFE_SB_ValueToMsgId(CFE_SB_ONESUB_TLM_MID),
                  sizeof(CFE_SB.SubRprtMsg));
 
@@ -279,7 +280,7 @@ int32 CFE_SB_AppInit(void){
     /* Ensure a ground commanded reset does not get blocked if SB mem pool  */
     /* becomes fully configured (DCR6772) */
     Status = CFE_ES_GetPoolBuf(&TmpPtr, CFE_SB.Mem.PoolHdl,
-                                        sizeof(CFE_ES_Restart_t));
+                                        sizeof(CFE_ES_RestartCmd_t));
 
     if(Status < 0){
       CFE_ES_WriteToSysLog("SB:Init error, GetPool Failed:RC=0x%08X\n",(unsigned int)Status);
@@ -358,46 +359,47 @@ bool CFE_SB_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
 **    Function to control actions when an SB command is received.
 **
 **  Arguments:
-**    none
+**    Software bus buffer pointer
 **
 **  Return:
 **    none
 */
-void CFE_SB_ProcessCmdPipePkt(void) {
+void CFE_SB_ProcessCmdPipePkt(CFE_SB_Buffer_t *SBBufPtr)
+{
    CFE_SB_MsgId_t MessageID = CFE_SB_INVALID_MSG_ID;
    CFE_MSG_FcnCode_t FcnCode = 0;
 
-   CFE_MSG_GetMsgId(CFE_SB.CmdPipePktPtr, &MessageID);
+   CFE_MSG_GetMsgId(&SBBufPtr->Msg, &MessageID);
 
    switch(CFE_SB_MsgIdToValue(MessageID)){
 
       case CFE_SB_SEND_HK_MID:
          /* Note: Command counter not incremented for this command */
-         CFE_SB_SendHKTlmCmd((CFE_SB_CmdHdr_t *)CFE_SB.CmdPipePktPtr);
+         CFE_SB_SendHKTlmCmd((CFE_MSG_CommandHeader_t *)SBBufPtr);
          break;
 
       case CFE_SB_SUB_RPT_CTRL_MID:
          /* Note: Command counter not incremented for this command */
-         CFE_MSG_GetFcnCode(CFE_SB.CmdPipePktPtr, &FcnCode);
+         CFE_MSG_GetFcnCode(&SBBufPtr->Msg, &FcnCode);
          switch (FcnCode) {
             case CFE_SB_SEND_PREV_SUBS_CC:
-                if (CFE_SB_VerifyCmdLength(CFE_SB.CmdPipePktPtr, sizeof(CFE_SB_SendPrevSubs_t)))
+                if (CFE_SB_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_SB_SendPrevSubsCmd_t)))
                 {
-                    CFE_SB_SendPrevSubsCmd((CFE_SB_SendPrevSubs_t *)CFE_SB.CmdPipePktPtr);
+                    CFE_SB_SendPrevSubsCmd((CFE_SB_SendPrevSubsCmd_t *)SBBufPtr);
                 }
                 break;
 
             case CFE_SB_ENABLE_SUB_REPORTING_CC:
-                if (CFE_SB_VerifyCmdLength(CFE_SB.CmdPipePktPtr, sizeof(CFE_SB_EnableSubReporting_t)))
+                if (CFE_SB_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_SB_EnableSubReportingCmd_t)))
                 {
-                    CFE_SB_EnableSubReportingCmd((CFE_SB_EnableSubReporting_t *)CFE_SB.CmdPipePktPtr);
+                    CFE_SB_EnableSubReportingCmd((CFE_SB_EnableSubReportingCmd_t *)SBBufPtr);
                 }
                 break;
 
             case CFE_SB_DISABLE_SUB_REPORTING_CC:
-                if (CFE_SB_VerifyCmdLength(CFE_SB.CmdPipePktPtr, sizeof(CFE_SB_DisableSubReporting_t)))
+                if (CFE_SB_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_SB_DisableSubReportingCmd_t)))
                 {
-                    CFE_SB_DisableSubReportingCmd((CFE_SB_DisableSubReporting_t *)CFE_SB.CmdPipePktPtr);
+                    CFE_SB_DisableSubReportingCmd((CFE_SB_DisableSubReportingCmd_t *)SBBufPtr);
                 }
                 break;
 
@@ -410,62 +412,62 @@ void CFE_SB_ProcessCmdPipePkt(void) {
          break;
 
       case CFE_SB_CMD_MID:
-         CFE_MSG_GetFcnCode(CFE_SB.CmdPipePktPtr, &FcnCode);
+         CFE_MSG_GetFcnCode(&SBBufPtr->Msg, &FcnCode);
          switch (FcnCode) {
             case CFE_SB_NOOP_CC:
-                if (CFE_SB_VerifyCmdLength(CFE_SB.CmdPipePktPtr, sizeof(CFE_SB_Noop_t)))
+                if (CFE_SB_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_SB_NoopCmd_t)))
                 {
-                    CFE_SB_NoopCmd((CFE_SB_Noop_t *)CFE_SB.CmdPipePktPtr);
+                    CFE_SB_NoopCmd((CFE_SB_NoopCmd_t *)SBBufPtr);
                 }
                 break;
 
             case CFE_SB_RESET_COUNTERS_CC:
-                if (CFE_SB_VerifyCmdLength(CFE_SB.CmdPipePktPtr, sizeof(CFE_SB_ResetCounters_t)))
+                if (CFE_SB_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_SB_ResetCountersCmd_t)))
                 {
                     /* Note: Command counter not incremented for this command */
-                    CFE_SB_ResetCountersCmd((CFE_SB_ResetCounters_t *)CFE_SB.CmdPipePktPtr);
+                    CFE_SB_ResetCountersCmd((CFE_SB_ResetCountersCmd_t *)SBBufPtr);
                 }
                 break;
 
             case CFE_SB_SEND_SB_STATS_CC:
-                if (CFE_SB_VerifyCmdLength(CFE_SB.CmdPipePktPtr, sizeof(CFE_SB_SendSbStats_t)))
+                if (CFE_SB_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_SB_SendSbStatsCmd_t)))
                 {
-                    CFE_SB_SendStatsCmd((CFE_SB_SendSbStats_t *)CFE_SB.CmdPipePktPtr);
+                    CFE_SB_SendStatsCmd((CFE_SB_SendSbStatsCmd_t *)SBBufPtr);
                 }
                 break;
 
             case CFE_SB_SEND_ROUTING_INFO_CC:
-                if (CFE_SB_VerifyCmdLength(CFE_SB.CmdPipePktPtr, sizeof(CFE_SB_SendRoutingInfo_t)))
+                if (CFE_SB_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_SB_SendRoutingInfoCmd_t)))
                 {
-                    CFE_SB_SendRoutingInfoCmd((CFE_SB_SendRoutingInfo_t *)CFE_SB.CmdPipePktPtr);
+                    CFE_SB_SendRoutingInfoCmd((CFE_SB_SendRoutingInfoCmd_t *)SBBufPtr);
                 }
                 break;
 
             case CFE_SB_ENABLE_ROUTE_CC:
-                if (CFE_SB_VerifyCmdLength(CFE_SB.CmdPipePktPtr, sizeof(CFE_SB_EnableRoute_t)))
+                if (CFE_SB_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_SB_EnableRouteCmd_t)))
                 {
-                    CFE_SB_EnableRouteCmd((CFE_SB_EnableRoute_t *)CFE_SB.CmdPipePktPtr);
+                    CFE_SB_EnableRouteCmd((CFE_SB_EnableRouteCmd_t *)SBBufPtr);
                 }
                 break;
 
             case CFE_SB_DISABLE_ROUTE_CC:
-                if (CFE_SB_VerifyCmdLength(CFE_SB.CmdPipePktPtr, sizeof(CFE_SB_DisableRoute_t)))
+                if (CFE_SB_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_SB_DisableRouteCmd_t)))
                 {
-                    CFE_SB_DisableRouteCmd((CFE_SB_DisableRoute_t *)CFE_SB.CmdPipePktPtr);
+                    CFE_SB_DisableRouteCmd((CFE_SB_DisableRouteCmd_t *)SBBufPtr);
                 }
                 break;
 
             case CFE_SB_SEND_PIPE_INFO_CC:
-                if (CFE_SB_VerifyCmdLength(CFE_SB.CmdPipePktPtr, sizeof(CFE_SB_SendPipeInfo_t)))
+                if (CFE_SB_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_SB_SendPipeInfoCmd_t)))
                 {
-                    CFE_SB_SendPipeInfoCmd((CFE_SB_SendPipeInfo_t *)CFE_SB.CmdPipePktPtr);
+                    CFE_SB_SendPipeInfoCmd((CFE_SB_SendPipeInfoCmd_t *)SBBufPtr);
                 }
                 break;
 
             case CFE_SB_SEND_MAP_INFO_CC:
-                if (CFE_SB_VerifyCmdLength(CFE_SB.CmdPipePktPtr, sizeof(CFE_SB_SendMapInfo_t)))
+                if (CFE_SB_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_SB_SendMapInfoCmd_t)))
                 {
-                    CFE_SB_SendMapInfoCmd((CFE_SB_SendMapInfo_t *)CFE_SB.CmdPipePktPtr);
+                    CFE_SB_SendMapInfoCmd((CFE_SB_SendMapInfoCmd_t *)SBBufPtr);
                 }
                 break;
 
@@ -497,7 +499,7 @@ void CFE_SB_ProcessCmdPipePkt(void) {
 **    Handler function the SB command
 **
 */
-int32 CFE_SB_NoopCmd(const CFE_SB_Noop_t *data)
+int32 CFE_SB_NoopCmd(const CFE_SB_NoopCmd_t *data)
 {
     CFE_EVS_SendEvent(CFE_SB_CMD0_RCVD_EID,CFE_EVS_EventType_INFORMATION,
             "No-op Cmd Rcvd. %s", CFE_VERSION_STRING);
@@ -513,7 +515,7 @@ int32 CFE_SB_NoopCmd(const CFE_SB_Noop_t *data)
 **    Handler function the SB command
 **
 */
-int32 CFE_SB_ResetCountersCmd(const CFE_SB_ResetCounters_t *data)
+int32 CFE_SB_ResetCountersCmd(const CFE_SB_ResetCountersCmd_t *data)
 {
     CFE_EVS_SendEvent(CFE_SB_CMD1_RCVD_EID,CFE_EVS_EventType_DEBUG,
             "Reset Counters Cmd Rcvd");
@@ -530,7 +532,7 @@ int32 CFE_SB_ResetCountersCmd(const CFE_SB_ResetCounters_t *data)
 **    Handler function the SB command
 **
 */
-int32 CFE_SB_EnableSubReportingCmd(const CFE_SB_EnableSubReporting_t *data)
+int32 CFE_SB_EnableSubReportingCmd(const CFE_SB_EnableSubReportingCmd_t *data)
 {
     CFE_SB_SetSubscriptionReporting(CFE_SB_ENABLE);
     return CFE_SUCCESS;
@@ -543,7 +545,7 @@ int32 CFE_SB_EnableSubReportingCmd(const CFE_SB_EnableSubReporting_t *data)
 **    Handler function the SB command
 **
 */
-int32 CFE_SB_DisableSubReportingCmd(const CFE_SB_DisableSubReporting_t *data)
+int32 CFE_SB_DisableSubReportingCmd(const CFE_SB_DisableSubReportingCmd_t *data)
 {
     CFE_SB_SetSubscriptionReporting(CFE_SB_DISABLE);
     return CFE_SUCCESS;
@@ -565,13 +567,13 @@ int32 CFE_SB_DisableSubReportingCmd(const CFE_SB_DisableSubReporting_t *data)
 **  Return:
 **    none
 */
-int32 CFE_SB_SendHKTlmCmd(const CFE_SB_CmdHdr_t *data)
+int32 CFE_SB_SendHKTlmCmd(const CFE_MSG_CommandHeader_t *data)
 {
     CFE_SB.HKTlmMsg.Payload.MemInUse        = CFE_SB.StatTlmMsg.Payload.MemInUse;
     CFE_SB.HKTlmMsg.Payload.UnmarkedMem     = CFE_PLATFORM_SB_BUF_MEMORY_BYTES - CFE_SB.StatTlmMsg.Payload.PeakMemInUse;
     
-    CFE_SB_TimeStampMsg((CFE_MSG_Message_t *) &CFE_SB.HKTlmMsg);
-    CFE_SB_SendMsg((CFE_MSG_Message_t *)&CFE_SB.HKTlmMsg);
+    CFE_SB_TimeStampMsg(&CFE_SB.HKTlmMsg.Hdr.Msg);
+    CFE_SB_TransmitMsg(&CFE_SB.HKTlmMsg.Hdr.Msg, true);
 
     return CFE_SUCCESS;
 }/* end CFE_SB_SendHKTlmCmd */
@@ -622,7 +624,7 @@ void CFE_SB_ResetCounters(void){
 **  Return:
 **    None
 */
-int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRoute_t *data)
+int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data)
 {
     CFE_SB_MsgId_t          MsgId;
     CFE_SB_PipeId_t         PipeId;
@@ -687,7 +689,7 @@ int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRoute_t *data)
 **  Return:
 **    None
 */
-int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRoute_t *data)
+int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data)
 {
     CFE_SB_MsgId_t          MsgId;
     CFE_SB_PipeId_t         PipeId;
@@ -749,11 +751,11 @@ int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRoute_t *data)
 **  Return:
 **    None
 */
-int32 CFE_SB_SendStatsCmd(const CFE_SB_SendSbStats_t *data)
+int32 CFE_SB_SendStatsCmd(const CFE_SB_SendSbStatsCmd_t *data)
 {
 
-    CFE_SB_TimeStampMsg((CFE_MSG_Message_t *) &CFE_SB.StatTlmMsg);
-    CFE_SB_SendMsg((CFE_MSG_Message_t *)&CFE_SB.StatTlmMsg);
+    CFE_SB_TimeStampMsg(&CFE_SB.StatTlmMsg.Hdr.Msg);
+    CFE_SB_TransmitMsg(&CFE_SB.StatTlmMsg.Hdr.Msg, true);
 
     CFE_EVS_SendEvent(CFE_SB_SND_STATS_EID,CFE_EVS_EventType_DEBUG,
                       "Software Bus Statistics packet sent");
@@ -776,7 +778,7 @@ int32 CFE_SB_SendStatsCmd(const CFE_SB_SendSbStats_t *data)
 **  Return:
 **    None
 */
-int32 CFE_SB_SendRoutingInfoCmd(const CFE_SB_SendRoutingInfo_t *data)
+int32 CFE_SB_SendRoutingInfoCmd(const CFE_SB_SendRoutingInfoCmd_t *data)
 {
     const CFE_SB_WriteFileInfoCmd_Payload_t *ptr;
     char LocalFilename[OS_MAX_PATH_LEN];
@@ -806,7 +808,7 @@ int32 CFE_SB_SendRoutingInfoCmd(const CFE_SB_SendRoutingInfo_t *data)
 **  Return:
 **    None
 */
-int32 CFE_SB_SendPipeInfoCmd(const CFE_SB_SendPipeInfo_t *data)
+int32 CFE_SB_SendPipeInfoCmd(const CFE_SB_SendPipeInfoCmd_t *data)
 {
     const CFE_SB_WriteFileInfoCmd_Payload_t *ptr;
     char LocalFilename[OS_MAX_PATH_LEN];
@@ -836,7 +838,7 @@ int32 CFE_SB_SendPipeInfoCmd(const CFE_SB_SendPipeInfo_t *data)
 **  Return:
 **    None
 */
-int32 CFE_SB_SendMapInfoCmd(const CFE_SB_SendMapInfo_t *data)
+int32 CFE_SB_SendMapInfoCmd(const CFE_SB_SendMapInfoCmd_t *data)
 {
     const CFE_SB_WriteFileInfoCmd_Payload_t *ptr;
     char LocalFilename[OS_MAX_PATH_LEN];
@@ -1160,7 +1162,7 @@ void CFE_SB_SendRouteSub(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
             if(CFE_SB.PrevSubMsg.Payload.Entries >= CFE_SB_SUB_ENTRIES_PER_PKT)
             {
                 CFE_SB_UnlockSharedData(__func__,__LINE__);
-                status = CFE_SB_SendMsg((CFE_MSG_Message_t *)&CFE_SB.PrevSubMsg);
+                status = CFE_SB_TransmitMsg(&CFE_SB.PrevSubMsg.Hdr.Msg, true);
                 CFE_EVS_SendEvent(CFE_SB_FULL_SUB_PKT_EID, CFE_EVS_EventType_DEBUG,
                                   "Full Sub Pkt %d Sent,Entries=%d,Stat=0x%x\n",
                                   (int)CFE_SB.PrevSubMsg.Payload.PktSegment,
@@ -1199,7 +1201,7 @@ void CFE_SB_SendRouteSub(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
 **  Return:
 **    None
 */
-int32 CFE_SB_SendPrevSubsCmd(const CFE_SB_SendPrevSubs_t *data)
+int32 CFE_SB_SendPrevSubsCmd(const CFE_SB_SendPrevSubsCmd_t *data)
 {
     int32 status;
 
@@ -1218,7 +1220,7 @@ int32 CFE_SB_SendPrevSubsCmd(const CFE_SB_SendPrevSubs_t *data)
     /* if pkt has any number of entries, send it as a partial pkt */
     if(CFE_SB.PrevSubMsg.Payload.Entries > 0)
     {
-        status = CFE_SB_SendMsg((CFE_MSG_Message_t *)&CFE_SB.PrevSubMsg);
+        status = CFE_SB_TransmitMsg(&CFE_SB.PrevSubMsg.Hdr.Msg, true);
         CFE_EVS_SendEvent(CFE_SB_PART_SUB_PKT_EID, CFE_EVS_EventType_DEBUG,
                           "Partial Sub Pkt %d Sent,Entries=%d,Stat=0x%x",
                           (int)CFE_SB.PrevSubMsg.Payload.PktSegment, (int)CFE_SB.PrevSubMsg.Payload.Entries,

--- a/fsw/cfe-core/src/sb/cfe_sb_util.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_util.c
@@ -86,11 +86,11 @@ size_t CFE_SB_MsgHdrSize(const CFE_MSG_Message_t *MsgPtr)
     }
     else if(type == CFE_MSG_Type_Cmd)
     {
-        size = sizeof(CFE_SB_CmdHdr_t);
+        size = sizeof(CFE_MSG_CommandHeader_t);
     }
     else if(type == CFE_MSG_Type_Tlm)
     {
-        size = sizeof(CFE_SB_TlmHdr_t);
+        size = sizeof(CFE_MSG_TelemetryHeader_t);
     }
 
     return size;

--- a/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
@@ -142,14 +142,14 @@ int32 CFE_TBL_EarlyInit (void)
     /*
     ** Initialize housekeeping packet (clear user data area)...
     */
-    CFE_MSG_Init(&CFE_TBL_TaskData.HkPacket.TlmHeader.BaseMsg,
+    CFE_MSG_Init(&CFE_TBL_TaskData.HkPacket.TlmHeader.Msg,
                  CFE_SB_ValueToMsgId(CFE_TBL_HK_TLM_MID),
                  sizeof(CFE_TBL_TaskData.HkPacket));
 
     /*
     ** Initialize table registry report packet (clear user data area)...
     */
-    CFE_MSG_Init(&CFE_TBL_TaskData.TblRegPacket.TlmHeader.BaseMsg,
+    CFE_MSG_Init(&CFE_TBL_TaskData.TblRegPacket.TlmHeader.Msg,
                  CFE_SB_ValueToMsgId(CFE_TBL_REG_TLM_MID),
                  sizeof(CFE_TBL_TaskData.TblRegPacket));
 
@@ -1511,18 +1511,18 @@ int32 CFE_TBL_SendNotificationMsg(CFE_TBL_RegistryRec_t *RegRecPtr)
         /*
         ** Initialize notification message packet (clear user data area)...
         */
-        CFE_MSG_Init((CFE_MSG_Message_t *)&CFE_TBL_TaskData.NotifyMsg,
+        CFE_MSG_Init(&CFE_TBL_TaskData.NotifyMsg.CmdHeader.Msg,
                      RegRecPtr->NotificationMsgId,
-                     sizeof(CFE_TBL_NotifyCmd_t));
+                     sizeof(CFE_TBL_TaskData.NotifyMsg));
         
         /* Set the command code */
-        CFE_MSG_SetFcnCode((CFE_MSG_Message_t *) &CFE_TBL_TaskData.NotifyMsg, RegRecPtr->NotificationCC);
+        CFE_MSG_SetFcnCode(&CFE_TBL_TaskData.NotifyMsg.CmdHeader.Msg, RegRecPtr->NotificationCC);
         
         /* Set the command parameter */
         CFE_TBL_TaskData.NotifyMsg.Payload.Parameter = RegRecPtr->NotificationParam;
     
-        CFE_SB_TimeStampMsg((CFE_MSG_Message_t *) &CFE_TBL_TaskData.NotifyMsg);
-        Status = CFE_SB_SendMsg((CFE_MSG_Message_t *) &CFE_TBL_TaskData.NotifyMsg);
+        CFE_SB_TimeStampMsg(&CFE_TBL_TaskData.NotifyMsg.CmdHeader.Msg);
+        Status = CFE_SB_TransmitMsg(&CFE_TBL_TaskData.NotifyMsg.CmdHeader.Msg, false);
     
         if (Status != CFE_SUCCESS)
         {

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task.h
@@ -308,7 +308,6 @@ typedef struct
   /*
   ** Task operational data (not reported in housekeeping)...
   */
-  CFE_MSG_Message_t     *MsgPtr;                          /**< \brief Pointer to most recently received command message */
   CFE_SB_PipeId_t        CmdPipe;                         /**< \brief Table Task command pipe ID as obtained from Software Bus */
 
   /*
@@ -404,7 +403,7 @@ int32 CFE_TBL_TaskInit(void);
 **
 ** 
 ******************************************************************************/
-void  CFE_TBL_TaskPipe(CFE_MSG_Message_t *MessagePtr);
+void  CFE_TBL_TaskPipe(CFE_SB_Buffer_t *SBBufPtr);
 
 /*****************************************************************************/
 /**

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.c
@@ -53,7 +53,7 @@
 ** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
 ********************************************************************/
 
-int32 CFE_TBL_HousekeepingCmd(const CFE_SB_CmdHdr_t *data)
+int32 CFE_TBL_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
 {
     int32                     Status;
     uint32                    i;
@@ -69,8 +69,8 @@ int32 CFE_TBL_HousekeepingCmd(const CFE_SB_CmdHdr_t *data)
     /*
     ** Send housekeeping telemetry packet
     */
-    CFE_SB_TimeStampMsg((CFE_MSG_Message_t *) &CFE_TBL_TaskData.HkPacket);
-    Status = CFE_SB_SendMsg((CFE_MSG_Message_t *) &CFE_TBL_TaskData.HkPacket);
+    CFE_SB_TimeStampMsg(&CFE_TBL_TaskData.HkPacket.TlmHeader.Msg);
+    Status = CFE_SB_TransmitMsg(&CFE_TBL_TaskData.HkPacket.TlmHeader.Msg, true);
 
     if (Status != CFE_SUCCESS)
     {
@@ -88,8 +88,8 @@ int32 CFE_TBL_HousekeepingCmd(const CFE_SB_CmdHdr_t *data)
         /*
         ** Send Table Registry Info Packet
         */
-        CFE_SB_TimeStampMsg((CFE_MSG_Message_t *) &CFE_TBL_TaskData.TblRegPacket);
-        CFE_SB_SendMsg((CFE_MSG_Message_t *) &CFE_TBL_TaskData.TblRegPacket);
+        CFE_SB_TimeStampMsg(&CFE_TBL_TaskData.TblRegPacket.TlmHeader.Msg);
+        CFE_SB_TransmitMsg(&CFE_TBL_TaskData.TblRegPacket.TlmHeader.Msg, true);
 
         /* Once the data has been sent, clear the index so that we don't send it again and again */
         CFE_TBL_TaskData.HkTlmTblRegIndex = CFE_TBL_NOT_FOUND;
@@ -325,7 +325,7 @@ void CFE_TBL_GetTblRegData(void)
 ** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
 ********************************************************************/
 
-int32 CFE_TBL_NoopCmd(const CFE_TBL_Noop_t *data)
+int32 CFE_TBL_NoopCmd(const CFE_TBL_NoopCmd_t *data)
 {
     /* Acknowledge receipt of NOOP with Event Message */
     CFE_EVS_SendEvent(CFE_TBL_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op command. %s", CFE_VERSION_STRING);
@@ -342,7 +342,7 @@ int32 CFE_TBL_NoopCmd(const CFE_TBL_Noop_t *data)
 ** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
 ********************************************************************/
 
-int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCounters_t *data)
+int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCountersCmd_t *data)
 {
     CFE_TBL_TaskData.CommandCounter = 0;
     CFE_TBL_TaskData.CommandErrorCounter = 0;
@@ -367,7 +367,7 @@ int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCounters_t *data)
 ** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
 ********************************************************************/
 
-int32 CFE_TBL_LoadCmd(const CFE_TBL_Load_t *data)
+int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t        ReturnCode = CFE_TBL_INC_ERR_CTR;        /* Assume failure */
     const CFE_TBL_LoadCmd_Payload_t    *CmdPtr = &data->Payload;
@@ -572,7 +572,7 @@ int32 CFE_TBL_LoadCmd(const CFE_TBL_Load_t *data)
 ** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
 ********************************************************************/
 
-int32 CFE_TBL_DumpCmd(const CFE_TBL_Dump_t *data)
+int32 CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t        ReturnCode = CFE_TBL_INC_ERR_CTR;        /* Assume failure */
     int16                       RegIndex;
@@ -865,7 +865,7 @@ CFE_TBL_CmdProcRet_t CFE_TBL_DumpToFile( const char *DumpFilename, const char *T
 ** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
 ********************************************************************/
 
-int32 CFE_TBL_ValidateCmd(const CFE_TBL_Validate_t *data)
+int32 CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t         ReturnCode = CFE_TBL_INC_ERR_CTR;        /* Assume failure */
     int16                        RegIndex;
@@ -1023,7 +1023,7 @@ int32 CFE_TBL_ValidateCmd(const CFE_TBL_Validate_t *data)
 ** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
 ********************************************************************/
 
-int32 CFE_TBL_ActivateCmd(const CFE_TBL_Activate_t *data)
+int32 CFE_TBL_ActivateCmd(const CFE_TBL_ActivateCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t         ReturnCode = CFE_TBL_INC_ERR_CTR;        /* Assume failure */
     int16                        RegIndex;
@@ -1115,7 +1115,7 @@ int32 CFE_TBL_ActivateCmd(const CFE_TBL_Activate_t *data)
 ** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
 ********************************************************************/
 
-int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistry_t *data)
+int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t        ReturnCode = CFE_TBL_INC_ERR_CTR;        /* Assume failure */
     bool                        FileExistedPrev = false;
@@ -1301,7 +1301,7 @@ int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistry_t *data)
 ** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
 ********************************************************************/
 
-int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistry_t *data)
+int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t         ReturnCode = CFE_TBL_INC_ERR_CTR;        /* Assume failure */
     int16                        RegIndex;
@@ -1348,7 +1348,7 @@ int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistry_t *data)
 ** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
 ********************************************************************/
 
-int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDS_t *data)
+int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t         ReturnCode = CFE_TBL_INC_ERR_CTR;        /* Assume failure */
     const CFE_TBL_DelCDSCmd_Payload_t   *CmdPtr = &data->Payload;
@@ -1446,7 +1446,7 @@ int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDS_t *data)
 ** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
 ********************************************************************/
 
-int32 CFE_TBL_AbortLoadCmd(const CFE_TBL_AbortLoad_t *data)
+int32 CFE_TBL_AbortLoadCmd(const CFE_TBL_AbortLoadCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t         ReturnCode = CFE_TBL_INC_ERR_CTR;        /* Assume failure */
     int16                        RegIndex;

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.h
@@ -126,7 +126,7 @@ extern void CFE_TBL_GetTblRegData(void);
 **
 ** \retval #CFE_TBL_DONT_INC_CTR \copydoc CFE_TBL_DONT_INC_CTR
 ******************************************************************************/
-int32 CFE_TBL_HousekeepingCmd(const CFE_SB_CmdHdr_t *data);
+int32 CFE_TBL_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data);
 
 /*****************************************************************************/
 /**
@@ -143,7 +143,7 @@ int32 CFE_TBL_HousekeepingCmd(const CFE_SB_CmdHdr_t *data);
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
 ******************************************************************************/
-int32 CFE_TBL_NoopCmd(const CFE_TBL_Noop_t *data);
+int32 CFE_TBL_NoopCmd(const CFE_TBL_NoopCmd_t *data);
 
 /*****************************************************************************/
 /**
@@ -159,7 +159,7 @@ int32 CFE_TBL_NoopCmd(const CFE_TBL_Noop_t *data);
 **
 ** \retval #CFE_TBL_DONT_INC_CTR \copydoc CFE_TBL_DONT_INC_CTR
 ******************************************************************************/
-int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCounters_t *data);
+int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCountersCmd_t *data);
 
 /*****************************************************************************/
 /**
@@ -177,7 +177,7 @@ int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCounters_t *data);
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
 ******************************************************************************/
-int32 CFE_TBL_LoadCmd(const CFE_TBL_Load_t *data);
+int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data);
 
 /*****************************************************************************/
 /**
@@ -195,7 +195,7 @@ int32 CFE_TBL_LoadCmd(const CFE_TBL_Load_t *data);
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
 ******************************************************************************/
-int32 CFE_TBL_DumpCmd(const CFE_TBL_Dump_t *data);
+int32 CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data);
 
 /*****************************************************************************/
 /**
@@ -214,7 +214,7 @@ int32 CFE_TBL_DumpCmd(const CFE_TBL_Dump_t *data);
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
 ******************************************************************************/
-int32 CFE_TBL_ValidateCmd(const CFE_TBL_Validate_t *data);
+int32 CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data);
 
 /*****************************************************************************/
 /**
@@ -232,7 +232,7 @@ int32 CFE_TBL_ValidateCmd(const CFE_TBL_Validate_t *data);
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
 ******************************************************************************/
-int32 CFE_TBL_ActivateCmd(const CFE_TBL_Activate_t *data);
+int32 CFE_TBL_ActivateCmd(const CFE_TBL_ActivateCmd_t *data);
 
 /*****************************************************************************/
 /**
@@ -249,7 +249,7 @@ int32 CFE_TBL_ActivateCmd(const CFE_TBL_Activate_t *data);
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
 ******************************************************************************/
-int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistry_t *data);
+int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data);
 
 /*****************************************************************************/
 /**
@@ -267,7 +267,7 @@ int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistry_t *data);
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
 ******************************************************************************/
-int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistry_t *data);
+int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data);
 
 /*****************************************************************************/
 /**
@@ -284,7 +284,7 @@ int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistry_t *data);
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
 ******************************************************************************/
-int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDS_t *data);
+int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data);
 
 /*****************************************************************************/
 /**
@@ -301,7 +301,7 @@ int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDS_t *data);
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
 ******************************************************************************/
-int32 CFE_TBL_AbortLoadCmd(const CFE_TBL_AbortLoad_t *data);
+int32 CFE_TBL_AbortLoadCmd(const CFE_TBL_AbortLoadCmd_t *data);
 
 
 /*****************************************************************************/

--- a/fsw/cfe-core/src/time/cfe_time_tone.c
+++ b/fsw/cfe-core/src/time/cfe_time_tone.c
@@ -165,7 +165,7 @@ void CFE_TIME_ToneSend(void)
     /*
     ** Send "time at the tone" command data packet...
     */
-    CFE_SB_SendMsg((CFE_MSG_Message_t *) &CFE_TIME_TaskData.ToneDataCmd);
+    CFE_SB_TransmitMsg(&CFE_TIME_TaskData.ToneDataCmd.CmdHeader.Msg, false);
 
     /*
     ** Count of "time at the tone" commands sent with internal data...
@@ -305,7 +305,7 @@ int32 CFE_TIME_ToneSendMET(CFE_TIME_SysTime_t NewMET)
             /*
             ** Send "time at the tone" command data packet...
             */
-            CFE_SB_SendMsg((CFE_MSG_Message_t *) &CFE_TIME_TaskData.ToneDataCmd);
+            CFE_SB_TransmitMsg(&CFE_TIME_TaskData.ToneDataCmd.CmdHeader.Msg, false);
 
             /*
             ** Count of "time at the tone" commands sent with external data...
@@ -459,7 +459,7 @@ int32 CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps)
             /*
             ** Send "time at the tone" command data packet...
             */
-            CFE_SB_SendMsg((CFE_MSG_Message_t *) &CFE_TIME_TaskData.ToneDataCmd);
+            CFE_SB_TransmitMsg(&CFE_TIME_TaskData.ToneDataCmd.CmdHeader.Msg, false);
 
             /*
             ** Count of "time at the tone" commands sent with external data...
@@ -612,7 +612,7 @@ int32 CFE_TIME_ToneSendTime(CFE_TIME_SysTime_t NewTime)
             /*
             ** Send "time at the tone" command data packet...
             */
-            CFE_SB_SendMsg((CFE_MSG_Message_t *) &CFE_TIME_TaskData.ToneDataCmd);
+            CFE_SB_TransmitMsg(&CFE_TIME_TaskData.ToneDataCmd.CmdHeader.Msg, false);
 
             /*
             ** Count of "time at the tone" commands sent with external data...
@@ -1217,7 +1217,7 @@ void CFE_TIME_Tone1HzTask(void)
             /*
             ** Send tone signal command packet...
             */
-            CFE_SB_SendMsg((CFE_MSG_Message_t *) &CFE_TIME_TaskData.ToneSignalCmd);
+            CFE_SB_TransmitMsg(&CFE_TIME_TaskData.ToneSignalCmd.CmdHeader.Msg, false);
 
 #if (CFE_MISSION_TIME_CFG_FAKE_TONE == true)
             /*
@@ -1225,7 +1225,7 @@ void CFE_TIME_Tone1HzTask(void)
             ** to send the tone to other time clients.
             ** (this is done by scheduler in non-fake mode)
             */
-            CFE_SB_SendMsg((CFE_MSG_Message_t *) &CFE_TIME_TaskData.ToneSendCmd);
+            CFE_SB_TransmitMsg(&CFE_TIME_TaskData.ToneSendCmd.CmdHeader.Msg, false);
 #endif
 
             /*
@@ -1434,7 +1434,7 @@ void CFE_TIME_Local1HzTask(void)
             ** This used to be optional in previous CFE versions, but it is now required
             ** as TIME subscribes to this itself to do state machine tasks.
             */
-            CFE_SB_SendMsg((CFE_MSG_Message_t *) &CFE_TIME_TaskData.Local1HzCmd);
+            CFE_SB_TransmitMsg(&CFE_TIME_TaskData.Local1HzCmd.CmdHeader.Msg, false);
 
             CFE_TIME_TaskData.LocalTaskCounter++;
         }

--- a/fsw/cfe-core/src/time/cfe_time_utils.c
+++ b/fsw/cfe-core/src/time/cfe_time_utils.c
@@ -388,21 +388,21 @@ void CFE_TIME_InitData(void)
     /*
     ** Initialize housekeeping packet (clear user data area)...
     */
-    CFE_MSG_Init(&CFE_TIME_TaskData.HkPacket.TlmHeader.BaseMsg,
+    CFE_MSG_Init(&CFE_TIME_TaskData.HkPacket.TlmHeader.Msg,
                  CFE_SB_ValueToMsgId(CFE_TIME_HK_TLM_MID),
                  sizeof(CFE_TIME_TaskData.HkPacket));
 
     /*
     ** Initialize diagnostic packet (clear user data area)...
     */
-    CFE_MSG_Init(&CFE_TIME_TaskData.DiagPacket.TlmHeader.BaseMsg,
+    CFE_MSG_Init(&CFE_TIME_TaskData.DiagPacket.TlmHeader.Msg,
                  CFE_SB_ValueToMsgId(CFE_TIME_DIAG_TLM_MID),
                  sizeof(CFE_TIME_TaskData.DiagPacket));
 
     /*
     ** Initialize "time at the tone" signal command packet...
     */
-    CFE_MSG_Init(&CFE_TIME_TaskData.ToneSignalCmd.CmdHeader.BaseMsg,
+    CFE_MSG_Init(&CFE_TIME_TaskData.ToneSignalCmd.CmdHeader.Msg,
                  CFE_SB_ValueToMsgId(CFE_TIME_TONE_CMD_MID),
                  sizeof(CFE_TIME_TaskData.ToneSignalCmd));
 
@@ -410,7 +410,7 @@ void CFE_TIME_InitData(void)
     ** Initialize "time at the tone" data command packet...
     */
     #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
-    CFE_MSG_Init((CFE_MSG_Message_t *)&CFE_TIME_TaskData.ToneDataCmd,
+    CFE_MSG_Init(&CFE_TIME_TaskData.ToneDataCmd.CmdHeader.Msg,
                  CFE_SB_ValueToMsgId(CFE_TIME_DATA_CMD_MID),
                  sizeof(CFE_TIME_TaskData.ToneDataCmd));
     #endif
@@ -419,7 +419,7 @@ void CFE_TIME_InitData(void)
     ** Initialize simulated tone send message ("fake tone" mode only)...
     */
 #if (CFE_MISSION_TIME_CFG_FAKE_TONE == true)
-    CFE_MSG_Init(&CFE_TIME_TaskData.ToneSendCmd.BaseMsg,
+    CFE_MSG_Init(&CFE_TIME_TaskData.ToneSendCmd.CmdHeader.Msg,
                  CFE_SB_ValueToMsgId(CFE_TIME_SEND_CMD_MID),
                  sizeof(CFE_TIME_TaskData.ToneSendCmd));
 #endif
@@ -427,9 +427,9 @@ void CFE_TIME_InitData(void)
     /*
     ** Initialize local 1Hz "wake-up" command packet (optional)...
     */
-    CFE_MSG_Init((CFE_MSG_Message_t *)&CFE_TIME_TaskData.Local1HzCmd,
-                    CFE_SB_ValueToMsgId(CFE_TIME_1HZ_CMD_MID),
-                    sizeof(CFE_TIME_TaskData.Local1HzCmd));
+    CFE_MSG_Init(&CFE_TIME_TaskData.Local1HzCmd.CmdHeader.Msg,
+                 CFE_SB_ValueToMsgId(CFE_TIME_1HZ_CMD_MID),
+                 sizeof(CFE_TIME_TaskData.Local1HzCmd));
 
     return;
 

--- a/fsw/cfe-core/src/time/cfe_time_utils.h
+++ b/fsw/cfe-core/src/time/cfe_time_utils.h
@@ -183,7 +183,6 @@ typedef struct
   /*
   ** Task operational data (not reported in housekeeping)...
   */
-  CFE_MSG_Message_t *MsgPtr;
   CFE_SB_PipeId_t    CmdPipe;
 
   /*
@@ -277,7 +276,7 @@ typedef struct
   /*
   ** Local 1Hz wake-up command packet (not related to time at tone)...
   */
-  CFE_SB_CmdHdr_t Local1HzCmd;
+  CFE_TIME_1HzCmd_t Local1HzCmd;
 
   /*
   ** Time at the tone command packets (sent by time servers)...
@@ -294,7 +293,7 @@ typedef struct
    * "tone signal" message above.
    */
 #if (CFE_MISSION_TIME_CFG_FAKE_TONE == true)
-  CFE_SB_CmdHdr_t  ToneSendCmd;
+  CFE_TIME_FakeToneCmd_t ToneSendCmd;
 #endif
 
   /*
@@ -349,7 +348,7 @@ CFE_TIME_SysTime_t CFE_TIME_LatchClock(void);
 ** Function prototypes (Time Services utilities data)...
 */
 int32 CFE_TIME_TaskInit (void);
-void  CFE_TIME_TaskPipe(CFE_MSG_Message_t *MsgPtr);
+void  CFE_TIME_TaskPipe(CFE_SB_Buffer_t *SBBufPtr);
 void CFE_TIME_InitData(void);
 void CFE_TIME_QueryResetVars(void);
 void CFE_TIME_UpdateResetVars(const CFE_TIME_Reference_t *Reference);

--- a/fsw/cfe-core/unit-test/CMakeLists.txt
+++ b/fsw/cfe-core/unit-test/CMakeLists.txt
@@ -71,7 +71,7 @@ foreach(MODULE ${CFE_CORE_MODULES})
         ${UT_COVERAGE_LINK_FLAGS}
         ut_cfe-core_support
         ut_cfe-core_stubs
-        sbr  # TODO remove this
+        sbr  # Will be removed when sbr stubs are implemented
         ut_assert)
 
   add_test(${UT_TARGET_NAME}_UT ${UT_TARGET_NAME}_UT)

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -2624,23 +2624,26 @@ void TestTask(void)
     osal_id_t                   UT_ContextTask;
     union
     {
-        CFE_MSG_Message_t        Msg;
-        CFE_ES_NoArgsCmd_t       NoArgsCmd;
-        CFE_ES_Restart_t         RestartCmd;
-        CFE_ES_StartApp_t        StartAppCmd;
-        CFE_ES_StopApp_t         StopAppCmd;
-        CFE_ES_RestartApp_t      RestartAppCmd;
-        CFE_ES_ReloadApp_t       ReloadAppCmd;
-        CFE_ES_QueryOne_t        QueryOneCmd;
-        CFE_ES_QueryAll_t        QueryAllCmd;
-        CFE_ES_OverWriteSyslog_t OverwriteSysLogCmd;
-        CFE_ES_WriteSyslog_t     WriteSyslogCmd;
-        CFE_ES_WriteERLog_t      WriteERlogCmd;
-        CFE_ES_SetMaxPRCount_t   SetMaxPRCountCmd;
-        CFE_ES_DeleteCDS_t       DeleteCDSCmd;
-        CFE_ES_SendMemPoolStats_t TlmPoolStatsCmd;
-        CFE_ES_DumpCDSRegistry_t DumpCDSRegCmd;
-        CFE_ES_QueryAllTasks_t   QueryAllTasksCmd;
+        CFE_MSG_Message_t            Msg;
+        CFE_ES_NoArgsCmd_t           NoArgsCmd;
+        CFE_ES_ClearSysLogCmd_t      ClearSysLogCmd;
+        CFE_ES_ClearERLogCmd_t       ClearERLogCmd;
+        CFE_ES_ResetPRCountCmd_t     ResetPRCountCmd;
+        CFE_ES_RestartCmd_t          RestartCmd;
+        CFE_ES_StartAppCmd_t         StartAppCmd;
+        CFE_ES_StopAppCmd_t          StopAppCmd;
+        CFE_ES_RestartAppCmd_t       RestartAppCmd;
+        CFE_ES_ReloadAppCmd_t        ReloadAppCmd;
+        CFE_ES_QueryOneCmd_t         QueryOneCmd;
+        CFE_ES_QueryAllCmd_t         QueryAllCmd;
+        CFE_ES_OverWriteSysLogCmd_t  OverwriteSysLogCmd;
+        CFE_ES_WriteSysLogCmd_t      WriteSysLogCmd;
+        CFE_ES_WriteERLogCmd_t       WriteERLogCmd;
+        CFE_ES_SetMaxPRCountCmd_t    SetMaxPRCountCmd;
+        CFE_ES_DeleteCDSCmd_t        DeleteCDSCmd;
+        CFE_ES_SendMemPoolStatsCmd_t SendMemPoolStatsCmd;
+        CFE_ES_DumpCDSRegistryCmd_t  DumpCDSRegistryCmd;
+        CFE_ES_QueryAllTasksCmd_t    QueryAllTasksCmd;
     } CmdBuf;
     CFE_ES_AppRecord_t          *UtAppRecPtr;
     CFE_ES_TaskRecord_t         *UtTaskRecPtr;
@@ -2851,7 +2854,7 @@ void TestTask(void)
     /* Test cFE restart with bad restart type */
     ES_ResetUnitTest();
     CmdBuf.RestartCmd.Payload.RestartType = 4524;
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_Restart_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.RestartCmd),
             UT_TPID_CFE_ES_CMD_RESTART_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_BOOT_ERR_EID),
@@ -2870,7 +2873,7 @@ void TestTask(void)
     CmdBuf.StartAppCmd.Payload.Priority = 160;
     CmdBuf.StartAppCmd.Payload.StackSize = CFE_ES_MEMOFFSET_C(8192);
     CmdBuf.StartAppCmd.Payload.ExceptionAction = CFE_ES_ExceptionAction_RESTART_APP;
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_StartApp_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.StartAppCmd),
             UT_TPID_CFE_ES_CMD_START_APP_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_START_INF_EID),
@@ -2880,7 +2883,7 @@ void TestTask(void)
     /* Test app create with an OS task create failure */
     ES_ResetUnitTest();
     UT_SetDefaultReturnValue(UT_KEY(OS_TaskCreate), OS_ERROR);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_StartApp_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.StartAppCmd),
             UT_TPID_CFE_ES_CMD_START_APP_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_START_ERR_EID),
@@ -2899,7 +2902,7 @@ void TestTask(void)
     CmdBuf.StartAppCmd.Payload.Priority = 160;
     CmdBuf.StartAppCmd.Payload.StackSize = CFE_ES_MEMOFFSET_C(12096);
     CmdBuf.StartAppCmd.Payload.ExceptionAction = CFE_ES_ExceptionAction_RESTART_APP;
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_StartApp_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.StartAppCmd),
             UT_TPID_CFE_ES_CMD_START_APP_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_START_INVALID_FILENAME_ERR_EID),
@@ -2918,7 +2921,7 @@ void TestTask(void)
     CmdBuf.StartAppCmd.Payload.Priority = 160;
     CmdBuf.StartAppCmd.Payload.StackSize = CFE_ES_MEMOFFSET_C(12096);
     CmdBuf.StartAppCmd.Payload.ExceptionAction = CFE_ES_ExceptionAction_RESTART_APP;
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_StartApp_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.StartAppCmd),
             UT_TPID_CFE_ES_CMD_START_APP_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_START_INVALID_ENTRY_POINT_ERR_EID),
@@ -2937,7 +2940,7 @@ void TestTask(void)
     CmdBuf.StartAppCmd.Payload.Priority = 160;
     CmdBuf.StartAppCmd.Payload.StackSize = CFE_ES_MEMOFFSET_C(12096);
     CmdBuf.StartAppCmd.Payload.ExceptionAction = CFE_ES_ExceptionAction_RESTART_APP;
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_StartApp_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.StartAppCmd),
             UT_TPID_CFE_ES_CMD_START_APP_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_START_NULL_APP_NAME_ERR_EID),
@@ -2956,7 +2959,7 @@ void TestTask(void)
     CmdBuf.StartAppCmd.Payload.Priority = 160;
     CmdBuf.StartAppCmd.Payload.StackSize = CFE_ES_MEMOFFSET_C(12096);
     CmdBuf.StartAppCmd.Payload.ExceptionAction = 255;
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_StartApp_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.StartAppCmd),
             UT_TPID_CFE_ES_CMD_START_APP_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_START_EXC_ACTION_ERR_EID),
@@ -2975,7 +2978,7 @@ void TestTask(void)
     CmdBuf.StartAppCmd.Payload.Priority = 160;
     CmdBuf.StartAppCmd.Payload.StackSize = CFE_ES_MEMOFFSET_C(0);
     CmdBuf.StartAppCmd.Payload.ExceptionAction = CFE_ES_ExceptionAction_RESTART_APP;
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_StartApp_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.StartAppCmd),
             UT_TPID_CFE_ES_CMD_START_APP_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_START_INF_EID),
@@ -2994,7 +2997,7 @@ void TestTask(void)
     CmdBuf.StartAppCmd.Payload.Priority = 1000;
     CmdBuf.StartAppCmd.Payload.StackSize = CFE_ES_MEMOFFSET_C(12096);
     CmdBuf.StartAppCmd.Payload.ExceptionAction = CFE_ES_ExceptionAction_RESTART_APP;
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_StartApp_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.StartAppCmd),
             UT_TPID_CFE_ES_CMD_START_APP_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_START_PRIORITY_ERR_EID),
@@ -3006,7 +3009,7 @@ void TestTask(void)
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
     strncpy((char *) CmdBuf.StopAppCmd.Payload.Application, "CFE_ES",
             sizeof(CmdBuf.StopAppCmd.Payload.Application));
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_StopApp_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.StopAppCmd),
             UT_TPID_CFE_ES_CMD_STOP_APP_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_STOP_DBG_EID),
@@ -3016,7 +3019,7 @@ void TestTask(void)
     /* Test app stop failure */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_WAITING, "CFE_ES", NULL, NULL);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_StopApp_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.StopAppCmd),
             UT_TPID_CFE_ES_CMD_STOP_APP_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_STOP_ERR1_EID),
@@ -3028,7 +3031,7 @@ void TestTask(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     strncpy((char *) CmdBuf.StopAppCmd.Payload.Application, "BAD_APP_NAME",
             sizeof(CmdBuf.StopAppCmd.Payload.Application));
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_StopApp_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.StopAppCmd),
             UT_TPID_CFE_ES_CMD_STOP_APP_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_STOP_ERR2_EID),
@@ -3041,7 +3044,7 @@ void TestTask(void)
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
     strncpy((char *) CmdBuf.RestartAppCmd.Payload.Application, "CFE_ES",
             sizeof(CmdBuf.RestartAppCmd.Payload.Application));
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_RestartApp_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.RestartAppCmd),
             UT_TPID_CFE_ES_CMD_RESTART_APP_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_RESTART_APP_DBG_EID),
@@ -3053,7 +3056,7 @@ void TestTask(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     strncpy((char *) CmdBuf.RestartAppCmd.Payload.Application, "BAD_APP_NAME",
             sizeof(CmdBuf.RestartAppCmd.Payload.Application));
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_RestartApp_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.RestartAppCmd),
             UT_TPID_CFE_ES_CMD_RESTART_APP_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_RESTART_APP_ERR2_EID),
@@ -3066,7 +3069,7 @@ void TestTask(void)
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_WAITING, "CFE_ES", NULL, NULL);
     strncpy((char *) CmdBuf.RestartAppCmd.Payload.Application, "CFE_ES",
         sizeof(CmdBuf.RestartAppCmd.Payload.Application));
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_RestartApp_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.RestartAppCmd),
             UT_TPID_CFE_ES_CMD_RESTART_APP_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_RESTART_APP_ERR1_EID),
@@ -3081,7 +3084,7 @@ void TestTask(void)
             sizeof(CmdBuf.ReloadAppCmd.Payload.AppFileName));
     strncpy((char *) CmdBuf.ReloadAppCmd.Payload.Application, "CFE_ES",
             sizeof(CmdBuf.ReloadAppCmd.Payload.Application));
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_ReloadApp_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.ReloadAppCmd),
             UT_TPID_CFE_ES_CMD_RELOAD_APP_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_RELOAD_APP_DBG_EID),
@@ -3093,7 +3096,7 @@ void TestTask(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     strncpy((char *) CmdBuf.ReloadAppCmd.Payload.Application, "BAD_APP_NAME",
             sizeof(CmdBuf.ReloadAppCmd.Payload.Application));
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_ReloadApp_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.ReloadAppCmd),
             UT_TPID_CFE_ES_CMD_RELOAD_APP_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_RELOAD_APP_ERR2_EID),
@@ -3106,7 +3109,7 @@ void TestTask(void)
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_WAITING, "CFE_ES", NULL, NULL);
     strncpy((char *) CmdBuf.ReloadAppCmd.Payload.Application, "CFE_ES",
             sizeof(CmdBuf.ReloadAppCmd.Payload.Application));
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_ReloadApp_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.ReloadAppCmd),
             UT_TPID_CFE_ES_CMD_RELOAD_APP_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_RELOAD_APP_ERR1_EID),
@@ -3119,23 +3122,21 @@ void TestTask(void)
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_WAITING, "CFE_ES", NULL, NULL);
     strncpy((char *) CmdBuf.QueryOneCmd.Payload.Application, "CFE_ES",
             sizeof(CmdBuf.QueryOneCmd.Payload.Application));
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_QueryOne_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryOneCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ONE_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_ONE_APP_EID),
               "CFE_ES_QueryOneCmd",
               "Query application - success");
 
-    /* Test telemetry packet request for single app data with failure of
-     * CFE_SB_SendMsg
-     */
+    /* Test telemetry packet request for single app data with send message failure */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
     strncpy((char *) CmdBuf.QueryOneCmd.Payload.Application, "CFE_ES",
             sizeof(CmdBuf.QueryOneCmd.Payload.Application));
-    UT_SetDeferredRetcode(UT_KEY(CFE_SB_SendMsg), 1, -1);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_QueryOne_t),
+    UT_SetDeferredRetcode(UT_KEY(CFE_SB_TransmitMsg), 1, -1);
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryOneCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ONE_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_ONE_ERR_EID),
@@ -3148,7 +3149,7 @@ void TestTask(void)
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
     strncpy((char *) CmdBuf.QueryOneCmd.Payload.Application, "BAD_APP_NAME",
             sizeof(CmdBuf.QueryOneCmd.Payload.Application));
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_QueryOne_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryOneCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ONE_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_ONE_APPID_ERR_EID),
@@ -3161,7 +3162,7 @@ void TestTask(void)
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
     strncpy((char *) CmdBuf.QueryAllCmd.Payload.FileName, "AllFilename",
             sizeof(CmdBuf.QueryAllCmd.Payload.FileName));
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_QueryAll_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryAllCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ALL_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_ALL_APPS_EID),
@@ -3171,7 +3172,7 @@ void TestTask(void)
     /* Test write of all app data to file with a null file name */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_QueryAll_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryAllCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ALL_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_ALL_APPS_EID),
@@ -3182,7 +3183,7 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_WriteHeader), 1, OS_ERROR);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_QueryAll_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryAllCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ALL_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_WRHDR_ERR_EID),
@@ -3194,7 +3195,7 @@ void TestTask(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
     UT_SetDefaultReturnValue(UT_KEY(OS_write), OS_ERROR);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_QueryAll_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryAllCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ALL_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_TASKWR_ERR_EID),
@@ -3206,7 +3207,7 @@ void TestTask(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_QueryAll_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryAllCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ALL_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_OSCREATE_ERR_EID),
@@ -3217,7 +3218,7 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_QueryAllTasks_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryAllTasksCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ALL_TASKS_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_TASKINFO_EID),
@@ -3230,7 +3231,7 @@ void TestTask(void)
     strncpy((char *) CmdBuf.QueryAllTasksCmd.Payload.FileName, "filename",
             sizeof(CmdBuf.QueryAllTasksCmd.Payload.FileName));
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_WriteHeader), 1, -1);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_QueryAllTasks_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryAllTasksCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ALL_TASKS_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_TASKINFO_WRHDR_ERR_EID),
@@ -3242,7 +3243,7 @@ void TestTask(void)
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "UT", NULL, NULL);
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_SetDefaultReturnValue(UT_KEY(OS_write), OS_ERROR);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_QueryAllTasks_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryAllTasksCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ALL_TASKS_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_TASKINFO_WR_ERR_EID),
@@ -3253,7 +3254,7 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_QueryAllTasks_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryAllTasksCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ALL_TASKS_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_TASKINFO_OSCREATE_ERR_EID),
@@ -3263,70 +3264,71 @@ void TestTask(void)
     /* Test successful clearing of the system log */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_ClearSyslog_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.ClearSysLogCmd),
             UT_TPID_CFE_ES_CMD_CLEAR_SYSLOG_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_SYSLOG1_INF_EID),
-              "CFE_ES_ClearSyslogCmd",
+              "CFE_ES_ClearSysLogCmd",
               "Clear ES log data");
 
     /* Test successful overwriting of the system log using discard mode */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.OverwriteSysLogCmd.Payload.Mode = CFE_ES_LogMode_OVERWRITE;
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_OverWriteSyslog_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.OverwriteSysLogCmd),
             UT_TPID_CFE_ES_CMD_OVER_WRITE_SYSLOG_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_SYSLOGMODE_EID),
-              "CFE_ES_OverWriteSyslogCmd",
+              "CFE_ES_OverWriteSysLogCmd",
               "Overwrite system log received (discard mode)");
 
     /* Test overwriting the system log using an invalid mode */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.OverwriteSysLogCmd.Payload.Mode = 255;
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_OverWriteSyslog_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.OverwriteSysLogCmd),
             UT_TPID_CFE_ES_CMD_OVER_WRITE_SYSLOG_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_ERR_SYSLOGMODE_EID),
-              "CFE_ES_OverWriteSyslogCmd",
+              "CFE_ES_OverWriteSysLogCmd",
               "Overwrite system log using invalid mode");
 
     /* Test successful writing of the system log */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.WriteSyslogCmd.Payload.FileName, "filename",
-            sizeof(CmdBuf.WriteSyslogCmd.Payload.FileName));
+    strncpy((char *) CmdBuf.WriteSysLogCmd.Payload.FileName, "filename",
+            sizeof(CmdBuf.WriteSysLogCmd.Payload.FileName));
     CFE_ES_TaskData.HkPacket.Payload.SysLogEntries = 123;
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_WriteSyslog_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.WriteSysLogCmd),
             UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_SYSLOG2_EID),
-              "CFE_ES_WriteSyslogCmd",
+              "CFE_ES_WriteSysLogCmd",
               "Write system log; success");
 
     /* Test writing the system log using a null file name */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CmdBuf.WriteSyslogCmd.Payload.FileName[0] = '\0';
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_WriteSyslog_t),
+    CmdBuf.WriteSysLogCmd.Payload.FileName[0] = '\0';
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.WriteSysLogCmd),
             UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_SYSLOG2_EID),
-              "CFE_ES_WriteSyslogCmd",
+              "CFE_ES_WriteSysLogCmd",
               "Write system log; null file name");
 
     /* Test writing the system log with an OS create failure */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
-    strncpy((char *) CmdBuf.WriteSyslogCmd.Payload.FileName, "",
-            sizeof(CmdBuf.WriteSyslogCmd.Payload.FileName));
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_WriteSyslog_t),
+    UT_SetForceFail(UT_KEY(OS_OpenCreate), OS_ERROR);
+    strncpy((char *) CmdBuf.WriteSysLogCmd.Payload.FileName, "",
+            sizeof(CmdBuf.WriteSysLogCmd.Payload.FileName));
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.WriteSysLogCmd),
             UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_SYSLOG2_ERR_EID),
-              "CFE_ES_WriteSyslogCmd",
+              "CFE_ES_WriteSysLogCmd",
               "Write system log; OS create");
 
     /* Test writing the system log with an OS write failure */
@@ -3337,29 +3339,29 @@ void TestTask(void)
             sizeof(CFE_ES_ResetDataPtr->SystemLog),
             "0000-000-00:00:00.00000 Test Message\n");
     CFE_ES_ResetDataPtr->SystemLogEndIdx = CFE_ES_ResetDataPtr->SystemLogWriteIdx;
-    strncpy((char *) CmdBuf.WriteSyslogCmd.Payload.FileName, "",
-            sizeof(CmdBuf.WriteSyslogCmd.Payload.FileName));
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_WriteSyslog_t),
+    strncpy((char *) CmdBuf.WriteSysLogCmd.Payload.FileName, "",
+            sizeof(CmdBuf.WriteSysLogCmd.Payload.FileName));
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.WriteSysLogCmd),
             UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_FILEWRITE_ERR_EID),
-              "CFE_ES_WriteSyslogCmd",
+              "CFE_ES_WriteSysLogCmd",
               "Write system log; OS write");
 
     /* Test writing the system log with a write header failure */
     ES_ResetUnitTest();
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_WriteHeader), 1, OS_ERROR);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_WriteSyslog_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.WriteSysLogCmd),
             UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_FILEWRITE_ERR_EID),
-              "CFE_ES_WriteSyslogCmd",
+              "CFE_ES_WriteSysLogCmd",
               "Write system log; write header");
 
     /* Test successful clearing of the E&R log */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_ClearERLog_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.ClearERLogCmd),
             UT_TPID_CFE_ES_CMD_CLEAR_ER_LOG_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_ERLOG1_INF_EID),
@@ -3371,10 +3373,10 @@ void TestTask(void)
      * this just sets a flag for the background task */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy(CmdBuf.WriteERlogCmd.Payload.FileName, "filename",
-            sizeof(CmdBuf.WriteERlogCmd.Payload.FileName));
+    strncpy(CmdBuf.WriteERLogCmd.Payload.FileName, "filename",
+            sizeof(CmdBuf.WriteERLogCmd.Payload.FileName));
     CFE_ES_TaskData.BackgroundERLogDumpState.IsPending = false;
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_WriteERLog_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.WriteERLogCmd),
             UT_TPID_CFE_ES_CMD_WRITE_ER_LOG_CC);
     UT_Report(__FILE__, __LINE__,
             CFE_ES_TaskData.BackgroundERLogDumpState.IsPending,
@@ -3387,7 +3389,7 @@ void TestTask(void)
 
     /* sending the same command a second time should fail with an event
      * indicating a file write is already pending. */
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_WriteERLog_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.WriteERLogCmd),
             UT_TPID_CFE_ES_CMD_WRITE_ER_LOG_CC);
     UT_Report(__FILE__, __LINE__,
             UT_EventIsInHistory(CFE_ES_ERLOG_PENDING_ERR_EID),
@@ -3534,7 +3536,7 @@ void TestTask(void)
     /* Test resetting and setting the max for the processor reset count */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_ResetPRCount_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.ResetPRCountCmd),
             UT_TPID_CFE_ES_CMD_RESET_PR_COUNT_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_RESET_PR_COUNT_EID),
@@ -3545,7 +3547,7 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.SetMaxPRCountCmd.Payload.MaxPRCount = 3;
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_SetMaxPRCount_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.SetMaxPRCountCmd),
             UT_TPID_CFE_ES_CMD_SET_MAX_PR_COUNT_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_SET_MAX_PR_COUNT_EID),
@@ -3560,7 +3562,7 @@ void TestTask(void)
     strncpy(CmdBuf.DeleteCDSCmd.Payload.CdsName,
             "CFE_ES.CDS_NAME",
             sizeof(CmdBuf.DeleteCDSCmd.Payload.CdsName));
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_DeleteCDS_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.DeleteCDSCmd),
             UT_TPID_CFE_ES_CMD_DELETE_CDS_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_CDS_DELETE_ERR_EID),
@@ -3571,7 +3573,7 @@ void TestTask(void)
     /* NOTE - reuse command from previous test */
     ES_ResetUnitTest();
     ES_UT_SetupSingleCDSRegistry("CFE_ES.CDS_NAME", ES_UT_CDS_BLOCK_SIZE, true, NULL);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_DeleteCDS_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.DeleteCDSCmd),
             UT_TPID_CFE_ES_CMD_DELETE_CDS_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_CDS_DELETE_TBL_ERR_EID),
@@ -3584,7 +3586,7 @@ void TestTask(void)
     ES_UT_SetupSingleCDSRegistry("CFE_ES.CDS_NAME", ES_UT_CDS_BLOCK_SIZE, false, NULL);
 
     /* Set up the block to read what we need to from the CDS */
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_DeleteCDS_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.DeleteCDSCmd),
             UT_TPID_CFE_ES_CMD_DELETE_CDS_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_CDS_DELETED_INFO_EID),
@@ -3595,7 +3597,7 @@ void TestTask(void)
     ES_ResetUnitTest();
     ES_UT_SetupSingleCDSRegistry("CFE_ES.CDS_NAME", ES_UT_CDS_BLOCK_SIZE, false, NULL);
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_DeleteCDS_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.DeleteCDSCmd),
             UT_TPID_CFE_ES_CMD_DELETE_CDS_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_CDS_OWNER_ACTIVE_EID),
@@ -3607,7 +3609,7 @@ void TestTask(void)
     ES_UT_SetupSingleCDSRegistry("CFE_ES.CDS_NAME", ES_UT_CDS_BLOCK_SIZE, false, &UtCDSRegRecPtr);
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "CFE_BAD", NULL, NULL);
     CFE_ES_CDSBlockRecordSetFree(UtCDSRegRecPtr);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_DeleteCDS_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.DeleteCDSCmd),
             UT_TPID_CFE_ES_CMD_DELETE_CDS_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_CDS_NAME_ERR_EID),
@@ -3617,7 +3619,7 @@ void TestTask(void)
     /* Test successful dump of CDS to file using the default dump file name */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_DumpCDSRegistry_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.DumpCDSRegistryCmd),
             UT_TPID_CFE_ES_CMD_DUMP_CDS_REGISTRY_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_CDS_REG_DUMP_INF_EID),
@@ -3628,7 +3630,7 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_WriteHeader), 1, -1);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_DumpCDSRegistry_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.DumpCDSRegistryCmd),
             UT_TPID_CFE_ES_CMD_DUMP_CDS_REGISTRY_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_WRITE_CFE_HDR_ERR_EID),
@@ -3639,7 +3641,7 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_DumpCDSRegistry_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.DumpCDSRegistryCmd),
             UT_TPID_CFE_ES_CMD_DUMP_CDS_REGISTRY_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_CREATING_CDS_DUMP_ERR_EID),
@@ -3651,7 +3653,7 @@ void TestTask(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_SetDefaultReturnValue(UT_KEY(OS_write), OS_ERROR);
     ES_UT_SetupSingleCDSRegistry("CFE_ES.CDS_NAME", ES_UT_CDS_BLOCK_SIZE, false, NULL);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_DumpCDSRegistry_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.DumpCDSRegistryCmd),
             UT_TPID_CFE_ES_CMD_DUMP_CDS_REGISTRY_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_CDS_DUMP_ERR_EID),
@@ -3661,7 +3663,7 @@ void TestTask(void)
     /* Test telemetry pool statistics retrieval with an invalid handle */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_SendMemPoolStats_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.SendMemPoolStatsCmd),
             UT_TPID_CFE_ES_CMD_SEND_MEM_POOL_STATS_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_INVALID_POOL_HANDLE_ERR_EID),
@@ -3671,8 +3673,8 @@ void TestTask(void)
     /* Test successful telemetry pool statistics retrieval */
     ES_ResetUnitTest();
     ES_UT_SetupMemPoolId(&UtPoolRecPtr);
-    CmdBuf.TlmPoolStatsCmd.Payload.PoolHandle = CFE_ES_MemPoolRecordGetID(UtPoolRecPtr);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_SendMemPoolStats_t),
+    CmdBuf.SendMemPoolStatsCmd.Payload.PoolHandle = CFE_ES_MemPoolRecordGetID(UtPoolRecPtr);
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.SendMemPoolStatsCmd),
             UT_TPID_CFE_ES_CMD_SEND_MEM_POOL_STATS_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_TLM_POOL_STATS_INFO_EID),
@@ -3719,7 +3721,7 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.RestartCmd.Payload.RestartType = CFE_PSP_RST_TYPE_POWERON;
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_Restart_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.RestartCmd),
             UT_TPID_CFE_ES_CMD_RESTART_CC);
     UT_Report(__FILE__, __LINE__,
               !UT_EventIsInHistory(CFE_ES_BOOT_ERR_EID),
@@ -3751,7 +3753,7 @@ void TestTask(void)
     CmdBuf.StartAppCmd.Payload.ExceptionAction = CFE_ES_ExceptionAction_PROC_RESTART;
     CmdBuf.StartAppCmd.Payload.Priority = 160;
     CmdBuf.StartAppCmd.Payload.StackSize =  CFE_ES_MEMOFFSET_C(CFE_PLATFORM_ES_DEFAULT_STACK_SIZE);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_StartApp_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.StartAppCmd),
             UT_TPID_CFE_ES_CMD_START_APP_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_START_INF_EID),
@@ -3817,7 +3819,7 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_SetDeferredRetcode(UT_KEY(OS_OpenCreate), 1, OS_ERROR);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_QueryAll_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryAllCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ALL_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_ALL_APPS_EID),
@@ -3839,7 +3841,7 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_SetDeferredRetcode(UT_KEY(OS_OpenCreate), 1, OS_ERROR);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_QueryAllTasks_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryAllTasksCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ALL_TASKS_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_TASKINFO_EID),
@@ -3854,7 +3856,7 @@ void TestTask(void)
         UT_TPID_CFE_ES_CMD_CLEAR_SYSLOG_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_LEN_ERR_EID),
-              "CFE_ES_ClearSyslogCmd",
+              "CFE_ES_ClearSysLogCmd",
               "Clear system log command; invalid command length");
 
     /* Test sending a request to overwrite the system log with an
@@ -3865,7 +3867,7 @@ void TestTask(void)
         UT_TPID_CFE_ES_CMD_OVER_WRITE_SYSLOG_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_LEN_ERR_EID),
-              "CFE_ES_OverwriteSyslogCmd",
+              "CFE_ES_OverwriteSysLogCmd",
               "Overwrite system log command; invalid command length");
 
     /* Test sending a request to write the system log with an
@@ -3876,18 +3878,18 @@ void TestTask(void)
         UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_LEN_ERR_EID),
-              "CFE_ES_WriteSyslogCmd",
+              "CFE_ES_WriteSysLogCmd",
               "Write system log command; invalid command length");
 
     /* Test successful overwriting of the system log using overwrite mode */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.OverwriteSysLogCmd.Payload.Mode = CFE_ES_LogMode_OVERWRITE;
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_OverWriteSyslog_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.OverwriteSysLogCmd),
             UT_TPID_CFE_ES_CMD_OVER_WRITE_SYSLOG_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_SYSLOGMODE_EID),
-              "CFE_ES_OverWriteSyslogCmd",
+              "CFE_ES_OverWriteSysLogCmd",
               "Overwrite system log received (overwrite mode)");
 
     /* Test sending a request to write the error log with an
@@ -3951,9 +3953,9 @@ void TestTask(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
     ES_UT_SetupSingleCDSRegistry("CFE_ES.CDS_NAME", ES_UT_CDS_BLOCK_SIZE, false, NULL);
-    strncpy(CmdBuf.DumpCDSRegCmd.Payload.DumpFilename, "DumpFile",
-            sizeof(CmdBuf.DumpCDSRegCmd.Payload.DumpFilename));
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_DumpCDSRegistry_t),
+    strncpy(CmdBuf.DumpCDSRegistryCmd.Payload.DumpFilename, "DumpFile",
+            sizeof(CmdBuf.DumpCDSRegistryCmd.Payload.DumpFilename));
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.DumpCDSRegistryCmd),
             UT_TPID_CFE_ES_CMD_DUMP_CDS_REGISTRY_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_CDS_REG_DUMP_INF_EID),
@@ -3965,11 +3967,11 @@ void TestPerf(void)
 {
     union
     {
-        CFE_MSG_Message_t           Msg;
-        CFE_ES_StartPerfData_t      PerfStartCmd;
-        CFE_ES_StopPerfData_t       PerfStopCmd;
-        CFE_ES_SetPerfFilterMask_t  PerfSetFilterMaskCmd;
-        CFE_ES_SetPerfTriggerMask_t PerfSetTrigMaskCmd;
+        CFE_MSG_Message_t              Msg;
+        CFE_ES_StartPerfDataCmd_t      PerfStartCmd;
+        CFE_ES_StopPerfDataCmd_t       PerfStopCmd;
+        CFE_ES_SetPerfFilterMaskCmd_t  PerfSetFilterMaskCmd;
+        CFE_ES_SetPerfTriggerMaskCmd_t PerfSetTrigMaskCmd;
     } CmdBuf;
 
     UtPrintf("Begin Test Performance Log");
@@ -4123,7 +4125,7 @@ void TestPerf(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.PerfSetFilterMaskCmd.Payload.FilterMaskNum =
       CFE_ES_PERF_32BIT_WORDS_IN_MASK;
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_SetPerfFilterMask_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.PerfSetFilterMaskCmd),
             UT_TPID_CFE_ES_CMD_SET_PERF_FILTER_MASK_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_PERF_FILTMSKERR_EID),
@@ -4135,7 +4137,7 @@ void TestPerf(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.PerfSetFilterMaskCmd.Payload.FilterMaskNum =
       CFE_ES_PERF_32BIT_WORDS_IN_MASK / 2;
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_SetPerfFilterMask_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.PerfSetFilterMaskCmd),
             UT_TPID_CFE_ES_CMD_SET_PERF_FILTER_MASK_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_PERF_FILTMSKCMD_EID),
@@ -4147,7 +4149,7 @@ void TestPerf(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.PerfSetTrigMaskCmd.Payload.TriggerMaskNum = 0;
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_SetPerfTriggerMask_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.PerfSetTrigMaskCmd),
             UT_TPID_CFE_ES_CMD_SET_PERF_TRIGGER_MASK_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_PERF_TRIGMSKCMD_EID),
@@ -4161,7 +4163,7 @@ void TestPerf(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.PerfSetTrigMaskCmd.Payload.TriggerMaskNum =
       CFE_ES_PERF_32BIT_WORDS_IN_MASK - 1;
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_SetPerfTriggerMask_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.PerfSetTrigMaskCmd),
             UT_TPID_CFE_ES_CMD_SET_PERF_TRIGGER_MASK_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_PERF_TRIGMSKCMD_EID),
@@ -4175,7 +4177,7 @@ void TestPerf(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.PerfSetTrigMaskCmd.Payload.TriggerMaskNum =
       CFE_ES_PERF_32BIT_WORDS_IN_MASK + 1;
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_SetPerfTriggerMask_t),
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.PerfSetTrigMaskCmd),
             UT_TPID_CFE_ES_CMD_SET_PERF_TRIGGER_MASK_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_ES_PERF_TRIGMSKERR_EID),

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -3321,7 +3321,6 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
-    UT_SetForceFail(UT_KEY(OS_OpenCreate), OS_ERROR);
     strncpy((char *) CmdBuf.WriteSysLogCmd.Payload.FileName, "",
             sizeof(CmdBuf.WriteSysLogCmd.Payload.FileName));
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.WriteSysLogCmd),

--- a/fsw/cfe-core/unit-test/es_UT.h
+++ b/fsw/cfe-core/unit-test/es_UT.h
@@ -82,12 +82,6 @@
 **
 ** \returns
 **        This function does not return a value.
-**
-** \sa #UT_Init, #UT_SetCDSSize, #UT_SetSizeofESResetArea
-** \sa #UT_SetStatusBSPResetArea, #UT_SetReadBuffer, #UT_SetRtnCode
-** \sa #UT_SetDummyFuncRtn, #UT_SetBSPloadAppFileResult, #CFE_ES_Main
-** \sa #UT_Report
-**
 ******************************************************************************/
 void TestInit(void);
 
@@ -108,12 +102,6 @@ void TestInit(void);
 **
 ** \returns
 **        This function does not return a value.
-**
-** \sa #UT_SetRtnCode, #UT_SetOSFail, #CFE_ES_Main, #UT_Report
-** \sa #CFE_ES_SetupResetVariables, #UT_SetStatusBSPResetArea
-** \sa #UT_SetSizeofESResetArea, #CFE_ES_InitializeFileSystems, #UT_SetBSPFail
-** \sa #CFE_ES_CreateObjects
-**
 ******************************************************************************/
 void TestStartupErrorPaths(void);
 
@@ -132,14 +120,6 @@ void TestStartupErrorPaths(void);
 **
 ** \returns
 **        This function does not return a value.
-**
-** \sa #UT_SetReadBuffer, #UT_SetRtnCode, #CFE_ES_StartApplications
-** \sa #UT_Report, #UT_SetOSFail, #CFE_ES_ParseFileEntry
-** \sa #UT_SetBSPloadAppFileResult, #CFE_ES_AppCreate, #UT_SetDummyFuncRtn
-** \sa #CFE_ES_LoadLibrary, #CFE_ES_ScanAppTable, #CFE_ES_ProcessControlRequest
-** \sa #CFE_ES_GetAppInfo, #CFE_ES_CleanUpApp
-** \sa #CFE_ES_CleanupTaskResources
-**
 ******************************************************************************/
 void TestApps(void);
 
@@ -158,9 +138,6 @@ void TestApps(void);
 **
 ** \returns
 **        This function does not return a value.  
-**
-** \sa #CFE_ES_WriteToERLog, #UT_Report
-**
 ******************************************************************************/
 void TestERLog(void);
 
@@ -178,19 +155,6 @@ void TestERLog(void);
 **
 ** \returns
 **        This function does not return a value.  
-**
-** \sa #UT_SetRtnCode, #CFE_ES_TaskMain, #UT_Report, #UT_SetOSFail
-** \sa #CFE_ES_TaskInit, #UT_SetSBTotalMsgLen, #UT_SendMsg
-** \sa #UT_SetBSPloadAppFileResult, #UT_SetStatusBSPResetArea
-** \sa #CFE_ES_HousekeepingCmd, #CFE_ES_NoopCmd, #CFE_ES_ResetCountersCmd
-** \sa #CFE_ES_RestartCmd, #CFE_ES_StartAppCmd
-** \sa #CFE_ES_StopAppCmd, #CFE_ES_RestartAppCmd, #CFE_ES_ReloadAppCmd
-** \sa #CFE_ES_QueryOneCmd, #CFE_ES_QueryAllCmd, #CFE_ES_QueryAllTasksCmd
-** \sa #CFE_ES_ClearSyslogCmd, #CFE_ES_OverWriteSyslogCmd
-** \sa #CFE_ES_WriteSyslogCmd, #CFE_ES_ClearERLogCmd, #CFE_ES_WriteERLogCmd
-** \sa #CFE_ES_ResetPRCountCmd, #CFE_ES_SetMaxPRCountCmd, #CFE_ES_DeleteCDSCmd
-** \sa #CFE_ES_DumpCDSRegistryCmd, #CFE_ES_SendMemPoolStatsCmd, #CFE_ES_TaskPipe
-**
 ******************************************************************************/
 void TestTask(void);
 
@@ -207,7 +171,6 @@ void TestTask(void);
 **
 ** \returns
 **        This function does not return a value.
-**
 ******************************************************************************/
 void TestBackground(void);
 
@@ -224,13 +187,6 @@ void TestBackground(void);
 **
 ** \returns
 **        This function does not return a value.  
-**
-** \sa #CFE_ES_SetupPerfVariables, #UT_Report, #UT_SetRtnCode
-** \sa #UT_SetSBTotalMsgLen, #UT_SendMsg, #UT_SetBSPloadAppFileResult
-** \sa #CFE_ES_PerfLogDump, #CFE_ES_PerfLogAdd, #CFE_ES_StartPerfDataCmd
-** \sa #CFE_ES_StopPerfDataCmd, #CFE_ES_SetPerfFilterMaskCmd
-** \sa #CFE_ES_SetPerfTriggerMaskCmd, #CFE_ES_PerfLogDump, #CFE_ES_PerfLogAdd
-**
 ******************************************************************************/
 void TestPerf(void);
 
@@ -246,20 +202,6 @@ void TestPerf(void);
 **
 ** \returns
 **        This function does not return a value.  
-**
-** \sa #UT_SetRtnCode, #CFE_ES_ResetCFE, #UT_Report
-** \sa #CFE_ES_GetResetType, #CFE_ES_RestartApp, #CFE_ES_ReloadApp
-** \sa #CFE_ES_DeleteApp, #CFE_ES_ExitApp, #CFE_ES_RunLoop
-** \sa #CFE_ES_RegisterApp, #CFE_ES_GetAppID, #CFE_ES_GetAppName
-** \sa #CFE_ES_GetTaskInfo, #CFE_ES_CreateChildTask, #CFE_ES_DeleteChildTask
-** \sa #CFE_ES_ExitChildTask, #CFE_ES_RegisterChildTask, #CFE_ES_WriteToSysLog
-** \sa #CFE_ES_CalculateCRC, #CFE_ES_WaitForStartupSync, #CFE_ES_ProcessCoreException
-** \sa #UT_SetBSPFail, #CFE_ES_RegisterCDS, #CFE_ES_CopyToCDS
-** \sa #CFE_ES_RestoreFromCDS, #CFE_ES_LockSharedData, #CFE_ES_UnlockSharedData
-** \sa #CFE_ES_RegisterGenCounter, #CFE_ES_GetGenCounterIDByName
-** \sa #CFE_ES_DeleteGenCounter, #CFE_ES_IncrementGenCounter
-** \sa #CFE_ES_GetGenCount, #CFE_ES_SetGenCount
-**
 ******************************************************************************/
 void TestAPI(void);
 
@@ -276,13 +218,6 @@ void TestAPI(void);
 **
 ** \returns
 **        This function does not return a value.  
-**
-** \sa #UT_InitData, #UT_Report, #CFE_ES_CDS_ValidateAppID
-** \sa #UT_SetBSPFail, #CFE_ES_RebuildCDS, #UT_SetRtnCode
-** \sa #CFE_ES_InitCDSRegistry, #UT_SetCDSSize, #CFE_ES_CDS_EarlyInit
-** \sa #UT_SetCDSBSPCheckValidity, #CFE_ES_ValidateCDS, #UT_SetCDSReadGoodEnd
-** \sa #CFE_ES_InitCDSSignatures, #CFE_ES_RebuildCDS, #CFE_ES_DeleteCDS
-**
 ******************************************************************************/
 void TestCDS(void);
 
@@ -300,12 +235,6 @@ void TestCDS(void);
 **
 ** \returns
 **        This function does not return a value.  
-**
-** \sa #UT_InitData, #UT_Report, #CFE_ES_CreateCDSPool
-** \sa #CFE_ES_RebuildCDSPool, #UT_SetRtnCode, #UT_SetBSPFail
-** \sa #CFE_ES_GetCDSBlock, #CFE_ES_PutCDSBlock, #CFE_ES_CDSBlockWrite
-** \sa #CFE_ES_CDSBlockRead
-**
 ******************************************************************************/
 void TestCDSMempool(void);
 
@@ -323,12 +252,6 @@ void TestCDSMempool(void);
 **
 ** \returns
 **        This function does not return a value.  
-**
-** \sa #UT_InitData, #UT_Report, #CFE_ES_PoolCreateNoSem
-** \sa #CFE_ES_PoolCreate, #CFE_ES_GetPoolBuf, #CFE_ES_GetPoolBufInfo
-** \sa #CFE_ES_PutPoolBuf, #CFE_ES_ValidateHandle, #UT_SetRtnCode
-** \sa #CFE_ES_GetMemPoolStats, #CFE_ES_PoolCreateEx, #CFE_ES_PoolCreateNoSem
-**
 ******************************************************************************/
 void TestESMempool(void);
 

--- a/fsw/cfe-core/unit-test/evs_UT.h
+++ b/fsw/cfe-core/unit-test/evs_UT.h
@@ -70,12 +70,6 @@
 **
 ** \returns
 **        This function does not return a value.  
-**
-** \sa UT_InitData, #UT_SetSizeofESResetArea, #UT_SetRtnCode
-** \sa #CFE_EVS_EarlyInit, #UT_Report, #CFE_EVS_TaskMain
-** \sa #UT_SetStatusBSPResetArea, #UT_SetAppID, #UT_SendMsg
-** \sa #UT_SetSBTotalMsgLen
-**
 ******************************************************************************/
 void Test_Init(void);
 
@@ -91,12 +85,6 @@ void Test_Init(void);
 **
 ** \returns
 **        This function does not return a value.  
-**
-** \sa #UT_InitData, #UT_SetAppID, #UT_Report, #CFE_EVS_Register
-** \sa #CFE_EVS_SendEvent, #CFE_EVS_SendTimedEvent, #CFE_EVS_SendEventWithAppID
-** \sa #CFE_EVS_ResetFilter, #CFE_EVS_ResetAllFilters, #CFE_EVS_CleanUpApp
-** \sa #CFE_EVS_EnableAppEventTypesCmd, #CFE_EVS_DisablePortsCmd
-**
 ******************************************************************************/
 void Test_IllegalAppID(void);
 
@@ -112,12 +100,6 @@ void Test_IllegalAppID(void);
 **
 ** \returns
 **        This function does not return a value.  
-**
-** \sa #UT_InitData, #CFE_EVS_Unregister, #UT_Report
-** \sa #CFE_EVS_SendEvent, #CFE_EVS_ResetFilter, #CFE_EVS_ResetAllFilters
-** \sa #CFE_EVS_SendEventWithAppID, #CFE_EVS_SendTimedEvent
-** \sa #CFE_EVS_CleanUpApp, #CFE_EVS_Register
-**
 ******************************************************************************/
 void Test_UnregisteredApp(void);
 
@@ -133,11 +115,6 @@ void Test_UnregisteredApp(void);
 **
 ** \returns
 **        This function does not return a value.  
-**
-** \sa #UT_InitData, #UT_Report, #CFE_EVS_Register
-** \sa #UT_SetPutPoolFail, #UT_SetRtnCode, #CFE_EVS_Unregister
-** \sa #CFE_EVS_SendEvent, #CFE_ES_GetAppID
-**
 ******************************************************************************/
 void Test_FilterRegistration(void);
 
@@ -153,10 +130,6 @@ void Test_FilterRegistration(void);
 **
 ** \returns
 **        This function does not return a value.  
-**
-** \sa #UT_InitData, #UT_Report, #CFE_EVS_Register
-** \sa #CFE_EVS_ResetFilter, #CFE_EVS_ResetAllFilters
-**
 ******************************************************************************/
 void Test_FilterReset(void);
 
@@ -174,12 +147,6 @@ void Test_FilterReset(void);
 **
 ** \returns
 **        This function does not return a value.  
-**
-** \sa #UT_InitData, #UT_SetSBTotalMsgLen, #UT_SendMsg, #UT_Report
-** \sa #CFE_EVS_SendEvent, #UT_SetRtnCode, #CFE_EVS_SendTimedEvent
-** \sa #CFE_EVS_SendEventWithAppID, #CFE_EVS_EnableAppEventTypesCmd
-** \sa #CFE_EVS_SetEventFormatModeCmd
-**
 ******************************************************************************/
 void Test_Format(void);
 
@@ -195,11 +162,6 @@ void Test_Format(void);
 **
 ** \returns
 **        This function does not return a value.  
-**
-** \sa #UT_InitData, #UT_SetRtnCode, #UT_SetSBTotalMsgLen
-** \sa #UT_SendMsg, #UT_Report, #CFE_EVS_SendEvent, #CFE_EVS_EnablePortsCmd
-** \sa #CFE_EVS_DisablePortsCmd
-**
 ******************************************************************************/
 void Test_Ports(void);
 
@@ -215,13 +177,6 @@ void Test_Ports(void);
 **
 ** \returns
 **        This function does not return a value.  
-**
-** \sa #UT_InitData, #UT_SetSBTotalMsgLen, #UT_SendMsg
-** \sa #UT_Report, #UT_SetSizeofESResetArea, #UT_SetRtnCode
-** \sa #CFE_PSP_GetResetArea, #CFE_EVS_SendEvent, #UT_SetOSFail
-** \sa #CFE_EVS_SetLogModeCmd, #CFE_EVS_WriteLogDataFileCmd, #EVS_ClearLog
-** \sa #CFE_EVS_ProcessGroundCommand
-**
 ******************************************************************************/
 void Test_Logging(void);
 
@@ -237,11 +192,6 @@ void Test_Logging(void);
 **
 ** \returns
 **        This function does not return a value.  
-**
-** \sa #UT_InitData, #UT_SetSBTotalMsgLen, #UT_SendMsg
-** \sa #UT_Report, #UT_SetOSFail, #CFE_EVS_EnableAppEventTypesCmd
-** \sa #CFE_EVS_ResetCountersCmd, #CFE_EVS_WriteAppDataFileCmd
-**
 ******************************************************************************/
 void Test_WriteApp(void);
 
@@ -259,15 +209,6 @@ void Test_WriteApp(void);
 **
 ** \returns
 **        This function does not return a value.  
-**
-** \sa #UT_InitData, #UT_SetSBTotalMsgLen, #UT_SendMsg
-** \sa #UT_Report, #CFE_EVS_DisableAppEventTypesCmd
-** \sa #CFE_EVS_EnableAppEventTypesCmd, #CFE_EVS_EnableAppEventsCmd
-** \sa #CFE_EVS_DisableAppEventsCmd, #CFE_EVS_ResetAppEventCounterCmd
-** \sa #CFE_EVS_AddEventFilterCmd, #CFE_EVS_DeleteEventFilterCmd
-** \sa #CFE_EVS_SetFilterMaskCmd, #CFE_EVS_ResetFilterCmd
-** \sa #CFE_EVS_ResetAllFiltersCmd, #CFE_EVS_DisableAppEventTypesCmd
-**
 ******************************************************************************/
 void Test_BadAppCmd(void);
 
@@ -283,13 +224,6 @@ void Test_BadAppCmd(void);
 **
 ** \returns
 **        This function does not return a value.  
-**
-** \sa #UT_InitData, #UT_SetSBTotalMsgLen, #UT_SendMsg
-** \sa #CFE_EVS_SendEvent, #UT_Report, #CFE_EVS_DisableAppEventTypesCmd
-** \sa #CFE_EVS_EnableAppEventTypesCmd, #CFE_EVS_DisableAppEventsCmd
-** \sa #CFE_EVS_EnableAppEventsCmd, #CFE_EVS_DisableEventTypesCmd
-** \sa #CFE_EVS_EnableEventTypesCmd, #CFE_EVS_ResetAppEventCounterCmd
-**
 ******************************************************************************/
 void Test_EventCmd(void);
 
@@ -305,13 +239,6 @@ void Test_EventCmd(void);
 **
 ** \returns
 **        This function does not return a value.  
-**
-** \sa #UT_InitData, #UT_SetSBTotalMsgLen, #UT_SendMsg
-** \sa #UT_Report, #CFE_EVS_Register, #CFE_EVS_EnableAppEventTypesCmd
-** \sa #CFE_EVS_DeleteEventFilterCmd, #CFE_EVS_SetFilterMaskCmd
-** \sa #CFE_EVS_ResetFilterCmd, #CFE_EVS_ResetAllFiltersCmd
-** \sa #CFE_EVS_AddEventFilterCmd
-**
 ******************************************************************************/
 void Test_FilterCmd(void);
 
@@ -329,10 +256,6 @@ void Test_FilterCmd(void);
 **
 ** \returns
 **        This function does not return a value.  
-**
-** \sa #UT_InitData, #UT_SetSBTotalMsgLen, #UT_SendMsg
-** \sa #UT_Report, #CFE_EVS_ProcessGroundCommand, #CFE_EVS_VerifyCmdLength
-**
 ******************************************************************************/
 void Test_InvalidCmd(void);
 
@@ -348,12 +271,6 @@ void Test_InvalidCmd(void);
 **
 ** \returns
 **        This function does not return a value.  
-**
-** \sa #UT_InitData, #UT_Report, #EVS_GetApplicationInfo
-** \sa #UT_SetSBTotalMsgLen, #UT_SendMsg, #CFE_EVS_CleanUpApp
-** \sa #CFE_EVS_Register, #CFE_EVS_WriteLogDataFileCmd, #CFE_EVS_SetLogModeCmd
-** \sa #CFE_EVS_ReportHousekeepingCmd
-**
 ******************************************************************************/
 void Test_Misc(void);
 

--- a/fsw/cfe-core/unit-test/sb_UT.h
+++ b/fsw/cfe-core/unit-test/sb_UT.h
@@ -52,34 +52,34 @@
 ** Structures
 */
 typedef struct {
-     CFE_SB_CmdHdr_t Hdr; 
-     uint32          Cmd32Param1;
-     uint16          Cmd16Param1;
-     uint16          Cmd16Param2;
-     uint8           Cmd8Param1;
-     uint8           Cmd8Param2;
-     uint8           Cmd8Param3;
-     uint8           Cmd8Param4;
+     CFE_MSG_CommandHeader_t Hdr;
+     uint32                  Cmd32Param1;
+     uint16                  Cmd16Param1;
+     uint16                  Cmd16Param2;
+     uint8                   Cmd8Param1;
+     uint8                   Cmd8Param2;
+     uint8                   Cmd8Param3;
+     uint8                   Cmd8Param4;
 } SB_UT_Test_Cmd_t;
 
 typedef struct {
-     CFE_SB_TlmHdr_t Hdr; 
-     uint32          Tlm32Param1;
-     uint16          Tlm16Param1;
-     uint16          Tlm16Param2;
-     uint8           Tlm8Param1;
-     uint8           Tlm8Param2;
-     uint8           Tlm8Param3;
-     uint8           Tlm8Param4;
+     CFE_MSG_TelemetryHeader_t Hdr;
+     uint32                    Tlm32Param1;
+     uint16                    Tlm16Param1;
+     uint16                    Tlm16Param2;
+     uint8                     Tlm8Param1;
+     uint8                     Tlm8Param2;
+     uint8                     Tlm8Param3;
+     uint8                     Tlm8Param4;
 } SB_UT_Test_Tlm_t;
 
 typedef struct {
-     CFE_MSG_Message_t Pri; /* 6 bytes */
-     uint8        Tlm8Param1;
-     uint8        Tlm8Param2;
-     uint32       Tlm32Param1;
-     uint16       Tlm16Param1;
-     uint16       Tlm16Param2;
+     CFE_MSG_Message_t Pri;
+     uint8             Tlm8Param1;
+     uint8             Tlm8Param2;
+     uint32            Tlm32Param1;
+     uint16            Tlm16Param1;
+     uint16            Tlm16Param2;
 } SB_UT_TstPktWoSecHdr_t;
 
 #define SB_UT_CMD_MID_VALUE_BASE    CFE_PLATFORM_CMD_MID_BASE + 1
@@ -1860,7 +1860,7 @@ void Test_Unsubscribe_GetDestPtr(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SendMsg_API(void);
+void Test_TransmitMsg_API(void);
 
 /*****************************************************************************/
 /**
@@ -1876,7 +1876,7 @@ void Test_SendMsg_API(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SendMsg_NullPtr(void);
+void Test_TransmitMsg_NullPtr(void);
 
 /*****************************************************************************/
 /**
@@ -1892,7 +1892,7 @@ void Test_SendMsg_NullPtr(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SendMsg_InvalidMsgId(void);
+void Test_TransmitMsg_InvalidMsgId(void);
 
 /*****************************************************************************/
 /**
@@ -1908,7 +1908,7 @@ void Test_SendMsg_InvalidMsgId(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SendMsg_NoSubscribers(void);
+void Test_TransmitMsg_NoSubscribers(void);
 
 /*****************************************************************************/
 /**
@@ -1925,7 +1925,7 @@ void Test_SendMsg_NoSubscribers(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SendMsg_MaxMsgSizePlusOne(void);
+void Test_TransmitMsg_MaxMsgSizePlusOne(void);
 
 /*****************************************************************************/
 /**
@@ -1941,7 +1941,7 @@ void Test_SendMsg_MaxMsgSizePlusOne(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SendMsg_BasicSend(void);
+void Test_TransmitMsg_BasicSend(void);
 
 /*****************************************************************************/
 /**
@@ -1957,7 +1957,7 @@ void Test_SendMsg_BasicSend(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SendMsg_SequenceCount(void);
+void Test_TransmitMsg_SequenceCount(void);
 
 /*****************************************************************************/
 /**
@@ -1973,7 +1973,7 @@ void Test_SendMsg_SequenceCount(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SendMsg_QueuePutError(void);
+void Test_TransmitMsg_QueuePutError(void);
 
 /*****************************************************************************/
 /**
@@ -1989,7 +1989,7 @@ void Test_SendMsg_QueuePutError(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SendMsg_PipeFull(void);
+void Test_TransmitMsg_PipeFull(void);
 
 /*****************************************************************************/
 /**
@@ -2005,7 +2005,7 @@ void Test_SendMsg_PipeFull(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SendMsg_MsgLimitExceeded(void);
+void Test_TransmitMsg_MsgLimitExceeded(void);
 
 /*****************************************************************************/
 /**
@@ -2021,7 +2021,7 @@ void Test_SendMsg_MsgLimitExceeded(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SendMsg_GetPoolBufErr(void);
+void Test_TransmitMsg_GetPoolBufErr(void);
 
 /*****************************************************************************/
 /**
@@ -2038,7 +2038,7 @@ void Test_SendMsg_GetPoolBufErr(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SendMsg_ZeroCopyGetPtr(void);
+void Test_TransmitMsg_ZeroCopyGetPtr(void);
 
 /*****************************************************************************/
 /**
@@ -2055,7 +2055,7 @@ void Test_SendMsg_ZeroCopyGetPtr(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SendMsg_ZeroCopySend(void);
+void Test_TransmitBuffer_IncrementSeqCnt(void);
 
 /*****************************************************************************/
 /**
@@ -2072,7 +2072,7 @@ void Test_SendMsg_ZeroCopySend(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SendMsg_ZeroCopyPass(void);
+void Test_TransmitBuffer_NoIncrement(void);
 
 /*****************************************************************************/
 /**
@@ -2088,7 +2088,7 @@ void Test_SendMsg_ZeroCopyPass(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SendMsg_ZeroCopyReleasePtr(void);
+void Test_TransmitMsg_ZeroCopyReleasePtr(void);
 
 /*****************************************************************************/
 /**
@@ -2104,11 +2104,11 @@ void Test_SendMsg_ZeroCopyReleasePtr(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SendMsg_DisabledDestination(void);
+void Test_TransmitMsg_DisabledDestination(void);
 
 /*****************************************************************************/
 /**
-** \brief Test successfully sending a message with the metadata
+** \brief Test successful CFE_SB_TransmitBufferFull
 **
 ** \par Description
 **        This function tests successfully sending a message with the metadata.
@@ -2119,29 +2119,11 @@ void Test_SendMsg_DisabledDestination(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SendMsg_SendWithMetadata(void);
+void Test_TransmitBufferFull(void);
 
 /*****************************************************************************/
 /**
-** \brief Test response to sending a message with an invalid ID and ZeroCopy is
-**        set
-**
-** \par Description
-**        This function tests the response to sending a message with an invalid
-**        ID.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-******************************************************************************/
-void Test_SendMsg_InvalidMsgId_ZeroCopy(void);
-
-/*****************************************************************************/
-/**
-** \brief Test response to sending a message which has no subscribers and
-**        ZeroCopy is set
+** \brief Test response to sending a message which has no subscribers
 **
 ** \par Description
 **        This function tests the response to sending a message which has no
@@ -2153,12 +2135,12 @@ void Test_SendMsg_InvalidMsgId_ZeroCopy(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SendMsg_NoSubscribers_ZeroCopy(void);
+void Test_TransmitMsgValidate_NoSubscribers(void);
 
 /*****************************************************************************/
 /**
 ** \brief Test response to sending a message with the message size larger
-**        than allowed and ZeroCopy is set
+**        than allowed
 **
 ** \par Description
 **        This function tests the response to sending a message with the
@@ -2170,7 +2152,7 @@ void Test_SendMsg_NoSubscribers_ZeroCopy(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SendMsg_MaxMsgSizePlusOne_ZeroCopy(void);
+void Test_TransmitMsgValidate_MaxMsgSizePlusOne(void);
 
 /*****************************************************************************/
 /**
@@ -2185,7 +2167,7 @@ void Test_SendMsg_MaxMsgSizePlusOne_ZeroCopy(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_RcvMsg_API(void);
+void Test_ReceiveBuffer_API(void);
 
 /*****************************************************************************/
 /**
@@ -2202,7 +2184,7 @@ void Test_RcvMsg_API(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_RcvMsg_InvalidPipeId(void);
+void Test_ReceiveBuffer_InvalidPipeId(void);
 
 /*****************************************************************************/
 /**
@@ -2218,7 +2200,7 @@ void Test_RcvMsg_InvalidPipeId(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_RcvMsg_InvalidTimeout(void);
+void Test_ReceiveBuffer_InvalidTimeout(void);
 
 /*****************************************************************************/
 /**
@@ -2235,7 +2217,7 @@ void Test_RcvMsg_InvalidTimeout(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_RcvMsg_Poll(void);
+void Test_ReceiveBuffer_Poll(void);
 
 /*****************************************************************************/
 /**
@@ -2250,7 +2232,7 @@ void Test_RcvMsg_Poll(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_RcvMsg_Timeout(void);
+void Test_ReceiveBuffer_Timeout(void);
 
 /*****************************************************************************/
 /**
@@ -2266,7 +2248,7 @@ void Test_RcvMsg_Timeout(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_RcvMsg_PipeReadError(void);
+void Test_ReceiveBuffer_PipeReadError(void);
 
 /*****************************************************************************/
 /**
@@ -2282,7 +2264,7 @@ void Test_RcvMsg_PipeReadError(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_RcvMsg_PendForever(void);
+void Test_ReceiveBuffer_PendForever(void);
 
 /*****************************************************************************/
 /**
@@ -2298,7 +2280,7 @@ void Test_RcvMsg_PendForever(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_RcvMsg_InvalidBufferPtr(void);
+void Test_ReceiveBuffer_InvalidBufferPtr(void);
 
 /*****************************************************************************/
 /**
@@ -2508,10 +2490,10 @@ void Test_CFE_SB_BadPipeInfo(void);
 
 /*****************************************************************************/
 /**
-** \brief Test SendMsgFull function paths
+** \brief Test TransmitMsgFull function paths
 **
 ** \par Description
-**        This function tests branch paths in the SendMsgFull function.
+**        This function tests branch paths in the TransmitMsgFull function.
 **
 ** \par Assumptions, External Events, and Notes:
 **        None
@@ -2519,18 +2501,18 @@ void Test_CFE_SB_BadPipeInfo(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SB_SendMsgPaths_Nominal(void);
-void Test_SB_SendMsgPaths_LimitErr(void);
-void Test_SB_SendMsgPaths_FullErr(void);
-void Test_SB_SendMsgPaths_WriteErr(void);
-void Test_SB_SendMsgPaths_IgnoreOpt(void);
+void Test_SB_TransmitMsgPaths_Nominal(void);
+void Test_SB_TransmitMsgPaths_LimitErr(void);
+void Test_SB_TransmitMsgPaths_FullErr(void);
+void Test_SB_TransmitMsgPaths_WriteErr(void);
+void Test_SB_TransmitMsgPaths_IgnoreOpt(void);
 
 /*****************************************************************************/
 /**
-** \brief Test RcvMsg function unsubscribe/resubscribe path
+** \brief Test ReceiveBuffer function unsubscribe/resubscribe path
 **
 ** \par Description
-**        This function tests the branch path in the RcvMsg function when a
+**        This function tests the branch path in the ReceiveBuffer function when a
 **        message in the pipe is unsubscribed, then resubscribed.
 **
 ** \par Assumptions, External Events, and Notes:
@@ -2539,7 +2521,7 @@ void Test_SB_SendMsgPaths_IgnoreOpt(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_RcvMsg_UnsubResubPath(void);
+void Test_ReceiveBuffer_UnsubResubPath(void);
 
 /*****************************************************************************/
 /**

--- a/fsw/cfe-core/unit-test/tbl_UT.c
+++ b/fsw/cfe-core/unit-test/tbl_UT.c
@@ -455,8 +455,8 @@ void Test_CFE_TBL_SearchCmdHndlrTbl(void)
 */
 void Test_CFE_TBL_DeleteCDSCmd(void)
 {
-    int                 j, k;
-    CFE_TBL_DeleteCDS_t DelCDSCmd;
+    int                    j, k;
+    CFE_TBL_DeleteCDSCmd_t DelCDSCmd;
 
     UtPrintf("Begin Test Delete CDS Command");
 
@@ -544,7 +544,7 @@ void Test_CFE_TBL_DeleteCDSCmd(void)
 */
 void Test_CFE_TBL_TlmRegCmd(void)
 {
-    CFE_TBL_SendRegistry_t TlmRegCmd;
+    CFE_TBL_SendRegistryCmd_t TlmRegCmd;
 
     UtPrintf("Begin Test Telemetry Registry Command");
 
@@ -579,8 +579,8 @@ void Test_CFE_TBL_TlmRegCmd(void)
 */
 void Test_CFE_TBL_AbortLoadCmd(void)
 {
-    int load = (int) CFE_TBL_TaskData.Registry[0].LoadInProgress;
-    CFE_TBL_AbortLoad_t  AbortLdCmd;
+    int                    load = (int) CFE_TBL_TaskData.Registry[0].LoadInProgress;
+    CFE_TBL_AbortLoadCmd_t AbortLdCmd;
 
     UtPrintf("Begin Test Abort Load Command");
 
@@ -652,7 +652,7 @@ void Test_CFE_TBL_ActivateCmd(void)
 {
     int                   load = (int) CFE_TBL_TaskData.Registry[0].LoadInProgress;
     uint8                 dump = CFE_TBL_TaskData.Registry[0].DumpOnly;
-    CFE_TBL_Activate_t    ActivateCmd;
+    CFE_TBL_ActivateCmd_t ActivateCmd;
 
     UtPrintf("Begin Test Activate Command");
 
@@ -715,7 +715,7 @@ void Test_CFE_TBL_ActivateCmd(void)
      * progress, and a notification message should be sent
      */
     UT_InitData();
-    UT_SetDeferredRetcode(UT_KEY(CFE_SB_SendMsg), 1, CFE_SB_INTERNAL_ERR);
+    UT_SetDeferredRetcode(UT_KEY(CFE_SB_TransmitMsg), 1, CFE_SB_INTERNAL_ERR);
     CFE_TBL_TaskData.Registry[0].NotifyByMsg = true;
     CFE_TBL_TaskData.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
     UT_Report(__FILE__, __LINE__,
@@ -831,7 +831,7 @@ void Test_CFE_TBL_ValidateCmd(void)
     int                       i;
     uint8                     Buff;
     uint8                     *BuffPtr = &Buff;
-    CFE_TBL_Validate_t        ValidateCmd;
+    CFE_TBL_ValidateCmd_t     ValidateCmd;
     CFE_TBL_CallbackFuncPtr_t ValFuncPtr = (CFE_TBL_CallbackFuncPtr_t)
                                              ((unsigned long )
                                                &UT_InitializeTableRegistryNames);
@@ -937,7 +937,7 @@ void Test_CFE_TBL_ValidateCmd(void)
      * notification message should be sent
      */
     UT_InitData();
-    UT_SetDeferredRetcode(UT_KEY(CFE_SB_SendMsg), 1, CFE_SB_INTERNAL_ERR);
+    UT_SetDeferredRetcode(UT_KEY(CFE_SB_TransmitMsg), 1, CFE_SB_INTERNAL_ERR);
     CFE_TBL_TaskData.Registry[0].NotifyByMsg = true;
     CFE_TBL_TaskData.Registry[0].DoubleBuffered = false;
     CFE_TBL_TaskData.LoadBuffs[CFE_TBL_TaskData.Registry[0].LoadInProgress].BufferPtr = BuffPtr;
@@ -1135,9 +1135,9 @@ void Test_CFE_TBL_GetHkData(void)
 */
 void Test_CFE_TBL_DumpRegCmd(void)
 {
-    int                  q;
-    CFE_TBL_DumpRegistry_t DumpRegCmd;
-    CFE_ES_ResourceID_t AppID;
+    int                       q;
+    CFE_TBL_DumpRegistryCmd_t DumpRegCmd;
+    CFE_ES_ResourceID_t       AppID;
 
     /* Get the AppID being used for UT */
     CFE_ES_GetAppID(&AppID);
@@ -1228,11 +1228,11 @@ void Test_CFE_TBL_DumpRegCmd(void)
 */
 void Test_CFE_TBL_DumpCmd(void)
 {
-    int                i, k, u;
-    uint8              Buff;
+    int                 i, k, u;
+    uint8               Buff;
     uint8              *BuffPtr = &Buff;
-    CFE_TBL_LoadBuff_t Load = {0};
-    CFE_TBL_Dump_t     DumpCmd;
+    CFE_TBL_LoadBuff_t  Load = {0};
+    CFE_TBL_DumpCmd_t   DumpCmd;
     CFE_ES_ResourceID_t AppID;
 
     CFE_ES_GetAppID(&AppID);
@@ -1277,7 +1277,7 @@ void Test_CFE_TBL_DumpCmd(void)
     CFE_TBL_TaskData.Registry[2].DoubleBuffered = false;
     CFE_TBL_TaskData.LoadBuffs[CFE_TBL_TaskData.Registry[2].LoadInProgress] = Load;
     CFE_TBL_TaskData.Registry[2].NotifyByMsg = true;
-    UT_SetDeferredRetcode(UT_KEY(CFE_SB_SendMsg), 1, CFE_SB_INTERNAL_ERR);
+    UT_SetDeferredRetcode(UT_KEY(CFE_SB_TransmitMsg), 1, CFE_SB_INTERNAL_ERR);
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DumpCmd(&DumpCmd) ==
                 CFE_TBL_INC_CMD_CTR,
@@ -1406,11 +1406,11 @@ void Test_CFE_TBL_DumpCmd(void)
 */
 void Test_CFE_TBL_LoadCmd(void)
 {
-    int                i, j;
-    CFE_TBL_File_Hdr_t TblFileHeader;
-    CFE_FS_Header_t    StdFileHeader;
-    CFE_TBL_LoadBuff_t BufferPtr = CFE_TBL_TaskData.LoadBuffs[0];
-    CFE_TBL_Load_t     LoadCmd;
+    int                 i, j;
+    CFE_TBL_File_Hdr_t  TblFileHeader;
+    CFE_FS_Header_t     StdFileHeader;
+    CFE_TBL_LoadBuff_t  BufferPtr = CFE_TBL_TaskData.LoadBuffs[0];
+    CFE_TBL_LoadCmd_t   LoadCmd;
     CFE_ES_ResourceID_t AppID;
 
     CFE_ES_GetAppID(&AppID);
@@ -1686,7 +1686,7 @@ void Test_CFE_TBL_HousekeepingCmd(void)
         CFE_TBL_TaskData.DumpControlBlocks[i].State = CFE_TBL_DUMP_PENDING;
     }
 
-    UT_SetDeferredRetcode(UT_KEY(CFE_SB_SendMsg), 1, CFE_SUCCESS - 1);
+    UT_SetDeferredRetcode(UT_KEY(CFE_SB_TransmitMsg), 1, CFE_SUCCESS - 1);
     CFE_TBL_TaskData.HkTlmTblRegIndex = CFE_TBL_NOT_FOUND + 1;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_HousekeepingCmd(NULL) == CFE_TBL_DONT_INC_CTR,

--- a/fsw/cfe-core/unit-test/tbl_UT.h
+++ b/fsw/cfe-core/unit-test/tbl_UT.h
@@ -74,7 +74,7 @@ typedef struct
 
 /*****************************************************************************/
 /**
-** \brief Initialize the registry
+** \brief Initialize the registry names
 **
 ** \par Description
 **        Fill the whole table registry with known table names in order to
@@ -86,22 +86,12 @@ typedef struct
 **
 ** \returns
 **        This function does not return a value.
-**
 ******************************************************************************/
 void UT_InitializeTableRegistryNames(void);
 
 /*****************************************************************************/
 /**
 ** \brief Initialize table registry values
-**
-** \par Description
-**        This function serves as a pass-through for messages coming from the
-**        CFE_SB_SendMsg() stub function.  By using a common pass-through
-**        function name, the stub can be generic for all of the tests for the
-**        various services (i.e., EVS, TBL, etc.).
-**
-** \par Assumptions, External Events, and Notes:
-**        None
 **
 ** \returns
 **        This function does not return a value.

--- a/fsw/cfe-core/unit-test/time_UT.c
+++ b/fsw/cfe-core/unit-test/time_UT.c
@@ -1741,24 +1741,24 @@ void Test_PipeCmds(void)
     union
     {
         CFE_MSG_Message_t message;
-        CFE_SB_CmdHdr_t cmd;
+        CFE_MSG_CommandHeader_t cmd;
         CFE_TIME_ToneDataCmd_t tonedatacmd;
-        CFE_TIME_Noop_t noopcmd;
-        CFE_TIME_ResetCounters_t resetcountercmd;
-        CFE_TIME_SendDiagnosticTlm_t diagtlmcmd;
-        CFE_TIME_SetState_t statecmd;
-        CFE_TIME_SetSource_t sourcecmd;
-        CFE_TIME_SetSignal_t signalcmd;
-        CFE_TIME_AddDelay_t adddelaycmd;
-        CFE_TIME_SubDelay_t subdelaycmd;
-        CFE_TIME_SetTime_t settimecmd;
-        CFE_TIME_SetMET_t setmetcmd;
-        CFE_TIME_SetSTCF_t setstcfcmd;
-        CFE_TIME_SetLeapSeconds_t leapscmd;
-        CFE_TIME_AddAdjust_t addadjcmd;
-        CFE_TIME_SubAdjust_t subadjcmd;
-        CFE_TIME_Add1HZAdjustment_t add1hzadjcmd;
-        CFE_TIME_Sub1HZAdjustment_t sub1hzadjcmd;
+        CFE_TIME_NoopCmd_t noopcmd;
+        CFE_TIME_ResetCountersCmd_t resetcountercmd;
+        CFE_TIME_SendDiagnosticCmd_t diagtlmcmd;
+        CFE_TIME_SetStateCmd_t statecmd;
+        CFE_TIME_SetSourceCmd_t sourcecmd;
+        CFE_TIME_SetSignalCmd_t signalcmd;
+        CFE_TIME_AddDelayCmd_t adddelaycmd;
+        CFE_TIME_SubDelayCmd_t subdelaycmd;
+        CFE_TIME_SetTimeCmd_t settimecmd;
+        CFE_TIME_SetMETCmd_t setmetcmd;
+        CFE_TIME_SetSTCFCmd_t setstcfcmd;
+        CFE_TIME_SetLeapSecondsCmd_t leapscmd;
+        CFE_TIME_AddAdjustCmd_t addadjcmd;
+        CFE_TIME_SubAdjustCmd_t subadjcmd;
+        CFE_TIME_Add1HZAdjustmentCmd_t add1hzadjcmd;
+        CFE_TIME_Sub1HZAdjustmentCmd_t sub1hzadjcmd;
     } CmdBuf;
 
     UT_SoftwareBusSnapshot_Entry_t LocalSnapshotData =
@@ -1776,7 +1776,7 @@ void Test_PipeCmds(void)
 
     /* Test sending the housekeeping telemetry request command */
     UT_InitData();
-    UT_SetHookFunction(UT_KEY(CFE_SB_SendMsg), UT_SoftwareBusSnapshotHook, &LocalSnapshotData);
+    UT_SetHookFunction(UT_KEY(CFE_SB_TransmitMsg), UT_SoftwareBusSnapshotHook, &LocalSnapshotData);
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.cmd),
             UT_TPID_CFE_TIME_SEND_HK);
     UT_Report(__FILE__, __LINE__,

--- a/fsw/cfe-core/unit-test/time_UT.h
+++ b/fsw/cfe-core/unit-test/time_UT.h
@@ -66,9 +66,6 @@
 **
 ** \returns
 **        This function does not return a value.
-**
-** \sa #UT_InitData, CFE_TIME_TaskMain, #UT_Report, #UT_SetRtnCode
-**
 ******************************************************************************/
 void Test_Main(void);
 
@@ -86,10 +83,6 @@ void Test_Main(void);
 **
 ** \returns
 **        This function does not return a value.
-**
-** \sa #CFE_TIME_EarlyInit, #UT_InitData, #UT_Report,
-** \sa #CFE_TIME_TaskInit, #UT_SetRtnCode
-**
 ******************************************************************************/
 void Test_Init(void);
 
@@ -105,13 +98,6 @@ void Test_Init(void);
 **
 ** \returns
 **        This function does not return a value.
-**
-** \sa #UT_InitData, #UT_SetBSP_Time, #CFE_TIME_Print,
-** \sa #CFE_TIME_GetMET, #UT_Report, #CFE_TIME_GetMETseconds,
-** \sa #CFE_TIME_GetMETsubsecs, #CFE_TIME_Micro2SubSecs,
-** \sa #CFE_TIME_GetLeapSeconds, #CFE_TIME_GetTAI, #CFE_TIME_GetUTC,
-** \sa #CFE_TIME_GetSTCF, #CFE_TIME_GetClockState, #CFE_TIME_GetClockInfo
-**
 ******************************************************************************/
 void Test_GetTime(void);
 
@@ -127,10 +113,6 @@ void Test_GetTime(void);
 **
 ** \returns
 **        This function does not return a value.
-**
-** \sa #UT_InitData, #CFE_TIME_Add, #UT_Report, #CFE_TIME_Subtract,
-** \sa #CFE_TIME_Compare
-**
 ******************************************************************************/
 void Test_TimeOp(void);
 
@@ -146,10 +128,6 @@ void Test_TimeOp(void);
 **
 ** \returns
 **        This function does not return a value.
-**
-** \sa #UT_InitData, #CFE_TIME_Print, #CFE_TIME_MET2SCTime,
-** \sa #UT_Report, #CFE_TIME_Sub2MicroSecs, #CFE_TIME_Micro2SubSecs
-**
 ******************************************************************************/
 void Test_ConvertTime(void);
 
@@ -167,9 +145,6 @@ void Test_ConvertTime(void);
 **
 ** \returns
 **        This function does not return a value.
-**
-** \sa #UT_InitData, #CFE_TIME_Print, #UT_Report
-**
 ******************************************************************************/
 void Test_Print(void);
 
@@ -187,7 +162,6 @@ void Test_Print(void);
 **
 ** \returns
 **        This function returns CFE_SUCCESS
-**
 ******************************************************************************/
 int32 ut_time_MyCallbackFunc(void);
 
@@ -210,9 +184,6 @@ int32 ut_time_MyCallbackFunc(void);
 **
 ** \returns
 **        This function does not return a value.
-**
-** \sa #UT_InitData, #CFE_TIME_RegisterSynchCallback, #UT_Report
-**
 ******************************************************************************/
 void Test_RegisterSyncCallback(bool reportResults);
 
@@ -229,9 +200,6 @@ void Test_RegisterSyncCallback(bool reportResults);
 **
 ** \returns
 **        This function does not return a value.
-**
-** \sa #Test_RegisterSyncCallback
-**
 ******************************************************************************/
 void Test_RegisterSyncCallbackTrue(void);
 
@@ -247,10 +215,6 @@ void Test_RegisterSyncCallbackTrue(void);
 **
 ** \returns
 **        This function does not return a value.
-**
-** \sa #UT_InitData, #UT_SetBSP_Time, #CFE_TIME_ExternalTone,
-** \sa #UT_Report
-**
 ******************************************************************************/
 void Test_ExternalTone(void);
 
@@ -266,10 +230,6 @@ void Test_ExternalTone(void);
 **
 ** \returns
 **        This function does not return a value.
-**
-** \sa #UT_InitData, #CFE_TIME_ExternalMET, #UT_Report,
-** \sa #CFE_TIME_ExternalGPS, #CFE_TIME_ExternalTime
-**
 ******************************************************************************/
 void Test_External(void);
 
@@ -285,9 +245,6 @@ void Test_External(void);
 **
 ** \returns
 **        This function does not return a value.
-**
-** \sa #UT_InitData, #UT_SendMsg, #UT_Report, #UT_SetBSP_Time
-**
 ******************************************************************************/
 void Test_PipeCmds(void);
 
@@ -303,10 +260,6 @@ void Test_PipeCmds(void);
 **
 ** \returns
 **        This function does not return a value.
-**
-** \sa #UT_InitData, #UT_SetStatusBSPResetArea,
-** \sa #CFE_TIME_QueryResetVars, #CFE_TIME_UpdateResetVars, #UT_Report
-**
 ******************************************************************************/
 void Test_ResetArea(void);
 
@@ -322,10 +275,6 @@ void Test_ResetArea(void);
 **
 ** \returns
 **        This function does not return a value.
-**
-** \sa #UT_InitData, #UT_Report, #CFE_TIME_CalculateState,
-** \sa #CFE_TIME_SetState, #CFE_TIME_GetStateFlags
-**
 ******************************************************************************/
 void Test_State(void);
 
@@ -341,10 +290,6 @@ void Test_State(void);
 **
 ** \returns
 **        This function does not return a value.
-**
-** \sa #UT_InitData, #UT_SetBSP_Time, #CFE_TIME_GetReference,
-** \sa #UT_Report
-**
 ******************************************************************************/
 void Test_GetReference(void);
 
@@ -361,10 +306,6 @@ void Test_GetReference(void);
 **
 ** \returns
 **        This function does not return a value.
-**
-** \sa #UT_InitData, #CFE_TIME_SetState, #UT_SetBSP_Time,
-** \sa #UT_Report, #CFE_TIME_ToneSend, #CFE_TIME_ToneVerify, CFE_TIME_SetState,
-**
 ******************************************************************************/
 void Test_Tone(void);
 
@@ -382,11 +323,6 @@ void Test_Tone(void);
 **
 ** \returns
 **        This function does not return a value.
-**
-** \sa #UT_InitData, #CFE_TIME_Set1HzAdj, #CFE_TIME_Local1HzISR,
-** \sa #UT_Report, #UT_SetBSP_Time, #UT_SetBinSemFail, #CFE_TIME_Local1HzTask,
-** \sa #CFE_TIME_Tone1HzTask
-**
 ******************************************************************************/
 void Test_1Hz(void);
 
@@ -402,9 +338,6 @@ void Test_1Hz(void);
 **
 ** \returns
 **        This function does not return a value.
-**
-** \sa #UT_InitData, #CFE_TIME_UnregisterSynchCallback, #UT_Report
-**
 ******************************************************************************/
 void Test_UnregisterSynchCallback(void);
 
@@ -420,10 +353,6 @@ void Test_UnregisterSynchCallback(void);
 **
 ** \returns
 **        This function does not return a value.
-**
-** \sa #UT_InitData, #Test_RegisterSyncCallback,
-** \sa #CFE_TIME_CleanUpApp, #CFE_TIME_UnregisterSynchCallback, #UT_Report
-**
 ******************************************************************************/
 void Test_CleanUpApp(void);
 

--- a/fsw/cfe-core/unit-test/ut_support.h
+++ b/fsw/cfe-core/unit-test/ut_support.h
@@ -280,7 +280,7 @@ void UT_ReportFailures(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void UT_CallTaskPipe(void (*TaskPipeFunc)(CFE_MSG_Message_t*), CFE_MSG_Message_t *MsgPtr, uint32 MsgSize,
+void UT_CallTaskPipe(void (*TaskPipeFunc)(CFE_SB_Buffer_t*), CFE_MSG_Message_t *MsgPtr, size_t MsgSize,
         UT_TaskPipeDispatchId_t DispatchId);
 
 /*****************************************************************************/

--- a/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
@@ -282,7 +282,6 @@ int32 CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *PipeName)
 
     if (status >= 0)
     {
-        /* TODO: add GetPipeName */
         if (UT_Stub_CopyToLocal(UT_KEY(CFE_SB_GetPipeIdByName), (uint8*)PipeIdPtr, sizeof(*PipeIdPtr)) == sizeof(*PipeIdPtr))
         {
             status = CFE_SUCCESS;
@@ -403,7 +402,6 @@ void CFE_SB_InitMsg(void           *MsgPtr,
         UT_Stub_CopyToLocal(UT_KEY(CFE_SB_InitMsg), (uint8*)MsgPtr, Length);
     }
 }
-#endif /* CFE_OMIT_DEPRECATED_6_8 */
 
 /*****************************************************************************/
 /**
@@ -418,10 +416,10 @@ void CFE_SB_InitMsg(void           *MsgPtr,
 **        None
 **
 ** \returns
-**        Returns CFE_SUCCESS on the first call, then -1 on the second.
+**        Returns CFE_SUCCESS or overridden unit test value
 **
 ******************************************************************************/
-int32 CFE_SB_RcvMsg(CFE_MSG_Message_t **BufPtr,
+int32 CFE_SB_RcvMsg(CFE_SB_Buffer_t **BufPtr,
                     CFE_SB_PipeId_t PipeId,
                     int32 TimeOut)
 {
@@ -430,27 +428,124 @@ int32 CFE_SB_RcvMsg(CFE_MSG_Message_t **BufPtr,
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_SB_RcvMsg), TimeOut);
 
     int32 status;
-    static union
-    {
-        CFE_MSG_Message_t Msg;
-        uint8 Ext[CFE_MISSION_SB_MAX_SB_MSG_SIZE];
-    } Buffer;
-
 
     status = UT_DEFAULT_IMPL(CFE_SB_RcvMsg);
 
     if (status >= 0)
     {
-        if (UT_Stub_CopyToLocal(UT_KEY(CFE_SB_RcvMsg), (uint8*)BufPtr, sizeof(*BufPtr)) < sizeof(*BufPtr))
-        {
-            memset(&Buffer, 0, sizeof(Buffer));
-            *BufPtr = &Buffer.Msg;
-        }
+        UT_Stub_CopyToLocal(UT_KEY(CFE_SB_RcvMsg), (uint8*)BufPtr, sizeof(*BufPtr));
     }
 
     return status;
 }
 
+#endif /* CFE_OMIT_DEPRECATED_6_8 */
+
+/*****************************************************************************/
+/**
+** \brief CFE_SB_ReceiveBuffer stub function
+**
+** \par Description
+**        This function is used to mimic the response of the cFE SB function
+**        CFE_SB_ReceiveBuffer.  By default it will return the TIMEOUT error response,
+**        unless the test setup sequence has indicated otherwise.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        Returns CFE_SUCCESS or overridden unit test value
+**
+******************************************************************************/
+int32 CFE_SB_ReceiveBuffer(CFE_SB_Buffer_t **BufPtr,
+                           CFE_SB_PipeId_t PipeId,
+                           int32 TimeOut)
+{
+    UT_Stub_RegisterContext(UT_KEY(CFE_SB_ReceiveBuffer), BufPtr);
+    UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_SB_ReceiveBuffer), PipeId);
+    UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_SB_ReceiveBuffer), TimeOut);
+
+    int32 status;
+
+    status = UT_DEFAULT_IMPL(CFE_SB_ReceiveBuffer);
+
+    if (status >= 0)
+    {
+        UT_Stub_CopyToLocal(UT_KEY(CFE_SB_ReceiveBuffer), (uint8*)BufPtr, sizeof(*BufPtr));
+    }
+
+    return status;
+}
+
+/*****************************************************************************/
+/**
+** \brief CFE_SB_TransmitMsg stub function
+**
+** \par Description
+**        This function is implements the stub version of the real implementation.
+**        Adds the message pointer value to the test buffer if status is
+**        positive
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        Returns CFE_SUCCESS or overridden unit test value
+**
+******************************************************************************/
+int32 CFE_SB_TransmitMsg(CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount)
+{
+    UT_Stub_RegisterContext(UT_KEY(CFE_SB_TransmitMsg), MsgPtr);
+    UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_SB_TransmitMsg), IncrementSequenceCount);
+
+    int32            status = CFE_SUCCESS;
+
+    status = UT_DEFAULT_IMPL(CFE_SB_TransmitMsg);
+
+    if (status >= 0)
+    {
+        UT_Stub_CopyFromLocal(UT_KEY(CFE_SB_TransmitMsg), &MsgPtr, sizeof(MsgPtr));
+    }
+
+    return status;
+}
+
+/*****************************************************************************/
+/**
+** \brief CFE_SB_TransmitBuffer stub function
+**
+** \par Description
+**        This function is implements the stub version of the real implementation.
+**        Adds the buffer pointer value to the test buffer if status is
+**        positive
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        Returns CFE_SUCCESS or overridden unit test value
+**
+******************************************************************************/
+int32 CFE_SB_TransmitBuffer(CFE_SB_Buffer_t *BufPtr, CFE_SB_ZeroCopyHandle_t ZeroCopyHandle,
+                            bool IncrementSequenceCount)
+{
+    UT_Stub_RegisterContext(UT_KEY(CFE_SB_TransmitBuffer), BufPtr);
+    UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_SB_TransmitBuffer), ZeroCopyHandle);
+    UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_SB_TransmitBuffer), IncrementSequenceCount);
+
+    int32            status = CFE_SUCCESS;
+
+    status = UT_DEFAULT_IMPL(CFE_SB_TransmitBuffer);
+
+    if (status >= 0)
+    {
+        UT_Stub_CopyFromLocal(UT_KEY(CFE_SB_TransmitBuffer), &BufPtr, sizeof(BufPtr));
+    }
+
+    return status;
+}
+
+#ifndef CFE_OMIT_DEPRECATED_6_8
 /*****************************************************************************/
 /**
 ** \brief CFE_SB_SendMsg stub function
@@ -496,8 +591,6 @@ int32 CFE_SB_SendMsg(CFE_MSG_Message_t *MsgPtr)
 
     return status;
 }
-
-#ifndef CFE_OMIT_DEPRECATED_6_8
 
 /*****************************************************************************/
 /**
@@ -940,11 +1033,11 @@ void *CFE_SB_GetUserData(CFE_MSG_Message_t *MsgPtr)
         BytePtr = (uint8 *)MsgPtr;
         if ((MsgPtr->Byte[0] & 0x10) != 0)
         {
-            HdrSize = CFE_SB_CMD_HDR_SIZE;
+            HdrSize = sizeof(CFE_MSG_CommandHeader_t);
         }
         else
         {
-            HdrSize = CFE_SB_TLM_HDR_SIZE;
+            HdrSize = sizeof(CFE_MSG_TelemetryHeader_t);
         }
 
         Result = (BytePtr + HdrSize);
@@ -1082,27 +1175,28 @@ int32 CFE_SB_UnsubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId)
     return status;
 }
 
-CFE_MSG_Message_t *CFE_SB_ZeroCopyGetPtr(size_t MsgSize, CFE_SB_ZeroCopyHandle_t *BufferHandle)
+CFE_SB_Buffer_t *CFE_SB_ZeroCopyGetPtr(size_t MsgSize, CFE_SB_ZeroCopyHandle_t *BufferHandle)
 {
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_SB_ZeroCopyGetPtr), MsgSize);
     UT_Stub_RegisterContext(UT_KEY(CFE_SB_ZeroCopyGetPtr), BufferHandle);
 
     int32 status;
-    CFE_MSG_Message_t *MsgPtr;
+    CFE_SB_Buffer_t *SBBufPtr = NULL;
 
-    MsgPtr = NULL;
     status = UT_DEFAULT_IMPL(CFE_SB_ZeroCopyGetPtr);
+
     if (status == CFE_SUCCESS)
     {
-        UT_Stub_CopyToLocal(UT_KEY(CFE_SB_ZeroCopyGetPtr), &MsgPtr, sizeof(MsgPtr));
+        UT_Stub_CopyToLocal(UT_KEY(CFE_SB_ZeroCopyGetPtr), &SBBufPtr, sizeof(SBBufPtr));
     }
 
-    return MsgPtr;
+    return SBBufPtr;
 }
 
-int32 CFE_SB_ZeroCopyPass(CFE_MSG_Message_t *MsgPtr, CFE_SB_ZeroCopyHandle_t BufferHandle)
+#ifndef CFE_OMIT_DEPRECATED_6_8
+int32 CFE_SB_ZeroCopyPass(CFE_SB_Buffer_t *BufPtr, CFE_SB_ZeroCopyHandle_t BufferHandle)
 {
-    UT_Stub_RegisterContext(UT_KEY(CFE_SB_ZeroCopyPass), MsgPtr);
+    UT_Stub_RegisterContext(UT_KEY(CFE_SB_ZeroCopyPass), BufPtr);
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_SB_ZeroCopyPass), BufferHandle);
 
     int32 status;
@@ -1111,8 +1205,9 @@ int32 CFE_SB_ZeroCopyPass(CFE_MSG_Message_t *MsgPtr, CFE_SB_ZeroCopyHandle_t Buf
 
     return status;
 }
+#endif
 
-int32 CFE_SB_ZeroCopyReleasePtr(CFE_MSG_Message_t *Ptr2Release, CFE_SB_ZeroCopyHandle_t BufferHandle)
+int32 CFE_SB_ZeroCopyReleasePtr(CFE_SB_Buffer_t *Ptr2Release, CFE_SB_ZeroCopyHandle_t BufferHandle)
 {
     UT_Stub_RegisterContext(UT_KEY(CFE_SB_ZeroCopyReleasePtr), Ptr2Release);
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_SB_ZeroCopyReleasePtr), BufferHandle);
@@ -1124,9 +1219,10 @@ int32 CFE_SB_ZeroCopyReleasePtr(CFE_MSG_Message_t *Ptr2Release, CFE_SB_ZeroCopyH
     return status;
 }
 
-int32 CFE_SB_ZeroCopySend(CFE_MSG_Message_t *MsgPtr, CFE_SB_ZeroCopyHandle_t BufferHandle)
+#ifndef CFE_OMIT_DEPRECATED_6_8
+int32 CFE_SB_ZeroCopySend(CFE_SB_Buffer_t *BufPtr, CFE_SB_ZeroCopyHandle_t BufferHandle)
 {
-    UT_Stub_RegisterContext(UT_KEY(CFE_SB_ZeroCopySend), MsgPtr);
+    UT_Stub_RegisterContext(UT_KEY(CFE_SB_ZeroCopySend), BufPtr);
     UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_SB_ZeroCopySend), BufferHandle);
 
     int32 status;
@@ -1135,4 +1231,4 @@ int32 CFE_SB_ZeroCopySend(CFE_MSG_Message_t *MsgPtr, CFE_SB_ZeroCopyHandle_t Buf
 
     return status;
 }
-
+#endif

--- a/modules/msg/mission_inc/default_cfe_msg_hdr_pri.h
+++ b/modules/msg/mission_inc/default_cfe_msg_hdr_pri.h
@@ -55,13 +55,22 @@ typedef struct
 } CCSDS_SpacePacket_t;
 
 /**
+ * \brief cFS generic base message
+ */
+typedef union
+{
+    CCSDS_SpacePacket_t CCSDS;                             /**< \brief CCSDS Header (Pri or Pri + Ext) */
+    uint8               Byte[sizeof(CCSDS_SpacePacket_t)]; /**< \brief Byte level access */
+} CFE_MSG_Message_t;
+
+/**
  * \brief cFS command header
  */
 typedef struct
 {
 
-    CCSDS_SpacePacket_t              CCSDS; /**< \brief CCSDS header */
-    CFE_MSG_CommandSecondaryHeader_t Sec;   /**< \brief Secondary header */
+    CFE_MSG_Message_t                Msg; /**< \brief Base message */
+    CFE_MSG_CommandSecondaryHeader_t Sec; /**< \brief Secondary header */
 
 } CFE_MSG_CommandHeader_t;
 
@@ -71,19 +80,9 @@ typedef struct
 typedef struct
 {
 
-    CCSDS_SpacePacket_t                CCSDS; /**< \brief CCSDS header */
-    CFE_MSG_TelemetrySecondaryHeader_t Sec;   /**< \brief Secondary header */
+    CFE_MSG_Message_t                  Msg; /**< \brief Base message */
+    CFE_MSG_TelemetrySecondaryHeader_t Sec; /**< \brief Secondary header */
 
 } CFE_MSG_TelemetryHeader_t;
-
-/**
- * \brief cFS Generic packet header
- */
-typedef union
-{
-    CCSDS_SpacePacket_t CCSDS;                             /**< \brief CCSDS Header (Pri or Pri + Ext) */
-    uint32              Align;                             /**< \brief Force 32-bit alignment */
-    uint8               Byte[sizeof(CCSDS_SpacePacket_t)]; /**< \brief Byte level access */
-} CFE_MSG_Message_t;
 
 #endif /* _cfe_msg_hdr_ */

--- a/modules/msg/mission_inc/default_cfe_msg_hdr_priext.h
+++ b/modules/msg/mission_inc/default_cfe_msg_hdr_priext.h
@@ -56,13 +56,22 @@ typedef struct
 } CCSDS_SpacePacket_t;
 
 /**
+ * \brief cFS generic base message
+ */
+typedef union
+{
+    CCSDS_SpacePacket_t CCSDS;                             /**< \brief CCSDS Header (Pri or Pri + Ext) */
+    uint8               Byte[sizeof(CCSDS_SpacePacket_t)]; /**< \brief Byte level access */
+} CFE_MSG_Message_t;
+
+/**
  * \brief cFS command header
  */
 typedef struct
 {
 
-    CCSDS_SpacePacket_t              CCSDS; /**< \brief CCSDS header */
-    CFE_MSG_CommandSecondaryHeader_t Sec;   /**< \brief Secondary header */
+    CFE_MSG_Message_t                Msg; /**< \brief Base message */
+    CFE_MSG_CommandSecondaryHeader_t Sec; /**< \brief Secondary header */
 
 } CFE_MSG_CommandHeader_t;
 
@@ -72,19 +81,9 @@ typedef struct
 typedef struct
 {
 
-    CCSDS_SpacePacket_t                CCSDS; /**< \brief CCSDS header */
-    CFE_MSG_TelemetrySecondaryHeader_t Sec;   /**< \brief Secondary header */
+    CFE_MSG_Message_t                  Msg; /**< \brief Base message */
+    CFE_MSG_TelemetrySecondaryHeader_t Sec; /**< \brief Secondary header */
 
 } CFE_MSG_TelemetryHeader_t;
-
-/**
- * \brief cFS Generic packet header
- */
-typedef union
-{
-    CCSDS_SpacePacket_t CCSDS;                             /**< \brief CCSDS Header (Pri or Pri + Ext) */
-    uint32              Align;                             /**< \brief Force 32-bit alignment */
-    uint8               Byte[sizeof(CCSDS_SpacePacket_t)]; /**< \brief Byte level access */
-} CFE_MSG_Message_t;
 
 #endif /* _cfe_msg_hdr_ */

--- a/modules/msg/src/cfe_msg_sechdr_checksum.c
+++ b/modules/msg/src/cfe_msg_sechdr_checksum.c
@@ -35,7 +35,7 @@
 CFE_MSG_Checksum_t CFE_MSG_ComputeCheckSum(const CFE_MSG_Message_t *MsgPtr)
 {
 
-    uint32             PktLen  = 0;
+    CFE_MSG_Size_t     PktLen  = 0;
     const uint8 *      BytePtr = MsgPtr->Byte;
     CFE_MSG_Checksum_t chksum  = 0xFF;
 

--- a/modules/msg/unit-test-coverage/test_cfe_msg_checksum.c
+++ b/modules/msg/unit-test-coverage/test_cfe_msg_checksum.c
@@ -36,9 +36,9 @@
 
 void Test_MSG_Checksum(void)
 {
-    CFE_SB_CmdHdr_t    cmd;
-    CFE_MSG_Message_t *msgptr = (CFE_MSG_Message_t *)&cmd;
-    bool               actual;
+    CFE_MSG_CommandHeader_t cmd;
+    CFE_MSG_Message_t      *msgptr = &cmd.Msg;
+    bool                    actual;
 
     UtPrintf("Bad parameter tests, Null pointers");
     memset(&cmd, 0, sizeof(cmd));

--- a/modules/msg/unit-test-coverage/test_cfe_msg_fc.c
+++ b/modules/msg/unit-test-coverage/test_cfe_msg_fc.c
@@ -41,11 +41,11 @@
 
 void Test_MSG_FcnCode(void)
 {
-    CFE_SB_CmdHdr_t    cmd;
-    CFE_MSG_Message_t *msgptr  = (CFE_MSG_Message_t *)&cmd;
-    CFE_MSG_FcnCode_t  input[] = {0, TEST_FCNCODE_MAX / 2, TEST_FCNCODE_MAX};
-    CFE_MSG_FcnCode_t  actual  = TEST_FCNCODE_MAX;
-    int                i;
+    CFE_MSG_CommandHeader_t cmd;
+    CFE_MSG_Message_t      *msgptr  = &cmd.Msg;
+    CFE_MSG_FcnCode_t       input[] = {0, TEST_FCNCODE_MAX / 2, TEST_FCNCODE_MAX};
+    CFE_MSG_FcnCode_t       actual  = TEST_FCNCODE_MAX;
+    int                     i;
 
     UtPrintf("Bad parameter tests, Null pointers, invalid (max valid + 1, max)");
     memset(&cmd, 0, sizeof(cmd));

--- a/modules/msg/unit-test-coverage/test_cfe_msg_init.c
+++ b/modules/msg/unit-test-coverage/test_cfe_msg_init.c
@@ -43,7 +43,7 @@
 void Test_MSG_Init(void)
 {
 
-    CFE_MSG_Message_t          msg;
+    CFE_MSG_CommandHeader_t    cmd;
     CFE_MSG_Size_t             size;
     CFE_SB_MsgId_Atom_t        msgidval_exp;
     CFE_SB_MsgId_t             msgid_act;
@@ -54,28 +54,28 @@ void Test_MSG_Init(void)
     bool                       is_v1;
 
     UtPrintf("Bad parameter tests, Null pointer, invalid size, invalid msgid");
-    ASSERT_EQ(CFE_MSG_Init(NULL, CFE_SB_ValueToMsgId(0), sizeof(msg)), CFE_MSG_BAD_ARGUMENT);
-    ASSERT_EQ(CFE_MSG_Init(&msg, CFE_SB_ValueToMsgId(0), 0), CFE_MSG_BAD_ARGUMENT);
-    ASSERT_EQ(CFE_MSG_Init(&msg, CFE_SB_ValueToMsgId(CFE_PLATFORM_SB_HIGHEST_VALID_MSGID + 1), sizeof(msg)),
+    ASSERT_EQ(CFE_MSG_Init(NULL, CFE_SB_ValueToMsgId(0), sizeof(cmd)), CFE_MSG_BAD_ARGUMENT);
+    ASSERT_EQ(CFE_MSG_Init(&cmd.Msg, CFE_SB_ValueToMsgId(0), 0), CFE_MSG_BAD_ARGUMENT);
+    ASSERT_EQ(CFE_MSG_Init(&cmd.Msg, CFE_SB_ValueToMsgId(CFE_PLATFORM_SB_HIGHEST_VALID_MSGID + 1), sizeof(cmd)),
               CFE_MSG_BAD_ARGUMENT);
-    ASSERT_EQ(CFE_MSG_Init(&msg, CFE_SB_ValueToMsgId(-1), sizeof(msg)), CFE_MSG_BAD_ARGUMENT);
+    ASSERT_EQ(CFE_MSG_Init(&cmd.Msg, CFE_SB_ValueToMsgId(-1), sizeof(cmd)), CFE_MSG_BAD_ARGUMENT);
 
     UtPrintf("Set to all F's, msgid value = 0");
-    memset(&msg, 0xFF, sizeof(msg));
+    memset(&cmd, 0xFF, sizeof(cmd));
     msgidval_exp = 0;
 
-    ASSERT_EQ(CFE_MSG_Init(&msg, CFE_SB_ValueToMsgId(msgidval_exp), sizeof(msg)), CFE_SUCCESS);
-    Test_MSG_PrintMsg(&msg, 0);
-    ASSERT_EQ(CFE_MSG_GetMsgId(&msg, &msgid_act), CFE_SUCCESS);
+    ASSERT_EQ(CFE_MSG_Init(&cmd.Msg, CFE_SB_ValueToMsgId(msgidval_exp), sizeof(cmd)), CFE_SUCCESS);
+    Test_MSG_PrintMsg(&cmd.Msg, 0);
+    ASSERT_EQ(CFE_MSG_GetMsgId(&cmd.Msg, &msgid_act), CFE_SUCCESS);
     ASSERT_EQ(CFE_SB_MsgIdToValue(msgid_act), msgidval_exp);
-    ASSERT_EQ(CFE_MSG_GetSize(&msg, &size), CFE_SUCCESS);
-    ASSERT_EQ(size, sizeof(msg));
-    ASSERT_EQ(CFE_MSG_GetSegmentationFlag(&msg, &segflag), CFE_SUCCESS);
+    ASSERT_EQ(CFE_MSG_GetSize(&cmd.Msg, &size), CFE_SUCCESS);
+    ASSERT_EQ(size, sizeof(cmd));
+    ASSERT_EQ(CFE_MSG_GetSegmentationFlag(&cmd.Msg, &segflag), CFE_SUCCESS);
     ASSERT_EQ(segflag, CFE_MSG_SegFlag_Unsegmented);
 
-    ASSERT_EQ(CFE_MSG_GetApId(&msg, &apid), CFE_SUCCESS);
-    ASSERT_EQ(CFE_MSG_GetHeaderVersion(&msg, &hdrver), CFE_SUCCESS);
-    ASSERT_EQ(CFE_MSG_GetHasSecondaryHeader(&msg, &hassec), CFE_SUCCESS);
+    ASSERT_EQ(CFE_MSG_GetApId(&cmd.Msg, &apid), CFE_SUCCESS);
+    ASSERT_EQ(CFE_MSG_GetHeaderVersion(&cmd.Msg, &hdrver), CFE_SUCCESS);
+    ASSERT_EQ(CFE_MSG_GetHasSecondaryHeader(&cmd.Msg, &hassec), CFE_SUCCESS);
 
     /* A zero msgid will set hassec to false for v1 */
     is_v1 = !hassec;
@@ -92,25 +92,25 @@ void Test_MSG_Init(void)
     }
 
     /* Confirm the rest of the fields not already explicitly checked */
-    ASSERT_EQ(Test_MSG_Pri_NotZero(&msg) & ~(MSG_APID_FLAG | MSG_HDRVER_FLAG | MSG_HASSEC_FLAG),
+    ASSERT_EQ(Test_MSG_Pri_NotZero(&cmd.Msg) & ~(MSG_APID_FLAG | MSG_HDRVER_FLAG | MSG_HASSEC_FLAG),
               MSG_LENGTH_FLAG | MSG_SEGMENT_FLAG);
 
     UtPrintf("Set to all 0, max msgid value");
-    memset(&msg, 0, sizeof(msg));
+    memset(&cmd, 0, sizeof(cmd));
     msgidval_exp = CFE_PLATFORM_SB_HIGHEST_VALID_MSGID;
 
-    ASSERT_EQ(CFE_MSG_Init(&msg, CFE_SB_ValueToMsgId(msgidval_exp), sizeof(msg)), CFE_SUCCESS);
-    Test_MSG_PrintMsg(&msg, 0);
-    ASSERT_EQ(CFE_MSG_GetMsgId(&msg, &msgid_act), CFE_SUCCESS);
+    ASSERT_EQ(CFE_MSG_Init(&cmd.Msg, CFE_SB_ValueToMsgId(msgidval_exp), sizeof(cmd)), CFE_SUCCESS);
+    Test_MSG_PrintMsg(&cmd.Msg, 0);
+    ASSERT_EQ(CFE_MSG_GetMsgId(&cmd.Msg, &msgid_act), CFE_SUCCESS);
     ASSERT_EQ(CFE_SB_MsgIdToValue(msgid_act), msgidval_exp);
-    ASSERT_EQ(CFE_MSG_GetSize(&msg, &size), CFE_SUCCESS);
-    ASSERT_EQ(size, sizeof(msg));
-    ASSERT_EQ(CFE_MSG_GetSegmentationFlag(&msg, &segflag), CFE_SUCCESS);
+    ASSERT_EQ(CFE_MSG_GetSize(&cmd.Msg, &size), CFE_SUCCESS);
+    ASSERT_EQ(size, sizeof(cmd));
+    ASSERT_EQ(CFE_MSG_GetSegmentationFlag(&cmd.Msg, &segflag), CFE_SUCCESS);
     ASSERT_EQ(segflag, CFE_MSG_SegFlag_Unsegmented);
 
-    ASSERT_EQ(CFE_MSG_GetApId(&msg, &apid), CFE_SUCCESS);
-    ASSERT_EQ(CFE_MSG_GetHeaderVersion(&msg, &hdrver), CFE_SUCCESS);
-    ASSERT_EQ(CFE_MSG_GetHasSecondaryHeader(&msg, &hassec), CFE_SUCCESS);
+    ASSERT_EQ(CFE_MSG_GetApId(&cmd.Msg, &apid), CFE_SUCCESS);
+    ASSERT_EQ(CFE_MSG_GetHeaderVersion(&cmd.Msg, &hdrver), CFE_SUCCESS);
+    ASSERT_EQ(CFE_MSG_GetHasSecondaryHeader(&cmd.Msg, &hassec), CFE_SUCCESS);
     ASSERT_EQ(hassec, true);
     if (!is_v1)
     {
@@ -123,5 +123,6 @@ void Test_MSG_Init(void)
         ASSERT_EQ(hdrver, 0);
     }
 
-    ASSERT_EQ(Test_MSG_Pri_NotZero(&msg) & ~MSG_HDRVER_FLAG, MSG_APID_FLAG | MSG_HASSEC_FLAG | MSG_TYPE_FLAG | MSG_LENGTH_FLAG | MSG_SEGMENT_FLAG);
+    ASSERT_EQ(Test_MSG_Pri_NotZero(&cmd.Msg) & ~MSG_HDRVER_FLAG, MSG_APID_FLAG | MSG_HASSEC_FLAG | MSG_TYPE_FLAG |
+                                   MSG_LENGTH_FLAG | MSG_SEGMENT_FLAG);
 }

--- a/modules/msg/unit-test-coverage/test_cfe_msg_time.c
+++ b/modules/msg/unit-test-coverage/test_cfe_msg_time.c
@@ -36,11 +36,11 @@
 
 void Test_MSG_Time(void)
 {
-    CFE_SB_TlmHdr_t    tlm;
-    CFE_MSG_Message_t *msgptr  = (CFE_MSG_Message_t *)&tlm;
-    CFE_TIME_SysTime_t input[] = {{0, 0}, {0x12345678, 0xABCDEF12}, {0xFFFFFFFF, 0xFFFFFFFF}};
-    CFE_TIME_SysTime_t actual  = {0xFFFFFFFF, 0xFFFFFFFF};
-    int                i;
+    CFE_MSG_TelemetryHeader_t tlm;
+    CFE_MSG_Message_t        *msgptr  = &tlm.Msg;
+    CFE_TIME_SysTime_t        input[] = {{0, 0}, {0x12345678, 0xABCDEF12}, {0xFFFFFFFF, 0xFFFFFFFF}};
+    CFE_TIME_SysTime_t        actual  = {0xFFFFFFFF, 0xFFFFFFFF};
+    int                       i;
 
     UtPrintf("Bad parameter tests, Null pointers, no secondary header");
     memset(&tlm, 0, sizeof(tlm));


### PR DESCRIPTION
**Describe the contribution**
Fix #1009 
Partially addresses #1019 (adds CFE_SB_TransmitMsg, CFE_SB_TransmitBuffer, CFE_SB_ReceiveBuffer)

 - Main change is to utilize CFE_SB_Buffer_t and CFE_MSG_Message_t in a consistent manner to facilitate alignment
 - Deprecates CFE_SB_SendMsg, CFE_SB_PassMsg, CFE_SB_RcvMsg, CFE_SB_ZeroCopyPass, CFE_SB_ZeroCopySend
 - Deprecates CFE_SB_TlmHdr_t, CFE_SB_CmdHdr_t
 - Deprecates CFE_SB_CMD_HDR_SIZE and CFE_SB_TLM_HDR_SIZE
 - Redefines CFE_MSG_Size_t as size_t to minimize duplicated work and facilitate transition to just size_t

See also details in the individual commits.

Why is this necessary?
  - The former implementation wasn't clear on the use of CFE_SB_Msg_t vs CFE_MSG_Message_t, CFE_SB_TlmHdr_t vs CFE_MSG_TelemetryHeader_t, CFE_SB_CmdHdr_t vs CFE_SB_CommandHeader_t
  - Worst case alignment was enforce at the message level, making it impossible to use the message types in cmds/tlm without impacting the sizes of some of the cmds/tlm (they would get rounded up)
  - Still couldn't cast to a command type that contained anything that required more than 32 bit alignment

Now
  - CFE_SB_Buffer_t is aligned for up to a long double, so now for command processing cast alignment warnings are all resolved
  - Clear use of CFE_SB_Buffer_t and removal of duplicated/confusing terms
  - CFE_MSG_Message_t no longer requires any "extra" alignment and is available in the CFE_MSG_TelemetryHeader_t and CFE_MSG_CommandHeader_t structures so no cast is required to use the MSG APIs (just pass in the msg)
  - CFE_MSG_TelemetryHeader_t and CFE_MSG_CommandHeader_t can now be used in the definition of all cmd/tlm structures and avoid casts (no more uint8 header of size *_HDR_SIZE)

**Testing performed**
Bundle passed CI, unit tests pass.

**Expected behavior changes**
None, pattern change.

**System(s) tested on**
 - Hardware: cFS Dev server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + #998, although #1009 is the subject of this PR

**Additional context**
#777, #998 

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC