### PR TITLE
Fix #965, remove OSAL ID from App/LibInfo struct

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_api.c
+++ b/fsw/cfe-core/src/es/cfe_es_api.c
@@ -970,6 +970,7 @@ int32 CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, CFE_ES_ResourceID_t AppId)
    CFE_ES_AppRecord_t *AppRecPtr;
    CFE_ES_TaskRecord_t *TaskRecPtr;
    int32              Status;
+   osal_id_t          ModuleId;
    uint32             i;
 
    if ( AppInfo == NULL )
@@ -979,6 +980,7 @@ int32 CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, CFE_ES_ResourceID_t AppId)
    }
 
    memset(AppInfo, 0, sizeof(*AppInfo));
+   ModuleId = OS_OBJECT_ID_UNDEFINED;
 
    AppRecPtr = CFE_ES_LocateAppRecordByID(AppId);
 
@@ -1006,6 +1008,8 @@ int32 CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, CFE_ES_ResourceID_t AppId)
        AppInfo->ExceptionAction = AppRecPtr->StartParams.ExceptionAction;
        AppInfo->Priority = AppRecPtr->StartParams.Priority;
        AppInfo->MainTaskId = AppRecPtr->MainTaskId;
+
+       ModuleId = AppRecPtr->ModuleInfo.ModuleId;
 
        /*
        ** Calculate the number of child tasks
@@ -1044,7 +1048,7 @@ int32 CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, CFE_ES_ResourceID_t AppId)
    */
    if (Status == CFE_SUCCESS)
    {
-       CFE_ES_CopyModuleAddressInfo(AppInfo->ModuleId, AppInfo);
+       CFE_ES_CopyModuleAddressInfo(ModuleId, AppInfo);
    }
 
    return Status;
@@ -1057,12 +1061,16 @@ int32 CFE_ES_GetLibInfo(CFE_ES_AppInfo_t *LibInfo, CFE_ES_ResourceID_t LibId)
 {
     int32              Status;
     CFE_ES_LibRecord_t *LibRecPtr;
+    osal_id_t          ModuleId;
 
     if ( LibInfo == NULL )
     {
        CFE_ES_WriteToSysLog("CFE_ES_GetLibInfo: Invalid Parameter ( Null Pointer )\n");
        return CFE_ES_ERR_BUFFER;
     }
+
+    memset(LibInfo, 0, sizeof(*LibInfo));
+    ModuleId = OS_OBJECT_ID_UNDEFINED;
 
     LibRecPtr = CFE_ES_LocateLibRecordByID(LibId);
 
@@ -1086,6 +1094,8 @@ int32 CFE_ES_GetLibInfo(CFE_ES_AppInfo_t *LibInfo, CFE_ES_ResourceID_t LibId)
         CFE_ES_CopyModuleBasicInfo(&LibRecPtr->BasicInfo, LibInfo);
         CFE_ES_CopyModuleStatusInfo(&LibRecPtr->ModuleInfo, LibInfo);
 
+        ModuleId = LibRecPtr->ModuleInfo.ModuleId;
+
         Status = CFE_SUCCESS;
     }
 
@@ -1096,7 +1106,7 @@ int32 CFE_ES_GetLibInfo(CFE_ES_AppInfo_t *LibInfo, CFE_ES_ResourceID_t LibId)
      */
     if (Status == CFE_SUCCESS)
     {
-        CFE_ES_CopyModuleAddressInfo(LibInfo->ModuleId, LibInfo);
+        CFE_ES_CopyModuleAddressInfo(ModuleId, LibInfo);
     }
 
     return Status;

--- a/fsw/cfe-core/src/es/cfe_es_apps.c
+++ b/fsw/cfe-core/src/es/cfe_es_apps.c
@@ -1749,7 +1749,6 @@ void CFE_ES_CopyModuleBasicInfo(const CFE_ES_ModuleLoadParams_t *ParamsPtr, CFE_
 */
 void CFE_ES_CopyModuleStatusInfo(const CFE_ES_ModuleLoadStatus_t *StatusPtr, CFE_ES_AppInfo_t *AppInfoPtr)
 {
-    AppInfoPtr->ModuleId = StatusPtr->ModuleId;
     CFE_SB_SET_MEMADDR(AppInfoPtr->StartAddress, StatusPtr->EntryAddress);
 }
 

--- a/fsw/cfe-core/src/inc/cfe_es_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_es_msg.h
@@ -1406,8 +1406,6 @@ typedef struct CFE_ES_AppInfo
 
    CFE_ES_MemOffset_t   StackSize;             /**< \cfetlmmnemonic \ES_STACKSIZE
                                                     \brief The Stack Size of the Application */
-   osal_id_t   ModuleId;                       /**< \cfetlmmnemonic \ES_MODULEID
-                                                    \brief The ID of the Loadable Module for the Application */
    uint32   AddressesAreValid;                 /**< \cfetlmmnemonic \ES_ADDRVALID
                                                     \brief Indicates that the Code, Data, and BSS addresses/sizes are valid */
    CFE_ES_MemAddress_t CodeAddress;            /**< \cfetlmmnemonic \ES_CODEADDR


### PR DESCRIPTION
**Describe the contribution**
Removes the Module ID from the App/Lib info telemetry structures.

Fixes #965 

**Testing performed**
Build and sanity test CFE
Run all unit tests

**Expected behavior changes**
App and Lib info telemetry structures no longer contain the "ModuleId" value from OSAL.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
CFE code should be distinct about the types used in messages vs. the types used at runtime.  They may need to be different depending on mission architecture (i.e. mixing 32 and 64 bits, different local platform-specific sizes of things, etc).  All message definitions should be in the proper app-specific message typedef files and must have mission scope, not platform scope.

The "osal_id_t" type isn't defined in any of the CFE message/interface header files for use within telemetry, but this was included in the AppInfo and LibInfo telemetry structures.

This ID is an ephemeral runtime value and is not relevant to a ground system or anything outside CFE, so it makes most sense to simply remove this ID from the telemetry structure.  Note that all commands are name-based, not ID-based, hence why this ID is not really useful.

The alternative would be to use CFE_ES_ResourceID_t type instead.  This is the same underlying value but defined in ES rather than OSAL, in the typedefs file with all other message types.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
