### PR TITLE
Fix #1016, bogus warning in strncpy

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_apps.c
+++ b/fsw/cfe-core/src/es/cfe_es_apps.c
@@ -552,6 +552,7 @@ int32 CFE_ES_StartAppTask(const CFE_ES_AppStartParams_t* StartParams, CFE_ES_Res
 
         TaskRecPtr->AppId = RefAppId;
         strncpy(TaskRecPtr->TaskName, StartParams->BasicInfo.Name, sizeof(TaskRecPtr->TaskName)-1);
+        TaskRecPtr->TaskName[sizeof(TaskRecPtr->TaskName)-1] = 0;
         CFE_ES_TaskRecordSetUsed(TaskRecPtr, TaskId);
 
         /*


### PR DESCRIPTION
**Describe the contribution**

Add an extra write of a null char which squelches a warning.

Fixes #1016

**Testing performed**
Build and sanity check CFE with BUILDTYPE=release on focal

**Expected behavior changes**
None - just avoid extraneous warning

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Buffer was already zero'ed out via previous memset, so this extra zero really has no effect except (possibly) using an extra CPU cycle.  This just appeases some over-zealous compiler warning logic.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
