### PR TITLE
Fix #1004, default stack size

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_task.c
+++ b/fsw/cfe-core/src/es/cfe_es_task.c
@@ -861,6 +861,7 @@ int32 CFE_ES_StartAppCmd(const CFE_ES_StartApp_t *data)
     int32                 FilenameLen;
     int32                 AppEntryLen;
     int32                 AppNameLen;
+    size_t                AppStackSize;
     char                  LocalFile[OS_MAX_PATH_LEN];
     char                  LocalEntryPt[OS_MAX_API_NAME];
     char                  LocalAppName[OS_MAX_API_NAME];
@@ -897,13 +898,6 @@ int32 CFE_ES_StartAppCmd(const CFE_ES_StartApp_t *data)
         CFE_EVS_SendEvent(CFE_ES_START_NULL_APP_NAME_ERR_EID, CFE_EVS_EventType_ERROR,
                 "CFE_ES_StartAppCmd: App Name is NULL.");
     }
-    else if (cmd->StackSize < CFE_PLATFORM_ES_DEFAULT_STACK_SIZE)
-    {
-        CFE_ES_TaskData.CommandErrorCounter++;
-        CFE_EVS_SendEvent(CFE_ES_START_STACK_ERR_EID, CFE_EVS_EventType_ERROR,
-                "CFE_ES_StartAppCmd: Stack size is less than system Minimum: %d.",
-                CFE_PLATFORM_ES_DEFAULT_STACK_SIZE);
-    }
     else if (cmd->Priority > OS_MAX_PRIORITY)
     {
         CFE_ES_TaskData.CommandErrorCounter++;
@@ -921,15 +915,25 @@ int32 CFE_ES_StartAppCmd(const CFE_ES_StartApp_t *data)
     }
     else
     {
+       /* If stack size was provided, use it, otherwise use default. */
+       if (cmd->StackSize == 0)
+       {
+           AppStackSize = CFE_PLATFORM_ES_DEFAULT_STACK_SIZE;
+       }
+       else
+       {
+           AppStackSize = cmd->StackSize;
+       }
+
        /*
        ** Invoke application loader/startup function.
        */
        Result = CFE_ES_AppCreate(&AppID, LocalFile,
                    LocalEntryPt,
                    LocalAppName,
-                   (uint32) cmd->Priority,
-                   (uint32) cmd->StackSize,
-                   (uint32) cmd->ExceptionAction);
+                   cmd->Priority,
+                   AppStackSize,
+                   cmd->ExceptionAction);
 
         /*
         ** Send appropriate event message

--- a/fsw/cfe-core/src/inc/cfe_es_events.h
+++ b/fsw/cfe-core/src/inc/cfe_es_events.h
@@ -488,23 +488,6 @@
 **/
 #define CFE_ES_START_NULL_APP_NAME_ERR_EID     29
 
-/** \brief <tt> 'CFE_ES_StartAppCmd: Stack size is less than system Minimum: \%d.' </tt>
-**  \event <tt> 'CFE_ES_StartAppCmd: Stack size is less than system Minimum: \%d.' </tt>
-**
-**  \par Type: ERROR
-**
-**  \par Cause:
-**
-**  This event message is generated for an error encountered in response
-**  to an Executive Services \link #CFE_ES_START_APP_CC Start Application Command \endlink.
-**
-**  This message reports a command failure when the Application Stack Size parameter is 
-**  less than the default stack size defined in the cfe_platform_cfg.h file: CFE_PLATFORM_ES_DEFAULT_STACK_SIZE.
-**
-**  The \c 'd' term identifies the size of the stack that was given in the command.  
-**/
-#define CFE_ES_START_STACK_ERR_EID     30
-
 /** \brief <tt> 'CFE_ES_StartAppCmd: Priority is too large: \%d.' </tt>
 **  \event <tt> 'CFE_ES_StartAppCmd: Priority is too large: \%d.' </tt>
 **

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -2966,7 +2966,7 @@ void TestTask(void)
               "CFE_ES_StartAppCmd",
               "Invalid exception action");
 
-    /* Test app create with a bad stack size */
+    /* Test app create with a default stack size */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     strncpy((char *) CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
@@ -2981,9 +2981,9 @@ void TestTask(void)
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CFE_ES_StartApp_t),
             UT_TPID_CFE_ES_CMD_START_APP_CC);
     UT_Report(__FILE__, __LINE__,
-              UT_EventIsInHistory(CFE_ES_START_STACK_ERR_EID),
+              UT_EventIsInHistory(CFE_ES_START_INF_EID),
               "CFE_ES_StartAppCmd",
-              "Stack size too small");
+              "Default Stack Size");
 
     /* Test app create with a bad priority */
     ES_ResetUnitTest();


### PR DESCRIPTION
**Describe the contribution**

Do not enforce `CFE_PLATFORM_ES_DEFAULT_STACK_SIZE` as a minimum, it should be a default.

Fixes #1004

**Testing performed**
Build and sanity test CFE.
Run all unit tests.

**Expected behavior changes**
This affects the Start App command.
If stack size is specified as zero, then the default stack size value from platform config is used.  Otherwise the value in the command will be passed through and used as-is.  

**System(s) tested on**
Ubuntu 20.04
RTEMS 4.11

**Additional context**
No specific value is enforced at the ES level.  Many RTOS's will implement any stack size requested - so no need for ES to get in the way and put arbitrary restrictions.  Furthermore the value is documented as a default, not a minimum.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

