### PR TITLE
Fix #1023, correct stub appid parameter

### DIFF
--- a/fsw/cfe-core/ut-stubs/ut_evs_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_evs_stubs.c
@@ -288,7 +288,7 @@ int32 CFE_EVS_SendEventWithAppID(uint16 EventID,
 **        Returns either a user-defined status flag or CFE_SUCCESS.
 **
 ******************************************************************************/
-int32 CFE_EVS_CleanUpApp(uint32 AppId)
+int32 CFE_EVS_CleanUpApp(CFE_ES_ResourceID_t AppId)
 {
     int32 status;
 

--- a/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
@@ -765,7 +765,7 @@ uint16 CFE_SB_GetTotalMsgLength(const CFE_SB_Msg_t *MsgPtr)
 **        This function does not return a value.
 **
 ******************************************************************************/
-int32 CFE_SB_CleanUpApp(uint32 AppId)
+int32 CFE_SB_CleanUpApp(CFE_ES_ResourceID_t AppId)
 {
     int32 status;
 

--- a/fsw/cfe-core/ut-stubs/ut_tbl_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_tbl_stubs.c
@@ -91,7 +91,7 @@ void CFE_TBL_TaskMain(void)
 **        Returns CFE_SUCCESS.
 **
 ******************************************************************************/
-int32 CFE_TBL_CleanUpApp(uint32 AppId)
+int32 CFE_TBL_CleanUpApp(CFE_ES_ResourceID_t AppId)
 {
     int32 status;
 

--- a/fsw/cfe-core/ut-stubs/ut_time_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_time_stubs.c
@@ -171,7 +171,7 @@ CFE_TIME_SysTime_t CFE_TIME_GetTime(void)
 **        Returns either a user-defined status flag or CFE_SUCCESS.
 **
 ******************************************************************************/
-int32 CFE_TIME_CleanUpApp(uint32 AppId)
+int32 CFE_TIME_CleanUpApp(CFE_ES_ResourceID_t AppId)
 {
     int32 status;
 


### PR DESCRIPTION
**Describe the contribution**

The type of the AppID parameter on Cleanup routines should be `CFE_ES_ResourceID_t`, not `uint32`

Fixes #1023 

**Testing performed**
Build and run CFE
Run all unit tests

**Expected behavior changes**
None. 

**System(s) tested on**
Ubuntu 20.04

**Additional context**
These two are typedef equivalent in the main branch, so no change, but needed for consistency.  This was missed originally due to PR #1012 not being there yet.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
