### PR TITLE
Fix #914, Add toolchain file for RTEMS 5.1/pc-rtems

### DIFF
--- a/cmake/sample_defs/toolchain-i686-rtems5.cmake
+++ b/cmake/sample_defs/toolchain-i686-rtems5.cmake
@@ -12,7 +12,7 @@
 # Basic cross system configuration
 set(CMAKE_SYSTEM_NAME       RTEMS)
 set(CMAKE_SYSTEM_PROCESSOR  i386)
-set(CMAKE_SYSTEM_VERSION    4.11)
+set(CMAKE_SYSTEM_VERSION    5)
 
 # The TOOLS and BSP are allowed to be installed in different locations.
 # If the README was followed they will both be installed under $HOME
@@ -32,6 +32,7 @@ set(TARGETPREFIX                "${CMAKE_SYSTEM_PROCESSOR}-rtems${CMAKE_SYSTEM_V
 set(RTEMS_BSP_C_FLAGS           "-march=i686 -mtune=i686 -fno-common")
 set(RTEMS_BSP_CXX_FLAGS         ${RTEMS_BSP_C_FLAGS})
 
+
 SET(CMAKE_C_COMPILER            "${RTEMS_TOOLS_PREFIX}/bin/${TARGETPREFIX}gcc")
 SET(CMAKE_CXX_COMPILER          "${RTEMS_TOOLS_PREFIX}/bin/${TARGETPREFIX}g++")
 SET(CMAKE_LINKER                "${RTEMS_TOOLS_PREFIX}/bin/${TARGETPREFIX}ld")
@@ -44,6 +45,10 @@ SET(CMAKE_OBJCOPY               "${RTEMS_TOOLS_PREFIX}/bin/${TARGETPREFIX}objcop
 
 # Exception handling is very iffy.  These two options disable eh_frame creation.
 set(CMAKE_C_COMPILE_OPTIONS_PIC -fno-exceptions -fno-asynchronous-unwind-tables)
+
+# Link libraries needed for an RTEMS 5.x executable
+#  This was handled by the bsp_specs file in 4.11
+set(LINK_LIBRARIES              "-lrtemsdefaultconfig -lrtemsbsp -lrtemscpu")
 
 # search for programs in the build host directories
 SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM   NEVER)
@@ -59,6 +64,9 @@ SET(CMAKE_PREFIX_PATH                   /)
 SET(CFE_SYSTEM_PSPNAME                  pc-rtems)
 SET(OSAL_SYSTEM_BSPTYPE                 pc-rtems)
 SET(OSAL_SYSTEM_OSTYPE                  rtems)
+
+# This is for RTEMS 5 specific ifdefs needed by the OSAL
+ADD_DEFINITIONS(-D_RTEMS_5_)
 
 # Info regarding the RELOCADDR:
 #+--------------------------------------------------------------------------+


### PR DESCRIPTION
**Describe the contribution**
Fix #914 
This change makes a minor comment change to the rtems 4.11 i686 toolchain file to remove a reference to CEXP.
The change also adds an RTEMS 5.1 i686 toolchain file.

**Testing performed**
After building the RTEMS 4.11 and RTEMS 5.1 tools and BSPs for the i686, I was able to build the cFS bundle using:
make SIMULATION=i686-rtems-4.11 prep
make install

and

make SIMULATION=i686-rtems-5 prep
make install

and I was able to run the bundle on x86 QEMU according to the instructions in the PSP README.txt file:
https://github.com/nasa/PSP/blob/main/fsw/pc-rtems/README.txt
Note, that PSP ticket 197 and PR 220 have updates to the README.txt files.
Also, this depends on a PR for OSAL (TBD) for issue 608)

**Expected behavior changes**
 - Or no impact to behavior

**System(s) tested on**
 - Hardware: QEMU x86
 - OS: RTEMS
 - Versions: RTEMS 4.11 and RTEMS 5.1

**Additional context**
Requires a fix for OSAL, which is described in OSAL ticket 608. PR will be submitted. But the comment change does not affect current RTEMS 4.11 build.

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Alan Cudmore NASA/GSFC Code 582.0