### PR TITLE
Fix 1034, Atomic type for SystemState

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_global.h
+++ b/fsw/cfe-core/src/es/cfe_es_global.h
@@ -52,6 +52,8 @@
 #include "cfe_evs.h"
 #include "cfe_psp.h"
 
+#include <signal.h>
+
 
 /*
 ** Typedefs
@@ -104,7 +106,7 @@ typedef struct
    /*
    ** Startup Sync
    */
-   uint32  SystemState;
+   volatile sig_atomic_t SystemState;
 
    /*
    ** ES Task Table


### PR DESCRIPTION
**Describe the contribution**
Fix #1034 
- Use volatile sig_atomic_t for system state avoids race issue if uint32 isn't atomic on a system (microcontroller?)

**Testing performed**
Built and ran unit tests, passed.

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC