### PR TITLE
Fix #952, OSAL module flags to permit app reload

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_api.c
+++ b/fsw/cfe-core/src/es/cfe_es_api.c
@@ -1117,12 +1117,9 @@ int32 CFE_ES_GetLibInfo(CFE_ES_AppInfo_t *LibInfo, CFE_ES_ResourceID_t LibId)
 */
 int32 CFE_ES_GetModuleInfo(CFE_ES_AppInfo_t *ModuleInfo, CFE_ES_ResourceID_t ResourceId)
 {
-    uint32 ResourceType;
     int32 Status;
 
-    ResourceType = CFE_ES_ResourceID_ToInteger(ResourceId);
-    ResourceType -= ResourceType & CFE_ES_RESOURCEID_MAX;
-    switch(ResourceType)
+    switch(CFE_ES_ResourceID_GetBase(ResourceId))
     {
     case CFE_ES_APPID_BASE:
         Status = CFE_ES_GetAppInfo(ModuleInfo, ResourceId);

--- a/fsw/cfe-core/src/es/cfe_es_apps.h
+++ b/fsw/cfe-core/src/es/cfe_es_apps.h
@@ -198,7 +198,7 @@ int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens);
 ** This only loads the code and looks up relevent runtime information.
 ** It does not start any tasks.
 */
-int32 CFE_ES_LoadModule(const CFE_ES_ModuleLoadParams_t* LoadParams, CFE_ES_ModuleLoadStatus_t *LoadStatus);
+int32 CFE_ES_LoadModule(CFE_ES_ResourceID_t ResourceId, const CFE_ES_ModuleLoadParams_t* LoadParams, CFE_ES_ModuleLoadStatus_t *LoadStatus);
 
 /*
 ** Internal function to determine the entry point of an app.

--- a/fsw/cfe-core/src/es/cfe_es_resource.h
+++ b/fsw/cfe-core/src/es/cfe_es_resource.h
@@ -55,12 +55,34 @@
 #define CFE_ES_RESOURCEID_MAX   ((1 << CFE_ES_RESOURCEID_SHIFT)-1)
 #define CFE_ES_RESOURCEID_MARK  (0x02000000)
 
+/** 
+ * @defgroup CFEESResourceIDBase ES Resource ID base values 
+ * @{
+ */
 #define CFE_ES_APPID_BASE       (CFE_ES_RESOURCEID_MARK | ((OS_OBJECT_TYPE_USER+1) << CFE_ES_RESOURCEID_SHIFT))
 #define CFE_ES_LIBID_BASE       (CFE_ES_RESOURCEID_MARK | ((OS_OBJECT_TYPE_USER+2) << CFE_ES_RESOURCEID_SHIFT))
 #define CFE_ES_COUNTID_BASE     (CFE_ES_RESOURCEID_MARK | ((OS_OBJECT_TYPE_USER+3) << CFE_ES_RESOURCEID_SHIFT))
 #define CFE_ES_POOLID_BASE      (CFE_ES_RESOURCEID_MARK | ((OS_OBJECT_TYPE_USER+4) << CFE_ES_RESOURCEID_SHIFT))
 #define CFE_ES_CDSBLOCKID_BASE  (CFE_ES_RESOURCEID_MARK | ((OS_OBJECT_TYPE_USER+5) << CFE_ES_RESOURCEID_SHIFT))
+/** @} */
 
+/**
+ * @brief Get the Base value (type/category) from a resource ID value
+ *
+ * This masks out the ID serial number to obtain the base value, which is different
+ * for each resource type.
+ * 
+ * @note The value is NOT shifted or otherwise adjusted.  It should match one of the
+ * defined base values in @ref CFEESResourceIDBase.
+ *
+ * @param[in]   ResourceId   the resource ID to decode
+ * @returns     The base value associated with that ID
+ */
+static inline uint32 CFE_ES_ResourceID_GetBase(CFE_ES_ResourceID_t ResourceId)
+{
+    uint32 ResourceType = CFE_ES_ResourceID_ToInteger(ResourceId);
+    return (ResourceType - (ResourceType & CFE_ES_RESOURCEID_MAX));
+}
 
 /**
  * @brief Locate the next resource ID which does not map to an in-use table entry

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -1389,7 +1389,7 @@ void TestApps(void)
      * cannot be found
      */
     ES_ResetUnitTest();
-    UT_SetDeferredRetcode(UT_KEY(OS_SymbolLookup), 1, -1);
+    UT_SetDeferredRetcode(UT_KEY(OS_ModuleSymbolLookup), 1, -1);
     Return = CFE_ES_AppCreate(&Id,
                               "ut/filename.x",
                               "EntryPoint",
@@ -1405,7 +1405,7 @@ void TestApps(void)
      * cannot be found and module unload fails
      */
     ES_ResetUnitTest();
-    UT_SetDeferredRetcode(UT_KEY(OS_SymbolLookup), 1, -1);
+    UT_SetDeferredRetcode(UT_KEY(OS_ModuleSymbolLookup), 1, -1);
     UT_SetDeferredRetcode(UT_KEY(OS_ModuleUnload), 1, -1);
     Return = CFE_ES_AppCreate(&Id,
                               "ut/filename.x",
@@ -2272,7 +2272,7 @@ void TestLibs(void)
      * entry point symbol cannot be found
      */
     ES_ResetUnitTest();
-    UT_SetDeferredRetcode(UT_KEY(OS_SymbolLookup), 1, -1);
+    UT_SetDeferredRetcode(UT_KEY(OS_ModuleSymbolLookup), 1, -1);
     Return = CFE_ES_LoadLibrary(&Id,
                                 "/cf/apps/tst_lib.bundle",
                                 "TST_LIB_Init",


### PR DESCRIPTION
**Describe the contribution**
Set the flags parameter on the `OS_ModuleLoad()` properly to allow an app to be properly unloaded, which in turn allows the reload command to work as expected.

Fixes #952 

**Testing performed**
Build and run all unit tests
Test CFE app reload procedure:
- Run CFE as normal, confirm unmodified SAMPLE_APP is loaded and running 
- Build a modified SAMPLE_APP that has an additional `OS_printf()` call during startup, and install as `sample_new.so`
- Issue "reload" command (7) via cmdUtil, to reload SAMPLE_APP from `/cf/sample_new.so`
- Confirm that the expected printf message is visible (confirms that the new file was actually loaded)

**Expected behavior changes**
Module unload/reload works as expected on Linux.  Previously the unload would not actually unload, so it would end up restarting the same app code over again.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Needs sync delete fix in OSAL (see nasa/osal#642) to avoid task delete race condition.  Without this OSAL change, the task may still be running at the time CFE ES unloads it, which will likely cause a segfault/crash if that happens.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
