### PR TITLE
Fix #1042, remove use of osapi-os-loader.h

### DIFF
--- a/fsw/cfe-core/unit-test/es_UT.h
+++ b/fsw/cfe-core/unit-test/es_UT.h
@@ -50,7 +50,6 @@
 #include "cfe.h"
 #include "common_types.h"
 #include "osapi.h"
-#include "osapi-os-loader.h"
 #include "cfe_version.h"
 #include "cfe_es.h"
 #include "cfe_es_cds.h"


### PR DESCRIPTION
**Describe the contribution**
Remove use of `osapi-os-loader.h` from ES UT.  This is the only reference to OSAL header other than the standard `osapi.h` and `common_types.h` (which are staying).

Fixes #1042 

**Testing performed**
Build and run unit tests.

**Expected behavior changes**
None.  This header was redundant since it was already including `osapi.h` which has everything.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.