### PR TITLE
Fix #1052, Refactor UT_ClearForceFail to UT_ClearDefaultReturnValue

### DIFF
--- a/fsw/cfe-core/unit-test/ut_support.c
+++ b/fsw/cfe-core/unit-test/ut_support.c
@@ -295,7 +295,7 @@ void UT_SetStatusBSPResetArea(int32 status, uint32 Signature, uint32 ClockSignal
     }
     else
     {
-        UT_ClearForceFail(UT_KEY(CFE_PSP_GetResetArea));
+        UT_ClearDefaultReturnValue(UT_KEY(CFE_PSP_GetResetArea));
     }
 }
 


### PR DESCRIPTION
**Describe the contribution**
Fixes #1052
Rename UT_ClearForceFail to UT_ClearDefaultValue

**Testing performed**
Build and run unit test

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Dependant on nasa/osal#725

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC
