### PR TITLE
fix #1059 - corrects documentation for CFE_SB_GetPipeName() stub

### DIFF
--- a/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
@@ -201,9 +201,9 @@ int32 CFE_SB_DeletePipe(CFE_SB_PipeId_t PipeId)
 **
 ** \par Description
 **        This function is used to mimic the response of the cFE SB function
-**        CFE_SB_GetPipeName.  The user must set the value of UT_pipename prior
-**        to this function being called.  The function uses UT_pipename for the
-**        retrieved pipe name and returns CFE_SUCCESS.
+**        CFE_SB_GetPipeName. The user should set the data buffer using UT_SetDataBuffer
+**        prior to this function being called. Otherwise, the dummy "UT" name will
+**        be copied to PipeNameBuf.
 **
 ** \par Assumptions, External Events, and Notes:
 **        None


### PR DESCRIPTION
**Describe the contribution**
Closes #1059
This corrects the documentation for the CFE_SB_GetPipeName() unit test stub function.

**Testing performed**
Documentation update only.

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov