### PR TITLE
fix #1055 - CFE_SB_ReceiveBuffer stub returns timeout or empty if buffer

### DIFF
--- a/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
@@ -447,8 +447,7 @@ int32 CFE_SB_RcvMsg(CFE_SB_Buffer_t **BufPtr,
 **
 ** \par Description
 **        This function is used to mimic the response of the cFE SB function
-**        CFE_SB_ReceiveBuffer.  By default it will return the TIMEOUT error response,
-**        unless the test setup sequence has indicated otherwise.
+**        CFE_SB_ReceiveBuffer.
 **
 ** \par Assumptions, External Events, and Notes:
 **        None


### PR DESCRIPTION
Closes #1055

This changes the return value returned by the `CFE_SB_ReceiveBuffer()` stub when there has not been a buffer defined.

**Testing performed**
Tested with SB and SBN unit tests.

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov