### PR TITLE
fix #1062 - remove CFE_SB_TimeOut_t typedef

### DIFF
--- a/fsw/cfe-core/src/inc/cfe_sb.h
+++ b/fsw/cfe-core/src/inc/cfe_sb.h
@@ -152,14 +152,6 @@ typedef CFE_MSG_TelemetryHeader_t CFE_SB_TlmHdr_t;
 #define CFE_SB_TLM_HDR_SIZE     (sizeof(CFE_MSG_TelemetryHeader_t))/**< \brief Size of telemetry header */
 #endif /* CFE_OMIT_DEPRECATED_6_8 */
 
-/** \brief  CFE_SB_TimeOut_t to primitive type definition
-**
-** Internally used by SB in the #CFE_SB_ReceiveBuffer API. Translated from the
-** input parmater named TimeOut which specifies the maximum time in
-** milliseconds that the caller wants to wait for a message.
-*/
-typedef uint32 CFE_SB_TimeOut_t;
-
 /** \brief  CFE_SB_PipeId_t to primitive type definition
 **
 ** Software Bus pipe identifier used in many SB APIs

--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -1891,7 +1891,7 @@ int32 CFE_SB_ZeroCopyPass(CFE_SB_Buffer_t        *BufPtr,
 
 int32  CFE_SB_ReadQueue (CFE_SB_PipeD_t         *PipeDscPtr,
                          CFE_ES_ResourceID_t    TskId,
-                         CFE_SB_TimeOut_t       Time_Out,
+                         uint32                 Time_Out,
                          CFE_SB_BufferD_t       **Message)
 {
     int32              Status,TimeOut;

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.h
@@ -239,7 +239,7 @@ void   CFE_SB_LockSharedData(const char *FuncName, int32 LineNumber);
 void   CFE_SB_UnlockSharedData(const char *FuncName, int32 LineNumber);
 void   CFE_SB_ReleaseBuffer (CFE_SB_BufferD_t *bd, CFE_SB_DestinationD_t *dest);
 int32  CFE_SB_ReadQueue(CFE_SB_PipeD_t *PipeDscPtr,CFE_ES_ResourceID_t TskId,
-                        CFE_SB_TimeOut_t Time_Out,CFE_SB_BufferD_t **Message );
+                        uint32 Time_Out,CFE_SB_BufferD_t **Message );
 int32  CFE_SB_WriteQueue(CFE_SB_PipeD_t *pd,uint32 TskId,
                          const CFE_SB_BufferD_t *bd,CFE_SB_MsgId_t MsgId );
 uint8  CFE_SB_GetPipeIdx(CFE_SB_PipeId_t PipeId);


### PR DESCRIPTION
Closes #1062 

**Describe the contribution**
Removes the spurious CFE_SB_TimeOut_t typedef from cfe_sb.h

**Testing performed**
SB unit test

**Expected behavior changes**
None, may affect any apps that rely on the typedef (which they probably haven't done, given that no public API's use it.)

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov