### PR TITLE
cFE Integration Candidate: 2021-01-05

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,54 @@
+name: Static Analysis
+
+# Run this workflow every time a new commit pushed to your repository
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+
+  static-analysis:
+    name: Run cppcheck
+    runs-on: ubuntu-18.04
+
+    strategy:
+      fail-fast: false
+      matrix:
+        cppcheck: [all, cfe]
+
+    steps:
+
+      - name: Install cppcheck
+        run: sudo apt-get install cppcheck -y
+
+        # Checks out a copy of the cfs bundle
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Run bundle cppcheck
+        if: ${{matrix.cppcheck =='all'}}
+        run: cppcheck --force --inline-suppr --quiet . 2> ${{matrix.cppcheck}}_cppcheck_err.txt
+
+        # Run strict static analysis for embedded portions of cfe
+      - name: cfe strict cppcheck
+        if: ${{matrix.cppcheck =='cfe'}}
+        run: |
+          cppcheck --force --inline-suppr --std=c99 --language=c --enable=warning,performance,portability,style --suppress=variableScope --inconclusive ./fsw/cfe-core/src ./modules 2> ./${{matrix.cppcheck}}_cppcheck_err.txt
+
+      - name: Archive Static Analysis Artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{matrix.cppcheck}}-cppcheck-err
+          path: ./*cppcheck_err.txt
+
+      - name: Check for errors
+        run: |
+          if [[ -s ${{matrix.cppcheck}}_cppcheck_err.txt ]];
+          then
+            cat ${{matrix.cppcheck}}_cppcheck_err.txt
+            exit -1
+          fi

--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ The detailed cFE user's guide can be viewed at <https://github.com/nasa/cFS/blob
 
 ## Version History
 
+### Development Build: 6.8.0-rc1+dev236
+
+- Resolved doxygen warnings for osalguide and updated header file references
+- Corrects the documentation for the CFE_SB_GetPipeName() unit test stub function.
+- Adds a new github actions workflow file to run cppcheck
+- See <https://github.com/nasa/cFE/pull/1066>
+
 ### Development Build: 6.8.0-rc1+dev228
 
 - Remove use of `osapi-os-loader.h` from ES UT.

--- a/docs/src/osalmain.dox
+++ b/docs/src/osalmain.dox
@@ -6,27 +6,37 @@
     <UL>
        <LI> \subpage osalIntro
     </UL>
-    <LI> Core OS Module
+    <LI> Core
     <UL>
       <LI> \ref OSReturnCodes
       <LI> \ref OSObjectTypes
-      <LI> \ref OSSemaphoreStates
       <LI> APIs
       <UL>
         <LI> \ref OSAPICore
         <LI> \ref OSAPIObjUtil
         <LI> \ref OSAPITask
         <LI> \ref OSAPIMsgQueue
-        <LI> \ref OSAPISem
-        <LI> \ref OSAPITime
         <LI> \ref OSAPIHeap
         <LI> \ref OSAPIError
         <LI> \ref OSAPISelect
         <LI> \ref OSAPIPrintf
+        <LI> \ref OSAPIBsp
+        <LI> \ref OSAPIClock
+        <LI> \ref OSAPIShell
       </UL>
-      <LI> \subpage osapi-os-core.h "Core OS Module Reference"
+      <LI> \subpage osapi-common.h "Common Reference"
+      <LI> \subpage osapi-error.h "Return Code Reference"
+      <LI> \subpage osapi-idmap.h "Id Map Reference"
+      <LI> \subpage osapi-clock.h "Clock Reference"
+      <LI> \subpage osapi-task.h "Task Reference"
+      <LI> \subpage osapi-queue.h "Message Queue Reference"
+      <LI> \subpage osapi-heap.h "Heap Reference"
+      <LI> \subpage osapi-select.h "Select Reference"
+      <LI> \subpage osapi-printf.h "Printf Reference"
+      <LI> \subpage osapi-bsp.h "BSP Reference"
+      <LI> \subpage osapi-shell.h "Shell Reference"
     </UL>
-    <LI> OS File System
+    <LI> File System
     <UL>
       <LI> \subpage osalfsovr
       <LI> \subpage osalfsfd
@@ -37,9 +47,10 @@
         <LI> \ref OSAPIFile
         <LI> \ref OSAPIDir
         <LI> \ref OSAPIFileSys
-        <LI> \ref OSAPIShell
       </UL>
-      <LI> \subpage osapi-os-filesys.h "File System Module Reference"
+      <LI> \subpage osapi-filesys.h "File System Reference"
+      <LI> \subpage osapi-file.h "File Reference"
+      <LI> \subpage osapi-dir.h "Directory Reference"
     </UL>
     <LI> Object File Loader
     <UL>
@@ -47,25 +58,42 @@
       <UL>
         <LI> \ref OSAPILoader
       </UL>
-      <LI> \subpage osapi-os-loader.h "File Loader Module Reference"
+      <LI> \subpage osapi-module.h "File Loader Reference"
     </UL>
-    <LI> Network Module
+    <LI> Network
     <UL>
       <LI> APIs
       <UL>
+        <LI> \ref OSALAPINetwork
         <LI> \ref OSAPISocketAddr
         <LI> \ref OSALAPISocket
       </UL>
-      <LI> \subpage osapi-os-net.h "Network Module Reference"
+      <LI> \subpage osapi-network.h "Network Reference"
+      <LI> \subpage osapi-sockets.h "Socket Reference"
     </UL>
     <LI> Timer
     <UL>
       <LI> \subpage osaltimerover
       <LI> APIs
       <UL>
+        <LI> \ref OSAPITimebase
         <LI> \ref OSAPITimer
       </UL>
-      <LI> \subpage osapi-os-timer.h "Timer Module Reference"
+      <LI> \subpage osapi-timer.h "Timer Reference"
+      <LI> \subpage osapi-timebase.h "Time Base Reference"
+    </UL>
+    <LI> Semaphore and Mutex
+    <UL>
+      <LI> \ref OSSemaphoreStates
+      <LI> APIs
+      <UL>
+        <LI> \ref OSAPIBinSem
+        <LI> \ref OSAPICountSem
+        <LI> \ref OSAPIMutex
+      </UL>
+      <LI> \subpage osapi-binsem.h "Binary Semaphore Reference"
+      <LI> \subpage osapi-countsem.h "Counting Semaphore Reference"
+      <LI> \subpage osapi-mutex.h "Mutex Reference"
     </UL>
   </UL>
 **/

--- a/fsw/cfe-core/src/inc/cfe_version.h
+++ b/fsw/cfe-core/src/inc/cfe_version.h
@@ -35,7 +35,7 @@
 
 
 /* Development Build Macro Definitions */
-#define CFE_BUILD_NUMBER 228 /*!< Development Build: Number of commits since baseline */
+#define CFE_BUILD_NUMBER 236 /*!< Development Build: Number of commits since baseline */
 #define CFE_BUILD_BASELINE "v6.8.0-rc1" /*!< Development Build: git tag that is the base for the current development */
 
 /* Version Macro Definitions */

--- a/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
@@ -201,9 +201,9 @@ int32 CFE_SB_DeletePipe(CFE_SB_PipeId_t PipeId)
 **
 ** \par Description
 **        This function is used to mimic the response of the cFE SB function
-**        CFE_SB_GetPipeName.  The user must set the value of UT_pipename prior
-**        to this function being called.  The function uses UT_pipename for the
-**        retrieved pipe name and returns CFE_SUCCESS.
+**        CFE_SB_GetPipeName. The user should set the data buffer using UT_SetDataBuffer
+**        prior to this function being called. Otherwise, the dummy "UT" name will
+**        be copied to PipeNameBuf.
 **
 ** \par Assumptions, External Events, and Notes:
 **        None


### PR DESCRIPTION
**Describe the contribution**

Fix #1054, Resolve osal guide generation warnings
Fix #1059, Corrects documentation for CFE_SB_GetPipeName() stub
Fix #1064, Add cppcheck GitHub Actions workflow 

**Testing performed**
Github Actions Run <https://github.com/nasa/cFS/pull/172/checks>

**Expected behavior changes**
PR #1056 - Resolved doxygen warnings osalguide and updated header file references

PR #1060 - Corrects the documentation for the `CFE_SB_GetPipeName()` unit test stub function.

PR #1065 - Adds a new github actions workflow file to run cppcheck

**System(s) tested on**
Ubuntu 18.04

**Additional context**
Part of <https://github.com/nasa/cFS/pull/172>

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
@astrogeco 
@CDKnightNASA 
@skliper 