### PR TITLE
Fix #1070, patch PSP include directory reference

### DIFF
--- a/cmake/arch_build.cmake
+++ b/cmake/arch_build.cmake
@@ -62,7 +62,7 @@ endfunction(initialize_globals)
 function(add_psp_module MOD_NAME MOD_SRC_FILES)
 
   # Include the PSP shared directory so it can get to cfe_psp_module.h
-  include_directories(${MISSION_SOURCE_DIR}/psp/fsw/shared)
+  include_directories(${MISSION_SOURCE_DIR}/psp/fsw/shared/inc)
   add_definitions(-D_CFE_PSP_MODULE_)
   
   # Create the module


### PR DESCRIPTION
**Describe the contribution**

The PSP header files are located in fsw/shared/inc, not fsw/shared.
This corrects the reference.

Fixes #1070

**Testing performed**
Modify local config to use "eeprom_stub" PSP module to implement eeprom functions, which reproduces the build failure - I confirmed the error with respect to `#include "cfe_psp.h"`

With this patch applied, the build succeeds again.

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu 20.04

**Additional context**
This PR is based on Bootes RC2 as the bug exists there, recommend to patch it in prior to final release.
Should also merge this forward to `main` as the bug exists there too and this is the easiest short term fix.
Longer term fix should be #626 to prevent this type of issue from recurring.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
