### PR TITLE
Fix #1074, Refactor CFE_TIME_RegisterSynchCallback

### DIFF
--- a/fsw/cfe-core/src/time/cfe_time_api.c
+++ b/fsw/cfe-core/src/time/cfe_time_api.c
@@ -765,21 +765,20 @@ int32  CFE_TIME_RegisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPt
     if (Status == CFE_SUCCESS)
     {
         Status = CFE_ES_AppID_ToIndex(AppId, &AppIndex);
-    }
-    if (Status != CFE_SUCCESS)
-    {
-        /* Called from an invalid context */
-        return Status;
-    }
 
-    if (AppIndex >= (sizeof(CFE_TIME_TaskData.SynchCallback) / sizeof(CFE_TIME_TaskData.SynchCallback[0])) ||
-        CFE_TIME_TaskData.SynchCallback[AppIndex].Ptr != NULL)
-    {
-        Status = CFE_TIME_TOO_MANY_SYNCH_CALLBACKS;
-    }
-    else
-    {
-        CFE_TIME_TaskData.SynchCallback[AppIndex].Ptr = CallbackFuncPtr;
+        if (Status == CFE_SUCCESS)
+        {
+
+            if (AppIndex >= (sizeof(CFE_TIME_TaskData.SynchCallback) / sizeof(CFE_TIME_TaskData.SynchCallback[0])) ||
+                CFE_TIME_TaskData.SynchCallback[AppIndex].Ptr != NULL)
+            {
+                Status = CFE_TIME_TOO_MANY_SYNCH_CALLBACKS;
+            }
+            else
+            {
+                CFE_TIME_TaskData.SynchCallback[AppIndex].Ptr = CallbackFuncPtr;
+            }
+        }
     }
     
     return Status;


### PR DESCRIPTION
**Describe the contribution**
Fix #1074 
- One return point
- Eliminates "possible uninitialized variable" static analysis warning

**Testing performed**
Standard build, unit test

**Expected behavior changes**
None except eliminates static analysis warning

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
Partially just a conversation starter - do we want to avoid (invalid) warnings w/ similar refactors? Alternatively we could just ignore/repress the warnings.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC