### PR TITLE
Fix #449, Add OS_printf to CFE_ES_SYSLOG_APPEND

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_log.h
+++ b/fsw/cfe-core/src/es/cfe_es_log.h
@@ -105,6 +105,7 @@
             CFE_ES_LockSharedData(__func__, __LINE__);      \
             CFE_ES_SysLogAppend_Unsync(LogString);          \
             CFE_ES_UnlockSharedData(__func__, __LINE__);    \
+            OS_printf("%s", LogString);                     \
         }
 
 


### PR DESCRIPTION
**Describe the contribution**
Fix #449 - added OS_printf to CFE_ES_SYSLOG_APPEND so it behaves the same as CFE_ES_WriteToSysLog 

**Testing performed**
Built unit tests and confirmed CFE_ES_SYSLOG_APPEND calls OS_printf (observed outputs)

**Expected behavior changes**
CFE_ES_SYSLOG_APPEND will OS_print the message

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
nasa/osal#747 was submitted to see the OS_print in debug of unit tests

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC