### PR TITLE
Fix #488, Pad msg headers to 64 bit

### DIFF
--- a/modules/msg/mission_inc/default_cfe_msg_hdr_pri.h
+++ b/modules/msg/mission_inc/default_cfe_msg_hdr_pri.h
@@ -82,6 +82,7 @@ typedef struct
 
     CFE_MSG_Message_t                  Msg; /**< \brief Base message */
     CFE_MSG_TelemetrySecondaryHeader_t Sec; /**< \brief Secondary header */
+    uint8                              Spare[4]; /**< \brief Padding to end on 64 bit boundary */
 
 } CFE_MSG_TelemetryHeader_t;
 

--- a/modules/msg/mission_inc/default_cfe_msg_hdr_priext.h
+++ b/modules/msg/mission_inc/default_cfe_msg_hdr_priext.h
@@ -72,6 +72,7 @@ typedef struct
 
     CFE_MSG_Message_t                Msg; /**< \brief Base message */
     CFE_MSG_CommandSecondaryHeader_t Sec; /**< \brief Secondary header */
+    uint8                            Spare[4]; /**< /brief Padding to end on 64 bit boundary */
 
 } CFE_MSG_CommandHeader_t;
 


### PR DESCRIPTION
**Describe the contribution**
Fix #488 - pads headers to 64-bit so that CFE_SB_GetUserData will work for message structures with elements up to 64 bit

**Testing performed**
Added #903 (to catch errors from CFE_SB_GetUserData), built unit tests for both primary only and primary + extended headers, passed.

**Expected behavior changes**
For primary only config - telemetry header required to 64 bit boundary (affects all receivers)
For primary + extended config - command header required padding to 64 bit boundary (affects all senders)

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + #903 (only required for testing) + this commit

**Additional context**
Will require updates in cFS-GroundSystem, both cmdUtil, and cmd/tlm from the GUI

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC