### PR TITLE
Fix #1081, Correct deprecation directive typo

### DIFF
--- a/fsw/cfe-core/src/inc/cfe_sb.h
+++ b/fsw/cfe-core/src/inc/cfe_sb.h
@@ -646,7 +646,7 @@ CFE_Status_t  CFE_SB_PassMsg(CFE_MSG_Message_t *MsgPtr);
 **/
 CFE_Status_t CFE_SB_ReceiveBuffer(CFE_SB_Buffer_t **BufPtr, CFE_SB_PipeId_t PipeId, int32 TimeOut);
 
-#if CFE_OMIT_DEPRECATED_6_8
+#ifndef CFE_OMIT_DEPRECATED_6_8
 /**
  * \brief DEPRECATED: receive buffer
  * \deprecated use CFE_SB_ReceiveBuffer

--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -1455,7 +1455,7 @@ int32  CFE_SB_TransmitBufferFull(CFE_SB_BufferD_t *BufDscPtr,
 
 }
 
-#if CFE_OMIT_DEPRECATED_6_8
+#ifndef CFE_OMIT_DEPRECATED_6_8
 int32 CFE_SB_RcvMsg(CFE_SB_Buffer_t **BufPtr,
                     CFE_SB_PipeId_t   PipeId,
                     int32             TimeOut)


### PR DESCRIPTION
**Describe the contribution**
Fix #1081 - fixed 2 deprecation directive typos

**Testing performed**
Standard build and unit test

**Expected behavior changes**
Deprecation of CFE_SB_RcvMsg works correctly (won't show up if CFE_OMIT_DEPRECATED_6_8 is defined)

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this change

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC