### PR TITLE
Fix #877, Remove duplicate CFE_MISSION_REV define

### DIFF
--- a/cmake/sample_defs/cpu1_platform_cfg.h
+++ b/cmake/sample_defs/cpu1_platform_cfg.h
@@ -1814,21 +1814,6 @@
 #define CFE_PLATFORM_TBL_VALID_PRID_3            0
 #define CFE_PLATFORM_TBL_VALID_PRID_4            0
 
-/** \cfeescfg Mission specific version number for cFE
-**
-**  \par Description:
-**       The cFE version number consists of four parts:
-**       major version number, minor version number, revision
-**       number and mission specific revision number. The mission
-**       specific revision number is defined here and the other
-**       parts are defined in "cfe_version.h".
-**
-**  \par Limits:
-**       Must be defined as a numeric value that is greater than
-**       or equal to zero.
-*/
-#define CFE_MISSION_REV                  0
-
 /** \cfeescfg Poll timer for startup sync delay
 **
 **  \par Description:


### PR DESCRIPTION
**Describe the contribution**
Fix #877 - removed CFE_MISSION_REV from platform config.  Intent of this rev is to track mission cFE FSW mods/customization/code changes not as a more generic "MISSION" revision number.

**Testing performed**
Nominal build and run of unit tests

**Expected behavior changes**
None, although if CFE_MISSION_REV was being utilized somewhere and included from cpu1_platform_cfg.h this will break.  Arguably this was broken before removal also since it was a duplicate define...

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC