### PR TITLE
Fix #901, Remove UT_CheckForOpenSockets references

### DIFF
--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -155,8 +155,6 @@ void UtTest_Setup(void)
 */
 void SB_ResetUnitTest(void)
 {
-    /* If any sockets were left open then report and close them */
-    UT_CheckForOpenSockets();
     UT_InitData();
     CFE_SB_EarlyInit();
 } /* end SB_ResetUnitTest */

--- a/fsw/cfe-core/unit-test/ut_support.h
+++ b/fsw/cfe-core/unit-test/ut_support.h
@@ -573,23 +573,6 @@ void UT_DisplayPkt(CFE_MSG_Message_t *MsgPtr, size_t size);
 
 /*****************************************************************************/
 /**
-** \brief Report and close any sockets found open
-**
-** \par Description
-**        Determine if any sockets are open; if so, close them.  If UT_VERBOSE
-**        is defined then output the socket status to the test log file.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-**
-******************************************************************************/
-void UT_CheckForOpenSockets(void);
-
-/*****************************************************************************/
-/**
 ** \brief Gets a reference to the CFE ES Reset Data Object
 **
 ** \par Description


### PR DESCRIPTION
**Describe the contribution**
Fix #901 - removes all references to UT_CheckForOpenSockets.  No longer applicable since the UT framework resets the state for each unit test.

**Testing performed**
Built and ran unit tests, passed.

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
See also nasa/osal#753

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC