### PR TITLE
Fix #1090, UT event check bounds

### DIFF
--- a/fsw/cfe-core/unit-test/tbl_UT.c
+++ b/fsw/cfe-core/unit-test/tbl_UT.c
@@ -2807,7 +2807,7 @@ void Test_CFE_TBL_Load(void)
     RtnCode = CFE_TBL_Load(App1TblHandle2,
                            CFE_TBL_SRC_FILE,
                            "TblSrcFileName.dat");
-    EventsCorrect = (UT_EventIsInHistory(CFE_SUCCESS) == true &&
+    EventsCorrect = (UT_EventIsInHistory(CFE_TBL_LOAD_TBLNAME_MISMATCH_ERR_EID) == true &&
                      UT_GetNumEventsSent() == 1);
     UT_Report(__FILE__, __LINE__,
               RtnCode == CFE_TBL_ERR_FILE_FOR_WRONG_TABLE && EventsCorrect,
@@ -2846,7 +2846,7 @@ void Test_CFE_TBL_Load(void)
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(Test_CFE_TBL_ValidationFunc), 1, -1);
     RtnCode = CFE_TBL_Load(App1TblHandle1, CFE_TBL_SRC_ADDRESS, &TestTable1);
-    EventsCorrect = (UT_EventIsInHistory(CFE_SUCCESS) == true &&
+    EventsCorrect = (UT_EventIsInHistory(CFE_TBL_VALIDATION_ERR_EID) == true &&
                      UT_GetNumEventsSent() == 1);
     UT_Report(__FILE__, __LINE__,
               RtnCode == -1 && EventsCorrect,
@@ -2859,7 +2859,7 @@ void Test_CFE_TBL_Load(void)
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(Test_CFE_TBL_ValidationFunc), 1, 1);
     RtnCode = CFE_TBL_Load(App1TblHandle1, CFE_TBL_SRC_ADDRESS, &TestTable1);
-    EventsCorrect = (UT_EventIsInHistory(CFE_SUCCESS) == true &&
+    EventsCorrect = (UT_EventIsInHistory(CFE_TBL_LOAD_VAL_ERR_EID) == true &&
                      UT_GetNumEventsSent() == 2);
     UT_Report(__FILE__, __LINE__,
               RtnCode == -1 && EventsCorrect,

--- a/fsw/cfe-core/unit-test/ut_support.c
+++ b/fsw/cfe-core/unit-test/ut_support.c
@@ -399,6 +399,7 @@ static bool UT_CheckEventHistoryFromFunc(UT_EntryKey_t Func, uint16 EventIDToSea
     UT_GetDataBuffer(Func, (void**)&EvBuf, &MaxSize, &Position);
     if (EvBuf != NULL && MaxSize > 0)
     {
+        Position /= sizeof(*EvBuf);
         while (Position > 0)
         {
             if (*EvBuf == EventIDToSearchFor)


### PR DESCRIPTION
**Describe the contribution**

Fixes `UT_CheckEventHistoryFromFunc()` helper routine to read the correct number of IDs.  Divide the "position" (in bytes) by the size of the event IDs to get the number of events.

Also correct bad event checks in TBL UT.

Fixes #1090

**Testing performed**
Build and run all unit tests

**Expected behavior changes**
UT_CheckEventHistoryFromFunc() works properly now.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Only Unit test is affected, no FSW

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

