### PR TITLE
Fix #932 and #1089, strncpy cleanup and UT updates for mission sizing of API_LEN and PATH_LEN

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_api.c
+++ b/fsw/cfe-core/src/es/cfe_es_api.c
@@ -871,7 +871,7 @@ int32 CFE_ES_GetAppName(char *AppName, CFE_ES_ResourceID_t AppId, size_t BufferL
     */
    if (CFE_ES_AppRecordIsMatch(AppRecPtr, AppId))
    {
-       strncpy(AppName, CFE_ES_AppRecordGetName(AppRecPtr), BufferLength);
+       strncpy(AppName, CFE_ES_AppRecordGetName(AppRecPtr), BufferLength - 1);
        AppName[BufferLength - 1] = '\0';
        Result = CFE_SUCCESS;
    }
@@ -1306,8 +1306,8 @@ int32 CFE_ES_CreateChildTask(CFE_ES_ResourceID_t *TaskIdPtr,
 
                CFE_ES_TaskRecordSetUsed(TaskRecPtr, ChildTaskId);
                TaskRecPtr->AppId = CFE_ES_AppRecordGetID(AppRecPtr);
-               strncpy((char *)TaskRecPtr->TaskName,TaskName,OS_MAX_API_NAME);
-               TaskRecPtr->TaskName[OS_MAX_API_NAME - 1] = '\0';
+               strncpy(TaskRecPtr->TaskName,TaskName,sizeof(TaskRecPtr->TaskName) - 1);
+               TaskRecPtr->TaskName[sizeof(TaskRecPtr->TaskName) - 1] = '\0';
                CFE_ES_Global.RegisteredTasks++;
 
                *TaskIdPtr = ChildTaskId;
@@ -1737,8 +1737,8 @@ int32 CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *CDSHandlePtr, size_t BlockSize, con
 
            /* Perform a buffer overrun safe copy of name for debug log message */
 
-           strncpy(CDSName, Name, CFE_MISSION_ES_CDS_MAX_NAME_LENGTH);
-           CDSName[CFE_MISSION_ES_CDS_MAX_NAME_LENGTH-1] = '\0';
+           strncpy(CDSName, Name, sizeof(CDSName) - 1);
+           CDSName[sizeof(CDSName) - 1] = '\0';
            CFE_ES_WriteToSysLog("CFE_CDS:Register-CDS Name (%s) is too long\n", CDSName);
         }
         else
@@ -1925,7 +1925,8 @@ int32 CFE_ES_RegisterGenCounter(CFE_ES_ResourceID_t *CounterIdPtr, const char *C
        else
        {
            strncpy(CountRecPtr->CounterName,CounterName,
-                   sizeof(CountRecPtr->CounterName));
+                   sizeof(CountRecPtr->CounterName) - 1);
+           CountRecPtr->CounterName[sizeof(CountRecPtr->CounterName) - 1] = '\0';
            CountRecPtr->Counter = 0;
            CFE_ES_CounterRecordSetUsed(CountRecPtr, PendingCounterId);
            CFE_ES_Global.LastCounterId = PendingCounterId;

--- a/fsw/cfe-core/src/es/cfe_es_apps.c
+++ b/fsw/cfe-core/src/es/cfe_es_apps.c
@@ -707,12 +707,16 @@ int32 CFE_ES_AppCreate(CFE_ES_ResourceID_t *ApplicationIdPtr,
            AppRecPtr->Type = CFE_ES_AppType_EXTERNAL;
            strncpy(AppRecPtr->StartParams.BasicInfo.Name, AppName,
                    sizeof(AppRecPtr->StartParams.BasicInfo.Name)-1);
+           AppRecPtr->StartParams.BasicInfo.Name[sizeof(AppRecPtr->StartParams.BasicInfo.Name)-1] = '\0';
            strncpy(AppRecPtr->StartParams.BasicInfo.FileName, FileName,
                    sizeof(AppRecPtr->StartParams.BasicInfo.FileName)-1);
+           AppRecPtr->StartParams.BasicInfo.FileName[sizeof(AppRecPtr->StartParams.BasicInfo.FileName)-1] = '\0';
            if (EntryPointName != NULL && strcmp(EntryPointName, "NULL") != 0)
            {
                strncpy(AppRecPtr->StartParams.BasicInfo.EntryPoint, EntryPointName,
                        sizeof(AppRecPtr->StartParams.BasicInfo.EntryPoint)-1);
+               AppRecPtr->StartParams.BasicInfo.EntryPoint[
+                       sizeof(AppRecPtr->StartParams.BasicInfo.EntryPoint)-1] = '\0';
            }
 
            AppRecPtr->StartParams.StackSize = StackSize;
@@ -883,12 +887,15 @@ int32 CFE_ES_LoadLibrary(CFE_ES_ResourceID_t       *LibraryIdPtr,
             */
            strncpy(LibSlotPtr->BasicInfo.Name, LibName,
                    sizeof(LibSlotPtr->BasicInfo.Name)-1);
+           LibSlotPtr->BasicInfo.Name[sizeof(LibSlotPtr->BasicInfo.Name)-1] = '\0';
            strncpy(LibSlotPtr->BasicInfo.FileName, FileName,
                    sizeof(LibSlotPtr->BasicInfo.FileName)-1);
+           LibSlotPtr->BasicInfo.FileName[sizeof(LibSlotPtr->BasicInfo.FileName)-1] = '\0';
            if (EntryPointName != NULL && strcmp(EntryPointName, "NULL") != 0)
            {
               strncpy(LibSlotPtr->BasicInfo.EntryPoint, EntryPointName,
                       sizeof(LibSlotPtr->BasicInfo.EntryPoint)-1);
+              LibSlotPtr->BasicInfo.EntryPoint[sizeof(LibSlotPtr->BasicInfo.EntryPoint)-1] = '\0';
            }
 
            CFE_ES_LibRecordSetUsed(LibSlotPtr, CFE_ES_RESOURCEID_RESERVED);

--- a/fsw/cfe-core/src/es/cfe_es_erlog.c
+++ b/fsw/cfe-core/src/es/cfe_es_erlog.c
@@ -139,7 +139,8 @@ int32 CFE_ES_WriteToERLogWithContext( CFE_ES_LogEntryType_Enum_t EntryType,   ui
    /*
    ** Copy the Description string to the log.
    */
-   strncpy(EntryPtr->BaseInfo.Description, Description, sizeof(EntryPtr->BaseInfo.Description));
+   strncpy(EntryPtr->BaseInfo.Description, Description, sizeof(EntryPtr->BaseInfo.Description) - 1);
+   EntryPtr->BaseInfo.Description[sizeof(EntryPtr->BaseInfo.Description) - 1] = '\0';
 
    /*
     * Store the context info (if any)

--- a/fsw/cfe-core/src/es/cfe_es_start.c
+++ b/fsw/cfe-core/src/es/cfe_es_start.c
@@ -769,6 +769,7 @@ void  CFE_ES_CreateObjects(void)
                 AppRecPtr->Type = CFE_ES_AppType_CORE;
                 strncpy(AppRecPtr->StartParams.BasicInfo.Name, CFE_ES_ObjectTable[i].ObjectName,
                         sizeof(AppRecPtr->StartParams.BasicInfo.Name)-1);
+                AppRecPtr->StartParams.BasicInfo.Name[sizeof(AppRecPtr->StartParams.BasicInfo.Name)-1] = '\0';
 
                 /* FileName and EntryPoint is not valid for core apps */
                 AppRecPtr->StartParams.StackSize = CFE_ES_ObjectTable[i].ObjectSize;

--- a/fsw/cfe-core/src/es/cfe_es_task.c
+++ b/fsw/cfe-core/src/es/cfe_es_task.c
@@ -217,15 +217,6 @@ int32 CFE_ES_TaskInit(void)
     CFE_ES_TaskData.CommandErrorCounter = 0;
 
     /*
-    ** Initialize task configuration data
-    */
-    strcpy(CFE_ES_TaskData.PipeName, "ES_CMD_PIPE");
-    CFE_ES_TaskData.PipeDepth = 12;
-
-    CFE_ES_TaskData.LimitHK   = 2;
-    CFE_ES_TaskData.LimitCmd  = 4;
-
-    /*
     ** Initialize systemlog to default Power On or Processor Reset mode
     */
     if (CFE_ES_GetResetType(NULL) == CFE_PSP_RST_TYPE_POWERON)                                                                   
@@ -271,7 +262,7 @@ int32 CFE_ES_TaskInit(void)
     /*
     ** Create Software Bus message pipe
     */
-    Status = CFE_SB_CreatePipe(&CFE_ES_TaskData.CmdPipe, CFE_ES_TaskData.PipeDepth, CFE_ES_TaskData.PipeName);
+    Status = CFE_SB_CreatePipe(&CFE_ES_TaskData.CmdPipe, CFE_ES_PIPE_DEPTH, CFE_ES_PIPE_NAME);
     if ( Status != CFE_SUCCESS )
     {
         CFE_ES_WriteToSysLog("ES:Cannot Create SB Pipe, RC = 0x%08X\n", (unsigned int)Status);
@@ -282,7 +273,7 @@ int32 CFE_ES_TaskInit(void)
     ** Subscribe to Housekeeping request commands
     */
     Status = CFE_SB_SubscribeEx(CFE_SB_ValueToMsgId(CFE_ES_SEND_HK_MID), CFE_ES_TaskData.CmdPipe,
-                                CFE_SB_Default_Qos, CFE_ES_TaskData.LimitHK);
+                                CFE_SB_Default_Qos, CFE_ES_LIMIT_HK);
     if ( Status != CFE_SUCCESS )
     {
         CFE_ES_WriteToSysLog("ES:Cannot Subscribe to HK packet, RC = 0x%08X\n", (unsigned int)Status);
@@ -293,7 +284,7 @@ int32 CFE_ES_TaskInit(void)
     ** Subscribe to ES task ground command packets
     */
     Status = CFE_SB_SubscribeEx(CFE_SB_ValueToMsgId(CFE_ES_CMD_MID), CFE_ES_TaskData.CmdPipe,
-                                CFE_SB_Default_Qos, CFE_ES_TaskData.LimitCmd);
+                                CFE_SB_Default_Qos, CFE_ES_LIMIT_CMD);
     if ( Status != CFE_SUCCESS )
     {
         CFE_ES_WriteToSysLog("ES:Cannot Subscribe to ES ground commands, RC = 0x%08X\n", (unsigned int)Status);

--- a/fsw/cfe-core/src/es/cfe_es_task.h
+++ b/fsw/cfe-core/src/es/cfe_es_task.h
@@ -47,6 +47,11 @@
 
 /*************************************************************************/
 
+#define CFE_ES_PIPE_NAME  "ES_CMD_PIPE"
+#define CFE_ES_PIPE_DEPTH 12
+#define CFE_ES_LIMIT_HK   2
+#define CFE_ES_LIMIT_CMD  4
+
 /*
 ** ES File descriptions
 */
@@ -123,9 +128,6 @@ typedef struct
   /*
   ** ES Task initialization data (not reported in housekeeping)
   */
-  char                  PipeName[OS_MAX_API_NAME];
-  uint16                PipeDepth;
-
   uint8                 LimitHK;
   uint8                 LimitCmd;
 

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.c
@@ -346,10 +346,10 @@ char *CFE_SB_GetAppTskName(CFE_ES_ResourceID_t TaskId,char *FullName){
     }else{
 
       /* AppName and TskName buffers and strncpy are needed to limit string sizes */
-      strncpy(AppName,(char *)ptr->AppName,OS_MAX_API_NAME-1);
-      AppName[OS_MAX_API_NAME-1] = '\0';
-      strncpy(TskName,(char *)ptr->TaskName,OS_MAX_API_NAME-1);
-      TskName[OS_MAX_API_NAME-1] = '\0';
+      strncpy(AppName,(char *)ptr->AppName,sizeof(AppName)-1);
+      AppName[sizeof(AppName)-1] = '\0';
+      strncpy(TskName,(char *)ptr->TaskName,sizeof(TskName)-1);
+      TskName[sizeof(TskName)-1] = '\0';
 
       sprintf(FullName,"%s.%s",AppName,TskName);
 

--- a/fsw/cfe-core/src/tbl/cfe_tbl_api.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_api.c
@@ -81,8 +81,8 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
             Status = CFE_TBL_ERR_INVALID_NAME;
 
             /* Perform a buffer overrun safe copy of name for debug log message */
-            strncpy(TblName, Name, CFE_MISSION_TBL_MAX_NAME_LENGTH);
-            TblName[CFE_MISSION_TBL_MAX_NAME_LENGTH-1] = '\0';
+            strncpy(TblName, Name, sizeof(TblName) - 1);
+            TblName[sizeof(TblName) - 1] = '\0';
             CFE_ES_WriteToSysLog("CFE_TBL:Register-Table Name (%s) is bad length (%d)",TblName,(int)NameLen);
         }
         else
@@ -314,7 +314,8 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
                     RegRecPtr->ValidationFuncPtr = TblValidationFuncPtr;
 
                     /* Save Table Name in Registry */
-                    strncpy(RegRecPtr->Name, TblName, CFE_TBL_MAX_FULL_NAME_LEN);
+                    strncpy(RegRecPtr->Name, TblName, sizeof(RegRecPtr->Name) - 1);
+                    RegRecPtr->Name[sizeof(RegRecPtr->Name) - 1] = '\0';
 
                     /* Set the "Dump Only" flag to value based upon selected option */
                     if ((TblOptionFlags & CFE_TBL_OPT_LD_DMP_MSK) == CFE_TBL_OPT_DUMP_ONLY)
@@ -398,10 +399,14 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
                             
                                 if ((CritRegRecPtr != NULL) && (CritRegRecPtr->TableLoadedOnce))
                                 {
-                                    strncpy(WorkingBufferPtr->DataSource, CritRegRecPtr->LastFileLoaded, OS_MAX_PATH_LEN);
+                                    strncpy(WorkingBufferPtr->DataSource, CritRegRecPtr->LastFileLoaded,
+                                            sizeof(WorkingBufferPtr->DataSource) - 1);
+                                    WorkingBufferPtr->DataSource[sizeof(WorkingBufferPtr->DataSource) - 1] = '\0';
                                     WorkingBufferPtr->FileCreateTimeSecs = CritRegRecPtr->FileCreateTimeSecs;
                                     WorkingBufferPtr->FileCreateTimeSubSecs = CritRegRecPtr->FileCreateTimeSubSecs;
-                                    strncpy(RegRecPtr->LastFileLoaded, CritRegRecPtr->LastFileLoaded, OS_MAX_PATH_LEN);
+                                    strncpy(RegRecPtr->LastFileLoaded, CritRegRecPtr->LastFileLoaded,
+                                            sizeof(RegRecPtr->LastFileLoaded) - 1);
+                                    RegRecPtr->LastFileLoaded[sizeof(RegRecPtr->LastFileLoaded) - 1] = '\0';
                                     RegRecPtr->TimeOfLastUpdate.Seconds = CritRegRecPtr->TimeOfLastUpdate.Seconds;
                                     RegRecPtr->TimeOfLastUpdate.Subseconds = CritRegRecPtr->TimeOfLastUpdate.Subseconds;
                                     RegRecPtr->TableLoadedOnce = CritRegRecPtr->TableLoadedOnce;
@@ -441,7 +446,8 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
                             if (CritRegRecPtr != NULL)
                             {
                                 CritRegRecPtr->CDSHandle = RegRecPtr->CDSHandle;
-                                strncpy(CritRegRecPtr->Name, TblName, CFE_TBL_MAX_FULL_NAME_LEN);
+                                strncpy(CritRegRecPtr->Name, TblName, sizeof(CritRegRecPtr->Name) - 1);
+                                CritRegRecPtr->Name[sizeof(CritRegRecPtr->Name) - 1] = '\0';
                                 CritRegRecPtr->FileCreateTimeSecs = 0;
                                 CritRegRecPtr->FileCreateTimeSubSecs = 0;
                                 CritRegRecPtr->LastFileLoaded[0] = '\0';
@@ -874,7 +880,8 @@ int32 CFE_TBL_Load( CFE_TBL_Handle_t TblHandle,
         /* On initial loads, make sure registry is given file/address of data source */
         strncpy(RegRecPtr->LastFileLoaded,
                 WorkingBufferPtr->DataSource,
-                OS_MAX_PATH_LEN);
+                sizeof(RegRecPtr->LastFileLoaded) - 1);
+        RegRecPtr->LastFileLoaded[sizeof(RegRecPtr->LastFileLoaded) - 1] = '\0';
 
         CFE_TBL_NotifyTblUsersOfUpdate(RegRecPtr);
                 
@@ -1494,7 +1501,7 @@ int32 CFE_TBL_Modified( CFE_TBL_Handle_t TblHandle )
         
         /* Keep a record of change for the ground operators reference */
         RegRecPtr->TimeOfLastUpdate = CFE_TIME_GetTime();
-        RegRecPtr->LastFileLoaded[OS_MAX_PATH_LEN-1] = '\0';
+        RegRecPtr->LastFileLoaded[sizeof(RegRecPtr->LastFileLoaded)-1] = '\0';
         
         /* Update CRC on contents of table */
         RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].Crc = 
@@ -1504,13 +1511,13 @@ int32 CFE_TBL_Modified( CFE_TBL_Handle_t TblHandle )
                                 CFE_MISSION_ES_DEFAULT_CRC);
 
         FilenameLen = strlen(RegRecPtr->LastFileLoaded);
-        if (FilenameLen < (OS_MAX_PATH_LEN-4))
+        if (FilenameLen < (sizeof(RegRecPtr->LastFileLoaded)-4))
         {
             strncpy(&RegRecPtr->LastFileLoaded[FilenameLen], "(*)", 4);
         }
         else
         {
-            strncpy(&RegRecPtr->LastFileLoaded[(OS_MAX_PATH_LEN-4)], "(*)", 4);
+            strncpy(&RegRecPtr->LastFileLoaded[sizeof(RegRecPtr->LastFileLoaded)-4], "(*)", 4);
         }
 
         AccessIterator = RegRecPtr->HeadOfAccessList;

--- a/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
@@ -1002,8 +1002,8 @@ int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBuffe
         return CFE_TBL_ERR_FILE_TOO_LARGE;
     }
 
-    memset(WorkingBufferPtr->DataSource, 0, OS_MAX_PATH_LEN);
-    strncpy(WorkingBufferPtr->DataSource, Filename, OS_MAX_PATH_LEN);
+    memset(WorkingBufferPtr->DataSource, 0, sizeof(WorkingBufferPtr->DataSource));
+    strncpy(WorkingBufferPtr->DataSource, Filename, sizeof(WorkingBufferPtr->DataSource) - 1);
 
     /* Save file creation time for later storage into Registry */
     WorkingBufferPtr->FileCreateTimeSecs = StdFileHeader.TimeSeconds;
@@ -1054,7 +1054,8 @@ int32 CFE_TBL_UpdateInternal( CFE_TBL_Handle_t TblHandle,
             /* However, we need to copy it into active registry area */
             strncpy(RegRecPtr->LastFileLoaded,
                     RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].DataSource,
-                    OS_MAX_PATH_LEN);
+                    sizeof(RegRecPtr->LastFileLoaded) - 1);
+            RegRecPtr->LastFileLoaded[sizeof(RegRecPtr->LastFileLoaded) - 1] = '\0';
 
             CFE_TBL_NotifyTblUsersOfUpdate(RegRecPtr);
             
@@ -1470,7 +1471,8 @@ void CFE_TBL_UpdateCriticalTblCDS(CFE_TBL_RegistryRec_t *RegRecPtr)
             /* Save information related to the source of the data stored in the table in Critical Table Registry */
             CritRegRecPtr->FileCreateTimeSecs = RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].FileCreateTimeSecs;
             CritRegRecPtr->FileCreateTimeSubSecs = RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].FileCreateTimeSubSecs;
-            strncpy(CritRegRecPtr->LastFileLoaded, RegRecPtr->LastFileLoaded, OS_MAX_PATH_LEN);
+            strncpy(CritRegRecPtr->LastFileLoaded, RegRecPtr->LastFileLoaded, sizeof(CritRegRecPtr->LastFileLoaded) - 1);
+            CritRegRecPtr->LastFileLoaded[sizeof(CritRegRecPtr->LastFileLoaded) - 1] = '\0';
             CritRegRecPtr->TimeOfLastUpdate = RegRecPtr->TimeOfLastUpdate;
             CritRegRecPtr->TableLoadedOnce = RegRecPtr->TableLoadedOnce;
             

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task.c
@@ -181,9 +181,7 @@ int32 CFE_TBL_TaskInit(void)
     /*
     ** Create Software Bus message pipe
     */
-    Status = CFE_SB_CreatePipe(&CFE_TBL_TaskData.CmdPipe,
-                                CFE_TBL_TaskData.PipeDepth,
-                                CFE_TBL_TaskData.PipeName);
+    Status = CFE_SB_CreatePipe(&CFE_TBL_TaskData.CmdPipe, CFE_TBL_TASK_PIPE_DEPTH, CFE_TBL_TASK_PIPE_NAME);
     if(Status != CFE_SUCCESS)
     {
       CFE_ES_WriteToSysLog("TBL:Error creating cmd pipe:RC=0x%08X\n",(unsigned int)Status);
@@ -240,10 +238,6 @@ void CFE_TBL_InitData(void)
 
     /* Get the assigned Application ID for the Table Services Task */
     CFE_ES_GetAppID(&CFE_TBL_TaskData.TableTaskAppId);
-
-    /* Initialize Command Pipe Parameters */
-    CFE_TBL_TaskData.PipeDepth = CFE_TBL_TASK_PIPE_DEPTH;
-    strncpy(CFE_TBL_TaskData.PipeName, CFE_TBL_TASK_PIPE_NAME, 16);
 
     /* Initialize Packet Headers */
     CFE_MSG_Init(&CFE_TBL_TaskData.HkPacket.TlmHeader.Msg,

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task.h
@@ -313,8 +313,6 @@ typedef struct
   /*
   ** Task initialization data (not reported in housekeeping)...
   */
-  char                   PipeName[16];                    /**< \brief Contains name of Table Task command pipe */
-  uint16                 PipeDepth;                       /**< \brief Contains depth of Table Task command pipe */
   CFE_ES_ResourceID_t    TableTaskAppId;                  /**< \brief Contains Table Task Application ID as assigned by OS AL */
 
   int16                  HkTlmTblRegIndex;                /**< \brief Index of table registry entry to be telemetered with Housekeeping */

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.c
@@ -484,9 +484,13 @@ int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
                             
                                     /* Save file information statistics for housekeeping telemetry */
                                     strncpy(CFE_TBL_TaskData.HkPacket.Payload.LastFileLoaded, LoadFilename,
-                                            sizeof(CFE_TBL_TaskData.HkPacket.Payload.LastFileLoaded));
+                                            sizeof(CFE_TBL_TaskData.HkPacket.Payload.LastFileLoaded) - 1);
+                                    CFE_TBL_TaskData.HkPacket.Payload.LastFileLoaded[
+                                            sizeof(CFE_TBL_TaskData.HkPacket.Payload.LastFileLoaded) - 1] = '\0';
                                     strncpy(CFE_TBL_TaskData.HkPacket.Payload.LastTableLoaded, TblFileHeader.TableName,
-                                            sizeof(CFE_TBL_TaskData.HkPacket.Payload.LastTableLoaded));
+                                            sizeof(CFE_TBL_TaskData.HkPacket.Payload.LastTableLoaded) - 1);
+                                    CFE_TBL_TaskData.HkPacket.Payload.LastTableLoaded[
+                                            sizeof(CFE_TBL_TaskData.HkPacket.Payload.LastTableLoaded) - 1] = '\0';
 
                                     /* Increment successful command completion counter */
                                     ReturnCode = CFE_TBL_INC_CMD_CTR;

--- a/fsw/cfe-core/src/time/cfe_time_task.c
+++ b/fsw/cfe-core/src/time/cfe_time_task.c
@@ -265,9 +265,7 @@ int32 CFE_TIME_TaskInit(void)
     }/* end if */
 
 
-    Status = CFE_SB_CreatePipe(&CFE_TIME_TaskData.CmdPipe,
-                                CFE_TIME_TaskData.PipeDepth,
-                                CFE_TIME_TaskData.PipeName);
+    Status = CFE_SB_CreatePipe(&CFE_TIME_TaskData.CmdPipe, CFE_TIME_TASK_PIPE_DEPTH, CFE_TIME_TASK_PIPE_NAME);
     if(Status != CFE_SUCCESS)
     {
       CFE_ES_WriteToSysLog("TIME:Error creating cmd pipe:RC=0x%08X\n",(unsigned int)Status);

--- a/fsw/cfe-core/src/time/cfe_time_utils.c
+++ b/fsw/cfe-core/src/time/cfe_time_utils.c
@@ -256,9 +256,6 @@ void CFE_TIME_InitData(void)
     /*
     ** Initialize task configuration data...
     */
-    strcpy(CFE_TIME_TaskData.PipeName, CFE_TIME_TASK_PIPE_NAME);
-    CFE_TIME_TaskData.PipeDepth = CFE_TIME_TASK_PIPE_DEPTH;
-    
     memset((void*)CFE_TIME_TaskData.ReferenceState, 0, sizeof(CFE_TIME_TaskData.ReferenceState));
     for (i = 0; i < CFE_TIME_REFERENCE_BUF_DEPTH; ++i)
     {

--- a/fsw/cfe-core/src/time/cfe_time_utils.h
+++ b/fsw/cfe-core/src/time/cfe_time_utils.h
@@ -188,9 +188,6 @@ typedef struct
   /*
   ** Task initialization data (not reported in housekeeping)...
   */
-  char                  PipeName[16];
-  uint16                PipeDepth;
-
   int16                 ClockSource;
   int16                 ClockSignal;
   int16                 ServerFlyState;

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -690,8 +690,8 @@ void TestInit(void)
             "CFE_APP, /cf/apps/ci.bundle, CI_task_main, CI_APP, 70, 4096, 0x0, 1; "
             "CFE_APP, /cf/apps/sch.bundle, SCH_TaskMain, SCH_APP, 120, 4096, 0x0, 1; "
             "CFE_APP, /cf/apps/to.bundle, TO_task_main, TO_APP, 74, 4096, 0x0, 1; !",
-            MAX_STARTUP_SCRIPT);
-    StartupScript[MAX_STARTUP_SCRIPT - 1] = '\0';
+            sizeof(StartupScript) - 1);
+    StartupScript[sizeof(StartupScript) - 1] = '\0';
     UT_SetReadBuffer(StartupScript, strlen(StartupScript));
 
     /* Go through ES_Main and cover normal paths */
@@ -723,8 +723,8 @@ void TestStartupErrorPaths(void)
             "CFE_APP, /cf/apps/ci.bundle, CI_task_main, CI_APP, 70, 4096, 0x0, 1; "
             "CFE_APP, /cf/apps/sch.bundle, SCH_TaskMain, SCH_APP, 120, 4096, 0x0, 1; "
             "CFE_APP, /cf/apps/to.bundle, TO_task_main, TO_APP, 74, 4096, 0x0, 1; !",
-            MAX_STARTUP_SCRIPT);
-    StartupScript[MAX_STARTUP_SCRIPT - 1] = '\0';
+            sizeof(StartupScript) - 1);
+    StartupScript[sizeof(StartupScript) - 1] = '\0';
 
     /* Perform ES main startup with a mutex creation failure */
     ES_ResetUnitTest();
@@ -1167,8 +1167,8 @@ void TestApps(void)
             "70, 4096, 0x0, 1; CFE_APP, /cf/apps/sch.bundle, SCH_TaskMain, "
             "SCH_APP, 120, 4096, 0x0, 1; CFE_APP, /cf/apps/to.bundle, "
             "TO_task_main, TO_APP, 74, 4096, 0x0, 1; !",
-            MAX_STARTUP_SCRIPT);
-    StartupScript[MAX_STARTUP_SCRIPT - 1] = '\0';
+            sizeof(StartupScript) - 1);
+    StartupScript[sizeof(StartupScript) - 1] = '\0';
     NumBytes = strlen(StartupScript);
     UT_SetReadBuffer(StartupScript, NumBytes);
     CFE_ES_StartApplications(CFE_PSP_RST_TYPE_PROCESSOR,
@@ -1182,8 +1182,8 @@ void TestApps(void)
             "CFE_APP, /cf/apps/ci.bundle, CI_task_main, CI_APP, 70, 4096, 0x0, 1; "
             "CFE_APP, /cf/apps/sch.bundle, SCH_TaskMain, SCH_APP, 120, 4096, 0x0, 1; "
             "CFE_APP, /cf/apps/to.bundle, TO_task_main, TO_APP, 74, 4096, 0x0, 1; !",
-            MAX_STARTUP_SCRIPT);
-    StartupScript[MAX_STARTUP_SCRIPT - 1] = '\0';
+            sizeof(StartupScript) - 1);
+    StartupScript[sizeof(StartupScript) - 1] = '\0';
     NumBytes = strlen(StartupScript);
     UT_SetReadBuffer(StartupScript, NumBytes);
 
@@ -1474,13 +1474,12 @@ void TestApps(void)
     /* Test a successful control action request to exit an application */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.FileName,
-            "/ram/Filename", OS_MAX_PATH_LEN);
-    UtAppRecPtr->StartParams.BasicInfo.FileName[OS_MAX_PATH_LEN - 1] = '\0';
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.EntryPoint,
-            "NotNULL", OS_MAX_API_NAME);
-    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[OS_MAX_API_NAME - 1] =
-        '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.FileName, 
+            "/ram/Filename", sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1);
+    UtAppRecPtr->StartParams.BasicInfo.FileName[sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1] = '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.EntryPoint,
+            "NotNULL", sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1);
+    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1] = '\0';
     UtAppRecPtr->StartParams.Priority = 255;
     UtAppRecPtr->StartParams.StackSize = 8192;
     UtAppRecPtr->StartParams.ExceptionAction = 0;
@@ -1589,13 +1588,12 @@ void TestApps(void)
      */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.FileName,
-            "/ram/FileName", OS_MAX_PATH_LEN);
-    UtAppRecPtr->StartParams.BasicInfo.FileName[OS_MAX_PATH_LEN - 1] = '\0';
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
-            OS_MAX_API_NAME);
-    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[OS_MAX_API_NAME - 1] =
-        '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.FileName,
+            "/ram/FileName", sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1);
+    UtAppRecPtr->StartParams.BasicInfo.FileName[sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1] = '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
+            sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1);
+    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1] = '\0';
     UtAppRecPtr->StartParams.Priority = 255;
     UtAppRecPtr->StartParams.StackSize = 8192;
     UtAppRecPtr->StartParams.ExceptionAction = 0;
@@ -1626,13 +1624,12 @@ void TestApps(void)
     /* Test a successful control action request to stop an application */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.FileName,
-            "/ram/FileName", OS_MAX_PATH_LEN);
-    UtAppRecPtr->StartParams.BasicInfo.FileName[OS_MAX_PATH_LEN - 1] = '\0';
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
-            OS_MAX_API_NAME);
-    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[OS_MAX_API_NAME - 1] =
-        '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.FileName,
+            "/ram/FileName", sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1);
+    UtAppRecPtr->StartParams.BasicInfo.FileName[sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1] = '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
+            sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1);
+    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1] = '\0';
     UtAppRecPtr->StartParams.Priority = 255;
     UtAppRecPtr->StartParams.StackSize = 8192;
     UtAppRecPtr->StartParams.ExceptionAction = 0;
@@ -1648,13 +1645,12 @@ void TestApps(void)
     /* Test a successful control action request to restart an application */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.FileName,
-            "/ram/FileName", OS_MAX_PATH_LEN);
-    UtAppRecPtr->StartParams.BasicInfo.FileName[OS_MAX_PATH_LEN - 1] = '\0';
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
-            OS_MAX_API_NAME);
-    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[OS_MAX_API_NAME - 1] =
-        '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.FileName,
+            "/ram/FileName", sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1);
+    UtAppRecPtr->StartParams.BasicInfo.FileName[sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1] = '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
+            sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1);
+    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1] = '\0';
     UtAppRecPtr->StartParams.Priority = 255;
     UtAppRecPtr->StartParams.StackSize = 8192;
     UtAppRecPtr->StartParams.ExceptionAction = 0;
@@ -1670,13 +1666,12 @@ void TestApps(void)
     /* Test a successful control action request to reload an application */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.FileName,
-            "/ram/FileName", OS_MAX_PATH_LEN);
-    UtAppRecPtr->StartParams.BasicInfo.FileName[OS_MAX_PATH_LEN - 1] = '\0';
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
-            OS_MAX_API_NAME);
-    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[OS_MAX_API_NAME - 1] =
-        '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.FileName,
+            "/ram/FileName", sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) -1);
+    UtAppRecPtr->StartParams.BasicInfo.FileName[sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) -1] = '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
+            sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1);
+    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1] = '\0';
     UtAppRecPtr->StartParams.Priority = 255;
     UtAppRecPtr->StartParams.StackSize = 8192;
     UtAppRecPtr->StartParams.ExceptionAction = 0;
@@ -1694,13 +1689,12 @@ void TestApps(void)
      */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.FileName,
-            "/ram/FileName", OS_MAX_PATH_LEN);
-    UtAppRecPtr->StartParams.BasicInfo.FileName[OS_MAX_PATH_LEN - 1] = '\0';
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
-            OS_MAX_API_NAME);
-    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[OS_MAX_API_NAME - 1] =
-        '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.FileName,
+            "/ram/FileName", sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1);
+    UtAppRecPtr->StartParams.BasicInfo.FileName[sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1] = '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
+            sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1);
+    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1] = '\0';
     UtAppRecPtr->StartParams.Priority = 255;
     UtAppRecPtr->StartParams.StackSize = 8192;
     UtAppRecPtr->StartParams.ExceptionAction = 0;
@@ -2839,12 +2833,15 @@ void TestTask(void)
     /* Test successful app create */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint));
+    strncpy(CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1);
+    CmdBuf.StartAppCmd.Payload.AppFileName[sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1);
+    CmdBuf.StartAppCmd.Payload.AppEntryPoint[sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1] = '\0';
     memset(CmdBuf.StartAppCmd.Payload.Application, 'x', 
-            sizeof(CmdBuf.StartAppCmd.Payload.Application));
+            sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1);
+    CmdBuf.StartAppCmd.Payload.Application[sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1] = '\0';
     CmdBuf.StartAppCmd.Payload.Priority = 160;
     CmdBuf.StartAppCmd.Payload.StackSize = CFE_ES_MEMOFFSET_C(8192);
     CmdBuf.StartAppCmd.Payload.ExceptionAction = CFE_ES_ExceptionAction_RESTART_APP;
@@ -2868,12 +2865,15 @@ void TestTask(void)
     /* Test app create with the file name too short */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppFileName, "123",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.Application, "appName",
-            sizeof(CmdBuf.StartAppCmd.Payload.Application));
+    strncpy(CmdBuf.StartAppCmd.Payload.AppFileName, "123",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1);
+    CmdBuf.StartAppCmd.Payload.AppFileName[sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1);
+    CmdBuf.StartAppCmd.Payload.AppEntryPoint[sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.Application, "appName",
+            sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1);
+    CmdBuf.StartAppCmd.Payload.Application[sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1] = '\0';
     CmdBuf.StartAppCmd.Payload.Priority = 160;
     CmdBuf.StartAppCmd.Payload.StackSize = CFE_ES_MEMOFFSET_C(12096);
     CmdBuf.StartAppCmd.Payload.ExceptionAction = CFE_ES_ExceptionAction_RESTART_APP;
@@ -2887,12 +2887,13 @@ void TestTask(void)
     /* Test app create with a null application entry point */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppEntryPoint, "",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.Application, "appName",
-            sizeof(CmdBuf.StartAppCmd.Payload.Application));
+    strncpy(CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1);
+    CmdBuf.StartAppCmd.Payload.AppFileName[sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1] = '\0';
+    CmdBuf.StartAppCmd.Payload.AppEntryPoint[0] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.Application, "appName",
+            sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1);
+    CmdBuf.StartAppCmd.Payload.Application[sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1] = '\0';
     CmdBuf.StartAppCmd.Payload.Priority = 160;
     CmdBuf.StartAppCmd.Payload.StackSize = CFE_ES_MEMOFFSET_C(12096);
     CmdBuf.StartAppCmd.Payload.ExceptionAction = CFE_ES_ExceptionAction_RESTART_APP;
@@ -2906,12 +2907,13 @@ void TestTask(void)
     /* Test app create with a null application name */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.Application, "",
-            sizeof(CmdBuf.StartAppCmd.Payload.Application));
+    strncpy(CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1);
+    CmdBuf.StartAppCmd.Payload.AppFileName[sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1);
+    CmdBuf.StartAppCmd.Payload.AppEntryPoint[sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1] = '\0';
+    CmdBuf.StartAppCmd.Payload.Application[0] = '\0';
     CmdBuf.StartAppCmd.Payload.Priority = 160;
     CmdBuf.StartAppCmd.Payload.StackSize = CFE_ES_MEMOFFSET_C(12096);
     CmdBuf.StartAppCmd.Payload.ExceptionAction = CFE_ES_ExceptionAction_RESTART_APP;
@@ -2925,12 +2927,15 @@ void TestTask(void)
     /* Test app create with with an invalid exception action */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.Application, "appName",
-            sizeof(CmdBuf.StartAppCmd.Payload.Application));
+    strncpy(CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1);
+    CmdBuf.StartAppCmd.Payload.AppFileName[sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
+           sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1);
+    CmdBuf.StartAppCmd.Payload.AppEntryPoint[sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.Application, "appName",
+            sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1);
+    CmdBuf.StartAppCmd.Payload.Application[sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1] = '\0';
     CmdBuf.StartAppCmd.Payload.Priority = 160;
     CmdBuf.StartAppCmd.Payload.StackSize = CFE_ES_MEMOFFSET_C(12096);
     CmdBuf.StartAppCmd.Payload.ExceptionAction = 255;
@@ -2944,12 +2949,15 @@ void TestTask(void)
     /* Test app create with a default stack size */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.Application, "appName",
-            sizeof(CmdBuf.StartAppCmd.Payload.Application));
+    strncpy(CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1);
+    CmdBuf.StartAppCmd.Payload.AppFileName[sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
+           sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1);
+    CmdBuf.StartAppCmd.Payload.AppEntryPoint[sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.Application, "appName",
+            sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1);
+    CmdBuf.StartAppCmd.Payload.Application[sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1] = '\0';
     CmdBuf.StartAppCmd.Payload.Priority = 160;
     CmdBuf.StartAppCmd.Payload.StackSize = CFE_ES_MEMOFFSET_C(0);
     CmdBuf.StartAppCmd.Payload.ExceptionAction = CFE_ES_ExceptionAction_RESTART_APP;
@@ -2963,12 +2971,15 @@ void TestTask(void)
     /* Test app create with a bad priority */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.Application, "appName",
-            sizeof(CmdBuf.StartAppCmd.Payload.Application));
+    strncpy(CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1);
+    CmdBuf.StartAppCmd.Payload.AppFileName[sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
+           sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1);
+    CmdBuf.StartAppCmd.Payload.AppEntryPoint[sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.Application, "appName",
+            sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1);
+    CmdBuf.StartAppCmd.Payload.Application[sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1] = '\0';
     CmdBuf.StartAppCmd.Payload.Priority = 1000;
     CmdBuf.StartAppCmd.Payload.StackSize = CFE_ES_MEMOFFSET_C(12096);
     CmdBuf.StartAppCmd.Payload.ExceptionAction = CFE_ES_ExceptionAction_RESTART_APP;
@@ -2982,8 +2993,9 @@ void TestTask(void)
     /* Test successful app stop */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
-    strncpy((char *) CmdBuf.StopAppCmd.Payload.Application, "CFE_ES",
-            sizeof(CmdBuf.StopAppCmd.Payload.Application));
+    strncpy(CmdBuf.StopAppCmd.Payload.Application, "CFE_ES",
+            sizeof(CmdBuf.StopAppCmd.Payload.Application) - 1);
+    CmdBuf.StopAppCmd.Payload.Application[sizeof(CmdBuf.StopAppCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.StopAppCmd),
             UT_TPID_CFE_ES_CMD_STOP_APP_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3004,8 +3016,9 @@ void TestTask(void)
     /* Test app stop with a bad app name */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.StopAppCmd.Payload.Application, "BAD_APP_NAME",
-            sizeof(CmdBuf.StopAppCmd.Payload.Application));
+    strncpy(CmdBuf.StopAppCmd.Payload.Application, "BAD_APP_NAME",
+            sizeof(CmdBuf.StopAppCmd.Payload.Application) - 1);
+    CmdBuf.StopAppCmd.Payload.Application[sizeof(CmdBuf.StopAppCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.StopAppCmd),
             UT_TPID_CFE_ES_CMD_STOP_APP_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3017,8 +3030,9 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
-    strncpy((char *) CmdBuf.RestartAppCmd.Payload.Application, "CFE_ES",
-            sizeof(CmdBuf.RestartAppCmd.Payload.Application));
+    strncpy(CmdBuf.RestartAppCmd.Payload.Application, "CFE_ES",
+            sizeof(CmdBuf.RestartAppCmd.Payload.Application) - 1);
+    CmdBuf.RestartAppCmd.Payload.Application[sizeof(CmdBuf.RestartAppCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.RestartAppCmd),
             UT_TPID_CFE_ES_CMD_RESTART_APP_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3029,8 +3043,9 @@ void TestTask(void)
     /* Test app restart with a bad app name */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.RestartAppCmd.Payload.Application, "BAD_APP_NAME",
-            sizeof(CmdBuf.RestartAppCmd.Payload.Application));
+    strncpy(CmdBuf.RestartAppCmd.Payload.Application, "BAD_APP_NAME",
+            sizeof(CmdBuf.RestartAppCmd.Payload.Application) - 1);
+    CmdBuf.RestartAppCmd.Payload.Application[sizeof(CmdBuf.RestartAppCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.RestartAppCmd),
             UT_TPID_CFE_ES_CMD_RESTART_APP_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3042,8 +3057,9 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_WAITING, "CFE_ES", NULL, NULL);
-    strncpy((char *) CmdBuf.RestartAppCmd.Payload.Application, "CFE_ES",
-        sizeof(CmdBuf.RestartAppCmd.Payload.Application));
+    strncpy(CmdBuf.RestartAppCmd.Payload.Application, "CFE_ES",
+        sizeof(CmdBuf.RestartAppCmd.Payload.Application) - 1);
+    CmdBuf.RestartAppCmd.Payload.Application[sizeof(CmdBuf.RestartAppCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.RestartAppCmd),
             UT_TPID_CFE_ES_CMD_RESTART_APP_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3055,10 +3071,12 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
-    strncpy((char *) CmdBuf.ReloadAppCmd.Payload.AppFileName, "New_Name",
-            sizeof(CmdBuf.ReloadAppCmd.Payload.AppFileName));
-    strncpy((char *) CmdBuf.ReloadAppCmd.Payload.Application, "CFE_ES",
-            sizeof(CmdBuf.ReloadAppCmd.Payload.Application));
+    strncpy(CmdBuf.ReloadAppCmd.Payload.AppFileName, "New_Name",
+            sizeof(CmdBuf.ReloadAppCmd.Payload.AppFileName) - 1);
+    CmdBuf.ReloadAppCmd.Payload.AppFileName[sizeof(CmdBuf.ReloadAppCmd.Payload.AppFileName) - 1] = '\0';
+    strncpy(CmdBuf.ReloadAppCmd.Payload.Application, "CFE_ES",
+            sizeof(CmdBuf.ReloadAppCmd.Payload.Application) - 1);
+    CmdBuf.ReloadAppCmd.Payload.Application[sizeof(CmdBuf.ReloadAppCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.ReloadAppCmd),
             UT_TPID_CFE_ES_CMD_RELOAD_APP_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3069,8 +3087,9 @@ void TestTask(void)
     /* Test app reload with a bad app name */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.ReloadAppCmd.Payload.Application, "BAD_APP_NAME",
-            sizeof(CmdBuf.ReloadAppCmd.Payload.Application));
+    strncpy(CmdBuf.ReloadAppCmd.Payload.Application, "BAD_APP_NAME",
+            sizeof(CmdBuf.ReloadAppCmd.Payload.Application) - 1);
+    CmdBuf.ReloadAppCmd.Payload.Application[sizeof(CmdBuf.ReloadAppCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.ReloadAppCmd),
             UT_TPID_CFE_ES_CMD_RELOAD_APP_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3082,8 +3101,9 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_WAITING, "CFE_ES", NULL, NULL);
-    strncpy((char *) CmdBuf.ReloadAppCmd.Payload.Application, "CFE_ES",
-            sizeof(CmdBuf.ReloadAppCmd.Payload.Application));
+    strncpy(CmdBuf.ReloadAppCmd.Payload.Application, "CFE_ES",
+            sizeof(CmdBuf.ReloadAppCmd.Payload.Application) - 1);
+    CmdBuf.ReloadAppCmd.Payload.Application[sizeof(CmdBuf.ReloadAppCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.ReloadAppCmd),
             UT_TPID_CFE_ES_CMD_RELOAD_APP_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3095,8 +3115,9 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_WAITING, "CFE_ES", NULL, NULL);
-    strncpy((char *) CmdBuf.QueryOneCmd.Payload.Application, "CFE_ES",
-            sizeof(CmdBuf.QueryOneCmd.Payload.Application));
+    strncpy(CmdBuf.QueryOneCmd.Payload.Application, "CFE_ES",
+            sizeof(CmdBuf.QueryOneCmd.Payload.Application) - 1);
+    CmdBuf.QueryOneCmd.Payload.Application[sizeof(CmdBuf.QueryOneCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryOneCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ONE_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3108,8 +3129,9 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
-    strncpy((char *) CmdBuf.QueryOneCmd.Payload.Application, "CFE_ES",
-            sizeof(CmdBuf.QueryOneCmd.Payload.Application));
+    strncpy(CmdBuf.QueryOneCmd.Payload.Application, "CFE_ES",
+            sizeof(CmdBuf.QueryOneCmd.Payload.Application) - 1);
+    CmdBuf.QueryOneCmd.Payload.Application[sizeof(CmdBuf.QueryOneCmd.Payload.Application) - 1] = '\0';
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_TransmitMsg), 1, -1);
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryOneCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ONE_CC);
@@ -3122,8 +3144,9 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
-    strncpy((char *) CmdBuf.QueryOneCmd.Payload.Application, "BAD_APP_NAME",
-            sizeof(CmdBuf.QueryOneCmd.Payload.Application));
+    strncpy(CmdBuf.QueryOneCmd.Payload.Application, "BAD_APP_NAME",
+            sizeof(CmdBuf.QueryOneCmd.Payload.Application) - 1);
+    CmdBuf.QueryOneCmd.Payload.Application[sizeof(CmdBuf.QueryOneCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryOneCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ONE_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3135,8 +3158,9 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
-    strncpy((char *) CmdBuf.QueryAllCmd.Payload.FileName, "AllFilename",
-            sizeof(CmdBuf.QueryAllCmd.Payload.FileName));
+    strncpy(CmdBuf.QueryAllCmd.Payload.FileName, "AllFilename",
+            sizeof(CmdBuf.QueryAllCmd.Payload.FileName) - 1);
+    CmdBuf.QueryAllCmd.Payload.FileName[sizeof(CmdBuf.QueryAllCmd.Payload.FileName) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryAllCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ALL_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3203,8 +3227,9 @@ void TestTask(void)
     /* Test write of all task data to a file with write header failure */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.QueryAllTasksCmd.Payload.FileName, "filename",
-            sizeof(CmdBuf.QueryAllTasksCmd.Payload.FileName));
+    strncpy(CmdBuf.QueryAllTasksCmd.Payload.FileName, "filename",
+            sizeof(CmdBuf.QueryAllTasksCmd.Payload.FileName) - 1);
+    CmdBuf.QueryAllTasksCmd.Payload.FileName[sizeof(CmdBuf.QueryAllTasksCmd.Payload.FileName) - 1] = '\0';
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_WriteHeader), 1, -1);
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryAllTasksCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ALL_TASKS_CC);
@@ -3271,8 +3296,9 @@ void TestTask(void)
     /* Test successful writing of the system log */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.WriteSysLogCmd.Payload.FileName, "filename",
-            sizeof(CmdBuf.WriteSysLogCmd.Payload.FileName));
+    strncpy(CmdBuf.WriteSysLogCmd.Payload.FileName, "filename",
+            sizeof(CmdBuf.WriteSysLogCmd.Payload.FileName) - 1);
+    CmdBuf.WriteSysLogCmd.Payload.FileName[sizeof(CmdBuf.WriteSysLogCmd.Payload.FileName) - 1] = '\0';
     CFE_ES_TaskData.HkPacket.Payload.SysLogEntries = 123;
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.WriteSysLogCmd),
             UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
@@ -3296,8 +3322,7 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
-    strncpy((char *) CmdBuf.WriteSysLogCmd.Payload.FileName, "",
-            sizeof(CmdBuf.WriteSysLogCmd.Payload.FileName));
+    CmdBuf.WriteSysLogCmd.Payload.FileName[0] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.WriteSysLogCmd),
             UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3313,8 +3338,7 @@ void TestTask(void)
             sizeof(CFE_ES_ResetDataPtr->SystemLog),
             "0000-000-00:00:00.00000 Test Message\n");
     CFE_ES_ResetDataPtr->SystemLogEndIdx = CFE_ES_ResetDataPtr->SystemLogWriteIdx;
-    strncpy((char *) CmdBuf.WriteSysLogCmd.Payload.FileName, "",
-            sizeof(CmdBuf.WriteSysLogCmd.Payload.FileName));
+    CmdBuf.WriteSysLogCmd.Payload.FileName[0] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.WriteSysLogCmd),
             UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3348,7 +3372,8 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     strncpy(CmdBuf.WriteERLogCmd.Payload.FileName, "filename",
-            sizeof(CmdBuf.WriteERLogCmd.Payload.FileName));
+            sizeof(CmdBuf.WriteERLogCmd.Payload.FileName) - 1);
+    CmdBuf.WriteERLogCmd.Payload.FileName[sizeof(CmdBuf.WriteERLogCmd.Payload.FileName) - 1] = '\0';
     CFE_ES_TaskData.BackgroundERLogDumpState.IsPending = false;
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.WriteERLogCmd),
             UT_TPID_CFE_ES_CMD_WRITE_ER_LOG_CC);
@@ -3535,7 +3560,8 @@ void TestTask(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     strncpy(CmdBuf.DeleteCDSCmd.Payload.CdsName,
             "CFE_ES.CDS_NAME",
-            sizeof(CmdBuf.DeleteCDSCmd.Payload.CdsName));
+            sizeof(CmdBuf.DeleteCDSCmd.Payload.CdsName) - 1);
+    CmdBuf.DeleteCDSCmd.Payload.CdsName[sizeof(CmdBuf.DeleteCDSCmd.Payload.CdsName) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.DeleteCDSCmd),
             UT_TPID_CFE_ES_CMD_DELETE_CDS_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3718,12 +3744,15 @@ void TestTask(void)
      */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.Application, "appName",
-            sizeof(CmdBuf.StartAppCmd.Payload.Application));
+    strncpy(CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1);
+    CmdBuf.StartAppCmd.Payload.AppFileName[sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1);
+    CmdBuf.StartAppCmd.Payload.AppEntryPoint[sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.Application, "appName",
+            sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1);
+    CmdBuf.StartAppCmd.Payload.Application[sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1] = '\0';
     CmdBuf.StartAppCmd.Payload.ExceptionAction = CFE_ES_ExceptionAction_PROC_RESTART;
     CmdBuf.StartAppCmd.Payload.Priority = 160;
     CmdBuf.StartAppCmd.Payload.StackSize =  CFE_ES_MEMOFFSET_C(CFE_PLATFORM_ES_DEFAULT_STACK_SIZE);
@@ -3928,7 +3957,8 @@ void TestTask(void)
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
     ES_UT_SetupSingleCDSRegistry("CFE_ES.CDS_NAME", ES_UT_CDS_BLOCK_SIZE, false, NULL);
     strncpy(CmdBuf.DumpCDSRegistryCmd.Payload.DumpFilename, "DumpFile",
-            sizeof(CmdBuf.DumpCDSRegistryCmd.Payload.DumpFilename));
+            sizeof(CmdBuf.DumpCDSRegistryCmd.Payload.DumpFilename) - 1);
+    CmdBuf.DumpCDSRegistryCmd.Payload.DumpFilename[sizeof(CmdBuf.DumpCDSRegistryCmd.Payload.DumpFilename) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.DumpCDSRegistryCmd),
             UT_TPID_CFE_ES_CMD_DUMP_CDS_REGISTRY_CC);
     UT_Report(__FILE__, __LINE__,
@@ -4075,7 +4105,8 @@ void TestPerf(void)
     memset(&CFE_ES_TaskData.BackgroundPerfDumpState, 0,
             sizeof(CFE_ES_TaskData.BackgroundPerfDumpState));
     strncpy(CmdBuf.PerfStopCmd.Payload.DataFileName, "filename",
-        sizeof(CmdBuf.PerfStopCmd.Payload.DataFileName));
+        sizeof(CmdBuf.PerfStopCmd.Payload.DataFileName) - 1);
+    CmdBuf.PerfStopCmd.Payload.DataFileName[sizeof(CmdBuf.PerfStopCmd.Payload.DataFileName) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.PerfStopCmd),
             UT_TPID_CFE_ES_CMD_STOP_PERF_DATA_CC);
     UT_Report(__FILE__, __LINE__,

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -2195,7 +2195,7 @@ void TestLibs(void)
               "Load shared library bad argument (NULL library name)");
 
     /* Test Load library returning an error on a too long library name */
-    memset(&LongLibraryName[0], 'a', sizeof(LongLibraryName)-1);
+    memset(LongLibraryName, 'a', sizeof(LongLibraryName)-1);
     LongLibraryName[sizeof(LongLibraryName)-1] = '\0';
     Return = CFE_ES_LoadLibrary(&Id,
                                 "filename",
@@ -4710,7 +4710,7 @@ void TestAPI(void)
     ES_ResetUnitTest();
     AppId = ES_UT_MakeAppIdForIndex(99999);
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_GetAppName(AppName, AppId, 32) == CFE_ES_ERR_RESOURCEID_NOT_VALID,
+              CFE_ES_GetAppName(AppName, AppId, sizeof(AppName)) == CFE_ES_ERR_RESOURCEID_NOT_VALID,
               "CFE_ES_GetAppName",
               "Get application name by ID; bad application ID");
 
@@ -4721,7 +4721,7 @@ void TestAPI(void)
     UT_Report(__FILE__, __LINE__,
               CFE_ES_GetAppName(AppName,
                                 AppId,
-                                32) == CFE_ES_ERR_RESOURCEID_NOT_VALID,
+                                sizeof(AppName)) == CFE_ES_ERR_RESOURCEID_NOT_VALID,
               "CFE_ES_GetAppName",
               "Get application name by ID; ID out of range");
 
@@ -4730,7 +4730,7 @@ void TestAPI(void)
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, "UT", &UtAppRecPtr, NULL);
     AppId = CFE_ES_AppRecordGetID(UtAppRecPtr);
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_GetAppName(AppName, AppId, 32) == CFE_SUCCESS,
+              CFE_ES_GetAppName(AppName, AppId, sizeof(AppName)) == CFE_SUCCESS,
               "CFE_ES_GetAppName",
               "Get application name by ID successful");
 

--- a/fsw/cfe-core/unit-test/evs_UT.c
+++ b/fsw/cfe-core/unit-test/evs_UT.c
@@ -303,8 +303,9 @@ void Test_Init(void)
 
     UtPrintf("Begin Test Init");
 
-    strncpy((char *) appbitcmd.Payload.AppName, "ut_cfe_evs",
-            sizeof(appbitcmd.Payload.AppName));
+    strncpy(appbitcmd.Payload.AppName, "ut_cfe_evs",
+            sizeof(appbitcmd.Payload.AppName) - 1);
+    appbitcmd.Payload.AppName[sizeof(appbitcmd.Payload.AppName) - 1] = '\0';
 
     /* Test successful early initialization of the cFE EVS */
     UT_InitData();
@@ -941,8 +942,9 @@ void Test_Format(void)
 
     /* Enable DEBUG message output */
     UT_InitData();
-    strncpy((char *) appbitcmd.Payload.AppName, "ut_cfe_evs",
-            sizeof(appbitcmd.Payload.AppName));
+    strncpy(appbitcmd.Payload.AppName, "ut_cfe_evs",
+            sizeof(appbitcmd.Payload.AppName) - 1);
+    appbitcmd.Payload.AppName[sizeof(appbitcmd.Payload.AppName) - 1] = '\0';
     modecmd.Payload.MsgFormat = CFE_EVS_MsgFormat_LONG;
     appbitcmd.Payload.BitMask = CFE_EVS_DEBUG_BIT | CFE_EVS_INFORMATION_BIT |
                         CFE_EVS_ERROR_BIT | CFE_EVS_CRITICAL_BIT;
@@ -1404,8 +1406,9 @@ void Test_Logging(void)
      */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(OS_MutSemCreate), 1, OS_SUCCESS);
-    strncpy((char *) CmdBuf.logfilecmd.Payload.LogFilename, "LogFile",
-            sizeof(CmdBuf.logfilecmd.Payload.LogFilename));
+    strncpy(CmdBuf.logfilecmd.Payload.LogFilename, "LogFile",
+            sizeof(CmdBuf.logfilecmd.Payload.LogFilename) - 1);
+    CmdBuf.logfilecmd.Payload.LogFilename[sizeof(CmdBuf.logfilecmd.Payload.LogFilename) - 1] = '\0';
     UT_Report(__FILE__, __LINE__,
               CFE_EVS_WriteLogDataFileCmd(&CmdBuf.logfilecmd) == CFE_SUCCESS,
               "CFE_EVS_WriteLogDataFileCmd",
@@ -1442,8 +1445,9 @@ void Test_WriteApp(void)
     /* Enable DEBUG message output */
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.appbitcmd.Payload.AppName, "ut_cfe_evs",
-            sizeof(CmdBuf.appbitcmd.Payload.AppName));
+    strncpy(CmdBuf.appbitcmd.Payload.AppName, "ut_cfe_evs",
+            sizeof(CmdBuf.appbitcmd.Payload.AppName) - 1);
+    CmdBuf.appbitcmd.Payload.AppName[sizeof(CmdBuf.appbitcmd.Payload.AppName) - 1] = '\0';
     CmdBuf.appbitcmd.Payload.BitMask = CFE_EVS_DEBUG_BIT | CFE_EVS_INFORMATION_BIT |
                         CFE_EVS_ERROR_BIT | CFE_EVS_CRITICAL_BIT;
     UT_EVS_DoDispatchCheckEvents(&CmdBuf.appbitcmd, sizeof(CmdBuf.appbitcmd),
@@ -1468,8 +1472,9 @@ void Test_WriteApp(void)
      * file name
      */
     UT_InitData();
-    strncpy((char *) CmdBuf.AppDataCmd.Payload.AppDataFilename, "ut_cfe_evs",
-            sizeof(CmdBuf.AppDataCmd.Payload.AppDataFilename));
+    strncpy(CmdBuf.AppDataCmd.Payload.AppDataFilename, "ut_cfe_evs",
+            sizeof(CmdBuf.AppDataCmd.Payload.AppDataFilename) - 1);
+    CmdBuf.AppDataCmd.Payload.AppDataFilename[sizeof(CmdBuf.AppDataCmd.Payload.AppDataFilename) - 1] = '\0';
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
     UT_EVS_DoDispatchCheckEvents(&CmdBuf.AppDataCmd, sizeof(CmdBuf.AppDataCmd),
                UT_TPID_CFE_EVS_CMD_WRITE_APP_DATA_FILE_CC,
@@ -1505,8 +1510,9 @@ void Test_WriteApp(void)
      * file name
      */
     UT_InitData();
-    strncpy((char *) CmdBuf.AppDataCmd.Payload.AppDataFilename, "AppDataFileName",
-            sizeof(CmdBuf.AppDataCmd.Payload.AppDataFilename));
+    strncpy(CmdBuf.AppDataCmd.Payload.AppDataFilename, "AppDataFileName",
+            sizeof(CmdBuf.AppDataCmd.Payload.AppDataFilename) - 1);
+    CmdBuf.AppDataCmd.Payload.AppDataFilename[sizeof(CmdBuf.AppDataCmd.Payload.AppDataFilename) - 1] = '\0';
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
     UT_EVS_DoDispatchCheckEvents(&CmdBuf.AppDataCmd, sizeof(CmdBuf.AppDataCmd),
                UT_TPID_CFE_EVS_CMD_WRITE_APP_DATA_FILE_CC,
@@ -1549,14 +1555,18 @@ void Test_BadAppCmd(void)
     appmaskcmd.Payload.EventID = 0;
     appcmdcmd.Payload.EventID = 0;
 
-    strncpy((char *) appbitcmd.Payload.AppName, "unknown_name",
-            sizeof(appbitcmd.Payload.AppName));
-    strncpy((char *) appnamecmd.Payload.AppName, "unknown_name",
-            sizeof(appnamecmd.Payload.AppName));
-    strncpy((char *) appmaskcmd.Payload.AppName, "unknown_name",
-            sizeof(appmaskcmd.Payload.AppName));
-    strncpy((char *) appcmdcmd.Payload.AppName, "unknown_name",
-            sizeof(appcmdcmd.Payload.AppName));
+    strncpy(appbitcmd.Payload.AppName, "unknown_name",
+            sizeof(appbitcmd.Payload.AppName) - 1);
+    appbitcmd.Payload.AppName[sizeof(appbitcmd.Payload.AppName) - 1] = '\0';
+    strncpy(appnamecmd.Payload.AppName, "unknown_name",
+            sizeof(appnamecmd.Payload.AppName) - 1);
+    appnamecmd.Payload.AppName[sizeof(appnamecmd.Payload.AppName) - 1] = '\0';
+    strncpy(appmaskcmd.Payload.AppName, "unknown_name",
+            sizeof(appmaskcmd.Payload.AppName) - 1);
+    appmaskcmd.Payload.AppName[sizeof(appmaskcmd.Payload.AppName) - 1] = '\0';
+    strncpy(appcmdcmd.Payload.AppName, "unknown_name",
+            sizeof(appcmdcmd.Payload.AppName) - 1);
+    appcmdcmd.Payload.AppName[sizeof(appcmdcmd.Payload.AppName) - 1] = '\0';
 
     /* Test disabling application event types with an unknown application ID */
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_GetAppIDByName), CFE_ES_ERR_NAME_NOT_FOUND);
@@ -1674,14 +1684,18 @@ void Test_BadAppCmd(void)
 
     /* Test disabling application event types with an illegal application ID */
     UT_InitData();
-    strncpy((char *) appbitcmd.Payload.AppName, "illegal_id",
-            sizeof(appbitcmd.Payload.AppName));
-    strncpy((char *) appnamecmd.Payload.AppName, "illegal_id",
-            sizeof(appnamecmd.Payload.AppName));
-    strncpy((char *) appmaskcmd.Payload.AppName, "illegal_id",
-            sizeof(appmaskcmd.Payload.AppName));
-    strncpy((char *) appcmdcmd.Payload.AppName, "illegal_id",
-            sizeof(appcmdcmd.Payload.AppName));
+    strncpy(appbitcmd.Payload.AppName, "illegal_id",
+            sizeof(appbitcmd.Payload.AppName) - 1);
+    appbitcmd.Payload.AppName[sizeof(appbitcmd.Payload.AppName) - 1] = '\0';
+    strncpy(appnamecmd.Payload.AppName, "illegal_id",
+            sizeof(appnamecmd.Payload.AppName) - 1);
+    appnamecmd.Payload.AppName[sizeof(appnamecmd.Payload.AppName) - 1] = '\0';
+    strncpy(appmaskcmd.Payload.AppName, "illegal_id",
+            sizeof(appmaskcmd.Payload.AppName) - 1);
+    appmaskcmd.Payload.AppName[sizeof(appmaskcmd.Payload.AppName) - 1] = '\0';
+    strncpy(appcmdcmd.Payload.AppName, "illegal_id",
+            sizeof(appcmdcmd.Payload.AppName) - 1);
+    appcmdcmd.Payload.AppName[sizeof(appcmdcmd.Payload.AppName) - 1] = '\0';
 
     /*
      * Generate an illegal AppID error when looking up the UT appID (first call),
@@ -1805,14 +1819,18 @@ void Test_BadAppCmd(void)
     UT_InitData();
     TestAppIndex = 2;
     UT_SetDataBuffer(UT_KEY(CFE_ES_AppID_ToIndex), &TestAppIndex, sizeof(TestAppIndex), false);
-    strncpy((char *) appbitcmd.Payload.AppName, "unregistered_app",
-            sizeof(appbitcmd.Payload.AppName));
-    strncpy((char *) appnamecmd.Payload.AppName, "unregistered_app",
-            sizeof(appnamecmd.Payload.AppName));
-    strncpy((char *) appmaskcmd.Payload.AppName, "unregistered_app",
-            sizeof(appmaskcmd.Payload.AppName));
-    strncpy((char *) appcmdcmd.Payload.AppName, "unregistered_app",
-            sizeof(appcmdcmd.Payload.AppName));
+    strncpy(appbitcmd.Payload.AppName, "unregistered_app",
+            sizeof(appbitcmd.Payload.AppName) - 1);
+    appbitcmd.Payload.AppName[sizeof(appbitcmd.Payload.AppName) - 1] = '\0';
+    strncpy(appnamecmd.Payload.AppName, "unregistered_app",
+            sizeof(appnamecmd.Payload.AppName) - 1);
+    appnamecmd.Payload.AppName[sizeof(appnamecmd.Payload.AppName) - 1] = '\0';
+    strncpy(appmaskcmd.Payload.AppName, "unregistered_app",
+            sizeof(appmaskcmd.Payload.AppName) - 1);
+    appmaskcmd.Payload.AppName[sizeof(appmaskcmd.Payload.AppName) - 1] = '\0';
+    strncpy(appcmdcmd.Payload.AppName, "unregistered_app",
+            sizeof(appcmdcmd.Payload.AppName) - 1);
+    appcmdcmd.Payload.AppName[sizeof(appcmdcmd.Payload.AppName) - 1] = '\0';
     UT_EVS_DoDispatchCheckEvents(&appbitcmd, sizeof(appbitcmd),
                UT_TPID_CFE_EVS_CMD_DISABLE_APP_EVENT_TYPE_CC,
                &UT_EVS_EventBuf);
@@ -1949,10 +1967,12 @@ void Test_EventCmd(void)
     UT_InitData();
 
     /* Run the next series of tests with valid, registered application name */
-    strncpy((char *) appbitcmd.Payload.AppName, "ut_cfe_evs",
-            sizeof(appbitcmd.Payload.AppName));
-    strncpy((char *) appnamecmd.Payload.AppName, "ut_cfe_evs",
-            sizeof(appnamecmd.Payload.AppName));
+    strncpy(appbitcmd.Payload.AppName, "ut_cfe_evs",
+            sizeof(appbitcmd.Payload.AppName) - 1);
+    appbitcmd.Payload.AppName[sizeof(appbitcmd.Payload.AppName) - 1] = '\0';
+    strncpy(appnamecmd.Payload.AppName, "ut_cfe_evs",
+            sizeof(appnamecmd.Payload.AppName) - 1);
+    appnamecmd.Payload.AppName[sizeof(appnamecmd.Payload.AppName) - 1] = '\0';
 
     /* Test disabling of all events */
     appbitcmd.Payload.BitMask = CFE_EVS_DEBUG_BIT | CFE_EVS_INFORMATION_BIT |
@@ -2195,14 +2215,18 @@ void Test_FilterCmd(void)
     appcmdcmd.Payload.EventID = 0;
 
     /* Run the next series of tests with valid, registered application name */
-    strncpy((char *) appnamecmd.Payload.AppName, "ut_cfe_evs",
-            sizeof(appnamecmd.Payload.AppName));
-    strncpy((char *) appmaskcmd.Payload.AppName, "ut_cfe_evs",
-            sizeof(appmaskcmd.Payload.AppName));
-    strncpy((char *) appcmdcmd.Payload.AppName, "ut_cfe_evs",
-            sizeof(appcmdcmd.Payload.AppName));
-    strncpy((char *) appbitcmd.Payload.AppName, "ut_cfe_evs",
-            sizeof(appbitcmd.Payload.AppName));
+    strncpy(appnamecmd.Payload.AppName, "ut_cfe_evs",
+            sizeof(appnamecmd.Payload.AppName) - 1);
+    appnamecmd.Payload.AppName[sizeof(appnamecmd.Payload.AppName) - 1] = '\0';
+    strncpy(appmaskcmd.Payload.AppName, "ut_cfe_evs",
+            sizeof(appmaskcmd.Payload.AppName) - 1);
+    appmaskcmd.Payload.AppName[sizeof(appmaskcmd.Payload.AppName) - 1] = '\0';
+    strncpy(appcmdcmd.Payload.AppName, "ut_cfe_evs",
+            sizeof(appcmdcmd.Payload.AppName) - 1);
+    appcmdcmd.Payload.AppName[sizeof(appcmdcmd.Payload.AppName) - 1] = '\0';
+    strncpy(appbitcmd.Payload.AppName, "ut_cfe_evs",
+            sizeof(appbitcmd.Payload.AppName) - 1);
+    appbitcmd.Payload.AppName[sizeof(appbitcmd.Payload.AppName) - 1] = '\0';
 
     /* Enable all application event message output */
     appbitcmd.Payload.BitMask = CFE_EVS_DEBUG_BIT | CFE_EVS_INFORMATION_BIT |

--- a/fsw/cfe-core/unit-test/fs_UT.c
+++ b/fsw/cfe-core/unit-test/fs_UT.c
@@ -247,8 +247,8 @@ void Test_CFE_FS_ExtractFileNameFromPath(void)
      * missing the path
      */
     UT_InitData();
-    strncpy(Original, "/cf/appslibrary.gz", OS_MAX_PATH_LEN);
-    Original[OS_MAX_PATH_LEN - 1] = '\0';
+    strncpy(Original, "/cf/appslibrary.gz", sizeof(Original) - 1);
+    Original[sizeof(Original) - 1] = '\0';
     UT_Report(__FILE__, __LINE__,
               CFE_FS_ExtractFilenameFromPath("name", FileName) ==
                   CFE_FS_INVALID_PATH,

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -221,7 +221,8 @@ void Test_SB_AppInit_EVSSendEvtFail(void)
      * path with different app/task names is followed on at least one event.
      */
     memset(&TestTaskInfo, 0, sizeof(TestTaskInfo));
-    strncpy((char*)TestTaskInfo.TaskName, "test", sizeof(TestTaskInfo.TaskName)-1);
+    strncpy(TestTaskInfo.TaskName, "test", sizeof(TestTaskInfo.TaskName)-1);
+    TestTaskInfo.TaskName[sizeof(TestTaskInfo.TaskName)-1] = '\0';
     UT_SetDataBuffer(UT_KEY(CFE_ES_GetTaskInfo), &TestTaskInfo, sizeof(TestTaskInfo), false);
 
     /* There are three events prior to init, pipe created (1) and subscription
@@ -508,7 +509,7 @@ void Test_SB_Cmds_RoutingInfoDef(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    strncpy((char *)SendRoutingInfo.Cmd.Payload.Filename, "", sizeof(SendRoutingInfo.Cmd.Payload.Filename));
+    SendRoutingInfo.Cmd.Payload.Filename[0] = '\0';
 
     /* Make some routing info by calling CFE_SB_AppInit */
     SETUP(CFE_SB_AppInit());
@@ -546,8 +547,9 @@ void Test_SB_Cmds_RoutingInfoSpec(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    strncpy((char *)SendRoutingInfo.Cmd.Payload.Filename, "RoutingTstFile",
-            sizeof(SendRoutingInfo.Cmd.Payload.Filename));
+    strncpy(SendRoutingInfo.Cmd.Payload.Filename, "RoutingTstFile",
+            sizeof(SendRoutingInfo.Cmd.Payload.Filename) - 1);
+    SendRoutingInfo.Cmd.Payload.Filename[sizeof(SendRoutingInfo.Cmd.Payload.Filename) - 1] = '\0';
 
     CFE_SB_ProcessCmdPipePkt(&SendRoutingInfo.SBBuf);
 
@@ -574,8 +576,9 @@ void Test_SB_Cmds_RoutingInfoCreateFail(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    strncpy((char *)SendRoutingInfo.Cmd.Payload.Filename, "RoutingTstFile",
-            sizeof(SendRoutingInfo.Cmd.Payload.Filename));
+    strncpy(SendRoutingInfo.Cmd.Payload.Filename, "RoutingTstFile",
+            sizeof(SendRoutingInfo.Cmd.Payload.Filename) - 1);
+    SendRoutingInfo.Cmd.Payload.Filename[sizeof(SendRoutingInfo.Cmd.Payload.Filename) - 1] = '\0';
 
     /* Make function CFE_SB_SendRtgInfo return CFE_SB_FILE_IO_ERR */
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
@@ -651,7 +654,7 @@ void Test_SB_Cmds_PipeInfoDef(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    strncpy((char *)SendPipeInfo.Cmd.Payload.Filename, "", sizeof(SendPipeInfo.Cmd.Payload.Filename));
+    SendPipeInfo.Cmd.Payload.Filename[0] = '\0';
 
     /* Create some pipe info */
     SETUP(CFE_SB_CreatePipe(&PipeId1, PipeDepth, "TestPipe1"));
@@ -688,8 +691,10 @@ void Test_SB_Cmds_PipeInfoSpec(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    strncpy((char *)SendPipeInfo.Cmd.Payload.Filename, "PipeTstFile",
-            sizeof(SendPipeInfo.Cmd.Payload.Filename));
+    strncpy(SendPipeInfo.Cmd.Payload.Filename, "PipeTstFile",
+            sizeof(SendPipeInfo.Cmd.Payload.Filename) - 1);
+    SendPipeInfo.Cmd.Payload.Filename[sizeof(SendPipeInfo.Cmd.Payload.Filename) - 1] = '\0';
+
     CFE_SB_ProcessCmdPipePkt(&SendPipeInfo.SBBuf);
 
     EVTCNT(1);
@@ -783,7 +788,7 @@ void Test_SB_Cmds_MapInfoDef(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    strncpy((char *)SendMapInfo.Cmd.Payload.Filename, "", sizeof(SendMapInfo.Cmd.Payload.Filename));
+    SendMapInfo.Cmd.Payload.Filename[0] = '\0';
 
     /* Create some map info */
     SETUP(CFE_SB_CreatePipe(&PipeId1, PipeDepth, "TestPipe1"));
@@ -830,8 +835,9 @@ void Test_SB_Cmds_MapInfoSpec(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    strncpy((char *)SendMapInfo.Cmd.Payload.Filename, "MapTstFile",
-            sizeof(SendMapInfo.Cmd.Payload.Filename));
+    strncpy(SendMapInfo.Cmd.Payload.Filename, "MapTstFile",
+            sizeof(SendMapInfo.Cmd.Payload.Filename) - 1);
+    SendMapInfo.Cmd.Payload.Filename[sizeof(SendMapInfo.Cmd.Payload.Filename) - 1] = '\0';
 
     CFE_SB_ProcessCmdPipePkt(&SendMapInfo.SBBuf);
 

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -1685,15 +1685,15 @@ void Test_CreatePipe_MaxPipes(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_ResourceID_ToIndex), 1+CFE_PLATFORM_SB_MAX_PIPES, -1);
     for (i = 0; i < (CFE_PLATFORM_SB_MAX_PIPES + 1); i++)
     {
-        snprintf(PipeName, OS_MAX_API_NAME, "TestPipe%ld", (long) i);
+        snprintf(PipeName, sizeof(PipeName), "TestPipe%ld", (long) i);
 
         if (i < CFE_PLATFORM_SB_MAX_PIPES)
         {
-        	SETUP(CFE_SB_CreatePipe(&PipeIdReturned[i], PipeDepth, &PipeName[0]));
+            SETUP(CFE_SB_CreatePipe(&PipeIdReturned[i], PipeDepth, PipeName));
         }
         else
         {
-        	ASSERT_EQ(CFE_SB_CreatePipe(&PipeIdReturned[i], PipeDepth, &PipeName[0]), CFE_SB_MAX_PIPES_MET);
+            ASSERT_EQ(CFE_SB_CreatePipe(&PipeIdReturned[i], PipeDepth, PipeName), CFE_SB_MAX_PIPES_MET);
         }
     }
 
@@ -1913,7 +1913,7 @@ void Test_GetPipeName_InvalidId(void)
     SETUP(CFE_SB_CreatePipe(&PipeId, 4, "TestPipe"));
 
     UT_SetDeferredRetcode(UT_KEY(OS_GetResourceName), 1, OS_ERROR);
-    ASSERT_EQ(CFE_SB_GetPipeName(PipeName, OS_MAX_API_NAME, PipeId), CFE_SB_BAD_ARGUMENT);
+    ASSERT_EQ(CFE_SB_GetPipeName(PipeName, sizeof(PipeName), PipeId), CFE_SB_BAD_ARGUMENT);
 
     EVTSENT(CFE_SB_GETPIPENAME_ID_ERR_EID);
 
@@ -1940,7 +1940,7 @@ void Test_GetPipeName(void)
         &queue_info, sizeof(queue_info),
         false);
 
-    ASSERT(CFE_SB_GetPipeName(PipeName, OS_MAX_API_NAME, PipeId));
+    ASSERT(CFE_SB_GetPipeName(PipeName, sizeof(PipeName), PipeId));
 
     EVTSENT(CFE_SB_GETPIPENAME_EID);
 
@@ -2279,8 +2279,8 @@ void Test_Subscribe_MaxDestCount(void)
     /* Create pipes */
     for (i = 0; i < CFE_PLATFORM_SB_MAX_DEST_PER_PKT + 1; i++)
     {
-        snprintf(PipeName, OS_MAX_API_NAME, "TestPipe%ld", (long) i);
-        SETUP(CFE_SB_CreatePipe(&PipeId[i], PipeDepth, &PipeName[0]));
+        snprintf(PipeName, sizeof(PipeName), "TestPipe%ld", (long) i);
+        SETUP(CFE_SB_CreatePipe(&PipeId[i], PipeDepth, PipeName));
     }
 
     /* Do subscriptions */

--- a/fsw/cfe-core/unit-test/tbl_UT.c
+++ b/fsw/cfe-core/unit-test/tbl_UT.c
@@ -463,7 +463,8 @@ void Test_CFE_TBL_DeleteCDSCmd(void)
     /* Test successfully finding the table name in the table registry */
     UT_InitData();
     strncpy(DelCDSCmd.Payload.TableName, "0",
-            sizeof(DelCDSCmd.Payload.TableName));
+            sizeof(DelCDSCmd.Payload.TableName) - 1);
+    DelCDSCmd.Payload.TableName[sizeof(DelCDSCmd.Payload.TableName) - 1] = '\0';
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DeleteCDSCmd(&DelCDSCmd) ==
                                        CFE_TBL_INC_ERR_CTR,
@@ -481,7 +482,8 @@ void Test_CFE_TBL_DeleteCDSCmd(void)
     }
 
     strncpy(DelCDSCmd.Payload.TableName, "-1", 
-        sizeof(DelCDSCmd.Payload.TableName));
+        sizeof(DelCDSCmd.Payload.TableName) - 1);
+    DelCDSCmd.Payload.TableName[sizeof(DelCDSCmd.Payload.TableName) - 1] = '\0';
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DeleteCDSCmd(&DelCDSCmd) ==
                                        CFE_TBL_INC_ERR_CTR,
@@ -554,8 +556,9 @@ void Test_CFE_TBL_TlmRegCmd(void)
     /* Registry[0].Name used because it is confirmed to be a registered
      * table name
      */
-    strncpy((char *)TlmRegCmd.Payload.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(TlmRegCmd.Payload.TableName));
+    strncpy(TlmRegCmd.Payload.TableName, CFE_TBL_TaskData.Registry[0].Name,
+            sizeof(TlmRegCmd.Payload.TableName) - 1);
+    TlmRegCmd.Payload.TableName[sizeof(TlmRegCmd.Payload.TableName) - 1] = '\0';
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_SendRegistryCmd(&TlmRegCmd) ==
                 CFE_TBL_INC_CMD_CTR,
@@ -590,8 +593,9 @@ void Test_CFE_TBL_AbortLoadCmd(void)
     /* Entering the if statement with a table name that has to be in
      * the registry
      */
-    strncpy((char *)AbortLdCmd.Payload.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(AbortLdCmd.Payload.TableName));
+    strncpy(AbortLdCmd.Payload.TableName, CFE_TBL_TaskData.Registry[0].Name,
+            sizeof(AbortLdCmd.Payload.TableName) - 1);
+    AbortLdCmd.Payload.TableName[sizeof(AbortLdCmd.Payload.TableName) - 1] = '\0';
     CFE_TBL_TaskData.Registry[0].LoadInProgress = 1;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_AbortLoadCmd(&AbortLdCmd) ==
@@ -658,7 +662,8 @@ void Test_CFE_TBL_ActivateCmd(void)
 
     /* Enter the if statement with a table name that is in the registry */
     strncpy(ActivateCmd.Payload.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(ActivateCmd.Payload.TableName));
+            sizeof(ActivateCmd.Payload.TableName) - 1);
+    ActivateCmd.Payload.TableName[sizeof(ActivateCmd.Payload.TableName) - 1] = '\0';
 
     /* Test when table name exists, but attempts to activate a dump-only
      * table
@@ -852,8 +857,9 @@ void Test_CFE_TBL_ValidateCmd(void)
      * have been requested
      */
     UT_InitData();
-    strncpy((char *)ValidateCmd.Payload.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(ValidateCmd.Payload.TableName));
+    strncpy(ValidateCmd.Payload.TableName, CFE_TBL_TaskData.Registry[0].Name,
+            sizeof(ValidateCmd.Payload.TableName) - 1);
+    ValidateCmd.Payload.TableName[sizeof(ValidateCmd.Payload.TableName) - 1] = '\0';
     ValidateCmd.Payload.ActiveTableFlag = CFE_TBL_BufferSelect_ACTIVE;
     CFE_TBL_TaskData.Registry[0].
       Buffers[CFE_TBL_TaskData.Registry[0].ActiveBufferIndex].
@@ -1152,8 +1158,7 @@ void Test_CFE_TBL_DumpRegCmd(void)
 
     /* Test with an error creating the dump file */
     UT_InitData();
-    strncpy((char *)DumpRegCmd.Payload.DumpFilename, "",
-            sizeof(DumpRegCmd.Payload.DumpFilename));
+    DumpRegCmd.Payload.DumpFilename[0] = '\0';
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DumpRegistryCmd(&DumpRegCmd) ==
@@ -1215,7 +1220,8 @@ void Test_CFE_TBL_DumpRegCmd(void)
 
     /* Test using the default dump file name */
     UT_InitData();
-    strcpy(DumpRegCmd.Payload.DumpFilename, "X");
+    strncpy(DumpRegCmd.Payload.DumpFilename, "X", sizeof(DumpRegCmd.Payload.DumpFilename) - 1);
+    DumpRegCmd.Payload.DumpFilename[sizeof(DumpRegCmd.Payload.DumpFilename) - 1] = '\0';
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DumpRegistryCmd(&DumpRegCmd) ==
                 CFE_TBL_INC_CMD_CTR,
@@ -1257,11 +1263,12 @@ void Test_CFE_TBL_DumpCmd(void)
      */
     UT_InitData();
     strncpy(CFE_TBL_TaskData.Registry[2].Name, "DumpCmdTest",
-            CFE_TBL_MAX_FULL_NAME_LEN);
-    CFE_TBL_TaskData.Registry[2].Name[CFE_TBL_MAX_FULL_NAME_LEN - 1] = '\0';
+            sizeof(CFE_TBL_TaskData.Registry[2].Name) - 1);
+    CFE_TBL_TaskData.Registry[2].Name[sizeof(CFE_TBL_TaskData.Registry[2].Name) - 1] = '\0';
     CFE_TBL_TaskData.Registry[2].OwnerAppId = AppID;
     strncpy(DumpCmd.Payload.TableName, CFE_TBL_TaskData.Registry[2].Name,
-            sizeof(DumpCmd.Payload.TableName));
+            sizeof(DumpCmd.Payload.TableName) - 1);
+    DumpCmd.Payload.TableName[sizeof(DumpCmd.Payload.TableName) - 1] = '\0';
     DumpCmd.Payload.ActiveTableFlag = CFE_TBL_BufferSelect_ACTIVE;
     CFE_TBL_TaskData.Registry[2].Buffers[CFE_TBL_TaskData.Registry[2].ActiveBufferIndex].BufferPtr = BuffPtr;
 
@@ -1357,7 +1364,8 @@ void Test_CFE_TBL_DumpCmd(void)
     CFE_TBL_TaskData.LoadBuffs[CFE_TBL_TaskData.Registry[2].LoadInProgress].BufferPtr = BuffPtr;
     CFE_TBL_TaskData.Registry[2].DumpOnly = false;
     strncpy(DumpCmd.Payload.DumpFilename, CFE_TBL_TaskData.Registry[2].LastFileLoaded,
-            sizeof(DumpCmd.Payload.DumpFilename));
+            sizeof(DumpCmd.Payload.DumpFilename) - 1);
+    DumpCmd.Payload.DumpFilename[sizeof(DumpCmd.Payload.DumpFilename) - 1] = '\0';
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DumpCmd(&DumpCmd) ==
                 CFE_TBL_INC_CMD_CTR,
@@ -1422,8 +1430,9 @@ void Test_CFE_TBL_LoadCmd(void)
 
     /* Test response to inability to open file */
     UT_InitData();
-    strncpy((char *)LoadCmd.Payload.LoadFilename, "LoadFileName",
-            sizeof(LoadCmd.Payload.LoadFilename));
+    strncpy(LoadCmd.Payload.LoadFilename, "LoadFileName",
+            sizeof(LoadCmd.Payload.LoadFilename) - 1);
+    LoadCmd.Payload.LoadFilename[sizeof(LoadCmd.Payload.LoadFilename) - 1] = '\0';
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_LoadCmd(&LoadCmd) ==
@@ -1440,10 +1449,11 @@ void Test_CFE_TBL_LoadCmd(void)
         CFE_TBL_TaskData.Registry[i].LoadPending = false;
     }
 
-    strncpy((char *)TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     strncpy(StdFileHeader.Description, "FS header description",
-            sizeof(StdFileHeader.Description));
+            sizeof(StdFileHeader.Description) - 1);
     StdFileHeader.Description[sizeof(StdFileHeader.Description) - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
@@ -1510,8 +1520,9 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(CFE_TBL_File_Hdr_t));
 
     UT_SetDeferredRetcode(UT_KEY(OS_read), 3, 0);
-    strncpy((char *)TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UT_Report(__FILE__, __LINE__,
@@ -1529,8 +1540,9 @@ void Test_CFE_TBL_LoadCmd(void)
         CFE_TBL_ByteSwapUint32(&TblFileHeader.NumBytes);
     }
 
-    strncpy((char *)TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetDeferredRetcode(UT_KEY(OS_read), 2, 0);
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
@@ -1552,8 +1564,9 @@ void Test_CFE_TBL_LoadCmd(void)
         CFE_TBL_TaskData.LoadBuffs[j].Taken = true;
     }
 
-    strncpy((char *)TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UT_Report(__FILE__, __LINE__,
@@ -1567,8 +1580,9 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(CFE_TBL_File_Hdr_t));
 
     CFE_TBL_TaskData.Registry[0].Size = sizeof(CFE_TBL_File_Hdr_t) - 1;
-    strncpy((char *)TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UT_Report(__FILE__, __LINE__,
@@ -1581,8 +1595,9 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_InitData();
     UT_TBL_SetupHeader(&TblFileHeader, 0, 0);
 
-    strncpy((char *)TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UT_Report(__FILE__, __LINE__,
@@ -1600,8 +1615,9 @@ void Test_CFE_TBL_LoadCmd(void)
     CFE_TBL_TaskData.Registry[0].TableLoadedOnce = false;
 
     CFE_TBL_TaskData.Registry[0].Size = sizeof(CFE_TBL_File_Hdr_t);
-    strncpy((char *)TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UT_Report(__FILE__, __LINE__,
@@ -1621,7 +1637,8 @@ void Test_CFE_TBL_LoadCmd(void)
 
     CFE_TBL_TaskData.Registry[0].Size = sizeof(CFE_TBL_File_Hdr_t);
     strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(TblFileHeader.TableName));
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UT_Report(__FILE__, __LINE__,
@@ -1634,7 +1651,8 @@ void Test_CFE_TBL_LoadCmd(void)
     /* Test response to inability to read the file header */
     UT_InitData();
     strncpy(LoadCmd.Payload.LoadFilename, "LoadFileName",
-            sizeof(LoadCmd.Payload.LoadFilename));
+            sizeof(LoadCmd.Payload.LoadFilename) - 1);
+    LoadCmd.Payload.LoadFilename[sizeof(LoadCmd.Payload.LoadFilename) - 1] = '\0';
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_ReadHeader), 1, sizeof(CFE_FS_Header_t) - 1);
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_LoadCmd(&LoadCmd) ==
@@ -1665,8 +1683,8 @@ void Test_CFE_TBL_HousekeepingCmd(void)
      */
     UT_InitData();
     strncpy(CFE_TBL_TaskData.DumpControlBlocks[0].TableName,
-           "housekeepingtest", CFE_TBL_MAX_FULL_NAME_LEN);
-    CFE_TBL_TaskData.DumpControlBlocks[0].TableName[CFE_TBL_MAX_FULL_NAME_LEN - 1] = '\0';
+           "housekeepingtest", sizeof(CFE_TBL_TaskData.DumpControlBlocks[0].TableName) - 1);
+    CFE_TBL_TaskData.DumpControlBlocks[0].TableName[sizeof(CFE_TBL_TaskData.DumpControlBlocks[0].TableName) - 1] = '\0';
     CFE_TBL_TaskData.DumpControlBlocks[0].Size = 10;
     LoadInProg = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
     RegRecPtr.LoadInProgress = LoadInProg;
@@ -1676,8 +1694,8 @@ void Test_CFE_TBL_HousekeepingCmd(void)
     DumpBuffPtr->BufferPtr = BuffPtr;
     DumpBuffPtr->FileCreateTimeSecs = Secs;
     DumpBuffPtr->FileCreateTimeSubSecs = SubSecs;
-    strncpy(DumpBuffPtr->DataSource, "hkSource", OS_MAX_PATH_LEN);
-    DumpBuffPtr->DataSource[OS_MAX_PATH_LEN - 1] = '\0';
+    strncpy(DumpBuffPtr->DataSource, "hkSource", sizeof(DumpBuffPtr->DataSource) - 1);
+    DumpBuffPtr->DataSource[sizeof(DumpBuffPtr->DataSource) - 1] = '\0';
     CFE_TBL_TaskData.DumpControlBlocks[0].DumpBufferPtr = DumpBuffPtr;
     CFE_TBL_TaskData.DumpControlBlocks[0].State = CFE_TBL_DUMP_PERFORMED;
 
@@ -2521,11 +2539,13 @@ void Test_CFE_TBL_Share(void)
     /* Test successful first load of a table */
     UT_InitData();
     strncpy(StdFileHeader.Description, "FS header description",
-            sizeof(StdFileHeader.Description));
+            sizeof(StdFileHeader.Description) - 1);
+    StdFileHeader.Description[sizeof(StdFileHeader.Description) - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table4",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table4",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
 
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
@@ -2703,11 +2723,13 @@ void Test_CFE_TBL_Load(void)
     /* Test attempt to perform partial INITIAL load */
     UT_InitData();
     strncpy(StdFileHeader.Description,"Test description",
-            sizeof(StdFileHeader.Description));
+            sizeof(StdFileHeader.Description) - 1);
+    StdFileHeader.Description[sizeof(StdFileHeader.Description) - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 1, sizeof(UT_Table1_t)-1);
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -2749,11 +2771,13 @@ void Test_CFE_TBL_Load(void)
      */
     UT_InitData();
     strncpy(StdFileHeader.Description,"Test description",
-            sizeof(StdFileHeader.Description));
+            sizeof(StdFileHeader.Description) - 1);
+    StdFileHeader.Description[sizeof(StdFileHeader.Description) - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.NotUT_Table1",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.NotUT_Table1",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -2790,11 +2814,13 @@ void Test_CFE_TBL_Load(void)
      */
     UT_InitData();
     strncpy(StdFileHeader.Description,"Test description",
-            sizeof(StdFileHeader.Description));
+            sizeof(StdFileHeader.Description) - 1);
+    StdFileHeader.Description[sizeof(StdFileHeader.Description) - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
     strncpy(TblFileHeader.TableName, "ut_cfe_tbl.NotUT_Table1",
-            sizeof(TblFileHeader.TableName));
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -3257,7 +3283,8 @@ void Test_CFE_TBL_Manage(void)
     CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
     CFE_TBL_TaskData.ValidationResults[0].Result = 0;
     strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table1", CFE_TBL_MAX_FULL_NAME_LEN);
+            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
+    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
     CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
     CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = false;
     RegRecPtr->ValidateInactiveIndex = 0;
@@ -3283,7 +3310,8 @@ void Test_CFE_TBL_Manage(void)
     CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
     CFE_TBL_TaskData.ValidationResults[0].Result = 0;
     strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table1", CFE_TBL_MAX_FULL_NAME_LEN);
+            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
+    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
     CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
     CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = false;
     RegRecPtr->ValidateInactiveIndex = 0;
@@ -3309,7 +3337,8 @@ void Test_CFE_TBL_Manage(void)
     CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
     CFE_TBL_TaskData.ValidationResults[0].Result = 1;
     strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table1", CFE_TBL_MAX_FULL_NAME_LEN);
+            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
+    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
     CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
     CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = false;
     RegRecPtr->ValidateInactiveIndex = 0;
@@ -3335,7 +3364,8 @@ void Test_CFE_TBL_Manage(void)
     CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
     CFE_TBL_TaskData.ValidationResults[0].Result = 0;
     strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table1", CFE_TBL_MAX_FULL_NAME_LEN);
+            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
+    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
     CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
     CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = true;
     RegRecPtr->ValidateActiveIndex = 0;
@@ -3361,7 +3391,8 @@ void Test_CFE_TBL_Manage(void)
     CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
     CFE_TBL_TaskData.ValidationResults[0].Result = 0;
     strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table1", CFE_TBL_MAX_FULL_NAME_LEN);
+            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
+    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
     CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
     CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = true;
     RegRecPtr->ValidateActiveIndex = 0;
@@ -3387,7 +3418,8 @@ void Test_CFE_TBL_Manage(void)
     CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
     CFE_TBL_TaskData.ValidationResults[0].Result = 1;
     strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table1", CFE_TBL_MAX_FULL_NAME_LEN);
+            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
+    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
     CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
     CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = true;
     RegRecPtr->ValidateActiveIndex = 0;
@@ -3504,7 +3536,8 @@ void Test_CFE_TBL_Manage(void)
     CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
     CFE_TBL_TaskData.ValidationResults[0].Result = 0;
     strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table2", CFE_TBL_MAX_FULL_NAME_LEN);
+            "ut_cfe_tbl.UT_Table2", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
+    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
     CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
     CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = false;
     RegRecPtr->ValidateInactiveIndex = 0;
@@ -3530,7 +3563,8 @@ void Test_CFE_TBL_Manage(void)
     CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
     CFE_TBL_TaskData.ValidationResults[0].Result = 1;
     strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table2", CFE_TBL_MAX_FULL_NAME_LEN);
+            "ut_cfe_tbl.UT_Table2", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
+    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
     CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
     CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = false;
     RegRecPtr->ValidateInactiveIndex = 0;
@@ -3556,7 +3590,8 @@ void Test_CFE_TBL_Manage(void)
     CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
     CFE_TBL_TaskData.ValidationResults[0].Result = 0;
     strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table2", CFE_TBL_MAX_FULL_NAME_LEN);
+            "ut_cfe_tbl.UT_Table2", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
+    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
     CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
     CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = true;
     RegRecPtr->ValidateActiveIndex = 0;
@@ -3582,7 +3617,8 @@ void Test_CFE_TBL_Manage(void)
     CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
     CFE_TBL_TaskData.ValidationResults[0].Result = 1;
     strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table2", CFE_TBL_MAX_FULL_NAME_LEN);
+            "ut_cfe_tbl.UT_Table2", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
+    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
     CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
     CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = true;
     RegRecPtr->ValidateActiveIndex = 0;
@@ -3609,14 +3645,13 @@ void Test_CFE_TBL_Manage(void)
      * later
      */
     CFE_TBL_TaskData.DumpControlBlocks[0].DumpBufferPtr = WorkingBufferPtr;
-    strncpy(CFE_TBL_TaskData.DumpControlBlocks[0].
-                     DumpBufferPtr->DataSource,
-                   "MyDumpFilename", OS_MAX_PATH_LEN-1);
-    CFE_TBL_TaskData.DumpControlBlocks[0].
-                         DumpBufferPtr->DataSource[OS_MAX_PATH_LEN-1] = 0;
-    strncpy(CFE_TBL_TaskData.DumpControlBlocks[0].TableName,
-                   "ut_cfe_tbl.UT_Table2", CFE_TBL_MAX_FULL_NAME_LEN-1);
-    CFE_TBL_TaskData.DumpControlBlocks[0].TableName[CFE_TBL_MAX_FULL_NAME_LEN-1] = 0;
+    strncpy(CFE_TBL_TaskData.DumpControlBlocks[0].DumpBufferPtr->DataSource,
+            "MyDumpFilename", sizeof(CFE_TBL_TaskData.DumpControlBlocks[0].DumpBufferPtr->DataSource) - 1);
+    CFE_TBL_TaskData.DumpControlBlocks[0].DumpBufferPtr->DataSource[
+            sizeof(CFE_TBL_TaskData.DumpControlBlocks[0].DumpBufferPtr->DataSource) - 1] = 0;
+    strncpy(CFE_TBL_TaskData.DumpControlBlocks[0].TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(CFE_TBL_TaskData.DumpControlBlocks[0].TableName) - 1);
+    CFE_TBL_TaskData.DumpControlBlocks[0].TableName[sizeof(CFE_TBL_TaskData.DumpControlBlocks[0].TableName) - 1] = 0;
     CFE_TBL_TaskData.DumpControlBlocks[0].Size = RegRecPtr->Size;
     RegRecPtr->DumpControlIndex = 0;
     RtnCode = CFE_TBL_Manage(App1TblHandle2);
@@ -3794,13 +3829,15 @@ void Test_CFE_TBL_TblMod(void)
 
     /* Configure for successful file read to initialize table */
     strncpy(FileHeader.Description, "FS header description",
-            sizeof(FileHeader.Description));
+            sizeof(FileHeader.Description) - 1);
+    FileHeader.Description[sizeof(FileHeader.Description) - 1] = '\0';
     FileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     FileHeader.SubType = CFE_FS_SubType_TBL_IMG;
     FileHeader.TimeSeconds = 1704;
     FileHeader.TimeSubSeconds = 104;
-    strncpy((char *)File.TblHeader.TableName, "ut_cfe_tbl.UT_Table1",
-            sizeof(File.TblHeader.TableName));
+    strncpy(File.TblHeader.TableName, "ut_cfe_tbl.UT_Table1",
+            sizeof(File.TblHeader.TableName) - 1);
+    File.TblHeader.TableName[sizeof(File.TblHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&File.TblHeader, 0, sizeof(UT_Table1_t));
 
     if (UT_Endianess == UT_LITTLE_ENDIAN)
@@ -3878,13 +3915,15 @@ void Test_CFE_TBL_TblMod(void)
 
     /* Configure for successful file read to initialize table */
     strncpy(FileHeader.Description, "FS header description",
-            sizeof(FileHeader.Description));
+            sizeof(FileHeader.Description) - 1);
+    FileHeader.Description[sizeof(FileHeader.Description) - 1] = '\0';
     FileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     FileHeader.SubType = CFE_FS_SubType_TBL_IMG;
     FileHeader.TimeSeconds = 1704;
     FileHeader.TimeSubSeconds = 104;
-    strncpy((char *)File.TblHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(File.TblHeader.TableName));
+    strncpy(File.TblHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(File.TblHeader.TableName) - 1);
+    File.TblHeader.TableName[sizeof(File.TblHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&File.TblHeader, 0, sizeof(UT_Table1_t));
 
     File.TblData.TblElement1 = 0x04030201;
@@ -3973,8 +4012,8 @@ void Test_CFE_TBL_Internal(void)
     AccessDescPtr = &CFE_TBL_TaskData.Handles[App1TblHandle2];
     RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
     strncpy(RegRecPtr->Name, "ut_cfe_tbl.UT_Table3",
-            CFE_TBL_MAX_FULL_NAME_LEN);
-    RegRecPtr->Name[CFE_TBL_MAX_FULL_NAME_LEN - 1] = '\0';
+            sizeof(RegRecPtr->Name) - 1);
+    RegRecPtr->Name[sizeof(RegRecPtr->Name) - 1] = '\0';
     RegRecPtr->TableLoadedOnce = false;
     RegRecPtr->LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
     RtnCode = CFE_TBL_GetWorkingBuffer(&WorkingBufferPtr, RegRecPtr, true);
@@ -4023,12 +4062,13 @@ void Test_CFE_TBL_Internal(void)
     UT_InitData();
     Filename[OS_MAX_PATH_LEN - 1] = '\0';
     strncpy(StdFileHeader.Description, "FS header description",
-            sizeof(StdFileHeader.Description));
-    StdFileHeader.Description[CFE_FS_HDR_DESC_MAX_LEN - 1] = '\0';
+            sizeof(StdFileHeader.Description) - 1);
+    StdFileHeader.Description[sizeof(StdFileHeader.Description) - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 1, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4048,8 +4088,9 @@ void Test_CFE_TBL_Internal(void)
     Filename[OS_MAX_PATH_LEN - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4070,10 +4111,11 @@ void Test_CFE_TBL_Internal(void)
     Filename[OS_MAX_PATH_LEN - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
-//
+
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UT_SetDeferredRetcode(UT_KEY(OS_read), 2, sizeof(UT_Table1_t) - 1);
@@ -4093,8 +4135,9 @@ void Test_CFE_TBL_Internal(void)
     Filename[OS_MAX_PATH_LEN - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.NotUT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.NotUT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4113,8 +4156,9 @@ void Test_CFE_TBL_Internal(void)
     Filename[OS_MAX_PATH_LEN - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4133,8 +4177,9 @@ void Test_CFE_TBL_Internal(void)
     Filename[OS_MAX_PATH_LEN - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t)-1);
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4154,13 +4199,14 @@ void Test_CFE_TBL_Internal(void)
     Filename[OS_MAX_PATH_LEN - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t)-1);
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
-    strncpy(Filename, "MyTestInputFilename", sizeof(Filename));
+    strncpy(Filename, "MyTestInputFilename", sizeof(Filename) - 1);
     Filename[sizeof(Filename) - 1] = '\0';
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_ReadHeader), 1, sizeof(CFE_FS_Header_t) - 1);
     RtnCode = CFE_TBL_ReadHeaders(FileDescriptor, &StdFileHeader,
@@ -4180,8 +4226,9 @@ void Test_CFE_TBL_Internal(void)
     Filename[OS_MAX_PATH_LEN - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID - 1;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     TblFileHeader.NumBytes = sizeof(UT_Table1_t) - 1;
     TblFileHeader.Offset = 0;
 
@@ -4207,8 +4254,9 @@ void Test_CFE_TBL_Internal(void)
     Filename[OS_MAX_PATH_LEN - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG - 1;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t)-1);
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4230,8 +4278,9 @@ void Test_CFE_TBL_Internal(void)
     Filename[OS_MAX_PATH_LEN - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t)-1);
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4370,8 +4419,9 @@ void Test_CFE_TBL_Internal(void)
     UT_InitData();
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4391,8 +4441,9 @@ void Test_CFE_TBL_Internal(void)
     UT_InitData();
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4412,8 +4463,9 @@ void Test_CFE_TBL_Internal(void)
     UT_InitData();
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4433,8 +4485,9 @@ void Test_CFE_TBL_Internal(void)
     UT_InitData();
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4457,8 +4510,9 @@ void Test_CFE_TBL_Internal(void)
     UT_InitData();
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4497,8 +4551,9 @@ void Test_CFE_TBL_Internal(void)
     UT_ClearEventHistory();
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4538,8 +4593,9 @@ void Test_CFE_TBL_Internal(void)
     UT_ClearEventHistory();
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4581,8 +4637,9 @@ void Test_CFE_TBL_Internal(void)
     UT_ClearEventHistory();
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4655,8 +4712,9 @@ void Test_CFE_TBL_Internal(void)
     UT_InitData();
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4822,7 +4880,8 @@ void Test_CFE_TBL_Internal(void)
     StdFileHeader.SpacecraftID = -1;
     StdFileHeader.ProcessorID = CFE_PLATFORM_TBL_VALID_PRID_1;
     strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
-            sizeof(TblFileHeader.TableName));
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     TblFileHeader.NumBytes = sizeof(UT_Table1_t) - 1;
     TblFileHeader.Offset = 0;
 
@@ -4834,7 +4893,7 @@ void Test_CFE_TBL_Internal(void)
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
-    strncpy(Filename, "MyTestInputFilename", sizeof(Filename));
+    strncpy(Filename, "MyTestInputFilename", sizeof(Filename) - 1);
     Filename[sizeof(Filename) - 1] = '\0';
     RtnCode = CFE_TBL_ReadHeaders(FileDescriptor, &StdFileHeader,
                                   &TblFileHeader, Filename);
@@ -4861,7 +4920,8 @@ void Test_CFE_TBL_Internal(void)
     StdFileHeader.SpacecraftID = CFE_PLATFORM_TBL_VALID_SCID_1;
     StdFileHeader.ProcessorID = -1;
     strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
-            sizeof(TblFileHeader.TableName));
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     TblFileHeader.NumBytes = sizeof(UT_Table1_t) - 1;
     TblFileHeader.Offset = 0;
 
@@ -4873,7 +4933,7 @@ void Test_CFE_TBL_Internal(void)
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
-    strncpy(Filename, "MyTestInputFilename", sizeof(Filename));
+    strncpy(Filename, "MyTestInputFilename", sizeof(Filename) - 1);
     Filename[sizeof(Filename) - 1] = '\0';
     RtnCode = CFE_TBL_ReadHeaders(FileDescriptor, &StdFileHeader,
                                   &TblFileHeader, Filename);


### PR DESCRIPTION
**Describe the contribution**
Fix #1089 - this cleans up the use of strncpy (and other minor hardcoded references) which solves most of #932
Fix #932 - remainder of cleanup in unit tests now that `CFE_MISSION_MAX_API_LEN` and `CFE_MISSION_MAX_PATH_LEN` can be bigger than `OS_MAX_API_NAME` and `OS_MAX_PATH_LENGTH`

Other minor mods 
- Moved ES pipe name, lengths to defines (someday these could be cfg items, but just matched pattern of other services for now)
- Removed PipeName and PipeDepth variables from app global where they didn't add anything (just sent and passed)
- Removed many unnecessary (char *) casts
- Simplified &stingname[0] to stringname where observed

**Testing performed**
Built and ran unit tests with sample config (where values are equal), and with CFE_MISSION* += 4, passed

**Expected behavior changes**
None, just easier maintenance and allows for use case of mission with multiple OS's w/ different limits to have standard cmd/tlm and the unit tests will still pass

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC