### PR TITLE
Fix #933, Remove SenderReporting from SB global

### DIFF
--- a/cmake/sample_defs/cpu1_platform_cfg.h
+++ b/cmake/sample_defs/cpu1_platform_cfg.h
@@ -305,21 +305,6 @@
 #define CFE_PLATFORM_SB_MAX_BLOCK_SIZE             (CFE_MISSION_SB_MAX_SB_MSG_SIZE + 40)
 
 /**
-**  \cfesbcfg Define Default Sender Information Storage Mode
-**
-**  \par Description:
-**       Defines the default mode for the storing of sender information when sending
-**       a software bus message. If set to 1, the sender information will be stored.
-**       If set to 0, the sender information will not be stored.
-**
-**  \par Limits
-**       There is a lower limit of 0 and an upper limit of 1 on this configuration
-**       paramater.
-*/
-#define CFE_PLATFORM_SB_DEFAULT_REPORT_SENDER      1
-
-
-/**
 **  \cfetimecfg Time Server or Time Client Selection
 **
 **  \par Description:

--- a/fsw/cfe-core/src/sb/cfe_sb_init.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_init.c
@@ -99,9 +99,6 @@ int32 CFE_SB_EarlyInit (void) {
     /* Initialize the state of susbcription reporting */
     CFE_SB.SubscriptionReporting = CFE_SB_DISABLE;
 
-    /* Initialize the state of sender reporting */
-    CFE_SB.SenderReporting = CFE_PLATFORM_SB_DEFAULT_REPORT_SENDER;
-
      /* Initialize memory partition. */
     Stat = CFE_SB_InitBuffers();
     if(Stat != CFE_SUCCESS){

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.h
@@ -186,7 +186,6 @@ typedef struct
 {
     osal_id_t                      SharedDataMutexId;
     uint32                         SubscriptionReporting;
-    uint32                         SenderReporting;
     CFE_ES_ResourceID_t            AppId;
     uint32                         StopRecurseFlags[OS_MAX_TASKS];
     void                          *ZeroCopyTail;

--- a/fsw/cfe-core/src/sb/cfe_sb_verify.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_verify.h
@@ -154,14 +154,6 @@
     #error CFE_PLATFORM_SB_MEM_BLOCK_SIZE_16 must be less than CFE_PLATFORM_SB_MAX_BLOCK_SIZE
 #endif
 
-#if CFE_PLATFORM_SB_DEFAULT_REPORT_SENDER < 0
-    #error CFE_PLATFORM_SB_DEFAULT_REPORT_SENDER cannot be less than 0!
-#endif
-
-#if CFE_PLATFORM_SB_DEFAULT_REPORT_SENDER > 1
-    #error CFE_PLATFORM_SB_DEFAULT_REPORT_SENDER cannot be greater than 1!
-#endif
-
 #if CFE_PLATFORM_SB_DEFAULT_MSG_LIMIT < 4
     #error CFE_PLATFORM_SB_DEFAULT_MSG_LIMIT cannot be less than 4!
 #endif

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -3946,7 +3946,6 @@ void Test_SB_TransmitMsgPaths_Nominal(void)
     MsgId = SB_UT_CMD_MID;
     Size = sizeof(TlmPkt);
     Type = CFE_MSG_Type_Cmd;
-    CFE_SB.SenderReporting = 0;
     SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "TestPipe"));
 
     /* Will fail because of deferred CFE_ES_GetPoolBuf failure return */


### PR DESCRIPTION
**Describe the contribution**
Fix #933 - removes unused SenderReporting and CFE_PLATFORM_SB_DEFAULT_REPORT_SENDER

**Testing performed**
Build and run unit tests

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
Replaces #934

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC