### PR TITLE
Fix #945, Finish CFE_PLATFORM_ES_PERF_MAX_IDS removal

### DIFF
--- a/cmake/sample_defs/cpu1_platform_cfg.h
+++ b/cmake/sample_defs/cpu1_platform_cfg.h
@@ -1035,19 +1035,6 @@
 #define CFE_PLATFORM_ES_DEFAULT_PR_SYSLOG_MODE      1
 
 /**
-**  \cfeescfg Define Max Number of Performance IDs
-**
-**  \par Description:
-**       Defines the maximum number of perf ids allowed.
-**
-**
-**  \par Limits
-**       This number must always be divisible by 32. There is a lower limit of 32 and
-**       an upper limit of 512 on this configuration paramater.
-*/
-#define CFE_PLATFORM_ES_PERF_MAX_IDS                  128
-
-/**
 **  \cfeescfg Define Max Size of Performance Data Buffer
 **
 **  \par Description:

--- a/cmake/sample_defs/sample_perfids.h
+++ b/cmake/sample_defs/sample_perfids.h
@@ -26,7 +26,7 @@
 ** Design Notes:
 **   Each performance id is used to identify something that needs to be
 **   measured.  Performance ids are limited to the range of 0 to
-**   CFE_PLATFORM_ES_PERF_MAX_IDS - 1.  Any performance ids outside of this range
+**   CFE_MISSION_ES_PERF_MAX_IDS - 1.  Any performance ids outside of this range
 **   will be ignored and will be flagged as an error.  Note that
 **   performance ids 0-31 are reserved for the cFE Core.
 **

--- a/fsw/cfe-core/src/inc/cfe_es_events.h
+++ b/fsw/cfe-core/src/inc/cfe_es_events.h
@@ -996,12 +996,8 @@
 **/
 #define CFE_ES_PERF_FILTMSKCMD_EID  63
 
-/** \brief  <tt> 'Error:Performance Filter Mask Index value  
-** greater than CFE_ES_PERF_32BIT_WORDS_IN_MASK (which is a whole number derived from 
-** CFE_PLATFORM_ES_PERF_MAX_IDS / 32)' </tt>
-**  \event <tt> 'Error:Performance Filter Mask Index value  
-** greater than CFE_ES_PERF_32BIT_WORDS_IN_MASK (which is a whole number derived from 
-** CFE_PLATFORM_ES_PERF_MAX_IDS / 32)' </tt>
+/** \brief  <tt> 'Performance Filter Mask Cmd Error,Index(%u)out of range(%u)' </tt>
+**  \event <tt> 'Performance Filter Mask Cmd Error,Index(%u)out of range(%u)' </tt>
 **
 **  \par Type: ERROR
 **
@@ -1027,12 +1023,8 @@
 **/
 #define CFE_ES_PERF_TRIGMSKCMD_EID 65
 
-/** \brief  <tt> 'Error: Performance Trigger Mask Index value  
-** greater than CFE_ES_PERF_32BIT_WORDS_IN_MASK (which is a whole number derived from 
-** CFE_PLATFORM_ES_PERF_MAX_IDS / 32)' </tt>
-**  \event <tt> 'Error: Performance Trigger Mask Index value  
-** greater than CFE_ES_PERF_32BIT_WORDS_IN_MASK (which is a whole number derived from 
-** CFE_PLATFORM_ES_PERF_MAX_IDS / 32)' </tt>
+/** \brief  <tt> 'Performance Trigger Mask Cmd Error,Index(%u)out of range(%u)' </tt>
+**  \event <tt> 'Performance Trigger Mask Cmd Error,Index(%u)out of range(%u)' </tt>
 **
 **  \par Type: ERROR
 **

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -4188,7 +4188,7 @@ void TestPerf(void)
     Perf->MetaData.TriggerCount = CFE_PLATFORM_ES_PERF_DATA_BUFFER_SIZE +1;
     Perf->MetaData.InvalidMarkerReported = false;
     Perf->MetaData.DataEnd = CFE_PLATFORM_ES_PERF_DATA_BUFFER_SIZE +1 ;
-    CFE_ES_PerfLogAdd(CFE_PLATFORM_ES_PERF_MAX_IDS, 0);
+    CFE_ES_PerfLogAdd(CFE_MISSION_ES_PERF_MAX_IDS, 0);
     UT_Report(__FILE__, __LINE__,
               Perf->MetaData.InvalidMarkerReported == true,
               "CFE_ES_PerfLogAdd",
@@ -4242,7 +4242,7 @@ void TestPerf(void)
     ES_ResetUnitTest();
     Perf->MetaData.State = CFE_ES_PERF_TRIGGERED;
     Perf->MetaData.InvalidMarkerReported = 2;
-    CFE_ES_PerfLogAdd(CFE_PLATFORM_ES_PERF_MAX_IDS + 1, 0);
+    CFE_ES_PerfLogAdd(CFE_MISSION_ES_PERF_MAX_IDS + 1, 0);
     UT_Report(__FILE__, __LINE__,
               Perf->MetaData.InvalidMarkerReported == 2,
               "CFE_ES_PerfLogAdd",


### PR DESCRIPTION
**Describe the contribution**
Fix #945 - Removes the rest of the references/uses of `CFE_PLATFORM_ES_PERF_MAX_IDS` (in favor of `CFE_MISSION_ES_PERF_MAX_IDS `)

**Testing performed**
Build and run unit tests, passed

**Expected behavior changes**
None, just avoids issues that could happen if the platform/mission defines diverged

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
#1103 is open for consideration, but future work

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC