### PR TITLE
Fix #954, Handle debug events in unit test

### DIFF
--- a/fsw/cfe-core/unit-test/evs_UT.c
+++ b/fsw/cfe-core/unit-test/evs_UT.c
@@ -2693,7 +2693,7 @@ void Test_Misc(void)
             UT_TPID_CFE_EVS_CMD_WRITE_LOG_DATA_FILE_CC,
             &UT_EVS_EventBuf);
     UT_Report(__FILE__, __LINE__,
-              UT_EVS_EventBuf.EventID ==  0xFFFF,
+              (UT_EVS_EventBuf.EventID == 0xFFFF) || (UT_EVS_EventBuf.EventID == CFE_EVS_WRLOG_EID),
               "CFE_EVS_WriteLogDataFileCmd",
               "Write log data - successful");
 
@@ -2703,7 +2703,7 @@ void Test_Misc(void)
             UT_TPID_CFE_EVS_CMD_SET_LOG_MODE_CC,
             &UT_EVS_EventBuf);
     UT_Report(__FILE__, __LINE__,
-              UT_EVS_EventBuf.EventID ==  0xFFFF,
+              (UT_EVS_EventBuf.EventID == 0xFFFF) || (UT_EVS_EventBuf.EventID == CFE_EVS_LOGMODE_EID),
               "CFE_EVS_SetLogModeCmd",
               "Set logging mode - successful");
 


### PR DESCRIPTION
**Describe the contribution**
Fix #954 - updates asserts to handle debug events if enabled via CFE_PLATFORM_EVS_DEFAULT_TYPE_FLAG in platform config.

**Testing performed**
Built and ran unit tests with default (0xE) and debug enabled (0xF), passed

**Expected behavior changes**
None except tests pass w/ debug events enabled

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC