### PR TITLE
cFE Integration candidate: 2021-01-19

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,40 @@ The detailed cFE user's guide can be viewed at <https://github.com/nasa/cFS/blob
 
 ## Version History
 
+### Development Build: 6.8.0-rc1+dev288
+
+- Documentation: Add Security.md with instructions to report vulnerability
+- Documentation: Update cpuname/MISSION_CPUNAMES documentation
+- Fixes `UT_CheckEventHistoryFromFunc()` helper routine to read the correct number of IDs so it checks the correct number of events. Also correct bad event checks in TBL UT.
+- Adds `OS_printf` to `CFE_ES_SYSLOG_APPEND` so it matches `CFE_ES_WriteToSysLog`
+- Removes unused `SenderReporting` and `CFE_PLATFORM_SB_DEFAULT_REPORT_SENDER`
+- Tests pass when debug events are enabled via `CFE_PLATFORM_EVS_DEFAULT_TYPE_FLAG` in platform config.
+- Removes references to `UT_CheckForOpenSockets` which is no longer applicable since the UT framework resets the state for each unit test.
+- Rename `UT_ClearForceFail` as `UT_ClearDefaultValue` given change in https://github.com/nasa/osal/issues/724
+- Adds checks that ensure `CFE_SB_GetUserData` works with all payload data types.
+- Adds header padding to 64-bit so that `CFE_SB_GetUserData` will work for message structures with elements up to 64 bit
+- For primary-only header config: telemetry header required to 64 bit boundary (affects all receivers)
+- For primary and extended header config: command header required padding to 64 bit boundary (affects all senders)
+- Refactor `CFE_TIME_RegisterSynchCallback` to only have one return point and eliminates "possible uninitialized variable" static analysis warning
+- None of these changes are expected to cause problematic.
+- Addresses message delivery issues due to inconsistent locking by reworking cFE-SB API implementation. Ensures all events are generated and counters are incremented consistently by avoiding early returns in functions and using the `PendingEventID` register to record what event ID should be sent per the current operation.
+- Employs the `CFE_ES_ResourceID_t` type and related patterns for managing the SB Pipe IDs.
+- Will break code which directly accessed these items without going through the lookup function.
+- **`CFE_SB_PipeId_t` type is no longer usable as a direct array index**, increased in size from 8 to 32 bits, and is now consistent with all other ID types in both behavior and size.
+- **The "pipe stats" structure in the Pipe TLM is also changed**. This structure contained a `CFE_SB_PipeId_t` value, hence why it had to be updated because the type is now bigger. The spare bytes are also moved to the end of the struct.
+- Removes `OS_printf` checks of stub calls in unit tests and checks for specific format string in history instead to confirm the right path was taken.
+- Removes `CFE_MISSION_REV` from platform config.
+- Removes the rest of the references and uses of `CFE_PLATFORM_ES_PERF_MAX_IDS` in favor of `CFE_MISSION_ES_PERF_MAX_IDS`
+- Remove uses of strncpy and other minor hardcoded references
+- Cleanup unit tests to reflect size changes in `CFE_MISSION_MAX_API_LEN` and `CFE_MISSION_MAX_PATH_LEN`.
+- Moved ES pipe name and lengths to defines
+- Removed PipeName and PipeDepth variables from app global
+- Removed unnecessary (char *) casts
+- Simplified `&stingname[0]` to `stringname` where observed
+- Enables projects that have OSs with different limits to maintain a standard cmd/tlm and have unit tests pass.
+- Make `CFE_ES_WriteToSysLog` stub unit test more informative by adding `UtDebug` output
+- See <https://github.com/nasa/cFE/pull/1109>
+
 ### Development Build: 6.8.0-rc1+dev248
 
 - Replace `OS_FileSysStatVolume()` with`OS_fsBlocksFree()` which will be deprecated. This call reports the number of total blocks, not just the free blocks, making the check more accurate and removing the need for a workaround for desktop machines.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,16 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+To report a vulnerability for the cFE subsystem please [submit an issue](https://github.com/nasa/cFE/issues/new/choose).
+
+For general cFS vulnerabilities please [open a cFS framework issue](https://github.com/nasa/cfs/issues/new/choose) and see our [top-level security policy](https://github.com/nasa/cFS/security/policy).
+
+In either case please use the "Bug Report" template and provide as much information as possible. Apply appropraite labels for each report. For security related reports, tag the issue with the "security" label.
+
+## Additional Support
+
+For additional support, email us at cfs-program@lists.nasa.gov. For help using OSAL and cFS, [subscribe to our mailing list](https://lists.nasa.gov/mailman/listinfo/cfs-community) that includes all the community members/users of the NASA core Flight Software (cFS) product line. The mailing list is used to communicate any information related to the cFS product such as current releases, bug findings and fixes, enhancement requests, community meeting notifications, sending out meeting minutes, etc.
+
+If you wish to report a cybersecurity incident or concern please contact the NASA Security Operations Center either by phone at 1-877-627-2732 or via email address soc@nasa.gov.
+

--- a/cmake/sample_defs/cpu1_platform_cfg.h
+++ b/cmake/sample_defs/cpu1_platform_cfg.h
@@ -1020,19 +1020,6 @@
 #define CFE_PLATFORM_ES_DEFAULT_PR_SYSLOG_MODE      1
 
 /**
-**  \cfeescfg Define Max Number of Performance IDs
-**
-**  \par Description:
-**       Defines the maximum number of perf ids allowed.
-**
-**
-**  \par Limits
-**       This number must always be divisible by 32. There is a lower limit of 32 and
-**       an upper limit of 512 on this configuration paramater.
-*/
-#define CFE_PLATFORM_ES_PERF_MAX_IDS                  128
-
-/**
 **  \cfeescfg Define Max Size of Performance Data Buffer
 **
 **  \par Description:

--- a/cmake/sample_defs/cpu1_platform_cfg.h
+++ b/cmake/sample_defs/cpu1_platform_cfg.h
@@ -305,21 +305,6 @@
 #define CFE_PLATFORM_SB_MAX_BLOCK_SIZE             (CFE_MISSION_SB_MAX_SB_MSG_SIZE + 40)
 
 /**
-**  \cfesbcfg Define Default Sender Information Storage Mode
-**
-**  \par Description:
-**       Defines the default mode for the storing of sender information when sending
-**       a software bus message. If set to 1, the sender information will be stored.
-**       If set to 0, the sender information will not be stored.
-**
-**  \par Limits
-**       There is a lower limit of 0 and an upper limit of 1 on this configuration
-**       paramater.
-*/
-#define CFE_PLATFORM_SB_DEFAULT_REPORT_SENDER      1
-
-
-/**
 **  \cfetimecfg Time Server or Time Client Selection
 **
 **  \par Description:

--- a/cmake/sample_defs/cpu1_platform_cfg.h
+++ b/cmake/sample_defs/cpu1_platform_cfg.h
@@ -1799,21 +1799,6 @@
 #define CFE_PLATFORM_TBL_VALID_PRID_3            0
 #define CFE_PLATFORM_TBL_VALID_PRID_4            0
 
-/** \cfeescfg Mission specific version number for cFE
-**
-**  \par Description:
-**       The cFE version number consists of four parts:
-**       major version number, minor version number, revision
-**       number and mission specific revision number. The mission
-**       specific revision number is defined here and the other
-**       parts are defined in "cfe_version.h".
-**
-**  \par Limits:
-**       Must be defined as a numeric value that is greater than
-**       or equal to zero.
-*/
-#define CFE_MISSION_REV                  0
-
 /** \cfeescfg Poll timer for startup sync delay
 **
 **  \par Description:

--- a/cmake/sample_defs/sample_perfids.h
+++ b/cmake/sample_defs/sample_perfids.h
@@ -26,7 +26,7 @@
 ** Design Notes:
 **   Each performance id is used to identify something that needs to be
 **   measured.  Performance ids are limited to the range of 0 to
-**   CFE_PLATFORM_ES_PERF_MAX_IDS - 1.  Any performance ids outside of this range
+**   CFE_MISSION_ES_PERF_MAX_IDS - 1.  Any performance ids outside of this range
 **   will be ignored and will be flagged as an error.  Note that
 **   performance ids 0-31 are reserved for the cFE Core.
 **

--- a/cmake/sample_defs/targets.cmake
+++ b/cmake/sample_defs/targets.cmake
@@ -5,11 +5,11 @@
 # This file indicates the architecture and configuration of the
 # target boards that will run core flight software.
 #
-# The following variables are defined per board, where <x> is the
-# CPU number starting with 1:
+# The following variables are defined per board, where <cpuname>
+# is a specific name within MISSION_CPUNAMES list:
 #
-#  <cpuname>_NAME : the user-friendly name of the cpu.  Should be simple
-#       word with no punctuation.  This MUST be specified.
+#  MISSION_CPUNAMES : list of user-friendly cpu names.  Should be simple
+#       words with no punctuation.  This MUST be specified.
 #  <cpuname>_APPLIST : list of applications to build and install on the CPU.
 #       These are built as dynamically-loaded applications and installed
 #       as files in the non-volatile storage of the target, and loaded

--- a/fsw/cfe-core/src/es/cfe_es_api.c
+++ b/fsw/cfe-core/src/es/cfe_es_api.c
@@ -1877,9 +1877,11 @@ int32 CFE_ES_RestoreFromCDS(void *RestoreToMemory, CFE_ES_CDSHandle_t Handle)
     return CFE_ES_CDSBlockRead(RestoreToMemory, Handle);
 } /* End of CFE_ES_RestoreFromCDS() */
 
-/* end of file */
-
-
+/*
+** Function: CFE_ES_RegisterGenCounter
+**
+** Purpose:  Allocates a generic counter resource and assigns ID
+*/
 int32 CFE_ES_RegisterGenCounter(CFE_ES_ResourceID_t *CounterIdPtr, const char *CounterName)
 {
    CFE_ES_GenCounterRecord_t *CountRecPtr;
@@ -1912,7 +1914,7 @@ int32 CFE_ES_RegisterGenCounter(CFE_ES_ResourceID_t *CounterIdPtr, const char *C
    else
    {
        /* scan for a free slot */
-       PendingCounterId = CFE_ES_FindNextAvailableId(CFE_ES_Global.LastCounterId, CFE_PLATFORM_ES_MAX_GEN_COUNTERS);
+       PendingCounterId = CFE_ES_FindNextAvailableId(CFE_ES_Global.LastCounterId, CFE_PLATFORM_ES_MAX_GEN_COUNTERS, CFE_ES_CheckCounterIdSlotUsed);
        CountRecPtr = CFE_ES_LocateCounterRecordByID(PendingCounterId);
 
        if (CountRecPtr == NULL)
@@ -2108,7 +2110,7 @@ CFE_Status_t CFE_ES_GetGenCounterName(char *CounterName, CFE_ES_ResourceID_t Cou
  */
 int32 CFE_ES_AppID_ToIndex(CFE_ES_ResourceID_t AppID, uint32 *Idx)
 {
-    return CFE_ES_ResourceID_ToIndex_Internal(
+    return CFE_ES_ResourceID_ToIndex(
             CFE_ES_ResourceID_ToInteger(AppID) - CFE_ES_APPID_BASE,
             CFE_PLATFORM_ES_MAX_APPLICATIONS,
             Idx);
@@ -2120,7 +2122,7 @@ int32 CFE_ES_AppID_ToIndex(CFE_ES_ResourceID_t AppID, uint32 *Idx)
  */
 int32 CFE_ES_LibID_ToIndex(CFE_ES_ResourceID_t LibId, uint32 *Idx)
 {
-    return CFE_ES_ResourceID_ToIndex_Internal(
+    return CFE_ES_ResourceID_ToIndex(
             CFE_ES_ResourceID_ToInteger(LibId) - CFE_ES_LIBID_BASE,
             CFE_PLATFORM_ES_MAX_LIBRARIES,
             Idx);
@@ -2160,7 +2162,7 @@ int32 CFE_ES_TaskID_ToIndex(CFE_ES_ResourceID_t TaskID, uint32 *Idx)
  */
 int32 CFE_ES_CounterID_ToIndex(CFE_ES_ResourceID_t CounterId, uint32 *Idx)
 {
-    return CFE_ES_ResourceID_ToIndex_Internal(
+    return CFE_ES_ResourceID_ToIndex(
             CFE_ES_ResourceID_ToInteger(CounterId) - CFE_ES_COUNTID_BASE,
             CFE_PLATFORM_ES_MAX_GEN_COUNTERS,
             Idx);

--- a/fsw/cfe-core/src/es/cfe_es_api.c
+++ b/fsw/cfe-core/src/es/cfe_es_api.c
@@ -871,7 +871,7 @@ int32 CFE_ES_GetAppName(char *AppName, CFE_ES_ResourceID_t AppId, size_t BufferL
     */
    if (CFE_ES_AppRecordIsMatch(AppRecPtr, AppId))
    {
-       strncpy(AppName, CFE_ES_AppRecordGetName(AppRecPtr), BufferLength);
+       strncpy(AppName, CFE_ES_AppRecordGetName(AppRecPtr), BufferLength - 1);
        AppName[BufferLength - 1] = '\0';
        Result = CFE_SUCCESS;
    }
@@ -1306,8 +1306,8 @@ int32 CFE_ES_CreateChildTask(CFE_ES_ResourceID_t *TaskIdPtr,
 
                CFE_ES_TaskRecordSetUsed(TaskRecPtr, ChildTaskId);
                TaskRecPtr->AppId = CFE_ES_AppRecordGetID(AppRecPtr);
-               strncpy((char *)TaskRecPtr->TaskName,TaskName,OS_MAX_API_NAME);
-               TaskRecPtr->TaskName[OS_MAX_API_NAME - 1] = '\0';
+               strncpy(TaskRecPtr->TaskName,TaskName,sizeof(TaskRecPtr->TaskName) - 1);
+               TaskRecPtr->TaskName[sizeof(TaskRecPtr->TaskName) - 1] = '\0';
                CFE_ES_Global.RegisteredTasks++;
 
                *TaskIdPtr = ChildTaskId;
@@ -1737,8 +1737,8 @@ int32 CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *CDSHandlePtr, size_t BlockSize, con
 
            /* Perform a buffer overrun safe copy of name for debug log message */
 
-           strncpy(CDSName, Name, CFE_MISSION_ES_CDS_MAX_NAME_LENGTH);
-           CDSName[CFE_MISSION_ES_CDS_MAX_NAME_LENGTH-1] = '\0';
+           strncpy(CDSName, Name, sizeof(CDSName) - 1);
+           CDSName[sizeof(CDSName) - 1] = '\0';
            CFE_ES_WriteToSysLog("CFE_CDS:Register-CDS Name (%s) is too long\n", CDSName);
         }
         else
@@ -1925,7 +1925,8 @@ int32 CFE_ES_RegisterGenCounter(CFE_ES_ResourceID_t *CounterIdPtr, const char *C
        else
        {
            strncpy(CountRecPtr->CounterName,CounterName,
-                   sizeof(CountRecPtr->CounterName));
+                   sizeof(CountRecPtr->CounterName) - 1);
+           CountRecPtr->CounterName[sizeof(CountRecPtr->CounterName) - 1] = '\0';
            CountRecPtr->Counter = 0;
            CFE_ES_CounterRecordSetUsed(CountRecPtr, PendingCounterId);
            CFE_ES_Global.LastCounterId = PendingCounterId;

--- a/fsw/cfe-core/src/es/cfe_es_apps.c
+++ b/fsw/cfe-core/src/es/cfe_es_apps.c
@@ -688,7 +688,7 @@ int32 CFE_ES_AppCreate(CFE_ES_ResourceID_t *ApplicationIdPtr,
    else
    {
        /* scan for a free slot */
-       PendingAppId = CFE_ES_FindNextAvailableId(CFE_ES_Global.LastAppId, CFE_PLATFORM_ES_MAX_APPLICATIONS);
+       PendingAppId = CFE_ES_FindNextAvailableId(CFE_ES_Global.LastAppId, CFE_PLATFORM_ES_MAX_APPLICATIONS, CFE_ES_CheckAppIdSlotUsed);
        AppRecPtr = CFE_ES_LocateAppRecordByID(PendingAppId);
 
        if (AppRecPtr == NULL)
@@ -795,6 +795,7 @@ int32 CFE_ES_AppCreate(CFE_ES_ResourceID_t *ApplicationIdPtr,
    return Status;
 
 } /* End Function */
+
 /*
 **---------------------------------------------------------------------------------------
 ** Name: CFE_ES_LoadLibrary
@@ -864,7 +865,7 @@ int32 CFE_ES_LoadLibrary(CFE_ES_ResourceID_t       *LibraryIdPtr,
    else
    {
        /* scan for a free slot */
-       PendingLibId = CFE_ES_FindNextAvailableId(CFE_ES_Global.LastLibId, CFE_PLATFORM_ES_MAX_LIBRARIES);
+       PendingLibId = CFE_ES_FindNextAvailableId(CFE_ES_Global.LastLibId, CFE_PLATFORM_ES_MAX_LIBRARIES, CFE_ES_CheckLibIdSlotUsed);
        LibSlotPtr = CFE_ES_LocateLibRecordByID(PendingLibId);
 
        if (LibSlotPtr == NULL)

--- a/fsw/cfe-core/src/es/cfe_es_apps.c
+++ b/fsw/cfe-core/src/es/cfe_es_apps.c
@@ -707,12 +707,16 @@ int32 CFE_ES_AppCreate(CFE_ES_ResourceID_t *ApplicationIdPtr,
            AppRecPtr->Type = CFE_ES_AppType_EXTERNAL;
            strncpy(AppRecPtr->StartParams.BasicInfo.Name, AppName,
                    sizeof(AppRecPtr->StartParams.BasicInfo.Name)-1);
+           AppRecPtr->StartParams.BasicInfo.Name[sizeof(AppRecPtr->StartParams.BasicInfo.Name)-1] = '\0';
            strncpy(AppRecPtr->StartParams.BasicInfo.FileName, FileName,
                    sizeof(AppRecPtr->StartParams.BasicInfo.FileName)-1);
+           AppRecPtr->StartParams.BasicInfo.FileName[sizeof(AppRecPtr->StartParams.BasicInfo.FileName)-1] = '\0';
            if (EntryPointName != NULL && strcmp(EntryPointName, "NULL") != 0)
            {
                strncpy(AppRecPtr->StartParams.BasicInfo.EntryPoint, EntryPointName,
                        sizeof(AppRecPtr->StartParams.BasicInfo.EntryPoint)-1);
+               AppRecPtr->StartParams.BasicInfo.EntryPoint[
+                       sizeof(AppRecPtr->StartParams.BasicInfo.EntryPoint)-1] = '\0';
            }
 
            AppRecPtr->StartParams.StackSize = StackSize;
@@ -883,12 +887,15 @@ int32 CFE_ES_LoadLibrary(CFE_ES_ResourceID_t       *LibraryIdPtr,
             */
            strncpy(LibSlotPtr->BasicInfo.Name, LibName,
                    sizeof(LibSlotPtr->BasicInfo.Name)-1);
+           LibSlotPtr->BasicInfo.Name[sizeof(LibSlotPtr->BasicInfo.Name)-1] = '\0';
            strncpy(LibSlotPtr->BasicInfo.FileName, FileName,
                    sizeof(LibSlotPtr->BasicInfo.FileName)-1);
+           LibSlotPtr->BasicInfo.FileName[sizeof(LibSlotPtr->BasicInfo.FileName)-1] = '\0';
            if (EntryPointName != NULL && strcmp(EntryPointName, "NULL") != 0)
            {
               strncpy(LibSlotPtr->BasicInfo.EntryPoint, EntryPointName,
                       sizeof(LibSlotPtr->BasicInfo.EntryPoint)-1);
+              LibSlotPtr->BasicInfo.EntryPoint[sizeof(LibSlotPtr->BasicInfo.EntryPoint)-1] = '\0';
            }
 
            CFE_ES_LibRecordSetUsed(LibSlotPtr, CFE_ES_RESOURCEID_RESERVED);

--- a/fsw/cfe-core/src/es/cfe_es_cds.c
+++ b/fsw/cfe-core/src/es/cfe_es_cds.c
@@ -163,10 +163,22 @@ int32 CFE_ES_CDS_EarlyInit(void)
 /*******************************************************************/
 int32 CFE_ES_CDSBlockID_ToIndex(CFE_ES_ResourceID_t BlockID, uint32 *Idx)
 {
-    return CFE_ES_ResourceID_ToIndex_Internal(
+    return CFE_ES_ResourceID_ToIndex(
             CFE_ES_ResourceID_ToInteger(BlockID) - CFE_ES_CDSBLOCKID_BASE,
             CFE_PLATFORM_ES_CDS_MAX_NUM_ENTRIES,
             Idx);
+}
+
+/*---------------------------------------------------------------------------------------
+ * Function: CFE_ES_CheckCDSBlockIdSlotUsed
+ * 
+ * Purpose: Helper function, Aids in allocating a new ID by checking if 
+ * a given ID is available.  Must be called while locked.
+ *---------------------------------------------------------------------------------------
+ */
+bool CFE_ES_CheckCDSBlockIdSlotUsed(CFE_ES_ResourceID_t CheckId)
+{
+    return CFE_ES_CDSBlockRecordIsUsed(CFE_ES_LocateCDSBlockRecordByID(CheckId));
 }
 
 /*******************************************************************/
@@ -347,7 +359,7 @@ int32 CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr, size_t UserBlockSize, 
     else
     {
         /* scan for a free slot */
-        PendingBlockId = CFE_ES_FindNextAvailableId(CDS->LastCDSBlockId, CFE_PLATFORM_ES_CDS_MAX_NUM_ENTRIES);
+        PendingBlockId = CFE_ES_FindNextAvailableId(CDS->LastCDSBlockId, CFE_PLATFORM_ES_CDS_MAX_NUM_ENTRIES, CFE_ES_CheckCDSBlockIdSlotUsed);
         RegRecPtr = CFE_ES_LocateCDSBlockRecordByID(PendingBlockId);
 
         if (RegRecPtr != NULL)

--- a/fsw/cfe-core/src/es/cfe_es_cds.h
+++ b/fsw/cfe-core/src/es/cfe_es_cds.h
@@ -391,6 +391,20 @@ static inline size_t CFE_ES_CDSBlockRecordGetUserSize(const CFE_ES_CDS_RegRec_t 
     return (CDSBlockRecPtr->BlockSize - sizeof(CFE_ES_CDS_BlockHeader_t));
 }
 
+/**
+ * @brief Check if a CDS Block ID table slot is used
+ *
+ * Checks if a table slot is available for a potential new ID
+ * This is a helper function intended to be used with 
+ * CFE_ES_FindNextAvailableID() for allocating new IDs
+ * 
+ * As this dereferences fields within the record, global data must be
+ * locked prior to invoking this function.
+ *
+ * @param[in]   CheckId       pending/candidate Block ID to check
+ * @returns true if the table slot for the ID is occupied, false if available
+ */
+bool CFE_ES_CheckCDSBlockIdSlotUsed(CFE_ES_ResourceID_t CheckId);
 
 /*****************************************************************************/
 /**

--- a/fsw/cfe-core/src/es/cfe_es_erlog.c
+++ b/fsw/cfe-core/src/es/cfe_es_erlog.c
@@ -139,7 +139,8 @@ int32 CFE_ES_WriteToERLogWithContext( CFE_ES_LogEntryType_Enum_t EntryType,   ui
    /*
    ** Copy the Description string to the log.
    */
-   strncpy(EntryPtr->BaseInfo.Description, Description, sizeof(EntryPtr->BaseInfo.Description));
+   strncpy(EntryPtr->BaseInfo.Description, Description, sizeof(EntryPtr->BaseInfo.Description) - 1);
+   EntryPtr->BaseInfo.Description[sizeof(EntryPtr->BaseInfo.Description) - 1] = '\0';
 
    /*
     * Store the context info (if any)

--- a/fsw/cfe-core/src/es/cfe_es_log.h
+++ b/fsw/cfe-core/src/es/cfe_es_log.h
@@ -105,6 +105,7 @@
             CFE_ES_LockSharedData(__func__, __LINE__);      \
             CFE_ES_SysLogAppend_Unsync(LogString);          \
             CFE_ES_UnlockSharedData(__func__, __LINE__);    \
+            OS_printf("%s", LogString);                     \
         }
 
 

--- a/fsw/cfe-core/src/es/cfe_es_mempool.c
+++ b/fsw/cfe-core/src/es/cfe_es_mempool.c
@@ -108,10 +108,22 @@ int32 CFE_ES_MemPoolDirectCommit(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offs
 
 int32 CFE_ES_MemPoolID_ToIndex(CFE_ES_MemHandle_t PoolID, uint32 *Idx)
 {
-    return CFE_ES_ResourceID_ToIndex_Internal(
+    return CFE_ES_ResourceID_ToIndex(
             CFE_ES_ResourceID_ToInteger(PoolID) - CFE_ES_POOLID_BASE,
             CFE_PLATFORM_ES_MAX_MEMORY_POOLS,
             Idx);
+}
+
+/*---------------------------------------------------------------------------------------
+ * Function: CFE_ES_CheckMemPoolSlotUsed
+ * 
+ * Purpose: Helper function, Aids in allocating a new ID by checking if 
+ * a given table slot is available.  Must be called while locked.
+ *---------------------------------------------------------------------------------------
+ */
+bool CFE_ES_CheckMemPoolSlotUsed(CFE_ES_ResourceID_t CheckId)
+{
+    return CFE_ES_MemPoolRecordIsUsed(CFE_ES_LocateMemPoolRecordByID(CheckId));
 }
 
 CFE_ES_MemPoolRecord_t* CFE_ES_LocateMemPoolRecordByID(CFE_ES_MemHandle_t PoolID)
@@ -211,7 +223,7 @@ int32 CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t       *PoolID,
     CFE_ES_LockSharedData(__func__,__LINE__);
 
     /* scan for a free slot */
-    PendingID = CFE_ES_FindNextAvailableId(CFE_ES_Global.LastMemPoolId, CFE_PLATFORM_ES_MAX_MEMORY_POOLS);
+    PendingID = CFE_ES_FindNextAvailableId(CFE_ES_Global.LastMemPoolId, CFE_PLATFORM_ES_MAX_MEMORY_POOLS, CFE_ES_CheckMemPoolSlotUsed);
     PoolRecPtr = CFE_ES_LocateMemPoolRecordByID(PendingID);
 
     if (PoolRecPtr == NULL)

--- a/fsw/cfe-core/src/es/cfe_es_mempool.h
+++ b/fsw/cfe-core/src/es/cfe_es_mempool.h
@@ -164,12 +164,38 @@ static inline void CFE_ES_MemPoolRecordSetFree(CFE_ES_MemPoolRecord_t *PoolRecPt
     PoolRecPtr->PoolID = CFE_ES_RESOURCEID_UNDEFINED;
 }
 
-
+/**
+ * @brief Check if an Mem Pool record is a match for the given Pool ID
+ *
+ * This routine confirms that the previously-located record is valid
+ * and matches the expected Pool ID.
+ *
+ * As this dereferences fields within the record, global data must be
+ * locked prior to invoking this function.
+ *
+ * @param[in]   PoolRecPtr   pointer to Pool table entry
+ * @param[in]   PoolID       expected Pool ID
+ * @returns true if the entry matches the given pool ID
+ */
 static inline bool CFE_ES_MemPoolRecordIsMatch(const CFE_ES_MemPoolRecord_t *PoolRecPtr, CFE_ES_MemHandle_t PoolID)
 {
     return (PoolRecPtr != NULL && CFE_ES_ResourceID_Equal(PoolRecPtr->PoolID, PoolID));
 }
 
+/**
+ * @brief Check if a Pool ID table slot is used
+ *
+ * Checks if a table slot is available for a potential new ID
+ * This is a helper function intended to be used with 
+ * CFE_ES_FindNextAvailableID() for allocating new IDs
+ * 
+ * As this dereferences fields within the record, global data must be
+ * locked prior to invoking this function.
+ *
+ * @param[in]   CheckId       pending/candidate Pool ID to check
+ * @returns true if the table slot for the ID is occupied, false if available
+ */
+bool CFE_ES_CheckMemPoolSlotUsed(CFE_ES_ResourceID_t CheckId);
 
 
 #endif  /* _CFE_ES_MEMPOOL_H_ */

--- a/fsw/cfe-core/src/es/cfe_es_resource.c
+++ b/fsw/cfe-core/src/es/cfe_es_resource.c
@@ -43,11 +43,11 @@
 
 /*********************************************************************/
 /*
- * CFE_ES_ResourceID_ToIndex_Internal
+ * CFE_ES_ResourceID_ToIndex
  *
  * For complete API information, see prototype in header
  */
-int32 CFE_ES_ResourceID_ToIndex_Internal(uint32 Serial, uint32 TableSize, uint32 *Idx)
+int32 CFE_ES_ResourceID_ToIndex(uint32 Serial, uint32 TableSize, uint32 *Idx)
 {
     if (Idx == NULL)
     {
@@ -94,7 +94,7 @@ CFE_ES_ResourceID_t CFE_ES_ResourceID_FromOSAL(osal_id_t id)
  *
  * For complete API information, see prototype in header
  */
-CFE_ES_ResourceID_t CFE_ES_FindNextAvailableId(CFE_ES_ResourceID_t StartId, uint32 TableSize)
+CFE_ES_ResourceID_t CFE_ES_FindNextAvailableId(CFE_ES_ResourceID_t StartId, uint32 TableSize, bool (*CheckFunc)(CFE_ES_ResourceID_t))
 {
     uint32 Serial;
     uint32 Count;
@@ -124,27 +124,7 @@ CFE_ES_ResourceID_t CFE_ES_FindNextAvailableId(CFE_ES_ResourceID_t StartId, uint
         }
         CheckId = CFE_ES_ResourceID_FromInteger(ResourceType + Serial);
 
-        switch (ResourceType)
-        {
-        case CFE_ES_APPID_BASE:
-            IsTaken = CFE_ES_AppRecordIsUsed(CFE_ES_LocateAppRecordByID(CheckId));
-            break;
-        case CFE_ES_LIBID_BASE:
-            IsTaken = CFE_ES_LibRecordIsUsed(CFE_ES_LocateLibRecordByID(CheckId));
-            break;
-        case CFE_ES_COUNTID_BASE:
-            IsTaken = CFE_ES_CounterRecordIsUsed(CFE_ES_LocateCounterRecordByID(CheckId));
-            break;
-        case CFE_ES_POOLID_BASE:
-            IsTaken = CFE_ES_MemPoolRecordIsUsed(CFE_ES_LocateMemPoolRecordByID(CheckId));
-            break;
-        case CFE_ES_CDSBLOCKID_BASE:
-            IsTaken = CFE_ES_CDSBlockRecordIsUsed(CFE_ES_LocateCDSBlockRecordByID(CheckId));
-            break;
-        default:
-            /* do nothing, should never happen */
-            break;
-        }
+        IsTaken = CheckFunc(CheckId);
     }
     while (IsTaken);
 
@@ -428,6 +408,45 @@ CFE_ES_AppRecord_t *CFE_ES_GetAppRecordByContext(void)
     }
 
     return AppRecPtr;
+}
+
+/*
+ * ---------------------------------------------------------------------------------------
+ * Function: CFE_ES_CheckCounterIdSlotUsed
+ * 
+ * Purpose: Helper function, Aids in allocating a new ID by checking if 
+ * a given ID is available.  Must be called while locked.
+ * ---------------------------------------------------------------------------------------
+ */
+bool CFE_ES_CheckCounterIdSlotUsed(CFE_ES_ResourceID_t CheckId)
+{
+    return CFE_ES_CounterRecordIsUsed(CFE_ES_LocateCounterRecordByID(CheckId));
+}
+
+/*
+ *---------------------------------------------------------------------------------------
+ * Function: CFE_ES_CheckAppIdSlotUsed
+ * 
+ * Purpose: Helper function, Aids in allocating a new ID by checking if 
+ * a given ID is available.  Must be called while locked.
+ *---------------------------------------------------------------------------------------
+ */
+bool CFE_ES_CheckAppIdSlotUsed(CFE_ES_ResourceID_t CheckId)
+{
+    return CFE_ES_AppRecordIsUsed(CFE_ES_LocateAppRecordByID(CheckId));
+}
+
+/*
+ * ---------------------------------------------------------------------------------------
+ * Function: CFE_ES_CheckLibIdSlotUsed
+ * 
+ * Purpose: Helper function, Aids in allocating a new ID by checking if 
+ * a given ID is available.  Must be called while locked.
+ * ---------------------------------------------------------------------------------------
+ */
+bool CFE_ES_CheckLibIdSlotUsed(CFE_ES_ResourceID_t CheckId)
+{
+    return CFE_ES_LibRecordIsUsed(CFE_ES_LocateLibRecordByID(CheckId));
 }
 
 

--- a/fsw/cfe-core/src/es/cfe_es_start.c
+++ b/fsw/cfe-core/src/es/cfe_es_start.c
@@ -759,7 +759,7 @@ void  CFE_ES_CreateObjects(void)
             */
             CFE_ES_LockSharedData(__func__,__LINE__);
 
-            PendingAppId = CFE_ES_FindNextAvailableId(CFE_ES_Global.LastAppId, CFE_PLATFORM_ES_MAX_APPLICATIONS);
+            PendingAppId = CFE_ES_FindNextAvailableId(CFE_ES_Global.LastAppId, CFE_PLATFORM_ES_MAX_APPLICATIONS, CFE_ES_CheckAppIdSlotUsed);
             AppRecPtr = CFE_ES_LocateAppRecordByID(PendingAppId);
             if (AppRecPtr != NULL)
             {

--- a/fsw/cfe-core/src/es/cfe_es_start.c
+++ b/fsw/cfe-core/src/es/cfe_es_start.c
@@ -769,6 +769,7 @@ void  CFE_ES_CreateObjects(void)
                 AppRecPtr->Type = CFE_ES_AppType_CORE;
                 strncpy(AppRecPtr->StartParams.BasicInfo.Name, CFE_ES_ObjectTable[i].ObjectName,
                         sizeof(AppRecPtr->StartParams.BasicInfo.Name)-1);
+                AppRecPtr->StartParams.BasicInfo.Name[sizeof(AppRecPtr->StartParams.BasicInfo.Name)-1] = '\0';
 
                 /* FileName and EntryPoint is not valid for core apps */
                 AppRecPtr->StartParams.StackSize = CFE_ES_ObjectTable[i].ObjectSize;

--- a/fsw/cfe-core/src/es/cfe_es_task.c
+++ b/fsw/cfe-core/src/es/cfe_es_task.c
@@ -217,15 +217,6 @@ int32 CFE_ES_TaskInit(void)
     CFE_ES_TaskData.CommandErrorCounter = 0;
 
     /*
-    ** Initialize task configuration data
-    */
-    strcpy(CFE_ES_TaskData.PipeName, "ES_CMD_PIPE");
-    CFE_ES_TaskData.PipeDepth = 12;
-
-    CFE_ES_TaskData.LimitHK   = 2;
-    CFE_ES_TaskData.LimitCmd  = 4;
-
-    /*
     ** Initialize systemlog to default Power On or Processor Reset mode
     */
     if (CFE_ES_GetResetType(NULL) == CFE_PSP_RST_TYPE_POWERON)                                                                   
@@ -271,7 +262,7 @@ int32 CFE_ES_TaskInit(void)
     /*
     ** Create Software Bus message pipe
     */
-    Status = CFE_SB_CreatePipe(&CFE_ES_TaskData.CmdPipe, CFE_ES_TaskData.PipeDepth, CFE_ES_TaskData.PipeName);
+    Status = CFE_SB_CreatePipe(&CFE_ES_TaskData.CmdPipe, CFE_ES_PIPE_DEPTH, CFE_ES_PIPE_NAME);
     if ( Status != CFE_SUCCESS )
     {
         CFE_ES_WriteToSysLog("ES:Cannot Create SB Pipe, RC = 0x%08X\n", (unsigned int)Status);
@@ -282,7 +273,7 @@ int32 CFE_ES_TaskInit(void)
     ** Subscribe to Housekeeping request commands
     */
     Status = CFE_SB_SubscribeEx(CFE_SB_ValueToMsgId(CFE_ES_SEND_HK_MID), CFE_ES_TaskData.CmdPipe,
-                                CFE_SB_Default_Qos, CFE_ES_TaskData.LimitHK);
+                                CFE_SB_Default_Qos, CFE_ES_LIMIT_HK);
     if ( Status != CFE_SUCCESS )
     {
         CFE_ES_WriteToSysLog("ES:Cannot Subscribe to HK packet, RC = 0x%08X\n", (unsigned int)Status);
@@ -293,7 +284,7 @@ int32 CFE_ES_TaskInit(void)
     ** Subscribe to ES task ground command packets
     */
     Status = CFE_SB_SubscribeEx(CFE_SB_ValueToMsgId(CFE_ES_CMD_MID), CFE_ES_TaskData.CmdPipe,
-                                CFE_SB_Default_Qos, CFE_ES_TaskData.LimitCmd);
+                                CFE_SB_Default_Qos, CFE_ES_LIMIT_CMD);
     if ( Status != CFE_SUCCESS )
     {
         CFE_ES_WriteToSysLog("ES:Cannot Subscribe to ES ground commands, RC = 0x%08X\n", (unsigned int)Status);

--- a/fsw/cfe-core/src/es/cfe_es_task.h
+++ b/fsw/cfe-core/src/es/cfe_es_task.h
@@ -47,6 +47,11 @@
 
 /*************************************************************************/
 
+#define CFE_ES_PIPE_NAME  "ES_CMD_PIPE"
+#define CFE_ES_PIPE_DEPTH 12
+#define CFE_ES_LIMIT_HK   2
+#define CFE_ES_LIMIT_CMD  4
+
 /*
 ** ES File descriptions
 */
@@ -123,9 +128,6 @@ typedef struct
   /*
   ** ES Task initialization data (not reported in housekeeping)
   */
-  char                  PipeName[OS_MAX_API_NAME];
-  uint16                PipeDepth;
-
   uint8                 LimitHK;
   uint8                 LimitCmd;
 

--- a/fsw/cfe-core/src/inc/cfe_es.h
+++ b/fsw/cfe-core/src/inc/cfe_es.h
@@ -43,6 +43,7 @@
 #include "cfe_mission_cfg.h"
 #include "cfe_perfids.h"
 #include "cfe_error.h"
+#include "cfe_resourceid.h"
 
 /*****************************************************************************/
 
@@ -63,32 +64,6 @@
 #define CFE_ES_DTEST(i,x) (((i) & CFE_ES_DBIT(x)) != 0)               /* true iff bit x of i is set */
 #define CFE_ES_TEST_LONG_MASK(m,s)  (CFE_ES_DTEST(m[(s)/32],(s)%32))  /* Test a bit within an array of 32-bit integers. */
 
-
-/** \name Resource ID predefined values */
-/** \{ */
-
-/**
- * @brief A resource ID value that represents an undefined/unused resource
- *
- * This constant may be used to initialize local variables of the
- * CFE_ES_ResourceID_t type to a safe value that will not alias a valid ID.
- *
- * By design, this value is also the result of zeroing a CFE_ES_ResourceID_t
- * type via standard functions like memset(), such that objects initialized
- * using this method will also be set to safe values.
- */
-#define CFE_ES_RESOURCEID_UNDEFINED     ((CFE_ES_ResourceID_t)0)
-
-/**
- * @brief A resource ID value that represents a reserved entry
- *
- * This is not a valid value for any resource type, but is used to mark
- * table entries that are not available for use.  For instance, this may
- * be used while setting up an entry initially.
- */
-#define CFE_ES_RESOURCEID_RESERVED      ((CFE_ES_ResourceID_t)0xFFFFFFFF)
-
-/** \} */
 
 /*
 ** Note about reset type and subtypes:
@@ -213,82 +188,6 @@ typedef void* CFE_ES_MemPoolBuf_t;
 /** @defgroup CFEAPIESResourceID cFE Resource ID APIs
  * @{
  */
-
-/**
- * @brief Convert a resource ID to an integer.
- *
- * This is primarily intended for logging purposes, such was writing
- * to debug console, event messages, or log files, using printf-like APIs.
- *
- * For compatibility with C library APIs, this returns an "unsigned long"
- * type and should be used with the "%lx" format specifier in a printf
- * format string.
- *
- * @note No assumptions should be made about the actual integer value,
- * such as its base/range.  It may be printed, but should not be modified
- * or tested/compared using other arithmetic ops, and should never be used
- * as the index to an array or table.  See the related function
- * CFE_ES_ResourceID_ToIndex() for cases where a zero-based array/table index
- * is needed.
- *
- * @sa CFE_ES_ResourceID_FromInteger()
- *
- * @param[in]   id    Resource ID to convert
- * @returns Integer value corresponding to ID
- */
-static inline unsigned long CFE_ES_ResourceID_ToInteger(CFE_ES_ResourceID_t id)
-{
-    return ((unsigned long)id);
-}
-
-/**
- * @brief Convert an integer to a resource ID.
- *
- * This is the inverse of CFE_ES_ResourceID_ToInteger(), and reconstitutes
- * the original CFE_ES_ResourceID_t value from the integer representation.
- *
- * This may be used, for instance, where an ID value is parsed from a text
- * file or message using C library APIs such as scanf() or strtoul().
- *
- * @sa CFE_ES_ResourceID_ToInteger()
- *
- * @param[in]   Value    Integer value to convert
- * @returns ID value corresponding to integer
- */
-static inline CFE_ES_ResourceID_t CFE_ES_ResourceID_FromInteger(unsigned long Value)
-{
-    return ((CFE_ES_ResourceID_t)Value);
-}
-
-/**
- * @brief Compare two Resource ID values for equality
- *
- * @param[in]   id1    Resource ID to check
- * @param[in]   id2    Resource ID to check
- * @returns true if id1 and id2 are equal, false otherwise.
- */
-static inline bool CFE_ES_ResourceID_Equal(CFE_ES_ResourceID_t id1, CFE_ES_ResourceID_t id2)
-{
-    return (id1 == id2);
-}
-
-/**
- * @brief Check if a resource ID value is defined
- *
- * The constant #CFE_ES_RESOURCEID_UNDEFINED represents an undefined ID value,
- * such that the expression:
- *
- *      CFE_ES_ResourceID_IsDefined(CFE_ES_RESOURCEID_UNDEFINED)
- *
- * Always returns false.
- *
- * @param[in]   id    Resource ID to check
- * @returns True if the ID may refer to a defined entity, false if invalid/undefined.
- */
-static inline bool CFE_ES_ResourceID_IsDefined(CFE_ES_ResourceID_t id)
-{
-    return (id != 0);
-}
 
 /**
  * @brief Obtain an index value correlating to an ES Application ID

--- a/fsw/cfe-core/src/inc/cfe_es_events.h
+++ b/fsw/cfe-core/src/inc/cfe_es_events.h
@@ -996,12 +996,8 @@
 **/
 #define CFE_ES_PERF_FILTMSKCMD_EID  63
 
-/** \brief  <tt> 'Error:Performance Filter Mask Index value  
-** greater than CFE_ES_PERF_32BIT_WORDS_IN_MASK (which is a whole number derived from 
-** CFE_PLATFORM_ES_PERF_MAX_IDS / 32)' </tt>
-**  \event <tt> 'Error:Performance Filter Mask Index value  
-** greater than CFE_ES_PERF_32BIT_WORDS_IN_MASK (which is a whole number derived from 
-** CFE_PLATFORM_ES_PERF_MAX_IDS / 32)' </tt>
+/** \brief  <tt> 'Performance Filter Mask Cmd Error,Index(%u)out of range(%u)' </tt>
+**  \event <tt> 'Performance Filter Mask Cmd Error,Index(%u)out of range(%u)' </tt>
 **
 **  \par Type: ERROR
 **
@@ -1027,12 +1023,8 @@
 **/
 #define CFE_ES_PERF_TRIGMSKCMD_EID 65
 
-/** \brief  <tt> 'Error: Performance Trigger Mask Index value  
-** greater than CFE_ES_PERF_32BIT_WORDS_IN_MASK (which is a whole number derived from 
-** CFE_PLATFORM_ES_PERF_MAX_IDS / 32)' </tt>
-**  \event <tt> 'Error: Performance Trigger Mask Index value  
-** greater than CFE_ES_PERF_32BIT_WORDS_IN_MASK (which is a whole number derived from 
-** CFE_PLATFORM_ES_PERF_MAX_IDS / 32)' </tt>
+/** \brief  <tt> 'Performance Trigger Mask Cmd Error,Index(%u)out of range(%u)' </tt>
+**  \event <tt> 'Performance Trigger Mask Cmd Error,Index(%u)out of range(%u)' </tt>
 **
 **  \par Type: ERROR
 **

--- a/fsw/cfe-core/src/inc/cfe_resourceid.h
+++ b/fsw/cfe-core/src/inc/cfe_resourceid.h
@@ -1,0 +1,150 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * \file cfe_resourceid.h
+ *
+ * Contains global prototypes and definitions related to resource
+ * management and related CFE resource IDs.
+ *
+ * A CFE ES Resource ID is a common way to identify CFE-managed resources such
+ * as apps, tasks, counters, memory pools, CDS blocks, and other entities.
+ */
+
+#ifndef CFE_RESOURCEID_H
+#define CFE_RESOURCEID_H
+
+/*
+** Include Files
+**
+** The actual CFE_ES_ResourceID_t type is part of the ES global/extern typedefs,
+** as the concept originated in ES and has been extended across all of CFE.
+*/
+#include "cfe_es_extern_typedefs.h"
+
+/*
+** Defines
+*/
+
+/** \name Resource ID predefined values */
+/** \{ */
+
+/**
+ * @brief A resource ID value that represents an undefined/unused resource
+ *
+ * This constant may be used to initialize local variables of the
+ * CFE_ES_ResourceID_t type to a safe value that will not alias a valid ID.
+ *
+ * By design, this value is also the result of zeroing a CFE_ES_ResourceID_t
+ * type via standard functions like memset(), such that objects initialized
+ * using this method will also be set to safe values.
+ */
+#define CFE_ES_RESOURCEID_UNDEFINED     ((CFE_ES_ResourceID_t){0})
+
+/**
+ * @brief A resource ID value that represents a reserved entry
+ *
+ * This is not a valid value for any resource type, but is used to mark
+ * table entries that are not available for use.  For instance, this may
+ * be used while setting up an entry initially.
+ */
+#define CFE_ES_RESOURCEID_RESERVED      ((CFE_ES_ResourceID_t){0xFFFFFFFF})
+
+/** \} */
+
+
+/**
+ * @brief Convert a resource ID to an integer.
+ *
+ * This is primarily intended for logging purposes, such was writing
+ * to debug console, event messages, or log files, using printf-like APIs.
+ *
+ * For compatibility with C library APIs, this returns an "unsigned long"
+ * type and should be used with the "%lx" format specifier in a printf
+ * format string.
+ *
+ * @note No assumptions should be made about the actual integer value,
+ * such as its base/range.  It may be printed, but should not be modified
+ * or tested/compared using other arithmetic ops, and should never be used
+ * as the index to an array or table.  See the related function
+ * CFE_ES_ResourceID_ToIndex() for cases where a zero-based array/table index
+ * is needed.
+ *
+ * @sa CFE_ES_ResourceID_FromInteger()
+ *
+ * @param[in]   id    Resource ID to convert
+ * @returns Integer value corresponding to ID
+ */
+static inline unsigned long CFE_ES_ResourceID_ToInteger(CFE_ES_ResourceID_t id)
+{
+    return ((unsigned long)id);
+}
+
+/**
+ * @brief Convert an integer to a resource ID.
+ *
+ * This is the inverse of CFE_ES_ResourceID_ToInteger(), and reconstitutes
+ * the original CFE_ES_ResourceID_t value from the integer representation.
+ *
+ * This may be used, for instance, where an ID value is parsed from a text
+ * file or message using C library APIs such as scanf() or strtoul().
+ *
+ * @sa CFE_ES_ResourceID_ToInteger()
+ *
+ * @param[in]   Value    Integer value to convert
+ * @returns ID value corresponding to integer
+ */
+static inline CFE_ES_ResourceID_t CFE_ES_ResourceID_FromInteger(unsigned long Value)
+{
+    return ((CFE_ES_ResourceID_t)Value);
+}
+
+/**
+ * @brief Compare two Resource ID values for equality
+ *
+ * @param[in]   id1    Resource ID to check
+ * @param[in]   id2    Resource ID to check
+ * @returns true if id1 and id2 are equal, false otherwise.
+ */
+static inline bool CFE_ES_ResourceID_Equal(CFE_ES_ResourceID_t id1, CFE_ES_ResourceID_t id2)
+{
+    return (id1 == id2);
+}
+
+/**
+ * @brief Check if a resource ID value is defined
+ *
+ * The constant #CFE_ES_RESOURCEID_UNDEFINED represents an undefined ID value,
+ * such that the expression:
+ *
+ *      CFE_ES_ResourceID_IsDefined(CFE_ES_RESOURCEID_UNDEFINED)
+ *
+ * Always returns false.
+ *
+ * @param[in]   id    Resource ID to check
+ * @returns True if the ID may refer to a defined entity, false if invalid/undefined.
+ */
+static inline bool CFE_ES_ResourceID_IsDefined(CFE_ES_ResourceID_t id)
+{
+    return (id != 0);
+}
+
+
+#endif  /* CFE_RESOURCEID_H */

--- a/fsw/cfe-core/src/inc/cfe_sb.h
+++ b/fsw/cfe-core/src/inc/cfe_sb.h
@@ -43,6 +43,7 @@
 #include "cfe_mission_cfg.h"
 #include "ccsds.h"
 #include "cfe_time.h"
+#include "cfe_resourceid.h"
 
 
 /*
@@ -122,6 +123,13 @@
 #define CFE_CLR(i,x) ((i) &= ~CFE_BIT(x))     /**< \brief Clears bit x of i */
 #define CFE_TST(i,x) (((i) & CFE_BIT(x)) != 0)/**< \brief true(non zero) if bit x of i is set */
 
+/** 
+ * \brief  A CFE_SB_PipeId_t value which is always invalid
+ * 
+ * This may be used as a safe initializer for CFE_SB_PipeId_t values
+ */
+#define CFE_SB_INVALID_PIPE  CFE_ES_RESOURCEID_UNDEFINED
+
 /*
 ** Pipe option bit fields.
 */
@@ -156,7 +164,7 @@ typedef CFE_MSG_TelemetryHeader_t CFE_SB_TlmHdr_t;
 **
 ** Software Bus pipe identifier used in many SB APIs
 */
-typedef uint8  CFE_SB_PipeId_t;
+typedef CFE_ES_ResourceID_t  CFE_SB_PipeId_t;
 
 #ifndef CFE_OMIT_DEPRECATED_6_8
 /** \brief  Pointer to an SB Message */
@@ -255,6 +263,32 @@ CFE_Status_t  CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16 Depth, const 
 ** \sa #CFE_SB_CreatePipe #CFE_SB_GetPipeOpts #CFE_SB_SetPipeOpts #CFE_SB_GetPipeIdByName
 **/
 CFE_Status_t  CFE_SB_DeletePipe(CFE_SB_PipeId_t PipeId);
+
+/**
+ * @brief Obtain an index value correlating to an SB Pipe ID
+ *
+ * This calculates a zero based integer value that may be used for indexing
+ * into a local resource table/array.
+ *
+ * Index values are only guaranteed to be unique for resources of the same
+ * type.  For instance, the indices corresponding to two [valid] application
+ * IDs will never overlap, but the index of a pipe ID and an app ID
+ * may be the same.  Furthermore, indices may be reused if a resource is
+ * deleted and re-created.
+ *
+ * @note There is no inverse of this function - indices cannot be converted
+ * back to the original PipeID value.  The caller should retain the original ID
+ * for future use.
+ *
+ * @param[in]   PipeID  Pipe ID to convert
+ * @param[out]  Idx    Buffer where the calculated index will be stored
+ *
+ * @return Execution status, see @ref CFEReturnCodes
+ * @retval #CFE_SUCCESS                      @copybrief CFE_SUCCESS
+ * @retval #CFE_ES_ERR_RESOURCEID_NOT_VALID  @copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID
+ */
+CFE_Status_t CFE_SB_PipeId_ToIndex(CFE_SB_PipeId_t PipeID, uint32 *Idx);
+
 
 /*****************************************************************************/
 /**

--- a/fsw/cfe-core/src/inc/cfe_sb_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_sb_msg.h
@@ -604,14 +604,14 @@ typedef struct CFE_SB_PipeDepthStats {
 
     CFE_SB_PipeId_t     PipeId;/**< \cfetlmmnemonic \SB_PDPIPEID
                                     \brief Pipe Id associated with the stats below */
-    uint8               Spare;/**< \cfetlmmnemonic \SB_PDSPARE
-                                   \brief Spare byte to ensure alignment */
     uint16              Depth;/**< \cfetlmmnemonic \SB_PDDEPTH
                                    \brief Number of messages the pipe can hold */
     uint16              InUse;/**< \cfetlmmnemonic \SB_PDINUSE
                                    \brief Number of messages currently on the pipe */
     uint16              PeakInUse;/**< \cfetlmmnemonic \SB_PDPKINUSE
                                        \brief Peak number of messages that have been on the pipe */
+    uint16              Spare;/**< \cfetlmmnemonic \SB_PDSPARE
+                                   \brief Spare word to ensure alignment */
 
 }CFE_SB_PipeDepthStats_t;
 

--- a/fsw/cfe-core/src/inc/cfe_sb_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_sb_msg.h
@@ -616,6 +616,36 @@ typedef struct CFE_SB_PipeDepthStats {
 }CFE_SB_PipeDepthStats_t;
 
 /**
+** \brief SB Pipe Information File Entry
+**
+** This statistics structure is output as part of the CFE SB
+** "Send Pipe Info" command (CFE_SB_SEND_PIPE_INFO_CC).
+** 
+** Previous versions of CFE simply wrote the internal CFE_SB_PipeD_t object
+** to the file, but this also contains information such as pointers which are
+** not relevant outside the running CFE process.  
+**
+** By defining the pipe info structure separately, it also provides some
+** independence, such that the internal CFE_SB_PipeD_t definition
+** can evolve without changing the binary format of the information
+** file.
+*/
+typedef struct CFE_SB_PipeInfoEntry
+{
+    CFE_SB_PipeId_t     PipeId;                            /**< The runtime ID of the pipe */
+    CFE_ES_ResourceID_t AppId;                             /**< The runtime ID of the application that owns the pipe */
+    char                PipeName[CFE_MISSION_MAX_API_LEN]; /**< The Name of the pipe */
+    char                AppName[CFE_MISSION_MAX_API_LEN];  /**< The Name of the application that owns the pipe */
+    uint16              MaxQueueDepth;                     /**< The allocated depth of the pipe (max capacity) */
+    uint16              CurrentQueueDepth;                 /**< The current depth of the pipe */
+    uint16              PeakQueueDepth;                    /**< The peak depth of the pipe (high watermark) */
+    uint16              SendErrors;                        /**< Number of errors when writing to this pipe */
+    uint8               Opts;                              /**< Pipe options set (bitmask) */
+    uint8               Spare[3];                          /**< Padding to make this structure a multiple of 4 bytes */
+
+} CFE_SB_PipeInfoEntry_t;
+
+/**
 ** \cfesbtlm SB Statistics Telemetry Packet
 **
 ** SB Statistics packet sent in response to #CFE_SB_SEND_SB_STATS_CC

--- a/fsw/cfe-core/src/inc/cfe_version.h
+++ b/fsw/cfe-core/src/inc/cfe_version.h
@@ -35,7 +35,7 @@
 
 
 /* Development Build Macro Definitions */
-#define CFE_BUILD_NUMBER 248 /*!< Development Build: Number of commits since baseline */
+#define CFE_BUILD_NUMBER 288 /*!< Development Build: Number of commits since baseline */
 #define CFE_BUILD_BASELINE "v6.8.0-rc1" /*!< Development Build: git tag that is the base for the current development */
 
 /* Version Macro Definitions */

--- a/fsw/cfe-core/src/inc/private/cfe_resourceid_internal.h
+++ b/fsw/cfe-core/src/inc/private/cfe_resourceid_internal.h
@@ -1,0 +1,165 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * \file cfe_resourceid_internal.h
+ *
+ * Contains CFE internal prototypes and definitions related to resource
+ * management and related CFE resource IDs.
+ *
+ * A CFE ES Resource ID is a common way to identify CFE-managed resources such
+ * as apps, tasks, counters, memory pools, CDS blocks, and other entities.
+ */
+
+#ifndef CFE_RESOURCEID_INTERNAL_H
+#define CFE_RESOURCEID_INTERNAL_H
+
+/*
+** Include Files
+*/
+#include "cfe_resourceid.h"
+#include "osapi-idmap.h"
+
+/*
+** Defines
+*/
+
+/*
+ * Limits/definitions related to CFE_ES_ResourceID_t values.
+ *
+ * Defining based on OSAL ID values makes this object a superset of
+ * the OSAL ID type, such that OSAL IDs can be represented as ES resource IDs
+ * and not conflict with/alias each other.
+ *
+ * NOTE: This reflects a bit if "inside knowledge" about how OSAL IDs are
+ * constructed.  The overlap between OSAL IDs and ES IDs may not always be
+ * consistent, and they can diverge in a future version.
+ */
+#define CFE_ES_RESOURCEID_SHIFT OS_OBJECT_TYPE_SHIFT
+#define CFE_ES_RESOURCEID_MAX   ((1 << CFE_ES_RESOURCEID_SHIFT)-1)
+#define CFE_ES_RESOURCEID_MARK  (0x02000000)
+
+/** 
+ * @defgroup CFEResourceIDBase Resource ID base values 
+ * @{
+ */
+
+/* ES managed resources */
+#define CFE_ES_APPID_BASE       (CFE_ES_RESOURCEID_MARK | ((OS_OBJECT_TYPE_USER+1) << CFE_ES_RESOURCEID_SHIFT))
+#define CFE_ES_LIBID_BASE       (CFE_ES_RESOURCEID_MARK | ((OS_OBJECT_TYPE_USER+2) << CFE_ES_RESOURCEID_SHIFT))
+#define CFE_ES_COUNTID_BASE     (CFE_ES_RESOURCEID_MARK | ((OS_OBJECT_TYPE_USER+3) << CFE_ES_RESOURCEID_SHIFT))
+#define CFE_ES_POOLID_BASE      (CFE_ES_RESOURCEID_MARK | ((OS_OBJECT_TYPE_USER+4) << CFE_ES_RESOURCEID_SHIFT))
+#define CFE_ES_CDSBLOCKID_BASE  (CFE_ES_RESOURCEID_MARK | ((OS_OBJECT_TYPE_USER+5) << CFE_ES_RESOURCEID_SHIFT))
+
+/* SB managed resources */
+#define CFE_SB_PIPEID_BASE      (CFE_ES_RESOURCEID_MARK | ((OS_OBJECT_TYPE_USER+6) << CFE_ES_RESOURCEID_SHIFT))
+
+/** @} */
+
+
+/**
+ * @brief Get the Base value (type/category) from a resource ID value
+ *
+ * This masks out the ID serial number to obtain the base value, which is different
+ * for each resource type.
+ * 
+ * @note The value is NOT shifted or otherwise adjusted.  It should match one of the
+ * defined base values in @ref CFEESResourceIDBase.
+ *
+ * @param[in]   ResourceId   the resource ID to decode
+ * @returns     The base value associated with that ID
+ */
+static inline uint32 CFE_ES_ResourceID_GetBase(CFE_ES_ResourceID_t ResourceId)
+{
+    uint32 ResourceType = CFE_ES_ResourceID_ToInteger(ResourceId);
+    return (ResourceType - (ResourceType & CFE_ES_RESOURCEID_MAX));
+}
+
+/**
+ * @brief Locate the next resource ID which does not map to an in-use table entry
+ *
+ * This begins searching from StartId which should be the most recently issued ID
+ * for the resource category.  This will then search for the next ID which does
+ * _not_ map to a table entry that is in use.  That is, it does not alias any
+ * valid ID when converted to an array index.
+ *
+ * returns an undefined ID value if no open slots are available
+ *
+ * @param[in]   StartId   the last issued ID for the resource category (app, lib, etc).
+ * @param[in]   TableSize the maximum size of the target table
+ * @param[in]   CheckFunc a function to check if the given ID is available
+ * @returns     Next ID value which does not map to a valid entry
+ * @retval      #CFE_ES_RESOURCEID_UNDEFINED if no open slots.
+ *
+ */
+CFE_ES_ResourceID_t CFE_ES_FindNextAvailableId(CFE_ES_ResourceID_t StartId, uint32 TableSize, bool (*CheckFunc)(CFE_ES_ResourceID_t) );
+
+/**
+ * @brief Convert an ES Task ID to an OSAL task ID
+ *
+ * Task IDs created via CFE ES are also OSAL task IDs, but technically
+ * do refer to a different scope and therefore have a different type
+ * to represent them.
+ *
+ * This function facilitates converting between the types.
+ *
+ * @note Currently the numeric values are the same and can be interchanged
+ * for backward compatibility, however they may diverge in a future version.
+ * New code should not assume equivalence between OSAL and ES task IDs.
+ *
+ * @sa CFE_ES_ResourceID_FromOSAL
+ *
+ * @param[in] id    The ES task ID
+ * @returns         The OSAL task ID
+ */
+osal_id_t CFE_ES_ResourceID_ToOSAL(CFE_ES_ResourceID_t id);
+
+/**
+ * @brief Convert an ES Task ID to an OSAL task ID
+ *
+ * Task IDs created via CFE ES are also OSAL task IDs, but technically
+ * do refer to a different scope and therefore have a different type
+ * to represent them.
+ *
+ * This function facilitates converting between the types.
+ *
+ * @note Currently the numeric values are the same and can be interchanged
+ * for backward compatibility, however they may diverge in a future version.
+ * New code should not assume equivalence between OSAL and ES task IDs.
+ *
+ * @sa CFE_ES_ResourceID_ToOSAL
+ *
+ * @param[in] id    The OSAL task ID
+ * @returns         The ES task ID
+ */
+CFE_ES_ResourceID_t CFE_ES_ResourceID_FromOSAL(osal_id_t id);
+
+/**
+ * @brief Internal routine to aid in converting an ES resource ID to an array index
+
+ * @param[in]  Serial    The resource serial number (type info masked out)
+ * @param[in]  TableSize The size of the internal table (MAX value)
+ * @param[out] Idx       The output index
+ * @returns Status code, CFE_SUCCESS if successful.
+ */
+int32 CFE_ES_ResourceID_ToIndex(uint32 Serial, uint32 TableSize, uint32 *Idx);
+
+
+#endif  /* CFE_RESOURCEID_H */

--- a/fsw/cfe-core/src/sb/cfe_sb_buf.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_buf.c
@@ -91,7 +91,7 @@ CFE_SB_BufferD_t * CFE_SB_GetBufferFromPool(CFE_SB_MsgId_t MsgId, size_t Size) {
     bd->MsgId     = MsgId;
     bd->UseCount  = 1;
     bd->Size      = Size;
-    bd->Buffer    = (void *)address;
+    bd->Buffer    = (CFE_SB_Buffer_t *)address;
 
     return bd;
 
@@ -156,6 +156,32 @@ int32 CFE_SB_ReturnBufferToPool(CFE_SB_BufferD_t *bd){
 }/* end CFE_SB_ReturnBufferToPool */
 
 
+/******************************************************************************
+**  Function:   CFE_SB_IncrBufUseCnt()
+**
+**  Purpose:
+**    This function will increment the UseCount of a particular buffer.
+**
+**  Note:
+**    UseCount is a variable in the CFE_SB_BufferD_t and is used only to
+**    determine when a buffer may be returned to the memory pool.
+**
+**  Arguments:
+**    bd : Pointer to the buffer descriptor.
+**
+**  Return:
+**    CFE_SUCCESS for normal operation.
+*/
+void CFE_SB_IncrBufUseCnt(CFE_SB_BufferD_t *bd)
+{
+    /* range check the UseCount variable */
+    if(bd->UseCount < 0x7FFF)
+    {
+        ++bd->UseCount;
+    }
+
+}/* end CFE_SB_DecrBufUseCnt */
+
 
 /******************************************************************************
 **  Function:   CFE_SB_DecrBufUseCnt()
@@ -175,20 +201,18 @@ int32 CFE_SB_ReturnBufferToPool(CFE_SB_BufferD_t *bd){
 **  Return:
 **    CFE_SUCCESS for normal operation.
 */
-int32 CFE_SB_DecrBufUseCnt(CFE_SB_BufferD_t *bd){
-
+void CFE_SB_DecrBufUseCnt(CFE_SB_BufferD_t *bd)
+{
     /* range check the UseCount variable */
-    if(bd->UseCount > 0){
+    if(bd->UseCount > 0)
+    {
+        --bd->UseCount;
 
-        bd->UseCount--;
-
-        if (bd->UseCount == 0) {
+        if (bd->UseCount == 0) 
+        {
            CFE_SB_ReturnBufferToPool(bd);
-        }/* end if */
-
+        }
     }
-
-    return CFE_SUCCESS;
 
 }/* end CFE_SB_DecrBufUseCnt */
 

--- a/fsw/cfe-core/src/sb/cfe_sb_init.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_init.c
@@ -87,6 +87,9 @@ int32 CFE_SB_EarlyInit (void) {
 
     int32 Stat;
 
+    /* ensure entire CFE_SB global data structure is purged first */
+    memset(&CFE_SB, 0, sizeof(CFE_SB));
+
     CFE_SB_Default_Qos.Priority    = CFE_SB_QOS_LOW_PRIORITY;
     CFE_SB_Default_Qos.Reliability = CFE_SB_QOS_LOW_RELIABILITY;
 
@@ -175,16 +178,9 @@ int32  CFE_SB_InitBuffers(void) {
 **  Return:
 **    none
 */
-void CFE_SB_InitPipeTbl(void){
-
-    uint8  i;
-
-    for(i=0;i<CFE_PLATFORM_SB_MAX_PIPES;i++){
-        CFE_SB.PipeTbl[i].InUse         = CFE_SB_NOT_IN_USE;
-        CFE_SB.PipeTbl[i].SysQueueId    = CFE_SB_UNUSED_QUEUE;
-        CFE_SB.PipeTbl[i].PipeId        = CFE_SB_INVALID_PIPE;
-        CFE_SB.PipeTbl[i].CurrentBuff   = NULL;
-    }/* end for */
+void CFE_SB_InitPipeTbl(void)
+{
+    CFE_SB.LastPipeId = CFE_ES_ResourceID_FromInteger(CFE_SB_PIPEID_BASE);
 
 }/* end CFE_SB_InitPipeTbl */
 

--- a/fsw/cfe-core/src/sb/cfe_sb_init.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_init.c
@@ -99,9 +99,6 @@ int32 CFE_SB_EarlyInit (void) {
     /* Initialize the state of susbcription reporting */
     CFE_SB.SubscriptionReporting = CFE_SB_DISABLE;
 
-    /* Initialize the state of sender reporting */
-    CFE_SB.SenderReporting = CFE_PLATFORM_SB_DEFAULT_REPORT_SENDER;
-
      /* Initialize memory partition. */
     Stat = CFE_SB_InitBuffers();
     if(Stat != CFE_SUCCESS){

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.c
@@ -346,10 +346,10 @@ char *CFE_SB_GetAppTskName(CFE_ES_ResourceID_t TaskId,char *FullName){
     }else{
 
       /* AppName and TskName buffers and strncpy are needed to limit string sizes */
-      strncpy(AppName,(char *)ptr->AppName,OS_MAX_API_NAME-1);
-      AppName[OS_MAX_API_NAME-1] = '\0';
-      strncpy(TskName,(char *)ptr->TaskName,OS_MAX_API_NAME-1);
-      TskName[OS_MAX_API_NAME-1] = '\0';
+      strncpy(AppName,(char *)ptr->AppName,sizeof(AppName)-1);
+      AppName[sizeof(AppName)-1] = '\0';
+      strncpy(TskName,(char *)ptr->TaskName,sizeof(TskName)-1);
+      TskName[sizeof(TskName)-1] = '\0';
 
       sprintf(FullName,"%s.%s",AppName,TskName);
 

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.h
@@ -186,7 +186,6 @@ typedef struct
 {
     osal_id_t                      SharedDataMutexId;
     uint32                         SubscriptionReporting;
-    uint32                         SenderReporting;
     CFE_ES_ResourceID_t            AppId;
     uint32                         StopRecurseFlags[OS_MAX_TASKS];
     void                          *ZeroCopyTail;

--- a/fsw/cfe-core/src/sb/cfe_sb_task.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_task.c
@@ -233,10 +233,6 @@ int32 CFE_SB_AppInit(void){
                  CFE_SB_ValueToMsgId(CFE_SB_ALLSUBS_TLM_MID),
                  sizeof(CFE_SB.PrevSubMsg));
 
-    CFE_MSG_Init(&CFE_SB.SubRprtMsg.Hdr.Msg,
-                 CFE_SB_ValueToMsgId(CFE_SB_ONESUB_TLM_MID),
-                 sizeof(CFE_SB.SubRprtMsg));
-
     /* Populate the fixed fields in the HK Tlm Msg */
     CFE_SB.HKTlmMsg.Payload.MemPoolHandle = CFE_SB.Mem.PoolHdl;
     
@@ -569,9 +565,13 @@ int32 CFE_SB_DisableSubReportingCmd(const CFE_SB_DisableSubReportingCmd_t *data)
 */
 int32 CFE_SB_SendHKTlmCmd(const CFE_MSG_CommandHeader_t *data)
 {
+    CFE_SB_LockSharedData(__FILE__, __LINE__);
+
     CFE_SB.HKTlmMsg.Payload.MemInUse        = CFE_SB.StatTlmMsg.Payload.MemInUse;
     CFE_SB.HKTlmMsg.Payload.UnmarkedMem     = CFE_PLATFORM_SB_BUF_MEMORY_BYTES - CFE_SB.StatTlmMsg.Payload.PeakMemInUse;
-    
+
+    CFE_SB_UnlockSharedData(__FILE__, __LINE__);
+
     CFE_SB_TimeStampMsg(&CFE_SB.HKTlmMsg.Hdr.Msg);
     CFE_SB_TransmitMsg(&CFE_SB.HKTlmMsg.Hdr.Msg, true);
 
@@ -627,49 +627,66 @@ void CFE_SB_ResetCounters(void){
 int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data)
 {
     CFE_SB_MsgId_t          MsgId;
-    CFE_SB_PipeId_t         PipeId;
+    CFE_SB_PipeD_t          *PipeDscPtr;
     CFE_SB_DestinationD_t   *DestPtr;
     const CFE_SB_RouteCmd_Payload_t      *CmdPtr;
+    uint16 PendingEventID;
 
+    PendingEventID = 0;
     CmdPtr = &data->Payload;
 
     MsgId  = CmdPtr->MsgId;
-    PipeId = CmdPtr->Pipe;
+
+    CFE_SB_LockSharedData(__func__,__LINE__);
 
     /* check cmd parameters */
+    PipeDscPtr = CFE_SB_LocatePipeDescByID(CmdPtr->Pipe);
     if(!CFE_SB_IsValidMsgId(MsgId) ||
-       (CFE_SB_ValidatePipeId(PipeId) != CFE_SUCCESS))
+       !CFE_SB_PipeDescIsMatch(PipeDscPtr,CmdPtr->Pipe))
     {
-        CFE_EVS_SendEvent(CFE_SB_ENBL_RTE3_EID,CFE_EVS_EventType_ERROR,
-                      "Enbl Route Cmd:Invalid Param.Msg 0x%x,Pipe %d",
-                      (unsigned int)CFE_SB_MsgIdToValue(MsgId),(int)PipeId);
+        PendingEventID = CFE_SB_ENBL_RTE3_EID;
         CFE_SB.HKTlmMsg.Payload.CommandErrorCounter++;
-        /*
-         * returning "success" here as there is no other recourse;
-         * the full extent of the error recovery has been done
-         */
-       return CFE_SUCCESS;
-    }/* end if */
+    }
+    else
+    {
+        DestPtr = CFE_SB_GetDestPtr(CFE_SBR_GetRouteId(MsgId), CmdPtr->Pipe);
+        if(DestPtr == NULL)
+        {
+            PendingEventID = CFE_SB_ENBL_RTE1_EID;
+            CFE_SB.HKTlmMsg.Payload.CommandErrorCounter++;
+        }
+        else
+        {
+            DestPtr->Active = CFE_SB_ACTIVE;
+            PendingEventID = CFE_SB_ENBL_RTE2_EID;
+            CFE_SB.HKTlmMsg.Payload.CommandCounter++;
+        }
 
-    DestPtr = CFE_SB_GetDestPtr(CFE_SBR_GetRouteId(MsgId), PipeId);
-    if(DestPtr == NULL){
-        CFE_EVS_SendEvent(CFE_SB_ENBL_RTE1_EID,CFE_EVS_EventType_ERROR,
-                "Enbl Route Cmd:Route does not exist.Msg 0x%x,Pipe %d",
-                (unsigned int)CFE_SB_MsgIdToValue(MsgId),(int)PipeId);
-        CFE_SB.HKTlmMsg.Payload.CommandErrorCounter++;
-        /*
-         * returning "success" here as there is no other recourse;
-         * the full extent of the error recovery has been done
-         */
-       return CFE_SUCCESS;
-    }/* end if */
+    }/* end if */    
 
-    DestPtr->Active = CFE_SB_ACTIVE;
-    CFE_EVS_SendEvent(CFE_SB_ENBL_RTE2_EID,CFE_EVS_EventType_DEBUG,
-                      "Enabling Route,Msg 0x%x,Pipe %d",
-                      (unsigned int)CFE_SB_MsgIdToValue(MsgId),(int)PipeId);
+    CFE_SB_UnlockSharedData(__func__,__LINE__);
 
-    CFE_SB.HKTlmMsg.Payload.CommandCounter++;
+    switch(PendingEventID)
+    {
+        case CFE_SB_ENBL_RTE1_EID:
+            CFE_EVS_SendEvent(CFE_SB_ENBL_RTE1_EID,CFE_EVS_EventType_ERROR,
+                "Enbl Route Cmd:Route does not exist.Msg 0x%x,Pipe %lu",
+                (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+                CFE_ES_ResourceID_ToInteger(CmdPtr->Pipe));
+            break;
+        case CFE_SB_ENBL_RTE3_EID:
+            CFE_EVS_SendEvent(CFE_SB_ENBL_RTE3_EID,CFE_EVS_EventType_ERROR,
+                      "Enbl Route Cmd:Invalid Param.Msg 0x%x,Pipe %lu",
+                      (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+                      CFE_ES_ResourceID_ToInteger(CmdPtr->Pipe));
+            break;
+        case CFE_SB_ENBL_RTE2_EID:
+            CFE_EVS_SendEvent(CFE_SB_ENBL_RTE2_EID,CFE_EVS_EventType_DEBUG,
+                      "Enabling Route,Msg 0x%x,Pipe %lu",
+                      (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+                      CFE_ES_ResourceID_ToInteger(CmdPtr->Pipe));
+            break;
+    }
 
     return CFE_SUCCESS;
 }/* end CFE_SB_EnableRouteCmd */
@@ -692,48 +709,67 @@ int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data)
 int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data)
 {
     CFE_SB_MsgId_t          MsgId;
-    CFE_SB_PipeId_t         PipeId;
+    CFE_SB_PipeD_t          *PipeDscPtr;
     CFE_SB_DestinationD_t   *DestPtr;
     const CFE_SB_RouteCmd_Payload_t      *CmdPtr;
+    uint16 PendingEventID;
 
+    PendingEventID = 0;
     CmdPtr = &data->Payload;
 
     MsgId  = CmdPtr->MsgId;
-    PipeId = CmdPtr->Pipe;
+
+    CFE_SB_LockSharedData(__func__,__LINE__);
 
     /* check cmd parameters */
+    PipeDscPtr = CFE_SB_LocatePipeDescByID(CmdPtr->Pipe);
     if(!CFE_SB_IsValidMsgId(MsgId) ||
-       (CFE_SB_ValidatePipeId(PipeId) != CFE_SUCCESS)){
-        CFE_EVS_SendEvent(CFE_SB_DSBL_RTE3_EID,CFE_EVS_EventType_ERROR,
-                   "Disable Route Cmd:Invalid Param.Msg 0x%x,Pipe %d",
-                   (unsigned int)CFE_SB_MsgIdToValue(MsgId),(int)PipeId);
+       !CFE_SB_PipeDescIsMatch(PipeDscPtr,CmdPtr->Pipe))
+    {
+        PendingEventID = CFE_SB_DSBL_RTE3_EID;
         CFE_SB.HKTlmMsg.Payload.CommandErrorCounter++;
-        /*
-         * returning "success" here as there is no other recourse;
-         * the full extent of the error recovery has been done
-         */
-       return CFE_SUCCESS;
-    }/* end if */
+    }
+    else
+    {
+        DestPtr = CFE_SB_GetDestPtr(CFE_SBR_GetRouteId(MsgId), CmdPtr->Pipe);
+        if(DestPtr == NULL)
+        {
+            PendingEventID = CFE_SB_DSBL_RTE1_EID;
+            CFE_SB.HKTlmMsg.Payload.CommandErrorCounter++;
+        }
+        else
+        {
+            DestPtr->Active = CFE_SB_INACTIVE;
+            PendingEventID = CFE_SB_DSBL_RTE2_EID;
+            CFE_SB.HKTlmMsg.Payload.CommandCounter++;
+        }
 
-    DestPtr = CFE_SB_GetDestPtr(CFE_SBR_GetRouteId(MsgId), PipeId);
-    if(DestPtr == NULL){
-        CFE_EVS_SendEvent(CFE_SB_DSBL_RTE1_EID,CFE_EVS_EventType_ERROR,
-            "Disable Route Cmd:Route does not exist,Msg 0x%x,Pipe %d",
-            (unsigned int)CFE_SB_MsgIdToValue(MsgId),(int)PipeId);
-        CFE_SB.HKTlmMsg.Payload.CommandErrorCounter++;
-        /*
-         * returning "success" here as there is no other recourse;
-         * the full extent of the error recovery has been done
-         */
-       return CFE_SUCCESS;
-    }/* end if */
+    }/* end if */    
 
-    DestPtr->Active = CFE_SB_INACTIVE;
+    CFE_SB_UnlockSharedData(__func__,__LINE__);
 
-    CFE_EVS_SendEvent(CFE_SB_DSBL_RTE2_EID,CFE_EVS_EventType_DEBUG,
-                      "Route Disabled,Msg 0x%x,Pipe %d",
-                      (unsigned int)CFE_SB_MsgIdToValue(MsgId),(int)PipeId);
-    CFE_SB.HKTlmMsg.Payload.CommandCounter++;
+
+    switch(PendingEventID)
+    {
+        case CFE_SB_DSBL_RTE1_EID:
+            CFE_EVS_SendEvent(CFE_SB_DSBL_RTE1_EID,CFE_EVS_EventType_ERROR,
+                "Disable Route Cmd:Route does not exist,Msg 0x%x,Pipe %lu",
+                (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+                CFE_ES_ResourceID_ToInteger(CmdPtr->Pipe));
+            break;
+        case CFE_SB_DSBL_RTE3_EID:
+            CFE_EVS_SendEvent(CFE_SB_DSBL_RTE3_EID,CFE_EVS_EventType_ERROR,
+                   "Disable Route Cmd:Invalid Param.Msg 0x%x,Pipe %lu",
+                   (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+                   CFE_ES_ResourceID_ToInteger(CmdPtr->Pipe));
+            break;
+        case CFE_SB_DSBL_RTE2_EID:
+            CFE_EVS_SendEvent(CFE_SB_DSBL_RTE2_EID,CFE_EVS_EventType_DEBUG,
+                      "Route Disabled,Msg 0x%x,Pipe %lu",
+                      (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+                      CFE_ES_ResourceID_ToInteger(CmdPtr->Pipe));
+            break;
+    }
 
     return CFE_SUCCESS;
 }/* end CFE_SB_DisableRouteCmd */
@@ -753,6 +789,45 @@ int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data)
 */
 int32 CFE_SB_SendStatsCmd(const CFE_SB_SendSbStatsCmd_t *data)
 {
+    uint32 PipeDscCount;
+    uint32 PipeStatCount;
+    CFE_SB_PipeD_t *PipeDscPtr;
+    CFE_SB_PipeDepthStats_t *PipeStatPtr;
+
+    CFE_SB_LockSharedData(__FILE__, __LINE__);
+
+    /* Collect data on pipes */
+    PipeDscCount = CFE_PLATFORM_SB_MAX_PIPES;
+    PipeStatCount = CFE_MISSION_SB_MAX_PIPES;
+    PipeDscPtr = CFE_SB.PipeTbl;
+    PipeStatPtr = CFE_SB.StatTlmMsg.Payload.PipeDepthStats;
+
+    while (PipeDscCount > 0 && PipeStatCount > 0)
+    {
+        if (CFE_SB_PipeDescIsUsed(PipeDscPtr))
+        {
+            PipeStatPtr->PipeId = PipeDscPtr->PipeId;
+            PipeStatPtr->InUse = PipeDscPtr->CurrentDepth;
+            PipeStatPtr->PeakInUse = PipeDscPtr->PeakDepth;
+            PipeStatPtr->Depth = PipeDscPtr->QueueDepth;
+
+            ++PipeStatPtr;
+            --PipeStatCount;
+        }
+
+        --PipeDscCount;
+        ++PipeDscPtr;
+    }
+
+    CFE_SB_UnlockSharedData(__FILE__, __LINE__);
+
+    while (PipeStatCount > 0)
+    {
+        memset(PipeStatPtr, 0, sizeof(*PipeStatPtr));
+
+        ++PipeStatPtr;
+        --PipeStatCount;
+    }
 
     CFE_SB_TimeStampMsg(&CFE_SB.StatTlmMsg.Hdr.Msg);
     CFE_SB_TransmitMsg(&CFE_SB.StatTlmMsg.Hdr.Msg, true);
@@ -861,56 +936,128 @@ int32 CFE_SB_SendMapInfoCmd(const CFE_SB_SendMapInfoCmd_t *data)
  */
 void CFE_SB_WriteRouteToFile(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
 {
+    struct RouteInfo
+    {
+        CFE_SB_PipeId_t PipeId;
+        uint8           Active;
+        uint16          DestCnt;
+    };
+
     CFE_SB_FileWriteCallback_t *args;
     CFE_SB_DestinationD_t      *destptr;
     CFE_SB_PipeD_t             *pipedptr;
     int32                       status;
     CFE_SB_RoutingFileEntry_t   entry;
+    struct RouteInfo RouteInfo[CFE_PLATFORM_SB_MAX_DEST_PER_PKT];
+    struct RouteInfo *RouteInfoPtr;
+    uint32 NumDest;
 
     /* Cast arguments for local use */
     args = (CFE_SB_FileWriteCallback_t *)ArgPtr;
 
+    NumDest = 0;
+
+    /* Data must be locked to snapshot the route info */
+    CFE_SB_LockSharedData(__FILE__, __LINE__);
+
     destptr = CFE_SBR_GetDestListHeadPtr(RouteId);
+    entry.MsgId = CFE_SBR_GetMsgId(RouteId);
+    RouteInfoPtr = RouteInfo;
 
-    while((destptr != NULL) && (args->Status != CFE_SB_FILE_IO_ERR))
+    while((destptr != NULL) && NumDest < CFE_PLATFORM_SB_MAX_DEST_PER_PKT)
     {
-
-        pipedptr = CFE_SB_GetPipePtr(destptr->PipeId);
+        pipedptr = CFE_SB_LocatePipeDescByID(destptr->PipeId);
 
         /* If invalid id, continue on to next entry */
-        if (pipedptr != NULL)
+        if (CFE_SB_PipeDescIsMatch(pipedptr,destptr->PipeId))
         {
-
-            entry.MsgId     = CFE_SBR_GetMsgId(RouteId);
-            entry.PipeId    = destptr->PipeId;
-            entry.State     = destptr->Active;
-            entry.MsgCnt    = destptr->DestCnt;
-
-            entry.AppName[0] = 0;
-            /*
-             * NOTE: as long as CFE_ES_GetAppName() returns success, then it
-             * guarantees null termination of the output.  Return code is not
-             * checked here (bad) but in case of error it does not seem to touch
-             * the buffer, therefore the initialization above will protect for now
-             */
-            CFE_ES_GetAppName(entry.AppName, pipedptr->AppId, sizeof(entry.AppName));
-            CFE_SB_GetPipeName(entry.PipeName, sizeof(entry.PipeName), entry.PipeId);
-
-            status = OS_write (args->Fd, &entry, sizeof(CFE_SB_RoutingFileEntry_t));
-            if(status != sizeof(CFE_SB_RoutingFileEntry_t))
-            {
-                CFE_SB_FileWriteByteCntErr(args->Filename, sizeof(CFE_SB_RoutingFileEntry_t), status);
-                OS_close(args->Fd);
-                args->Status = CFE_SB_FILE_IO_ERR;
-            }
-
-            args->FileSize += status;
-            args->EntryCount++;
+            RouteInfoPtr->PipeId = destptr->PipeId;
+            RouteInfoPtr->Active = destptr->Active;
+            RouteInfoPtr->DestCnt = destptr->DestCnt;
+            ++RouteInfoPtr;
+            ++NumDest;
         }
 
         destptr = destptr->Next;
     }
+
+    CFE_SB_UnlockSharedData(__FILE__, __LINE__);
+
+    RouteInfoPtr = RouteInfo;
+    while (NumDest > 0)
+    {
+        entry.PipeId    = RouteInfoPtr->PipeId;
+        entry.State     = RouteInfoPtr->Active;
+        entry.MsgCnt    = RouteInfoPtr->DestCnt;
+
+        entry.AppName[0] = 0;
+
+        /*
+         * NOTE: as long as CFE_ES_GetAppName() returns success, then it
+         * guarantees null termination of the output.  Return code is not
+         * checked here (bad) but in case of error it does not seem to touch
+         * the buffer, therefore the initialization above will protect for now
+         */
+        CFE_ES_GetAppName(entry.AppName, pipedptr->AppId, sizeof(entry.AppName));
+        CFE_SB_GetPipeName(entry.PipeName, sizeof(entry.PipeName), entry.PipeId);
+
+        status = OS_write (args->Fd, &entry, sizeof(CFE_SB_RoutingFileEntry_t));
+        if(status != sizeof(CFE_SB_RoutingFileEntry_t))
+        {
+            CFE_SB_FileWriteByteCntErr(args->Filename, sizeof(CFE_SB_RoutingFileEntry_t), status);
+            OS_close(args->Fd);
+            args->Status = CFE_SB_FILE_IO_ERR;
+        }
+
+        args->FileSize += status;
+        args->EntryCount++;
+
+        ++RouteInfoPtr;
+        --NumDest;
+    }
 }
+
+/******************************************************************************
+**  Function:  CFE_SB_SendSubscriptionReport()
+**
+**  Purpose:
+**    SB internal function to generate the "ONESUB_TLM" message after a subscription.
+**    No-op when subscription reporting is disabled.
+**
+**  Arguments:
+**    Payload of notification message - MsgId, PipeId, QOS
+**
+**  Return:
+**    CFE_SUCCESS or error code
+*/
+int32 CFE_SB_SendSubscriptionReport(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_Qos_t Quality)
+{
+    CFE_SB_SingleSubscriptionTlm_t SubRptMsg;
+    int32  Status;
+
+    Status = CFE_SUCCESS;
+
+    if (CFE_SB.SubscriptionReporting == CFE_SB_ENABLE)
+    {
+        CFE_MSG_Init(&SubRptMsg.Hdr.Msg,
+                    CFE_SB_ValueToMsgId(CFE_SB_ONESUB_TLM_MID),
+                    sizeof(SubRptMsg));
+
+        SubRptMsg.Payload.MsgId = MsgId;
+        SubRptMsg.Payload.Pipe = PipeId;
+        SubRptMsg.Payload.Qos = Quality;
+        SubRptMsg.Payload.SubType = CFE_SB_SUBSCRIPTION;
+
+        Status = CFE_SB_TransmitMsg(&SubRptMsg.Hdr.Msg, true);
+        CFE_EVS_SendEventWithAppID(CFE_SB_SUBSCRIPTION_RPT_EID,CFE_EVS_EventType_DEBUG,CFE_SB.AppId,
+                "Sending Subscription Report Msg=0x%x,Pipe=%lu,Stat=0x%x",
+                (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+                CFE_ES_ResourceID_ToInteger(PipeId),(unsigned int)Status);
+    }
+
+    return Status;
+}
+
 
 /******************************************************************************
 **  Function:  CFE_SB_SendRoutingInfo()
@@ -993,6 +1140,8 @@ int32 CFE_SB_SendPipeInfo(const char *Filename)
     uint32 FileSize = 0;
     uint32 EntryCount = 0;
     CFE_FS_Header_t FileHdr;
+    CFE_SB_PipeD_t *PipeDscPtr;
+    CFE_SB_PipeD_t entry;   /* NOTE: Should be separate/dedicated type */
 
     Status = OS_OpenCreate(&fd, Filename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
 
@@ -1015,13 +1164,21 @@ int32 CFE_SB_SendPipeInfo(const char *Filename)
 
     FileSize = Status;
 
-    /* loop through the pipe table */
-    for(i=0;i<CFE_PLATFORM_SB_MAX_PIPES;i++){
+    /* loop through the pipe table */   
+    CFE_SB_LockSharedData(__FILE__,__LINE__); 
+    PipeDscPtr = CFE_SB.PipeTbl;
 
-        if(CFE_SB.PipeTbl[i].InUse==CFE_SB_IN_USE){
+    for (i=0;i<CFE_PLATFORM_SB_MAX_PIPES;i++)
+    {
+        if (CFE_SB_PipeDescIsUsed(PipeDscPtr))
+        {
+            memcpy(&entry, PipeDscPtr, sizeof(CFE_SB_PipeD_t));
 
-            Status = OS_write (fd, &(CFE_SB.PipeTbl[i]), sizeof(CFE_SB_PipeD_t));
-            if(Status != sizeof(CFE_SB_PipeD_t)){
+            CFE_SB_UnlockSharedData(__FILE__,__LINE__); 
+
+            Status = OS_write (fd, &entry, sizeof(CFE_SB_PipeD_t));
+            if (Status != sizeof(CFE_SB_PipeD_t))
+            {
                 CFE_SB_FileWriteByteCntErr(Filename,sizeof(CFE_SB_PipeD_t),Status);
                 OS_close(fd);
                 return CFE_SB_FILE_IO_ERR;
@@ -1030,9 +1187,15 @@ int32 CFE_SB_SendPipeInfo(const char *Filename)
             FileSize += Status;
             EntryCount ++;
 
+            CFE_SB_LockSharedData(__FILE__,__LINE__); 
+
         }/* end if */
 
+        ++PipeDscPtr;
+
     }/* end for */
+
+    CFE_SB_UnlockSharedData(__FILE__,__LINE__); 
 
     OS_close(fd);
 
@@ -1059,8 +1222,10 @@ void CFE_SB_WriteMapToFile(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
 
     if(args->Status != CFE_SB_FILE_IO_ERR)
     {
+        CFE_SB_LockSharedData(__FILE__,__LINE__); 
         entry.MsgId = CFE_SBR_GetMsgId(RouteId);
         entry.Index = CFE_SBR_RouteIdToValue(RouteId);
+        CFE_SB_UnlockSharedData(__FILE__,__LINE__); 
 
         status = OS_write (args->Fd, &entry, sizeof(CFE_SB_MsgMapFileEntry_t));
         if(status != sizeof(CFE_SB_MsgMapFileEntry_t))
@@ -1295,8 +1460,3 @@ void CFE_SB_SetSubscriptionReporting(uint32 state){
     CFE_SB.SubscriptionReporting = state;
 
 }/* end CFE_SB_SetSubscriptionReporting */
-
-
-
-
-

--- a/fsw/cfe-core/src/sb/cfe_sb_verify.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_verify.h
@@ -154,14 +154,6 @@
     #error CFE_PLATFORM_SB_MEM_BLOCK_SIZE_16 must be less than CFE_PLATFORM_SB_MAX_BLOCK_SIZE
 #endif
 
-#if CFE_PLATFORM_SB_DEFAULT_REPORT_SENDER < 0
-    #error CFE_PLATFORM_SB_DEFAULT_REPORT_SENDER cannot be less than 0!
-#endif
-
-#if CFE_PLATFORM_SB_DEFAULT_REPORT_SENDER > 1
-    #error CFE_PLATFORM_SB_DEFAULT_REPORT_SENDER cannot be greater than 1!
-#endif
-
 #if CFE_PLATFORM_SB_DEFAULT_MSG_LIMIT < 4
     #error CFE_PLATFORM_SB_DEFAULT_MSG_LIMIT cannot be less than 4!
 #endif

--- a/fsw/cfe-core/src/tbl/cfe_tbl_api.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_api.c
@@ -81,8 +81,8 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
             Status = CFE_TBL_ERR_INVALID_NAME;
 
             /* Perform a buffer overrun safe copy of name for debug log message */
-            strncpy(TblName, Name, CFE_MISSION_TBL_MAX_NAME_LENGTH);
-            TblName[CFE_MISSION_TBL_MAX_NAME_LENGTH-1] = '\0';
+            strncpy(TblName, Name, sizeof(TblName) - 1);
+            TblName[sizeof(TblName) - 1] = '\0';
             CFE_ES_WriteToSysLog("CFE_TBL:Register-Table Name (%s) is bad length (%d)",TblName,(int)NameLen);
         }
         else
@@ -314,7 +314,8 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
                     RegRecPtr->ValidationFuncPtr = TblValidationFuncPtr;
 
                     /* Save Table Name in Registry */
-                    strncpy(RegRecPtr->Name, TblName, CFE_TBL_MAX_FULL_NAME_LEN);
+                    strncpy(RegRecPtr->Name, TblName, sizeof(RegRecPtr->Name) - 1);
+                    RegRecPtr->Name[sizeof(RegRecPtr->Name) - 1] = '\0';
 
                     /* Set the "Dump Only" flag to value based upon selected option */
                     if ((TblOptionFlags & CFE_TBL_OPT_LD_DMP_MSK) == CFE_TBL_OPT_DUMP_ONLY)
@@ -398,10 +399,14 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
                             
                                 if ((CritRegRecPtr != NULL) && (CritRegRecPtr->TableLoadedOnce))
                                 {
-                                    strncpy(WorkingBufferPtr->DataSource, CritRegRecPtr->LastFileLoaded, OS_MAX_PATH_LEN);
+                                    strncpy(WorkingBufferPtr->DataSource, CritRegRecPtr->LastFileLoaded,
+                                            sizeof(WorkingBufferPtr->DataSource) - 1);
+                                    WorkingBufferPtr->DataSource[sizeof(WorkingBufferPtr->DataSource) - 1] = '\0';
                                     WorkingBufferPtr->FileCreateTimeSecs = CritRegRecPtr->FileCreateTimeSecs;
                                     WorkingBufferPtr->FileCreateTimeSubSecs = CritRegRecPtr->FileCreateTimeSubSecs;
-                                    strncpy(RegRecPtr->LastFileLoaded, CritRegRecPtr->LastFileLoaded, OS_MAX_PATH_LEN);
+                                    strncpy(RegRecPtr->LastFileLoaded, CritRegRecPtr->LastFileLoaded,
+                                            sizeof(RegRecPtr->LastFileLoaded) - 1);
+                                    RegRecPtr->LastFileLoaded[sizeof(RegRecPtr->LastFileLoaded) - 1] = '\0';
                                     RegRecPtr->TimeOfLastUpdate.Seconds = CritRegRecPtr->TimeOfLastUpdate.Seconds;
                                     RegRecPtr->TimeOfLastUpdate.Subseconds = CritRegRecPtr->TimeOfLastUpdate.Subseconds;
                                     RegRecPtr->TableLoadedOnce = CritRegRecPtr->TableLoadedOnce;
@@ -441,7 +446,8 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
                             if (CritRegRecPtr != NULL)
                             {
                                 CritRegRecPtr->CDSHandle = RegRecPtr->CDSHandle;
-                                strncpy(CritRegRecPtr->Name, TblName, CFE_TBL_MAX_FULL_NAME_LEN);
+                                strncpy(CritRegRecPtr->Name, TblName, sizeof(CritRegRecPtr->Name) - 1);
+                                CritRegRecPtr->Name[sizeof(CritRegRecPtr->Name) - 1] = '\0';
                                 CritRegRecPtr->FileCreateTimeSecs = 0;
                                 CritRegRecPtr->FileCreateTimeSubSecs = 0;
                                 CritRegRecPtr->LastFileLoaded[0] = '\0';
@@ -874,7 +880,8 @@ int32 CFE_TBL_Load( CFE_TBL_Handle_t TblHandle,
         /* On initial loads, make sure registry is given file/address of data source */
         strncpy(RegRecPtr->LastFileLoaded,
                 WorkingBufferPtr->DataSource,
-                OS_MAX_PATH_LEN);
+                sizeof(RegRecPtr->LastFileLoaded) - 1);
+        RegRecPtr->LastFileLoaded[sizeof(RegRecPtr->LastFileLoaded) - 1] = '\0';
 
         CFE_TBL_NotifyTblUsersOfUpdate(RegRecPtr);
                 
@@ -1494,7 +1501,7 @@ int32 CFE_TBL_Modified( CFE_TBL_Handle_t TblHandle )
         
         /* Keep a record of change for the ground operators reference */
         RegRecPtr->TimeOfLastUpdate = CFE_TIME_GetTime();
-        RegRecPtr->LastFileLoaded[OS_MAX_PATH_LEN-1] = '\0';
+        RegRecPtr->LastFileLoaded[sizeof(RegRecPtr->LastFileLoaded)-1] = '\0';
         
         /* Update CRC on contents of table */
         RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].Crc = 
@@ -1504,13 +1511,13 @@ int32 CFE_TBL_Modified( CFE_TBL_Handle_t TblHandle )
                                 CFE_MISSION_ES_DEFAULT_CRC);
 
         FilenameLen = strlen(RegRecPtr->LastFileLoaded);
-        if (FilenameLen < (OS_MAX_PATH_LEN-4))
+        if (FilenameLen < (sizeof(RegRecPtr->LastFileLoaded)-4))
         {
             strncpy(&RegRecPtr->LastFileLoaded[FilenameLen], "(*)", 4);
         }
         else
         {
-            strncpy(&RegRecPtr->LastFileLoaded[(OS_MAX_PATH_LEN-4)], "(*)", 4);
+            strncpy(&RegRecPtr->LastFileLoaded[sizeof(RegRecPtr->LastFileLoaded)-4], "(*)", 4);
         }
 
         AccessIterator = RegRecPtr->HeadOfAccessList;

--- a/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
@@ -1002,8 +1002,8 @@ int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBuffe
         return CFE_TBL_ERR_FILE_TOO_LARGE;
     }
 
-    memset(WorkingBufferPtr->DataSource, 0, OS_MAX_PATH_LEN);
-    strncpy(WorkingBufferPtr->DataSource, Filename, OS_MAX_PATH_LEN);
+    memset(WorkingBufferPtr->DataSource, 0, sizeof(WorkingBufferPtr->DataSource));
+    strncpy(WorkingBufferPtr->DataSource, Filename, sizeof(WorkingBufferPtr->DataSource) - 1);
 
     /* Save file creation time for later storage into Registry */
     WorkingBufferPtr->FileCreateTimeSecs = StdFileHeader.TimeSeconds;
@@ -1054,7 +1054,8 @@ int32 CFE_TBL_UpdateInternal( CFE_TBL_Handle_t TblHandle,
             /* However, we need to copy it into active registry area */
             strncpy(RegRecPtr->LastFileLoaded,
                     RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].DataSource,
-                    OS_MAX_PATH_LEN);
+                    sizeof(RegRecPtr->LastFileLoaded) - 1);
+            RegRecPtr->LastFileLoaded[sizeof(RegRecPtr->LastFileLoaded) - 1] = '\0';
 
             CFE_TBL_NotifyTblUsersOfUpdate(RegRecPtr);
             
@@ -1470,7 +1471,8 @@ void CFE_TBL_UpdateCriticalTblCDS(CFE_TBL_RegistryRec_t *RegRecPtr)
             /* Save information related to the source of the data stored in the table in Critical Table Registry */
             CritRegRecPtr->FileCreateTimeSecs = RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].FileCreateTimeSecs;
             CritRegRecPtr->FileCreateTimeSubSecs = RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].FileCreateTimeSubSecs;
-            strncpy(CritRegRecPtr->LastFileLoaded, RegRecPtr->LastFileLoaded, OS_MAX_PATH_LEN);
+            strncpy(CritRegRecPtr->LastFileLoaded, RegRecPtr->LastFileLoaded, sizeof(CritRegRecPtr->LastFileLoaded) - 1);
+            CritRegRecPtr->LastFileLoaded[sizeof(CritRegRecPtr->LastFileLoaded) - 1] = '\0';
             CritRegRecPtr->TimeOfLastUpdate = RegRecPtr->TimeOfLastUpdate;
             CritRegRecPtr->TableLoadedOnce = RegRecPtr->TableLoadedOnce;
             

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task.c
@@ -181,9 +181,7 @@ int32 CFE_TBL_TaskInit(void)
     /*
     ** Create Software Bus message pipe
     */
-    Status = CFE_SB_CreatePipe(&CFE_TBL_TaskData.CmdPipe,
-                                CFE_TBL_TaskData.PipeDepth,
-                                CFE_TBL_TaskData.PipeName);
+    Status = CFE_SB_CreatePipe(&CFE_TBL_TaskData.CmdPipe, CFE_TBL_TASK_PIPE_DEPTH, CFE_TBL_TASK_PIPE_NAME);
     if(Status != CFE_SUCCESS)
     {
       CFE_ES_WriteToSysLog("TBL:Error creating cmd pipe:RC=0x%08X\n",(unsigned int)Status);
@@ -240,10 +238,6 @@ void CFE_TBL_InitData(void)
 
     /* Get the assigned Application ID for the Table Services Task */
     CFE_ES_GetAppID(&CFE_TBL_TaskData.TableTaskAppId);
-
-    /* Initialize Command Pipe Parameters */
-    CFE_TBL_TaskData.PipeDepth = CFE_TBL_TASK_PIPE_DEPTH;
-    strncpy(CFE_TBL_TaskData.PipeName, CFE_TBL_TASK_PIPE_NAME, 16);
 
     /* Initialize Packet Headers */
     CFE_MSG_Init(&CFE_TBL_TaskData.HkPacket.TlmHeader.Msg,

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task.h
@@ -313,8 +313,6 @@ typedef struct
   /*
   ** Task initialization data (not reported in housekeeping)...
   */
-  char                   PipeName[16];                    /**< \brief Contains name of Table Task command pipe */
-  uint16                 PipeDepth;                       /**< \brief Contains depth of Table Task command pipe */
   CFE_ES_ResourceID_t    TableTaskAppId;                  /**< \brief Contains Table Task Application ID as assigned by OS AL */
 
   int16                  HkTlmTblRegIndex;                /**< \brief Index of table registry entry to be telemetered with Housekeeping */

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.c
@@ -484,9 +484,13 @@ int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
                             
                                     /* Save file information statistics for housekeeping telemetry */
                                     strncpy(CFE_TBL_TaskData.HkPacket.Payload.LastFileLoaded, LoadFilename,
-                                            sizeof(CFE_TBL_TaskData.HkPacket.Payload.LastFileLoaded));
+                                            sizeof(CFE_TBL_TaskData.HkPacket.Payload.LastFileLoaded) - 1);
+                                    CFE_TBL_TaskData.HkPacket.Payload.LastFileLoaded[
+                                            sizeof(CFE_TBL_TaskData.HkPacket.Payload.LastFileLoaded) - 1] = '\0';
                                     strncpy(CFE_TBL_TaskData.HkPacket.Payload.LastTableLoaded, TblFileHeader.TableName,
-                                            sizeof(CFE_TBL_TaskData.HkPacket.Payload.LastTableLoaded));
+                                            sizeof(CFE_TBL_TaskData.HkPacket.Payload.LastTableLoaded) - 1);
+                                    CFE_TBL_TaskData.HkPacket.Payload.LastTableLoaded[
+                                            sizeof(CFE_TBL_TaskData.HkPacket.Payload.LastTableLoaded) - 1] = '\0';
 
                                     /* Increment successful command completion counter */
                                     ReturnCode = CFE_TBL_INC_CMD_CTR;

--- a/fsw/cfe-core/src/time/cfe_time_api.c
+++ b/fsw/cfe-core/src/time/cfe_time_api.c
@@ -697,21 +697,20 @@ int32  CFE_TIME_RegisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPt
     if (Status == CFE_SUCCESS)
     {
         Status = CFE_ES_AppID_ToIndex(AppId, &AppIndex);
-    }
-    if (Status != CFE_SUCCESS)
-    {
-        /* Called from an invalid context */
-        return Status;
-    }
 
-    if (AppIndex >= (sizeof(CFE_TIME_TaskData.SynchCallback) / sizeof(CFE_TIME_TaskData.SynchCallback[0])) ||
-        CFE_TIME_TaskData.SynchCallback[AppIndex].Ptr != NULL)
-    {
-        Status = CFE_TIME_TOO_MANY_SYNCH_CALLBACKS;
-    }
-    else
-    {
-        CFE_TIME_TaskData.SynchCallback[AppIndex].Ptr = CallbackFuncPtr;
+        if (Status == CFE_SUCCESS)
+        {
+
+            if (AppIndex >= (sizeof(CFE_TIME_TaskData.SynchCallback) / sizeof(CFE_TIME_TaskData.SynchCallback[0])) ||
+                CFE_TIME_TaskData.SynchCallback[AppIndex].Ptr != NULL)
+            {
+                Status = CFE_TIME_TOO_MANY_SYNCH_CALLBACKS;
+            }
+            else
+            {
+                CFE_TIME_TaskData.SynchCallback[AppIndex].Ptr = CallbackFuncPtr;
+            }
+        }
     }
     
     return Status;

--- a/fsw/cfe-core/src/time/cfe_time_task.c
+++ b/fsw/cfe-core/src/time/cfe_time_task.c
@@ -265,9 +265,7 @@ int32 CFE_TIME_TaskInit(void)
     }/* end if */
 
 
-    Status = CFE_SB_CreatePipe(&CFE_TIME_TaskData.CmdPipe,
-                                CFE_TIME_TaskData.PipeDepth,
-                                CFE_TIME_TaskData.PipeName);
+    Status = CFE_SB_CreatePipe(&CFE_TIME_TaskData.CmdPipe, CFE_TIME_TASK_PIPE_DEPTH, CFE_TIME_TASK_PIPE_NAME);
     if(Status != CFE_SUCCESS)
     {
       CFE_ES_WriteToSysLog("TIME:Error creating cmd pipe:RC=0x%08X\n",(unsigned int)Status);

--- a/fsw/cfe-core/src/time/cfe_time_tone.c
+++ b/fsw/cfe-core/src/time/cfe_time_tone.c
@@ -1459,7 +1459,7 @@ void CFE_TIME_Local1HzTask(void)
 /*                                                                 */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
 
-void CFE_TIME_NotifyTimeSynchApps(void)
+void  CFE_TIME_NotifyTimeSynchApps(void)
 {
     uint32      i = 0;
     CFE_TIME_SynchCallbackPtr_t Func;

--- a/fsw/cfe-core/src/time/cfe_time_utils.c
+++ b/fsw/cfe-core/src/time/cfe_time_utils.c
@@ -256,9 +256,6 @@ void CFE_TIME_InitData(void)
     /*
     ** Initialize task configuration data...
     */
-    strcpy(CFE_TIME_TaskData.PipeName, CFE_TIME_TASK_PIPE_NAME);
-    CFE_TIME_TaskData.PipeDepth = CFE_TIME_TASK_PIPE_DEPTH;
-    
     memset((void*)CFE_TIME_TaskData.ReferenceState, 0, sizeof(CFE_TIME_TaskData.ReferenceState));
     for (i = 0; i < CFE_TIME_REFERENCE_BUF_DEPTH; ++i)
     {

--- a/fsw/cfe-core/src/time/cfe_time_utils.h
+++ b/fsw/cfe-core/src/time/cfe_time_utils.h
@@ -188,9 +188,6 @@ typedef struct
   /*
   ** Task initialization data (not reported in housekeeping)...
   */
-  char                  PipeName[16];
-  uint16                PipeDepth;
-
   int16                 ClockSource;
   int16                 ClockSignal;
   int16                 ServerFlyState;

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -4164,7 +4164,7 @@ void TestPerf(void)
     Perf->MetaData.TriggerCount = CFE_PLATFORM_ES_PERF_DATA_BUFFER_SIZE +1;
     Perf->MetaData.InvalidMarkerReported = false;
     Perf->MetaData.DataEnd = CFE_PLATFORM_ES_PERF_DATA_BUFFER_SIZE +1 ;
-    CFE_ES_PerfLogAdd(CFE_PLATFORM_ES_PERF_MAX_IDS, 0);
+    CFE_ES_PerfLogAdd(CFE_MISSION_ES_PERF_MAX_IDS, 0);
     UT_Report(__FILE__, __LINE__,
               Perf->MetaData.InvalidMarkerReported == true,
               "CFE_ES_PerfLogAdd",
@@ -4218,7 +4218,7 @@ void TestPerf(void)
     ES_ResetUnitTest();
     Perf->MetaData.State = CFE_ES_PERF_TRIGGERED;
     Perf->MetaData.InvalidMarkerReported = 2;
-    CFE_ES_PerfLogAdd(CFE_PLATFORM_ES_PERF_MAX_IDS + 1, 0);
+    CFE_ES_PerfLogAdd(CFE_MISSION_ES_PERF_MAX_IDS + 1, 0);
     UT_Report(__FILE__, __LINE__,
               Perf->MetaData.InvalidMarkerReported == 2,
               "CFE_ES_PerfLogAdd",

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -882,8 +882,7 @@ void TestStartupErrorPaths(void)
     CFE_ES_InitializeFileSystems(CFE_PSP_RST_TYPE_POWERON);
     UT_Report(__FILE__, __LINE__,
               UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_CREATE_VOLATILE]) &&
-              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_MOUNT_VOLATILE]) && 
-              UT_GetStubCount(UT_KEY(OS_printf)) == 2,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_MOUNT_VOLATILE]),
               "CFE_ES_InitializeFileSystems",
               "Power on reset; error creating volatile (RAM) volume");
 
@@ -906,8 +905,7 @@ void TestStartupErrorPaths(void)
               UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_CREATE_VOLATILE]) && 
               UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_INIT_VOLATILE]) &&
               UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_MOUNT_VOLATILE]) &&
-              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_REFORMAT_VOLATILE]) &&
-              UT_GetStubCount(UT_KEY(OS_printf)) == 7,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_REFORMAT_VOLATILE]),
               "CFE_ES_InitializeFileSystems",
               "Processor reset; error reformatting volatile (RAM) volume");
 
@@ -919,8 +917,7 @@ void TestStartupErrorPaths(void)
     UT_SetDataBuffer(UT_KEY(OS_FileSysStatVolume), &StatBuf, sizeof(StatBuf), false);
     CFE_ES_InitializeFileSystems(CFE_PSP_RST_TYPE_PROCESSOR);
     UT_Report(__FILE__, __LINE__,
-              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_INSUFF_FREE_SPACE]) &&
-              UT_GetStubCount(UT_KEY(OS_printf)) == 3,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_INSUFF_FREE_SPACE]),
               "CFE_ES_InitializeFileSystems",
               "Processor reset; cannot get memory for volatile disk");
 
@@ -933,8 +930,7 @@ void TestStartupErrorPaths(void)
     CFE_ES_InitializeFileSystems(CFE_PSP_RST_TYPE_PROCESSOR);
     UT_Report(__FILE__, __LINE__,
               UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_INSUFF_FREE_SPACE]) &&
-               UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_REMOVE_VOLATILE]) && 
-               UT_GetStubCount(UT_KEY(OS_printf)) == 3,
+               UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_REMOVE_VOLATILE]),
               "CFE_ES_InitializeFileSystems",
               "Processor reset; error removing volatile (RAM) volume");
 
@@ -947,8 +943,7 @@ void TestStartupErrorPaths(void)
     CFE_ES_InitializeFileSystems(CFE_PSP_RST_TYPE_PROCESSOR);
     UT_Report(__FILE__, __LINE__,
               UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_INSUFF_FREE_SPACE]) &&
-              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_UNMOUNT_VOLATILE]) && 
-              UT_GetStubCount(UT_KEY(OS_printf)) == 3,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_UNMOUNT_VOLATILE]),
               "CFE_ES_InitializeFileSystems",
               "Processor reset; error unmounting volatile (RAM) volume");
 
@@ -956,7 +951,7 @@ void TestStartupErrorPaths(void)
     ES_ResetUnitTest();
     CFE_ES_InitializeFileSystems(4564564);
     UT_Report(__FILE__, __LINE__,
-              UT_GetStubCount(UT_KEY(OS_printf)) == 0,
+              UT_GetStubCount(UT_KEY(CFE_PSP_Panic)) == 0,
               "CFE_ES_InitializeFileSystems",
               "Initialize file systems; successful");
 
@@ -970,8 +965,7 @@ void TestStartupErrorPaths(void)
     UT_Report(__FILE__, __LINE__,
               UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_INSUFF_FREE_SPACE]) &&
               UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_MOUNT_VOLATILE]) && 
-              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_REMOUNT_VOLATILE]) &&
-              UT_GetStubCount(UT_KEY(OS_printf)) == 4,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_REMOUNT_VOLATILE]),
               "CFE_ES_InitializeFileSystems",
               "Processor reset; error remounting volatile (RAM) volume");
 
@@ -982,8 +976,7 @@ void TestStartupErrorPaths(void)
     UT_SetDeferredRetcode(UT_KEY(OS_FileSysStatVolume), 1, -1);
     CFE_ES_InitializeFileSystems(CFE_PSP_RST_TYPE_PROCESSOR);
     UT_Report(__FILE__, __LINE__,
-              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_DETERMINE_BLOCKS]) &&
-                  UT_GetStubCount(UT_KEY(OS_printf)) == 1,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_DETERMINE_BLOCKS]),
               "CFE_ES_InitializeFileSystems",
               "Processor reset; error determining blocks free on volume");
 
@@ -1002,8 +995,7 @@ void TestStartupErrorPaths(void)
     UT_SetHookFunction(UT_KEY(OS_TaskCreate), ES_UT_SetAppStateHook, NULL);
     CFE_ES_CreateObjects();
     UT_Report(__FILE__, __LINE__,
-              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_RECORD_USED]) &&
-                  UT_GetStubCount(UT_KEY(OS_printf)) == 13,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_RECORD_USED]),
               "CFE_ES_CreateObjects",
               "Record used error");
 
@@ -1026,8 +1018,7 @@ void TestStartupErrorPaths(void)
     CFE_ES_CreateObjects();
     UT_Report(__FILE__, __LINE__,
               UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_RECORD_USED]) && 
-              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_EARLYINIT]) &&
-              UT_GetStubCount(UT_KEY(OS_printf)) == 14,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_EARLYINIT]),
               "CFE_ES_CreateObjects",
               "Error returned when calling function");
 
@@ -1040,8 +1031,7 @@ void TestStartupErrorPaths(void)
     UT_SetHookFunction(UT_KEY(OS_TaskCreate), ES_UT_SetAppStateHook, NULL);
     CFE_ES_CreateObjects();
     UT_Report(__FILE__, __LINE__,
-              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_CORE_APP_CREATE]) &&
-                  UT_GetStubCount(UT_KEY(OS_printf)) == 18,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_CORE_APP_CREATE]),
               "CFE_ES_CreateObjects",
               "Error creating core application");
 
@@ -1059,10 +1049,6 @@ void TestStartupErrorPaths(void)
               UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_NO_FREE_CORE_APP_SLOTS]) == 5,
               "CFE_ES_CreateObjects",
               "No free application slots available, message");
-    UT_Report(__FILE__, __LINE__,
-              UT_GetStubCount(UT_KEY(OS_printf)) == 18,
-              "CFE_ES_CreateObjects",
-              "No free application slots available, printf count");
 
     /* Test reading the object table with a NULL function pointer */
     ES_ResetUnitTest();
@@ -1083,10 +1069,6 @@ void TestStartupErrorPaths(void)
               UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_FUNCTION_POINTER]),
               "CFE_ES_CreateObjects",
               "Bad function pointer message");
-    UT_Report(__FILE__, __LINE__,
-              UT_GetStubCount(UT_KEY(OS_printf)) == 19,
-              "CFE_ES_CreateObjects",
-              "Bad function pointer, printf count");
 
     /* Test response to an invalid startup type */
     ES_ResetUnitTest();
@@ -1110,8 +1092,7 @@ void TestStartupErrorPaths(void)
               UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_INSUFF_FREE_SPACE]) &&
               UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_INIT_VOLATILE]) && 
               UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_MOUNT_VOLATILE]) &&
-              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_REMOUNT_VOLATILE]) &&
-              UT_GetStubCount(UT_KEY(OS_printf)) == 6,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_REMOUNT_VOLATILE]),
               "CFE_ES_InitializeFileSystems",
               "Processor reset; error initializing and mounting volatile "
                 "(RAM) volume");
@@ -1194,7 +1175,6 @@ void TestApps(void)
                              CFE_PLATFORM_ES_NONVOL_STARTUP_FILE);
     UtAssert_NONZERO(UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_FILE_LINE_TOO_LONG]));
     UtAssert_NONZERO(UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_ES_APP_STARTUP_OPEN]));
-    UtAssert_UINT32_EQ(UT_GetStubCount(UT_KEY(OS_printf)), 5);
 
     /* Create a valid startup script for subsequent tests */
     strncpy(StartupScript,
@@ -1214,8 +1194,7 @@ void TestApps(void)
                              CFE_PLATFORM_ES_NONVOL_STARTUP_FILE);
     UT_Report(__FILE__, __LINE__,
               UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_STARTUP_READ]) &&
-              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_ES_APP_STARTUP_OPEN]) && 
-              UT_GetStubCount(UT_KEY(OS_printf)) == 2,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_ES_APP_STARTUP_OPEN]),
               "CFE_ES_StartApplications",
               "Error reading startup file");
 
@@ -1227,8 +1206,7 @@ void TestApps(void)
     CFE_ES_StartApplications(CFE_PSP_RST_TYPE_PROCESSOR,
                              CFE_PLATFORM_ES_NONVOL_STARTUP_FILE);
     UT_Report(__FILE__, __LINE__,
-              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_ES_APP_STARTUP_OPEN]) &&
-              UT_GetStubCount(UT_KEY(OS_printf)) == 1,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_ES_APP_STARTUP_OPEN]),
               "CFE_ES_StartApplications",
               "End of file reached");
 
@@ -1238,8 +1216,7 @@ void TestApps(void)
     CFE_ES_StartApplications(CFE_PSP_RST_TYPE_PROCESSOR,
                              CFE_PLATFORM_ES_NONVOL_STARTUP_FILE);
     UT_Report(__FILE__, __LINE__,
-              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_CANNOT_OPEN_ES_APP_STARTUP]) &&
-                 UT_GetStubCount(UT_KEY(OS_printf)) == 2,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_CANNOT_OPEN_ES_APP_STARTUP]),
               "CFE_ES_StartApplications",
               "Can't open ES application startup file");
 
@@ -1250,7 +1227,6 @@ void TestApps(void)
     CFE_ES_StartApplications(CFE_PSP_RST_TYPE_PROCESSOR,
                              CFE_PLATFORM_ES_NONVOL_STARTUP_FILE);
     UtAssert_NONZERO(UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_ES_APP_STARTUP_OPEN]));
-    UtAssert_UINT32_EQ(UT_GetStubCount(UT_KEY(OS_printf)), 5);
 
     /* Test parsing the startup script with an unknown entry type */
     ES_ResetUnitTest();
@@ -2680,10 +2656,6 @@ void TestTask(void)
               UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_COMMAND_PIPE]),
               "CFE_ES_TaskMain",
               "Command pipe error, UT_OSP_COMMAND_PIPE message");
-    UT_Report(__FILE__, __LINE__,
-              UT_GetStubCount(UT_KEY(OS_printf)) == 2,
-              "CFE_ES_TaskMain",
-              "Command pipe error, printf count");
 
     /* Test task main process loop with an initialization failure */
     ES_ResetUnitTest();
@@ -2697,10 +2669,6 @@ void TestTask(void)
               UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_REGISTER_APP]),
               "CFE_ES_TaskMain",
               "Task initialization fail, UT_OSP_REGISTER_APP message");
-    UT_Report(__FILE__, __LINE__,
-              UT_GetStubCount(UT_KEY(OS_printf)) == 2,
-              "CFE_ES_TaskMain",
-              "Task initialization fail, printf count");
 
     /* Test task main process loop with bad checksum information */
     ES_ResetUnitTest();
@@ -4493,8 +4461,7 @@ void TestAPI(void)
     UT_Report(__FILE__, __LINE__,
               CFE_ES_ResetCFE(ResetType) == CFE_ES_NOT_IMPLEMENTED &&
                   UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_POR_MAX_PROC_RESETS]) &&
-                  UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_PROC_RESET_COMMANDED]) && 
-                  UT_GetStubCount(UT_KEY(OS_printf)) == 2,
+                  UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_PROC_RESET_COMMANDED]),
               "CFE_ES_ResetCFE",
               "Processor reset");
 
@@ -4514,8 +4481,7 @@ void TestAPI(void)
     ResetType = CFE_PSP_RST_TYPE_POWERON;
     UT_Report(__FILE__, __LINE__,
               CFE_ES_ResetCFE(ResetType) == CFE_ES_NOT_IMPLEMENTED &&
-                  UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_POR_COMMANDED]) &&
-                  UT_GetStubCount(UT_KEY(OS_printf)) == 1,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_POR_COMMANDED]),
               "CFE_ES_ResetCFE",
               "Power on reset");
 
@@ -4568,8 +4534,7 @@ void TestAPI(void)
     CFE_ES_ExitApp(CFE_ES_RunStatus_CORE_APP_INIT_ERROR);
     UT_Report(__FILE__, __LINE__,
               UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_CORE_INIT]) &&
-              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_POR_MAX_PROC_RESETS]) && 
-                  UT_GetStubCount(UT_KEY(OS_printf)) == 3,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_POR_MAX_PROC_RESETS]),
               "CFE_ES_ExitApp",
               "Application initialization error");
 
@@ -4578,8 +4543,7 @@ void TestAPI(void)
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_STOPPED, NULL, &UtAppRecPtr, NULL);
     CFE_ES_ExitApp(CFE_ES_RunStatus_CORE_APP_RUNTIME_ERROR);
     UT_Report(__FILE__, __LINE__,
-              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_CORE_RUNTIME]) &&
-                  UT_GetStubCount(UT_KEY(OS_printf)) == 1,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_CORE_RUNTIME]),
               "CFE_ES_ExitApp",
               "Application runtime error");
 
@@ -4592,8 +4556,7 @@ void TestAPI(void)
     UtAppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_APP_RUN;
     CFE_ES_ExitApp(1000);
     UT_Report(__FILE__, __LINE__,
-              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_CORE_APP_EXIT]) &&
-                  UT_GetStubCount(UT_KEY(OS_printf)) == 2,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_CORE_APP_EXIT]),
               "CFE_ES_ExitApp",
               "Application exit error");
     UtAssert_True(UtAppRecPtr->ControlReq.AppControlRequest == CFE_ES_RunStatus_APP_ERROR,
@@ -4987,8 +4950,7 @@ void TestAPI(void)
     ES_UT_SetupChildTaskId(UtAppRecPtr, NULL, &UtTaskRecPtr);
     CFE_ES_ExitChildTask();
     UT_Report(__FILE__, __LINE__,
-              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_CANNOT_CALL_APP_MAIN]) &&
-                  UT_GetStubCount(UT_KEY(OS_printf)) == 1,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_CANNOT_CALL_APP_MAIN]),
               "CFE_ES_ExitChildTask",
               "Cannot call from a cFE application main task");
 
@@ -4996,8 +4958,7 @@ void TestAPI(void)
     ES_ResetUnitTest();
     CFE_ES_ExitChildTask();
     UT_Report(__FILE__, __LINE__,
-              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_TASKEXIT_BAD_CONTEXT]) &&
-                  UT_GetStubCount(UT_KEY(OS_printf)) == 1,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_TASKEXIT_BAD_CONTEXT]),
               "CFE_ES_ExitChildTask",
               "Invalid context");
 
@@ -5078,7 +5039,7 @@ void TestAPI(void)
     UT_SetDeferredRetcode(UT_KEY(OS_MutSemTake), 1, -1);
     CFE_ES_LockSharedData(__func__, 12345);
     UT_Report(__FILE__, __LINE__,
-              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_MUTEX_TAKE]) && UT_GetStubCount(UT_KEY(OS_printf)) == 1,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_MUTEX_TAKE]),
               "CFE_ES_LockSharedData",
               "Mutex take error");
 
@@ -5088,7 +5049,7 @@ void TestAPI(void)
     UT_SetDeferredRetcode(UT_KEY(OS_MutSemGive), 1, -1);
     CFE_ES_UnlockSharedData(__func__, 98765);
     UT_Report(__FILE__, __LINE__,
-              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_MUTEX_GIVE]) && UT_GetStubCount(UT_KEY(OS_printf)) == 1,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_MUTEX_GIVE]),
               "CFE_ES_UnlockSharedData",
               "Mutex release error");
 
@@ -6741,8 +6702,10 @@ void TestBackground(void)
     ES_ResetUnitTest();
     UT_SetDeferredRetcode(UT_KEY(OS_TaskRegister), 1, -1);
     CFE_ES_BackgroundTask();
-    /* this has no return value, but this can ensure that a syslog/printf was generated */
-    UtAssert_True(UT_GetStubCount(UT_KEY(OS_printf)) == 1, "CFE_ES_BackgroundTask - CFE_ES_RegisterChildTask failure");
+    UT_Report(__FILE__, __LINE__,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_BACKGROUND_REGISTER]),
+              "CFE_ES_BackgroundTask",
+              "Failed to register error");
 
     /*
      * When testing the background task loop, it is normally an infinite loop,
@@ -6758,8 +6721,10 @@ void TestBackground(void)
     CFE_ES_TaskData.BackgroundPerfDumpState.CurrentState = CFE_ES_PerfDumpState_INIT;
     UT_SetDeferredRetcode(UT_KEY(OS_BinSemTimedWait), 3, -4);
     CFE_ES_BackgroundTask();
-    /* this has no return value, but this can ensure that a syslog/printf was generated */
-    UtAssert_True(UT_GetStubCount(UT_KEY(OS_printf)) == 1, "CFE_ES_BackgroundTask - Nominal");
+    UT_Report(__FILE__, __LINE__,
+              UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_BACKGROUND_TAKE]),
+              "CFE_ES_BackgroundTask",
+              "Failed to take background sem");
     /* The number of jobs running should be 1 (perf log dump) */
     UtAssert_True(CFE_ES_Global.BackgroundTask.NumJobsRunning == 1,
             "CFE_ES_BackgroundTask - Nominal, CFE_ES_Global.BackgroundTask.NumJobsRunning (%u) == 1",

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -690,8 +690,8 @@ void TestInit(void)
             "CFE_APP, /cf/apps/ci.bundle, CI_task_main, CI_APP, 70, 4096, 0x0, 1; "
             "CFE_APP, /cf/apps/sch.bundle, SCH_TaskMain, SCH_APP, 120, 4096, 0x0, 1; "
             "CFE_APP, /cf/apps/to.bundle, TO_task_main, TO_APP, 74, 4096, 0x0, 1; !",
-            MAX_STARTUP_SCRIPT);
-    StartupScript[MAX_STARTUP_SCRIPT - 1] = '\0';
+            sizeof(StartupScript) - 1);
+    StartupScript[sizeof(StartupScript) - 1] = '\0';
     UT_SetReadBuffer(StartupScript, strlen(StartupScript));
 
     /* Go through ES_Main and cover normal paths */
@@ -723,8 +723,8 @@ void TestStartupErrorPaths(void)
             "CFE_APP, /cf/apps/ci.bundle, CI_task_main, CI_APP, 70, 4096, 0x0, 1; "
             "CFE_APP, /cf/apps/sch.bundle, SCH_TaskMain, SCH_APP, 120, 4096, 0x0, 1; "
             "CFE_APP, /cf/apps/to.bundle, TO_task_main, TO_APP, 74, 4096, 0x0, 1; !",
-            MAX_STARTUP_SCRIPT);
-    StartupScript[MAX_STARTUP_SCRIPT - 1] = '\0';
+            sizeof(StartupScript) - 1);
+    StartupScript[sizeof(StartupScript) - 1] = '\0';
 
     /* Perform ES main startup with a mutex creation failure */
     ES_ResetUnitTest();
@@ -1167,8 +1167,8 @@ void TestApps(void)
             "70, 4096, 0x0, 1; CFE_APP, /cf/apps/sch.bundle, SCH_TaskMain, "
             "SCH_APP, 120, 4096, 0x0, 1; CFE_APP, /cf/apps/to.bundle, "
             "TO_task_main, TO_APP, 74, 4096, 0x0, 1; !",
-            MAX_STARTUP_SCRIPT);
-    StartupScript[MAX_STARTUP_SCRIPT - 1] = '\0';
+            sizeof(StartupScript) - 1);
+    StartupScript[sizeof(StartupScript) - 1] = '\0';
     NumBytes = strlen(StartupScript);
     UT_SetReadBuffer(StartupScript, NumBytes);
     CFE_ES_StartApplications(CFE_PSP_RST_TYPE_PROCESSOR,
@@ -1182,8 +1182,8 @@ void TestApps(void)
             "CFE_APP, /cf/apps/ci.bundle, CI_task_main, CI_APP, 70, 4096, 0x0, 1; "
             "CFE_APP, /cf/apps/sch.bundle, SCH_TaskMain, SCH_APP, 120, 4096, 0x0, 1; "
             "CFE_APP, /cf/apps/to.bundle, TO_task_main, TO_APP, 74, 4096, 0x0, 1; !",
-            MAX_STARTUP_SCRIPT);
-    StartupScript[MAX_STARTUP_SCRIPT - 1] = '\0';
+            sizeof(StartupScript) - 1);
+    StartupScript[sizeof(StartupScript) - 1] = '\0';
     NumBytes = strlen(StartupScript);
     UT_SetReadBuffer(StartupScript, NumBytes);
 
@@ -1474,13 +1474,12 @@ void TestApps(void)
     /* Test a successful control action request to exit an application */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.FileName,
-            "/ram/Filename", OS_MAX_PATH_LEN);
-    UtAppRecPtr->StartParams.BasicInfo.FileName[OS_MAX_PATH_LEN - 1] = '\0';
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.EntryPoint,
-            "NotNULL", OS_MAX_API_NAME);
-    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[OS_MAX_API_NAME - 1] =
-        '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.FileName, 
+            "/ram/Filename", sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1);
+    UtAppRecPtr->StartParams.BasicInfo.FileName[sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1] = '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.EntryPoint,
+            "NotNULL", sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1);
+    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1] = '\0';
     UtAppRecPtr->StartParams.Priority = 255;
     UtAppRecPtr->StartParams.StackSize = 8192;
     UtAppRecPtr->StartParams.ExceptionAction = 0;
@@ -1589,13 +1588,12 @@ void TestApps(void)
      */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.FileName,
-            "/ram/FileName", OS_MAX_PATH_LEN);
-    UtAppRecPtr->StartParams.BasicInfo.FileName[OS_MAX_PATH_LEN - 1] = '\0';
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
-            OS_MAX_API_NAME);
-    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[OS_MAX_API_NAME - 1] =
-        '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.FileName,
+            "/ram/FileName", sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1);
+    UtAppRecPtr->StartParams.BasicInfo.FileName[sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1] = '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
+            sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1);
+    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1] = '\0';
     UtAppRecPtr->StartParams.Priority = 255;
     UtAppRecPtr->StartParams.StackSize = 8192;
     UtAppRecPtr->StartParams.ExceptionAction = 0;
@@ -1626,13 +1624,12 @@ void TestApps(void)
     /* Test a successful control action request to stop an application */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.FileName,
-            "/ram/FileName", OS_MAX_PATH_LEN);
-    UtAppRecPtr->StartParams.BasicInfo.FileName[OS_MAX_PATH_LEN - 1] = '\0';
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
-            OS_MAX_API_NAME);
-    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[OS_MAX_API_NAME - 1] =
-        '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.FileName,
+            "/ram/FileName", sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1);
+    UtAppRecPtr->StartParams.BasicInfo.FileName[sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1] = '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
+            sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1);
+    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1] = '\0';
     UtAppRecPtr->StartParams.Priority = 255;
     UtAppRecPtr->StartParams.StackSize = 8192;
     UtAppRecPtr->StartParams.ExceptionAction = 0;
@@ -1648,13 +1645,12 @@ void TestApps(void)
     /* Test a successful control action request to restart an application */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.FileName,
-            "/ram/FileName", OS_MAX_PATH_LEN);
-    UtAppRecPtr->StartParams.BasicInfo.FileName[OS_MAX_PATH_LEN - 1] = '\0';
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
-            OS_MAX_API_NAME);
-    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[OS_MAX_API_NAME - 1] =
-        '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.FileName,
+            "/ram/FileName", sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1);
+    UtAppRecPtr->StartParams.BasicInfo.FileName[sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1] = '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
+            sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1);
+    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1] = '\0';
     UtAppRecPtr->StartParams.Priority = 255;
     UtAppRecPtr->StartParams.StackSize = 8192;
     UtAppRecPtr->StartParams.ExceptionAction = 0;
@@ -1670,13 +1666,12 @@ void TestApps(void)
     /* Test a successful control action request to reload an application */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.FileName,
-            "/ram/FileName", OS_MAX_PATH_LEN);
-    UtAppRecPtr->StartParams.BasicInfo.FileName[OS_MAX_PATH_LEN - 1] = '\0';
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
-            OS_MAX_API_NAME);
-    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[OS_MAX_API_NAME - 1] =
-        '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.FileName,
+            "/ram/FileName", sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) -1);
+    UtAppRecPtr->StartParams.BasicInfo.FileName[sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) -1] = '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
+            sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1);
+    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1] = '\0';
     UtAppRecPtr->StartParams.Priority = 255;
     UtAppRecPtr->StartParams.StackSize = 8192;
     UtAppRecPtr->StartParams.ExceptionAction = 0;
@@ -1694,13 +1689,12 @@ void TestApps(void)
      */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.FileName,
-            "/ram/FileName", OS_MAX_PATH_LEN);
-    UtAppRecPtr->StartParams.BasicInfo.FileName[OS_MAX_PATH_LEN - 1] = '\0';
-    strncpy((char *) UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
-            OS_MAX_API_NAME);
-    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[OS_MAX_API_NAME - 1] =
-        '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.FileName,
+            "/ram/FileName", sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1);
+    UtAppRecPtr->StartParams.BasicInfo.FileName[sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1] = '\0';
+    strncpy(UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
+            sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1);
+    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1] = '\0';
     UtAppRecPtr->StartParams.Priority = 255;
     UtAppRecPtr->StartParams.StackSize = 8192;
     UtAppRecPtr->StartParams.ExceptionAction = 0;
@@ -2201,7 +2195,7 @@ void TestLibs(void)
               "Load shared library bad argument (NULL library name)");
 
     /* Test Load library returning an error on a too long library name */
-    memset(&LongLibraryName[0], 'a', sizeof(LongLibraryName)-1);
+    memset(LongLibraryName, 'a', sizeof(LongLibraryName)-1);
     LongLibraryName[sizeof(LongLibraryName)-1] = '\0';
     Return = CFE_ES_LoadLibrary(&Id,
                                 "filename",
@@ -2839,12 +2833,15 @@ void TestTask(void)
     /* Test successful app create */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint));
+    strncpy(CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1);
+    CmdBuf.StartAppCmd.Payload.AppFileName[sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1);
+    CmdBuf.StartAppCmd.Payload.AppEntryPoint[sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1] = '\0';
     memset(CmdBuf.StartAppCmd.Payload.Application, 'x', 
-            sizeof(CmdBuf.StartAppCmd.Payload.Application));
+            sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1);
+    CmdBuf.StartAppCmd.Payload.Application[sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1] = '\0';
     CmdBuf.StartAppCmd.Payload.Priority = 160;
     CmdBuf.StartAppCmd.Payload.StackSize = CFE_ES_MEMOFFSET_C(8192);
     CmdBuf.StartAppCmd.Payload.ExceptionAction = CFE_ES_ExceptionAction_RESTART_APP;
@@ -2868,12 +2865,15 @@ void TestTask(void)
     /* Test app create with the file name too short */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppFileName, "123",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.Application, "appName",
-            sizeof(CmdBuf.StartAppCmd.Payload.Application));
+    strncpy(CmdBuf.StartAppCmd.Payload.AppFileName, "123",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1);
+    CmdBuf.StartAppCmd.Payload.AppFileName[sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1);
+    CmdBuf.StartAppCmd.Payload.AppEntryPoint[sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.Application, "appName",
+            sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1);
+    CmdBuf.StartAppCmd.Payload.Application[sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1] = '\0';
     CmdBuf.StartAppCmd.Payload.Priority = 160;
     CmdBuf.StartAppCmd.Payload.StackSize = CFE_ES_MEMOFFSET_C(12096);
     CmdBuf.StartAppCmd.Payload.ExceptionAction = CFE_ES_ExceptionAction_RESTART_APP;
@@ -2887,12 +2887,13 @@ void TestTask(void)
     /* Test app create with a null application entry point */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppEntryPoint, "",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.Application, "appName",
-            sizeof(CmdBuf.StartAppCmd.Payload.Application));
+    strncpy(CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1);
+    CmdBuf.StartAppCmd.Payload.AppFileName[sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1] = '\0';
+    CmdBuf.StartAppCmd.Payload.AppEntryPoint[0] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.Application, "appName",
+            sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1);
+    CmdBuf.StartAppCmd.Payload.Application[sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1] = '\0';
     CmdBuf.StartAppCmd.Payload.Priority = 160;
     CmdBuf.StartAppCmd.Payload.StackSize = CFE_ES_MEMOFFSET_C(12096);
     CmdBuf.StartAppCmd.Payload.ExceptionAction = CFE_ES_ExceptionAction_RESTART_APP;
@@ -2906,12 +2907,13 @@ void TestTask(void)
     /* Test app create with a null application name */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.Application, "",
-            sizeof(CmdBuf.StartAppCmd.Payload.Application));
+    strncpy(CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1);
+    CmdBuf.StartAppCmd.Payload.AppFileName[sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1);
+    CmdBuf.StartAppCmd.Payload.AppEntryPoint[sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1] = '\0';
+    CmdBuf.StartAppCmd.Payload.Application[0] = '\0';
     CmdBuf.StartAppCmd.Payload.Priority = 160;
     CmdBuf.StartAppCmd.Payload.StackSize = CFE_ES_MEMOFFSET_C(12096);
     CmdBuf.StartAppCmd.Payload.ExceptionAction = CFE_ES_ExceptionAction_RESTART_APP;
@@ -2925,12 +2927,15 @@ void TestTask(void)
     /* Test app create with with an invalid exception action */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.Application, "appName",
-            sizeof(CmdBuf.StartAppCmd.Payload.Application));
+    strncpy(CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1);
+    CmdBuf.StartAppCmd.Payload.AppFileName[sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
+           sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1);
+    CmdBuf.StartAppCmd.Payload.AppEntryPoint[sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.Application, "appName",
+            sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1);
+    CmdBuf.StartAppCmd.Payload.Application[sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1] = '\0';
     CmdBuf.StartAppCmd.Payload.Priority = 160;
     CmdBuf.StartAppCmd.Payload.StackSize = CFE_ES_MEMOFFSET_C(12096);
     CmdBuf.StartAppCmd.Payload.ExceptionAction = 255;
@@ -2944,12 +2949,15 @@ void TestTask(void)
     /* Test app create with a default stack size */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.Application, "appName",
-            sizeof(CmdBuf.StartAppCmd.Payload.Application));
+    strncpy(CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1);
+    CmdBuf.StartAppCmd.Payload.AppFileName[sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
+           sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1);
+    CmdBuf.StartAppCmd.Payload.AppEntryPoint[sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.Application, "appName",
+            sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1);
+    CmdBuf.StartAppCmd.Payload.Application[sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1] = '\0';
     CmdBuf.StartAppCmd.Payload.Priority = 160;
     CmdBuf.StartAppCmd.Payload.StackSize = CFE_ES_MEMOFFSET_C(0);
     CmdBuf.StartAppCmd.Payload.ExceptionAction = CFE_ES_ExceptionAction_RESTART_APP;
@@ -2963,12 +2971,15 @@ void TestTask(void)
     /* Test app create with a bad priority */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.Application, "appName",
-            sizeof(CmdBuf.StartAppCmd.Payload.Application));
+    strncpy(CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1);
+    CmdBuf.StartAppCmd.Payload.AppFileName[sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
+           sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1);
+    CmdBuf.StartAppCmd.Payload.AppEntryPoint[sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.Application, "appName",
+            sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1);
+    CmdBuf.StartAppCmd.Payload.Application[sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1] = '\0';
     CmdBuf.StartAppCmd.Payload.Priority = 1000;
     CmdBuf.StartAppCmd.Payload.StackSize = CFE_ES_MEMOFFSET_C(12096);
     CmdBuf.StartAppCmd.Payload.ExceptionAction = CFE_ES_ExceptionAction_RESTART_APP;
@@ -2982,8 +2993,9 @@ void TestTask(void)
     /* Test successful app stop */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
-    strncpy((char *) CmdBuf.StopAppCmd.Payload.Application, "CFE_ES",
-            sizeof(CmdBuf.StopAppCmd.Payload.Application));
+    strncpy(CmdBuf.StopAppCmd.Payload.Application, "CFE_ES",
+            sizeof(CmdBuf.StopAppCmd.Payload.Application) - 1);
+    CmdBuf.StopAppCmd.Payload.Application[sizeof(CmdBuf.StopAppCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.StopAppCmd),
             UT_TPID_CFE_ES_CMD_STOP_APP_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3004,8 +3016,9 @@ void TestTask(void)
     /* Test app stop with a bad app name */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.StopAppCmd.Payload.Application, "BAD_APP_NAME",
-            sizeof(CmdBuf.StopAppCmd.Payload.Application));
+    strncpy(CmdBuf.StopAppCmd.Payload.Application, "BAD_APP_NAME",
+            sizeof(CmdBuf.StopAppCmd.Payload.Application) - 1);
+    CmdBuf.StopAppCmd.Payload.Application[sizeof(CmdBuf.StopAppCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.StopAppCmd),
             UT_TPID_CFE_ES_CMD_STOP_APP_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3017,8 +3030,9 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
-    strncpy((char *) CmdBuf.RestartAppCmd.Payload.Application, "CFE_ES",
-            sizeof(CmdBuf.RestartAppCmd.Payload.Application));
+    strncpy(CmdBuf.RestartAppCmd.Payload.Application, "CFE_ES",
+            sizeof(CmdBuf.RestartAppCmd.Payload.Application) - 1);
+    CmdBuf.RestartAppCmd.Payload.Application[sizeof(CmdBuf.RestartAppCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.RestartAppCmd),
             UT_TPID_CFE_ES_CMD_RESTART_APP_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3029,8 +3043,9 @@ void TestTask(void)
     /* Test app restart with a bad app name */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.RestartAppCmd.Payload.Application, "BAD_APP_NAME",
-            sizeof(CmdBuf.RestartAppCmd.Payload.Application));
+    strncpy(CmdBuf.RestartAppCmd.Payload.Application, "BAD_APP_NAME",
+            sizeof(CmdBuf.RestartAppCmd.Payload.Application) - 1);
+    CmdBuf.RestartAppCmd.Payload.Application[sizeof(CmdBuf.RestartAppCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.RestartAppCmd),
             UT_TPID_CFE_ES_CMD_RESTART_APP_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3042,8 +3057,9 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_WAITING, "CFE_ES", NULL, NULL);
-    strncpy((char *) CmdBuf.RestartAppCmd.Payload.Application, "CFE_ES",
-        sizeof(CmdBuf.RestartAppCmd.Payload.Application));
+    strncpy(CmdBuf.RestartAppCmd.Payload.Application, "CFE_ES",
+        sizeof(CmdBuf.RestartAppCmd.Payload.Application) - 1);
+    CmdBuf.RestartAppCmd.Payload.Application[sizeof(CmdBuf.RestartAppCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.RestartAppCmd),
             UT_TPID_CFE_ES_CMD_RESTART_APP_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3055,10 +3071,12 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
-    strncpy((char *) CmdBuf.ReloadAppCmd.Payload.AppFileName, "New_Name",
-            sizeof(CmdBuf.ReloadAppCmd.Payload.AppFileName));
-    strncpy((char *) CmdBuf.ReloadAppCmd.Payload.Application, "CFE_ES",
-            sizeof(CmdBuf.ReloadAppCmd.Payload.Application));
+    strncpy(CmdBuf.ReloadAppCmd.Payload.AppFileName, "New_Name",
+            sizeof(CmdBuf.ReloadAppCmd.Payload.AppFileName) - 1);
+    CmdBuf.ReloadAppCmd.Payload.AppFileName[sizeof(CmdBuf.ReloadAppCmd.Payload.AppFileName) - 1] = '\0';
+    strncpy(CmdBuf.ReloadAppCmd.Payload.Application, "CFE_ES",
+            sizeof(CmdBuf.ReloadAppCmd.Payload.Application) - 1);
+    CmdBuf.ReloadAppCmd.Payload.Application[sizeof(CmdBuf.ReloadAppCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.ReloadAppCmd),
             UT_TPID_CFE_ES_CMD_RELOAD_APP_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3069,8 +3087,9 @@ void TestTask(void)
     /* Test app reload with a bad app name */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.ReloadAppCmd.Payload.Application, "BAD_APP_NAME",
-            sizeof(CmdBuf.ReloadAppCmd.Payload.Application));
+    strncpy(CmdBuf.ReloadAppCmd.Payload.Application, "BAD_APP_NAME",
+            sizeof(CmdBuf.ReloadAppCmd.Payload.Application) - 1);
+    CmdBuf.ReloadAppCmd.Payload.Application[sizeof(CmdBuf.ReloadAppCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.ReloadAppCmd),
             UT_TPID_CFE_ES_CMD_RELOAD_APP_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3082,8 +3101,9 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_WAITING, "CFE_ES", NULL, NULL);
-    strncpy((char *) CmdBuf.ReloadAppCmd.Payload.Application, "CFE_ES",
-            sizeof(CmdBuf.ReloadAppCmd.Payload.Application));
+    strncpy(CmdBuf.ReloadAppCmd.Payload.Application, "CFE_ES",
+            sizeof(CmdBuf.ReloadAppCmd.Payload.Application) - 1);
+    CmdBuf.ReloadAppCmd.Payload.Application[sizeof(CmdBuf.ReloadAppCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.ReloadAppCmd),
             UT_TPID_CFE_ES_CMD_RELOAD_APP_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3095,8 +3115,9 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_WAITING, "CFE_ES", NULL, NULL);
-    strncpy((char *) CmdBuf.QueryOneCmd.Payload.Application, "CFE_ES",
-            sizeof(CmdBuf.QueryOneCmd.Payload.Application));
+    strncpy(CmdBuf.QueryOneCmd.Payload.Application, "CFE_ES",
+            sizeof(CmdBuf.QueryOneCmd.Payload.Application) - 1);
+    CmdBuf.QueryOneCmd.Payload.Application[sizeof(CmdBuf.QueryOneCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryOneCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ONE_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3108,8 +3129,9 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
-    strncpy((char *) CmdBuf.QueryOneCmd.Payload.Application, "CFE_ES",
-            sizeof(CmdBuf.QueryOneCmd.Payload.Application));
+    strncpy(CmdBuf.QueryOneCmd.Payload.Application, "CFE_ES",
+            sizeof(CmdBuf.QueryOneCmd.Payload.Application) - 1);
+    CmdBuf.QueryOneCmd.Payload.Application[sizeof(CmdBuf.QueryOneCmd.Payload.Application) - 1] = '\0';
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_TransmitMsg), 1, -1);
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryOneCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ONE_CC);
@@ -3122,8 +3144,9 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
-    strncpy((char *) CmdBuf.QueryOneCmd.Payload.Application, "BAD_APP_NAME",
-            sizeof(CmdBuf.QueryOneCmd.Payload.Application));
+    strncpy(CmdBuf.QueryOneCmd.Payload.Application, "BAD_APP_NAME",
+            sizeof(CmdBuf.QueryOneCmd.Payload.Application) - 1);
+    CmdBuf.QueryOneCmd.Payload.Application[sizeof(CmdBuf.QueryOneCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryOneCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ONE_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3135,8 +3158,9 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
-    strncpy((char *) CmdBuf.QueryAllCmd.Payload.FileName, "AllFilename",
-            sizeof(CmdBuf.QueryAllCmd.Payload.FileName));
+    strncpy(CmdBuf.QueryAllCmd.Payload.FileName, "AllFilename",
+            sizeof(CmdBuf.QueryAllCmd.Payload.FileName) - 1);
+    CmdBuf.QueryAllCmd.Payload.FileName[sizeof(CmdBuf.QueryAllCmd.Payload.FileName) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryAllCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ALL_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3203,8 +3227,9 @@ void TestTask(void)
     /* Test write of all task data to a file with write header failure */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.QueryAllTasksCmd.Payload.FileName, "filename",
-            sizeof(CmdBuf.QueryAllTasksCmd.Payload.FileName));
+    strncpy(CmdBuf.QueryAllTasksCmd.Payload.FileName, "filename",
+            sizeof(CmdBuf.QueryAllTasksCmd.Payload.FileName) - 1);
+    CmdBuf.QueryAllTasksCmd.Payload.FileName[sizeof(CmdBuf.QueryAllTasksCmd.Payload.FileName) - 1] = '\0';
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_WriteHeader), 1, -1);
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryAllTasksCmd),
             UT_TPID_CFE_ES_CMD_QUERY_ALL_TASKS_CC);
@@ -3271,8 +3296,9 @@ void TestTask(void)
     /* Test successful writing of the system log */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.WriteSysLogCmd.Payload.FileName, "filename",
-            sizeof(CmdBuf.WriteSysLogCmd.Payload.FileName));
+    strncpy(CmdBuf.WriteSysLogCmd.Payload.FileName, "filename",
+            sizeof(CmdBuf.WriteSysLogCmd.Payload.FileName) - 1);
+    CmdBuf.WriteSysLogCmd.Payload.FileName[sizeof(CmdBuf.WriteSysLogCmd.Payload.FileName) - 1] = '\0';
     CFE_ES_TaskData.HkPacket.Payload.SysLogEntries = 123;
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.WriteSysLogCmd),
             UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
@@ -3296,8 +3322,7 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
-    strncpy((char *) CmdBuf.WriteSysLogCmd.Payload.FileName, "",
-            sizeof(CmdBuf.WriteSysLogCmd.Payload.FileName));
+    CmdBuf.WriteSysLogCmd.Payload.FileName[0] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.WriteSysLogCmd),
             UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3313,8 +3338,7 @@ void TestTask(void)
             sizeof(CFE_ES_ResetDataPtr->SystemLog),
             "0000-000-00:00:00.00000 Test Message\n");
     CFE_ES_ResetDataPtr->SystemLogEndIdx = CFE_ES_ResetDataPtr->SystemLogWriteIdx;
-    strncpy((char *) CmdBuf.WriteSysLogCmd.Payload.FileName, "",
-            sizeof(CmdBuf.WriteSysLogCmd.Payload.FileName));
+    CmdBuf.WriteSysLogCmd.Payload.FileName[0] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.WriteSysLogCmd),
             UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3348,7 +3372,8 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     strncpy(CmdBuf.WriteERLogCmd.Payload.FileName, "filename",
-            sizeof(CmdBuf.WriteERLogCmd.Payload.FileName));
+            sizeof(CmdBuf.WriteERLogCmd.Payload.FileName) - 1);
+    CmdBuf.WriteERLogCmd.Payload.FileName[sizeof(CmdBuf.WriteERLogCmd.Payload.FileName) - 1] = '\0';
     CFE_ES_TaskData.BackgroundERLogDumpState.IsPending = false;
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.WriteERLogCmd),
             UT_TPID_CFE_ES_CMD_WRITE_ER_LOG_CC);
@@ -3535,7 +3560,8 @@ void TestTask(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     strncpy(CmdBuf.DeleteCDSCmd.Payload.CdsName,
             "CFE_ES.CDS_NAME",
-            sizeof(CmdBuf.DeleteCDSCmd.Payload.CdsName));
+            sizeof(CmdBuf.DeleteCDSCmd.Payload.CdsName) - 1);
+    CmdBuf.DeleteCDSCmd.Payload.CdsName[sizeof(CmdBuf.DeleteCDSCmd.Payload.CdsName) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.DeleteCDSCmd),
             UT_TPID_CFE_ES_CMD_DELETE_CDS_CC);
     UT_Report(__FILE__, __LINE__,
@@ -3718,12 +3744,15 @@ void TestTask(void)
      */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
-            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint));
-    strncpy((char *) CmdBuf.StartAppCmd.Payload.Application, "appName",
-            sizeof(CmdBuf.StartAppCmd.Payload.Application));
+    strncpy(CmdBuf.StartAppCmd.Payload.AppFileName, "filename",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1);
+    CmdBuf.StartAppCmd.Payload.AppFileName[sizeof(CmdBuf.StartAppCmd.Payload.AppFileName) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.AppEntryPoint, "entrypoint",
+            sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1);
+    CmdBuf.StartAppCmd.Payload.AppEntryPoint[sizeof(CmdBuf.StartAppCmd.Payload.AppEntryPoint) - 1] = '\0';
+    strncpy(CmdBuf.StartAppCmd.Payload.Application, "appName",
+            sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1);
+    CmdBuf.StartAppCmd.Payload.Application[sizeof(CmdBuf.StartAppCmd.Payload.Application) - 1] = '\0';
     CmdBuf.StartAppCmd.Payload.ExceptionAction = CFE_ES_ExceptionAction_PROC_RESTART;
     CmdBuf.StartAppCmd.Payload.Priority = 160;
     CmdBuf.StartAppCmd.Payload.StackSize =  CFE_ES_MEMOFFSET_C(CFE_PLATFORM_ES_DEFAULT_STACK_SIZE);
@@ -3928,7 +3957,8 @@ void TestTask(void)
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
     ES_UT_SetupSingleCDSRegistry("CFE_ES.CDS_NAME", ES_UT_CDS_BLOCK_SIZE, false, NULL);
     strncpy(CmdBuf.DumpCDSRegistryCmd.Payload.DumpFilename, "DumpFile",
-            sizeof(CmdBuf.DumpCDSRegistryCmd.Payload.DumpFilename));
+            sizeof(CmdBuf.DumpCDSRegistryCmd.Payload.DumpFilename) - 1);
+    CmdBuf.DumpCDSRegistryCmd.Payload.DumpFilename[sizeof(CmdBuf.DumpCDSRegistryCmd.Payload.DumpFilename) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.DumpCDSRegistryCmd),
             UT_TPID_CFE_ES_CMD_DUMP_CDS_REGISTRY_CC);
     UT_Report(__FILE__, __LINE__,
@@ -4075,7 +4105,8 @@ void TestPerf(void)
     memset(&CFE_ES_TaskData.BackgroundPerfDumpState, 0,
             sizeof(CFE_ES_TaskData.BackgroundPerfDumpState));
     strncpy(CmdBuf.PerfStopCmd.Payload.DataFileName, "filename",
-        sizeof(CmdBuf.PerfStopCmd.Payload.DataFileName));
+        sizeof(CmdBuf.PerfStopCmd.Payload.DataFileName) - 1);
+    CmdBuf.PerfStopCmd.Payload.DataFileName[sizeof(CmdBuf.PerfStopCmd.Payload.DataFileName) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.PerfStopCmd),
             UT_TPID_CFE_ES_CMD_STOP_PERF_DATA_CC);
     UT_Report(__FILE__, __LINE__,
@@ -4679,7 +4710,7 @@ void TestAPI(void)
     ES_ResetUnitTest();
     AppId = ES_UT_MakeAppIdForIndex(99999);
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_GetAppName(AppName, AppId, 32) == CFE_ES_ERR_RESOURCEID_NOT_VALID,
+              CFE_ES_GetAppName(AppName, AppId, sizeof(AppName)) == CFE_ES_ERR_RESOURCEID_NOT_VALID,
               "CFE_ES_GetAppName",
               "Get application name by ID; bad application ID");
 
@@ -4690,7 +4721,7 @@ void TestAPI(void)
     UT_Report(__FILE__, __LINE__,
               CFE_ES_GetAppName(AppName,
                                 AppId,
-                                32) == CFE_ES_ERR_RESOURCEID_NOT_VALID,
+                                sizeof(AppName)) == CFE_ES_ERR_RESOURCEID_NOT_VALID,
               "CFE_ES_GetAppName",
               "Get application name by ID; ID out of range");
 
@@ -4699,7 +4730,7 @@ void TestAPI(void)
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, "UT", &UtAppRecPtr, NULL);
     AppId = CFE_ES_AppRecordGetID(UtAppRecPtr);
     UT_Report(__FILE__, __LINE__,
-              CFE_ES_GetAppName(AppName, AppId, 32) == CFE_SUCCESS,
+              CFE_ES_GetAppName(AppName, AppId, sizeof(AppName)) == CFE_SUCCESS,
               "CFE_ES_GetAppName",
               "Get application name by ID successful");
 

--- a/fsw/cfe-core/unit-test/evs_UT.c
+++ b/fsw/cfe-core/unit-test/evs_UT.c
@@ -1091,8 +1091,7 @@ void Test_Ports(void)
                UT_TPID_CFE_EVS_CMD_ENABLE_PORTS_CC,
                &UT_EVS_EventBuf);
     UT_Report(__FILE__, __LINE__,
-              UT_EVS_EventBuf.EventID ==  CFE_EVS_ENAPORT_EID &&
-              UT_GetStubCount(UT_KEY(OS_printf)) == 4,
+              UT_EVS_EventBuf.EventID ==  CFE_EVS_ENAPORT_EID,
               "CFE_EVS_EnablePortsCmd",
               "Enable ports command received with port bit mask = 0x0f");
 
@@ -1101,8 +1100,7 @@ void Test_Ports(void)
     UT_SetHookFunction(UT_KEY(CFE_SB_TransmitMsg), UT_SoftwareBusSnapshotHook, &LocalSnapshotData);
     CFE_EVS_SendEvent(0, CFE_EVS_EventType_INFORMATION, "Test ports message");
     UT_Report(__FILE__, __LINE__,
-              LocalSnapshotData.Count == 1 &&
-              UT_GetStubCount(UT_KEY(OS_printf)) == 4,
+              LocalSnapshotData.Count == 1,
               "CFE_EVS_EnablePortsCmd",
               "Test ports output");
 

--- a/fsw/cfe-core/unit-test/evs_UT.c
+++ b/fsw/cfe-core/unit-test/evs_UT.c
@@ -2693,7 +2693,7 @@ void Test_Misc(void)
             UT_TPID_CFE_EVS_CMD_WRITE_LOG_DATA_FILE_CC,
             &UT_EVS_EventBuf);
     UT_Report(__FILE__, __LINE__,
-              UT_EVS_EventBuf.EventID ==  0xFFFF,
+              (UT_EVS_EventBuf.EventID == 0xFFFF) || (UT_EVS_EventBuf.EventID == CFE_EVS_WRLOG_EID),
               "CFE_EVS_WriteLogDataFileCmd",
               "Write log data - successful");
 
@@ -2703,7 +2703,7 @@ void Test_Misc(void)
             UT_TPID_CFE_EVS_CMD_SET_LOG_MODE_CC,
             &UT_EVS_EventBuf);
     UT_Report(__FILE__, __LINE__,
-              UT_EVS_EventBuf.EventID ==  0xFFFF,
+              (UT_EVS_EventBuf.EventID == 0xFFFF) || (UT_EVS_EventBuf.EventID == CFE_EVS_LOGMODE_EID),
               "CFE_EVS_SetLogModeCmd",
               "Set logging mode - successful");
 

--- a/fsw/cfe-core/unit-test/evs_UT.c
+++ b/fsw/cfe-core/unit-test/evs_UT.c
@@ -303,8 +303,9 @@ void Test_Init(void)
 
     UtPrintf("Begin Test Init");
 
-    strncpy((char *) appbitcmd.Payload.AppName, "ut_cfe_evs",
-            sizeof(appbitcmd.Payload.AppName));
+    strncpy(appbitcmd.Payload.AppName, "ut_cfe_evs",
+            sizeof(appbitcmd.Payload.AppName) - 1);
+    appbitcmd.Payload.AppName[sizeof(appbitcmd.Payload.AppName) - 1] = '\0';
 
     /* Test successful early initialization of the cFE EVS */
     UT_InitData();
@@ -941,8 +942,9 @@ void Test_Format(void)
 
     /* Enable DEBUG message output */
     UT_InitData();
-    strncpy((char *) appbitcmd.Payload.AppName, "ut_cfe_evs",
-            sizeof(appbitcmd.Payload.AppName));
+    strncpy(appbitcmd.Payload.AppName, "ut_cfe_evs",
+            sizeof(appbitcmd.Payload.AppName) - 1);
+    appbitcmd.Payload.AppName[sizeof(appbitcmd.Payload.AppName) - 1] = '\0';
     modecmd.Payload.MsgFormat = CFE_EVS_MsgFormat_LONG;
     appbitcmd.Payload.BitMask = CFE_EVS_DEBUG_BIT | CFE_EVS_INFORMATION_BIT |
                         CFE_EVS_ERROR_BIT | CFE_EVS_CRITICAL_BIT;
@@ -1404,8 +1406,9 @@ void Test_Logging(void)
      */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(OS_MutSemCreate), 1, OS_SUCCESS);
-    strncpy((char *) CmdBuf.logfilecmd.Payload.LogFilename, "LogFile",
-            sizeof(CmdBuf.logfilecmd.Payload.LogFilename));
+    strncpy(CmdBuf.logfilecmd.Payload.LogFilename, "LogFile",
+            sizeof(CmdBuf.logfilecmd.Payload.LogFilename) - 1);
+    CmdBuf.logfilecmd.Payload.LogFilename[sizeof(CmdBuf.logfilecmd.Payload.LogFilename) - 1] = '\0';
     UT_Report(__FILE__, __LINE__,
               CFE_EVS_WriteLogDataFileCmd(&CmdBuf.logfilecmd) == CFE_SUCCESS,
               "CFE_EVS_WriteLogDataFileCmd",
@@ -1442,8 +1445,9 @@ void Test_WriteApp(void)
     /* Enable DEBUG message output */
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    strncpy((char *) CmdBuf.appbitcmd.Payload.AppName, "ut_cfe_evs",
-            sizeof(CmdBuf.appbitcmd.Payload.AppName));
+    strncpy(CmdBuf.appbitcmd.Payload.AppName, "ut_cfe_evs",
+            sizeof(CmdBuf.appbitcmd.Payload.AppName) - 1);
+    CmdBuf.appbitcmd.Payload.AppName[sizeof(CmdBuf.appbitcmd.Payload.AppName) - 1] = '\0';
     CmdBuf.appbitcmd.Payload.BitMask = CFE_EVS_DEBUG_BIT | CFE_EVS_INFORMATION_BIT |
                         CFE_EVS_ERROR_BIT | CFE_EVS_CRITICAL_BIT;
     UT_EVS_DoDispatchCheckEvents(&CmdBuf.appbitcmd, sizeof(CmdBuf.appbitcmd),
@@ -1468,8 +1472,9 @@ void Test_WriteApp(void)
      * file name
      */
     UT_InitData();
-    strncpy((char *) CmdBuf.AppDataCmd.Payload.AppDataFilename, "ut_cfe_evs",
-            sizeof(CmdBuf.AppDataCmd.Payload.AppDataFilename));
+    strncpy(CmdBuf.AppDataCmd.Payload.AppDataFilename, "ut_cfe_evs",
+            sizeof(CmdBuf.AppDataCmd.Payload.AppDataFilename) - 1);
+    CmdBuf.AppDataCmd.Payload.AppDataFilename[sizeof(CmdBuf.AppDataCmd.Payload.AppDataFilename) - 1] = '\0';
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
     UT_EVS_DoDispatchCheckEvents(&CmdBuf.AppDataCmd, sizeof(CmdBuf.AppDataCmd),
                UT_TPID_CFE_EVS_CMD_WRITE_APP_DATA_FILE_CC,
@@ -1505,8 +1510,9 @@ void Test_WriteApp(void)
      * file name
      */
     UT_InitData();
-    strncpy((char *) CmdBuf.AppDataCmd.Payload.AppDataFilename, "AppDataFileName",
-            sizeof(CmdBuf.AppDataCmd.Payload.AppDataFilename));
+    strncpy(CmdBuf.AppDataCmd.Payload.AppDataFilename, "AppDataFileName",
+            sizeof(CmdBuf.AppDataCmd.Payload.AppDataFilename) - 1);
+    CmdBuf.AppDataCmd.Payload.AppDataFilename[sizeof(CmdBuf.AppDataCmd.Payload.AppDataFilename) - 1] = '\0';
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
     UT_EVS_DoDispatchCheckEvents(&CmdBuf.AppDataCmd, sizeof(CmdBuf.AppDataCmd),
                UT_TPID_CFE_EVS_CMD_WRITE_APP_DATA_FILE_CC,
@@ -1549,14 +1555,18 @@ void Test_BadAppCmd(void)
     appmaskcmd.Payload.EventID = 0;
     appcmdcmd.Payload.EventID = 0;
 
-    strncpy((char *) appbitcmd.Payload.AppName, "unknown_name",
-            sizeof(appbitcmd.Payload.AppName));
-    strncpy((char *) appnamecmd.Payload.AppName, "unknown_name",
-            sizeof(appnamecmd.Payload.AppName));
-    strncpy((char *) appmaskcmd.Payload.AppName, "unknown_name",
-            sizeof(appmaskcmd.Payload.AppName));
-    strncpy((char *) appcmdcmd.Payload.AppName, "unknown_name",
-            sizeof(appcmdcmd.Payload.AppName));
+    strncpy(appbitcmd.Payload.AppName, "unknown_name",
+            sizeof(appbitcmd.Payload.AppName) - 1);
+    appbitcmd.Payload.AppName[sizeof(appbitcmd.Payload.AppName) - 1] = '\0';
+    strncpy(appnamecmd.Payload.AppName, "unknown_name",
+            sizeof(appnamecmd.Payload.AppName) - 1);
+    appnamecmd.Payload.AppName[sizeof(appnamecmd.Payload.AppName) - 1] = '\0';
+    strncpy(appmaskcmd.Payload.AppName, "unknown_name",
+            sizeof(appmaskcmd.Payload.AppName) - 1);
+    appmaskcmd.Payload.AppName[sizeof(appmaskcmd.Payload.AppName) - 1] = '\0';
+    strncpy(appcmdcmd.Payload.AppName, "unknown_name",
+            sizeof(appcmdcmd.Payload.AppName) - 1);
+    appcmdcmd.Payload.AppName[sizeof(appcmdcmd.Payload.AppName) - 1] = '\0';
 
     /* Test disabling application event types with an unknown application ID */
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_GetAppIDByName), CFE_ES_ERR_NAME_NOT_FOUND);
@@ -1674,14 +1684,18 @@ void Test_BadAppCmd(void)
 
     /* Test disabling application event types with an illegal application ID */
     UT_InitData();
-    strncpy((char *) appbitcmd.Payload.AppName, "illegal_id",
-            sizeof(appbitcmd.Payload.AppName));
-    strncpy((char *) appnamecmd.Payload.AppName, "illegal_id",
-            sizeof(appnamecmd.Payload.AppName));
-    strncpy((char *) appmaskcmd.Payload.AppName, "illegal_id",
-            sizeof(appmaskcmd.Payload.AppName));
-    strncpy((char *) appcmdcmd.Payload.AppName, "illegal_id",
-            sizeof(appcmdcmd.Payload.AppName));
+    strncpy(appbitcmd.Payload.AppName, "illegal_id",
+            sizeof(appbitcmd.Payload.AppName) - 1);
+    appbitcmd.Payload.AppName[sizeof(appbitcmd.Payload.AppName) - 1] = '\0';
+    strncpy(appnamecmd.Payload.AppName, "illegal_id",
+            sizeof(appnamecmd.Payload.AppName) - 1);
+    appnamecmd.Payload.AppName[sizeof(appnamecmd.Payload.AppName) - 1] = '\0';
+    strncpy(appmaskcmd.Payload.AppName, "illegal_id",
+            sizeof(appmaskcmd.Payload.AppName) - 1);
+    appmaskcmd.Payload.AppName[sizeof(appmaskcmd.Payload.AppName) - 1] = '\0';
+    strncpy(appcmdcmd.Payload.AppName, "illegal_id",
+            sizeof(appcmdcmd.Payload.AppName) - 1);
+    appcmdcmd.Payload.AppName[sizeof(appcmdcmd.Payload.AppName) - 1] = '\0';
 
     /*
      * Generate an illegal AppID error when looking up the UT appID (first call),
@@ -1805,14 +1819,18 @@ void Test_BadAppCmd(void)
     UT_InitData();
     TestAppIndex = 2;
     UT_SetDataBuffer(UT_KEY(CFE_ES_AppID_ToIndex), &TestAppIndex, sizeof(TestAppIndex), false);
-    strncpy((char *) appbitcmd.Payload.AppName, "unregistered_app",
-            sizeof(appbitcmd.Payload.AppName));
-    strncpy((char *) appnamecmd.Payload.AppName, "unregistered_app",
-            sizeof(appnamecmd.Payload.AppName));
-    strncpy((char *) appmaskcmd.Payload.AppName, "unregistered_app",
-            sizeof(appmaskcmd.Payload.AppName));
-    strncpy((char *) appcmdcmd.Payload.AppName, "unregistered_app",
-            sizeof(appcmdcmd.Payload.AppName));
+    strncpy(appbitcmd.Payload.AppName, "unregistered_app",
+            sizeof(appbitcmd.Payload.AppName) - 1);
+    appbitcmd.Payload.AppName[sizeof(appbitcmd.Payload.AppName) - 1] = '\0';
+    strncpy(appnamecmd.Payload.AppName, "unregistered_app",
+            sizeof(appnamecmd.Payload.AppName) - 1);
+    appnamecmd.Payload.AppName[sizeof(appnamecmd.Payload.AppName) - 1] = '\0';
+    strncpy(appmaskcmd.Payload.AppName, "unregistered_app",
+            sizeof(appmaskcmd.Payload.AppName) - 1);
+    appmaskcmd.Payload.AppName[sizeof(appmaskcmd.Payload.AppName) - 1] = '\0';
+    strncpy(appcmdcmd.Payload.AppName, "unregistered_app",
+            sizeof(appcmdcmd.Payload.AppName) - 1);
+    appcmdcmd.Payload.AppName[sizeof(appcmdcmd.Payload.AppName) - 1] = '\0';
     UT_EVS_DoDispatchCheckEvents(&appbitcmd, sizeof(appbitcmd),
                UT_TPID_CFE_EVS_CMD_DISABLE_APP_EVENT_TYPE_CC,
                &UT_EVS_EventBuf);
@@ -1949,10 +1967,12 @@ void Test_EventCmd(void)
     UT_InitData();
 
     /* Run the next series of tests with valid, registered application name */
-    strncpy((char *) appbitcmd.Payload.AppName, "ut_cfe_evs",
-            sizeof(appbitcmd.Payload.AppName));
-    strncpy((char *) appnamecmd.Payload.AppName, "ut_cfe_evs",
-            sizeof(appnamecmd.Payload.AppName));
+    strncpy(appbitcmd.Payload.AppName, "ut_cfe_evs",
+            sizeof(appbitcmd.Payload.AppName) - 1);
+    appbitcmd.Payload.AppName[sizeof(appbitcmd.Payload.AppName) - 1] = '\0';
+    strncpy(appnamecmd.Payload.AppName, "ut_cfe_evs",
+            sizeof(appnamecmd.Payload.AppName) - 1);
+    appnamecmd.Payload.AppName[sizeof(appnamecmd.Payload.AppName) - 1] = '\0';
 
     /* Test disabling of all events */
     appbitcmd.Payload.BitMask = CFE_EVS_DEBUG_BIT | CFE_EVS_INFORMATION_BIT |
@@ -2195,14 +2215,18 @@ void Test_FilterCmd(void)
     appcmdcmd.Payload.EventID = 0;
 
     /* Run the next series of tests with valid, registered application name */
-    strncpy((char *) appnamecmd.Payload.AppName, "ut_cfe_evs",
-            sizeof(appnamecmd.Payload.AppName));
-    strncpy((char *) appmaskcmd.Payload.AppName, "ut_cfe_evs",
-            sizeof(appmaskcmd.Payload.AppName));
-    strncpy((char *) appcmdcmd.Payload.AppName, "ut_cfe_evs",
-            sizeof(appcmdcmd.Payload.AppName));
-    strncpy((char *) appbitcmd.Payload.AppName, "ut_cfe_evs",
-            sizeof(appbitcmd.Payload.AppName));
+    strncpy(appnamecmd.Payload.AppName, "ut_cfe_evs",
+            sizeof(appnamecmd.Payload.AppName) - 1);
+    appnamecmd.Payload.AppName[sizeof(appnamecmd.Payload.AppName) - 1] = '\0';
+    strncpy(appmaskcmd.Payload.AppName, "ut_cfe_evs",
+            sizeof(appmaskcmd.Payload.AppName) - 1);
+    appmaskcmd.Payload.AppName[sizeof(appmaskcmd.Payload.AppName) - 1] = '\0';
+    strncpy(appcmdcmd.Payload.AppName, "ut_cfe_evs",
+            sizeof(appcmdcmd.Payload.AppName) - 1);
+    appcmdcmd.Payload.AppName[sizeof(appcmdcmd.Payload.AppName) - 1] = '\0';
+    strncpy(appbitcmd.Payload.AppName, "ut_cfe_evs",
+            sizeof(appbitcmd.Payload.AppName) - 1);
+    appbitcmd.Payload.AppName[sizeof(appbitcmd.Payload.AppName) - 1] = '\0';
 
     /* Enable all application event message output */
     appbitcmd.Payload.BitMask = CFE_EVS_DEBUG_BIT | CFE_EVS_INFORMATION_BIT |

--- a/fsw/cfe-core/unit-test/fs_UT.c
+++ b/fsw/cfe-core/unit-test/fs_UT.c
@@ -247,8 +247,8 @@ void Test_CFE_FS_ExtractFileNameFromPath(void)
      * missing the path
      */
     UT_InitData();
-    strncpy(Original, "/cf/appslibrary.gz", OS_MAX_PATH_LEN);
-    Original[OS_MAX_PATH_LEN - 1] = '\0';
+    strncpy(Original, "/cf/appslibrary.gz", sizeof(Original) - 1);
+    Original[sizeof(Original) - 1] = '\0';
     UT_Report(__FILE__, __LINE__,
               CFE_FS_ExtractFilenameFromPath("name", FileName) ==
                   CFE_FS_INVALID_PATH,

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -112,6 +112,12 @@ const CFE_SB_MsgId_t SB_UT_ALTERNATE_INVALID_MID = CFE_SB_MSGID_WRAP_VALUE(CFE_P
 const CFE_SB_MsgId_t SB_UT_BARE_CMD_MID3 = CFE_SB_MSGID_WRAP_VALUE(0x1003);
 const CFE_SB_MsgId_t SB_UT_BARE_TLM_MID3 = CFE_SB_MSGID_WRAP_VALUE(0x0003);
 
+const CFE_SB_PipeId_t SB_UT_PIPEID_0  = { CFE_SB_PIPEID_BASE + 0 };
+const CFE_SB_PipeId_t SB_UT_PIPEID_1  = { CFE_SB_PIPEID_BASE + 1 };
+const CFE_SB_PipeId_t SB_UT_PIPEID_2  = { CFE_SB_PIPEID_BASE + 2 };
+const CFE_SB_PipeId_t SB_UT_PIPEID_3  = { CFE_SB_PIPEID_BASE + 3 };
+const CFE_SB_PipeId_t SB_UT_ALTERNATE_INVALID_PIPEID = { 0xDEADBEEF };
+
 /*
  * Helper function to "corrupt" a resource ID value in a consistent/predicatble way,
  * which can also be un-done easily.
@@ -225,7 +231,7 @@ void Test_SB_AppInit_EVSSendEvtFail(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_EVS_SendEvent), 1, ForcedRtnVal);
     ASSERT_EQ(CFE_SB_AppInit(), ForcedRtnVal);
 
-    EVTCNT(7);
+    EVTCNT(4);
 
     TEARDOWN(CFE_SB_DeletePipe(CFE_SB.CmdPipe));
 
@@ -253,8 +259,6 @@ void Test_SB_AppInit_CrPipeFail(void)
 */
 void Test_SB_AppInit_Sub1Fail(void)
 {
-    CFE_SB_PipeId_t PipeId = 0;
-
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetPoolBuf), 1, -1);
     ASSERT_EQ(CFE_SB_AppInit(), CFE_SB_BUF_ALOC_ERR);
 
@@ -262,7 +266,7 @@ void Test_SB_AppInit_Sub1Fail(void)
 
     EVTSENT(CFE_SB_DEST_BLK_ERR_EID);
 
-    TEARDOWN(CFE_SB_DeletePipe(PipeId));
+    TEARDOWN(CFE_SB_DeletePipe(CFE_SB.CmdPipe));
 
 } /* end Test_SB_AppInit_Sub1Fail */
 
@@ -271,16 +275,14 @@ void Test_SB_AppInit_Sub1Fail(void)
 */
 void Test_SB_AppInit_Sub2Fail(void)
 {
-    CFE_SB_PipeId_t PipeId = 0;
-
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetPoolBuf), 2, -1);
     ASSERT_EQ(CFE_SB_AppInit(), CFE_SB_BUF_ALOC_ERR);
 
-    EVTCNT(5);
+    EVTCNT(4);
 
     EVTSENT(CFE_SB_DEST_BLK_ERR_EID);
 
-    TEARDOWN(CFE_SB_DeletePipe(PipeId));
+    TEARDOWN(CFE_SB_DeletePipe(CFE_SB.CmdPipe));
 
 } /* end Test_SB_AppInit_Sub2Fail */
 
@@ -289,16 +291,15 @@ void Test_SB_AppInit_Sub2Fail(void)
 */
 void Test_SB_AppInit_GetPoolFail(void)
 {
-    CFE_SB_PipeId_t PipeId = 0;
     int32           ForcedRtnVal = -1;
 
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetPoolBuf), 4, ForcedRtnVal);
 
     ASSERT_EQ(CFE_SB_AppInit(), ForcedRtnVal);
 
-    EVTCNT(7);
+    EVTCNT(4);
 
-    TEARDOWN(CFE_SB_DeletePipe(PipeId));
+    TEARDOWN(CFE_SB_DeletePipe(CFE_SB.CmdPipe));
 
 } /* end Test_SB_AppInit_GetPoolFail */
 
@@ -307,16 +308,15 @@ void Test_SB_AppInit_GetPoolFail(void)
 */
 void Test_SB_AppInit_PutPoolFail(void)
 {
-    CFE_SB_PipeId_t PipeId = 0;
     int32           ForcedRtnVal = -1;
 
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_PutPoolBuf), 1, ForcedRtnVal);
 
     ASSERT_EQ(CFE_SB_AppInit(), ForcedRtnVal);
 
-    EVTCNT(7);
+    EVTCNT(4);
 
-    TEARDOWN(CFE_SB_DeletePipe(PipeId));
+    TEARDOWN(CFE_SB_DeletePipe(CFE_SB.CmdPipe));
 
 } /* end Test_SB_AppInit_PutPoolFail */
 
@@ -334,18 +334,16 @@ void Test_SB_MainRoutine(void)
 */
 void Test_SB_Main_RcvErr(void)
 {
-    CFE_SB_PipeId_t PipeId = 0;
-
     UT_SetDeferredRetcode(UT_KEY(OS_QueueGet), 1, -1);
     CFE_SB_TaskMain();
 
-    EVTCNT(10);
+    EVTCNT(6);
 
     EVTSENT(CFE_SB_INIT_EID);
 
     EVTSENT(CFE_SB_Q_RD_ERR_EID);
 
-    TEARDOWN(CFE_SB_DeletePipe(PipeId));
+    TEARDOWN(CFE_SB_DeletePipe(CFE_SB.CmdPipe));
 
 } /* end Test_SB_Main_RcvErr */
 
@@ -354,14 +352,12 @@ void Test_SB_Main_RcvErr(void)
 */
 void Test_SB_Main_InitErr(void)
 {
-    CFE_SB_PipeId_t PipeId = 0;
-
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_PutPoolBuf), 1, -1);
     CFE_SB_TaskMain();
 
-    EVTCNT(7);
+    EVTCNT(4);
 
-    TEARDOWN(CFE_SB_DeletePipe(PipeId));
+    TEARDOWN(CFE_SB_DeletePipe(CFE_SB.CmdPipe));
 
 } /* end Test_SB_Main_InitErr */
 
@@ -505,7 +501,6 @@ void Test_SB_Cmds_RoutingInfoDef(void)
         CFE_SB_Buffer_t             SBBuf;
         CFE_SB_SendRoutingInfoCmd_t Cmd;
     } SendRoutingInfo;
-    CFE_SB_PipeId_t   PipeId = 0;
     CFE_MSG_FcnCode_t FcnCode = CFE_SB_SEND_ROUTING_INFO_CC;
     CFE_SB_MsgId_t    MsgId = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
     CFE_MSG_Size_t    Size = sizeof(SendRoutingInfo.Cmd);
@@ -520,7 +515,7 @@ void Test_SB_Cmds_RoutingInfoDef(void)
 
     CFE_SB_ProcessCmdPipePkt(&SendRoutingInfo.SBBuf);
 
-    EVTCNT(12);
+    EVTCNT(9);
 
     EVTSENT(CFE_SB_INIT_EID);
 
@@ -530,7 +525,7 @@ void Test_SB_Cmds_RoutingInfoDef(void)
 
     EVTSENT(CFE_SB_SND_RTG_EID);
 
-    TEARDOWN(CFE_SB_DeletePipe(PipeId));
+    TEARDOWN(CFE_SB_DeletePipe(CFE_SB.CmdPipe));
 
 } /* end Test_SB_Cmds_RoutingInfoDef */
 
@@ -614,8 +609,6 @@ void Test_SB_Cmds_RoutingInfoHdrFail(void)
 */
 void Test_SB_Cmds_RoutingInfoWriteFail(void)
 {
-    CFE_SB_PipeId_t PipeId = 0;
-
     /* Make some routing info by calling CFE_SB_AppInit */
     SETUP(CFE_SB_AppInit());
 
@@ -623,7 +616,7 @@ void Test_SB_Cmds_RoutingInfoWriteFail(void)
 
     ASSERT_EQ(CFE_SB_SendRtgInfo("RoutingTstFile"), CFE_SB_FILE_IO_ERR);
 
-    EVTCNT(11);
+    EVTCNT(9);
 
     EVTSENT(CFE_SB_PIPE_ADDED_EID);
 
@@ -633,7 +626,7 @@ void Test_SB_Cmds_RoutingInfoWriteFail(void)
 
     EVTSENT(CFE_SB_FILEWRITE_ERR_EID);
 
-    TEARDOWN(CFE_SB_DeletePipe(PipeId));
+    TEARDOWN(CFE_SB_DeletePipe(CFE_SB.CmdPipe));
 
 } /* end Test_SB_Cmds_RoutingInfoWriteFail */
 
@@ -806,7 +799,7 @@ void Test_SB_Cmds_MapInfoDef(void)
 
     CFE_SB_ProcessCmdPipePkt(&SendMapInfo.SBBuf);
 
-    EVTCNT(18);
+    EVTCNT(11);
 
     EVTSENT(CFE_SB_SND_RTG_EID);
 
@@ -908,7 +901,7 @@ void Test_SB_Cmds_MapInfoWriteFail(void)
 
     ASSERT_EQ(CFE_SB_SendMapInfo("MapTstFile"), CFE_SB_FILE_IO_ERR);
 
-    EVTCNT(18);
+    EVTCNT(11);
 
     EVTSENT(CFE_SB_FILEWRITE_ERR_EID);
 
@@ -951,7 +944,7 @@ void Test_SB_Cmds_EnRouteValParam(void)
 
     CFE_SB_ProcessCmdPipePkt(&EnableRoute.SBBuf);
 
-    EVTCNT(4);
+    EVTCNT(3);
 
     EVTSENT(CFE_SB_PIPE_ADDED_EID);
 
@@ -993,7 +986,7 @@ void Test_SB_Cmds_EnRouteNonExist(void)
 
     CFE_SB_ProcessCmdPipePkt(&EnableRoute.SBBuf);
 
-    EVTCNT(5);
+    EVTCNT(4);
 
     EVTSENT(CFE_SB_PIPE_ADDED_EID);
     EVTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
@@ -1023,7 +1016,7 @@ void Test_SB_Cmds_EnRouteInvParam(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     EnableRoute.Cmd.Payload.MsgId = SB_UT_LAST_VALID_MID;
-    EnableRoute.Cmd.Payload.Pipe = 3;
+    EnableRoute.Cmd.Payload.Pipe = SB_UT_PIPEID_3;
 
     CFE_SB_ProcessCmdPipePkt(&EnableRoute.SBBuf);
 
@@ -1052,7 +1045,7 @@ void Test_SB_Cmds_EnRouteInvParam2(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     EnableRoute.Cmd.Payload.MsgId = CFE_SB_INVALID_MSG_ID;
-    EnableRoute.Cmd.Payload.Pipe = 3;
+    EnableRoute.Cmd.Payload.Pipe = SB_UT_PIPEID_3;
 
     CFE_SB_ProcessCmdPipePkt(&EnableRoute.SBBuf);
 
@@ -1082,7 +1075,7 @@ void Test_SB_Cmds_EnRouteInvParam3(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     EnableRoute.Cmd.Payload.MsgId = SB_UT_ALTERNATE_INVALID_MID;
-    EnableRoute.Cmd.Payload.Pipe = 0;
+    EnableRoute.Cmd.Payload.Pipe = SB_UT_PIPEID_0;
 
     CFE_SB_ProcessCmdPipePkt(&EnableRoute.SBBuf);
 
@@ -1120,7 +1113,7 @@ void Test_SB_Cmds_DisRouteValParam(void)
 
     CFE_SB_ProcessCmdPipePkt(&DisableRoute.SBBuf);
 
-    EVTCNT(4);
+    EVTCNT(3);
 
     EVTSENT(CFE_SB_PIPE_ADDED_EID);
 
@@ -1161,7 +1154,7 @@ void Test_SB_Cmds_DisRouteNonExist(void)
 
     CFE_SB_ProcessCmdPipePkt(&DisableRoute.SBBuf);
 
-    EVTCNT(5);
+    EVTCNT(4);
 
     EVTSENT(CFE_SB_PIPE_ADDED_EID);
     EVTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
@@ -1191,7 +1184,7 @@ void Test_SB_Cmds_DisRouteInvParam(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     DisableRoute.Cmd.Payload.MsgId = SB_UT_LAST_VALID_MID;
-    DisableRoute.Cmd.Payload.Pipe = 3;
+    DisableRoute.Cmd.Payload.Pipe = SB_UT_PIPEID_3;
 
     CFE_SB_ProcessCmdPipePkt(&DisableRoute.SBBuf);
 
@@ -1220,7 +1213,7 @@ void Test_SB_Cmds_DisRouteInvParam2(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     DisableRoute.Cmd.Payload.MsgId = CFE_SB_INVALID_MSG_ID;
-    DisableRoute.Cmd.Payload.Pipe = 3;
+    DisableRoute.Cmd.Payload.Pipe = SB_UT_PIPEID_3;
 
     CFE_SB_ProcessCmdPipePkt(&DisableRoute.SBBuf);
 
@@ -1250,7 +1243,7 @@ void Test_SB_Cmds_DisRouteInvParam3(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     DisableRoute.Cmd.Payload.MsgId = SB_UT_ALTERNATE_INVALID_MID;
-    DisableRoute.Cmd.Payload.Pipe = 0;
+    DisableRoute.Cmd.Payload.Pipe = SB_UT_PIPEID_0;
 
     CFE_SB_ProcessCmdPipePkt(&DisableRoute.SBBuf);
 
@@ -1330,7 +1323,7 @@ void Test_SB_Cmds_SendPrevSubs(void)
          * */
         if (i != CFE_SB_ALLSUBS_TLM_MID)
         {
-            NumEvts += 2;
+            NumEvts += 1;
             SETUP(CFE_SB_Subscribe(CFE_SB_ValueToMsgId(i), PipeId1));
         }
     }
@@ -1356,7 +1349,7 @@ void Test_SB_Cmds_SendPrevSubs(void)
 
     CFE_SB_ProcessCmdPipePkt(&SendPrevSubs.SBBuf);
 
-    NumEvts += 8;  /* +2 for the subscribe, +6 for the SEND_PREV_SUBS_CC */
+    NumEvts += 7;  /* +1 for the subscribe, +6 for the SEND_PREV_SUBS_CC */
 
     /* Event count is only exact if there were no collisions */
     if (UT_EventIsInHistory(CFE_SB_HASHCOLLISION_EID))
@@ -1374,7 +1367,7 @@ void Test_SB_Cmds_SendPrevSubs(void)
     for (; i < CFE_SB_SUB_ENTRIES_PER_PKT * 3; i++)
     {
         SETUP(CFE_SB_Subscribe(CFE_SB_ValueToMsgId(i), PipeId1));
-        NumEvts += 2;
+        NumEvts += 1;
     }
 
     SETUP(CFE_SB_SubscribeLocal(MsgId, PipeId2, MsgLim));
@@ -1683,6 +1676,7 @@ void Test_CreatePipe_MaxPipes(void)
     /* Create maximum number of pipes + 1. Only one 'create pipe' failure
      * expected
      */
+    UT_SetDeferredRetcode(UT_KEY(CFE_ES_ResourceID_ToIndex), 1+CFE_PLATFORM_SB_MAX_PIPES, -1);
     for (i = 0; i < (CFE_PLATFORM_SB_MAX_PIPES + 1); i++)
     {
         snprintf(PipeName, OS_MAX_API_NAME, "TestPipe%ld", (long) i);
@@ -1712,8 +1706,8 @@ void Test_CreatePipe_MaxPipes(void)
 */
 void Test_CreatePipe_SamePipeName(void)
 {
-    CFE_SB_PipeId_t FirstPipeId = -1;
-    CFE_SB_PipeId_t PipeId = -1;
+    CFE_SB_PipeId_t FirstPipeId = CFE_SB_INVALID_PIPE;
+    CFE_SB_PipeId_t PipeId = CFE_SB_INVALID_PIPE;
     uint16 PipeDepth = 1;
     char PipeName[] = "Test_CFE_SB";
 
@@ -1729,7 +1723,7 @@ void Test_CreatePipe_SamePipeName(void)
     /* Second call to CFE_SB_CreatePipe with same PipeName should fail */
     ASSERT_EQ(CFE_SB_CreatePipe(&PipeId, PipeDepth, PipeName), CFE_SB_PIPE_CR_ERR);
 
-    ASSERT_EQ(PipeId, FirstPipeId);
+    ASSERT_TRUE(CFE_ES_ResourceID_Equal(PipeId, FirstPipeId));
 
     EVTCNT(2);
 
@@ -1789,7 +1783,7 @@ void Test_DeletePipe_WithSubs(void)
     SETUP(CFE_SB_Subscribe(MsgId3, PipedId));
     ASSERT(CFE_SB_DeletePipe(PipedId));
 
-    EVTCNT(10);
+    EVTCNT(6);
 
     EVTSENT(CFE_SB_PIPE_ADDED_EID);
     EVTSENT(CFE_SB_PIPE_DELETED_EID);
@@ -1801,7 +1795,7 @@ void Test_DeletePipe_WithSubs(void)
 */
 void Test_DeletePipe_InvalidPipeId(void)
 {
-    CFE_SB_PipeId_t PipeId = 30;
+    CFE_SB_PipeId_t PipeId = SB_UT_ALTERNATE_INVALID_PIPEID;
 
     ASSERT_EQ(CFE_SB_DeletePipe(PipeId), CFE_SB_BAD_ARGUMENT);
 
@@ -1817,16 +1811,18 @@ void Test_DeletePipe_InvalidPipeId(void)
 void Test_DeletePipe_InvalidPipeOwner(void)
 {
     CFE_SB_PipeId_t PipedId;
+    CFE_SB_PipeD_t  *PipeDscPtr;
     CFE_ES_ResourceID_t  RealOwner;
     uint16          PipeDepth = 10;
 
     SETUP(CFE_SB_CreatePipe(&PipedId, PipeDepth, "TestPipe"));
 
     /* Change owner of pipe through memory corruption */
-    RealOwner = CFE_SB.PipeTbl[PipedId].AppId;
+    PipeDscPtr = CFE_SB_LocatePipeDescByID(PipedId);
+    RealOwner = PipeDscPtr->AppId;
 
     /* Choose a value that is sure not to be owner */
-    CFE_SB.PipeTbl[PipedId].AppId = UT_SB_ResourceID_Modify(RealOwner, 1);
+    PipeDscPtr->AppId = UT_SB_ResourceID_Modify(RealOwner, 1);
     ASSERT_EQ(CFE_SB_DeletePipe(PipedId), CFE_SB_BAD_ARGUMENT);
 
     EVTCNT(2);
@@ -1834,7 +1830,7 @@ void Test_DeletePipe_InvalidPipeOwner(void)
     EVTSENT(CFE_SB_DEL_PIPE_ERR2_EID);
 
     /* Restore owner id and delete pipe since test is complete */
-    CFE_SB.PipeTbl[PipedId].AppId = RealOwner;
+    PipeDscPtr->AppId = RealOwner;
     TEARDOWN(CFE_SB_DeletePipe(PipedId));
 
 } /* end Test_DeletePipe_InvalidPipeId */
@@ -1857,7 +1853,7 @@ void Test_DeletePipe_WithAppid(void)
 
     ASSERT(CFE_SB_DeletePipeWithAppId(PipedId, AppId));
 
-    EVTCNT(10);
+    EVTCNT(6);
 
 } /* end Test_DeletePipe_WithAppid */
 
@@ -1889,9 +1885,14 @@ void Test_GetPipeName_API(void)
 */
 void Test_GetPipeName_NullPtr(void)
 {
-    ASSERT_EQ(CFE_SB_GetPipeName(NULL, OS_MAX_API_NAME, 0), CFE_SB_BAD_ARGUMENT);
+    CFE_SB_PipeId_t PipeId;
+
+    SETUP(CFE_SB_CreatePipe(&PipeId, 4, "TestPipe"));
+    ASSERT_EQ(CFE_SB_GetPipeName(NULL, OS_MAX_API_NAME, PipeId), CFE_SB_BAD_ARGUMENT);
 
     EVTSENT(CFE_SB_GETPIPENAME_NULL_PTR_EID);
+
+    TEARDOWN(CFE_SB_DeletePipe(PipeId));
 
 } /* end Test_GetPipeName_NullPtr */
 
@@ -1901,12 +1902,16 @@ void Test_GetPipeName_NullPtr(void)
 void Test_GetPipeName_InvalidId(void)
 {
     char PipeName[OS_MAX_API_NAME];
+    CFE_SB_PipeId_t PipeId;
 
-    UT_SetDeferredRetcode(UT_KEY(OS_QueueGetInfo), 1, OS_ERROR);
+    SETUP(CFE_SB_CreatePipe(&PipeId, 4, "TestPipe"));
 
-    ASSERT_EQ(CFE_SB_GetPipeName(PipeName, OS_MAX_API_NAME, 0), CFE_SB_BAD_ARGUMENT);
+    UT_SetDeferredRetcode(UT_KEY(OS_GetResourceName), 1, OS_ERROR);
+    ASSERT_EQ(CFE_SB_GetPipeName(PipeName, OS_MAX_API_NAME, PipeId), CFE_SB_BAD_ARGUMENT);
 
     EVTSENT(CFE_SB_GETPIPENAME_ID_ERR_EID);
+
+    TEARDOWN(CFE_SB_DeletePipe(PipeId));
 
 } /* end Test_GetPipeName_InvalidId */
 
@@ -1916,7 +1921,7 @@ void Test_GetPipeName_InvalidId(void)
 void Test_GetPipeName(void)
 {
     char PipeName[OS_MAX_API_NAME];
-    CFE_SB_PipeId_t PipeId = 0;
+    CFE_SB_PipeId_t PipeId = SB_UT_PIPEID_0;
 
     OS_queue_prop_t queue_info = {
         "TestPipe1"
@@ -1952,7 +1957,7 @@ void Test_GetPipeIdByName_API(void)
 */
 void Test_GetPipeIdByName_NullPtrs(void)
 {
-    CFE_SB_PipeId_t PipeIDOut = 0;
+    CFE_SB_PipeId_t PipeIDOut;
 
 	ASSERT_EQ(CFE_SB_GetPipeIdByName(&PipeIDOut, NULL), CFE_SB_BAD_ARGUMENT);
 
@@ -1969,8 +1974,9 @@ void Test_GetPipeIdByName_NullPtrs(void)
 */
 void Test_GetPipeIdByName_InvalidName(void)
 {
-    CFE_SB_PipeId_t PipeIdOut = 0;
+    CFE_SB_PipeId_t PipeIdOut;
 
+    UT_SetDeferredRetcode(UT_KEY(OS_QueueGetIdByName), 1, OS_ERR_NAME_NOT_FOUND);
 	ASSERT_EQ(CFE_SB_GetPipeIdByName(&PipeIdOut, "invalid"), CFE_SB_BAD_ARGUMENT);
 
     EVTSENT(CFE_SB_GETPIPEIDBYNAME_NAME_ERR_EID);
@@ -1982,7 +1988,8 @@ void Test_GetPipeIdByName_InvalidName(void)
 */
 void Test_GetPipeIdByName(void)
 {
-    CFE_SB_PipeId_t PipeId = 0, PipeIdOut = 0;
+    CFE_SB_PipeId_t PipeId = SB_UT_PIPEID_0;
+    CFE_SB_PipeId_t PipeIdOut;
 
     SETUP(CFE_SB_CreatePipe(&PipeId, 4, "TestPipe1"));
 
@@ -2005,7 +2012,7 @@ void Test_GetPipeIdByName(void)
 */
 void Test_SetPipeOpts_BadID(void)
 {
-	ASSERT_EQ(CFE_SB_SetPipeOpts(CFE_PLATFORM_SB_MAX_PIPES, 0), CFE_SB_BAD_ARGUMENT);
+	ASSERT_EQ(CFE_SB_SetPipeOpts(SB_UT_ALTERNATE_INVALID_PIPEID, 0), CFE_SB_BAD_ARGUMENT);
 
     EVTSENT(CFE_SB_SETPIPEOPTS_ID_ERR_EID);
 
@@ -2016,19 +2023,20 @@ void Test_SetPipeOpts_BadID(void)
 */
 void Test_SetPipeOpts_NotOwner(void)
 {
-    CFE_SB_PipeId_t PipeID = 0;
-    uint8 PipeTblIdx = 0;
+    CFE_SB_PipeId_t PipeID;
+    CFE_SB_PipeD_t  *PipeDscPtr;
     CFE_ES_ResourceID_t OrigOwner;
 
     SETUP(CFE_SB_CreatePipe(&PipeID, 4, "TestPipe1"));
 
-    PipeTblIdx = CFE_SB_GetPipeIdx(PipeID);
+    PipeDscPtr = CFE_SB_LocatePipeDescByID(PipeID);
 
-    OrigOwner = CFE_SB.PipeTbl[PipeTblIdx].AppId;
-    CFE_SB.PipeTbl[PipeTblIdx].AppId = UT_SB_ResourceID_Modify(OrigOwner, 1);
+    OrigOwner = PipeDscPtr->AppId;
+    PipeDscPtr->AppId = UT_SB_ResourceID_Modify(OrigOwner, 1);
+
     ASSERT_EQ(CFE_SB_SetPipeOpts(PipeID, 0), CFE_SB_BAD_ARGUMENT);
 
-    CFE_SB.PipeTbl[PipeTblIdx].AppId = OrigOwner;
+    PipeDscPtr->AppId = OrigOwner;
 
     EVTSENT(CFE_SB_SETPIPEOPTS_OWNER_ERR_EID);
 
@@ -2041,7 +2049,7 @@ void Test_SetPipeOpts_NotOwner(void)
 */
 void Test_SetPipeOpts(void)
 {
-    CFE_SB_PipeId_t PipeID = 0;
+    CFE_SB_PipeId_t PipeID;
 
     SETUP(CFE_SB_CreatePipe(&PipeID, 4, "TestPipe1"));
 
@@ -2060,7 +2068,7 @@ void Test_GetPipeOpts_BadID(void)
 {
     uint8 Opts = 0;
 
-    ASSERT_EQ(CFE_SB_GetPipeOpts(CFE_PLATFORM_SB_MAX_PIPES, &Opts), CFE_SB_BAD_ARGUMENT);
+    ASSERT_EQ(CFE_SB_GetPipeOpts(SB_UT_ALTERNATE_INVALID_PIPEID, &Opts), CFE_SB_BAD_ARGUMENT);
 
     EVTSENT(CFE_SB_GETPIPEOPTS_ID_ERR_EID);
 
@@ -2071,7 +2079,7 @@ void Test_GetPipeOpts_BadID(void)
 */
 void Test_GetPipeOpts_BadPtr(void)
 {
-    CFE_SB_PipeId_t PipeID = 0;
+    CFE_SB_PipeId_t PipeID;
 
     SETUP(CFE_SB_CreatePipe(&PipeID, 4, "TestPipe1"));
 
@@ -2088,7 +2096,7 @@ void Test_GetPipeOpts_BadPtr(void)
 */
 void Test_GetPipeOpts(void)
 {
-    CFE_SB_PipeId_t PipeID = 0;
+    CFE_SB_PipeId_t PipeID;
     uint8 Opts = 0;
 
     SETUP(CFE_SB_CreatePipe(&PipeID, 4, "TestPipe1"));
@@ -2135,7 +2143,7 @@ void Test_Subscribe_SubscribeEx(void)
 
     ASSERT(CFE_SB_SubscribeEx(MsgId, PipeId, Quality, MsgLim));
 
-    EVTCNT(3);
+    EVTCNT(2);
 
     EVTSENT(CFE_SB_PIPE_ADDED_EID);
     EVTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
@@ -2149,7 +2157,7 @@ void Test_Subscribe_SubscribeEx(void)
 */
 void Test_Subscribe_InvalidPipeId(void)
 {
-    CFE_SB_PipeId_t PipeId = 2;
+    CFE_SB_PipeId_t PipeId = SB_UT_PIPEID_2;
     CFE_SB_MsgId_t  MsgId = SB_UT_ALTERNATE_INVALID_MID;
 
     ASSERT_EQ(CFE_SB_Subscribe(MsgId, PipeId), CFE_SB_BAD_ARGUMENT);
@@ -2197,7 +2205,7 @@ void Test_Subscribe_MaxMsgLim(void)
 
     ASSERT(CFE_SB_SubscribeEx(MsgId, PipeId, Quality, MsgLim));
 
-    EVTCNT(3);
+    EVTCNT(2);
 
     EVTSENT(CFE_SB_PIPE_ADDED_EID);
 
@@ -2219,9 +2227,10 @@ void Test_Subscribe_DuplicateSubscription(void)
     ASSERT(CFE_SB_Subscribe(MsgId, PipeId));
     ASSERT(CFE_SB_Subscribe(MsgId, PipeId));
 
-    EVTCNT(5);
+    EVTCNT(4);
 
     EVTSENT(CFE_SB_PIPE_ADDED_EID);
+    EVTSENT(CFE_SB_DUP_SUBSCRIP_EID);
 
     TEARDOWN(CFE_SB_DeletePipe(PipeId));
 
@@ -2241,9 +2250,10 @@ void Test_Subscribe_LocalSubscription(void)
 
     ASSERT(CFE_SB_SubscribeLocal(MsgId, PipeId, MsgLim));
 
-    EVTCNT(3);
+    EVTCNT(2);
 
     EVTSENT(CFE_SB_PIPE_ADDED_EID);
+    EVTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
     TEARDOWN(CFE_SB_DeletePipe(PipeId));
 
@@ -2272,17 +2282,18 @@ void Test_Subscribe_MaxDestCount(void)
     {
         if (i < CFE_PLATFORM_SB_MAX_DEST_PER_PKT)
         {
-            SETUP(CFE_SB_Subscribe(MsgId, i));
+            SETUP(CFE_SB_Subscribe(MsgId, PipeId[i]));
         }
         else
         {
-            ASSERT_EQ(CFE_SB_Subscribe(MsgId, i), CFE_SB_MAX_DESTS_MET);
+            ASSERT_EQ(CFE_SB_Subscribe(MsgId, PipeId[i]), CFE_SB_MAX_DESTS_MET);
         }
     }
 
-    EVTCNT(3 * (CFE_PLATFORM_SB_MAX_DEST_PER_PKT + 1));
+    EVTCNT((2 * CFE_PLATFORM_SB_MAX_DEST_PER_PKT) + 3);
 
     EVTSENT(CFE_SB_PIPE_ADDED_EID);
+    EVTSENT(CFE_SB_MAX_DESTS_MET_EID);
 
     /* Delete pipes */
     for (i = 0; i < CFE_PLATFORM_SB_MAX_DEST_PER_PKT + 1; i++)
@@ -2366,7 +2377,7 @@ void Test_Subscribe_SendPrevSubs(void)
 
     ASSERT(CFE_SB_SendPrevSubsCmd(&SendPrevSubsMsg));
 
-    EVTCNT(19);
+    EVTCNT(12);
 
     EVTSENT(CFE_SB_PART_SUB_PKT_EID);
 
@@ -2382,7 +2393,7 @@ void Test_Subscribe_SendPrevSubs(void)
 void Test_Subscribe_PipeNonexistent(void)
 {
     CFE_SB_MsgId_t  MsgId = SB_UT_CMD_MID;
-    CFE_SB_PipeId_t PipeId = 55;
+    CFE_SB_PipeId_t PipeId = SB_UT_ALTERNATE_INVALID_PIPEID;
 
     ASSERT_EQ(CFE_SB_Subscribe(MsgId, PipeId), CFE_SB_BAD_ARGUMENT);
 
@@ -2411,7 +2422,7 @@ void Test_Subscribe_SubscriptionReporting(void)
 
     /* For internal TransmitMsg call that will report subscription */
     MsgIdRpt = CFE_SB_ValueToMsgId(CFE_SB_ONESUB_TLM_MID);
-    Size = sizeof(CFE_SB.SubRprtMsg);
+    Size = sizeof(CFE_SB_SingleSubscriptionTlm_t);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdRpt, sizeof(MsgIdRpt), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
 
@@ -2424,7 +2435,7 @@ void Test_Subscribe_SubscriptionReporting(void)
     /* Subscribe to message: LOCAL */
     ASSERT(CFE_SB_SubscribeFull(MsgId, PipeId, Quality, CFE_PLATFORM_SB_DEFAULT_MSG_LIMIT, CFE_SB_LOCAL));
 
-    EVTCNT(8);
+    EVTCNT(6);
 
     EVTSENT(CFE_SB_SUBSCRIPTION_RPT_EID);
 
@@ -2441,6 +2452,7 @@ void Test_Subscribe_SubscriptionReporting(void)
 void Test_Subscribe_InvalidPipeOwner(void)
 {
     CFE_SB_PipeId_t PipeId;
+    CFE_SB_PipeD_t  *PipeDscPtr;
     CFE_SB_MsgId_t  MsgId = SB_UT_TLM_MID;
     uint16          PipeDepth = 10;
     CFE_ES_ResourceID_t  RealOwner;
@@ -2448,10 +2460,11 @@ void Test_Subscribe_InvalidPipeOwner(void)
     SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "TestPipe"));
 
     /* Change owner of pipe through memory corruption */
-    RealOwner = CFE_SB.PipeTbl[PipeId].AppId;
+    PipeDscPtr = CFE_SB_LocatePipeDescByID(PipeId);
+    RealOwner = PipeDscPtr->AppId;
 
     /* Choose a value that is sure not to be owner */
-    CFE_SB.PipeTbl[PipeId].AppId = UT_SB_ResourceID_Modify(RealOwner, 1);
+    PipeDscPtr->AppId = UT_SB_ResourceID_Modify(RealOwner, 1);
     CFE_SB_Subscribe(MsgId, PipeId);
 
     EVTCNT(3);
@@ -2459,7 +2472,7 @@ void Test_Subscribe_InvalidPipeOwner(void)
     EVTSENT(CFE_SB_SUB_INV_CALLER_EID);
 
     /* Restore owner id and delete pipe since test is complete */
-    CFE_SB.PipeTbl[PipeId].AppId = RealOwner;
+    PipeDscPtr->AppId = RealOwner;
     TEARDOWN(CFE_SB_DeletePipe(PipeId));
 
 } /* end Test_Subscribe_InvalidPipeOwner */
@@ -2494,7 +2507,7 @@ void Test_Unsubscribe_Basic(void)
 
     ASSERT(CFE_SB_Unsubscribe(MsgId, TestPipe));
 
-    EVTCNT(4);
+    EVTCNT(3);
 
     EVTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
@@ -2522,7 +2535,7 @@ void Test_Unsubscribe_Local(void)
 
     ASSERT(CFE_SB_UnsubscribeLocal(SB_UT_LAST_VALID_MID, TestPipe));
 
-    EVTCNT(5);
+    EVTCNT(4);
 
     EVTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
@@ -2537,6 +2550,7 @@ void Test_Unsubscribe_InvalParam(void)
 {
     CFE_SB_PipeId_t TestPipe;
     CFE_ES_ResourceID_t  CallerId;
+    CFE_SB_PipeD_t  *PipeDscPtr;
     uint16          PipeDepth = 50;
     CFE_SB_PipeId_t SavedPipeId;
 
@@ -2556,17 +2570,18 @@ void Test_Unsubscribe_InvalParam(void)
      * bad pipe ID is caught by CFE_SB_GetPipeIdx() before it gets to
      * CFE_SB_ValidatePipeId()
      */
-    SavedPipeId = CFE_SB.PipeTbl[0].PipeId;
-    CFE_SB.PipeTbl[0].PipeId = CFE_PLATFORM_SB_MAX_PIPES;
-    CFE_SB.PipeTbl[0].InUse = 1;
-    ASSERT_EQ(CFE_SB_Unsubscribe(SB_UT_FIRST_VALID_MID, CFE_PLATFORM_SB_MAX_PIPES), CFE_SB_BAD_ARGUMENT);
+    PipeDscPtr = CFE_SB_LocatePipeDescByID(TestPipe);
+    SavedPipeId = CFE_SB_PipeDescGetID(PipeDscPtr);
+    PipeDscPtr->PipeId = SB_UT_ALTERNATE_INVALID_PIPEID;
+    ASSERT_EQ(CFE_SB_Unsubscribe(SB_UT_FIRST_VALID_MID, TestPipe), CFE_SB_BAD_ARGUMENT);
 
     /* We must restore the old value so CFE_SB_DeletePipe() works */
-    CFE_SB.PipeTbl[0].PipeId = SavedPipeId;
+    PipeDscPtr->PipeId = SavedPipeId;
 
     EVTCNT(4);
 
     EVTSENT(CFE_SB_UNSUB_ARG_ERR_EID);
+    EVTSENT(CFE_SB_UNSUB_INV_PIPE_EID);
 
     TEARDOWN(CFE_SB_DeletePipe(TestPipe));
 
@@ -2612,9 +2627,9 @@ void Test_Unsubscribe_InvalidPipe(void)
     SETUP(CFE_SB_CreatePipe(&TestPipe, PipeDepth, "TestPipe"));
     SETUP(CFE_SB_Subscribe(MsgId, TestPipe));
 
-    ASSERT_EQ(CFE_SB_Unsubscribe(MsgId, TestPipe + 1), CFE_SB_BAD_ARGUMENT);
+    ASSERT_EQ(CFE_SB_Unsubscribe(MsgId, SB_UT_ALTERNATE_INVALID_PIPEID), CFE_SB_BAD_ARGUMENT);
 
-    EVTCNT(4);
+    EVTCNT(3);
 
     EVTSENT(CFE_SB_UNSUB_INV_PIPE_EID);
 
@@ -2629,6 +2644,7 @@ void Test_Unsubscribe_InvalidPipeOwner(void)
 {
     CFE_SB_PipeId_t PipeId;
     CFE_SB_MsgId_t  MsgId = SB_UT_TLM_MID;
+    CFE_SB_PipeD_t  *PipeDscPtr;
     CFE_ES_ResourceID_t RealOwner;
     uint16          PipeDepth = 10;
 
@@ -2637,17 +2653,18 @@ void Test_Unsubscribe_InvalidPipeOwner(void)
     SETUP(CFE_SB_Subscribe(MsgId, PipeId));
 
     /* Change owner of pipe through memory corruption */
-    RealOwner = CFE_SB.PipeTbl[PipeId].AppId;
+    PipeDscPtr = CFE_SB_LocatePipeDescByID(PipeId);
+    RealOwner = PipeDscPtr->AppId;
 
     /* Choose a value that is sure not be owner */
-    CFE_SB.PipeTbl[PipeId].AppId = UT_SB_ResourceID_Modify(RealOwner, 1);
+    PipeDscPtr->AppId = UT_SB_ResourceID_Modify(RealOwner, 1);
     ASSERT_EQ(CFE_SB_Unsubscribe(MsgId, PipeId), CFE_SB_BAD_ARGUMENT);
 
-    EVTCNT(4);
+    EVTCNT(3);
 
     EVTSENT(CFE_SB_UNSUB_INV_CALLER_EID);
 
-    CFE_SB.PipeTbl[PipeId].AppId = RealOwner;
+    PipeDscPtr->AppId = RealOwner;
 
     TEARDOWN(CFE_SB_DeletePipe(PipeId));
 
@@ -2674,9 +2691,10 @@ void Test_Unsubscribe_FirstDestWithMany(void)
 
     ASSERT(CFE_SB_Unsubscribe(MsgId, TestPipe1));
 
-    EVTCNT(10);
+    EVTCNT(7);
 
     EVTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+    EVTSENT(CFE_SB_SUBSCRIPTION_REMOVED_EID);
 
     TEARDOWN(CFE_SB_DeletePipe(TestPipe1));
     TEARDOWN(CFE_SB_DeletePipe(TestPipe2));
@@ -2705,9 +2723,10 @@ void Test_Unsubscribe_MiddleDestWithMany(void)
 
     ASSERT(CFE_SB_Unsubscribe(MsgId, TestPipe2));
 
-    EVTCNT(10);
+    EVTCNT(7);
 
     EVTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+    EVTSENT(CFE_SB_SUBSCRIPTION_REMOVED_EID);
 
     TEARDOWN(CFE_SB_DeletePipe(TestPipe1));
     TEARDOWN(CFE_SB_DeletePipe(TestPipe2));
@@ -2737,9 +2756,10 @@ void Test_Unsubscribe_GetDestPtr(void)
     RouteId = CFE_SBR_GetRouteId(MsgId);
     ASSERT_TRUE(CFE_SB_GetDestPtr(RouteId, TestPipe2) == NULL);
 
-    EVTCNT(7);
+    EVTCNT(5);
 
     EVTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+    EVTSENT(CFE_SB_SUBSCRIPTION_REMOVED_EID);
 
     TEARDOWN(CFE_SB_DeletePipe(TestPipe1));
     TEARDOWN(CFE_SB_DeletePipe(TestPipe2));
@@ -2844,7 +2864,7 @@ void Test_TransmitMsg_BasicSend(void)
 
     ASSERT(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
 
-    EVTCNT(3);
+    EVTCNT(2);
 
     TEARDOWN(CFE_SB_DeletePipe(PipeId));
 
@@ -2901,7 +2921,7 @@ void Test_TransmitMsg_SequenceCount(void)
     ASSERT_EQ(SeqCnt, 2);
     ASSERT_EQ(UT_GetStubCount(UT_KEY(CFE_MSG_SetSequenceCount)), 2);
 
-    EVTCNT(3);
+    EVTCNT(2);
     EVTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
     SETUP(CFE_SB_Unsubscribe(MsgId, PipeId)); /* should have no subscribers now */
@@ -2946,7 +2966,7 @@ void Test_TransmitMsg_QueuePutError(void)
 
     ASSERT(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
 
-    EVTCNT(5);
+    EVTCNT(4);
 
     EVTSENT(CFE_SB_Q_WR_ERR_EID);
 
@@ -2985,7 +3005,7 @@ void Test_TransmitMsg_PipeFull(void)
     /* Pipe overflow causes TransmitMsg to return CFE_SUCCESS */
     ASSERT(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
 
-    EVTCNT(5);
+    EVTCNT(4);
 
     EVTSENT(CFE_SB_Q_FULL_ERR_EID);
 
@@ -3026,7 +3046,7 @@ void Test_TransmitMsg_MsgLimitExceeded(void)
      */
     ASSERT(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
 
-    EVTCNT(5);
+    EVTCNT(4);
 
     EVTSENT(CFE_SB_MSGID_LIM_ERR_EID);
 
@@ -3057,7 +3077,7 @@ void Test_TransmitMsg_GetPoolBufErr(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetPoolBuf), 1, CFE_ES_ERR_MEM_BLOCK_SIZE);
     ASSERT_EQ(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true), CFE_SB_BUF_ALOC_ERR);
 
-    EVTCNT(4);
+    EVTCNT(3);
 
     EVTSENT(CFE_SB_GET_BUF_ERR_EID);
 
@@ -3162,7 +3182,7 @@ void Test_TransmitBuffer_IncrementSeqCnt(void)
 
     ASSERT_EQ(SeqCnt, 1);
 
-    EVTCNT(3);
+    EVTCNT(2);
 
     EVTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
@@ -3214,7 +3234,7 @@ void Test_TransmitBuffer_NoIncrement(void)
     ASSERT_TRUE(SendPtr == ReceivePtr);
     ASSERT_EQ(SeqCnt, 22);
 
-    EVTCNT(3);
+    EVTCNT(2);
 
     EVTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
@@ -3302,7 +3322,7 @@ void Test_TransmitMsg_DisabledDestination(void)
 
     ASSERT(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
 
-    EVTCNT(3);
+    EVTCNT(2);
 
     EVTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
@@ -3318,11 +3338,11 @@ void Test_TransmitBufferFull(void)
     CFE_SB_PipeId_t   PipeId;
     CFE_SB_MsgId_t    MsgId = SB_UT_TLM_MID;
     CFE_SB_BufferD_t  SBBufD;
-    CFE_MSG_Message_t Msg;
+    CFE_SB_Buffer_t   MsgBuf;
     int32             PipeDepth;
     CFE_SBR_RouteId_t RouteId;
 
-    SBBufD.Buffer = &Msg;
+    SBBufD.Buffer = &MsgBuf;
     PipeDepth = 2;
     SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "TestPipe"));
     SETUP(CFE_SB_Subscribe(MsgId, PipeId));
@@ -3331,7 +3351,7 @@ void Test_TransmitBufferFull(void)
 
     ASSERT(CFE_SB_TransmitBufferFull(&SBBufD, RouteId, MsgId));
 
-    EVTCNT(3);
+    EVTCNT(2);
 
     TEARDOWN(CFE_SB_DeletePipe(PipeId));
 
@@ -3408,9 +3428,7 @@ void Test_ReceiveBuffer_API(void)
 void Test_ReceiveBuffer_InvalidPipeId(void)
 {
     CFE_SB_Buffer_t   *SBBufPtr;
-    CFE_SB_PipeId_t    InvalidPipeId = 20;
-
-    CFE_SB.PipeTbl[InvalidPipeId].InUse = CFE_SB_NOT_IN_USE;
+    CFE_SB_PipeId_t    InvalidPipeId = SB_UT_ALTERNATE_INVALID_PIPEID;
 
     ASSERT_EQ(CFE_SB_ReceiveBuffer(&SBBufPtr, InvalidPipeId, CFE_SB_POLL), CFE_SB_BAD_ARGUMENT);
 
@@ -3500,7 +3518,7 @@ void Test_ReceiveBuffer_PipeReadError(void)
     UT_SetDeferredRetcode(UT_KEY(OS_QueueGet), 1, OS_ERROR);
     ASSERT_EQ(CFE_SB_ReceiveBuffer(&SBBufPtr, PipeId, CFE_SB_PEND_FOREVER), CFE_SB_PIPE_RD_ERR);
 
-    EVTCNT(3);
+    EVTCNT(2);
 
     EVTSENT(CFE_SB_Q_RD_ERR_EID);
 
@@ -3517,7 +3535,6 @@ void Test_ReceiveBuffer_PendForever(void)
     CFE_SB_MsgId_t     MsgId = SB_UT_TLM_MID;
     CFE_SB_PipeId_t    PipeId;
     SB_UT_Test_Tlm_t   TlmPkt;
-    CFE_SB_PipeD_t    *PipeDscPtr;
     uint32             PipeDepth = 10;
     CFE_MSG_Type_t     Type = CFE_MSG_Type_Tlm;
     CFE_MSG_Size_t     Size = sizeof(TlmPkt);
@@ -3533,14 +3550,10 @@ void Test_ReceiveBuffer_PendForever(void)
   
     ASSERT_TRUE(SBBufPtr != NULL);
 
-    EVTCNT(3);
+    EVTCNT(2);
 
     EVTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
-    PipeDscPtr = CFE_SB_GetPipePtr(PipeId);
-    PipeDscPtr->ToTrashBuff = PipeDscPtr->CurrentBuff;
-    PipeDscPtr->CurrentBuff = NULL;
-    
     TEARDOWN(CFE_SB_DeletePipe(PipeId));
 
 } /* end Test_ReceiveBuffer_PendForever */
@@ -3562,7 +3575,7 @@ void Test_CleanupApp_API(void)
     CFE_SB_ZeroCopyGetPtr(PipeDepth, &ZeroCpyBufHndl);
 
     /* Set second application ID to provide complete branch path coverage */
-    CFE_SB.PipeTbl[1].InUse = CFE_SB_IN_USE;
+    CFE_SB.PipeTbl[1].PipeId = SB_UT_PIPEID_1;
     CFE_SB.PipeTbl[1].AppId = AppID;
 
     ASSERT_TRUE(CFE_SB.ZeroCopyTail != NULL);
@@ -3577,7 +3590,7 @@ void Test_CleanupApp_API(void)
 
     ASSERT_TRUE(CFE_SB.ZeroCopyTail == NULL);
 
-    EVTCNT(3);
+    EVTCNT(2);
 
     EVTSENT(CFE_SB_PIPE_ADDED_EID);
 
@@ -3792,7 +3805,6 @@ void Test_SB_SpecialCases(void)
     SB_UT_ADD_SUBTEST(Test_OS_MutSem_ErrLogic);
     SB_UT_ADD_SUBTEST(Test_ReqToSendEvent_ErrLogic);
     SB_UT_ADD_SUBTEST(Test_PutDestBlk_ErrLogic);
-    SB_UT_ADD_SUBTEST(Test_CFE_SB_GetPipeIdx);
     SB_UT_ADD_SUBTEST(Test_CFE_SB_Buffers);
     SB_UT_ADD_SUBTEST(Test_CFE_SB_BadPipeInfo);
     SB_UT_ADD_SUBTEST(Test_SB_TransmitMsgPaths_Nominal);
@@ -3819,7 +3831,7 @@ void Test_OS_MutSem_ErrLogic(void)
 
     ASSERT(CFE_SB_Subscribe(MsgId, PipeId));
 
-    EVTCNT(3);
+    EVTCNT(2);
 
     EVTSENT(CFE_SB_PIPE_ADDED_EID);
     EVTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
@@ -3863,19 +3875,6 @@ void Test_PutDestBlk_ErrLogic(void)
     EVTCNT(0);
 
 } /* end Test_PutDestBlk_ErrLogic */
-
-/*
-** Test internal function to get the pipe table index for the given pipe ID
-*/
-void Test_CFE_SB_GetPipeIdx(void)
-{
-    CFE_SB.PipeTbl[0].PipeId = 0;
-    CFE_SB.PipeTbl[0].InUse = CFE_SB_NOT_IN_USE;
-    ASSERT_EQ(CFE_SB_GetPipeIdx(0), CFE_SB_INVALID_PIPE);
-
-    EVTCNT(0);
-
-} /* end Test_CFE_SB_GetPipeIdx */
 
 /*
 ** Test functions that involve a buffer in the SB buffer pool
@@ -3923,6 +3922,7 @@ void Test_CFE_SB_Buffers(void)
 void Test_CFE_SB_BadPipeInfo(void)
 {
     CFE_SB_PipeId_t PipeId;
+    CFE_SB_PipeD_t  *PipeDscPtr;
     uint16          PipeDepth = 10;
     CFE_SB_Qos_t    CFE_SB_Default_Qos;
     CFE_ES_ResourceID_t AppID;
@@ -3930,17 +3930,17 @@ void Test_CFE_SB_BadPipeInfo(void)
     SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "TestPipe1"));
 
     /* Set the pipe ID to an erroneous value and attempt to delete the pipe */
-    CFE_SB.PipeTbl[0].PipeId = 1;
-    CFE_SB.PipeTbl[0].InUse = 1;
+    PipeDscPtr = CFE_SB_LocatePipeDescByID(PipeId);
+    PipeDscPtr->PipeId = SB_UT_PIPEID_1;
     CFE_ES_GetAppID(&AppID);
-    ASSERT_EQ(CFE_SB_DeletePipeFull(0, AppID), CFE_SB_BAD_ARGUMENT);
+    ASSERT_EQ(CFE_SB_DeletePipeFull(SB_UT_PIPEID_0, AppID), CFE_SB_BAD_ARGUMENT);
 
     EVTCNT(2);
 
     /* Reset the pipe ID and delete the pipe */
-    CFE_SB.PipeTbl[0].PipeId = 0;
+    PipeDscPtr->PipeId = PipeId;
 
-    ASSERT_EQ(CFE_SB_SubscribeFull(SB_UT_FIRST_VALID_MID ,0, CFE_SB_Default_Qos,
+    ASSERT_EQ(CFE_SB_SubscribeFull(SB_UT_FIRST_VALID_MID , PipeId, CFE_SB_Default_Qos,
                                   CFE_PLATFORM_SB_DEFAULT_MSG_LIMIT, 2), CFE_SB_BAD_ARGUMENT);
 
     EVTCNT(4);
@@ -4101,7 +4101,7 @@ void Test_SB_TransmitMsgPaths_FullErr(void)
 
     ASSERT_TRUE(!UT_EventIsInHistory(CFE_SB_Q_FULL_ERR_EID_BIT));
 
-    EVTCNT(3);
+    EVTCNT(2);
 
     TEARDOWN(CFE_SB_DeletePipe(PipeId));
 } /* end Test_SB_TransmitMsgPaths */
@@ -4135,7 +4135,7 @@ void Test_SB_TransmitMsgPaths_WriteErr(void)
 
     ASSERT(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
 
-    EVTCNT(3);
+    EVTCNT(2);
 
     ASSERT_TRUE(!UT_EventIsInHistory(CFE_SB_Q_WR_ERR_EID));
 
@@ -4198,9 +4198,10 @@ void Test_ReceiveBuffer_UnsubResubPath(void)
 
     ASSERT_TRUE(SBBufPtr != NULL);
 
-    EVTCNT(6);
+    EVTCNT(4);
 
     EVTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+    EVTSENT(CFE_SB_SUBSCRIPTION_REMOVED_EID);
 
     TEARDOWN(CFE_SB_DeletePipe(PipeId));
 

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -3659,9 +3659,49 @@ void Test_CFE_SB_MsgHdrSize(void)
 void Test_CFE_SB_GetUserData(void)
 {
     CFE_MSG_Message_t msg;
-    uint8            *ExpAdrReturned;
+    uint8            *expected;
     bool              hassec;
     CFE_MSG_Type_t    type = CFE_MSG_Type_Invalid;
+    struct
+    {
+        CFE_MSG_CommandHeader_t cmd;
+        uint8                   payload;
+    } cmd_uint8;
+    struct
+    {
+        CFE_MSG_CommandHeader_t cmd;
+        uint16                  payload;
+    } cmd_uint16;
+    struct
+    {
+        CFE_MSG_CommandHeader_t cmd;
+        uint32                  payload;
+    } cmd_uint32;
+    struct
+    {
+        CFE_MSG_CommandHeader_t cmd;
+        uint64                  payload;
+    } cmd_uint64;
+    struct
+    {
+        CFE_MSG_TelemetryHeader_t tlm;
+        uint8           payload;
+    } tlm_uint8;
+    struct
+    {
+        CFE_MSG_TelemetryHeader_t tlm;
+        uint16          payload;
+    } tlm_uint16;
+    struct
+    {
+        CFE_MSG_TelemetryHeader_t tlm;
+        uint32          payload;
+    } tlm_uint32;
+    struct
+    {
+        CFE_MSG_TelemetryHeader_t tlm;
+        uint64          payload;
+    } tlm_uint64;
 
     /* No secondary */
     hassec = false;
@@ -3669,9 +3709,39 @@ void Test_CFE_SB_GetUserData(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
 
     /* Expected return */
-    ExpAdrReturned = (uint8 *)&msg + sizeof(CCSDS_SpacePacket_t);
+    expected = (uint8 *)&msg + sizeof(CCSDS_SpacePacket_t);
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&msg), expected);
 
-    ASSERT_TRUE(CFE_SB_GetUserData(&msg) == ExpAdrReturned);
+    /* Commands */
+    hassec = true;
+    type = CFE_MSG_Type_Cmd;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&cmd_uint8.cmd.Msg), &(cmd_uint8.payload));
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&cmd_uint16.cmd.Msg), &(cmd_uint16.payload));
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&cmd_uint32.cmd.Msg), &(cmd_uint32.payload));
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&cmd_uint64.cmd.Msg), &(cmd_uint64.payload));
+
+    /* Telemetry */
+    type = CFE_MSG_Type_Tlm;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&tlm_uint8.tlm.Msg), &(tlm_uint8.payload));
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&tlm_uint16.tlm.Msg), &(tlm_uint16.payload));
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&tlm_uint32.tlm.Msg), &(tlm_uint32.payload));
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&tlm_uint64.tlm.Msg), &(tlm_uint64.payload));
 
 } /* end Test_CFE_SB_GetUserData */
 

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -221,7 +221,8 @@ void Test_SB_AppInit_EVSSendEvtFail(void)
      * path with different app/task names is followed on at least one event.
      */
     memset(&TestTaskInfo, 0, sizeof(TestTaskInfo));
-    strncpy((char*)TestTaskInfo.TaskName, "test", sizeof(TestTaskInfo.TaskName)-1);
+    strncpy(TestTaskInfo.TaskName, "test", sizeof(TestTaskInfo.TaskName)-1);
+    TestTaskInfo.TaskName[sizeof(TestTaskInfo.TaskName)-1] = '\0';
     UT_SetDataBuffer(UT_KEY(CFE_ES_GetTaskInfo), &TestTaskInfo, sizeof(TestTaskInfo), false);
 
     /* There are three events prior to init, pipe created (1) and subscription
@@ -508,7 +509,7 @@ void Test_SB_Cmds_RoutingInfoDef(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    strncpy((char *)SendRoutingInfo.Cmd.Payload.Filename, "", sizeof(SendRoutingInfo.Cmd.Payload.Filename));
+    SendRoutingInfo.Cmd.Payload.Filename[0] = '\0';
 
     /* Make some routing info by calling CFE_SB_AppInit */
     SETUP(CFE_SB_AppInit());
@@ -546,8 +547,9 @@ void Test_SB_Cmds_RoutingInfoSpec(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    strncpy((char *)SendRoutingInfo.Cmd.Payload.Filename, "RoutingTstFile",
-            sizeof(SendRoutingInfo.Cmd.Payload.Filename));
+    strncpy(SendRoutingInfo.Cmd.Payload.Filename, "RoutingTstFile",
+            sizeof(SendRoutingInfo.Cmd.Payload.Filename) - 1);
+    SendRoutingInfo.Cmd.Payload.Filename[sizeof(SendRoutingInfo.Cmd.Payload.Filename) - 1] = '\0';
 
     CFE_SB_ProcessCmdPipePkt(&SendRoutingInfo.SBBuf);
 
@@ -574,8 +576,9 @@ void Test_SB_Cmds_RoutingInfoCreateFail(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    strncpy((char *)SendRoutingInfo.Cmd.Payload.Filename, "RoutingTstFile",
-            sizeof(SendRoutingInfo.Cmd.Payload.Filename));
+    strncpy(SendRoutingInfo.Cmd.Payload.Filename, "RoutingTstFile",
+            sizeof(SendRoutingInfo.Cmd.Payload.Filename) - 1);
+    SendRoutingInfo.Cmd.Payload.Filename[sizeof(SendRoutingInfo.Cmd.Payload.Filename) - 1] = '\0';
 
     /* Make function CFE_SB_SendRtgInfo return CFE_SB_FILE_IO_ERR */
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
@@ -651,7 +654,7 @@ void Test_SB_Cmds_PipeInfoDef(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    strncpy((char *)SendPipeInfo.Cmd.Payload.Filename, "", sizeof(SendPipeInfo.Cmd.Payload.Filename));
+    SendPipeInfo.Cmd.Payload.Filename[0] = '\0';
 
     /* Create some pipe info */
     SETUP(CFE_SB_CreatePipe(&PipeId1, PipeDepth, "TestPipe1"));
@@ -688,8 +691,10 @@ void Test_SB_Cmds_PipeInfoSpec(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    strncpy((char *)SendPipeInfo.Cmd.Payload.Filename, "PipeTstFile",
-            sizeof(SendPipeInfo.Cmd.Payload.Filename));
+    strncpy(SendPipeInfo.Cmd.Payload.Filename, "PipeTstFile",
+            sizeof(SendPipeInfo.Cmd.Payload.Filename) - 1);
+    SendPipeInfo.Cmd.Payload.Filename[sizeof(SendPipeInfo.Cmd.Payload.Filename) - 1] = '\0';
+
     CFE_SB_ProcessCmdPipePkt(&SendPipeInfo.SBBuf);
 
     EVTCNT(1);
@@ -783,7 +788,7 @@ void Test_SB_Cmds_MapInfoDef(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    strncpy((char *)SendMapInfo.Cmd.Payload.Filename, "", sizeof(SendMapInfo.Cmd.Payload.Filename));
+    SendMapInfo.Cmd.Payload.Filename[0] = '\0';
 
     /* Create some map info */
     SETUP(CFE_SB_CreatePipe(&PipeId1, PipeDepth, "TestPipe1"));
@@ -830,8 +835,9 @@ void Test_SB_Cmds_MapInfoSpec(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    strncpy((char *)SendMapInfo.Cmd.Payload.Filename, "MapTstFile",
-            sizeof(SendMapInfo.Cmd.Payload.Filename));
+    strncpy(SendMapInfo.Cmd.Payload.Filename, "MapTstFile",
+            sizeof(SendMapInfo.Cmd.Payload.Filename) - 1);
+    SendMapInfo.Cmd.Payload.Filename[sizeof(SendMapInfo.Cmd.Payload.Filename) - 1] = '\0';
 
     CFE_SB_ProcessCmdPipePkt(&SendMapInfo.SBBuf);
 
@@ -1679,15 +1685,15 @@ void Test_CreatePipe_MaxPipes(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_ResourceID_ToIndex), 1+CFE_PLATFORM_SB_MAX_PIPES, -1);
     for (i = 0; i < (CFE_PLATFORM_SB_MAX_PIPES + 1); i++)
     {
-        snprintf(PipeName, OS_MAX_API_NAME, "TestPipe%ld", (long) i);
+        snprintf(PipeName, sizeof(PipeName), "TestPipe%ld", (long) i);
 
         if (i < CFE_PLATFORM_SB_MAX_PIPES)
         {
-        	SETUP(CFE_SB_CreatePipe(&PipeIdReturned[i], PipeDepth, &PipeName[0]));
+            SETUP(CFE_SB_CreatePipe(&PipeIdReturned[i], PipeDepth, PipeName));
         }
         else
         {
-        	ASSERT_EQ(CFE_SB_CreatePipe(&PipeIdReturned[i], PipeDepth, &PipeName[0]), CFE_SB_MAX_PIPES_MET);
+            ASSERT_EQ(CFE_SB_CreatePipe(&PipeIdReturned[i], PipeDepth, PipeName), CFE_SB_MAX_PIPES_MET);
         }
     }
 
@@ -1907,7 +1913,7 @@ void Test_GetPipeName_InvalidId(void)
     SETUP(CFE_SB_CreatePipe(&PipeId, 4, "TestPipe"));
 
     UT_SetDeferredRetcode(UT_KEY(OS_GetResourceName), 1, OS_ERROR);
-    ASSERT_EQ(CFE_SB_GetPipeName(PipeName, OS_MAX_API_NAME, PipeId), CFE_SB_BAD_ARGUMENT);
+    ASSERT_EQ(CFE_SB_GetPipeName(PipeName, sizeof(PipeName), PipeId), CFE_SB_BAD_ARGUMENT);
 
     EVTSENT(CFE_SB_GETPIPENAME_ID_ERR_EID);
 
@@ -1934,7 +1940,7 @@ void Test_GetPipeName(void)
         &queue_info, sizeof(queue_info),
         false);
 
-    ASSERT(CFE_SB_GetPipeName(PipeName, OS_MAX_API_NAME, PipeId));
+    ASSERT(CFE_SB_GetPipeName(PipeName, sizeof(PipeName), PipeId));
 
     EVTSENT(CFE_SB_GETPIPENAME_EID);
 
@@ -2273,8 +2279,8 @@ void Test_Subscribe_MaxDestCount(void)
     /* Create pipes */
     for (i = 0; i < CFE_PLATFORM_SB_MAX_DEST_PER_PKT + 1; i++)
     {
-        snprintf(PipeName, OS_MAX_API_NAME, "TestPipe%ld", (long) i);
-        SETUP(CFE_SB_CreatePipe(&PipeId[i], PipeDepth, &PipeName[0]));
+        snprintf(PipeName, sizeof(PipeName), "TestPipe%ld", (long) i);
+        SETUP(CFE_SB_CreatePipe(&PipeId[i], PipeDepth, PipeName));
     }
 
     /* Do subscriptions */

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -155,8 +155,6 @@ void UtTest_Setup(void)
 */
 void SB_ResetUnitTest(void)
 {
-    /* If any sockets were left open then report and close them */
-    UT_CheckForOpenSockets();
     UT_InitData();
     CFE_SB_EarlyInit();
 } /* end SB_ResetUnitTest */

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -3946,7 +3946,6 @@ void Test_SB_TransmitMsgPaths_Nominal(void)
     MsgId = SB_UT_CMD_MID;
     Size = sizeof(TlmPkt);
     Type = CFE_MSG_Type_Cmd;
-    CFE_SB.SenderReporting = 0;
     SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "TestPipe"));
 
     /* Will fail because of deferred CFE_ES_GetPoolBuf failure return */

--- a/fsw/cfe-core/unit-test/sb_UT.h
+++ b/fsw/cfe-core/unit-test/sb_UT.h
@@ -2442,23 +2442,6 @@ void Test_PutDestBlk_ErrLogic(void);
 
 /*****************************************************************************/
 /**
-** \brief Test internal function to get the pipe table index for the given pipe
-**        ID
-**
-** \par Description
-**        This function tests the internal function to get the pipe table index
-**        for the given pipe ID when the ID is not in use.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-******************************************************************************/
-void Test_CFE_SB_GetPipeIdx(void);
-
-/*****************************************************************************/
-/**
 ** \brief Test functions that involve a buffer in the SB buffer pool
 **
 ** \par Description

--- a/fsw/cfe-core/unit-test/tbl_UT.c
+++ b/fsw/cfe-core/unit-test/tbl_UT.c
@@ -463,7 +463,8 @@ void Test_CFE_TBL_DeleteCDSCmd(void)
     /* Test successfully finding the table name in the table registry */
     UT_InitData();
     strncpy(DelCDSCmd.Payload.TableName, "0",
-            sizeof(DelCDSCmd.Payload.TableName));
+            sizeof(DelCDSCmd.Payload.TableName) - 1);
+    DelCDSCmd.Payload.TableName[sizeof(DelCDSCmd.Payload.TableName) - 1] = '\0';
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DeleteCDSCmd(&DelCDSCmd) ==
                                        CFE_TBL_INC_ERR_CTR,
@@ -481,7 +482,8 @@ void Test_CFE_TBL_DeleteCDSCmd(void)
     }
 
     strncpy(DelCDSCmd.Payload.TableName, "-1", 
-        sizeof(DelCDSCmd.Payload.TableName));
+        sizeof(DelCDSCmd.Payload.TableName) - 1);
+    DelCDSCmd.Payload.TableName[sizeof(DelCDSCmd.Payload.TableName) - 1] = '\0';
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DeleteCDSCmd(&DelCDSCmd) ==
                                        CFE_TBL_INC_ERR_CTR,
@@ -554,8 +556,9 @@ void Test_CFE_TBL_TlmRegCmd(void)
     /* Registry[0].Name used because it is confirmed to be a registered
      * table name
      */
-    strncpy((char *)TlmRegCmd.Payload.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(TlmRegCmd.Payload.TableName));
+    strncpy(TlmRegCmd.Payload.TableName, CFE_TBL_TaskData.Registry[0].Name,
+            sizeof(TlmRegCmd.Payload.TableName) - 1);
+    TlmRegCmd.Payload.TableName[sizeof(TlmRegCmd.Payload.TableName) - 1] = '\0';
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_SendRegistryCmd(&TlmRegCmd) ==
                 CFE_TBL_INC_CMD_CTR,
@@ -590,8 +593,9 @@ void Test_CFE_TBL_AbortLoadCmd(void)
     /* Entering the if statement with a table name that has to be in
      * the registry
      */
-    strncpy((char *)AbortLdCmd.Payload.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(AbortLdCmd.Payload.TableName));
+    strncpy(AbortLdCmd.Payload.TableName, CFE_TBL_TaskData.Registry[0].Name,
+            sizeof(AbortLdCmd.Payload.TableName) - 1);
+    AbortLdCmd.Payload.TableName[sizeof(AbortLdCmd.Payload.TableName) - 1] = '\0';
     CFE_TBL_TaskData.Registry[0].LoadInProgress = 1;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_AbortLoadCmd(&AbortLdCmd) ==
@@ -658,7 +662,8 @@ void Test_CFE_TBL_ActivateCmd(void)
 
     /* Enter the if statement with a table name that is in the registry */
     strncpy(ActivateCmd.Payload.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(ActivateCmd.Payload.TableName));
+            sizeof(ActivateCmd.Payload.TableName) - 1);
+    ActivateCmd.Payload.TableName[sizeof(ActivateCmd.Payload.TableName) - 1] = '\0';
 
     /* Test when table name exists, but attempts to activate a dump-only
      * table
@@ -852,8 +857,9 @@ void Test_CFE_TBL_ValidateCmd(void)
      * have been requested
      */
     UT_InitData();
-    strncpy((char *)ValidateCmd.Payload.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(ValidateCmd.Payload.TableName));
+    strncpy(ValidateCmd.Payload.TableName, CFE_TBL_TaskData.Registry[0].Name,
+            sizeof(ValidateCmd.Payload.TableName) - 1);
+    ValidateCmd.Payload.TableName[sizeof(ValidateCmd.Payload.TableName) - 1] = '\0';
     ValidateCmd.Payload.ActiveTableFlag = CFE_TBL_BufferSelect_ACTIVE;
     CFE_TBL_TaskData.Registry[0].
       Buffers[CFE_TBL_TaskData.Registry[0].ActiveBufferIndex].
@@ -1152,8 +1158,7 @@ void Test_CFE_TBL_DumpRegCmd(void)
 
     /* Test with an error creating the dump file */
     UT_InitData();
-    strncpy((char *)DumpRegCmd.Payload.DumpFilename, "",
-            sizeof(DumpRegCmd.Payload.DumpFilename));
+    DumpRegCmd.Payload.DumpFilename[0] = '\0';
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DumpRegistryCmd(&DumpRegCmd) ==
@@ -1215,7 +1220,8 @@ void Test_CFE_TBL_DumpRegCmd(void)
 
     /* Test using the default dump file name */
     UT_InitData();
-    strcpy(DumpRegCmd.Payload.DumpFilename, "X");
+    strncpy(DumpRegCmd.Payload.DumpFilename, "X", sizeof(DumpRegCmd.Payload.DumpFilename) - 1);
+    DumpRegCmd.Payload.DumpFilename[sizeof(DumpRegCmd.Payload.DumpFilename) - 1] = '\0';
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DumpRegistryCmd(&DumpRegCmd) ==
                 CFE_TBL_INC_CMD_CTR,
@@ -1257,11 +1263,12 @@ void Test_CFE_TBL_DumpCmd(void)
      */
     UT_InitData();
     strncpy(CFE_TBL_TaskData.Registry[2].Name, "DumpCmdTest",
-            CFE_TBL_MAX_FULL_NAME_LEN);
-    CFE_TBL_TaskData.Registry[2].Name[CFE_TBL_MAX_FULL_NAME_LEN - 1] = '\0';
+            sizeof(CFE_TBL_TaskData.Registry[2].Name) - 1);
+    CFE_TBL_TaskData.Registry[2].Name[sizeof(CFE_TBL_TaskData.Registry[2].Name) - 1] = '\0';
     CFE_TBL_TaskData.Registry[2].OwnerAppId = AppID;
     strncpy(DumpCmd.Payload.TableName, CFE_TBL_TaskData.Registry[2].Name,
-            sizeof(DumpCmd.Payload.TableName));
+            sizeof(DumpCmd.Payload.TableName) - 1);
+    DumpCmd.Payload.TableName[sizeof(DumpCmd.Payload.TableName) - 1] = '\0';
     DumpCmd.Payload.ActiveTableFlag = CFE_TBL_BufferSelect_ACTIVE;
     CFE_TBL_TaskData.Registry[2].Buffers[CFE_TBL_TaskData.Registry[2].ActiveBufferIndex].BufferPtr = BuffPtr;
 
@@ -1357,7 +1364,8 @@ void Test_CFE_TBL_DumpCmd(void)
     CFE_TBL_TaskData.LoadBuffs[CFE_TBL_TaskData.Registry[2].LoadInProgress].BufferPtr = BuffPtr;
     CFE_TBL_TaskData.Registry[2].DumpOnly = false;
     strncpy(DumpCmd.Payload.DumpFilename, CFE_TBL_TaskData.Registry[2].LastFileLoaded,
-            sizeof(DumpCmd.Payload.DumpFilename));
+            sizeof(DumpCmd.Payload.DumpFilename) - 1);
+    DumpCmd.Payload.DumpFilename[sizeof(DumpCmd.Payload.DumpFilename) - 1] = '\0';
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DumpCmd(&DumpCmd) ==
                 CFE_TBL_INC_CMD_CTR,
@@ -1422,8 +1430,9 @@ void Test_CFE_TBL_LoadCmd(void)
 
     /* Test response to inability to open file */
     UT_InitData();
-    strncpy((char *)LoadCmd.Payload.LoadFilename, "LoadFileName",
-            sizeof(LoadCmd.Payload.LoadFilename));
+    strncpy(LoadCmd.Payload.LoadFilename, "LoadFileName",
+            sizeof(LoadCmd.Payload.LoadFilename) - 1);
+    LoadCmd.Payload.LoadFilename[sizeof(LoadCmd.Payload.LoadFilename) - 1] = '\0';
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_LoadCmd(&LoadCmd) ==
@@ -1440,10 +1449,11 @@ void Test_CFE_TBL_LoadCmd(void)
         CFE_TBL_TaskData.Registry[i].LoadPending = false;
     }
 
-    strncpy((char *)TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     strncpy(StdFileHeader.Description, "FS header description",
-            sizeof(StdFileHeader.Description));
+            sizeof(StdFileHeader.Description) - 1);
     StdFileHeader.Description[sizeof(StdFileHeader.Description) - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
@@ -1510,8 +1520,9 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(CFE_TBL_File_Hdr_t));
 
     UT_SetDeferredRetcode(UT_KEY(OS_read), 3, 0);
-    strncpy((char *)TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UT_Report(__FILE__, __LINE__,
@@ -1529,8 +1540,9 @@ void Test_CFE_TBL_LoadCmd(void)
         CFE_TBL_ByteSwapUint32(&TblFileHeader.NumBytes);
     }
 
-    strncpy((char *)TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetDeferredRetcode(UT_KEY(OS_read), 2, 0);
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
@@ -1552,8 +1564,9 @@ void Test_CFE_TBL_LoadCmd(void)
         CFE_TBL_TaskData.LoadBuffs[j].Taken = true;
     }
 
-    strncpy((char *)TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UT_Report(__FILE__, __LINE__,
@@ -1567,8 +1580,9 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(CFE_TBL_File_Hdr_t));
 
     CFE_TBL_TaskData.Registry[0].Size = sizeof(CFE_TBL_File_Hdr_t) - 1;
-    strncpy((char *)TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UT_Report(__FILE__, __LINE__,
@@ -1581,8 +1595,9 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_InitData();
     UT_TBL_SetupHeader(&TblFileHeader, 0, 0);
 
-    strncpy((char *)TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UT_Report(__FILE__, __LINE__,
@@ -1600,8 +1615,9 @@ void Test_CFE_TBL_LoadCmd(void)
     CFE_TBL_TaskData.Registry[0].TableLoadedOnce = false;
 
     CFE_TBL_TaskData.Registry[0].Size = sizeof(CFE_TBL_File_Hdr_t);
-    strncpy((char *)TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UT_Report(__FILE__, __LINE__,
@@ -1621,7 +1637,8 @@ void Test_CFE_TBL_LoadCmd(void)
 
     CFE_TBL_TaskData.Registry[0].Size = sizeof(CFE_TBL_File_Hdr_t);
     strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
-            sizeof(TblFileHeader.TableName));
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UT_Report(__FILE__, __LINE__,
@@ -1634,7 +1651,8 @@ void Test_CFE_TBL_LoadCmd(void)
     /* Test response to inability to read the file header */
     UT_InitData();
     strncpy(LoadCmd.Payload.LoadFilename, "LoadFileName",
-            sizeof(LoadCmd.Payload.LoadFilename));
+            sizeof(LoadCmd.Payload.LoadFilename) - 1);
+    LoadCmd.Payload.LoadFilename[sizeof(LoadCmd.Payload.LoadFilename) - 1] = '\0';
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_ReadHeader), 1, sizeof(CFE_FS_Header_t) - 1);
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_LoadCmd(&LoadCmd) ==
@@ -1665,8 +1683,8 @@ void Test_CFE_TBL_HousekeepingCmd(void)
      */
     UT_InitData();
     strncpy(CFE_TBL_TaskData.DumpControlBlocks[0].TableName,
-           "housekeepingtest", CFE_TBL_MAX_FULL_NAME_LEN);
-    CFE_TBL_TaskData.DumpControlBlocks[0].TableName[CFE_TBL_MAX_FULL_NAME_LEN - 1] = '\0';
+           "housekeepingtest", sizeof(CFE_TBL_TaskData.DumpControlBlocks[0].TableName) - 1);
+    CFE_TBL_TaskData.DumpControlBlocks[0].TableName[sizeof(CFE_TBL_TaskData.DumpControlBlocks[0].TableName) - 1] = '\0';
     CFE_TBL_TaskData.DumpControlBlocks[0].Size = 10;
     LoadInProg = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
     RegRecPtr.LoadInProgress = LoadInProg;
@@ -1676,8 +1694,8 @@ void Test_CFE_TBL_HousekeepingCmd(void)
     DumpBuffPtr->BufferPtr = BuffPtr;
     DumpBuffPtr->FileCreateTimeSecs = Secs;
     DumpBuffPtr->FileCreateTimeSubSecs = SubSecs;
-    strncpy(DumpBuffPtr->DataSource, "hkSource", OS_MAX_PATH_LEN);
-    DumpBuffPtr->DataSource[OS_MAX_PATH_LEN - 1] = '\0';
+    strncpy(DumpBuffPtr->DataSource, "hkSource", sizeof(DumpBuffPtr->DataSource) - 1);
+    DumpBuffPtr->DataSource[sizeof(DumpBuffPtr->DataSource) - 1] = '\0';
     CFE_TBL_TaskData.DumpControlBlocks[0].DumpBufferPtr = DumpBuffPtr;
     CFE_TBL_TaskData.DumpControlBlocks[0].State = CFE_TBL_DUMP_PERFORMED;
 
@@ -2521,11 +2539,13 @@ void Test_CFE_TBL_Share(void)
     /* Test successful first load of a table */
     UT_InitData();
     strncpy(StdFileHeader.Description, "FS header description",
-            sizeof(StdFileHeader.Description));
+            sizeof(StdFileHeader.Description) - 1);
+    StdFileHeader.Description[sizeof(StdFileHeader.Description) - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table4",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table4",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
 
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
@@ -2703,11 +2723,13 @@ void Test_CFE_TBL_Load(void)
     /* Test attempt to perform partial INITIAL load */
     UT_InitData();
     strncpy(StdFileHeader.Description,"Test description",
-            sizeof(StdFileHeader.Description));
+            sizeof(StdFileHeader.Description) - 1);
+    StdFileHeader.Description[sizeof(StdFileHeader.Description) - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 1, sizeof(UT_Table1_t)-1);
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -2749,11 +2771,13 @@ void Test_CFE_TBL_Load(void)
      */
     UT_InitData();
     strncpy(StdFileHeader.Description,"Test description",
-            sizeof(StdFileHeader.Description));
+            sizeof(StdFileHeader.Description) - 1);
+    StdFileHeader.Description[sizeof(StdFileHeader.Description) - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.NotUT_Table1",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.NotUT_Table1",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -2790,11 +2814,13 @@ void Test_CFE_TBL_Load(void)
      */
     UT_InitData();
     strncpy(StdFileHeader.Description,"Test description",
-            sizeof(StdFileHeader.Description));
+            sizeof(StdFileHeader.Description) - 1);
+    StdFileHeader.Description[sizeof(StdFileHeader.Description) - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
     strncpy(TblFileHeader.TableName, "ut_cfe_tbl.NotUT_Table1",
-            sizeof(TblFileHeader.TableName));
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -3257,7 +3283,8 @@ void Test_CFE_TBL_Manage(void)
     CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
     CFE_TBL_TaskData.ValidationResults[0].Result = 0;
     strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table1", CFE_TBL_MAX_FULL_NAME_LEN);
+            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
+    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
     CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
     CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = false;
     RegRecPtr->ValidateInactiveIndex = 0;
@@ -3283,7 +3310,8 @@ void Test_CFE_TBL_Manage(void)
     CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
     CFE_TBL_TaskData.ValidationResults[0].Result = 0;
     strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table1", CFE_TBL_MAX_FULL_NAME_LEN);
+            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
+    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
     CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
     CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = false;
     RegRecPtr->ValidateInactiveIndex = 0;
@@ -3309,7 +3337,8 @@ void Test_CFE_TBL_Manage(void)
     CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
     CFE_TBL_TaskData.ValidationResults[0].Result = 1;
     strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table1", CFE_TBL_MAX_FULL_NAME_LEN);
+            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
+    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
     CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
     CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = false;
     RegRecPtr->ValidateInactiveIndex = 0;
@@ -3335,7 +3364,8 @@ void Test_CFE_TBL_Manage(void)
     CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
     CFE_TBL_TaskData.ValidationResults[0].Result = 0;
     strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table1", CFE_TBL_MAX_FULL_NAME_LEN);
+            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
+    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
     CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
     CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = true;
     RegRecPtr->ValidateActiveIndex = 0;
@@ -3361,7 +3391,8 @@ void Test_CFE_TBL_Manage(void)
     CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
     CFE_TBL_TaskData.ValidationResults[0].Result = 0;
     strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table1", CFE_TBL_MAX_FULL_NAME_LEN);
+            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
+    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
     CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
     CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = true;
     RegRecPtr->ValidateActiveIndex = 0;
@@ -3387,7 +3418,8 @@ void Test_CFE_TBL_Manage(void)
     CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
     CFE_TBL_TaskData.ValidationResults[0].Result = 1;
     strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table1", CFE_TBL_MAX_FULL_NAME_LEN);
+            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
+    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
     CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
     CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = true;
     RegRecPtr->ValidateActiveIndex = 0;
@@ -3504,7 +3536,8 @@ void Test_CFE_TBL_Manage(void)
     CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
     CFE_TBL_TaskData.ValidationResults[0].Result = 0;
     strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table2", CFE_TBL_MAX_FULL_NAME_LEN);
+            "ut_cfe_tbl.UT_Table2", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
+    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
     CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
     CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = false;
     RegRecPtr->ValidateInactiveIndex = 0;
@@ -3530,7 +3563,8 @@ void Test_CFE_TBL_Manage(void)
     CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
     CFE_TBL_TaskData.ValidationResults[0].Result = 1;
     strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table2", CFE_TBL_MAX_FULL_NAME_LEN);
+            "ut_cfe_tbl.UT_Table2", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
+    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
     CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
     CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = false;
     RegRecPtr->ValidateInactiveIndex = 0;
@@ -3556,7 +3590,8 @@ void Test_CFE_TBL_Manage(void)
     CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
     CFE_TBL_TaskData.ValidationResults[0].Result = 0;
     strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table2", CFE_TBL_MAX_FULL_NAME_LEN);
+            "ut_cfe_tbl.UT_Table2", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
+    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
     CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
     CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = true;
     RegRecPtr->ValidateActiveIndex = 0;
@@ -3582,7 +3617,8 @@ void Test_CFE_TBL_Manage(void)
     CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
     CFE_TBL_TaskData.ValidationResults[0].Result = 1;
     strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table2", CFE_TBL_MAX_FULL_NAME_LEN);
+            "ut_cfe_tbl.UT_Table2", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
+    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
     CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
     CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = true;
     RegRecPtr->ValidateActiveIndex = 0;
@@ -3609,14 +3645,13 @@ void Test_CFE_TBL_Manage(void)
      * later
      */
     CFE_TBL_TaskData.DumpControlBlocks[0].DumpBufferPtr = WorkingBufferPtr;
-    strncpy(CFE_TBL_TaskData.DumpControlBlocks[0].
-                     DumpBufferPtr->DataSource,
-                   "MyDumpFilename", OS_MAX_PATH_LEN-1);
-    CFE_TBL_TaskData.DumpControlBlocks[0].
-                         DumpBufferPtr->DataSource[OS_MAX_PATH_LEN-1] = 0;
-    strncpy(CFE_TBL_TaskData.DumpControlBlocks[0].TableName,
-                   "ut_cfe_tbl.UT_Table2", CFE_TBL_MAX_FULL_NAME_LEN-1);
-    CFE_TBL_TaskData.DumpControlBlocks[0].TableName[CFE_TBL_MAX_FULL_NAME_LEN-1] = 0;
+    strncpy(CFE_TBL_TaskData.DumpControlBlocks[0].DumpBufferPtr->DataSource,
+            "MyDumpFilename", sizeof(CFE_TBL_TaskData.DumpControlBlocks[0].DumpBufferPtr->DataSource) - 1);
+    CFE_TBL_TaskData.DumpControlBlocks[0].DumpBufferPtr->DataSource[
+            sizeof(CFE_TBL_TaskData.DumpControlBlocks[0].DumpBufferPtr->DataSource) - 1] = 0;
+    strncpy(CFE_TBL_TaskData.DumpControlBlocks[0].TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(CFE_TBL_TaskData.DumpControlBlocks[0].TableName) - 1);
+    CFE_TBL_TaskData.DumpControlBlocks[0].TableName[sizeof(CFE_TBL_TaskData.DumpControlBlocks[0].TableName) - 1] = 0;
     CFE_TBL_TaskData.DumpControlBlocks[0].Size = RegRecPtr->Size;
     RegRecPtr->DumpControlIndex = 0;
     RtnCode = CFE_TBL_Manage(App1TblHandle2);
@@ -3794,13 +3829,15 @@ void Test_CFE_TBL_TblMod(void)
 
     /* Configure for successful file read to initialize table */
     strncpy(FileHeader.Description, "FS header description",
-            sizeof(FileHeader.Description));
+            sizeof(FileHeader.Description) - 1);
+    FileHeader.Description[sizeof(FileHeader.Description) - 1] = '\0';
     FileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     FileHeader.SubType = CFE_FS_SubType_TBL_IMG;
     FileHeader.TimeSeconds = 1704;
     FileHeader.TimeSubSeconds = 104;
-    strncpy((char *)File.TblHeader.TableName, "ut_cfe_tbl.UT_Table1",
-            sizeof(File.TblHeader.TableName));
+    strncpy(File.TblHeader.TableName, "ut_cfe_tbl.UT_Table1",
+            sizeof(File.TblHeader.TableName) - 1);
+    File.TblHeader.TableName[sizeof(File.TblHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&File.TblHeader, 0, sizeof(UT_Table1_t));
 
     if (UT_Endianess == UT_LITTLE_ENDIAN)
@@ -3878,13 +3915,15 @@ void Test_CFE_TBL_TblMod(void)
 
     /* Configure for successful file read to initialize table */
     strncpy(FileHeader.Description, "FS header description",
-            sizeof(FileHeader.Description));
+            sizeof(FileHeader.Description) - 1);
+    FileHeader.Description[sizeof(FileHeader.Description) - 1] = '\0';
     FileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     FileHeader.SubType = CFE_FS_SubType_TBL_IMG;
     FileHeader.TimeSeconds = 1704;
     FileHeader.TimeSubSeconds = 104;
-    strncpy((char *)File.TblHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(File.TblHeader.TableName));
+    strncpy(File.TblHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(File.TblHeader.TableName) - 1);
+    File.TblHeader.TableName[sizeof(File.TblHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&File.TblHeader, 0, sizeof(UT_Table1_t));
 
     File.TblData.TblElement1 = 0x04030201;
@@ -3894,33 +3933,29 @@ void Test_CFE_TBL_TblMod(void)
     UT_SetDeferredRetcode(UT_KEY(OS_read), 3, 0);
 
     /* Perform load with extra long filename */
-    for (Index = 0; Index < OS_MAX_PATH_LEN - 1; Index++)
+    for (Index = 0; Index < sizeof(MyFilename) - 1; Index++)
     {
         MyFilename[Index] = 'a';
     }
+    MyFilename[sizeof(MyFilename) - 1] = '\0';
 
-    MyFilename[(OS_MAX_PATH_LEN - 1)] = '\0';
-    RtnCode = CFE_TBL_Load(App1TblHandle1, CFE_TBL_SRC_FILE, MyFilename);
-    EventsCorrect = (UT_GetNumEventsSent() == 1 &&
-                     UT_EventIsInHistory(CFE_TBL_LOAD_SUCCESS_INF_EID) ==
-                         true);
+    ASSERT(CFE_TBL_Load(App1TblHandle1, CFE_TBL_SRC_FILE, MyFilename));
+    ASSERT_EQ(UT_GetNumEventsSent(), 1);
+    ASSERT_TRUE(UT_EventIsInHistory(CFE_TBL_LOAD_SUCCESS_INF_EID));
 
     /* Notify Table Services that the table has been modified */
-    RtnCode = CFE_TBL_Modified(App1TblHandle1);
-    RtnCode2 = CFE_TBL_GetInfo(&TblInfo1, "ut_cfe_tbl.UT_Table2");
-    UT_Report(__FILE__, __LINE__,
-              RtnCode == CFE_SUCCESS &&
-              RtnCode2 == CFE_SUCCESS &&
-              EventsCorrect &&
-              TblInfo1.TimeOfLastUpdate.Seconds ==
-                  TblInfo1.TimeOfLastUpdate.Subseconds &&
-              strncmp(TblInfo1.LastFileLoaded,
-                      MyFilename, OS_MAX_PATH_LEN - 4) == 0 &&
-              strncmp(&TblInfo1.LastFileLoaded[OS_MAX_PATH_LEN - 4],
-                      "(*)", 3) == 0,
-              "CFE_TBL_Modified",
-              "Add TBL API for notifying table services that table has "
-                "been updated by application");
+    ASSERT(CFE_TBL_Modified(App1TblHandle1));
+    ASSERT(CFE_TBL_GetInfo(&TblInfo1, "ut_cfe_tbl.UT_Table2"));
+    ASSERT_EQ(TblInfo1.TimeOfLastUpdate.Seconds, TblInfo1.TimeOfLastUpdate.Subseconds);
+
+    /*
+     * LastFileLoaded (limited by mission) can be bigger than MyFilename (limited by osal),
+     * need to adjust length of check to account for difference and modified marking
+     */
+    UtAssert_StrnCmp(TblInfo1.LastFileLoaded, MyFilename, sizeof(MyFilename) - 4, "%s == %s, %ld",
+                     TblInfo1.LastFileLoaded, MyFilename, (long)sizeof(MyFilename) - 4);
+    UtAssert_StrCmp(&TblInfo1.LastFileLoaded[sizeof(MyFilename) - 4], "(*)", "%s == (*)",
+                    &TblInfo1.LastFileLoaded[sizeof(MyFilename) - 4]);
 
     /* Test response to an invalid handle */
     RtnCode = CFE_TBL_Modified(CFE_TBL_BAD_TABLE_HANDLE);
@@ -3940,7 +3975,8 @@ void Test_CFE_TBL_Internal(void)
     CFE_TBL_LoadBuff_t         *WorkingBufferPtr;
     CFE_TBL_RegistryRec_t      *RegRecPtr;
     CFE_TBL_AccessDescriptor_t *AccessDescPtr;
-    char                       Filename[OS_MAX_PATH_LEN + 10];
+    char                       FilenameLong[OS_MAX_PATH_LEN + 10];
+    char                       Filename[OS_MAX_PATH_LEN];
     int32                      i;
     CFE_FS_Header_t            StdFileHeader;
     CFE_TBL_File_Hdr_t         TblFileHeader;
@@ -3973,8 +4009,8 @@ void Test_CFE_TBL_Internal(void)
     AccessDescPtr = &CFE_TBL_TaskData.Handles[App1TblHandle2];
     RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
     strncpy(RegRecPtr->Name, "ut_cfe_tbl.UT_Table3",
-            CFE_TBL_MAX_FULL_NAME_LEN);
-    RegRecPtr->Name[CFE_TBL_MAX_FULL_NAME_LEN - 1] = '\0';
+            sizeof(RegRecPtr->Name) - 1);
+    RegRecPtr->Name[sizeof(RegRecPtr->Name) - 1] = '\0';
     RegRecPtr->TableLoadedOnce = false;
     RegRecPtr->LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
     RtnCode = CFE_TBL_GetWorkingBuffer(&WorkingBufferPtr, RegRecPtr, true);
@@ -4003,13 +4039,13 @@ void Test_CFE_TBL_Internal(void)
     /* Test CFE_TBL_LoadFromFile response to a file name that is too long */
     UT_InitData();
 
-    for (i = 0; i < OS_MAX_PATH_LEN + 9; i++)
+    for (i = 0; i < sizeof(FilenameLong) - 1; i++)
     {
-        Filename[i] = 'a';
+        FilenameLong[i] = 'a';
     }
+    FilenameLong[i] = '\0'; /* Null terminate file name string */
 
-    Filename[i] = '\0'; /* Null terminate file name string */
-    RtnCode = CFE_TBL_LoadFromFile("UT", WorkingBufferPtr, RegRecPtr, Filename);
+    RtnCode = CFE_TBL_LoadFromFile("UT", WorkingBufferPtr, RegRecPtr, FilenameLong);
     EventsCorrect = (UT_EventIsInHistory(CFE_TBL_LOAD_FILENAME_LONG_ERR_EID) == true &&
         UT_GetNumEventsSent() == 1);
     UT_Report(__FILE__, __LINE__,
@@ -4021,14 +4057,16 @@ void Test_CFE_TBL_Internal(void)
      * (according to the header)
      */
     UT_InitData();
-    Filename[OS_MAX_PATH_LEN - 1] = '\0';
+    strncpy(Filename, FilenameLong, sizeof(Filename) - 1);
+    Filename[sizeof(Filename) - 1] = '\0';
     strncpy(StdFileHeader.Description, "FS header description",
-            sizeof(StdFileHeader.Description));
-    StdFileHeader.Description[CFE_FS_HDR_DESC_MAX_LEN - 1] = '\0';
+            sizeof(StdFileHeader.Description) - 1);
+    StdFileHeader.Description[sizeof(StdFileHeader.Description) - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 1, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4045,11 +4083,11 @@ void Test_CFE_TBL_Internal(void)
      * (too much content)
      */
     UT_InitData();
-    Filename[OS_MAX_PATH_LEN - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4067,13 +4105,13 @@ void Test_CFE_TBL_Internal(void)
      * incomplete
      */
     UT_InitData();
-    Filename[OS_MAX_PATH_LEN - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
-//
+
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UT_SetDeferredRetcode(UT_KEY(OS_read), 2, sizeof(UT_Table1_t) - 1);
@@ -4090,11 +4128,11 @@ void Test_CFE_TBL_Internal(void)
      * wrong table
      */
     UT_InitData();
-    Filename[OS_MAX_PATH_LEN - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.NotUT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.NotUT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4110,11 +4148,11 @@ void Test_CFE_TBL_Internal(void)
 
     /* Test CFE_TBL_LoadFromFile response to an OS open error */
     UT_InitData();
-    Filename[OS_MAX_PATH_LEN - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4130,11 +4168,11 @@ void Test_CFE_TBL_Internal(void)
 
     /* Test CFE_TBL_LoadFromFile response to a file too short warning */
     UT_InitData();
-    Filename[OS_MAX_PATH_LEN - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t)-1);
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4151,16 +4189,16 @@ void Test_CFE_TBL_Internal(void)
      * file header
      */
     UT_InitData();
-    Filename[OS_MAX_PATH_LEN - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t)-1);
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
-    strncpy(Filename, "MyTestInputFilename", sizeof(Filename));
+    strncpy(Filename, "MyTestInputFilename", sizeof(Filename) - 1);
     Filename[sizeof(Filename) - 1] = '\0';
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_ReadHeader), 1, sizeof(CFE_FS_Header_t) - 1);
     RtnCode = CFE_TBL_ReadHeaders(FileDescriptor, &StdFileHeader,
@@ -4177,11 +4215,11 @@ void Test_CFE_TBL_Internal(void)
      * standard header
      */
     UT_InitData();
-    Filename[OS_MAX_PATH_LEN - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID - 1;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     TblFileHeader.NumBytes = sizeof(UT_Table1_t) - 1;
     TblFileHeader.Offset = 0;
 
@@ -4204,11 +4242,11 @@ void Test_CFE_TBL_Internal(void)
 
     /* Test CFE_TBL_ReadHeaders response to a wrong cFE file subtype */
     UT_InitData();
-    Filename[OS_MAX_PATH_LEN - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG - 1;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t)-1);
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4227,11 +4265,11 @@ void Test_CFE_TBL_Internal(void)
      * table header
      */
     UT_InitData();
-    Filename[OS_MAX_PATH_LEN - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t)-1);
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4370,8 +4408,9 @@ void Test_CFE_TBL_Internal(void)
     UT_InitData();
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4391,8 +4430,9 @@ void Test_CFE_TBL_Internal(void)
     UT_InitData();
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4412,8 +4452,9 @@ void Test_CFE_TBL_Internal(void)
     UT_InitData();
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4433,8 +4474,9 @@ void Test_CFE_TBL_Internal(void)
     UT_InitData();
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4457,8 +4499,9 @@ void Test_CFE_TBL_Internal(void)
     UT_InitData();
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4497,8 +4540,9 @@ void Test_CFE_TBL_Internal(void)
     UT_ClearEventHistory();
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4538,8 +4582,9 @@ void Test_CFE_TBL_Internal(void)
     UT_ClearEventHistory();
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4581,8 +4626,9 @@ void Test_CFE_TBL_Internal(void)
     UT_ClearEventHistory();
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4655,8 +4701,9 @@ void Test_CFE_TBL_Internal(void)
     UT_InitData();
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
-    strncpy((char *)TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(TblFileHeader.TableName));
+    strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(UT_Table1_t));
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -4816,13 +4863,13 @@ void Test_CFE_TBL_Internal(void)
 #if (CFE_PLATFORM_TBL_VALID_SCID_COUNT > 0)
     /* Test CFE_TBL_ReadHeaders response to an invalid spacecraft ID */
     UT_InitData();
-    Filename[OS_MAX_PATH_LEN - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
     StdFileHeader.SpacecraftID = -1;
     StdFileHeader.ProcessorID = CFE_PLATFORM_TBL_VALID_PRID_1;
     strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
-            sizeof(TblFileHeader.TableName));
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     TblFileHeader.NumBytes = sizeof(UT_Table1_t) - 1;
     TblFileHeader.Offset = 0;
 
@@ -4834,7 +4881,7 @@ void Test_CFE_TBL_Internal(void)
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
-    strncpy(Filename, "MyTestInputFilename", sizeof(Filename));
+    strncpy(Filename, "MyTestInputFilename", sizeof(Filename) - 1);
     Filename[sizeof(Filename) - 1] = '\0';
     RtnCode = CFE_TBL_ReadHeaders(FileDescriptor, &StdFileHeader,
                                   &TblFileHeader, Filename);
@@ -4855,13 +4902,13 @@ void Test_CFE_TBL_Internal(void)
 #if (CFE_PLATFORM_TBL_VALID_PRID_COUNT > 0)
     /* Test CFE_TBL_ReadHeaders response to an invalid processor ID */
     UT_InitData();
-    Filename[OS_MAX_PATH_LEN - 1] = '\0';
     StdFileHeader.ContentType = CFE_FS_FILE_CONTENT_ID;
     StdFileHeader.SubType = CFE_FS_SubType_TBL_IMG;
     StdFileHeader.SpacecraftID = CFE_PLATFORM_TBL_VALID_SCID_1;
     StdFileHeader.ProcessorID = -1;
     strncpy(TblFileHeader.TableName, "ut_cfe_tbl.UT_Table1",
-            sizeof(TblFileHeader.TableName));
+            sizeof(TblFileHeader.TableName) - 1);
+    TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     TblFileHeader.NumBytes = sizeof(UT_Table1_t) - 1;
     TblFileHeader.Offset = 0;
 
@@ -4873,7 +4920,7 @@ void Test_CFE_TBL_Internal(void)
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
-    strncpy(Filename, "MyTestInputFilename", sizeof(Filename));
+    strncpy(Filename, "MyTestInputFilename", sizeof(Filename) - 1);
     Filename[sizeof(Filename) - 1] = '\0';
     RtnCode = CFE_TBL_ReadHeaders(FileDescriptor, &StdFileHeader,
                                   &TblFileHeader, Filename);

--- a/fsw/cfe-core/unit-test/tbl_UT.c
+++ b/fsw/cfe-core/unit-test/tbl_UT.c
@@ -2807,7 +2807,7 @@ void Test_CFE_TBL_Load(void)
     RtnCode = CFE_TBL_Load(App1TblHandle2,
                            CFE_TBL_SRC_FILE,
                            "TblSrcFileName.dat");
-    EventsCorrect = (UT_EventIsInHistory(CFE_SUCCESS) == true &&
+    EventsCorrect = (UT_EventIsInHistory(CFE_TBL_LOAD_TBLNAME_MISMATCH_ERR_EID) == true &&
                      UT_GetNumEventsSent() == 1);
     UT_Report(__FILE__, __LINE__,
               RtnCode == CFE_TBL_ERR_FILE_FOR_WRONG_TABLE && EventsCorrect,
@@ -2846,7 +2846,7 @@ void Test_CFE_TBL_Load(void)
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(Test_CFE_TBL_ValidationFunc), 1, -1);
     RtnCode = CFE_TBL_Load(App1TblHandle1, CFE_TBL_SRC_ADDRESS, &TestTable1);
-    EventsCorrect = (UT_EventIsInHistory(CFE_SUCCESS) == true &&
+    EventsCorrect = (UT_EventIsInHistory(CFE_TBL_VALIDATION_ERR_EID) == true &&
                      UT_GetNumEventsSent() == 1);
     UT_Report(__FILE__, __LINE__,
               RtnCode == -1 && EventsCorrect,
@@ -2859,7 +2859,7 @@ void Test_CFE_TBL_Load(void)
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(Test_CFE_TBL_ValidationFunc), 1, 1);
     RtnCode = CFE_TBL_Load(App1TblHandle1, CFE_TBL_SRC_ADDRESS, &TestTable1);
-    EventsCorrect = (UT_EventIsInHistory(CFE_SUCCESS) == true &&
+    EventsCorrect = (UT_EventIsInHistory(CFE_TBL_LOAD_VAL_ERR_EID) == true &&
                      UT_GetNumEventsSent() == 2);
     UT_Report(__FILE__, __LINE__,
               RtnCode == -1 && EventsCorrect,

--- a/fsw/cfe-core/unit-test/ut_osprintf_stubs.c
+++ b/fsw/cfe-core/unit-test/ut_osprintf_stubs.c
@@ -162,5 +162,7 @@ const char *UT_OSP_MESSAGES[] =
         [UT_OSP_RECORD_USED] = "ES Startup: Error: ES_TaskTable slot for ID %lx in use at task creation!\n",
         /* CFE_ES_ExitChildTask called from invalid task context */
         [UT_OSP_TASKEXIT_BAD_CONTEXT] = "CFE_ES_ExitChildTask called from invalid task context\n",
+        [UT_OSP_BACKGROUND_REGISTER] = "CFE_ES: Background Task Failed to register: %08lx\n",
+        [UT_OSP_BACKGROUND_TAKE] = "CFE_ES: Failed to take background sem: %08lx\n",
 };
 

--- a/fsw/cfe-core/unit-test/ut_osprintf_stubs.h
+++ b/fsw/cfe-core/unit-test/ut_osprintf_stubs.h
@@ -96,6 +96,8 @@
 #define UT_OSP_STARTUP_SYNC_FAIL_2        67
 #define UT_OSP_MODULE_UNLOAD_FAILED       68
 #define UT_OSP_TASKEXIT_BAD_CONTEXT       69
+#define UT_OSP_BACKGROUND_REGISTER        70
+#define UT_OSP_BACKGROUND_TAKE            71
 
 #endif
 

--- a/fsw/cfe-core/unit-test/ut_support.c
+++ b/fsw/cfe-core/unit-test/ut_support.c
@@ -398,6 +398,7 @@ static bool UT_CheckEventHistoryFromFunc(UT_EntryKey_t Func, uint16 EventIDToSea
     UT_GetDataBuffer(Func, (void**)&EvBuf, &MaxSize, &Position);
     if (EvBuf != NULL && MaxSize > 0)
     {
+        Position /= sizeof(*EvBuf);
         while (Position > 0)
         {
             if (*EvBuf == EventIDToSearchFor)

--- a/fsw/cfe-core/unit-test/ut_support.c
+++ b/fsw/cfe-core/unit-test/ut_support.c
@@ -295,7 +295,7 @@ void UT_SetStatusBSPResetArea(int32 status, uint32 Signature, uint32 ClockSignal
     }
     else
     {
-        UT_ClearForceFail(UT_KEY(CFE_PSP_GetResetArea));
+        UT_ClearDefaultReturnValue(UT_KEY(CFE_PSP_GetResetArea));
     }
 }
 

--- a/fsw/cfe-core/unit-test/ut_support.h
+++ b/fsw/cfe-core/unit-test/ut_support.h
@@ -573,23 +573,6 @@ void UT_DisplayPkt(CFE_MSG_Message_t *MsgPtr, size_t size);
 
 /*****************************************************************************/
 /**
-** \brief Report and close any sockets found open
-**
-** \par Description
-**        Determine if any sockets are open; if so, close them.  If UT_VERBOSE
-**        is defined then output the socket status to the test log file.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-**
-******************************************************************************/
-void UT_CheckForOpenSockets(void);
-
-/*****************************************************************************/
-/**
 ** \brief Gets a reference to the CFE ES Reset Data Object
 **
 ** \par Description

--- a/fsw/cfe-core/ut-stubs/ut_es_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_es_stubs.c
@@ -416,6 +416,21 @@ int32 CFE_ES_WriteToSysLog(const char *SpecStringPtr, ...)
 
     int32   status;
     va_list va;
+    char    str[128];
+    char   *newline;
+
+    va_start(va,SpecStringPtr);
+    vsnprintf(str, sizeof(str), SpecStringPtr, va);
+
+    /* Replace newline since UtDebug already adds one */
+    newline = strchr(str, '\n');
+    if (newline != NULL)
+    {
+        *newline = '\0';
+    }
+
+    UtDebug("CFE_ES_WriteToSysLog: %s", str);
+    va_end(va);
 
     va_start(va,SpecStringPtr);
     status = UT_DEFAULT_IMPL_VARARGS(CFE_ES_WriteToSysLog, va);

--- a/fsw/cfe-core/ut-stubs/ut_es_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_es_stubs.c
@@ -1320,3 +1320,49 @@ int32 CFE_ES_TaskID_ToIndex(CFE_ES_ResourceID_t TaskID, uint32 *Idx)
 
     return return_code;
 }
+
+CFE_ES_ResourceID_t CFE_ES_FindNextAvailableId(CFE_ES_ResourceID_t StartId, uint32 TableSize, bool (*CheckFunc)(CFE_ES_ResourceID_t))
+{
+    UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_FindNextAvailableId), StartId);
+    UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_FindNextAvailableId), TableSize);
+    UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_FindNextAvailableId), CheckFunc);
+
+    int32 return_code;
+
+    /* Using "1" by default here produces a sequential result when called multiple times */
+    return_code = UT_DEFAULT_IMPL_RC(CFE_ES_FindNextAvailableId, 1);
+
+    if (return_code < 0)
+    {
+        return CFE_ES_RESOURCEID_UNDEFINED;
+    }
+
+    /*
+     * The test case may set the return code to indicate the offset from the start ID 
+     */
+    return CFE_ES_ResourceID_FromInteger(CFE_ES_ResourceID_ToInteger(StartId) + return_code);
+}
+
+int32 CFE_ES_ResourceID_ToIndex(uint32 Serial, uint32 TableSize, uint32 *Idx)
+{
+    UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_ResourceID_ToIndex), Serial);
+    UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_ResourceID_ToIndex), TableSize);
+    UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_ES_ResourceID_ToIndex), Idx);
+
+    int32 return_code;
+
+    return_code = UT_DEFAULT_IMPL(CFE_ES_ResourceID_ToIndex);
+
+    if (return_code < 0)
+    {
+        /* fill with a very bad value that should cause a problem if used */
+        *Idx = 0xDEADBEEF;
+    }
+    else if (UT_Stub_CopyToLocal(UT_KEY(CFE_ES_ResourceID_ToIndex), Idx, sizeof(*Idx)) < sizeof(*Idx))
+    {
+        /* fill with default value if unspecified by test case */
+        *Idx = Serial % TableSize;
+    }
+
+    return return_code;
+}

--- a/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
@@ -289,7 +289,7 @@ int32 CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *PipeName)
         else
         {
             status = CFE_SB_BAD_ARGUMENT;
-            *PipeIdPtr = 0;
+            *PipeIdPtr = CFE_SB_INVALID_PIPE;
         }
     }
 

--- a/modules/msg/mission_inc/default_cfe_msg_hdr_pri.h
+++ b/modules/msg/mission_inc/default_cfe_msg_hdr_pri.h
@@ -82,6 +82,7 @@ typedef struct
 
     CFE_MSG_Message_t                  Msg; /**< \brief Base message */
     CFE_MSG_TelemetrySecondaryHeader_t Sec; /**< \brief Secondary header */
+    uint8                              Spare[4]; /**< \brief Padding to end on 64 bit boundary */
 
 } CFE_MSG_TelemetryHeader_t;
 

--- a/modules/msg/mission_inc/default_cfe_msg_hdr_priext.h
+++ b/modules/msg/mission_inc/default_cfe_msg_hdr_priext.h
@@ -72,6 +72,7 @@ typedef struct
 
     CFE_MSG_Message_t                Msg; /**< \brief Base message */
     CFE_MSG_CommandSecondaryHeader_t Sec; /**< \brief Secondary header */
+    uint8                            Spare[4]; /**< /brief Padding to end on 64 bit boundary */
 
 } CFE_MSG_CommandHeader_t;
 


### PR DESCRIPTION
**Describe the contribution**

Fix #1074, Refactor CFE_TIME_RegisterSynchCallback
Fix #449, Add OS_printf to CFE_ES_SYSLOG_APPEND
Fix #488, Pad msg headers to 64 bit
Fix #903, Add CFE_SB_GetUserData padding check
Fix #877, Remove duplicate CFE_MISSION_REV define
Fix #901, Remove UT_CheckForOpenSockets references
Fix #904, Update cpuname targets.cmake documentation
Fix #1090, UT event check bounds
Fix #1052, Refactor UT_ClearForceFail to UT_ClearDefaultReturnValue
Fix #1068, Create Security Policy
Fix #933, Remove SenderReporting from SB global
Fix #985, globalize "resource ID" definitions
Fix #1073, refactor SB API for proper global locks
Fix #945, Finish CFE_PLATFORM_ES_PERF_MAX_IDS removal
Fix #954, Handle debug events in unit test
Fix #955, Remove OS_printf stub count checks in UT
Fix #1089, Cleanup strncpy use - unit tests
Fix #1089, Cleanup strncpy use - main code
Fix #932, Update UT for CFE_MISSION* string sizing
Fix #1134, Add UtDebug output to CFE_ES_WriteToSysLog stub

**Testing performed**
See https://github.com/nasa/cFS/pull/177/checks

**Expected behavior changes**

PR #1048 - Documentation: Add Security.md with instructions to report vulnerability

PR #1086 - Documentation: Update cpuname/MISSION_CPUNAMES documentation

PR #1091 - Fixes `UT_CheckEventHistoryFromFunc()` helper routine to read the correct number of IDs so it checks the correct number of events. Also correct bad event checks in TBL UT.

PR #1076 - Adds `OS_printf` to `CFE_ES_SYSLOG_APPEND` so it matches `CFE_ES_WriteToSysLog`

PR #1099 - Removes unused `SenderReporting` and `CFE_PLATFORM_SB_DEFAULT_REPORT_SENDER`

PR #1106 - Tests pass when debug events are enabled via `CFE_PLATFORM_EVS_DEFAULT_TYPE_FLAG` in platform config.

PR #1085 - Removes references to `UT_CheckForOpenSockets` which is no longer applicable since the UT framework resets the state for each unit test.

PR #1053 - Rename `UT_ClearForceFail` as `UT_ClearDefaultValue` given change in https://github.com/nasa/osal/issues/724

PR #905 - Adds checks that ensure `CFE_SB_GetUserData` works with all payload data types.

PR #1077

 - Adds header padding to 64-bit so that `CFE_SB_GetUserData` will work for message structures with elements up to 64 bit
  - For primary-only header config: telemetry header required to 64 bit boundary (affects all receivers)
  - For primary and extended header config: command header required padding to 64 bit boundary (affects all senders)

PR #1075 - Refactor `CFE_TIME_RegisterSynchCallback` to only have one return point and eliminates "possible uninitialized variable" static analysis warning

PR #1092 - None of these changes are expected to cause problematic.

- Addresses message delivery issues due to inconsistent locking by reworking cFE-SB API implementation. Ensures all events are generated and counters are incremented consistently by avoiding early returns in functions and using the `PendingEventID` register to record what event ID should be sent per the current operation.

- Employs the `CFE_ES_ResourceID_t` type and related patterns for managing the SB Pipe IDs.  In particular this (intentionally) makes it not possible 

- Will break code which directly accessed these items without going through the lookup function.

- **`CFE_SB_PipeId_t` type is no longer usable as a direct array index**, increased in size from 8 to 32 bits, and is now consistent with all other ID types in both behavior and size. 

- **The "pipe stats" structure in the Pipe TLM is also changed**. This structure contained a `CFE_SB_PipeId_t` value, hence why it had to be updated because the type is now bigger. The spare bytes are also moved to the end of the struct.

PR #1107 - Removes `OS_printf` checks of stub calls in unit tests and checks for specific format string in history instead to confirm the right path was taken.

PR #1084 - Removes `CFE_MISSION_REV` from platform config.

PR #1104 - Removes the rest of the references and uses of `CFE_PLATFORM_ES_PERF_MAX_IDS` in favor of `CFE_MISSION_ES_PERF_MAX_IDS`

PR #1098 

- Remove uses of strncpy and other minor hardcoded references
- Cleanup unit tests to reflect size changes in `CFE_MISSION_MAX_API_LEN` and `CFE_MISSION_MAX_PATH_LEN`. 
- Moved ES pipe name and lengths to defines 
- Removed PipeName and PipeDepth variables from app global
- Removed unnecessary (char *) casts
- Simplified `&stingname[0]` to `stringname` where observed
- Enables projects that have OSs with different limits to maintain a standard cmd/tlm and have unit tests pass.

PR #1135 - Make `CFE_ES_WriteToSysLog` stub unit test more informative by adding `UtDebug` output


**System(s) tested on**
Ubuntu 18.04

**Additional context**
Part of https://github.com/nasa/cFS/pull/177

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
@skliper 
@zanzaben 
@ArielSAdamsNASA 
@jphickey 