### PR TITLE
Fix #996, Remove CFE_PLATFORM_SB_MAX_PIPE_DEPTH in favor of OS_QUEUE_MAX_DEPTH

### DIFF
--- a/cmake/sample_defs/cpu1_platform_cfg.h
+++ b/cmake/sample_defs/cpu1_platform_cfg.h
@@ -130,24 +130,6 @@
 */
 #define CFE_PLATFORM_SB_BUF_MEMORY_BYTES         524288
 
-
-/**
-**  \cfesbcfg Maximum depth allowed when creating an SB pipe
-**
-**  \par Description:
-**       The value of this constant dictates the maximum pipe depth that an
-**       application may request. The pipe depth is given as a paramter in the
-**       #CFE_SB_CreatePipe API.
-**
-**  \par Limits
-**       This parameter has a lower limit of 1.  There are no restrictions on the
-**       upper limit however, the maximum pipe depth is system dependent and should
-**       be verified.  Pipe Depth values that are checked against this configuration
-**       are defined by a 16 bit data word.
-*/
-#define CFE_PLATFORM_SB_MAX_PIPE_DEPTH           256
-
-
 /**
 **  \cfesbcfg Highest Valid Message Id
 **

--- a/fsw/cfe-core/src/inc/cfe_sb_events.h
+++ b/fsw/cfe-core/src/inc/cfe_sb_events.h
@@ -70,7 +70,7 @@
 **
 **  This error event message is issued when the #CFE_SB_CreatePipe API receives a bad
 **  argument. In this case, a bad argument is defined by the following:
-**  A NULL PipeIdPtr, PipeDepth = 0 and PipeDepth > cfg param #CFE_PLATFORM_SB_MAX_PIPE_DEPTH
+**  A NULL PipeIdPtr, PipeDepth = 0 and PipeDepth > maximum pipe depth
 **/
 #define CFE_SB_CR_PIPE_BAD_ARG_EID      2
 

--- a/fsw/cfe-core/src/inc/cfe_sb_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_sb_msg.h
@@ -687,7 +687,7 @@ typedef struct CFE_SB_StatsTlm_Payload {
                                                 \brief Max number of SB message buffers in use */
 
     uint32              MaxPipeDepthAllowed;/**< \cfetlmmnemonic \SB_SMMPDALW
-                                                 \brief cFE Cfg Param \link #CFE_PLATFORM_SB_MAX_PIPE_DEPTH \endlink */
+                                                 \brief Maximum allowed pipe depth */
     CFE_SB_PipeDepthStats_t PipeDepthStats[CFE_MISSION_SB_MAX_PIPES];/**< \cfetlmmnemonic \SB_SMPDS
                                                                   \brief Pipe Depth Statistics #CFE_SB_PipeDepthStats_t*/
 } CFE_SB_StatsTlm_Payload_t;

--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -126,7 +126,7 @@ int32  CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16  Depth, const char *
     CFE_ES_GetTaskID(&TskId);
 
     /* check input parameters */
-    if((PipeIdPtr == NULL) || (Depth > CFE_PLATFORM_SB_MAX_PIPE_DEPTH) || (Depth == 0))
+    if((PipeIdPtr == NULL) || (Depth > OS_QUEUE_MAX_DEPTH) || (Depth == 0))
     {
         PendingEventId = CFE_SB_CR_PIPE_BAD_ARG_EID;
         Status = CFE_SB_BAD_ARGUMENT;
@@ -255,7 +255,7 @@ int32  CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16  Depth, const char *
             case CFE_SB_CR_PIPE_BAD_ARG_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_CR_PIPE_BAD_ARG_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
                     "CreatePipeErr:Bad Input Arg:app=%s,ptr=0x%lx,depth=%d,maxdepth=%d",
-                    CFE_SB_GetAppTskName(TskId,FullName),(unsigned long)PipeIdPtr,(int)Depth,CFE_PLATFORM_SB_MAX_PIPE_DEPTH);
+                    CFE_SB_GetAppTskName(TskId,FullName),(unsigned long)PipeIdPtr,(int)Depth,OS_QUEUE_MAX_DEPTH);
                 break;
 
             case CFE_SB_MAX_PIPES_MET_EID:

--- a/fsw/cfe-core/src/sb/cfe_sb_task.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_task.c
@@ -240,7 +240,7 @@ int32 CFE_SB_AppInit(void){
     CFE_SB.StatTlmMsg.Payload.MaxMsgIdsAllowed = CFE_PLATFORM_SB_MAX_MSG_IDS;
     CFE_SB.StatTlmMsg.Payload.MaxPipesAllowed  = CFE_PLATFORM_SB_MAX_PIPES;
     CFE_SB.StatTlmMsg.Payload.MaxMemAllowed    = CFE_PLATFORM_SB_BUF_MEMORY_BYTES;
-    CFE_SB.StatTlmMsg.Payload.MaxPipeDepthAllowed = CFE_PLATFORM_SB_MAX_PIPE_DEPTH;
+    CFE_SB.StatTlmMsg.Payload.MaxPipeDepthAllowed = OS_QUEUE_MAX_DEPTH;
     CFE_SB.StatTlmMsg.Payload.MaxSubscriptionsAllowed =
                     ((CFE_PLATFORM_SB_MAX_MSG_IDS)*(CFE_PLATFORM_SB_MAX_DEST_PER_PKT));
     

--- a/fsw/cfe-core/src/sb/cfe_sb_verify.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_verify.h
@@ -50,10 +50,6 @@
     #error CFE_PLATFORM_SB_MAX_DEST_PER_PKT cannot be less than 1!
 #endif
 
-#if CFE_PLATFORM_SB_MAX_PIPE_DEPTH < 1
-    #error CFE_PLATFORM_SB_MAX_PIPE_DEPTH cannot be less than 1!
-#endif
-
 #if CFE_PLATFORM_SB_HIGHEST_VALID_MSGID < 1
   #error CFE_PLATFORM_SB_HIGHEST_VALID_MSGID cannot be less than 1!
 #endif

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -1631,20 +1631,17 @@ void Test_CreatePipe_NullPtr(void)
 */
 void Test_CreatePipe_ValPipeDepth(void)
 {
-    CFE_SB_PipeId_t PipeIdReturned[3];
+    CFE_SB_PipeId_t PipeIdReturned[2];
 
-    ASSERT(CFE_SB_CreatePipe(&PipeIdReturned[0], 99, "TestPipe99"));
-    ASSERT(CFE_SB_CreatePipe(&PipeIdReturned[1], 255, "TestPipe255"));
-    ASSERT(CFE_SB_CreatePipe(&PipeIdReturned[2],
-             CFE_PLATFORM_SB_MAX_PIPE_DEPTH, "TestPipeMaxDepth"));
+    ASSERT(CFE_SB_CreatePipe(&PipeIdReturned[0], 1, "TestPipeMin"));
+    ASSERT(CFE_SB_CreatePipe(&PipeIdReturned[1], OS_QUEUE_MAX_DEPTH, "TestPipeMax"));
 
-    EVTCNT(3);
+    EVTCNT(2);
 
     EVTSENT(CFE_SB_PIPE_ADDED_EID);
 
     TEARDOWN(CFE_SB_DeletePipe(PipeIdReturned[0]));
     TEARDOWN(CFE_SB_DeletePipe(PipeIdReturned[1]));
-    TEARDOWN(CFE_SB_DeletePipe(PipeIdReturned[2]));
 
 } /* end Test_CreatePipe_ValPipeDepth */
 
@@ -1659,7 +1656,7 @@ void Test_CreatePipe_InvalPipeDepth(void)
     ASSERT_EQ(CFE_SB_CreatePipe(&PipeIdReturned[0], 0, "TestPipe1"), CFE_SB_BAD_ARGUMENT);
     UT_SetDeferredRetcode(UT_KEY(OS_QueueCreate), 1, OS_SUCCESS);
     ASSERT_EQ(CFE_SB_CreatePipe(&PipeIdReturned[1],
-             CFE_PLATFORM_SB_MAX_PIPE_DEPTH + 1, "TestPipeMaxDepPlus1"), CFE_SB_BAD_ARGUMENT);
+             OS_QUEUE_MAX_DEPTH + 1, "TestPipeMaxDepPlus1"), CFE_SB_BAD_ARGUMENT);
     UT_SetDeferredRetcode(UT_KEY(OS_QueueCreate), 1, OS_SUCCESS);
     ASSERT_EQ(CFE_SB_CreatePipe(&PipeIdReturned[2], 0xffff, "TestPipeffff"), CFE_SB_BAD_ARGUMENT);
 


### PR DESCRIPTION
**Describe the contribution**
Fix #996, Remove CFE_PLATFORM_SB_MAX_PIPE_DEPTH in favor of OS_QUEUE_MAX_DEPTH

**Testing performed**
Built and ran unit tests, passed

**Expected behavior changes**
Depth parameter in command now checked prior to attempting OSAL call

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC