### PR TITLE
Fix #997, Simplify UT_InitData SB setup

### DIFF
--- a/fsw/cfe-core/unit-test/ut_support.c
+++ b/fsw/cfe-core/unit-test/ut_support.c
@@ -154,16 +154,12 @@ void UT_InitData(void)
      * Set up for the CFE_SB_ReceiveBuffer() call.
      *
      * The existing test cases assume that this will return success once,
-     * followed by a timeout response followed by a different error.
+     * followed by a timeout response.
      *
      * Specific test cases may provide an actual message buffer to return for
      * the first call, or they may override this default behavior entirely.
-     *
-     * The default behavior of the CFE_SB_ReceiveBuffer stub is to return success with a zero-ed out
-     * buffer returned to the caller.
      */
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_ReceiveBuffer), 2, CFE_SB_TIME_OUT);
-    UT_SetDeferredRetcode(UT_KEY(CFE_SB_ReceiveBuffer), 3, -1);
 
     /*
      * Set up CFE_ES_GetAppName() and friends


### PR DESCRIPTION
**Describe the contribution**
Fix #997 - Removes confusing and incorrectly implemented deferred return code of -1 for `CFE_SB_ReceiveBuffer` from software bus setup in UT_InitData.

**Testing performed**
Build and run unit tests, passed

**Expected behavior changes**
None in the core since nothing depended on this behavior, anything that did (other apps) should do it correctly.

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC