### PR TITLE
Fix #1110, Remove unimplemented ES prototypes

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_apps.h
+++ b/fsw/cfe-core/src/es/cfe_es_apps.h
@@ -239,17 +239,6 @@ int32 CFE_ES_LoadLibrary(CFE_ES_ResourceID_t *LibraryIdPtr,
                        const char   *LibName);
 
 /*
-** Get Application List
-*/
-int32 CFE_ES_AppGetList(uint32 AppIdArray[], uint32 ArraySize);
-
-/*
-** Dump All application properties to a file
-**  Note: Do we want to specify a file here?
-*/
-int32 CFE_ES_AppDumpAllInfo(void);
-
-/*
 ** Scan the Application Table for actions to take
 */
 bool CFE_ES_RunAppTableScan(uint32 ElapsedTime, void *Arg);


### PR DESCRIPTION
**Describe the contribution**
Fix #1110, removed unimplemented `CFE_ES_AppGetList` and `CFE_ES_AppDumpAllInfo` prototypes

**Testing performed**
Built and ran unit tests, passed.

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC