### PR TITLE
Fix #1071, Initialize Status in CFE_ES_WaitForSystemState

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_api.c
+++ b/fsw/cfe-core/src/es/cfe_es_api.c
@@ -545,7 +545,7 @@ bool CFE_ES_RunLoop(uint32 *RunStatus)
 */
 int32 CFE_ES_WaitForSystemState(uint32 MinSystemState, uint32 TimeOutMilliseconds)
 {
-    int32 Status;
+    int32 Status = CFE_SUCCESS;
     CFE_ES_AppRecord_t *AppRecPtr;
     uint32 RequiredAppState;
     uint32 WaitTime;

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -1142,6 +1142,14 @@ void TestStartupErrorPaths(void)
                                         CFE_ES_AppState_LATE_INIT,
               "CFE_ES_WaitForSystemState",
               "Min System State is CFE_ES_SystemState_APPS_INIT");
+
+    /* Test success */
+    ES_ResetUnitTest();
+    /* This prep is necessary so GetAppId works */
+    ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppType_CORE, NULL, &AppRecPtr, NULL);
+    CFE_ES_Global.SystemState = CFE_ES_SystemState_CORE_READY;
+    ASSERT(CFE_ES_WaitForSystemState(CFE_ES_SystemState_CORE_READY, 0));
+
 }
 
 void TestApps(void)


### PR DESCRIPTION
**Describe the contribution**
Fix #1071 - initializes status in CFE_ES_WaitForSystemState and added missing success test case (would have failed!)

**Testing performed**
Build and run unit tests, passed.  

**Expected behavior changes**
No longer returning uninitialized Status

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC