### PR TITLE
Fix #1069, Resolve mismatched types in SBR throttle

### DIFF
--- a/modules/sbr/src/cfe_sbr_route_unsorted.c
+++ b/modules/sbr/src/cfe_sbr_route_unsorted.c
@@ -178,39 +178,28 @@ CFE_MSG_SequenceCount_t CFE_SBR_GetSequenceCounter(CFE_SBR_RouteId_t RouteId)
 }
 
 /******************************************************************************
- * Local helper function for throttling foreach routines
- *
- * Updates StartIdxPtr, EndIdxPtr and ThrottlePtr.NextIndex.  Note EndIdxPtr
- * must be set to maximum prior to calling.
- */
-void CFE_SBR_Throttle(uint32 *StartIdxPtr, uint32 *EndIdxPtr, CFE_SBR_Throttle_t *ThrottlePtr)
-{
-    if (ThrottlePtr != NULL)
-    {
-        *StartIdxPtr = ThrottlePtr->StartIndex;
-
-        /* Return next index of zero if full range is processed */
-        ThrottlePtr->NextIndex = 0;
-
-        if ((*StartIdxPtr + ThrottlePtr->MaxLoop) < *EndIdxPtr)
-        {
-            *EndIdxPtr             = *StartIdxPtr + ThrottlePtr->MaxLoop;
-            ThrottlePtr->NextIndex = *EndIdxPtr;
-        }
-    }
-}
-
-/******************************************************************************
  *  Interface function - see API for description
  */
 void CFE_SBR_ForEachRouteId(CFE_SBR_CallbackPtr_t CallbackPtr, void *ArgPtr, CFE_SBR_Throttle_t *ThrottlePtr)
 {
     CFE_SB_RouteId_Atom_t routeidx;
-    CFE_SB_MsgId_Atom_t   startidx = 0;
-    CFE_SB_MsgId_Atom_t   endidx   = CFE_SBR_RDATA.RouteIdxTop;
+    CFE_SB_RouteId_Atom_t startidx = 0;
+    CFE_SB_RouteId_Atom_t endidx   = CFE_SBR_RDATA.RouteIdxTop;
 
     /* Update throttle settings if needed */
-    CFE_SBR_Throttle(&startidx, &endidx, ThrottlePtr);
+    if (ThrottlePtr != NULL)
+    {
+        startidx = ThrottlePtr->StartIndex;
+
+        /* Return next index of zero if full range is processed */
+        ThrottlePtr->NextIndex = 0;
+
+        if ((startidx + ThrottlePtr->MaxLoop) < endidx)
+        {
+            endidx                 = startidx + ThrottlePtr->MaxLoop;
+            ThrottlePtr->NextIndex = endidx;
+        }
+    }
 
     for (routeidx = startidx; routeidx < endidx; routeidx++)
     {


### PR DESCRIPTION
**Describe the contribution**
Fix #1069 - Switched throttle indexes to use `CFE_SB_RouteId_Atom_t` and combined helper function since separation no longer necessary (only 1 foreach function implemented).

**Testing performed**
Build and run unit tests, passed.

**Expected behavior changes**
None, just resolves static analysis warning

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC