### PR TITLE
Fix #1032, Send->Write name update for SB write cmds

### DIFF
--- a/docs/src/cfe_sb.dox
+++ b/docs/src/cfe_sb.dox
@@ -104,7 +104,7 @@
   The Pipe IDs are specific to a particular processor (that is, the same ID number
   may refer to a different pipe on each processor).  The pipe information for all
   pipes that have been created, may be requested at anytime by sending the
-  \link #CFE_SB_SEND_PIPE_INFO_CC 'Send Pipe Info' SB command \endlink. The software
+  \link #CFE_SB_WRITE_PIPE_INFO_CC 'Write Pipe Info' SB command \endlink. The software
   bus also provides a set of figures regarding capacity, current utilization and high
   water marks relevant to pipes. This information may be requested by sending the
   command to \link #CFE_SB_SEND_SB_STATS_CC dump the SB statistics packet \endlink.

--- a/fsw/cfe-core/src/inc/cfe_fs_extern_typedefs.h
+++ b/fsw/cfe-core/src/inc/cfe_fs_extern_typedefs.h
@@ -167,7 +167,7 @@ enum CFE_FS_SubType
     *
     *
     * Software Bus Pipe Data Dump File which is generated in response to a
-    * \link #CFE_SB_SEND_PIPE_INFO_CC \SB_WRITEPIPE2FILE \endlink
+    * \link #CFE_SB_WRITE_PIPE_INFO_CC \SB_WRITEPIPE2FILE \endlink
     * command.
     *
     */
@@ -178,7 +178,7 @@ enum CFE_FS_SubType
     *
     *
     * Software Bus Message Routing Data Dump File which is generated in response to a
-    * \link #CFE_SB_SEND_ROUTING_INFO_CC \SB_WRITEROUTING2FILE \endlink
+    * \link #CFE_SB_WRITE_ROUTING_INFO_CC \SB_WRITEROUTING2FILE \endlink
     * command.
     *
     */
@@ -189,7 +189,7 @@ enum CFE_FS_SubType
     *
     *
     * Software Bus Message Mapping Data Dump File which is generated in response to a
-    * \link #CFE_SB_SEND_MAP_INFO_CC \SB_WRITEMAP2FILE \endlink
+    * \link #CFE_SB_WRITE_MAP_INFO_CC \SB_WRITEMAP2FILE \endlink
     * command.
     *
     */

--- a/fsw/cfe-core/src/inc/cfe_sb_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_sb_msg.h
@@ -164,7 +164,7 @@
 **  \cfecmdmnemonic \SB_WRITEROUTING2FILE
 **
 **  \par Command Structure
-**       #CFE_SB_SendRoutingInfoCmd_t
+**       #CFE_SB_WriteRoutingInfoCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the
@@ -188,10 +188,8 @@
 **       This command is not inherently dangerous.  It will create a new
 **       file in the file system and could, if performed repeatedly without
 **       sufficient file management by the operator, fill the file system.
-**
-**  \sa #CFE_SB_SEND_PIPE_INFO_CC, #CFE_SB_SEND_MAP_INFO_CC, #CFE_SB_WriteFileInfoCmd_t
 */
-#define CFE_SB_SEND_ROUTING_INFO_CC     3
+#define CFE_SB_WRITE_ROUTING_INFO_CC     3
 
 /** \cfesbcmd Enable Software Bus Route
 **
@@ -211,7 +209,7 @@
 **       Successful execution of this command may be verified with the
 **       following telemetry:
 **       - \b \c \SB_CMDPC - command execution counter will increment
-**       - View routing information #CFE_SB_SEND_ROUTING_INFO_CC to verify
+**       - View routing information #CFE_SB_WRITE_ROUTING_INFO_CC to verify
 **         enable/disable state change
 **       - The #CFE_SB_ENBL_RTE2_EID debug event message will be generated. All
 **         debug events are filtered by default.
@@ -228,8 +226,6 @@
 **
 **  \par Criticality
 **       This command is not inherently dangerous.
-**
-**  \sa #CFE_SB_SEND_ROUTING_INFO_CC, #CFE_SB_DISABLE_ROUTE_CC, #CFE_SB_RouteCmd_t
 */
 #define CFE_SB_ENABLE_ROUTE_CC          4
 
@@ -249,7 +245,7 @@
 **       Successful execution of this command may be verified with the
 **       following telemetry:
 **       - \b \c \SB_CMDPC - command execution counter will increment
-**       - View routing information #CFE_SB_SEND_ROUTING_INFO_CC to verify
+**       - View routing information #CFE_SB_WRITE_ROUTING_INFO_CC to verify
 **         enable/disable state change
 **       - The #CFE_SB_DSBL_RTE2_EID debug event message will be generated. All
 **         debug events are filtered by default.
@@ -271,8 +267,6 @@
 **       with #CFE_SB_CMD_MID and the SB_Cmd_Pipe would inhibit any ground
 **       commanding to the software bus until the processor was reset. There
 **       are similar problems that may occur when using this command.
-**
-**  \sa #CFE_SB_SEND_ROUTING_INFO_CC, #CFE_SB_ENABLE_ROUTE_CC, #CFE_SB_RouteCmd_t
 */
 #define CFE_SB_DISABLE_ROUTE_CC         5
 
@@ -291,7 +285,7 @@
 **  \cfecmdmnemonic \SB_WRITEPIPE2FILE
 **
 **  \par Command Structure
-**       #CFE_SB_SendPipeInfoCmd_t
+**       #CFE_SB_WritePipeInfoCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the
@@ -315,10 +309,8 @@
 **       This command is not inherently dangerous.  It will create a new
 **       file in the file system and could, if performed repeatedly without
 **       sufficient file management by the operator, fill the file system.
-**
-**  \sa #CFE_SB_SEND_ROUTING_INFO_CC, #CFE_SB_SEND_MAP_INFO_CC
 */
-#define CFE_SB_SEND_PIPE_INFO_CC        7
+#define CFE_SB_WRITE_PIPE_INFO_CC        7
 
 /** \cfesbcmd Write Map Info to a File
 **
@@ -336,7 +328,7 @@
 **  \cfecmdmnemonic \SB_WRITEMAP2FILE
 **
 **  \par Command Structure
-**       #CFE_SB_SendMapInfoCmd_t
+**       #CFE_SB_WriteMapInfoCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the
@@ -360,10 +352,8 @@
 **       This command is not inherently dangerous.  It will create a new
 **       file in the file system and could, if performed repeatedly without
 **       sufficient file management by the operator, fill the file system.
-**
-**  \sa #CFE_SB_SEND_ROUTING_INFO_CC, #CFE_SB_SEND_PIPE_INFO_CC
 */
-#define CFE_SB_SEND_MAP_INFO_CC         8
+#define CFE_SB_WRITE_MAP_INFO_CC         8
 
 /** \cfesbcmd Enable Subscription Reporting Command
 **
@@ -486,10 +476,7 @@ typedef CFE_MSG_CommandHeader_t CFE_SB_SendPrevSubsCmd_t;
 /**
 **  \brief Write File Info Command Payload
 **
-**  This structure contains a generic definition used by three SB commands,
-**  'Write Routing Info to File' #CFE_SB_SEND_ROUTING_INFO_CC,
-**  'Write Pipe Info to File' #CFE_SB_SEND_PIPE_INFO_CC and
-**  'Write Map Info to File' #CFE_SB_SEND_MAP_INFO_CC.
+**  This structure contains a generic definition used by SB commands that write to a file
 */
 typedef struct CFE_SB_WriteFileInfoCmd_Payload {
    char Filename[CFE_MISSION_MAX_PATH_LEN];/**< \brief Path and Filename of data to be loaded */
@@ -506,9 +493,9 @@ typedef struct CFE_SB_WriteFileInfoCmd {
 /*
  * Create a unique typedef for each of the commands that share this format.
  */
-typedef CFE_SB_WriteFileInfoCmd_t CFE_SB_SendRoutingInfoCmd_t;
-typedef CFE_SB_WriteFileInfoCmd_t CFE_SB_SendPipeInfoCmd_t;
-typedef CFE_SB_WriteFileInfoCmd_t CFE_SB_SendMapInfoCmd_t;
+typedef CFE_SB_WriteFileInfoCmd_t CFE_SB_WriteRoutingInfoCmd_t;
+typedef CFE_SB_WriteFileInfoCmd_t CFE_SB_WritePipeInfoCmd_t;
+typedef CFE_SB_WriteFileInfoCmd_t CFE_SB_WriteMapInfoCmd_t;
 
 /**
 **  \brief Enable/Disable Route Command Payload
@@ -701,7 +688,7 @@ typedef struct CFE_SB_StatsTlm {
 /**
 ** \brief SB Routing File Entry
 **
-** Structure of one element of the routing information in response to #CFE_SB_SEND_ROUTING_INFO_CC
+** Structure of one element of the routing information in response to #CFE_SB_WRITE_ROUTING_INFO_CC
 */
 typedef struct CFE_SB_RoutingFileEntry {
     CFE_SB_MsgId_t      MsgId;/**< \brief Message Id portion of the route */
@@ -716,7 +703,7 @@ typedef struct CFE_SB_RoutingFileEntry {
 /**
 ** \brief SB Map File Entry
 **
-** Structure of one element of the map information in response to #CFE_SB_SEND_MAP_INFO_CC
+** Structure of one element of the map information in response to #CFE_SB_WRITE_MAP_INFO_CC
 */
 typedef struct CFE_SB_MsgMapFileEntry {
     CFE_SB_MsgId_t        MsgId;/**< \brief Message Id which has been subscribed to */

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.h
@@ -264,9 +264,9 @@ int32 CFE_SB_TransmitMsgValidate(CFE_MSG_Message_t *MsgPtr,
                                  CFE_SB_MsgId_t    *MsgIdPtr,
                                  CFE_MSG_Size_t    *SizePtr,
                                  CFE_SBR_RouteId_t *RouteIdPtr);
-int32 CFE_SB_SendRtgInfo(const char *Filename);
-int32 CFE_SB_SendPipeInfo(const char *Filename);
-int32 CFE_SB_SendMapInfo(const char *Filename);
+int32 CFE_SB_WriteRtgInfo(const char *Filename);
+int32 CFE_SB_WritePipeInfo(const char *Filename);
+int32 CFE_SB_WriteMapInfo(const char *Filename);
 int32 CFE_SB_ZeroCopyReleaseDesc(CFE_SB_Buffer_t *Ptr2Release, CFE_SB_ZeroCopyHandle_t BufferHandle);
 int32 CFE_SB_ZeroCopyReleaseAppId(CFE_ES_ResourceID_t         AppId);
 void CFE_SB_IncrBufUseCnt(CFE_SB_BufferD_t *bd);
@@ -369,9 +369,9 @@ int32 CFE_SB_SendHKTlmCmd(const CFE_MSG_CommandHeader_t *data);
 int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data);
 int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data);
 int32 CFE_SB_SendStatsCmd(const CFE_SB_SendSbStatsCmd_t *data);
-int32 CFE_SB_SendRoutingInfoCmd(const CFE_SB_SendRoutingInfoCmd_t *data);
-int32 CFE_SB_SendPipeInfoCmd(const CFE_SB_SendPipeInfoCmd_t *data);
-int32 CFE_SB_SendMapInfoCmd(const CFE_SB_SendMapInfoCmd_t *data);
+int32 CFE_SB_WriteRoutingInfoCmd(const CFE_SB_WriteRoutingInfoCmd_t *data);
+int32 CFE_SB_WritePipeInfoCmd(const CFE_SB_WritePipeInfoCmd_t *data);
+int32 CFE_SB_WriteMapInfoCmd(const CFE_SB_WriteMapInfoCmd_t *data);
 int32 CFE_SB_SendPrevSubsCmd(const CFE_SB_SendPrevSubsCmd_t *data);
 
 

--- a/fsw/cfe-core/src/sb/cfe_sb_task.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_task.c
@@ -432,10 +432,10 @@ void CFE_SB_ProcessCmdPipePkt(CFE_SB_Buffer_t *SBBufPtr)
                 }
                 break;
 
-            case CFE_SB_SEND_ROUTING_INFO_CC:
-                if (CFE_SB_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_SB_SendRoutingInfoCmd_t)))
+            case CFE_SB_WRITE_ROUTING_INFO_CC:
+                if (CFE_SB_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_SB_WriteRoutingInfoCmd_t)))
                 {
-                    CFE_SB_SendRoutingInfoCmd((CFE_SB_SendRoutingInfoCmd_t *)SBBufPtr);
+                    CFE_SB_WriteRoutingInfoCmd((CFE_SB_WriteRoutingInfoCmd_t *)SBBufPtr);
                 }
                 break;
 
@@ -453,17 +453,17 @@ void CFE_SB_ProcessCmdPipePkt(CFE_SB_Buffer_t *SBBufPtr)
                 }
                 break;
 
-            case CFE_SB_SEND_PIPE_INFO_CC:
-                if (CFE_SB_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_SB_SendPipeInfoCmd_t)))
+            case CFE_SB_WRITE_PIPE_INFO_CC:
+                if (CFE_SB_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_SB_WritePipeInfoCmd_t)))
                 {
-                    CFE_SB_SendPipeInfoCmd((CFE_SB_SendPipeInfoCmd_t *)SBBufPtr);
+                    CFE_SB_WritePipeInfoCmd((CFE_SB_WritePipeInfoCmd_t *)SBBufPtr);
                 }
                 break;
 
-            case CFE_SB_SEND_MAP_INFO_CC:
-                if (CFE_SB_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_SB_SendMapInfoCmd_t)))
+            case CFE_SB_WRITE_MAP_INFO_CC:
+                if (CFE_SB_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_SB_WriteMapInfoCmd_t)))
                 {
-                    CFE_SB_SendMapInfoCmd((CFE_SB_SendMapInfoCmd_t *)SBBufPtr);
+                    CFE_SB_WriteMapInfoCmd((CFE_SB_WriteMapInfoCmd_t *)SBBufPtr);
                 }
                 break;
 
@@ -842,94 +842,70 @@ int32 CFE_SB_SendStatsCmd(const CFE_SB_SendSbStatsCmd_t *data)
 
 
 /******************************************************************************
-**  Function:  CFE_SB_SendRoutingInfoCmd()
-**
-**  Purpose:
-**    SB internal function to handle processing of 'Send Routing Info' Cmd
-**
-**  Arguments:
-**    None
-**
-**  Return:
-**    None
-*/
-int32 CFE_SB_SendRoutingInfoCmd(const CFE_SB_SendRoutingInfoCmd_t *data)
+ * \brief SB internal function to handle processing of 'Write Routing Info' Cmd
+ *
+ * \param[in] data Pointer to command structure
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ */
+int32 CFE_SB_WriteRoutingInfoCmd(const CFE_SB_WriteRoutingInfoCmd_t *data)
 {
-    const CFE_SB_WriteFileInfoCmd_Payload_t *ptr;
     char LocalFilename[OS_MAX_PATH_LEN];
     int32 Stat;
 
-    ptr = &data->Payload;
+    CFE_SB_MessageStringGet(LocalFilename, data->Payload.Filename, CFE_PLATFORM_SB_DEFAULT_ROUTING_FILENAME,
+            sizeof(LocalFilename), sizeof(data->Payload.Filename));
 
-    CFE_SB_MessageStringGet(LocalFilename, ptr->Filename, CFE_PLATFORM_SB_DEFAULT_ROUTING_FILENAME,
-            sizeof(LocalFilename), sizeof(ptr->Filename));
-
-    Stat = CFE_SB_SendRtgInfo(LocalFilename);
+    Stat = CFE_SB_WriteRtgInfo(LocalFilename);
     CFE_SB_IncrCmdCtr(Stat);
 
     return CFE_SUCCESS;
-}/* end CFE_SB_SendRoutingInfoCmd */
+}
 
 
 /******************************************************************************
-**  Function:  CFE_SB_SendPipeInfoCmd()
-**
-**  Purpose:
-**    SB internal function to handle processing of 'Send Pipe Info' Cmd
-**
-**  Arguments:
-**    None
-**
-**  Return:
-**    None
-*/
-int32 CFE_SB_SendPipeInfoCmd(const CFE_SB_SendPipeInfoCmd_t *data)
+ * \brief SB internal function to handle processing of 'Write Pipe Info' Cmd
+ *
+ * \param[in] data Pointer to command structure
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ */
+int32 CFE_SB_WritePipeInfoCmd(const CFE_SB_WritePipeInfoCmd_t *data)
 {
-    const CFE_SB_WriteFileInfoCmd_Payload_t *ptr;
     char LocalFilename[OS_MAX_PATH_LEN];
     int32 Stat;
 
-    ptr = &data->Payload;
+    CFE_SB_MessageStringGet(LocalFilename, data->Payload.Filename, CFE_PLATFORM_SB_DEFAULT_PIPE_FILENAME,
+            sizeof(LocalFilename), sizeof(data->Payload.Filename));
 
-    CFE_SB_MessageStringGet(LocalFilename, ptr->Filename, CFE_PLATFORM_SB_DEFAULT_PIPE_FILENAME,
-            sizeof(LocalFilename), sizeof(ptr->Filename));
-
-    Stat = CFE_SB_SendPipeInfo(LocalFilename);
+    Stat = CFE_SB_WritePipeInfo(LocalFilename);
     CFE_SB_IncrCmdCtr(Stat);
 
     return CFE_SUCCESS;
-}/* end CFE_SB_SendPipeInfoCmd */
+}
 
 
 /******************************************************************************
-**  Function:  CFE_SB_SendMapInfoCmd()
-**
-**  Purpose:
-**    SB internal function to handle processing of 'Send Map Info' Cmd
-**
-**  Arguments:
-**    None
-**
-**  Return:
-**    None
-*/
-int32 CFE_SB_SendMapInfoCmd(const CFE_SB_SendMapInfoCmd_t *data)
+ * \brief SB internal function to handle processing of 'Write Map Info' Cmd
+ *
+ * \param[in] data Pointer to command structure
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ */
+int32 CFE_SB_WriteMapInfoCmd(const CFE_SB_WriteMapInfoCmd_t *data)
 {
-    const CFE_SB_WriteFileInfoCmd_Payload_t *ptr;
     char LocalFilename[OS_MAX_PATH_LEN];
     int32 Stat;
 
-    ptr = &data->Payload;
+    CFE_SB_MessageStringGet(LocalFilename, data->Payload.Filename, CFE_PLATFORM_SB_DEFAULT_MAP_FILENAME,
+            sizeof(LocalFilename), sizeof(data->Payload.Filename));
 
-    CFE_SB_MessageStringGet(LocalFilename, ptr->Filename, CFE_PLATFORM_SB_DEFAULT_MAP_FILENAME,
-            sizeof(LocalFilename), sizeof(ptr->Filename));
-
-    Stat = CFE_SB_SendMapInfo(LocalFilename);
+    Stat = CFE_SB_WriteMapInfo(LocalFilename);
 
     CFE_SB_IncrCmdCtr(Stat);
 
     return CFE_SUCCESS;
-}/* end CFE_SB_SendMapInfoCmd */
+}
 
 /******************************************************************************
  * Local callback helper for writing routing info to a file
@@ -1060,18 +1036,15 @@ int32 CFE_SB_SendSubscriptionReport(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId
 
 
 /******************************************************************************
-**  Function:  CFE_SB_SendRoutingInfo()
-**
-**  Purpose:
-**    SB internal function to write the routing information to a file
-**
-**  Arguments:
-**    Pointer to a filename
-**
-**  Return:
-**    CFE_SB_FILE_IO_ERR for file I/O errors or CFE_SUCCESS
-*/
-int32 CFE_SB_SendRtgInfo(const char *Filename)
+ * \brief SB internal function to write the routing information to a file
+ *
+ * \param[in] Filename Pointer the file name to write
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ * \retval #CFE_SUCCESS        \copybrief CFE_SUCCESS
+ * \retval #CFE_SB_FILE_IO_ERR \copybrief CFE_SB_FILE_IO_ERR
+ */
+int32 CFE_SB_WriteRtgInfo(const char *Filename)
 {
     CFE_SB_FileWriteCallback_t  args = {0};
     int32                       Status;
@@ -1117,22 +1090,19 @@ int32 CFE_SB_SendRtgInfo(const char *Filename)
         return CFE_SUCCESS;
     }
 
-}/* end CFE_SB_SendRtgInfo */
+}
 
 
 /******************************************************************************
-**  Function:  CFE_SB_SendPipeInfo()
-**
-**  Purpose:
-**    SB internal function to write the Pipe table to a file
-**
-**  Arguments:
-**    Pointer to a filename
-**
-**  Return:
-**    CFE_SB_FILE_IO_ERR for file I/O errors or CFE_SUCCESS
-*/
-int32 CFE_SB_SendPipeInfo(const char *Filename)
+ * \brief SB internal function to write the Pipe table to a file
+ *
+ * \param[in] Filename Pointer the file name to write
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ * \retval #CFE_SUCCESS        \copybrief CFE_SUCCESS
+ * \retval #CFE_SB_FILE_IO_ERR \copybrief CFE_SB_FILE_IO_ERR
+ */
+int32 CFE_SB_WritePipeInfo(const char *Filename)
 {
     uint16 i;
     osal_id_t  fd;
@@ -1230,8 +1200,7 @@ int32 CFE_SB_SendPipeInfo(const char *Filename)
 
     return CFE_SUCCESS;
 
-}/* end CFE_SB_SendPipeInfo */
-
+}
 
 /******************************************************************************
  * Local callback helper for writing map info to a file
@@ -1266,18 +1235,15 @@ void CFE_SB_WriteMapToFile(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
 }
 
 /******************************************************************************
-**  Function:  CFE_SB_SendMapInfo()
-**
-**  Purpose:
-**    SB internal function to write the Message Map to a file
-**
-**  Arguments:
-**    Pointer to a filename
-**
-**  Return:
-**    CFE_SB_FILE_IO_ERR for file I/O errors or CFE_SUCCESS
-*/
-int32 CFE_SB_SendMapInfo(const char *Filename)
+ * \brief SB internal function to write the Message Map to a file
+ *
+ * \param[in] Filename Pointer the file name to write
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ * \retval #CFE_SUCCESS        \copybrief CFE_SUCCESS
+ * \retval #CFE_SB_FILE_IO_ERR \copybrief CFE_SB_FILE_IO_ERR
+ */
+int32 CFE_SB_WriteMapInfo(const char *Filename)
 {
     CFE_SB_FileWriteCallback_t args = {0};
     int32                      Status;

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -493,28 +493,28 @@ void Test_SB_Cmds_Stats(void)
 } /* end Test_SB_Cmds_Stats */
 
 /*
-** Test send routing information command using the default file name
+** Test write routing information command using the default file name
 */
 void Test_SB_Cmds_RoutingInfoDef(void)
 {
     union
     {
-        CFE_SB_Buffer_t             SBBuf;
-        CFE_SB_SendRoutingInfoCmd_t Cmd;
-    } SendRoutingInfo;
-    CFE_MSG_FcnCode_t FcnCode = CFE_SB_SEND_ROUTING_INFO_CC;
+        CFE_SB_Buffer_t              SBBuf;
+        CFE_SB_WriteRoutingInfoCmd_t Cmd;
+    } WriteRoutingInfo;
+    CFE_MSG_FcnCode_t FcnCode = CFE_SB_WRITE_ROUTING_INFO_CC;
     CFE_SB_MsgId_t    MsgId = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size = sizeof(SendRoutingInfo.Cmd);
+    CFE_MSG_Size_t    Size = sizeof(WriteRoutingInfo.Cmd);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    SendRoutingInfo.Cmd.Payload.Filename[0] = '\0';
+    WriteRoutingInfo.Cmd.Payload.Filename[0] = '\0';
 
     /* Make some routing info by calling CFE_SB_AppInit */
     SETUP(CFE_SB_AppInit());
 
-    CFE_SB_ProcessCmdPipePkt(&SendRoutingInfo.SBBuf);
+    CFE_SB_ProcessCmdPipePkt(&WriteRoutingInfo.SBBuf);
 
     EVTCNT(9);
 
@@ -531,27 +531,27 @@ void Test_SB_Cmds_RoutingInfoDef(void)
 } /* end Test_SB_Cmds_RoutingInfoDef */
 
 /*
-** Test send routing information command using a specified file name
+** Test write routing information command using a specified file name
 */
 void Test_SB_Cmds_RoutingInfoSpec(void)
 {
     union
     {
-        CFE_SB_Buffer_t             SBBuf;
-        CFE_SB_SendRoutingInfoCmd_t Cmd;
-    } SendRoutingInfo;
-    CFE_MSG_FcnCode_t FcnCode = CFE_SB_SEND_ROUTING_INFO_CC;
+        CFE_SB_Buffer_t              SBBuf;
+        CFE_SB_WriteRoutingInfoCmd_t Cmd;
+    } WriteRoutingInfo;
+    CFE_MSG_FcnCode_t FcnCode = CFE_SB_WRITE_ROUTING_INFO_CC;
     CFE_SB_MsgId_t    MsgId = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size = sizeof(SendRoutingInfo.Cmd);
+    CFE_MSG_Size_t    Size = sizeof(WriteRoutingInfo.Cmd);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    strncpy(SendRoutingInfo.Cmd.Payload.Filename, "RoutingTstFile",
-            sizeof(SendRoutingInfo.Cmd.Payload.Filename) - 1);
-    SendRoutingInfo.Cmd.Payload.Filename[sizeof(SendRoutingInfo.Cmd.Payload.Filename) - 1] = '\0';
+    strncpy(WriteRoutingInfo.Cmd.Payload.Filename, "RoutingTstFile",
+            sizeof(WriteRoutingInfo.Cmd.Payload.Filename) - 1);
+    WriteRoutingInfo.Cmd.Payload.Filename[sizeof(WriteRoutingInfo.Cmd.Payload.Filename) - 1] = '\0';
 
-    CFE_SB_ProcessCmdPipePkt(&SendRoutingInfo.SBBuf);
+    CFE_SB_ProcessCmdPipePkt(&WriteRoutingInfo.SBBuf);
 
     EVTCNT(1);
 
@@ -560,30 +560,30 @@ void Test_SB_Cmds_RoutingInfoSpec(void)
 } /* end Test_SB_Cmds_RoutingInfoSpec */
 
 /*
-**  Test send routing information command with a file creation failure
+**  Test write routing information command with a file creation failure
 */
 void Test_SB_Cmds_RoutingInfoCreateFail(void)
 {
     union
     {
-        CFE_SB_Buffer_t             SBBuf;
-        CFE_SB_SendRoutingInfoCmd_t Cmd;
-    } SendRoutingInfo;
-    CFE_MSG_FcnCode_t FcnCode = CFE_SB_SEND_ROUTING_INFO_CC;
+        CFE_SB_Buffer_t              SBBuf;
+        CFE_SB_WriteRoutingInfoCmd_t Cmd;
+    } WriteRoutingInfo;
+    CFE_MSG_FcnCode_t FcnCode = CFE_SB_WRITE_ROUTING_INFO_CC;
     CFE_SB_MsgId_t    MsgId = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size = sizeof(SendRoutingInfo.Cmd);
+    CFE_MSG_Size_t    Size = sizeof(WriteRoutingInfo.Cmd);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    strncpy(SendRoutingInfo.Cmd.Payload.Filename, "RoutingTstFile",
-            sizeof(SendRoutingInfo.Cmd.Payload.Filename) - 1);
-    SendRoutingInfo.Cmd.Payload.Filename[sizeof(SendRoutingInfo.Cmd.Payload.Filename) - 1] = '\0';
+    strncpy(WriteRoutingInfo.Cmd.Payload.Filename, "RoutingTstFile",
+            sizeof(WriteRoutingInfo.Cmd.Payload.Filename) - 1);
+    WriteRoutingInfo.Cmd.Payload.Filename[sizeof(WriteRoutingInfo.Cmd.Payload.Filename) - 1] = '\0';
 
-    /* Make function CFE_SB_SendRtgInfo return CFE_SB_FILE_IO_ERR */
+    /* Make function CFE_SB_WriteRtgInfo return CFE_SB_FILE_IO_ERR */
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
 
-    CFE_SB_ProcessCmdPipePkt(&SendRoutingInfo.SBBuf);
+    CFE_SB_ProcessCmdPipePkt(&WriteRoutingInfo.SBBuf);
 
     EVTCNT(1);
 
@@ -592,13 +592,13 @@ void Test_SB_Cmds_RoutingInfoCreateFail(void)
 } /* end Test_SB_Cmds_RoutingInfoCreateFail */
 
 /*
-** Test send routing information command with a file header write failure
+** Test write routing information command with a file header write failure
 */
 void Test_SB_Cmds_RoutingInfoHdrFail(void)
 {
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_WriteHeader), 1, -1);
 
-    ASSERT_EQ(CFE_SB_SendRtgInfo("RoutingTstFile"), CFE_SB_FILE_IO_ERR);
+    ASSERT_EQ(CFE_SB_WriteRtgInfo("RoutingTstFile"), CFE_SB_FILE_IO_ERR);
 
     EVTCNT(1);
 
@@ -607,7 +607,7 @@ void Test_SB_Cmds_RoutingInfoHdrFail(void)
 } /* end Test_SB_Cmds_RoutingInfoHdrFail */
 
 /*
-** Test send routing information command with a file write failure on
+** Test write routing information command with a file write failure on
 ** the second write
 */
 void Test_SB_Cmds_RoutingInfoWriteFail(void)
@@ -617,7 +617,7 @@ void Test_SB_Cmds_RoutingInfoWriteFail(void)
 
     UT_SetDeferredRetcode(UT_KEY(OS_write), 2, -1);
 
-    ASSERT_EQ(CFE_SB_SendRtgInfo("RoutingTstFile"), CFE_SB_FILE_IO_ERR);
+    ASSERT_EQ(CFE_SB_WriteRtgInfo("RoutingTstFile"), CFE_SB_FILE_IO_ERR);
 
     EVTCNT(9);
 
@@ -634,34 +634,34 @@ void Test_SB_Cmds_RoutingInfoWriteFail(void)
 } /* end Test_SB_Cmds_RoutingInfoWriteFail */
 
 /*
-** Test send pipe information command using the default file name
+** Test write pipe information command using the default file name
 */
 void Test_SB_Cmds_PipeInfoDef(void)
 {
     union
     {
-        CFE_SB_Buffer_t          SBBuf;
-        CFE_SB_SendPipeInfoCmd_t Cmd;
-    } SendPipeInfo;
+        CFE_SB_Buffer_t           SBBuf;
+        CFE_SB_WritePipeInfoCmd_t Cmd;
+    } WritePipeInfo;
     CFE_SB_PipeId_t           PipeId1;
     CFE_SB_PipeId_t           PipeId2;
     CFE_SB_PipeId_t           PipeId3;
     uint16                    PipeDepth = 10;
-    CFE_MSG_FcnCode_t         FcnCode = CFE_SB_SEND_PIPE_INFO_CC;
+    CFE_MSG_FcnCode_t         FcnCode = CFE_SB_WRITE_PIPE_INFO_CC;
     CFE_SB_MsgId_t            MsgId = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t            Size = sizeof(SendPipeInfo.Cmd);
+    CFE_MSG_Size_t            Size = sizeof(WritePipeInfo.Cmd);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    SendPipeInfo.Cmd.Payload.Filename[0] = '\0';
+    WritePipeInfo.Cmd.Payload.Filename[0] = '\0';
 
     /* Create some pipe info */
     SETUP(CFE_SB_CreatePipe(&PipeId1, PipeDepth, "TestPipe1"));
     SETUP(CFE_SB_CreatePipe(&PipeId2, PipeDepth, "TestPipe2"));
     SETUP(CFE_SB_CreatePipe(&PipeId3, PipeDepth, "TestPipe3"));
 
-    CFE_SB_ProcessCmdPipePkt(&SendPipeInfo.SBBuf);
+    CFE_SB_ProcessCmdPipePkt(&WritePipeInfo.SBBuf);
 
     EVTCNT(4);
 
@@ -675,27 +675,27 @@ void Test_SB_Cmds_PipeInfoDef(void)
 } /* end Test_SB_Cmds_PipeInfoDef */
 
 /*
-** Test send pipe information command using a specified file name
+** Test write pipe information command using a specified file name
 */
 void Test_SB_Cmds_PipeInfoSpec(void)
 {
     union
     {
-        CFE_SB_Buffer_t          SBBuf;
-        CFE_SB_SendPipeInfoCmd_t Cmd;
-    } SendPipeInfo;
-    CFE_MSG_FcnCode_t         FcnCode = CFE_SB_SEND_PIPE_INFO_CC;
+        CFE_SB_Buffer_t           SBBuf;
+        CFE_SB_WritePipeInfoCmd_t Cmd;
+    } WritePipeInfo;
+    CFE_MSG_FcnCode_t         FcnCode = CFE_SB_WRITE_PIPE_INFO_CC;
     CFE_SB_MsgId_t            MsgId = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t            Size = sizeof(SendPipeInfo.Cmd);
+    CFE_MSG_Size_t            Size = sizeof(WritePipeInfo.Cmd);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    strncpy(SendPipeInfo.Cmd.Payload.Filename, "PipeTstFile",
-            sizeof(SendPipeInfo.Cmd.Payload.Filename) - 1);
-    SendPipeInfo.Cmd.Payload.Filename[sizeof(SendPipeInfo.Cmd.Payload.Filename) - 1] = '\0';
+    strncpy(WritePipeInfo.Cmd.Payload.Filename, "PipeTstFile",
+            sizeof(WritePipeInfo.Cmd.Payload.Filename) - 1);
+    WritePipeInfo.Cmd.Payload.Filename[sizeof(WritePipeInfo.Cmd.Payload.Filename) - 1] = '\0';
 
-    CFE_SB_ProcessCmdPipePkt(&SendPipeInfo.SBBuf);
+    CFE_SB_ProcessCmdPipePkt(&WritePipeInfo.SBBuf);
 
     EVTCNT(1);
 
@@ -704,12 +704,12 @@ void Test_SB_Cmds_PipeInfoSpec(void)
 } /* end Test_SB_Cmds_PipeInfoSpec */
 
 /*
-** Test send pipe information command with a file creation failure
+** Test write pipe information command with a file creation failure
 */
 void Test_SB_Cmds_PipeInfoCreateFail(void)
 {
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
-    ASSERT_EQ(CFE_SB_SendPipeInfo("PipeTstFile"), CFE_SB_FILE_IO_ERR);
+    ASSERT_EQ(CFE_SB_WritePipeInfo("PipeTstFile"), CFE_SB_FILE_IO_ERR);
 
     EVTCNT(1);
 
@@ -718,12 +718,12 @@ void Test_SB_Cmds_PipeInfoCreateFail(void)
 } /* end Test_SB_Cmds_PipeInfoCreateFail */
 
 /*
-** Test send pipe information command with a file header write failure
+** Test write pipe information command with a file header write failure
 */
 void Test_SB_Cmds_PipeInfoHdrFail(void)
 {
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_WriteHeader), 1, -1);
-    ASSERT_EQ(CFE_SB_SendPipeInfo("PipeTstFile"), CFE_SB_FILE_IO_ERR);
+    ASSERT_EQ(CFE_SB_WritePipeInfo("PipeTstFile"), CFE_SB_FILE_IO_ERR);
 
     EVTCNT(1);
 
@@ -732,7 +732,7 @@ void Test_SB_Cmds_PipeInfoHdrFail(void)
 } /* end Test_SB_Cmds_PipeInfoHdrFail */
 
 /*
-** Test send pipe information command with a file write failure on
+** Test write pipe information command with a file write failure on
 ** the second write
 */
 void Test_SB_Cmds_PipeInfoWriteFail(void)
@@ -747,7 +747,7 @@ void Test_SB_Cmds_PipeInfoWriteFail(void)
     SETUP(CFE_SB_CreatePipe(&PipeId3, PipeDepth, "TestPipe3"));
     UT_SetDeferredRetcode(UT_KEY(OS_write), 2, -1);
 
-    ASSERT_EQ(CFE_SB_SendPipeInfo("PipeTstFile"), CFE_SB_FILE_IO_ERR);
+    ASSERT_EQ(CFE_SB_WritePipeInfo("PipeTstFile"), CFE_SB_FILE_IO_ERR);
 
     EVTCNT(4);
 
@@ -762,15 +762,15 @@ void Test_SB_Cmds_PipeInfoWriteFail(void)
 } /* end Test_SB_Cmds_PipeInfoWriteFail */
 
 /*
-** Test send map information command using the default file name
+** Test write map information command using the default file name
 */
 void Test_SB_Cmds_MapInfoDef(void)
 {
     union
     {
-        CFE_SB_Buffer_t         SBBuf;
-        CFE_SB_SendMapInfoCmd_t Cmd;
-    } SendMapInfo;
+        CFE_SB_Buffer_t          SBBuf;
+        CFE_SB_WriteMapInfoCmd_t Cmd;
+    } WriteMapInfo;
     CFE_SB_PipeId_t           PipeId1;
     CFE_SB_PipeId_t           PipeId2;
     CFE_SB_PipeId_t           PipeId3;
@@ -781,14 +781,14 @@ void Test_SB_Cmds_MapInfoDef(void)
     CFE_SB_MsgId_t            MsgId4 = SB_UT_TLM_MID5;
     CFE_SB_MsgId_t            MsgId5 = SB_UT_TLM_MID6;
     uint16                    PipeDepth = 10;
-    CFE_MSG_FcnCode_t         FcnCode = CFE_SB_SEND_MAP_INFO_CC;
+    CFE_MSG_FcnCode_t         FcnCode = CFE_SB_WRITE_MAP_INFO_CC;
     CFE_SB_MsgId_t            MsgId = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t            Size = sizeof(SendMapInfo.Cmd);
+    CFE_MSG_Size_t            Size = sizeof(WriteMapInfo.Cmd);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    SendMapInfo.Cmd.Payload.Filename[0] = '\0';
+    WriteMapInfo.Cmd.Payload.Filename[0] = '\0';
 
     /* Create some map info */
     SETUP(CFE_SB_CreatePipe(&PipeId1, PipeDepth, "TestPipe1"));
@@ -802,7 +802,7 @@ void Test_SB_Cmds_MapInfoDef(void)
     SETUP(CFE_SB_Subscribe(MsgId4, PipeId3));
     SETUP(CFE_SB_Subscribe(MsgId5, PipeId2));
 
-    CFE_SB_ProcessCmdPipePkt(&SendMapInfo.SBBuf);
+    CFE_SB_ProcessCmdPipePkt(&WriteMapInfo.SBBuf);
 
     EVTCNT(11);
 
@@ -819,27 +819,27 @@ void Test_SB_Cmds_MapInfoDef(void)
 } /* end Test_SB_Cmds_MapInfoDef */
 
 /*
-** Test send map information command using a specified file name
+** Test write map information command using a specified file name
 */
 void Test_SB_Cmds_MapInfoSpec(void)
 {
     union
     {
-        CFE_SB_Buffer_t         SBBuf;
-        CFE_SB_SendMapInfoCmd_t Cmd;
-    } SendMapInfo;
-    CFE_MSG_FcnCode_t         FcnCode = CFE_SB_SEND_MAP_INFO_CC;
+        CFE_SB_Buffer_t          SBBuf;
+        CFE_SB_WriteMapInfoCmd_t Cmd;
+    } WriteMapInfo;
+    CFE_MSG_FcnCode_t         FcnCode = CFE_SB_WRITE_MAP_INFO_CC;
     CFE_SB_MsgId_t            MsgId = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t            Size = sizeof(SendMapInfo.Cmd);
+    CFE_MSG_Size_t            Size = sizeof(WriteMapInfo.Cmd);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    strncpy(SendMapInfo.Cmd.Payload.Filename, "MapTstFile",
-            sizeof(SendMapInfo.Cmd.Payload.Filename) - 1);
-    SendMapInfo.Cmd.Payload.Filename[sizeof(SendMapInfo.Cmd.Payload.Filename) - 1] = '\0';
+    strncpy(WriteMapInfo.Cmd.Payload.Filename, "MapTstFile",
+            sizeof(WriteMapInfo.Cmd.Payload.Filename) - 1);
+    WriteMapInfo.Cmd.Payload.Filename[sizeof(WriteMapInfo.Cmd.Payload.Filename) - 1] = '\0';
 
-    CFE_SB_ProcessCmdPipePkt(&SendMapInfo.SBBuf);
+    CFE_SB_ProcessCmdPipePkt(&WriteMapInfo.SBBuf);
 
     EVTCNT(1);
 
@@ -848,12 +848,12 @@ void Test_SB_Cmds_MapInfoSpec(void)
 } /* end Test_SB_Cmds_MapInfoSpec */
 
 /*
-** Test send map information command with a file creation failure
+** Test write map information command with a file creation failure
 */
 void Test_SB_Cmds_MapInfoCreateFail(void)
 {
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
-    ASSERT_EQ(CFE_SB_SendMapInfo("MapTstFile"), CFE_SB_FILE_IO_ERR);
+    ASSERT_EQ(CFE_SB_WriteMapInfo("MapTstFile"), CFE_SB_FILE_IO_ERR);
 
     EVTCNT(1);
 
@@ -862,12 +862,12 @@ void Test_SB_Cmds_MapInfoCreateFail(void)
 } /* end Test_SB_Cmds_MapInfoCreateFail */
 
 /*
-** Test send map information command with a file header write failure
+** Test write map information command with a file header write failure
 */
 void Test_SB_Cmds_MapInfoHdrFail(void)
 {
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_WriteHeader), 1, -1);
-    ASSERT_EQ(CFE_SB_SendMapInfo("MapTstFile"), CFE_SB_FILE_IO_ERR);
+    ASSERT_EQ(CFE_SB_WriteMapInfo("MapTstFile"), CFE_SB_FILE_IO_ERR);
 
     EVTCNT(1);
 
@@ -876,7 +876,7 @@ void Test_SB_Cmds_MapInfoHdrFail(void)
 } /* end Test_SB_Cmds_MapInfoHdrFail */
 
 /*
-** Test send map information command with a file write failure on
+** Test write map information command with a file write failure on
 ** the second write
 */
 void Test_SB_Cmds_MapInfoWriteFail(void)
@@ -905,7 +905,7 @@ void Test_SB_Cmds_MapInfoWriteFail(void)
     SETUP(CFE_SB_Subscribe(MsgId5, PipeId2));
     UT_SetDeferredRetcode(UT_KEY(OS_write), 2, -1);
 
-    ASSERT_EQ(CFE_SB_SendMapInfo("MapTstFile"), CFE_SB_FILE_IO_ERR);
+    ASSERT_EQ(CFE_SB_WriteMapInfo("MapTstFile"), CFE_SB_FILE_IO_ERR);
 
     EVTCNT(11);
 


### PR DESCRIPTION
**Describe the contribution**
Fix #1032 - updated "Send" to "Write" in command names that write files.  Includes function names, command code names and comments.

**Testing performed**
Standard build and run unit tests, passed.  Made user's guide w/ no errors/warnings.

**Expected behavior changes**
None, name change to fix misnomer

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
Additional update pending #1102 merge

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC