### PR TITLE
Fix #986, Remove unnecessary CFE_MSG_Init in TBL

### DIFF
--- a/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
@@ -139,20 +139,6 @@ int32 CFE_TBL_EarlyInit (void)
       return Status;
     }/* end if */
     
-    /*
-    ** Initialize housekeeping packet (clear user data area)...
-    */
-    CFE_MSG_Init(&CFE_TBL_TaskData.HkPacket.TlmHeader.Msg,
-                 CFE_SB_ValueToMsgId(CFE_TBL_HK_TLM_MID),
-                 sizeof(CFE_TBL_TaskData.HkPacket));
-
-    /*
-    ** Initialize table registry report packet (clear user data area)...
-    */
-    CFE_MSG_Init(&CFE_TBL_TaskData.TblRegPacket.TlmHeader.Msg,
-                 CFE_SB_ValueToMsgId(CFE_TBL_REG_TLM_MID),
-                 sizeof(CFE_TBL_TaskData.TblRegPacket));
-
     /* Initialize memory partition and allocate shared table buffers. */
     Status = CFE_ES_PoolCreate(&CFE_TBL_TaskData.Buf.PoolHdl,
                                 CFE_TBL_TaskData.Buf.Partition.Data,
@@ -1510,12 +1496,8 @@ int32 CFE_TBL_SendNotificationMsg(CFE_TBL_RegistryRec_t *RegRecPtr)
     /* First, determine if a message should be sent */
     if (RegRecPtr->NotifyByMsg)
     {
-        /*
-        ** Initialize notification message packet (clear user data area)...
-        */
-        CFE_MSG_Init(&CFE_TBL_TaskData.NotifyMsg.CmdHeader.Msg,
-                     RegRecPtr->NotificationMsgId,
-                     sizeof(CFE_TBL_TaskData.NotifyMsg));
+        /* Set the message ID */
+        CFE_MSG_SetMsgId(&CFE_TBL_TaskData.NotifyMsg.CmdHeader.Msg, RegRecPtr->NotificationMsgId);
         
         /* Set the command code */
         CFE_MSG_SetFcnCode(&CFE_TBL_TaskData.NotifyMsg.CmdHeader.Msg, RegRecPtr->NotificationCC);

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task.c
@@ -248,6 +248,11 @@ void CFE_TBL_InitData(void)
                  CFE_SB_ValueToMsgId(CFE_TBL_REG_TLM_MID),
                  sizeof(CFE_TBL_TaskData.TblRegPacket));
 
+    /* Message ID is set when sent, so OK as 0 here */
+    CFE_MSG_Init(&CFE_TBL_TaskData.NotifyMsg.CmdHeader.Msg,
+                 CFE_SB_ValueToMsgId(0),
+                 sizeof(CFE_TBL_TaskData.NotifyMsg));
+
 } /* End of CFE_TBL_InitData() */
 
 

--- a/fsw/cfe-core/unit-test/tbl_UT.c
+++ b/fsw/cfe-core/unit-test/tbl_UT.c
@@ -394,7 +394,7 @@ void Test_CFE_TBL_InitData(void)
     /* This function has only one possible path with no return code */
     UT_InitData();
     CFE_TBL_InitData();
-    ASSERT_EQ(UT_GetStubCount(UT_KEY(CFE_MSG_Init)), 2);
+    ASSERT_EQ(UT_GetStubCount(UT_KEY(CFE_MSG_Init)), 3);
 }
 
 /*


### PR DESCRIPTION
**Describe the contribution**
Fix #986 - removed the `HkPacket` and `TblRegPacket` message initializations from `CFE_TBL_EarlyInit`, they are initialized in `CFE_TBL_InitData`.  Moved the `NotifyMsg` message initialization to `CFE_TBL_InitData`, and just setting the message ID each time it's sent from `CFE_TBL_SendNotificationMsg`.

**Testing performed**
Build and run unit tests, passed.

**Expected behavior changes**
None (or just slightly better performance since the msg isn't initialized every call)

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC