### PR TITLE
Fix #1036, Clear task data in EarlyInit and standardize name

### DIFF
--- a/fsw/cfe-core/src/evs/cfe_evs_task.c
+++ b/fsw/cfe-core/src/evs/cfe_evs_task.c
@@ -47,7 +47,7 @@
 #include "private/cfe_es_resetdata_typedef.h"  /* Definition of CFE_ES_ResetData_t */
 
 /* Global Data */
-CFE_EVS_GlobalData_t CFE_EVS_GlobalData;
+CFE_EVS_Global_t CFE_EVS_Global;
 
 
 /*
@@ -83,17 +83,17 @@ int32 CFE_EVS_EarlyInit ( void )
 
 #endif
 
-   memset(&CFE_EVS_GlobalData, 0, sizeof(CFE_EVS_GlobalData_t));
+   memset(&CFE_EVS_Global, 0, sizeof(CFE_EVS_Global));
 
    /* Initialize housekeeping packet */
-   CFE_MSG_Init(&CFE_EVS_GlobalData.EVS_TlmPkt.TlmHeader.Msg, CFE_SB_ValueToMsgId(CFE_EVS_HK_TLM_MID),
-           sizeof(CFE_EVS_GlobalData.EVS_TlmPkt));
+   CFE_MSG_Init(&CFE_EVS_Global.EVS_TlmPkt.TlmHeader.Msg, CFE_SB_ValueToMsgId(CFE_EVS_HK_TLM_MID),
+           sizeof(CFE_EVS_Global.EVS_TlmPkt));
   
    /* Elements stored in the hk packet that have non-zero default values */
-   CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode = CFE_PLATFORM_EVS_DEFAULT_MSG_FORMAT_MODE;
-   CFE_EVS_GlobalData.EVS_TlmPkt.Payload.OutputPort = CFE_PLATFORM_EVS_PORT_DEFAULT;
-   CFE_EVS_GlobalData.EVS_TlmPkt.Payload.LogFullFlag = false;
-   CFE_EVS_GlobalData.EVS_TlmPkt.Payload.LogMode = CFE_PLATFORM_EVS_DEFAULT_LOG_MODE;
+   CFE_EVS_Global.EVS_TlmPkt.Payload.MessageFormatMode = CFE_PLATFORM_EVS_DEFAULT_MSG_FORMAT_MODE;
+   CFE_EVS_Global.EVS_TlmPkt.Payload.OutputPort = CFE_PLATFORM_EVS_PORT_DEFAULT;
+   CFE_EVS_Global.EVS_TlmPkt.Payload.LogFullFlag = false;
+   CFE_EVS_Global.EVS_TlmPkt.Payload.LogMode = CFE_PLATFORM_EVS_DEFAULT_LOG_MODE;
 
 #ifdef CFE_PLATFORM_EVS_LOG_ON
 
@@ -115,10 +115,10 @@ int32 CFE_EVS_EarlyInit ( void )
    {
       CFE_EVS_ResetDataPtr = (CFE_ES_ResetData_t *)resetAreaAddr;
       /* Save pointer to the EVS portion of the CFE reset area */
-      CFE_EVS_GlobalData.EVS_LogPtr = &CFE_EVS_ResetDataPtr->EVS_Log;
+      CFE_EVS_Global.EVS_LogPtr = &CFE_EVS_ResetDataPtr->EVS_Log;
 
       /* Create semaphore to serialize access to event log */
-      Status = OS_MutSemCreate(&CFE_EVS_GlobalData.EVS_SharedDataMutexID, "CFE_EVS_DataMutex", 0);
+      Status = OS_MutSemCreate(&CFE_EVS_Global.EVS_SharedDataMutexID, "CFE_EVS_DataMutex", 0);
 
       if (Status != OS_SUCCESS)
       {
@@ -127,38 +127,38 @@ int32 CFE_EVS_EarlyInit ( void )
       else
       {
          /* Enable access to the EVS event log */                                                            
-         CFE_EVS_GlobalData.EVS_TlmPkt.Payload.LogEnabled = true;
+         CFE_EVS_Global.EVS_TlmPkt.Payload.LogEnabled = true;
 
          /* Clear event log if power-on reset or bad contents */                                                            
          if (CFE_ES_GetResetType(NULL) == CFE_PSP_RST_TYPE_POWERON)                                                                   
          {
             CFE_ES_WriteToSysLog("Event Log cleared following power-on reset\n");
             EVS_ClearLog();                                                                                         
-            CFE_EVS_GlobalData.EVS_LogPtr->LogMode = CFE_PLATFORM_EVS_DEFAULT_LOG_MODE;
+            CFE_EVS_Global.EVS_LogPtr->LogMode = CFE_PLATFORM_EVS_DEFAULT_LOG_MODE;
          }
-         else if (((CFE_EVS_GlobalData.EVS_LogPtr->LogMode != CFE_EVS_LogMode_OVERWRITE) &&
-                   (CFE_EVS_GlobalData.EVS_LogPtr->LogMode != CFE_EVS_LogMode_DISCARD))  ||
-                  ((CFE_EVS_GlobalData.EVS_LogPtr->LogFullFlag != false)   &&
-                   (CFE_EVS_GlobalData.EVS_LogPtr->LogFullFlag != true))   ||
-                   (CFE_EVS_GlobalData.EVS_LogPtr->Next >= CFE_PLATFORM_EVS_LOG_MAX))
+         else if (((CFE_EVS_Global.EVS_LogPtr->LogMode != CFE_EVS_LogMode_OVERWRITE) &&
+                   (CFE_EVS_Global.EVS_LogPtr->LogMode != CFE_EVS_LogMode_DISCARD))  ||
+                  ((CFE_EVS_Global.EVS_LogPtr->LogFullFlag != false)   &&
+                   (CFE_EVS_Global.EVS_LogPtr->LogFullFlag != true))   ||
+                   (CFE_EVS_Global.EVS_LogPtr->Next >= CFE_PLATFORM_EVS_LOG_MAX))
          {
             CFE_ES_WriteToSysLog("Event Log cleared, n=%d, c=%d, f=%d, m=%d, o=%d\n",
-                                  (int)CFE_EVS_GlobalData.EVS_LogPtr->Next,
-                                  (int)CFE_EVS_GlobalData.EVS_LogPtr->LogCount,
-                                  (int)CFE_EVS_GlobalData.EVS_LogPtr->LogFullFlag,
-                                  (int)CFE_EVS_GlobalData.EVS_LogPtr->LogMode,
-                                  (int)CFE_EVS_GlobalData.EVS_LogPtr->LogOverflowCounter);
+                                  (int)CFE_EVS_Global.EVS_LogPtr->Next,
+                                  (int)CFE_EVS_Global.EVS_LogPtr->LogCount,
+                                  (int)CFE_EVS_Global.EVS_LogPtr->LogFullFlag,
+                                  (int)CFE_EVS_Global.EVS_LogPtr->LogMode,
+                                  (int)CFE_EVS_Global.EVS_LogPtr->LogOverflowCounter);
             EVS_ClearLog();                                                                                         
-            CFE_EVS_GlobalData.EVS_LogPtr->LogMode = CFE_PLATFORM_EVS_DEFAULT_LOG_MODE;
+            CFE_EVS_Global.EVS_LogPtr->LogMode = CFE_PLATFORM_EVS_DEFAULT_LOG_MODE;
          }
          else
          {
             CFE_ES_WriteToSysLog("Event Log restored, n=%d, c=%d, f=%d, m=%d, o=%d\n",
-                                  (int)CFE_EVS_GlobalData.EVS_LogPtr->Next,
-                                  (int)CFE_EVS_GlobalData.EVS_LogPtr->LogCount,
-                                  (int)CFE_EVS_GlobalData.EVS_LogPtr->LogFullFlag,
-                                  (int)CFE_EVS_GlobalData.EVS_LogPtr->LogMode,
-                                  (int)CFE_EVS_GlobalData.EVS_LogPtr->LogOverflowCounter);
+                                  (int)CFE_EVS_Global.EVS_LogPtr->Next,
+                                  (int)CFE_EVS_Global.EVS_LogPtr->LogCount,
+                                  (int)CFE_EVS_Global.EVS_LogPtr->LogFullFlag,
+                                  (int)CFE_EVS_Global.EVS_LogPtr->LogMode,
+                                  (int)CFE_EVS_Global.EVS_LogPtr->LogOverflowCounter);
          }
       }
    }
@@ -245,7 +245,7 @@ void CFE_EVS_TaskMain(void)
 
         /* Pend on receipt of packet */
         Status = CFE_SB_ReceiveBuffer(&SBBufPtr,
-                               CFE_EVS_GlobalData.EVS_CommandPipe, 
+                               CFE_EVS_Global.EVS_CommandPipe,
                                CFE_SB_PEND_FOREVER);
 
         CFE_ES_PerfLogEntry(CFE_MISSION_EVS_MAIN_PERF_ID);
@@ -307,7 +307,7 @@ int32 CFE_EVS_TaskInit ( void )
    }
     
    /* Create software bus command pipe */
-   Status = CFE_SB_CreatePipe(&CFE_EVS_GlobalData.EVS_CommandPipe,
+   Status = CFE_SB_CreatePipe(&CFE_EVS_Global.EVS_CommandPipe,
                                CFE_EVS_PIPE_DEPTH, CFE_EVS_PIPE_NAME);
    if (Status != CFE_SUCCESS)
    {
@@ -316,7 +316,7 @@ int32 CFE_EVS_TaskInit ( void )
    }
       
    /* Subscribe to command and telemetry requests coming in on the command pipe */
-   Status = CFE_SB_SubscribeEx(CFE_SB_ValueToMsgId(CFE_EVS_CMD_MID), CFE_EVS_GlobalData.EVS_CommandPipe,
+   Status = CFE_SB_SubscribeEx(CFE_SB_ValueToMsgId(CFE_EVS_CMD_MID), CFE_EVS_Global.EVS_CommandPipe,
                                CFE_SB_Default_Qos, CFE_EVS_MSG_LIMIT);
    if (Status != CFE_SUCCESS)
    {
@@ -324,7 +324,7 @@ int32 CFE_EVS_TaskInit ( void )
       return Status;
    }
   
-   Status = CFE_SB_SubscribeEx(CFE_SB_ValueToMsgId(CFE_EVS_SEND_HK_MID), CFE_EVS_GlobalData.EVS_CommandPipe,
+   Status = CFE_SB_SubscribeEx(CFE_SB_ValueToMsgId(CFE_EVS_SEND_HK_MID), CFE_EVS_Global.EVS_CommandPipe,
                                CFE_SB_Default_Qos, CFE_EVS_MSG_LIMIT);
    if (Status != CFE_SUCCESS)
    {
@@ -333,7 +333,7 @@ int32 CFE_EVS_TaskInit ( void )
    }
   
    /* Write the AppID to the global location, now that the rest of initialization is done */
-   CFE_EVS_GlobalData.EVS_AppID = AppID;
+   CFE_EVS_Global.EVS_AppID = AppID;
    EVS_SendEvent(CFE_EVS_STARTUP_EID, CFE_EVS_EventType_INFORMATION, "cFE EVS Initialized.%s", CFE_VERSION_STRING);
 
    return CFE_SUCCESS;
@@ -373,7 +373,7 @@ void CFE_EVS_ProcessCommandPacket(CFE_SB_Buffer_t *SBBufPtr)
 
         default:
             /* Unknown command -- should never occur */
-            CFE_EVS_GlobalData.EVS_TlmPkt.Payload.CommandErrorCounter++;
+            CFE_EVS_Global.EVS_TlmPkt.Payload.CommandErrorCounter++;
             EVS_SendEvent(CFE_EVS_ERR_MSGID_EID, CFE_EVS_EventType_ERROR,
                          "Invalid command packet, Message ID = 0x%08X",
                           (unsigned int)CFE_SB_MsgIdToValue(MessageID));
@@ -589,11 +589,11 @@ void CFE_EVS_ProcessGroundCommand(CFE_SB_Buffer_t *SBBufPtr, CFE_SB_MsgId_t MsgI
 
    if (Status == CFE_SUCCESS)
    {
-      CFE_EVS_GlobalData.EVS_TlmPkt.Payload.CommandCounter++;
+      CFE_EVS_Global.EVS_TlmPkt.Payload.CommandCounter++;
    }
    else if (Status < 0)  /* Negative values indicate errors */
    {
-      CFE_EVS_GlobalData.EVS_TlmPkt.Payload.CommandErrorCounter++;
+      CFE_EVS_Global.EVS_TlmPkt.Payload.CommandErrorCounter++;
    }
 
    return;
@@ -670,7 +670,7 @@ int32 CFE_EVS_ClearLogCmd(const CFE_EVS_ClearLogCmd_t *data)
 {
     int32 Status;
 
-    if (CFE_EVS_GlobalData.EVS_TlmPkt.Payload.LogEnabled == true)
+    if (CFE_EVS_Global.EVS_TlmPkt.Payload.LogEnabled == true)
     {
         EVS_ClearLog();
         Status = CFE_SUCCESS;
@@ -700,17 +700,17 @@ int32 CFE_EVS_ReportHousekeepingCmd (const CFE_MSG_CommandHeader_t *data)
    EVS_AppData_t *AppDataPtr;
    CFE_EVS_AppTlmData_t *AppTlmDataPtr;
 
-   if (CFE_EVS_GlobalData.EVS_TlmPkt.Payload.LogEnabled == true)
+   if (CFE_EVS_Global.EVS_TlmPkt.Payload.LogEnabled == true)
    {   
       /* Copy hk variables that are maintained in the event log */
-      CFE_EVS_GlobalData.EVS_TlmPkt.Payload.LogFullFlag = CFE_EVS_GlobalData.EVS_LogPtr->LogFullFlag;
-      CFE_EVS_GlobalData.EVS_TlmPkt.Payload.LogMode = CFE_EVS_GlobalData.EVS_LogPtr->LogMode;
-      CFE_EVS_GlobalData.EVS_TlmPkt.Payload.LogOverflowCounter = CFE_EVS_GlobalData.EVS_LogPtr->LogOverflowCounter;
+      CFE_EVS_Global.EVS_TlmPkt.Payload.LogFullFlag = CFE_EVS_Global.EVS_LogPtr->LogFullFlag;
+      CFE_EVS_Global.EVS_TlmPkt.Payload.LogMode = CFE_EVS_Global.EVS_LogPtr->LogMode;
+      CFE_EVS_Global.EVS_TlmPkt.Payload.LogOverflowCounter = CFE_EVS_Global.EVS_LogPtr->LogOverflowCounter;
    }
 
    /* Write event state data for registered apps to telemetry packet */
-   AppDataPtr = CFE_EVS_GlobalData.AppData;
-   AppTlmDataPtr = CFE_EVS_GlobalData.EVS_TlmPkt.Payload.AppData;
+   AppDataPtr = CFE_EVS_Global.AppData;
+   AppTlmDataPtr = CFE_EVS_Global.EVS_TlmPkt.Payload.AppData;
    for (i = 0, j = 0; j < CFE_MISSION_ES_MAX_APPLICATIONS && i < CFE_PLATFORM_ES_MAX_APPLICATIONS; i++)
    {
       if ( EVS_AppDataIsUsed(AppDataPtr) )
@@ -732,9 +732,9 @@ int32 CFE_EVS_ReportHousekeepingCmd (const CFE_MSG_CommandHeader_t *data)
        AppTlmDataPtr->AppMessageSentCounter = 0;
    }
 
-   CFE_SB_TimeStampMsg(&CFE_EVS_GlobalData.EVS_TlmPkt.TlmHeader.Msg);
+   CFE_SB_TimeStampMsg(&CFE_EVS_Global.EVS_TlmPkt.TlmHeader.Msg);
 
-   CFE_SB_TransmitMsg(&CFE_EVS_GlobalData.EVS_TlmPkt.TlmHeader.Msg, true);
+   CFE_SB_TransmitMsg(&CFE_EVS_Global.EVS_TlmPkt.TlmHeader.Msg, true);
 
    return CFE_STATUS_NO_COUNTER_INCREMENT;
 } /* End of CFE_EVS_ReportHousekeepingCmd() */
@@ -754,13 +754,13 @@ int32 CFE_EVS_ReportHousekeepingCmd (const CFE_MSG_CommandHeader_t *data)
 int32 CFE_EVS_ResetCountersCmd(const CFE_EVS_ResetCountersCmd_t *data)
 {
     /* Status of commands processed by EVS task */
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.CommandCounter  = 0;
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.CommandErrorCounter   =  0;
+    CFE_EVS_Global.EVS_TlmPkt.Payload.CommandCounter  = 0;
+    CFE_EVS_Global.EVS_TlmPkt.Payload.CommandErrorCounter   =  0;
 
     /* EVS telemetry counters */
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageSendCounter = 0;
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageTruncCounter = 0;
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.UnregisteredAppCounter = 0;
+    CFE_EVS_Global.EVS_TlmPkt.Payload.MessageSendCounter = 0;
+    CFE_EVS_Global.EVS_TlmPkt.Payload.MessageTruncCounter = 0;
+    CFE_EVS_Global.EVS_TlmPkt.Payload.UnregisteredAppCounter = 0;
 
     EVS_SendEvent(CFE_EVS_RSTCNT_EID, CFE_EVS_EventType_DEBUG, "Reset Counters Command Received");
 
@@ -877,19 +877,19 @@ int32 CFE_EVS_EnablePortsCmd(const CFE_EVS_EnablePortsCmd_t *data)
         /* Process command data */
         if(((CmdPtr->BitMask & CFE_EVS_PORT1_BIT) >> 0) == true)
         {
-            CFE_EVS_GlobalData.EVS_TlmPkt.Payload.OutputPort |= CFE_EVS_PORT1_BIT;
+            CFE_EVS_Global.EVS_TlmPkt.Payload.OutputPort |= CFE_EVS_PORT1_BIT;
         }
         if(((CmdPtr->BitMask & CFE_EVS_PORT2_BIT) >>1) == true)
         {
-            CFE_EVS_GlobalData.EVS_TlmPkt.Payload.OutputPort |= CFE_EVS_PORT2_BIT;
+            CFE_EVS_Global.EVS_TlmPkt.Payload.OutputPort |= CFE_EVS_PORT2_BIT;
         }
         if(((CmdPtr->BitMask & CFE_EVS_PORT3_BIT) >> 2) == true)
         {
-            CFE_EVS_GlobalData.EVS_TlmPkt.Payload.OutputPort |= CFE_EVS_PORT3_BIT;
+            CFE_EVS_Global.EVS_TlmPkt.Payload.OutputPort |= CFE_EVS_PORT3_BIT;
         }
         if(((CmdPtr->BitMask & CFE_EVS_PORT4_BIT) >>3) == true)
         {
-            CFE_EVS_GlobalData.EVS_TlmPkt.Payload.OutputPort |= CFE_EVS_PORT4_BIT;
+            CFE_EVS_Global.EVS_TlmPkt.Payload.OutputPort |= CFE_EVS_PORT4_BIT;
         }
 
         EVS_SendEvent(CFE_EVS_ENAPORT_EID, CFE_EVS_EventType_DEBUG,
@@ -933,19 +933,19 @@ int32 CFE_EVS_DisablePortsCmd(const CFE_EVS_DisablePortsCmd_t *data)
         /* Process command data */
         if(((CmdPtr->BitMask & CFE_EVS_PORT1_BIT) >>0) == true)
         {
-            CFE_EVS_GlobalData.EVS_TlmPkt.Payload.OutputPort &= ~CFE_EVS_PORT1_BIT;
+            CFE_EVS_Global.EVS_TlmPkt.Payload.OutputPort &= ~CFE_EVS_PORT1_BIT;
         }
         if(((CmdPtr->BitMask & CFE_EVS_PORT2_BIT) >> 1) == true)
         {
-            CFE_EVS_GlobalData.EVS_TlmPkt.Payload.OutputPort &= ~CFE_EVS_PORT2_BIT;
+            CFE_EVS_Global.EVS_TlmPkt.Payload.OutputPort &= ~CFE_EVS_PORT2_BIT;
         }
         if(((CmdPtr->BitMask & CFE_EVS_PORT3_BIT) >> 2) == true)
         {
-            CFE_EVS_GlobalData.EVS_TlmPkt.Payload.OutputPort &= ~CFE_EVS_PORT3_BIT;
+            CFE_EVS_Global.EVS_TlmPkt.Payload.OutputPort &= ~CFE_EVS_PORT3_BIT;
         }
         if(((CmdPtr->BitMask & CFE_EVS_PORT4_BIT) >>3) == true)
         {
-            CFE_EVS_GlobalData.EVS_TlmPkt.Payload.OutputPort &= ~CFE_EVS_PORT4_BIT;
+            CFE_EVS_Global.EVS_TlmPkt.Payload.OutputPort &= ~CFE_EVS_PORT4_BIT;
         }
 
         EVS_SendEvent(CFE_EVS_DISPORT_EID, CFE_EVS_EventType_DEBUG,
@@ -989,7 +989,7 @@ int32 CFE_EVS_EnableEventTypeCmd(const CFE_EVS_EnableEventTypeCmd_t *data)
    }
    else
    {
-       AppDataPtr = CFE_EVS_GlobalData.AppData;
+       AppDataPtr = CFE_EVS_Global.AppData;
        for (i = 0; i < CFE_PLATFORM_ES_MAX_APPLICATIONS; i++)
        {
            /* Make sure application is registered for event services */
@@ -1041,7 +1041,7 @@ int32 CFE_EVS_DisableEventTypeCmd(const CFE_EVS_DisableEventTypeCmd_t *data)
 
    else
    {
-       AppDataPtr = CFE_EVS_GlobalData.AppData;
+       AppDataPtr = CFE_EVS_Global.AppData;
        for (i = 0; i < CFE_PLATFORM_ES_MAX_APPLICATIONS; i++)
        {
            /* Make sure application is registered for event services */
@@ -1082,7 +1082,7 @@ int32 CFE_EVS_SetEventFormatModeCmd(const CFE_EVS_SetEventFormatModeCmd_t *data)
 
    if((CmdPtr->MsgFormat == CFE_EVS_MsgFormat_SHORT) || (CmdPtr->MsgFormat == CFE_EVS_MsgFormat_LONG))
    {
-      CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode = CmdPtr->MsgFormat;
+      CFE_EVS_Global.EVS_TlmPkt.Payload.MessageFormatMode = CmdPtr->MsgFormat;
 
       EVS_SendEvent(CFE_EVS_SETEVTFMTMOD_EID, CFE_EVS_EventType_DEBUG,
                         "Set Event Format Mode Command Received with Mode = 0x%02x",
@@ -1788,7 +1788,7 @@ int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFileCmd_t *data)
 
       if (BytesWritten == sizeof(CFE_FS_Header_t))
       {
-         AppDataPtr = CFE_EVS_GlobalData.AppData;
+         AppDataPtr = CFE_EVS_Global.AppData;
          for (i = 0; i < CFE_PLATFORM_ES_MAX_APPLICATIONS; i++)
          {
             /* Only have data for apps that are registered */

--- a/fsw/cfe-core/src/evs/cfe_evs_task.h
+++ b/fsw/cfe-core/src/evs/cfe_evs_task.h
@@ -126,12 +126,12 @@ typedef struct
    osal_id_t           EVS_SharedDataMutexID;
    CFE_ES_ResourceID_t EVS_AppID;
 
-} CFE_EVS_GlobalData_t;
+} CFE_EVS_Global_t;
 
 /*
  *  Global variable specific to EVS module
  */
-extern CFE_EVS_GlobalData_t   CFE_EVS_GlobalData;
+extern CFE_EVS_Global_t   CFE_EVS_Global;
 
 
 /*****************************  Function Prototypes   **********************************/

--- a/fsw/cfe-core/src/evs/cfe_evs_utils.c
+++ b/fsw/cfe-core/src/evs/cfe_evs_utils.c
@@ -72,7 +72,7 @@ EVS_AppData_t *EVS_GetAppDataByID (CFE_ES_ResourceID_t AppID)
    if (CFE_ES_AppID_ToIndex(AppID, &AppIndex) == CFE_SUCCESS &&
            AppIndex < CFE_PLATFORM_ES_MAX_APPLICATIONS)
    {
-       AppDataPtr = &CFE_EVS_GlobalData.AppData[AppIndex];
+       AppDataPtr = &CFE_EVS_Global.AppData[AppIndex];
    }
    else
    {
@@ -188,7 +188,7 @@ int32 EVS_NotRegistered (EVS_AppData_t *AppDataPtr, CFE_ES_ResourceID_t CallerID
    if ( !CFE_ES_ResourceID_Equal(AppDataPtr->UnregAppID, CallerID) )
    { 
       /* Increment count of "not registered" applications */
-      CFE_EVS_GlobalData.EVS_TlmPkt.Payload.UnregisteredAppCounter++;
+      CFE_EVS_Global.EVS_TlmPkt.Payload.UnregisteredAppCounter++;
 
       /* Indicate that "not registered" event has been sent for this app */
       AppDataPtr->UnregAppID = CallerID;
@@ -418,7 +418,7 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint1
     {
        /* Mark character before zero terminator to indicate truncation */
        LongEventTlm.Payload.Message[sizeof(LongEventTlm.Payload.Message) - 2] = CFE_EVS_MSG_TRUNCATED;
-       CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageTruncCounter++;
+       CFE_EVS_Global.EVS_TlmPkt.Payload.MessageTruncCounter++;
     }
 
     /* Obtain task and system information */
@@ -436,12 +436,12 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint1
     /* Send event via selected ports */
     EVS_SendViaPorts(&LongEventTlm);
 
-    if (CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode == CFE_EVS_MsgFormat_LONG)
+    if (CFE_EVS_Global.EVS_TlmPkt.Payload.MessageFormatMode == CFE_EVS_MsgFormat_LONG)
     {
         /* Send long event via SoftwareBus */
         CFE_SB_TransmitMsg(&LongEventTlm.TlmHeader.Msg, true);
     }
-    else if (CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode == CFE_EVS_MsgFormat_SHORT)
+    else if (CFE_EVS_Global.EVS_TlmPkt.Payload.MessageFormatMode == CFE_EVS_MsgFormat_SHORT)
     {
         /*
          * Initialize the short format event message from data that was already
@@ -457,9 +457,9 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint1
     }
 
     /* Increment message send counters (prevent rollover) */
-    if (CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageSendCounter < CFE_EVS_MAX_EVENT_SEND_COUNT)
+    if (CFE_EVS_Global.EVS_TlmPkt.Payload.MessageSendCounter < CFE_EVS_MAX_EVENT_SEND_COUNT)
     {
-       CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageSendCounter++;
+       CFE_EVS_Global.EVS_TlmPkt.Payload.MessageSendCounter++;
     }
 
     if (AppDataPtr->EventCount < CFE_EVS_MAX_EVENT_SEND_COUNT)
@@ -484,7 +484,7 @@ void EVS_SendViaPorts (CFE_EVS_LongEventTlm_t *EVS_PktPtr)
 {
    char PortMessage[CFE_EVS_MAX_PORT_MSG_LENGTH];
 
-   if (((CFE_EVS_GlobalData.EVS_TlmPkt.Payload.OutputPort & CFE_EVS_PORT1_BIT) >> 0) == true)
+   if (((CFE_EVS_Global.EVS_TlmPkt.Payload.OutputPort & CFE_EVS_PORT1_BIT) >> 0) == true)
    {
       /* Copy event message to string format */
       snprintf(PortMessage, CFE_EVS_MAX_PORT_MSG_LENGTH, "EVS Port1 %u/%u/%s %u: %s", (unsigned int) EVS_PktPtr->Payload.PacketID.SpacecraftID,
@@ -496,7 +496,7 @@ void EVS_SendViaPorts (CFE_EVS_LongEventTlm_t *EVS_PktPtr)
       EVS_OutputPort1(PortMessage);
    }
 
-   if (((CFE_EVS_GlobalData.EVS_TlmPkt.Payload.OutputPort & CFE_EVS_PORT2_BIT) >> 1) == true)
+   if (((CFE_EVS_Global.EVS_TlmPkt.Payload.OutputPort & CFE_EVS_PORT2_BIT) >> 1) == true)
    {
       /* Copy event message to string format */
       snprintf(PortMessage, CFE_EVS_MAX_PORT_MSG_LENGTH, "EVS Port2 %u/%u/%s %u: %s", (unsigned int) EVS_PktPtr->Payload.PacketID.SpacecraftID,
@@ -508,7 +508,7 @@ void EVS_SendViaPorts (CFE_EVS_LongEventTlm_t *EVS_PktPtr)
       EVS_OutputPort2(PortMessage);
    }
 
-   if (((CFE_EVS_GlobalData.EVS_TlmPkt.Payload.OutputPort & CFE_EVS_PORT3_BIT) >> 2) == true)
+   if (((CFE_EVS_Global.EVS_TlmPkt.Payload.OutputPort & CFE_EVS_PORT3_BIT) >> 2) == true)
    {
       /* Copy event message to string format */
       snprintf(PortMessage, CFE_EVS_MAX_PORT_MSG_LENGTH, "EVS Port3 %u/%u/%s %u: %s", (unsigned int) EVS_PktPtr->Payload.PacketID.SpacecraftID,
@@ -520,7 +520,7 @@ void EVS_SendViaPorts (CFE_EVS_LongEventTlm_t *EVS_PktPtr)
       EVS_OutputPort3(PortMessage);
    }
 
-   if (((CFE_EVS_GlobalData.EVS_TlmPkt.Payload.OutputPort & CFE_EVS_PORT4_BIT) >> 3) == true)
+   if (((CFE_EVS_Global.EVS_TlmPkt.Payload.OutputPort & CFE_EVS_PORT4_BIT) >> 3) == true)
    {
       /* Copy event message to string format */
       snprintf(PortMessage, CFE_EVS_MAX_PORT_MSG_LENGTH, "EVS Port4 %u/%u/%s %u: %s", (unsigned int) EVS_PktPtr->Payload.PacketID.SpacecraftID,
@@ -629,10 +629,10 @@ int32 EVS_SendEvent (uint16 EventID, uint16 EventType, const char *Spec, ... )
     * Must check that EVS_AppID is valid, which can happen if this is called
     * by some other thread before CFE_EVS_TaskInit() runs
     */
-   AppDataPtr = EVS_GetAppDataByID(CFE_EVS_GlobalData.EVS_AppID);
+   AppDataPtr = EVS_GetAppDataByID(CFE_EVS_Global.EVS_AppID);
 
    /* Unlikely, but possible that an EVS event filter was added by command */
-   if ( EVS_AppDataIsMatch(AppDataPtr, CFE_EVS_GlobalData.EVS_AppID) &&
+   if ( EVS_AppDataIsMatch(AppDataPtr, CFE_EVS_Global.EVS_AppID) &&
            EVS_IsFiltered(AppDataPtr, EventID, EventType) == false)
    {
       /* Get current spacecraft time */

--- a/fsw/cfe-core/src/fs/cfe_fs_priv.c
+++ b/fsw/cfe-core/src/fs/cfe_fs_priv.c
@@ -45,7 +45,7 @@
 ** Global data
 ** 
 */
-CFE_FS_t CFE_FS;
+CFE_FS_Global_t CFE_FS_Global;
 
 /******************************************************************************
 **  Function:  CFE_FS_EarlyInit()
@@ -65,7 +65,9 @@ int32 CFE_FS_EarlyInit (void)
 {
     int32 Stat;
 
-    Stat = OS_MutSemCreate(&CFE_FS.SharedDataMutexId, "CFE_FS_SharedMutex", 0);
+    memset(&CFE_FS_Global, 0, sizeof(CFE_FS_Global));
+
+    Stat = OS_MutSemCreate(&CFE_FS_Global.SharedDataMutexId, "CFE_FS_SharedMutex", 0);
     if( Stat != OS_SUCCESS )
     {
       CFE_ES_WriteToSysLog("FS Shared Data Mutex creation failed! RC=0x%08x\n",(unsigned int)Stat);
@@ -94,7 +96,7 @@ void CFE_FS_LockSharedData(const char *FunctionName)
     int32   Status;
     CFE_ES_ResourceID_t  AppId;
 
-    Status = OS_MutSemTake(CFE_FS.SharedDataMutexId);
+    Status = OS_MutSemTake(CFE_FS_Global.SharedDataMutexId);
     if (Status != OS_SUCCESS) 
     {
         CFE_ES_GetAppID(&AppId);
@@ -126,7 +128,7 @@ void CFE_FS_UnlockSharedData(const char *FunctionName)
    int32   Status;
    CFE_ES_ResourceID_t  AppId;
 
-   Status = OS_MutSemGive(CFE_FS.SharedDataMutexId);
+   Status = OS_MutSemGive(CFE_FS_Global.SharedDataMutexId);
    if (Status != OS_SUCCESS) 
    {
        CFE_ES_GetAppID(&AppId);

--- a/fsw/cfe-core/src/fs/cfe_fs_priv.h
+++ b/fsw/cfe-core/src/fs/cfe_fs_priv.h
@@ -50,7 +50,7 @@
 */
 
 /******************************************************************************
-**  Typedef: CFE_FS_t 
+**  Typedef: CFE_FS_Global_t
 **
 **  Purpose:
 **     This structure contains the FS global variables.
@@ -59,7 +59,7 @@ typedef struct
 {
     osal_id_t              SharedDataMutexId;
 
-} CFE_FS_t;
+} CFE_FS_Global_t;
 
 /*
 ** FS Function Prototypes

--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -73,7 +73,7 @@
  * Macro to reflect size of PipeDepthStats Telemetry array - 
  * this may or may not be the same as CFE_SB_MSG_MAX_PIPES
  */
-#define CFE_SB_TLM_PIPEDEPTHSTATS_SIZE     (sizeof(CFE_SB.StatTlmMsg.Payload.PipeDepthStats) / sizeof(CFE_SB.StatTlmMsg.Payload.PipeDepthStats[0]))
+#define CFE_SB_TLM_PIPEDEPTHSTATS_SIZE     (sizeof(CFE_SB_Global.StatTlmMsg.Payload.PipeDepthStats) / sizeof(CFE_SB_Global.StatTlmMsg.Payload.PipeDepthStats[0]))
 
 /* Local structure for remove pipe callbacks */
 typedef struct
@@ -137,7 +137,7 @@ int32  CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16  Depth, const char *
         CFE_SB_LockSharedData(__func__,__LINE__);
 
         /* get first available entry in pipe table */
-        PendingPipeId = CFE_ES_FindNextAvailableId(CFE_SB.LastPipeId, CFE_PLATFORM_SB_MAX_PIPES, CFE_SB_CheckPipeDescSlotUsed);
+        PendingPipeId = CFE_ES_FindNextAvailableId(CFE_SB_Global.LastPipeId, CFE_PLATFORM_SB_MAX_PIPES, CFE_SB_CheckPipeDescSlotUsed);
         PipeDscPtr = CFE_SB_LocatePipeDescByID(PendingPipeId);
 
         /* if pipe table is full, send event and return error */
@@ -152,7 +152,7 @@ int32  CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16  Depth, const char *
             memset(PipeDscPtr, 0, sizeof(*PipeDscPtr));
 
             CFE_SB_PipeDescSetUsed(PipeDscPtr, CFE_ES_RESOURCEID_RESERVED);
-            CFE_SB.LastPipeId = PendingPipeId;
+            CFE_SB_Global.LastPipeId = PendingPipeId;
         }
 
         CFE_SB_UnlockSharedData(__func__,__LINE__);
@@ -201,10 +201,10 @@ int32  CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16  Depth, const char *
 
         /* Increment the Pipes in use ctr and if it's > the high water mark,*/
         /* adjust the high water mark */
-        CFE_SB.StatTlmMsg.Payload.PipesInUse++;
-        if (CFE_SB.StatTlmMsg.Payload.PipesInUse > CFE_SB.StatTlmMsg.Payload.PeakPipesInUse)
+        CFE_SB_Global.StatTlmMsg.Payload.PipesInUse++;
+        if (CFE_SB_Global.StatTlmMsg.Payload.PipesInUse > CFE_SB_Global.StatTlmMsg.Payload.PeakPipesInUse)
         {
-            CFE_SB.StatTlmMsg.Payload.PeakPipesInUse = CFE_SB.StatTlmMsg.Payload.PipesInUse;
+            CFE_SB_Global.StatTlmMsg.Payload.PeakPipesInUse = CFE_SB_Global.StatTlmMsg.Payload.PipesInUse;
         }/* end if */
     }
     else
@@ -226,7 +226,7 @@ int32  CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16  Depth, const char *
         switch(PendingEventId)
         {
             case CFE_SB_CR_PIPE_BAD_ARG_EID:
-                ++CFE_SB.HKTlmMsg.Payload.CreatePipeErrorCounter;
+                ++CFE_SB_Global.HKTlmMsg.Payload.CreatePipeErrorCounter;
                 break;
             default:
                 /* no counter */
@@ -240,7 +240,7 @@ int32  CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16  Depth, const char *
     if (Status == CFE_SUCCESS)
     {
         /* send debug event */
-        CFE_EVS_SendEventWithAppID(CFE_SB_PIPE_ADDED_EID,CFE_EVS_EventType_DEBUG,CFE_SB.AppId,
+        CFE_EVS_SendEventWithAppID(CFE_SB_PIPE_ADDED_EID,CFE_EVS_EventType_DEBUG,CFE_SB_Global.AppId,
             "Pipe Created:name %s,id %d,app %s",
             PipeName, (int)CFE_ES_ResourceID_ToInteger(PendingPipeId),
             CFE_SB_GetAppTskName(TskId,FullName));
@@ -253,28 +253,28 @@ int32  CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16  Depth, const char *
         switch(PendingEventId)
         {
             case CFE_SB_CR_PIPE_BAD_ARG_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_CR_PIPE_BAD_ARG_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+                CFE_EVS_SendEventWithAppID(CFE_SB_CR_PIPE_BAD_ARG_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                     "CreatePipeErr:Bad Input Arg:app=%s,ptr=0x%lx,depth=%d,maxdepth=%d",
                     CFE_SB_GetAppTskName(TskId,FullName),(unsigned long)PipeIdPtr,(int)Depth,CFE_PLATFORM_SB_MAX_PIPE_DEPTH);
                 break;
 
             case CFE_SB_MAX_PIPES_MET_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_MAX_PIPES_MET_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+                CFE_EVS_SendEventWithAppID(CFE_SB_MAX_PIPES_MET_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                     "CreatePipeErr:Max Pipes(%d)In Use.app %s",
                     CFE_PLATFORM_SB_MAX_PIPES,CFE_SB_GetAppTskName(TskId,FullName));
                 break;
             case CFE_SB_CR_PIPE_NAME_TAKEN_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_CR_PIPE_NAME_TAKEN_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+                CFE_EVS_SendEventWithAppID(CFE_SB_CR_PIPE_NAME_TAKEN_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                     "CreatePipeErr:OS_QueueCreate failed, name taken (app=%s, name=%s)",
                     CFE_SB_GetAppTskName(TskId,FullName), PipeName);
                 break;
             case CFE_SB_CR_PIPE_NO_FREE_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_CR_PIPE_NO_FREE_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+                CFE_EVS_SendEventWithAppID(CFE_SB_CR_PIPE_NO_FREE_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                     "CreatePipeErr:OS_QueueCreate failed, no free id's (app=%s)",
                     CFE_SB_GetAppTskName(TskId,FullName));
                 break;
             case CFE_SB_CR_PIPE_ERR_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_CR_PIPE_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+                CFE_EVS_SendEventWithAppID(CFE_SB_CR_PIPE_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                     "CreatePipeErr:OS_QueueCreate returned %d,app %s",
                     (int)Status,CFE_SB_GetAppTskName(TskId,FullName));
                 break;
@@ -455,11 +455,11 @@ int32 CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId,CFE_ES_ResourceID_t AppId)
     if (Status == CFE_SUCCESS)
     {
         CFE_SB_PipeDescSetFree(PipeDscPtr);
-        --CFE_SB.StatTlmMsg.Payload.PipesInUse;
+        --CFE_SB_Global.StatTlmMsg.Payload.PipesInUse;
     }
     else if (PendingEventID != 0)
     {
-        CFE_SB.HKTlmMsg.Payload.CreatePipeErrorCounter++;
+        CFE_SB_Global.HKTlmMsg.Payload.CreatePipeErrorCounter++;
     }
 
     CFE_SB_UnlockSharedData(__func__,__LINE__);
@@ -474,7 +474,7 @@ int32 CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId,CFE_ES_ResourceID_t AppId)
          */
         CFE_ES_GetAppName(FullName, AppId, sizeof(FullName));
 
-        CFE_EVS_SendEventWithAppID(CFE_SB_PIPE_DELETED_EID,CFE_EVS_EventType_DEBUG,CFE_SB.AppId,
+        CFE_EVS_SendEventWithAppID(CFE_SB_PIPE_DELETED_EID,CFE_EVS_EventType_DEBUG,CFE_SB_Global.AppId,
             "Pipe Deleted:id %d,owner %s",(int)CFE_ES_ResourceID_ToInteger(PipeId), FullName);
     }
     else 
@@ -486,12 +486,12 @@ int32 CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId,CFE_ES_ResourceID_t AppId)
         switch (PendingEventID)
         {
             case CFE_SB_DEL_PIPE_ERR1_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_DEL_PIPE_ERR1_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+                CFE_EVS_SendEventWithAppID(CFE_SB_DEL_PIPE_ERR1_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                     "Pipe Delete Error:Bad Argument,PipedId %ld,Requestor %s",
                     CFE_ES_ResourceID_ToInteger(PipeId),FullName);
                 break;
             case CFE_SB_DEL_PIPE_ERR2_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_DEL_PIPE_ERR2_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+                CFE_EVS_SendEventWithAppID(CFE_SB_DEL_PIPE_ERR2_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                     "Pipe Delete Error:Caller(%s) is not the owner of pipe %ld", 
                     FullName, CFE_ES_ResourceID_ToInteger(PipeId));
                 break;
@@ -548,7 +548,7 @@ int32 CFE_SB_SetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 Opts)
     /* If anything went wrong, increment the error counter before unlock */
     if (Status != CFE_SUCCESS)
     {
-        CFE_SB.HKTlmMsg.Payload.PipeOptsErrorCounter++;
+        CFE_SB_Global.HKTlmMsg.Payload.PipeOptsErrorCounter++;
     }
 
     CFE_SB_UnlockSharedData(__func__,__LINE__);
@@ -559,7 +559,7 @@ int32 CFE_SB_SetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 Opts)
         /* get AppID of caller for events */
         CFE_ES_GetAppName(FullName, AppID, sizeof(FullName));
 
-        CFE_EVS_SendEventWithAppID(CFE_SB_SETPIPEOPTS_EID,CFE_EVS_EventType_DEBUG,CFE_SB.AppId,
+        CFE_EVS_SendEventWithAppID(CFE_SB_SETPIPEOPTS_EID,CFE_EVS_EventType_DEBUG,CFE_SB_Global.AppId,
             "Pipe opts set:id %lu,owner %s, opts=0x%02x",CFE_ES_ResourceID_ToInteger(PipeId), FullName, (unsigned int)Opts);
     }
     else
@@ -570,12 +570,12 @@ int32 CFE_SB_SetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 Opts)
         switch (PendingEventID)
         {
             case CFE_SB_SETPIPEOPTS_ID_ERR_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_SETPIPEOPTS_ID_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+                CFE_EVS_SendEventWithAppID(CFE_SB_SETPIPEOPTS_ID_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                     "Pipe Opts Error:Bad Argument,PipedId %lu,Requestor %s",
                     CFE_ES_ResourceID_ToInteger(PipeId),CFE_SB_GetAppTskName(TskId,FullName));
                 break;
             case CFE_SB_SETPIPEOPTS_OWNER_ERR_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_SETPIPEOPTS_OWNER_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+                CFE_EVS_SendEventWithAppID(CFE_SB_SETPIPEOPTS_OWNER_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                     "Pipe Opts Set Error: Caller(%s) is not the owner of pipe %lu",
                     CFE_SB_GetAppTskName(TskId,FullName),CFE_ES_ResourceID_ToInteger(PipeId));
                 break;
@@ -622,7 +622,7 @@ int32 CFE_SB_GetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 *OptsPtr)
     /* If anything went wrong, increment the error counter before unlock */
     if (Status != CFE_SUCCESS)
     {
-        CFE_SB.HKTlmMsg.Payload.PipeOptsErrorCounter++;
+        CFE_SB_Global.HKTlmMsg.Payload.PipeOptsErrorCounter++;
     }
 
     CFE_SB_UnlockSharedData(__func__,__LINE__);
@@ -630,7 +630,7 @@ int32 CFE_SB_GetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 *OptsPtr)
     /* Send events after unlocking SB */
     if (Status == CFE_SUCCESS)
     {
-        CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPEOPTS_EID,CFE_EVS_EventType_DEBUG,CFE_SB.AppId,
+        CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPEOPTS_EID,CFE_EVS_EventType_DEBUG,CFE_SB_Global.AppId,
               "Pipe opts get:id %lu, opts=0x%02x",CFE_ES_ResourceID_ToInteger(PipeId), (unsigned int)*OptsPtr);
     }
     else
@@ -641,12 +641,12 @@ int32 CFE_SB_GetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 *OptsPtr)
         switch(PendingEventID)
         {
             case CFE_SB_GETPIPEOPTS_PTR_ERR_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPEOPTS_PTR_ERR_EID, CFE_EVS_EventType_ERROR, CFE_SB.AppId,
+                CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPEOPTS_PTR_ERR_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                     "Pipe Opts Error:Bad Argument,Requestor %s",
                     CFE_SB_GetAppTskName(TskId,FullName));
                 break;
             case CFE_SB_GETPIPEOPTS_ID_ERR_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPEOPTS_ID_ERR_EID, CFE_EVS_EventType_ERROR, CFE_SB.AppId,
+                CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPEOPTS_ID_ERR_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                 "Pipe Opts Error:Bad Argument,PipedId %lu,Requestor %s",
                 CFE_ES_ResourceID_ToInteger(PipeId),CFE_SB_GetAppTskName(TskId,FullName));
                 break;
@@ -716,7 +716,7 @@ int32 CFE_SB_GetPipeName(char *PipeNameBuf, size_t PipeNameSize, CFE_SB_PipeId_t
     if (Status == CFE_SUCCESS)
     {
         CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPENAME_EID,
-                CFE_EVS_EventType_DEBUG,CFE_SB.AppId,
+                CFE_EVS_EventType_DEBUG,CFE_SB_Global.AppId,
                 "GetPipeName name=%s id=%lu",
                 PipeNameBuf, CFE_ES_ResourceID_ToInteger(PipeId));
     }
@@ -728,12 +728,12 @@ int32 CFE_SB_GetPipeName(char *PipeNameBuf, size_t PipeNameSize, CFE_SB_PipeId_t
         {
             case CFE_SB_GETPIPENAME_NULL_PTR_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPENAME_NULL_PTR_EID, CFE_EVS_EventType_ERROR,
-                    CFE_SB.AppId, "Pipe Name Error:NullPtr,Requestor %s",
+                    CFE_SB_Global.AppId, "Pipe Name Error:NullPtr,Requestor %s",
                     CFE_SB_GetAppTskName(TskId,FullName));
                 break;
             case CFE_SB_GETPIPENAME_ID_ERR_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPENAME_ID_ERR_EID, CFE_EVS_EventType_ERROR,
-                    CFE_SB.AppId, "Pipe Id Error:Bad Argument,Id=%lu,Requestor %s",
+                    CFE_SB_Global.AppId, "Pipe Id Error:Bad Argument,Id=%lu,Requestor %s",
                     CFE_ES_ResourceID_ToInteger(PipeId),CFE_SB_GetAppTskName(TskId,FullName));
                 break;
         }
@@ -790,7 +790,7 @@ int32 CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *PipeName)
     if (Status == CFE_SUCCESS)
     {
         Idx = CFE_PLATFORM_SB_MAX_PIPES;
-        PipeDscPtr = CFE_SB.PipeTbl;
+        PipeDscPtr = CFE_SB_Global.PipeTbl;
         while(true)
         {
             if (Idx == 0)
@@ -814,7 +814,7 @@ int32 CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *PipeName)
     
     if (Status != CFE_SUCCESS)
     {
-        ++CFE_SB.HKTlmMsg.Payload.GetPipeIdByNameErrorCounter;
+        ++CFE_SB_Global.HKTlmMsg.Payload.GetPipeIdByNameErrorCounter;
     }
 
     CFE_SB_UnlockSharedData(__func__,__LINE__);
@@ -823,7 +823,7 @@ int32 CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *PipeName)
     if (Status == CFE_SUCCESS)
     {
         CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPEIDBYNAME_EID,
-            CFE_EVS_EventType_DEBUG,CFE_SB.AppId,
+            CFE_EVS_EventType_DEBUG,CFE_SB_Global.AppId,
             "PipeIdByName name=%s id=%lu",
             PipeName, CFE_ES_ResourceID_ToInteger(*PipeIdPtr));
     }
@@ -836,14 +836,14 @@ int32 CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *PipeName)
         {
             case CFE_SB_GETPIPEIDBYNAME_NULL_ERR_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPEIDBYNAME_NULL_ERR_EID, 
-                    CFE_EVS_EventType_ERROR, CFE_SB.AppId,
+                    CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                     "Pipe ID By Name Error:Bad Argument,Requestor %s",
                     CFE_SB_GetAppTskName(TskId,FullName));
                 break;
 
             case CFE_SB_GETPIPEIDBYNAME_NAME_ERR_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPEIDBYNAME_NAME_ERR_EID,
-                    CFE_EVS_EventType_ERROR, CFE_SB.AppId,
+                    CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                     "Pipe ID By Name Error:Bad Argument,Requestor %s",
                     CFE_SB_GetAppTskName(TskId,FullName));
                 break;
@@ -864,7 +864,7 @@ int32  CFE_SB_SubscribeEx(CFE_SB_MsgId_t   MsgId,
                           CFE_SB_Qos_t     Quality,
                           uint16           MsgLim)
 {
-    return CFE_SB_SubscribeFull(MsgId,PipeId,Quality,MsgLim,(uint8)CFE_SB_GLOBAL);
+    return CFE_SB_SubscribeFull(MsgId,PipeId,Quality,MsgLim,(uint8)CFE_SB_MSG_GLOBAL);
 
 }/* end CFE_SB_SubscribeEx */
 
@@ -879,7 +879,7 @@ int32 CFE_SB_SubscribeLocal(CFE_SB_MsgId_t   MsgId,
                             uint16           MsgLim)
 {
     return CFE_SB_SubscribeFull(MsgId,PipeId,CFE_SB_Default_Qos,MsgLim,
-                                (uint8)CFE_SB_LOCAL);
+                                (uint8)CFE_SB_MSG_LOCAL);
 
 }/* end CFE_SB_SubscribeLocal */
 
@@ -891,7 +891,7 @@ int32 CFE_SB_Subscribe(CFE_SB_MsgId_t   MsgId,
 {
     return CFE_SB_SubscribeFull(MsgId,PipeId,CFE_SB_Default_Qos,
                                (uint16)CFE_PLATFORM_SB_DEFAULT_MSG_LIMIT,
-                               (uint8)CFE_SB_GLOBAL);
+                               (uint8)CFE_SB_MSG_GLOBAL);
 
 }/* end CFE_SB_Subscribe */
 
@@ -995,10 +995,10 @@ int32  CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
             {
                 /* Increment the MsgIds in use ctr and if it's > the high water mark,*/
                 /* adjust the high water mark */
-                CFE_SB.StatTlmMsg.Payload.MsgIdsInUse++;
-                if(CFE_SB.StatTlmMsg.Payload.MsgIdsInUse > CFE_SB.StatTlmMsg.Payload.PeakMsgIdsInUse)
+                CFE_SB_Global.StatTlmMsg.Payload.MsgIdsInUse++;
+                if(CFE_SB_Global.StatTlmMsg.Payload.MsgIdsInUse > CFE_SB_Global.StatTlmMsg.Payload.PeakMsgIdsInUse)
                 {
-                    CFE_SB.StatTlmMsg.Payload.PeakMsgIdsInUse = CFE_SB.StatTlmMsg.Payload.MsgIdsInUse;
+                    CFE_SB_Global.StatTlmMsg.Payload.PeakMsgIdsInUse = CFE_SB_Global.StatTlmMsg.Payload.MsgIdsInUse;
                 }/* end if */
             }
         }
@@ -1055,10 +1055,10 @@ int32  CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
                 /* add destination node */
                 CFE_SB_AddDestNode(RouteId, DestPtr);
 
-                CFE_SB.StatTlmMsg.Payload.SubscriptionsInUse++;
-                if(CFE_SB.StatTlmMsg.Payload.SubscriptionsInUse > CFE_SB.StatTlmMsg.Payload.PeakSubscriptionsInUse)
+                CFE_SB_Global.StatTlmMsg.Payload.SubscriptionsInUse++;
+                if(CFE_SB_Global.StatTlmMsg.Payload.SubscriptionsInUse > CFE_SB_Global.StatTlmMsg.Payload.PeakSubscriptionsInUse)
                 {
-                    CFE_SB.StatTlmMsg.Payload.PeakSubscriptionsInUse = CFE_SB.StatTlmMsg.Payload.SubscriptionsInUse;
+                    CFE_SB_Global.StatTlmMsg.Payload.PeakSubscriptionsInUse = CFE_SB_Global.StatTlmMsg.Payload.SubscriptionsInUse;
                 }
             }
         }
@@ -1073,10 +1073,10 @@ int32  CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
         case CFE_SB_MAX_MSGS_MET_EID:
         case CFE_SB_DEST_BLK_ERR_EID:
         case CFE_SB_MAX_DESTS_MET_EID:
-            CFE_SB.HKTlmMsg.Payload.SubscribeErrorCounter++;
+            CFE_SB_Global.HKTlmMsg.Payload.SubscribeErrorCounter++;
             break;
         case CFE_SB_DUP_SUBSCRIP_EID:
-            CFE_SB.HKTlmMsg.Payload.DuplicateSubscriptionsCounter++;
+            CFE_SB_Global.HKTlmMsg.Payload.DuplicateSubscriptionsCounter++;
             break;
     }
 
@@ -1090,48 +1090,48 @@ int32  CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
         switch(PendingEventID)
         {
         case CFE_SB_DUP_SUBSCRIP_EID:
-            CFE_EVS_SendEventWithAppID(CFE_SB_DUP_SUBSCRIP_EID,CFE_EVS_EventType_INFORMATION,CFE_SB.AppId,
+            CFE_EVS_SendEventWithAppID(CFE_SB_DUP_SUBSCRIP_EID,CFE_EVS_EventType_INFORMATION,CFE_SB_Global.AppId,
                 "Duplicate Subscription,MsgId 0x%x on %s pipe,app %s",
                 (unsigned int)CFE_SB_MsgIdToValue(MsgId),
                 PipeName,CFE_SB_GetAppTskName(TskId,FullName));
             break;
 
         case CFE_SB_SUB_INV_CALLER_EID:
-            CFE_EVS_SendEventWithAppID(CFE_SB_SUB_INV_CALLER_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+            CFE_EVS_SendEventWithAppID(CFE_SB_SUB_INV_CALLER_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                 "Subscribe Err:Caller(%s) is not the owner of pipe %lu,Msg=0x%x",
                 CFE_SB_GetAppTskName(TskId,FullName),CFE_ES_ResourceID_ToInteger(PipeId),
                 (unsigned int)CFE_SB_MsgIdToValue(MsgId));
             break;
 
         case CFE_SB_SUB_INV_PIPE_EID:
-            CFE_EVS_SendEventWithAppID(CFE_SB_SUB_INV_PIPE_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+            CFE_EVS_SendEventWithAppID(CFE_SB_SUB_INV_PIPE_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                 "Subscribe Err:Invalid Pipe Id,Msg=0x%x,PipeId=%lu,App %s",
                 (unsigned int)CFE_SB_MsgIdToValue(MsgId),
                 CFE_ES_ResourceID_ToInteger(PipeId), CFE_SB_GetAppTskName(TskId,FullName));
             break;
 
         case CFE_SB_DEST_BLK_ERR_EID:
-            CFE_EVS_SendEventWithAppID(CFE_SB_DEST_BLK_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+            CFE_EVS_SendEventWithAppID(CFE_SB_DEST_BLK_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                 "Subscribe Err:Request for Destination Blk failed for Msg 0x%x", 
                 (unsigned int)CFE_SB_MsgIdToValue(MsgId));
             break;
 
         case CFE_SB_MAX_DESTS_MET_EID:
-            CFE_EVS_SendEventWithAppID(CFE_SB_MAX_DESTS_MET_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+            CFE_EVS_SendEventWithAppID(CFE_SB_MAX_DESTS_MET_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                 "Subscribe Err:Max Dests(%d)In Use For Msg 0x%x,pipe %s,app %s",
                  CFE_PLATFORM_SB_MAX_DEST_PER_PKT, (unsigned int)CFE_SB_MsgIdToValue(MsgId),
                  PipeName, CFE_SB_GetAppTskName(TskId,FullName));
             break;
 
         case CFE_SB_MAX_MSGS_MET_EID:
-            CFE_EVS_SendEventWithAppID(CFE_SB_MAX_MSGS_MET_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+            CFE_EVS_SendEventWithAppID(CFE_SB_MAX_MSGS_MET_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                 "Subscribe Err:Max Msgs(%d)In Use,MsgId 0x%x,pipe %s,app %s",
                  CFE_PLATFORM_SB_MAX_MSG_IDS, (unsigned int)CFE_SB_MsgIdToValue(MsgId),
                  PipeName, CFE_SB_GetAppTskName(TskId,FullName));
             break;
 
         case CFE_SB_SUB_ARG_ERR_EID:
-            CFE_EVS_SendEventWithAppID(CFE_SB_SUB_ARG_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+            CFE_EVS_SendEventWithAppID(CFE_SB_SUB_ARG_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                 "Subscribe Err:Bad Arg,MsgId 0x%x,PipeId %lu,app %s,scope %d",
                 (unsigned int)CFE_SB_MsgIdToValue(MsgId),
                 CFE_ES_ResourceID_ToInteger(PipeId),CFE_SB_GetAppTskName(TskId,FullName),Scope);
@@ -1141,20 +1141,20 @@ int32  CFE_SB_SubscribeFull(CFE_SB_MsgId_t   MsgId,
     else if (Status == CFE_SUCCESS)
     {
         /* If no other event pending, send a debug event indicating success */
-        CFE_EVS_SendEventWithAppID(CFE_SB_SUBSCRIPTION_RCVD_EID,CFE_EVS_EventType_DEBUG,CFE_SB.AppId,
+        CFE_EVS_SendEventWithAppID(CFE_SB_SUBSCRIPTION_RCVD_EID,CFE_EVS_EventType_DEBUG,CFE_SB_Global.AppId,
             "Subscription Rcvd:MsgId 0x%x on %s(%lu),app %s",
             (unsigned int)CFE_SB_MsgIdToValue(MsgId),
             PipeName,CFE_ES_ResourceID_ToInteger(PipeId),CFE_SB_GetAppTskName(TskId,FullName));
     }
 
-    if (Status == CFE_SUCCESS && Scope == CFE_SB_GLOBAL)
+    if (Status == CFE_SUCCESS && Scope == CFE_SB_MSG_GLOBAL)
     {
         CFE_SB_SendSubscriptionReport(MsgId, PipeId, Quality);
     }
 
     if (Collisions != 0)
     {
-        CFE_EVS_SendEventWithAppID(CFE_SB_HASHCOLLISION_EID, CFE_EVS_EventType_DEBUG, CFE_SB.AppId,
+        CFE_EVS_SendEventWithAppID(CFE_SB_HASHCOLLISION_EID, CFE_EVS_EventType_DEBUG, CFE_SB_Global.AppId,
             "Msg hash collision: MsgId = 0x%x, collisions = %u",
             (unsigned int)CFE_SB_MsgIdToValue(MsgId), (unsigned int)Collisions);
     }
@@ -1175,7 +1175,7 @@ int32 CFE_SB_Unsubscribe(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId)
     /* get the callers Application Id */
     CFE_ES_GetAppID(&CallerId);
 
-    Status = CFE_SB_UnsubscribeFull(MsgId, PipeId, (uint8)CFE_SB_GLOBAL,CallerId);
+    Status = CFE_SB_UnsubscribeFull(MsgId, PipeId, (uint8)CFE_SB_MSG_GLOBAL,CallerId);
 
     return Status;
 
@@ -1193,7 +1193,7 @@ int32 CFE_SB_UnsubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId)
     /* get the callers Application Id */
     CFE_ES_GetAppID(&CallerId);
 
-    Status = CFE_SB_UnsubscribeFull(MsgId, PipeId, (uint8)CFE_SB_LOCAL,CallerId);
+    Status = CFE_SB_UnsubscribeFull(MsgId, PipeId, (uint8)CFE_SB_MSG_LOCAL,CallerId);
 
     return Status;
 
@@ -1228,7 +1228,7 @@ int32 CFE_SB_UnsubscribeWithAppId(CFE_SB_MsgId_t MsgId,
 {
     int32   Status = 0;
 
-    Status = CFE_SB_UnsubscribeFull(MsgId, PipeId, (uint8)CFE_SB_LOCAL, AppId);
+    Status = CFE_SB_UnsubscribeFull(MsgId, PipeId, (uint8)CFE_SB_MSG_LOCAL, AppId);
 
     return Status;
 
@@ -1340,28 +1340,28 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId,CFE_SB_PipeId_t PipeId,
         {
             case CFE_SB_UNSUB_NO_SUBS_EID:
                 CFE_SB_GetPipeName(PipeName, sizeof(PipeName), PipeId);
-                CFE_EVS_SendEventWithAppID(CFE_SB_UNSUB_NO_SUBS_EID,CFE_EVS_EventType_INFORMATION,CFE_SB.AppId,
+                CFE_EVS_SendEventWithAppID(CFE_SB_UNSUB_NO_SUBS_EID,CFE_EVS_EventType_INFORMATION,CFE_SB_Global.AppId,
                     "Unsubscribe Err:No subs for Msg 0x%x on %s,app %s",
                     (unsigned int)CFE_SB_MsgIdToValue(MsgId),
                     PipeName,CFE_SB_GetAppTskName(TskId,FullName));
                 break;
 
             case CFE_SB_UNSUB_INV_PIPE_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_UNSUB_INV_PIPE_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+                CFE_EVS_SendEventWithAppID(CFE_SB_UNSUB_INV_PIPE_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                         "Unsubscribe Err:Invalid Pipe Id Msg=0x%x,Pipe=%lu,app=%s",
                         (unsigned int)CFE_SB_MsgIdToValue(MsgId),
                         CFE_ES_ResourceID_ToInteger(PipeId),CFE_SB_GetAppTskName(TskId,FullName));
                 break;
 
             case CFE_SB_UNSUB_INV_CALLER_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_UNSUB_INV_CALLER_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+                CFE_EVS_SendEventWithAppID(CFE_SB_UNSUB_INV_CALLER_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                         "Unsubscribe Err:Caller(%s) is not the owner of pipe %lu,Msg=0x%x",
                         CFE_SB_GetAppTskName(TskId,FullName),CFE_ES_ResourceID_ToInteger(PipeId),
                         (unsigned int)CFE_SB_MsgIdToValue(MsgId));
                 break;
 
             case CFE_SB_UNSUB_ARG_ERR_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_UNSUB_ARG_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+                CFE_EVS_SendEventWithAppID(CFE_SB_UNSUB_ARG_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                     "UnSubscribe Err:Bad Arg,MsgId 0x%x,PipeId %lu,app %s,scope %d",
                     (unsigned int)CFE_SB_MsgIdToValue(MsgId),
                     CFE_ES_ResourceID_ToInteger(PipeId),CFE_SB_GetAppTskName(TskId,FullName),(int)Scope);
@@ -1371,7 +1371,7 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId,CFE_SB_PipeId_t PipeId,
     else if (Status == CFE_SUCCESS)
     {
         /* if no other event pending, send a debug event for successful unsubscribe */
-        CFE_EVS_SendEventWithAppID(CFE_SB_SUBSCRIPTION_REMOVED_EID,CFE_EVS_EventType_DEBUG,CFE_SB.AppId,
+        CFE_EVS_SendEventWithAppID(CFE_SB_SUBSCRIPTION_REMOVED_EID,CFE_EVS_EventType_DEBUG,CFE_SB_Global.AppId,
             "Subscription Removed:Msg 0x%x on pipe %lu,app %s",
             (unsigned int)CFE_SB_MsgIdToValue(MsgId),
             CFE_ES_ResourceID_ToInteger(PipeId),CFE_SB_GetAppTskName(TskId,FullName));
@@ -1436,7 +1436,7 @@ int32  CFE_SB_TransmitMsg(CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount
     {
         /* Increment error counter (inside lock) if not success */
         CFE_SB_LockSharedData(__func__, __LINE__);
-        CFE_SB.HKTlmMsg.Payload.MsgSendErrorCounter++;
+        CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter++;
         CFE_SB_UnlockSharedData(__func__, __LINE__);
     }
 
@@ -1447,7 +1447,7 @@ int32  CFE_SB_TransmitMsg(CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount
 
         if (CFE_SB_RequestToSendEvent(TskId,CFE_SB_GET_BUF_ERR_EID_BIT) == CFE_SB_GRANTED)
         {
-            CFE_EVS_SendEventWithAppID(CFE_SB_GET_BUF_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+            CFE_EVS_SendEventWithAppID(CFE_SB_GET_BUF_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                 "Send Err:Request for Buffer Failed. MsgId 0x%x,app %s,size %d",
                 (unsigned int)CFE_SB_MsgIdToValue(MsgId),
                 CFE_SB_GetAppTskName(TskId,FullName),(int)Size);
@@ -1553,7 +1553,7 @@ int32 CFE_SB_TransmitMsgValidate(CFE_MSG_Message_t *MsgPtr,
         /* increment the dropped pkt cnt, send event and return success */
         if(!CFE_SBR_IsValidRouteId(*RouteIdPtr))
         {
-            CFE_SB.HKTlmMsg.Payload.NoSubscribersCounter++;
+            CFE_SB_Global.HKTlmMsg.Payload.NoSubscribersCounter++;
             PendingEventID = CFE_SB_SEND_NO_SUBS_EID;
         }
 
@@ -1568,20 +1568,20 @@ int32 CFE_SB_TransmitMsgValidate(CFE_MSG_Message_t *MsgPtr,
         switch (PendingEventID)
         {
             case CFE_SB_SEND_BAD_ARG_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_SEND_BAD_ARG_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+                CFE_EVS_SendEventWithAppID(CFE_SB_SEND_BAD_ARG_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                     "Send Err:Bad input argument,Arg 0x%lx,App %s",
                     (unsigned long)MsgPtr,CFE_SB_GetAppTskName(TskId,FullName));
                 break;
 
             case CFE_SB_SEND_INV_MSGID_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_SEND_INV_MSGID_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+                CFE_EVS_SendEventWithAppID(CFE_SB_SEND_INV_MSGID_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                     "Send Err:Invalid MsgId(0x%x)in msg,App %s",
                     (unsigned int)CFE_SB_MsgIdToValue(*MsgIdPtr),
                     CFE_SB_GetAppTskName(TskId,FullName));
                 break;
 
             case CFE_SB_MSG_TOO_BIG_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_MSG_TOO_BIG_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+                CFE_EVS_SendEventWithAppID(CFE_SB_MSG_TOO_BIG_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                     "Send Err:Msg Too Big MsgId=0x%x,app=%s,size=%d,MaxSz=%d",
                     (unsigned int)CFE_SB_MsgIdToValue(*MsgIdPtr),
                     CFE_SB_GetAppTskName(TskId,FullName),(int)*SizePtr,CFE_MISSION_SB_MAX_SB_MSG_SIZE);
@@ -1591,7 +1591,7 @@ int32 CFE_SB_TransmitMsgValidate(CFE_MSG_Message_t *MsgPtr,
                 /* Determine if event can be sent without causing recursive event problem */
                 if (CFE_SB_RequestToSendEvent(TskId,CFE_SB_SEND_NO_SUBS_EID_BIT) == CFE_SB_GRANTED)
                 {
-                    CFE_EVS_SendEventWithAppID(CFE_SB_SEND_NO_SUBS_EID,CFE_EVS_EventType_INFORMATION,CFE_SB.AppId,
+                    CFE_EVS_SendEventWithAppID(CFE_SB_SEND_NO_SUBS_EID,CFE_EVS_EventType_INFORMATION,CFE_SB_Global.AppId,
                         "No subscribers for MsgId 0x%x,sender %s",
                         (unsigned int)CFE_SB_MsgIdToValue(*MsgIdPtr),
                         CFE_SB_GetAppTskName(TskId,FullName));
@@ -1672,7 +1672,7 @@ int32  CFE_SB_TransmitBufferFull(CFE_SB_BufferD_t *BufDscPtr,
             SBSndErr.EvtBuf[SBSndErr.EvtsToSnd].PipeId  = DestPtr->PipeId;
             SBSndErr.EvtBuf[SBSndErr.EvtsToSnd].EventId = CFE_SB_MSGID_LIM_ERR_EID;
             SBSndErr.EvtsToSnd++;
-            CFE_SB.HKTlmMsg.Payload.MsgLimitErrorCounter++;
+            CFE_SB_Global.HKTlmMsg.Payload.MsgLimitErrorCounter++;
             PipeDscPtr->SendErrors++;
 
             continue;
@@ -1706,7 +1706,7 @@ int32  CFE_SB_TransmitBufferFull(CFE_SB_BufferD_t *BufDscPtr,
                 SBSndErr.EvtBuf[SBSndErr.EvtsToSnd].PipeId  = DestPtr->PipeId;
                 SBSndErr.EvtBuf[SBSndErr.EvtsToSnd].EventId = CFE_SB_Q_FULL_ERR_EID;
                 SBSndErr.EvtsToSnd++;
-                CFE_SB.HKTlmMsg.Payload.PipeOverflowErrorCounter++;
+                CFE_SB_Global.HKTlmMsg.Payload.PipeOverflowErrorCounter++;
                 PipeDscPtr->SendErrors++;
             }
             else
@@ -1716,7 +1716,7 @@ int32  CFE_SB_TransmitBufferFull(CFE_SB_BufferD_t *BufDscPtr,
                 SBSndErr.EvtBuf[SBSndErr.EvtsToSnd].EventId = CFE_SB_Q_WR_ERR_EID;
                 SBSndErr.EvtBuf[SBSndErr.EvtsToSnd].ErrStat = Status;
                 SBSndErr.EvtsToSnd++;
-                CFE_SB.HKTlmMsg.Payload.InternalErrorCounter++;
+                CFE_SB_Global.HKTlmMsg.Payload.InternalErrorCounter++;
                 PipeDscPtr->SendErrors++;
             }/*end if */
 
@@ -1750,7 +1750,7 @@ int32  CFE_SB_TransmitBufferFull(CFE_SB_BufferD_t *BufDscPtr,
               CFE_ES_PerfLogEntry(CFE_MISSION_SB_MSG_LIM_PERF_ID);
               CFE_ES_PerfLogExit(CFE_MISSION_SB_MSG_LIM_PERF_ID);
 
-              CFE_EVS_SendEventWithAppID(CFE_SB_MSGID_LIM_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+              CFE_EVS_SendEventWithAppID(CFE_SB_MSGID_LIM_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                 "Msg Limit Err,MsgId 0x%x,pipe %s,sender %s",
                 (unsigned int)CFE_SB_MsgIdToValue(MsgId),
                 PipeName, CFE_SB_GetAppTskName(TskId,FullName));
@@ -1769,7 +1769,7 @@ int32  CFE_SB_TransmitBufferFull(CFE_SB_BufferD_t *BufDscPtr,
               CFE_ES_PerfLogEntry(CFE_MISSION_SB_PIPE_OFLOW_PERF_ID);
               CFE_ES_PerfLogExit(CFE_MISSION_SB_PIPE_OFLOW_PERF_ID);
 
-              CFE_EVS_SendEventWithAppID(CFE_SB_Q_FULL_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+              CFE_EVS_SendEventWithAppID(CFE_SB_Q_FULL_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                   "Pipe Overflow,MsgId 0x%x,pipe %s,sender %s",
                   (unsigned int)CFE_SB_MsgIdToValue(MsgId),
                   PipeName, CFE_SB_GetAppTskName(TskId,FullName));
@@ -1785,7 +1785,7 @@ int32  CFE_SB_TransmitBufferFull(CFE_SB_BufferD_t *BufDscPtr,
 
               CFE_SB_GetPipeName(PipeName, sizeof(PipeName), SBSndErr.EvtBuf[i].PipeId);
 
-              CFE_EVS_SendEventWithAppID(CFE_SB_Q_WR_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+              CFE_EVS_SendEventWithAppID(CFE_SB_Q_WR_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                 "Pipe Write Err,MsgId 0x%x,pipe %s,sender %s,stat 0x%x",
                 (unsigned int)CFE_SB_MsgIdToValue(MsgId),
                 PipeName, CFE_SB_GetAppTskName(TskId,FullName),
@@ -2021,12 +2021,12 @@ int32  CFE_SB_ReceiveBuffer(CFE_SB_Buffer_t **BufPtr,
     {
         if (PendingEventID == CFE_SB_RCV_BAD_ARG_EID || PendingEventID == CFE_SB_BAD_PIPEID_EID)
         {
-            ++CFE_SB.HKTlmMsg.Payload.MsgReceiveErrorCounter;
+            ++CFE_SB_Global.HKTlmMsg.Payload.MsgReceiveErrorCounter;
         }
         else
         {
             /* For any other unexpected error (e.g. CFE_SB_Q_RD_ERR_EID) */
-            ++CFE_SB.HKTlmMsg.Payload.InternalErrorCounter;
+            ++CFE_SB_Global.HKTlmMsg.Payload.InternalErrorCounter;
         }
     }
 
@@ -2041,17 +2041,17 @@ int32  CFE_SB_ReceiveBuffer(CFE_SB_Buffer_t **BufPtr,
         switch(PendingEventID)
         {
             case CFE_SB_Q_RD_ERR_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_Q_RD_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+                CFE_EVS_SendEventWithAppID(CFE_SB_Q_RD_ERR_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                     "Pipe Read Err,pipe %lu,app %s,stat 0x%x",
                     CFE_ES_ResourceID_ToInteger(PipeId),CFE_SB_GetAppTskName(TskId,FullName),(unsigned int)RcvStatus);
                 break;
             case CFE_SB_RCV_BAD_ARG_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_RCV_BAD_ARG_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+                CFE_EVS_SendEventWithAppID(CFE_SB_RCV_BAD_ARG_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                     "Rcv Err:Bad Input Arg:BufPtr 0x%lx,pipe %lu,t/o %d,app %s",
                     (unsigned long)BufPtr,CFE_ES_ResourceID_ToInteger(PipeId),(int)TimeOut,CFE_SB_GetAppTskName(TskId,FullName));
                 break;
             case CFE_SB_BAD_PIPEID_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_BAD_PIPEID_EID,CFE_EVS_EventType_ERROR,CFE_SB.AppId,
+                CFE_EVS_SendEventWithAppID(CFE_SB_BAD_PIPEID_EID,CFE_EVS_EventType_ERROR,CFE_SB_Global.AppId,
                     "Rcv Err:PipeId %lu does not exist,app %s",
                     CFE_ES_ResourceID_ToInteger(PipeId),CFE_SB_GetAppTskName(TskId,FullName));
                 break;
@@ -2083,7 +2083,7 @@ CFE_SB_Buffer_t *CFE_SB_ZeroCopyGetPtr(size_t MsgSize,
     CFE_SB_LockSharedData(__func__,__LINE__);
 
     /* Allocate a new zero copy descriptor from the SB memory pool.*/
-    stat1 = CFE_ES_GetPoolBuf((CFE_ES_MemPoolBuf_t*)&zcd, CFE_SB.Mem.PoolHdl,  sizeof(CFE_SB_ZeroCopyD_t));
+    stat1 = CFE_ES_GetPoolBuf((CFE_ES_MemPoolBuf_t*)&zcd, CFE_SB_Global.Mem.PoolHdl,  sizeof(CFE_SB_ZeroCopyD_t));
     if(stat1 < 0){
         CFE_SB_UnlockSharedData(__func__,__LINE__);
         return NULL;
@@ -2091,18 +2091,18 @@ CFE_SB_Buffer_t *CFE_SB_ZeroCopyGetPtr(size_t MsgSize,
 
     /* Add the size of a zero copy descriptor to the memory-in-use ctr and */
     /* adjust the high water mark if needed */
-    CFE_SB.StatTlmMsg.Payload.MemInUse+=stat1;
-    if(CFE_SB.StatTlmMsg.Payload.MemInUse > CFE_SB.StatTlmMsg.Payload.PeakMemInUse){
-       CFE_SB.StatTlmMsg.Payload.PeakMemInUse = CFE_SB.StatTlmMsg.Payload.MemInUse;
+    CFE_SB_Global.StatTlmMsg.Payload.MemInUse+=stat1;
+    if(CFE_SB_Global.StatTlmMsg.Payload.MemInUse > CFE_SB_Global.StatTlmMsg.Payload.PeakMemInUse){
+       CFE_SB_Global.StatTlmMsg.Payload.PeakMemInUse = CFE_SB_Global.StatTlmMsg.Payload.MemInUse;
     }/* end if */
 
     /* Allocate a new buffer (from the SB memory pool) to hold the message  */
-    stat1 = CFE_ES_GetPoolBuf((CFE_ES_MemPoolBuf_t*)&bd, CFE_SB.Mem.PoolHdl, MsgSize + sizeof(CFE_SB_BufferD_t));
+    stat1 = CFE_ES_GetPoolBuf((CFE_ES_MemPoolBuf_t*)&bd, CFE_SB_Global.Mem.PoolHdl, MsgSize + sizeof(CFE_SB_BufferD_t));
     if((stat1 < 0)||(bd==NULL)){
         /*deallocate the first buffer if the second buffer creation fails*/
-        stat1 = CFE_ES_PutPoolBuf(CFE_SB.Mem.PoolHdl, zcd);
+        stat1 = CFE_ES_PutPoolBuf(CFE_SB_Global.Mem.PoolHdl, zcd);
         if(stat1 > 0){
-            CFE_SB.StatTlmMsg.Payload.MemInUse-=stat1;
+            CFE_SB_Global.StatTlmMsg.Payload.MemInUse-=stat1;
         }
         CFE_SB_UnlockSharedData(__func__,__LINE__);
         return NULL;
@@ -2110,16 +2110,16 @@ CFE_SB_Buffer_t *CFE_SB_ZeroCopyGetPtr(size_t MsgSize,
 
     /* Increment the number of buffers in use by one even though two buffers */
     /* were allocated. SBBuffersInUse increments on a per-message basis */
-    CFE_SB.StatTlmMsg.Payload.SBBuffersInUse++;
-    if(CFE_SB.StatTlmMsg.Payload.SBBuffersInUse > CFE_SB.StatTlmMsg.Payload.PeakSBBuffersInUse){
-        CFE_SB.StatTlmMsg.Payload.PeakSBBuffersInUse = CFE_SB.StatTlmMsg.Payload.SBBuffersInUse;
+    CFE_SB_Global.StatTlmMsg.Payload.SBBuffersInUse++;
+    if(CFE_SB_Global.StatTlmMsg.Payload.SBBuffersInUse > CFE_SB_Global.StatTlmMsg.Payload.PeakSBBuffersInUse){
+        CFE_SB_Global.StatTlmMsg.Payload.PeakSBBuffersInUse = CFE_SB_Global.StatTlmMsg.Payload.SBBuffersInUse;
     }/* end if */
 
     /* Add the size of the actual buffer to the memory-in-use ctr and */
     /* adjust the high water mark if needed */
-    CFE_SB.StatTlmMsg.Payload.MemInUse+=stat1;
-    if(CFE_SB.StatTlmMsg.Payload.MemInUse > CFE_SB.StatTlmMsg.Payload.PeakMemInUse){
-       CFE_SB.StatTlmMsg.Payload.PeakMemInUse = CFE_SB.StatTlmMsg.Payload.MemInUse;
+    CFE_SB_Global.StatTlmMsg.Payload.MemInUse+=stat1;
+    if(CFE_SB_Global.StatTlmMsg.Payload.MemInUse > CFE_SB_Global.StatTlmMsg.Payload.PeakMemInUse){
+       CFE_SB_Global.StatTlmMsg.Payload.PeakMemInUse = CFE_SB_Global.StatTlmMsg.Payload.MemInUse;
     }/* end if */
 
     /* first set ptr to actual msg buffer the same as ptr to descriptor */
@@ -2134,11 +2134,11 @@ CFE_SB_Buffer_t *CFE_SB_ZeroCopyGetPtr(size_t MsgSize,
     zcd->Next      = NULL;
 
     /* Add this Zero Copy Descriptor to the end of the chain */
-    if(CFE_SB.ZeroCopyTail != NULL){
-        ((CFE_SB_ZeroCopyD_t *) CFE_SB.ZeroCopyTail)->Next = (void *)zcd;
+    if(CFE_SB_Global.ZeroCopyTail != NULL){
+        ((CFE_SB_ZeroCopyD_t *) CFE_SB_Global.ZeroCopyTail)->Next = (void *)zcd;
     }
-    zcd->Prev = CFE_SB.ZeroCopyTail;
-    CFE_SB.ZeroCopyTail = (void *)zcd;
+    zcd->Prev = CFE_SB_Global.ZeroCopyTail;
+    CFE_SB_Global.ZeroCopyTail = (void *)zcd;
 
     CFE_SB_UnlockSharedData(__func__,__LINE__);
 
@@ -2175,11 +2175,11 @@ int32 CFE_SB_ZeroCopyReleasePtr(CFE_SB_Buffer_t        *Ptr2Release,
     if(Status == CFE_SUCCESS){
         /* give the buffer back to the buffer pool */
         BufAddr = CFE_ES_MEMPOOLBUF_C((cpuaddr)Ptr2Release - sizeof(CFE_SB_BufferD_t));
-        Stat2 = CFE_ES_PutPoolBuf(CFE_SB.Mem.PoolHdl, BufAddr);
+        Stat2 = CFE_ES_PutPoolBuf(CFE_SB_Global.Mem.PoolHdl, BufAddr);
         if(Stat2 > 0){
              /* Substract the size of the actual buffer from the Memory in use ctr */
-            CFE_SB.StatTlmMsg.Payload.MemInUse-=Stat2;
-            CFE_SB.StatTlmMsg.Payload.SBBuffersInUse--;
+            CFE_SB_Global.StatTlmMsg.Payload.MemInUse-=Stat2;
+            CFE_SB_Global.StatTlmMsg.Payload.SBBuffersInUse--;
         }/* end if */
     }
 
@@ -2221,7 +2221,7 @@ int32 CFE_SB_ZeroCopyReleaseDesc(CFE_SB_Buffer_t        *Ptr2Release,
 
     CFE_SB_LockSharedData(__func__,__LINE__);
 
-    Stat = CFE_ES_GetPoolBufInfo(CFE_SB.Mem.PoolHdl, zcd);
+    Stat = CFE_ES_GetPoolBufInfo(CFE_SB_Global.Mem.PoolHdl, zcd);
 
     if((Ptr2Release == NULL) || (Stat < 0) || (zcd->Buffer != (void *)Ptr2Release)){
         CFE_SB_UnlockSharedData(__func__,__LINE__);
@@ -2235,15 +2235,15 @@ int32 CFE_SB_ZeroCopyReleaseDesc(CFE_SB_Buffer_t        *Ptr2Release,
     if(zcd->Next != NULL){
         ((CFE_SB_ZeroCopyD_t *) (zcd->Next))->Prev = zcd->Prev;
     }
-    if(CFE_SB.ZeroCopyTail == (void *)zcd){
-        CFE_SB.ZeroCopyTail = zcd->Prev;
+    if(CFE_SB_Global.ZeroCopyTail == (void *)zcd){
+        CFE_SB_Global.ZeroCopyTail = zcd->Prev;
     }
 
     /* give the descriptor back to the buffer pool */
-    Stat = CFE_ES_PutPoolBuf(CFE_SB.Mem.PoolHdl, zcd);
+    Stat = CFE_ES_PutPoolBuf(CFE_SB_Global.Mem.PoolHdl, zcd);
     if(Stat > 0){
         /* Substract the size of the actual buffer from the Memory in use ctr */
-        CFE_SB.StatTlmMsg.Payload.MemInUse-=Stat;
+        CFE_SB_Global.StatTlmMsg.Payload.MemInUse-=Stat;
     }/* end if */
 
     CFE_SB_UnlockSharedData(__func__,__LINE__);
@@ -2303,7 +2303,7 @@ int32 CFE_SB_TransmitBuffer(CFE_SB_Buffer_t *BufPtr,
         {
             /* Increment send error counter for validation failure */
             CFE_SB_LockSharedData(__func__, __LINE__);
-            CFE_SB.HKTlmMsg.Payload.MsgSendErrorCounter++;
+            CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter++;
             CFE_SB_UnlockSharedData(__func__, __LINE__);
         }
     }

--- a/fsw/cfe-core/src/sb/cfe_sb_buf.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_buf.c
@@ -63,22 +63,22 @@ CFE_SB_BufferD_t * CFE_SB_GetBufferFromPool(CFE_SB_MsgId_t MsgId, size_t Size) {
    CFE_SB_BufferD_t    *bd = NULL;
 
     /* Allocate a new buffer descriptor from the SB memory pool.*/
-    stat1 = CFE_ES_GetPoolBuf((CFE_ES_MemPoolBuf_t*)&bd, CFE_SB.Mem.PoolHdl,  Size + sizeof(CFE_SB_BufferD_t));
+    stat1 = CFE_ES_GetPoolBuf((CFE_ES_MemPoolBuf_t*)&bd, CFE_SB_Global.Mem.PoolHdl,  Size + sizeof(CFE_SB_BufferD_t));
     if(stat1 < 0){
         return NULL;
     }
 
     /* increment the number of buffers in use and adjust the high water mark if needed */
-    CFE_SB.StatTlmMsg.Payload.SBBuffersInUse++;
-    if(CFE_SB.StatTlmMsg.Payload.SBBuffersInUse > CFE_SB.StatTlmMsg.Payload.PeakSBBuffersInUse){
-        CFE_SB.StatTlmMsg.Payload.PeakSBBuffersInUse = CFE_SB.StatTlmMsg.Payload.SBBuffersInUse;
+    CFE_SB_Global.StatTlmMsg.Payload.SBBuffersInUse++;
+    if(CFE_SB_Global.StatTlmMsg.Payload.SBBuffersInUse > CFE_SB_Global.StatTlmMsg.Payload.PeakSBBuffersInUse){
+        CFE_SB_Global.StatTlmMsg.Payload.PeakSBBuffersInUse = CFE_SB_Global.StatTlmMsg.Payload.SBBuffersInUse;
     }/* end if */
 
     /* Add the size of the actual buffer to the memory-in-use ctr and */
     /* adjust the high water mark if needed */
-    CFE_SB.StatTlmMsg.Payload.MemInUse+=stat1;
-    if(CFE_SB.StatTlmMsg.Payload.MemInUse > CFE_SB.StatTlmMsg.Payload.PeakMemInUse){
-        CFE_SB.StatTlmMsg.Payload.PeakMemInUse = CFE_SB.StatTlmMsg.Payload.MemInUse;
+    CFE_SB_Global.StatTlmMsg.Payload.MemInUse+=stat1;
+    if(CFE_SB_Global.StatTlmMsg.Payload.MemInUse > CFE_SB_Global.StatTlmMsg.Payload.PeakMemInUse){
+        CFE_SB_Global.StatTlmMsg.Payload.PeakMemInUse = CFE_SB_Global.StatTlmMsg.Payload.MemInUse;
     }/* end if */
 
     /* first set ptr to actual msg buffer the same as ptr to descriptor */
@@ -144,11 +144,11 @@ int32 CFE_SB_ReturnBufferToPool(CFE_SB_BufferD_t *bd){
     int32    Stat;
 
     /* give the buf descriptor back to the buf descriptor pool */
-    Stat = CFE_ES_PutPoolBuf(CFE_SB.Mem.PoolHdl, bd);
+    Stat = CFE_ES_PutPoolBuf(CFE_SB_Global.Mem.PoolHdl, bd);
     if(Stat > 0){
-        CFE_SB.StatTlmMsg.Payload.SBBuffersInUse--;
+        CFE_SB_Global.StatTlmMsg.Payload.SBBuffersInUse--;
         /* Substract the size of a buffer descriptor from the Memory in use ctr */
-        CFE_SB.StatTlmMsg.Payload.MemInUse-=Stat;
+        CFE_SB_Global.StatTlmMsg.Payload.MemInUse-=Stat;
     }/* end if */
 
     return CFE_SUCCESS;
@@ -236,16 +236,16 @@ CFE_SB_DestinationD_t *CFE_SB_GetDestinationBlk(void)
     CFE_SB_DestinationD_t *Dest = NULL;
 
     /* Allocate a new destination descriptor from the SB memory pool.*/
-    Stat = CFE_ES_GetPoolBuf((CFE_ES_MemPoolBuf_t*)&Dest, CFE_SB.Mem.PoolHdl,  sizeof(CFE_SB_DestinationD_t));
+    Stat = CFE_ES_GetPoolBuf((CFE_ES_MemPoolBuf_t*)&Dest, CFE_SB_Global.Mem.PoolHdl,  sizeof(CFE_SB_DestinationD_t));
     if(Stat < 0){
         return NULL;
     }
 
     /* Add the size of a destination descriptor to the memory-in-use ctr and */
     /* adjust the high water mark if needed */
-    CFE_SB.StatTlmMsg.Payload.MemInUse+=Stat;
-    if(CFE_SB.StatTlmMsg.Payload.MemInUse > CFE_SB.StatTlmMsg.Payload.PeakMemInUse){
-       CFE_SB.StatTlmMsg.Payload.PeakMemInUse = CFE_SB.StatTlmMsg.Payload.MemInUse;
+    CFE_SB_Global.StatTlmMsg.Payload.MemInUse+=Stat;
+    if(CFE_SB_Global.StatTlmMsg.Payload.MemInUse > CFE_SB_Global.StatTlmMsg.Payload.PeakMemInUse){
+       CFE_SB_Global.StatTlmMsg.Payload.PeakMemInUse = CFE_SB_Global.StatTlmMsg.Payload.MemInUse;
     }/* end if */
 
     return Dest;
@@ -274,10 +274,10 @@ int32 CFE_SB_PutDestinationBlk(CFE_SB_DestinationD_t *Dest)
     }/* end if */
 
     /* give the destination block back to the SB memory pool */
-    Stat = CFE_ES_PutPoolBuf(CFE_SB.Mem.PoolHdl, Dest);
+    Stat = CFE_ES_PutPoolBuf(CFE_SB_Global.Mem.PoolHdl, Dest);
     if(Stat > 0){
         /* Substract the size of the destination block from the Memory in use ctr */
-        CFE_SB.StatTlmMsg.Payload.MemInUse-=Stat;
+        CFE_SB_Global.StatTlmMsg.Payload.MemInUse-=Stat;
     }/* end if */
 
     return CFE_SUCCESS;

--- a/fsw/cfe-core/src/sb/cfe_sb_init.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_init.c
@@ -87,20 +87,20 @@ int32 CFE_SB_EarlyInit (void) {
 
     int32 Stat;
 
-    /* ensure entire CFE_SB global data structure is purged first */
-    memset(&CFE_SB, 0, sizeof(CFE_SB));
+    /* Clear task global */
+    memset(&CFE_SB_Global, 0, sizeof(CFE_SB_Global));
 
     CFE_SB_Default_Qos.Priority    = CFE_SB_QOS_LOW_PRIORITY;
     CFE_SB_Default_Qos.Reliability = CFE_SB_QOS_LOW_RELIABILITY;
 
-    Stat = OS_MutSemCreate(&CFE_SB.SharedDataMutexId, "CFE_SB_DataMutex", 0);
+    Stat = OS_MutSemCreate(&CFE_SB_Global.SharedDataMutexId, "CFE_SB_DataMutex", 0);
     if(Stat != OS_SUCCESS){
       CFE_ES_WriteToSysLog("SB shared data mutex creation failed! RC=0x%08x\n",(unsigned int)Stat);
       return Stat;
     }/* end if */
     
     /* Initialize the state of susbcription reporting */
-    CFE_SB.SubscriptionReporting = CFE_SB_DISABLE;
+    CFE_SB_Global.SubscriptionReporting = CFE_SB_DISABLE;
 
      /* Initialize memory partition. */
     Stat = CFE_SB_InitBuffers();
@@ -116,11 +116,11 @@ int32 CFE_SB_EarlyInit (void) {
     CFE_SBR_Init();
 
     /* Initialize the SB Statistics Pkt */
-    CFE_MSG_Init(&CFE_SB.StatTlmMsg.Hdr.Msg,
+    CFE_MSG_Init(&CFE_SB_Global.StatTlmMsg.Hdr.Msg,
                  CFE_SB_ValueToMsgId(CFE_SB_STATS_TLM_MID),
-                 sizeof(CFE_SB.StatTlmMsg));
+                 sizeof(CFE_SB_Global.StatTlmMsg));
 
-    CFE_SB.ZeroCopyTail = NULL;
+    CFE_SB_Global.ZeroCopyTail = NULL;
 
     return Stat;
 
@@ -146,8 +146,8 @@ int32  CFE_SB_InitBuffers(void) {
 
     int32 Stat = 0;
 
-    Stat = CFE_ES_PoolCreateEx(&CFE_SB.Mem.PoolHdl, 
-                                CFE_SB.Mem.Partition.Data,
+    Stat = CFE_ES_PoolCreateEx(&CFE_SB_Global.Mem.PoolHdl, 
+                                CFE_SB_Global.Mem.Partition.Data,
                                 CFE_PLATFORM_SB_BUF_MEMORY_BYTES, 
                                 CFE_PLATFORM_ES_POOL_MAX_BUCKETS,
                                 &CFE_SB_MemPoolDefSize[0],
@@ -155,7 +155,7 @@ int32  CFE_SB_InitBuffers(void) {
     
     if(Stat != CFE_SUCCESS){
         CFE_ES_WriteToSysLog("PoolCreate failed for SB Buffers, gave adr 0x%lx,size %d,stat=0x%x\n",
-              (unsigned long)CFE_SB.Mem.Partition.Data,CFE_PLATFORM_SB_BUF_MEMORY_BYTES,(unsigned int)Stat);
+              (unsigned long)CFE_SB_Global.Mem.Partition.Data,CFE_PLATFORM_SB_BUF_MEMORY_BYTES,(unsigned int)Stat);
         return Stat;
     }
     
@@ -180,7 +180,7 @@ int32  CFE_SB_InitBuffers(void) {
 */
 void CFE_SB_InitPipeTbl(void)
 {
-    CFE_SB.LastPipeId = CFE_ES_ResourceID_FromInteger(CFE_SB_PIPEID_BASE);
+    CFE_SB_Global.LastPipeId = CFE_ES_ResourceID_FromInteger(CFE_SB_PIPEID_BASE);
 
 }/* end CFE_SB_InitPipeTbl */
 

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.c
@@ -105,7 +105,7 @@ int32 CFE_SB_CleanUpApp(CFE_ES_ResourceID_t AppId)
     CFE_SB_PipeD_t *PipeDscPtr;
     CFE_SB_PipeId_t DelList[CFE_PLATFORM_SB_MAX_PIPES];
 
-    PipeDscPtr = CFE_SB.PipeTbl;
+    PipeDscPtr = CFE_SB_Global.PipeTbl;
     DelCount = 0;
 
     CFE_SB_LockSharedData(__func__,__LINE__);
@@ -156,7 +156,7 @@ void CFE_SB_LockSharedData(const char *FuncName, int32 LineNumber){
     int32   Status;
     CFE_ES_ResourceID_t AppId;
 
-    Status = OS_MutSemTake(CFE_SB.SharedDataMutexId);
+    Status = OS_MutSemTake(CFE_SB_Global.SharedDataMutexId);
     if (Status != OS_SUCCESS) {
 
         CFE_ES_GetAppID(&AppId);
@@ -191,7 +191,7 @@ void CFE_SB_UnlockSharedData(const char *FuncName, int32 LineNumber){
    int32   Status;
    CFE_ES_ResourceID_t AppId;
 
-    Status = OS_MutSemGive(CFE_SB.SharedDataMutexId);
+    Status = OS_MutSemGive(CFE_SB_Global.SharedDataMutexId);
     if (Status != OS_SUCCESS) {
 
         CFE_ES_GetAppID(&AppId);
@@ -287,7 +287,7 @@ CFE_SB_PipeD_t *CFE_SB_LocatePipeDescByID(CFE_SB_PipeId_t PipeId)
 
     if (CFE_SB_PipeId_ToIndex(PipeId, &Idx) == CFE_SUCCESS)
     {
-        PipeDscPtr = &CFE_SB.PipeTbl[Idx];
+        PipeDscPtr = &CFE_SB_Global.PipeTbl[Idx];
     }
     else
     {
@@ -384,14 +384,14 @@ uint32 CFE_SB_RequestToSendEvent(CFE_ES_ResourceID_t TaskId, uint32 Bit){
     }
 
     /* if bit is set... */
-    if(CFE_TST(CFE_SB.StopRecurseFlags[Indx],Bit))
+    if(CFE_TST(CFE_SB_Global.StopRecurseFlags[Indx],Bit))
     {
 
       return CFE_SB_DENIED;
 
     }else{
 
-      CFE_SET(CFE_SB.StopRecurseFlags[Indx],Bit);
+      CFE_SET(CFE_SB_Global.StopRecurseFlags[Indx],Bit);
       return CFE_SB_GRANTED;
 
     }/* end if */
@@ -421,7 +421,7 @@ void CFE_SB_FinishSendEvent(CFE_ES_ResourceID_t TaskId, uint32 Bit){
     }
 
     /* clear the bit so the task may send this event again */
-    CFE_CLR(CFE_SB.StopRecurseFlags[Indx],Bit);
+    CFE_CLR(CFE_SB_Global.StopRecurseFlags[Indx],Bit);
 }/* end CFE_SB_RequestToSendEvent */
 
 /******************************************************************************
@@ -466,7 +466,7 @@ void CFE_SB_RemoveDest(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *DestPtr
 {
     CFE_SB_RemoveDestNode(RouteId, DestPtr);
     CFE_SB_PutDestinationBlk(DestPtr);
-    CFE_SB.StatTlmMsg.Payload.SubscriptionsInUse--;
+    CFE_SB_Global.StatTlmMsg.Payload.SubscriptionsInUse--;
 }
 
 /******************************************************************************
@@ -536,7 +536,7 @@ void CFE_SB_RemoveDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *Nod
 int32 CFE_SB_ZeroCopyReleaseAppId(CFE_ES_ResourceID_t         AppId)
 {
     CFE_SB_ZeroCopyD_t *prev = NULL;
-    CFE_SB_ZeroCopyD_t *zcd = (CFE_SB_ZeroCopyD_t *) (CFE_SB.ZeroCopyTail);
+    CFE_SB_ZeroCopyD_t *zcd = (CFE_SB_ZeroCopyD_t *) (CFE_SB_Global.ZeroCopyTail);
 
     while(zcd != NULL){
         prev = (CFE_SB_ZeroCopyD_t *) (zcd->Prev);

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.h
@@ -60,8 +60,8 @@
 #define CFE_SB_INACTIVE                 0
 #define CFE_SB_ACTIVE                   1
 
-#define CFE_SB_GLOBAL                   0
-#define CFE_SB_LOCAL                    1
+#define CFE_SB_MSG_GLOBAL               0
+#define CFE_SB_MSG_LOCAL                1
 
 #define CFE_SB_SEND_ZEROCOPY            0
 #define CFE_SB_SEND_ONECOPY             1
@@ -175,7 +175,7 @@ typedef struct {
 
 
 /******************************************************************************
-**  Typedef:  cfe_sb_t
+**  Typedef:  CFE_SB_Global_t
 **
 **  Purpose:
 **     This structure contains the SB global variables.
@@ -195,7 +195,8 @@ typedef struct
     CFE_SB_AllSubscriptionsTlm_t   PrevSubMsg;
     CFE_EVS_BinFilter_t            EventFilters[CFE_SB_MAX_CFG_FILE_EVENTS_TO_FILTER];
     CFE_SB_PipeId_t                LastPipeId;
-} cfe_sb_t;
+    CFE_SB_Qos_t                   Default_Qos;
+} CFE_SB_Global_t;
 
 
 /******************************************************************************
@@ -477,7 +478,7 @@ bool CFE_SB_CheckPipeDescSlotUsed(CFE_SB_PipeId_t CheckId);
  * External variables private to the software bus module
  */
 
-extern cfe_sb_t CFE_SB;
+extern CFE_SB_Global_t CFE_SB_Global;
 
 #endif /* _cfe_sb_priv_ */
 /*****************************************************************************/

--- a/fsw/cfe-core/src/sb/cfe_sb_task.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_task.c
@@ -45,7 +45,7 @@
 #include <string.h>
 
 /*  Task Globals */
-cfe_sb_t                CFE_SB;
+CFE_SB_Global_t         CFE_SB_Global;
 CFE_SB_Qos_t            CFE_SB_Default_Qos;
 
 /* Local structure for file writing callbacks */
@@ -68,6 +68,7 @@ typedef struct
 **    none
 **
 **  Return:
+u
 **    none
 */
 void CFE_SB_TaskMain(void)
@@ -105,7 +106,7 @@ void CFE_SB_TaskMain(void)
 
         /* Pend on receipt of packet */
         Status = CFE_SB_ReceiveBuffer(&SBBufPtr,
-                                CFE_SB.CmdPipe,
+                                CFE_SB_Global.CmdPipe,
                                 CFE_SB_PEND_FOREVER);
 
         CFE_ES_PerfLogEntry(CFE_MISSION_SB_MAIN_PERF_ID);
@@ -156,54 +157,54 @@ int32 CFE_SB_AppInit(void){
     }/* end if */
 
     /* Get the assigned Application ID for the SB Task */
-    CFE_ES_GetAppID(&CFE_SB.AppId);
+    CFE_ES_GetAppID(&CFE_SB_Global.AppId);
 
     /* Process the platform cfg file events to be filtered */
     if(CFE_PLATFORM_SB_FILTERED_EVENT1 != 0){
-      CFE_SB.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT1;
-      CFE_SB.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK1;      
+      CFE_SB_Global.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT1;
+      CFE_SB_Global.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK1;      
       CfgFileEventsToFilter++;
     }/* end if */           
 
     if(CFE_PLATFORM_SB_FILTERED_EVENT2 != 0){
-      CFE_SB.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT2;
-      CFE_SB.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK2;      
+      CFE_SB_Global.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT2;
+      CFE_SB_Global.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK2;      
       CfgFileEventsToFilter++;
     }/* end if */      
 
     if(CFE_PLATFORM_SB_FILTERED_EVENT3 != 0){
-      CFE_SB.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT3;
-      CFE_SB.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK3;      
+      CFE_SB_Global.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT3;
+      CFE_SB_Global.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK3;      
       CfgFileEventsToFilter++;
     }/* end if */      
 
     if(CFE_PLATFORM_SB_FILTERED_EVENT4 != 0){
-      CFE_SB.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT4;
-      CFE_SB.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK4;      
+      CFE_SB_Global.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT4;
+      CFE_SB_Global.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK4;      
       CfgFileEventsToFilter++;
     }/* end if */      
 
     if(CFE_PLATFORM_SB_FILTERED_EVENT5 != 0){
-      CFE_SB.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT5;
-      CFE_SB.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK5;      
+      CFE_SB_Global.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT5;
+      CFE_SB_Global.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK5;      
       CfgFileEventsToFilter++;
     }/* end if */      
 
     if(CFE_PLATFORM_SB_FILTERED_EVENT6 != 0){
-      CFE_SB.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT6;
-      CFE_SB.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK6;      
+      CFE_SB_Global.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT6;
+      CFE_SB_Global.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK6;      
       CfgFileEventsToFilter++;
     }/* end if */      
 
     if(CFE_PLATFORM_SB_FILTERED_EVENT7 != 0){
-      CFE_SB.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT7;
-      CFE_SB.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK7;      
+      CFE_SB_Global.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT7;
+      CFE_SB_Global.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK7;      
       CfgFileEventsToFilter++;
     }/* end if */      
 
     if(CFE_PLATFORM_SB_FILTERED_EVENT8 != 0){
-      CFE_SB.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT8;
-      CFE_SB.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK8;      
+      CFE_SB_Global.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT8;
+      CFE_SB_Global.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK8;      
       CfgFileEventsToFilter++;
     }/* end if */
     
@@ -215,7 +216,7 @@ int32 CFE_SB_AppInit(void){
 
 
     /* Register event filter table... */
-    Status = CFE_EVS_Register(CFE_SB.EventFilters,
+    Status = CFE_EVS_Register(CFE_SB_Global.EventFilters,
                               CfgFileEventsToFilter,
                               CFE_EVS_EventFilter_BINARY);
     if(Status != CFE_SUCCESS){
@@ -225,26 +226,26 @@ int32 CFE_SB_AppInit(void){
     
     CFE_ES_WriteToSysLog("SB:Registered %d events for filtering\n",(int)CfgFileEventsToFilter);
 
-    CFE_MSG_Init(&CFE_SB.HKTlmMsg.Hdr.Msg,
+    CFE_MSG_Init(&CFE_SB_Global.HKTlmMsg.Hdr.Msg,
                  CFE_SB_ValueToMsgId(CFE_SB_HK_TLM_MID),
-                 sizeof(CFE_SB.HKTlmMsg));
+                 sizeof(CFE_SB_Global.HKTlmMsg));
 
-    CFE_MSG_Init(&CFE_SB.PrevSubMsg.Hdr.Msg,
+    CFE_MSG_Init(&CFE_SB_Global.PrevSubMsg.Hdr.Msg,
                  CFE_SB_ValueToMsgId(CFE_SB_ALLSUBS_TLM_MID),
-                 sizeof(CFE_SB.PrevSubMsg));
+                 sizeof(CFE_SB_Global.PrevSubMsg));
 
     /* Populate the fixed fields in the HK Tlm Msg */
-    CFE_SB.HKTlmMsg.Payload.MemPoolHandle = CFE_SB.Mem.PoolHdl;
+    CFE_SB_Global.HKTlmMsg.Payload.MemPoolHandle = CFE_SB_Global.Mem.PoolHdl;
     
     /* Populate the fixed fields in the Stat Tlm Msg */
-    CFE_SB.StatTlmMsg.Payload.MaxMsgIdsAllowed = CFE_PLATFORM_SB_MAX_MSG_IDS;
-    CFE_SB.StatTlmMsg.Payload.MaxPipesAllowed  = CFE_PLATFORM_SB_MAX_PIPES;
-    CFE_SB.StatTlmMsg.Payload.MaxMemAllowed    = CFE_PLATFORM_SB_BUF_MEMORY_BYTES;
-    CFE_SB.StatTlmMsg.Payload.MaxPipeDepthAllowed = CFE_PLATFORM_SB_MAX_PIPE_DEPTH;
-    CFE_SB.StatTlmMsg.Payload.MaxSubscriptionsAllowed =
+    CFE_SB_Global.StatTlmMsg.Payload.MaxMsgIdsAllowed = CFE_PLATFORM_SB_MAX_MSG_IDS;
+    CFE_SB_Global.StatTlmMsg.Payload.MaxPipesAllowed  = CFE_PLATFORM_SB_MAX_PIPES;
+    CFE_SB_Global.StatTlmMsg.Payload.MaxMemAllowed    = CFE_PLATFORM_SB_BUF_MEMORY_BYTES;
+    CFE_SB_Global.StatTlmMsg.Payload.MaxPipeDepthAllowed = CFE_PLATFORM_SB_MAX_PIPE_DEPTH;
+    CFE_SB_Global.StatTlmMsg.Payload.MaxSubscriptionsAllowed =
                     ((CFE_PLATFORM_SB_MAX_MSG_IDS)*(CFE_PLATFORM_SB_MAX_DEST_PER_PKT));
     
-    Status = CFE_SB_CreatePipe(&CFE_SB.CmdPipe,
+    Status = CFE_SB_CreatePipe(&CFE_SB_Global.CmdPipe,
                                 CFE_SB_CMD_PIPE_DEPTH,
                                 CFE_SB_CMD_PIPE_NAME);
     if(Status != CFE_SUCCESS){
@@ -252,21 +253,21 @@ int32 CFE_SB_AppInit(void){
       return Status;
     }/* end if */                                
 
-    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_SB_CMD_MID),CFE_SB.CmdPipe);
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_SB_CMD_MID),CFE_SB_Global.CmdPipe);
 
     if(Status != CFE_SUCCESS){
       CFE_ES_WriteToSysLog("SB:Subscribe to Cmds Failed:RC=0x%08X\n",(unsigned int)Status);
       return Status;
     }/* end if */
         
-    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_SB_SEND_HK_MID),CFE_SB.CmdPipe);
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_SB_SEND_HK_MID),CFE_SB_Global.CmdPipe);
 
     if(Status != CFE_SUCCESS){
       CFE_ES_WriteToSysLog("SB:Subscribe to HK Request Failed:RC=0x%08X\n",(unsigned int)Status);
       return Status;
     }/* end if */
 
-    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_SB_SUB_RPT_CTRL_MID),CFE_SB.CmdPipe);
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_SB_SUB_RPT_CTRL_MID),CFE_SB_Global.CmdPipe);
 
     if(Status != CFE_SUCCESS){
       CFE_ES_WriteToSysLog("SB:Subscribe to Subscription Report Request Failed:RC=0x%08X\n",(unsigned int)Status);
@@ -275,7 +276,7 @@ int32 CFE_SB_AppInit(void){
      
     /* Ensure a ground commanded reset does not get blocked if SB mem pool  */
     /* becomes fully configured (DCR6772) */
-    Status = CFE_ES_GetPoolBuf(&TmpPtr, CFE_SB.Mem.PoolHdl,
+    Status = CFE_ES_GetPoolBuf(&TmpPtr, CFE_SB_Global.Mem.PoolHdl,
                                         sizeof(CFE_ES_RestartCmd_t));
 
     if(Status < 0){
@@ -285,7 +286,7 @@ int32 CFE_SB_AppInit(void){
 
     /* Return mem block used on previous call,the actual memory is not needed.*/
     /* The SB mem pool is now configured with a block size for the reset cmd. */
-    Status = CFE_ES_PutPoolBuf(CFE_SB.Mem.PoolHdl, TmpPtr);
+    Status = CFE_ES_PutPoolBuf(CFE_SB_Global.Mem.PoolHdl, TmpPtr);
 
     if(Status < 0){
       CFE_ES_WriteToSysLog("SB:Init error, PutPool Failed:RC=0x%08X\n",(unsigned int)Status);
@@ -339,7 +340,7 @@ bool CFE_SB_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
                           (unsigned int)CFE_SB_MsgIdToValue(MsgId), (unsigned int)FcnCode,
                           (unsigned int)ActualLength, (unsigned int)ExpectedLength);
         result = false;
-        ++CFE_SB.HKTlmMsg.Payload.CommandErrorCounter;
+        ++CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter;
     }
 
     return(result);
@@ -402,7 +403,7 @@ void CFE_SB_ProcessCmdPipePkt(CFE_SB_Buffer_t *SBBufPtr)
             default:
                CFE_EVS_SendEvent(CFE_SB_BAD_CMD_CODE_EID,CFE_EVS_EventType_ERROR,
                      "Invalid Cmd, Unexpected Command Code %u", (unsigned int)FcnCode);
-               CFE_SB.HKTlmMsg.Payload.CommandErrorCounter++;
+               CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter++;
                break;
          } /* end switch on cmd code */
          break;
@@ -470,7 +471,7 @@ void CFE_SB_ProcessCmdPipePkt(CFE_SB_Buffer_t *SBBufPtr)
             default:
                CFE_EVS_SendEvent(CFE_SB_BAD_CMD_CODE_EID,CFE_EVS_EventType_ERROR,
                      "Invalid Cmd, Unexpected Command Code %u", FcnCode);
-               CFE_SB.HKTlmMsg.Payload.CommandErrorCounter++;
+               CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter++;
                break;
          } /* end switch on cmd code */
          break;
@@ -479,7 +480,7 @@ void CFE_SB_ProcessCmdPipePkt(CFE_SB_Buffer_t *SBBufPtr)
             CFE_EVS_SendEvent(CFE_SB_BAD_MSGID_EID,CFE_EVS_EventType_ERROR,
                   "Invalid Cmd, Unexpected Msg Id: 0x%x",
                   (unsigned int)CFE_SB_MsgIdToValue(MessageID));
-            CFE_SB.HKTlmMsg.Payload.CommandErrorCounter++;
+            CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter++;
             break;
 
    } /* end switch on MsgId */
@@ -499,7 +500,7 @@ int32 CFE_SB_NoopCmd(const CFE_SB_NoopCmd_t *data)
 {
     CFE_EVS_SendEvent(CFE_SB_CMD0_RCVD_EID,CFE_EVS_EventType_INFORMATION,
             "No-op Cmd Rcvd. %s", CFE_VERSION_STRING);
-    CFE_SB.HKTlmMsg.Payload.CommandCounter++;
+    CFE_SB_Global.HKTlmMsg.Payload.CommandCounter++;
 
     return CFE_SUCCESS;
 }
@@ -567,13 +568,13 @@ int32 CFE_SB_SendHKTlmCmd(const CFE_MSG_CommandHeader_t *data)
 {
     CFE_SB_LockSharedData(__FILE__, __LINE__);
 
-    CFE_SB.HKTlmMsg.Payload.MemInUse        = CFE_SB.StatTlmMsg.Payload.MemInUse;
-    CFE_SB.HKTlmMsg.Payload.UnmarkedMem     = CFE_PLATFORM_SB_BUF_MEMORY_BYTES - CFE_SB.StatTlmMsg.Payload.PeakMemInUse;
+    CFE_SB_Global.HKTlmMsg.Payload.MemInUse        = CFE_SB_Global.StatTlmMsg.Payload.MemInUse;
+    CFE_SB_Global.HKTlmMsg.Payload.UnmarkedMem     = CFE_PLATFORM_SB_BUF_MEMORY_BYTES - CFE_SB_Global.StatTlmMsg.Payload.PeakMemInUse;
 
     CFE_SB_UnlockSharedData(__FILE__, __LINE__);
 
-    CFE_SB_TimeStampMsg(&CFE_SB.HKTlmMsg.Hdr.Msg);
-    CFE_SB_TransmitMsg(&CFE_SB.HKTlmMsg.Hdr.Msg, true);
+    CFE_SB_TimeStampMsg(&CFE_SB_Global.HKTlmMsg.Hdr.Msg);
+    CFE_SB_TransmitMsg(&CFE_SB_Global.HKTlmMsg.Hdr.Msg, true);
 
     return CFE_SUCCESS;
 }/* end CFE_SB_SendHKTlmCmd */
@@ -596,17 +597,17 @@ int32 CFE_SB_SendHKTlmCmd(const CFE_MSG_CommandHeader_t *data)
 */
 void CFE_SB_ResetCounters(void){
 
-   CFE_SB.HKTlmMsg.Payload.CommandCounter          = 0;
-   CFE_SB.HKTlmMsg.Payload.CommandErrorCounter           = 0;
-   CFE_SB.HKTlmMsg.Payload.NoSubscribersCounter    = 0;
-   CFE_SB.HKTlmMsg.Payload.DuplicateSubscriptionsCounter = 0;
-   CFE_SB.HKTlmMsg.Payload.MsgSendErrorCounter       = 0;
-   CFE_SB.HKTlmMsg.Payload.MsgReceiveErrorCounter    = 0;
-   CFE_SB.HKTlmMsg.Payload.InternalErrorCounter      = 0;
-   CFE_SB.HKTlmMsg.Payload.CreatePipeErrorCounter    = 0;
-   CFE_SB.HKTlmMsg.Payload.SubscribeErrorCounter     = 0;
-   CFE_SB.HKTlmMsg.Payload.PipeOverflowErrorCounter  = 0;
-   CFE_SB.HKTlmMsg.Payload.MsgLimitErrorCounter        = 0;
+   CFE_SB_Global.HKTlmMsg.Payload.CommandCounter          = 0;
+   CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter           = 0;
+   CFE_SB_Global.HKTlmMsg.Payload.NoSubscribersCounter    = 0;
+   CFE_SB_Global.HKTlmMsg.Payload.DuplicateSubscriptionsCounter = 0;
+   CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter       = 0;
+   CFE_SB_Global.HKTlmMsg.Payload.MsgReceiveErrorCounter    = 0;
+   CFE_SB_Global.HKTlmMsg.Payload.InternalErrorCounter      = 0;
+   CFE_SB_Global.HKTlmMsg.Payload.CreatePipeErrorCounter    = 0;
+   CFE_SB_Global.HKTlmMsg.Payload.SubscribeErrorCounter     = 0;
+   CFE_SB_Global.HKTlmMsg.Payload.PipeOverflowErrorCounter  = 0;
+   CFE_SB_Global.HKTlmMsg.Payload.MsgLimitErrorCounter        = 0;
 
 }/* end CFE_SB_ResetCounters */
 
@@ -645,7 +646,7 @@ int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data)
        !CFE_SB_PipeDescIsMatch(PipeDscPtr,CmdPtr->Pipe))
     {
         PendingEventID = CFE_SB_ENBL_RTE3_EID;
-        CFE_SB.HKTlmMsg.Payload.CommandErrorCounter++;
+        CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter++;
     }
     else
     {
@@ -653,13 +654,13 @@ int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data)
         if(DestPtr == NULL)
         {
             PendingEventID = CFE_SB_ENBL_RTE1_EID;
-            CFE_SB.HKTlmMsg.Payload.CommandErrorCounter++;
+            CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter++;
         }
         else
         {
             DestPtr->Active = CFE_SB_ACTIVE;
             PendingEventID = CFE_SB_ENBL_RTE2_EID;
-            CFE_SB.HKTlmMsg.Payload.CommandCounter++;
+            CFE_SB_Global.HKTlmMsg.Payload.CommandCounter++;
         }
 
     }/* end if */    
@@ -727,7 +728,7 @@ int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data)
        !CFE_SB_PipeDescIsMatch(PipeDscPtr,CmdPtr->Pipe))
     {
         PendingEventID = CFE_SB_DSBL_RTE3_EID;
-        CFE_SB.HKTlmMsg.Payload.CommandErrorCounter++;
+        CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter++;
     }
     else
     {
@@ -735,13 +736,13 @@ int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data)
         if(DestPtr == NULL)
         {
             PendingEventID = CFE_SB_DSBL_RTE1_EID;
-            CFE_SB.HKTlmMsg.Payload.CommandErrorCounter++;
+            CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter++;
         }
         else
         {
             DestPtr->Active = CFE_SB_INACTIVE;
             PendingEventID = CFE_SB_DSBL_RTE2_EID;
-            CFE_SB.HKTlmMsg.Payload.CommandCounter++;
+            CFE_SB_Global.HKTlmMsg.Payload.CommandCounter++;
         }
 
     }/* end if */    
@@ -799,8 +800,8 @@ int32 CFE_SB_SendStatsCmd(const CFE_SB_SendSbStatsCmd_t *data)
     /* Collect data on pipes */
     PipeDscCount = CFE_PLATFORM_SB_MAX_PIPES;
     PipeStatCount = CFE_MISSION_SB_MAX_PIPES;
-    PipeDscPtr = CFE_SB.PipeTbl;
-    PipeStatPtr = CFE_SB.StatTlmMsg.Payload.PipeDepthStats;
+    PipeDscPtr = CFE_SB_Global.PipeTbl;
+    PipeStatPtr = CFE_SB_Global.StatTlmMsg.Payload.PipeDepthStats;
 
     while (PipeDscCount > 0 && PipeStatCount > 0)
     {
@@ -829,13 +830,13 @@ int32 CFE_SB_SendStatsCmd(const CFE_SB_SendSbStatsCmd_t *data)
         --PipeStatCount;
     }
 
-    CFE_SB_TimeStampMsg(&CFE_SB.StatTlmMsg.Hdr.Msg);
-    CFE_SB_TransmitMsg(&CFE_SB.StatTlmMsg.Hdr.Msg, true);
+    CFE_SB_TimeStampMsg(&CFE_SB_Global.StatTlmMsg.Hdr.Msg);
+    CFE_SB_TransmitMsg(&CFE_SB_Global.StatTlmMsg.Hdr.Msg, true);
 
     CFE_EVS_SendEvent(CFE_SB_SND_STATS_EID,CFE_EVS_EventType_DEBUG,
                       "Software Bus Statistics packet sent");
 
-    CFE_SB.HKTlmMsg.Payload.CommandCounter++;
+    CFE_SB_Global.HKTlmMsg.Payload.CommandCounter++;
 
     return CFE_SUCCESS;
 }/* CFE_SB_SendStatsCmd */
@@ -1037,7 +1038,7 @@ int32 CFE_SB_SendSubscriptionReport(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId
 
     Status = CFE_SUCCESS;
 
-    if (CFE_SB.SubscriptionReporting == CFE_SB_ENABLE)
+    if (CFE_SB_Global.SubscriptionReporting == CFE_SB_ENABLE)
     {
         CFE_MSG_Init(&SubRptMsg.Hdr.Msg,
                     CFE_SB_ValueToMsgId(CFE_SB_ONESUB_TLM_MID),
@@ -1049,7 +1050,7 @@ int32 CFE_SB_SendSubscriptionReport(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId
         SubRptMsg.Payload.SubType = CFE_SB_SUBSCRIPTION;
 
         Status = CFE_SB_TransmitMsg(&SubRptMsg.Hdr.Msg, true);
-        CFE_EVS_SendEventWithAppID(CFE_SB_SUBSCRIPTION_RPT_EID,CFE_EVS_EventType_DEBUG,CFE_SB.AppId,
+        CFE_EVS_SendEventWithAppID(CFE_SB_SUBSCRIPTION_RPT_EID,CFE_EVS_EventType_DEBUG,CFE_SB_Global.AppId,
                 "Sending Subscription Report Msg=0x%x,Pipe=%lu,Stat=0x%x",
                 (unsigned int)CFE_SB_MsgIdToValue(MsgId),
                 CFE_ES_ResourceID_ToInteger(PipeId),(unsigned int)Status);
@@ -1167,7 +1168,7 @@ int32 CFE_SB_SendPipeInfo(const char *Filename)
 
     /* loop through the pipe table */   
     CFE_SB_LockSharedData(__FILE__,__LINE__); 
-    PipeDscPtr = CFE_SB.PipeTbl;
+    PipeDscPtr = CFE_SB_Global.PipeTbl;
 
     for (i=0;i<CFE_PLATFORM_SB_MAX_PIPES;i++)
     {
@@ -1339,27 +1340,27 @@ void CFE_SB_SendRouteSub(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
     while(destptr != NULL)
     {
 
-        if(destptr->Scope == CFE_SB_GLOBAL)
+        if(destptr->Scope == CFE_SB_MSG_GLOBAL)
         {
 
             /* ...add entry into pkt */
-            CFE_SB.PrevSubMsg.Payload.Entry[CFE_SB.PrevSubMsg.Payload.Entries].MsgId = CFE_SBR_GetMsgId(RouteId);
-            CFE_SB.PrevSubMsg.Payload.Entry[CFE_SB.PrevSubMsg.Payload.Entries].Qos.Priority = 0;
-            CFE_SB.PrevSubMsg.Payload.Entry[CFE_SB.PrevSubMsg.Payload.Entries].Qos.Reliability = 0;
-            CFE_SB.PrevSubMsg.Payload.Entries++;
+            CFE_SB_Global.PrevSubMsg.Payload.Entry[CFE_SB_Global.PrevSubMsg.Payload.Entries].MsgId = CFE_SBR_GetMsgId(RouteId);
+            CFE_SB_Global.PrevSubMsg.Payload.Entry[CFE_SB_Global.PrevSubMsg.Payload.Entries].Qos.Priority = 0;
+            CFE_SB_Global.PrevSubMsg.Payload.Entry[CFE_SB_Global.PrevSubMsg.Payload.Entries].Qos.Reliability = 0;
+            CFE_SB_Global.PrevSubMsg.Payload.Entries++;
 
             /* send pkt if full */
-            if(CFE_SB.PrevSubMsg.Payload.Entries >= CFE_SB_SUB_ENTRIES_PER_PKT)
+            if(CFE_SB_Global.PrevSubMsg.Payload.Entries >= CFE_SB_SUB_ENTRIES_PER_PKT)
             {
                 CFE_SB_UnlockSharedData(__func__,__LINE__);
-                status = CFE_SB_TransmitMsg(&CFE_SB.PrevSubMsg.Hdr.Msg, true);
+                status = CFE_SB_TransmitMsg(&CFE_SB_Global.PrevSubMsg.Hdr.Msg, true);
                 CFE_EVS_SendEvent(CFE_SB_FULL_SUB_PKT_EID, CFE_EVS_EventType_DEBUG,
                                   "Full Sub Pkt %d Sent,Entries=%d,Stat=0x%x\n",
-                                  (int)CFE_SB.PrevSubMsg.Payload.PktSegment,
-                                  (int)CFE_SB.PrevSubMsg.Payload.Entries, (unsigned int)status);
+                                  (int)CFE_SB_Global.PrevSubMsg.Payload.PktSegment,
+                                  (int)CFE_SB_Global.PrevSubMsg.Payload.Entries, (unsigned int)status);
                 CFE_SB_LockSharedData(__func__,__LINE__);
-                CFE_SB.PrevSubMsg.Payload.Entries = 0;
-                CFE_SB.PrevSubMsg.Payload.PktSegment++;
+                CFE_SB_Global.PrevSubMsg.Payload.Entries = 0;
+                CFE_SB_Global.PrevSubMsg.Payload.PktSegment++;
             }
 
             /*
@@ -1399,8 +1400,8 @@ int32 CFE_SB_SendPrevSubsCmd(const CFE_SB_SendPrevSubsCmd_t *data)
     CFE_SB_LockSharedData(__func__,__LINE__);
 
     /* Initialize entry/segment tracking */
-    CFE_SB.PrevSubMsg.Payload.PktSegment = 1;
-    CFE_SB.PrevSubMsg.Payload.Entries = 0;
+    CFE_SB_Global.PrevSubMsg.Payload.PktSegment = 1;
+    CFE_SB_Global.PrevSubMsg.Payload.Entries = 0;
 
     /* Send subcription for each route */
     CFE_SBR_ForEachRouteId(CFE_SB_SendRouteSub, NULL, NULL);
@@ -1408,12 +1409,12 @@ int32 CFE_SB_SendPrevSubsCmd(const CFE_SB_SendPrevSubsCmd_t *data)
     CFE_SB_UnlockSharedData(__func__,__LINE__);
 
     /* if pkt has any number of entries, send it as a partial pkt */
-    if(CFE_SB.PrevSubMsg.Payload.Entries > 0)
+    if(CFE_SB_Global.PrevSubMsg.Payload.Entries > 0)
     {
-        status = CFE_SB_TransmitMsg(&CFE_SB.PrevSubMsg.Hdr.Msg, true);
+        status = CFE_SB_TransmitMsg(&CFE_SB_Global.PrevSubMsg.Hdr.Msg, true);
         CFE_EVS_SendEvent(CFE_SB_PART_SUB_PKT_EID, CFE_EVS_EventType_DEBUG,
                           "Partial Sub Pkt %d Sent,Entries=%d,Stat=0x%x",
-                          (int)CFE_SB.PrevSubMsg.Payload.PktSegment, (int)CFE_SB.PrevSubMsg.Payload.Entries,
+                          (int)CFE_SB_Global.PrevSubMsg.Payload.PktSegment, (int)CFE_SB_Global.PrevSubMsg.Payload.Entries,
                           (unsigned int)status);
     }
 
@@ -1438,9 +1439,9 @@ int32 CFE_SB_SendPrevSubsCmd(const CFE_SB_SendPrevSubsCmd_t *data)
 void CFE_SB_IncrCmdCtr(int32 status){
 
     if(status==CFE_SUCCESS){
-      CFE_SB.HKTlmMsg.Payload.CommandCounter++;
+      CFE_SB_Global.HKTlmMsg.Payload.CommandCounter++;
     }else{
-      CFE_SB.HKTlmMsg.Payload.CommandErrorCounter++;
+      CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter++;
     }/* end if */
 
 }/* end CFE_SB_IncrCmdCtr */
@@ -1482,6 +1483,6 @@ void CFE_SB_FileWriteByteCntErr(const char *Filename,uint32 Requested,uint32 Act
 */
 void CFE_SB_SetSubscriptionReporting(uint32 state){
 
-    CFE_SB.SubscriptionReporting = state;
+    CFE_SB_Global.SubscriptionReporting = state;
 
 }/* end CFE_SB_SetSubscriptionReporting */

--- a/fsw/cfe-core/src/tbl/cfe_tbl_api.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_api.c
@@ -165,7 +165,7 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
         if (RegIndx != CFE_TBL_NOT_FOUND)
         {
             /* Get pointer to Registry Record Entry to speed up processing */
-            RegRecPtr = &CFE_TBL_TaskData.Registry[RegIndx];
+            RegRecPtr = &CFE_TBL_Global.Registry[RegIndx];
 
             /* If this app previously owned the table, then allow them to re-register */
             if ( CFE_ES_ResourceID_Equal(RegRecPtr->OwnerAppId, ThisAppId) )
@@ -192,15 +192,15 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
                     AccessIndex = RegRecPtr->HeadOfAccessList;
                     while ((AccessIndex != CFE_TBL_END_OF_LIST) && (*TblHandlePtr == CFE_TBL_BAD_TABLE_HANDLE))
                     {
-                        if ((CFE_TBL_TaskData.Handles[AccessIndex].UsedFlag == true) &&
-                            CFE_ES_ResourceID_Equal(CFE_TBL_TaskData.Handles[AccessIndex].AppId, ThisAppId) &&
-                            (CFE_TBL_TaskData.Handles[AccessIndex].RegIndex == RegIndx))
+                        if ((CFE_TBL_Global.Handles[AccessIndex].UsedFlag == true) &&
+                            CFE_ES_ResourceID_Equal(CFE_TBL_Global.Handles[AccessIndex].AppId, ThisAppId) &&
+                            (CFE_TBL_Global.Handles[AccessIndex].RegIndex == RegIndx))
                         {
                             *TblHandlePtr = AccessIndex;
                         }
                         else
                         {
-                            AccessIndex = CFE_TBL_TaskData.Handles[AccessIndex].NextLink;
+                            AccessIndex = CFE_TBL_Global.Handles[AccessIndex].NextLink;
                         }
                     }
                 }
@@ -245,7 +245,7 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
             if ((Status & CFE_SEVERITY_BITMASK) != CFE_SEVERITY_ERROR)
             {
                 /* Get pointer to Registry Record Entry to speed up processing */
-                RegRecPtr = &CFE_TBL_TaskData.Registry[RegIndx];
+                RegRecPtr = &CFE_TBL_Global.Registry[RegIndx];
             
                 /* Initialize Registry Record to default settings */
                 CFE_TBL_InitRegistryRecord(RegRecPtr);
@@ -256,12 +256,12 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
                 
                     /* Allocate the memory buffer(s) for the table and inactive table, if necessary */
                     Status = CFE_ES_GetPoolBuf(&RegRecPtr->Buffers[0].BufferPtr,
-                                               CFE_TBL_TaskData.Buf.PoolHdl,                                           
+                                               CFE_TBL_Global.Buf.PoolHdl,
                                                Size);
                     if(Status < 0)
                     {
                         CFE_ES_WriteToSysLog("CFE_TBL:Register-1st Buf Alloc GetPool fail Stat=0x%08X MemPoolHndl=0x%08lX\n",
-                                (unsigned int)Status, CFE_ES_ResourceID_ToInteger(CFE_TBL_TaskData.Buf.PoolHdl));
+                                (unsigned int)Status, CFE_ES_ResourceID_ToInteger(CFE_TBL_Global.Buf.PoolHdl));
                     }
                     else
                     {
@@ -282,12 +282,12 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
                 {
                     /* Allocate memory for the dedicated secondary buffer */
                     Status = CFE_ES_GetPoolBuf(&RegRecPtr->Buffers[1].BufferPtr,
-                                               CFE_TBL_TaskData.Buf.PoolHdl,                                           
+                                               CFE_TBL_Global.Buf.PoolHdl,
                                                Size);
                     if(Status < 0)
                     {
                         CFE_ES_WriteToSysLog("CFE_TBL:Register-2nd Buf Alloc GetPool fail Stat=0x%08X MemPoolHndl=0x%08lX\n",
-                                (unsigned int)Status, CFE_ES_ResourceID_ToInteger(CFE_TBL_TaskData.Buf.PoolHdl));
+                                (unsigned int)Status, CFE_ES_ResourceID_ToInteger(CFE_TBL_Global.Buf.PoolHdl));
                     }
                     else
                     {
@@ -328,7 +328,7 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
                     }
 
                     /* Initialize the Table Access Descriptor */
-                    AccessDescPtr = &CFE_TBL_TaskData.Handles[*TblHandlePtr];
+                    AccessDescPtr = &CFE_TBL_Global.Handles[*TblHandlePtr];
 
                     AccessDescPtr->AppId = ThisAppId;
                     AccessDescPtr->LockFlag = false;
@@ -455,7 +455,7 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
                                 CritRegRecPtr->TimeOfLastUpdate.Subseconds = 0;
                                 CritRegRecPtr->TableLoadedOnce = false;
                             
-                                CFE_ES_CopyToCDS(CFE_TBL_TaskData.CritRegHandle, CFE_TBL_TaskData.CritReg);
+                                CFE_ES_CopyToCDS(CFE_TBL_Global.CritRegHandle, CFE_TBL_Global.CritReg);
                             }
                             else
                             {
@@ -500,7 +500,7 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
 
         CFE_EVS_SendEventWithAppID(CFE_TBL_REGISTER_ERR_EID,
                                    CFE_EVS_EventType_ERROR,
-                                   CFE_TBL_TaskData.TableTaskAppId,
+                                   CFE_TBL_Global.TableTaskAppId,
                                    "%s Failed to Register '%s', Status=0x%08X",
                                    AppName, TblName, (unsigned int)Status);
     }
@@ -537,7 +537,7 @@ int32 CFE_TBL_Share( CFE_TBL_Handle_t *TblHandlePtr,
         if (RegIndx != CFE_TBL_NOT_FOUND)
         {
             /* Get pointer to Registry Record Entry to speed up processing */
-            RegRecPtr = &CFE_TBL_TaskData.Registry[RegIndx];
+            RegRecPtr = &CFE_TBL_Global.Registry[RegIndx];
 
             /* Search Access Descriptor Array for free Descriptor */
             *TblHandlePtr = CFE_TBL_FindFreeHandle();
@@ -551,7 +551,7 @@ int32 CFE_TBL_Share( CFE_TBL_Handle_t *TblHandlePtr,
             else
             {
                 /* Initialize the Table Access Descriptor */
-                AccessDescPtr = &CFE_TBL_TaskData.Handles[*TblHandlePtr];
+                AccessDescPtr = &CFE_TBL_Global.Handles[*TblHandlePtr];
 
                 AccessDescPtr->AppId = ThisAppId;
                 AccessDescPtr->LockFlag = false;
@@ -570,7 +570,7 @@ int32 CFE_TBL_Share( CFE_TBL_Handle_t *TblHandlePtr,
                 AccessDescPtr->NextLink = RegRecPtr->HeadOfAccessList;
 
                 /* Make sure the old head of the list now sees this as the head */
-                CFE_TBL_TaskData.Handles[RegRecPtr->HeadOfAccessList].PrevLink = *TblHandlePtr;
+                CFE_TBL_Global.Handles[RegRecPtr->HeadOfAccessList].PrevLink = *TblHandlePtr;
 
                 /* Make sure the Registry Record see this as the head of the list */
                 RegRecPtr->HeadOfAccessList = *TblHandlePtr;
@@ -599,7 +599,7 @@ int32 CFE_TBL_Share( CFE_TBL_Handle_t *TblHandlePtr,
 
         CFE_EVS_SendEventWithAppID(CFE_TBL_SHARE_ERR_EID,
                                    CFE_EVS_EventType_ERROR,
-                                   CFE_TBL_TaskData.TableTaskAppId,
+                                   CFE_TBL_Global.TableTaskAppId,
                                    "%s Failed to Share '%s', Status=0x%08X",
                                    AppName, TblName, (unsigned int)Status);
     }
@@ -625,10 +625,10 @@ int32 CFE_TBL_Unregister ( CFE_TBL_Handle_t TblHandle )
     if (Status == CFE_SUCCESS)
     {
         /* Get a pointer to the relevant Access Descriptor */
-        AccessDescPtr = &CFE_TBL_TaskData.Handles[TblHandle];
+        AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle];
 
         /* Get a pointer to the relevant entry in the registry */
-        RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+        RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
 
         /* Verify that the application unregistering the table owns the table */
         if (CFE_ES_ResourceID_Equal(RegRecPtr->OwnerAppId, ThisAppId))
@@ -663,7 +663,7 @@ int32 CFE_TBL_Unregister ( CFE_TBL_Handle_t TblHandle )
 
         CFE_EVS_SendEventWithAppID(CFE_TBL_UNREGISTER_ERR_EID,
                                    CFE_EVS_EventType_ERROR,
-                                   CFE_TBL_TaskData.TableTaskAppId,
+                                   CFE_TBL_Global.TableTaskAppId,
                                    "%s Failed to Unregister '?', Status=0x%08X",
                                    AppName, (unsigned int)Status);
     }
@@ -698,14 +698,14 @@ int32 CFE_TBL_Load( CFE_TBL_Handle_t TblHandle,
     if (Status != CFE_SUCCESS)
     {
         CFE_EVS_SendEventWithAppID(CFE_TBL_HANDLE_ACCESS_ERR_EID, CFE_EVS_EventType_ERROR,
-            CFE_TBL_TaskData.TableTaskAppId,
+            CFE_TBL_Global.TableTaskAppId,
             "%s: No access to Tbl Handle=%d", AppName, (int)TblHandle);
 
         return Status;
     }
 
-    AccessDescPtr = &CFE_TBL_TaskData.Handles[TblHandle];
-    RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+    AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle];
+    RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
 
     /* Translate AppID of caller into App Name */
     CFE_ES_GetAppName(AppName, ThisAppId, sizeof(AppName));
@@ -719,7 +719,7 @@ int32 CFE_TBL_Load( CFE_TBL_Handle_t TblHandle,
         if ((!RegRecPtr->UserDefAddr) ||(RegRecPtr->TableLoadedOnce))
         {
             CFE_EVS_SendEventWithAppID(CFE_TBL_LOADING_A_DUMP_ONLY_ERR_EID,
-                CFE_EVS_EventType_ERROR, CFE_TBL_TaskData.TableTaskAppId,
+                CFE_EVS_EventType_ERROR, CFE_TBL_Global.TableTaskAppId,
                 "%s: Attempted to load Dump Only Tbl '%s'", AppName, RegRecPtr->Name);
 
             return CFE_TBL_ERR_DUMP_ONLY;
@@ -737,7 +737,7 @@ int32 CFE_TBL_Load( CFE_TBL_Handle_t TblHandle,
 
         CFE_EVS_SendEventWithAppID(CFE_TBL_LOAD_SUCCESS_INF_EID,
                                    CFE_EVS_EventType_DEBUG,
-                                   CFE_TBL_TaskData.TableTaskAppId,
+                                   CFE_TBL_Global.TableTaskAppId,
                                    "Successfully loaded '%s' from '%s'",
                                    RegRecPtr->Name,
                                    RegRecPtr->Buffers[0].DataSource);
@@ -749,7 +749,7 @@ int32 CFE_TBL_Load( CFE_TBL_Handle_t TblHandle,
     if (RegRecPtr->LoadInProgress != CFE_TBL_NO_LOAD_IN_PROGRESS)
     {
         CFE_EVS_SendEventWithAppID(CFE_TBL_LOAD_IN_PROGRESS_ERR_EID, CFE_EVS_EventType_ERROR,
-            CFE_TBL_TaskData.TableTaskAppId,
+            CFE_TBL_Global.TableTaskAppId,
             "%s: Load already in progress for '%s'", AppName, RegRecPtr->Name);
 
         return CFE_TBL_ERR_LOAD_IN_PROGRESS;
@@ -761,7 +761,7 @@ int32 CFE_TBL_Load( CFE_TBL_Handle_t TblHandle,
     if (Status != CFE_SUCCESS)
     {
         CFE_EVS_SendEventWithAppID(CFE_TBL_NO_WORK_BUFFERS_ERR_EID, CFE_EVS_EventType_ERROR,
-            CFE_TBL_TaskData.TableTaskAppId,
+            CFE_TBL_Global.TableTaskAppId,
             "%s: Failed to get Working Buffer (Stat=%u)", AppName, (unsigned int)Status);
 
         return Status;
@@ -780,7 +780,7 @@ int32 CFE_TBL_Load( CFE_TBL_Handle_t TblHandle,
                 /* Uninitialized tables cannot be loaded with partial table loads */
                 /* Partial loads can only occur on previously loaded tables.      */
                 CFE_EVS_SendEventWithAppID(CFE_TBL_PARTIAL_LOAD_ERR_EID, CFE_EVS_EventType_ERROR,
-                    CFE_TBL_TaskData.TableTaskAppId,
+                    CFE_TBL_Global.TableTaskAppId,
                     "%s: Attempted to load from partial Tbl '%s' from '%s' (Stat=%u)",
                     AppName, RegRecPtr->Name, (const char *)SrcDataPtr, (unsigned int)Status);
 
@@ -807,7 +807,7 @@ int32 CFE_TBL_Load( CFE_TBL_Handle_t TblHandle,
             break;
         default:
             CFE_EVS_SendEventWithAppID(CFE_TBL_LOAD_TYPE_ERR_EID, CFE_EVS_EventType_ERROR,
-                CFE_TBL_TaskData.TableTaskAppId,
+                CFE_TBL_Global.TableTaskAppId,
                 "%s: Attempted to load from illegal source type=%d", AppName, (int)SrcType);
                                                                  
             Status = CFE_TBL_ERR_ILLEGAL_SRC_TYPE;
@@ -821,7 +821,7 @@ int32 CFE_TBL_Load( CFE_TBL_Handle_t TblHandle,
         if (Status > CFE_SUCCESS)
         {
             CFE_EVS_SendEventWithAppID(CFE_TBL_LOAD_VAL_ERR_EID, CFE_EVS_EventType_ERROR,
-                CFE_TBL_TaskData.TableTaskAppId,
+                CFE_TBL_Global.TableTaskAppId,
                 "%s: Validation func return code invalid (Stat=%u) for '%s'",
                 AppName, (unsigned int)Status, RegRecPtr->Name);
 
@@ -831,7 +831,7 @@ int32 CFE_TBL_Load( CFE_TBL_Handle_t TblHandle,
         if (Status < 0)
         {
             CFE_EVS_SendEventWithAppID(CFE_TBL_VALIDATION_ERR_EID, CFE_EVS_EventType_ERROR,
-                CFE_TBL_TaskData.TableTaskAppId,
+                CFE_TBL_Global.TableTaskAppId,
                 "%s: Validation func reports table invalid (Stat=%u) for '%s'",
                 AppName, (unsigned int)Status, RegRecPtr->Name);
 
@@ -847,7 +847,7 @@ int32 CFE_TBL_Load( CFE_TBL_Handle_t TblHandle,
         if ((!RegRecPtr->DoubleBuffered) && (RegRecPtr->TableLoadedOnce == true))
         {
             /* For single buffered tables, freeing entails resetting flag */
-            CFE_TBL_TaskData.LoadBuffs[RegRecPtr->LoadInProgress].Taken = false;
+            CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].Taken = false;
         }
 
         /* For double buffered tables, freeing buffer is simple */
@@ -870,7 +870,7 @@ int32 CFE_TBL_Load( CFE_TBL_Handle_t TblHandle,
         if (Status != CFE_SUCCESS)
         {
             CFE_EVS_SendEventWithAppID(CFE_TBL_UPDATE_ERR_EID, CFE_EVS_EventType_ERROR,
-                CFE_TBL_TaskData.TableTaskAppId,
+                CFE_TBL_Global.TableTaskAppId,
                 "%s: Failed to update '%s' (Stat=%u)",
                 AppName, RegRecPtr->Name, (unsigned int)Status);
         }
@@ -900,11 +900,11 @@ int32 CFE_TBL_Load( CFE_TBL_Handle_t TblHandle,
         /* to help eliminate a flood of events during a startup         */
         CFE_EVS_SendEventWithAppID(CFE_TBL_LOAD_SUCCESS_INF_EID,
             FirstTime ? CFE_EVS_EventType_DEBUG : CFE_EVS_EventType_INFORMATION,
-            CFE_TBL_TaskData.TableTaskAppId, "Successfully loaded '%s' from '%s'",
+            CFE_TBL_Global.TableTaskAppId, "Successfully loaded '%s' from '%s'",
             RegRecPtr->Name, RegRecPtr->LastFileLoaded);
         
         /* Save the index of the table for housekeeping telemetry */
-        CFE_TBL_TaskData.LastTblUpdated = AccessDescPtr->RegIndex;       
+        CFE_TBL_Global.LastTblUpdated = AccessDescPtr->RegIndex;
     }
 
     return Status;
@@ -928,8 +928,8 @@ int32 CFE_TBL_Update( CFE_TBL_Handle_t TblHandle )
     if (Status == CFE_SUCCESS)
     {
         /* Get pointers to pertinent records in registry and handles */
-        AccessDescPtr = &CFE_TBL_TaskData.Handles[TblHandle];
-        RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+        AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle];
+        RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
 
         Status = CFE_TBL_UpdateInternal(TblHandle, RegRecPtr, AccessDescPtr);
 
@@ -958,7 +958,7 @@ int32 CFE_TBL_Update( CFE_TBL_Handle_t TblHandle )
         {
             CFE_EVS_SendEventWithAppID(CFE_TBL_UPDATE_ERR_EID,
                                        CFE_EVS_EventType_ERROR,
-                                       CFE_TBL_TaskData.TableTaskAppId,
+                                       CFE_TBL_Global.TableTaskAppId,
                                        "%s Failed to Update '%s', Status=0x%08X",
                                        AppName, RegRecPtr->Name, (unsigned int)Status);
         }
@@ -966,7 +966,7 @@ int32 CFE_TBL_Update( CFE_TBL_Handle_t TblHandle )
         {
             CFE_EVS_SendEventWithAppID(CFE_TBL_UPDATE_ERR_EID,
                                        CFE_EVS_EventType_ERROR,
-                                       CFE_TBL_TaskData.TableTaskAppId,
+                                       CFE_TBL_Global.TableTaskAppId,
                                        "%s Failed to Update '?', Status=0x%08X",
                                        AppName, (unsigned int)Status);
         }
@@ -978,12 +978,12 @@ int32 CFE_TBL_Update( CFE_TBL_Handle_t TblHandle )
         {
             CFE_EVS_SendEventWithAppID(CFE_TBL_UPDATE_SUCCESS_INF_EID,
                                        CFE_EVS_EventType_INFORMATION,
-                                       CFE_TBL_TaskData.TableTaskAppId,
+                                       CFE_TBL_Global.TableTaskAppId,
                                        "%s Successfully Updated '%s'",
                                        AppName, RegRecPtr->Name);
                             
             /* Save the index of the table for housekeeping telemetry */
-            CFE_TBL_TaskData.LastTblUpdated = AccessDescPtr->RegIndex;
+            CFE_TBL_Global.LastTblUpdated = AccessDescPtr->RegIndex;
         }       
     }
 
@@ -1037,7 +1037,7 @@ int32 CFE_TBL_ReleaseAddress( CFE_TBL_Handle_t TblHandle )
     if (Status == CFE_SUCCESS)
     {
         /* Clear the lock flag */
-        CFE_TBL_TaskData.Handles[TblHandle].LockFlag = false;
+        CFE_TBL_Global.Handles[TblHandle].LockFlag = false;
 
         /* Return any pending warning or info status indicators */
         Status = CFE_TBL_GetNextNotification(TblHandle);
@@ -1146,8 +1146,8 @@ int32 CFE_TBL_Validate( CFE_TBL_Handle_t TblHandle )
     if (Status == CFE_SUCCESS)
     {
         /* Get pointers to pertinent records in registry and handles */
-        AccessDescPtr = &CFE_TBL_TaskData.Handles[TblHandle];
-        RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+        AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle];
+        RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
 
         CFE_ES_GetAppName(AppName, ThisAppId, sizeof(AppName));
 
@@ -1170,12 +1170,12 @@ int32 CFE_TBL_Validate( CFE_TBL_Handle_t TblHandle )
             {
                 /* Call the Application's Validation function for the appropriate shared buffer */
                 Status = (RegRecPtr->ValidationFuncPtr)
-                          (CFE_TBL_TaskData.LoadBuffs[RegRecPtr->LoadInProgress].BufferPtr);
+                          (CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].BufferPtr);
                 
                 /* Allow buffer to be activated after passing validation */
                 if (Status == CFE_SUCCESS)
                 {
-                    CFE_TBL_TaskData.LoadBuffs[RegRecPtr->LoadInProgress].Validated = true;       
+                    CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].Validated = true;
                 }
             }
 
@@ -1183,7 +1183,7 @@ int32 CFE_TBL_Validate( CFE_TBL_Handle_t TblHandle )
             {
                 CFE_EVS_SendEventWithAppID(CFE_TBL_VALIDATION_INF_EID,
                                            CFE_EVS_EventType_INFORMATION,
-                                           CFE_TBL_TaskData.TableTaskAppId,
+                                           CFE_TBL_Global.TableTaskAppId,
                                            "%s validation successful for Inactive '%s'",
                                            AppName, RegRecPtr->Name);
             }
@@ -1191,22 +1191,22 @@ int32 CFE_TBL_Validate( CFE_TBL_Handle_t TblHandle )
             {
                 CFE_EVS_SendEventWithAppID(CFE_TBL_VALIDATION_ERR_EID,
                                            CFE_EVS_EventType_ERROR,
-                                           CFE_TBL_TaskData.TableTaskAppId,
+                                           CFE_TBL_Global.TableTaskAppId,
                                            "%s validation failed for Inactive '%s', Status=0x%08X",
                                            AppName, RegRecPtr->Name, (unsigned int)Status);
                 
                 if (Status > CFE_SUCCESS)
                 {
                     CFE_ES_WriteToSysLog("CFE_TBL:Validate-App(%lu) Validation func return code invalid (Stat=0x%08X) for '%s'\n",
-                            CFE_ES_ResourceID_ToInteger(CFE_TBL_TaskData.TableTaskAppId), (unsigned int)Status, RegRecPtr->Name);
+                            CFE_ES_ResourceID_ToInteger(CFE_TBL_Global.TableTaskAppId), (unsigned int)Status, RegRecPtr->Name);
                 }
             }
 
             /* Save the result of the Validation function for the Table Services Task */
-            CFE_TBL_TaskData.ValidationResults[RegRecPtr->ValidateInactiveIndex].Result = Status;
+            CFE_TBL_Global.ValidationResults[RegRecPtr->ValidateInactiveIndex].Result = Status;
 
             /* Once validation is complete, set flags to indicate response is ready */
-            CFE_TBL_TaskData.ValidationResults[RegRecPtr->ValidateInactiveIndex].State = CFE_TBL_VALIDATION_PERFORMED;
+            CFE_TBL_Global.ValidationResults[RegRecPtr->ValidateInactiveIndex].State = CFE_TBL_VALIDATION_PERFORMED;
             RegRecPtr->ValidateInactiveIndex = CFE_TBL_NO_VALIDATION_PENDING;
 
             /* Since the validation was successfully performed (although maybe not a successful result) */
@@ -1232,7 +1232,7 @@ int32 CFE_TBL_Validate( CFE_TBL_Handle_t TblHandle )
             {
                 CFE_EVS_SendEventWithAppID(CFE_TBL_VALIDATION_INF_EID,
                                            CFE_EVS_EventType_INFORMATION,
-                                           CFE_TBL_TaskData.TableTaskAppId,
+                                           CFE_TBL_Global.TableTaskAppId,
                                            "%s validation successful for Active '%s'",
                                            AppName, RegRecPtr->Name);
             }
@@ -1240,22 +1240,22 @@ int32 CFE_TBL_Validate( CFE_TBL_Handle_t TblHandle )
             {
                 CFE_EVS_SendEventWithAppID(CFE_TBL_VALIDATION_ERR_EID,
                                            CFE_EVS_EventType_ERROR,
-                                           CFE_TBL_TaskData.TableTaskAppId,
+                                           CFE_TBL_Global.TableTaskAppId,
                                            "%s validation failed for Active '%s', Status=0x%08X",
                                            AppName, RegRecPtr->Name, (unsigned int)Status);
                 
                 if (Status > CFE_SUCCESS)
                 {
                     CFE_ES_WriteToSysLog("CFE_TBL:Validate-App(%lu) Validation func return code invalid (Stat=0x%08X) for '%s'\n",
-                            CFE_ES_ResourceID_ToInteger(CFE_TBL_TaskData.TableTaskAppId), (unsigned int)Status, RegRecPtr->Name);
+                            CFE_ES_ResourceID_ToInteger(CFE_TBL_Global.TableTaskAppId), (unsigned int)Status, RegRecPtr->Name);
                 }
             }
 
             /* Save the result of the Validation function for the Table Services Task */
-            CFE_TBL_TaskData.ValidationResults[RegRecPtr->ValidateActiveIndex].Result = Status;
+            CFE_TBL_Global.ValidationResults[RegRecPtr->ValidateActiveIndex].Result = Status;
 
             /* Once validation is complete, reset the flags */
-            CFE_TBL_TaskData.ValidationResults[RegRecPtr->ValidateActiveIndex].State = CFE_TBL_VALIDATION_PERFORMED;
+            CFE_TBL_Global.ValidationResults[RegRecPtr->ValidateActiveIndex].State = CFE_TBL_VALIDATION_PERFORMED;
             RegRecPtr->ValidateActiveIndex = CFE_TBL_NO_VALIDATION_PENDING;
 
             /* Since the validation was successfully performed (although maybe not a successful result) */
@@ -1349,8 +1349,8 @@ int32 CFE_TBL_GetStatus( CFE_TBL_Handle_t TblHandle )
     if (Status == CFE_SUCCESS)
     {
         /* Get pointers to pertinent records in registry and handles */
-        AccessDescPtr = &CFE_TBL_TaskData.Handles[TblHandle];
-        RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+        AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle];
+        RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
 
         /* Perform validations prior to performing any updates */
         if (RegRecPtr->LoadPending)
@@ -1394,7 +1394,7 @@ int32 CFE_TBL_GetInfo( CFE_TBL_Info_t *TblInfoPtr, const char *TblName )
     if (RegIndx != CFE_TBL_NOT_FOUND)
     {
         /* Get pointer to Registry Record Entry to speed up processing */
-        RegRecPtr = &CFE_TBL_TaskData.Registry[RegIndx];
+        RegRecPtr = &CFE_TBL_Global.Registry[RegIndx];
 
         /* Return table characteristics */        
         TblInfoPtr->Size        = RegRecPtr->Size;
@@ -1417,7 +1417,7 @@ int32 CFE_TBL_GetInfo( CFE_TBL_Info_t *TblInfoPtr, const char *TblName )
         while (HandleIterator != CFE_TBL_END_OF_LIST)
         {
             NumAccessDescriptors++;
-            HandleIterator = CFE_TBL_TaskData.Handles[HandleIterator].NextLink;
+            HandleIterator = CFE_TBL_Global.Handles[HandleIterator].NextLink;
         }
 
         TblInfoPtr->NumUsers = NumAccessDescriptors;
@@ -1447,9 +1447,9 @@ int32 CFE_TBL_DumpToBuffer( CFE_TBL_Handle_t TblHandle )
     Status = CFE_TBL_GetStatus(TblHandle);
     if (Status == CFE_TBL_INFO_DUMP_PENDING)
     {
-        AccessDescPtr = &CFE_TBL_TaskData.Handles[TblHandle];
-        RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
-        DumpCtrlPtr = &CFE_TBL_TaskData.DumpControlBlocks[RegRecPtr->DumpControlIndex];
+        AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle];
+        RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
+        DumpCtrlPtr = &CFE_TBL_Global.DumpControlBlocks[RegRecPtr->DumpControlIndex];
         
         /* Copy the contents of the active buffer to the assigned dump buffer */
         memcpy(DumpCtrlPtr->DumpBufferPtr->BufferPtr, RegRecPtr->Buffers[0].BufferPtr, DumpCtrlPtr->Size);
@@ -1490,8 +1490,8 @@ int32 CFE_TBL_Modified( CFE_TBL_Handle_t TblHandle )
     if (Status == CFE_SUCCESS)
     {
         /* Get pointers to pertinent records in registry and handles */
-        AccessDescPtr = &CFE_TBL_TaskData.Handles[TblHandle];
-        RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+        AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle];
+        RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
         
         /* If the table is a critical table, update the appropriate CDS with the new data */
         if (RegRecPtr->CriticalTable == true)
@@ -1524,12 +1524,12 @@ int32 CFE_TBL_Modified( CFE_TBL_Handle_t TblHandle )
         while (AccessIterator != CFE_TBL_END_OF_LIST)
         {
             /* Only notify *OTHER* applications that the contents have changed */
-            if (!CFE_ES_ResourceID_Equal(CFE_TBL_TaskData.Handles[AccessIterator].AppId, ThisAppId))
+            if (!CFE_ES_ResourceID_Equal(CFE_TBL_Global.Handles[AccessIterator].AppId, ThisAppId))
             {
-                CFE_TBL_TaskData.Handles[AccessIterator].Updated = true;
+                CFE_TBL_Global.Handles[AccessIterator].Updated = true;
             }
 
-            AccessIterator = CFE_TBL_TaskData.Handles[AccessIterator].NextLink;
+            AccessIterator = CFE_TBL_Global.Handles[AccessIterator].NextLink;
         }
     }
     else
@@ -1559,8 +1559,8 @@ int32 CFE_TBL_NotifyByMessage(CFE_TBL_Handle_t TblHandle, CFE_SB_MsgId_t MsgId, 
     if (Status == CFE_SUCCESS)
     {
         /* Get pointers to pertinent records in registry and handles */
-        AccessDescPtr = &CFE_TBL_TaskData.Handles[TblHandle];
-        RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+        AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle];
+        RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
         
         /* Verify that the calling application is the table owner */
         if (CFE_ES_ResourceID_Equal(RegRecPtr->OwnerAppId, ThisAppId))

--- a/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_internal.c
@@ -70,57 +70,45 @@ int32 CFE_TBL_EarlyInit (void)
     uint32 j;
     int32 Status;
 
+    /* Clear task global */
+    memset(&CFE_TBL_Global, 0, sizeof(CFE_TBL_Global));
 
     /* Initialize the Table Registry */
     for(i=0; i < CFE_PLATFORM_TBL_MAX_NUM_TABLES; i++)
     {
-        CFE_TBL_InitRegistryRecord(&CFE_TBL_TaskData.Registry[i]);
+        CFE_TBL_InitRegistryRecord(&CFE_TBL_Global.Registry[i]);
     }
 
-    /* Initialize the Table Access Descriptors */
+    /* Initialize the Table Access Descriptors nonzero values */
     for (i=0; i<CFE_PLATFORM_TBL_MAX_NUM_HANDLES; i++)
     {
-        CFE_TBL_TaskData.Handles[i].AppId = CFE_TBL_NOT_OWNED;
-        CFE_TBL_TaskData.Handles[i].RegIndex = 0;
-        CFE_TBL_TaskData.Handles[i].PrevLink = CFE_TBL_END_OF_LIST;
-        CFE_TBL_TaskData.Handles[i].NextLink = CFE_TBL_END_OF_LIST;
-        CFE_TBL_TaskData.Handles[i].UsedFlag = false;
-        CFE_TBL_TaskData.Handles[i].LockFlag = false;
-        CFE_TBL_TaskData.Handles[i].Updated = false;
-        CFE_TBL_TaskData.Handles[i].BufferIndex = 0;
+        CFE_TBL_Global.Handles[i].AppId = CFE_TBL_NOT_OWNED;
+        CFE_TBL_Global.Handles[i].PrevLink = CFE_TBL_END_OF_LIST;
+        CFE_TBL_Global.Handles[i].NextLink = CFE_TBL_END_OF_LIST;
     }
 
-    /* Initialize the Table Validation Results Records */
+    /* Initialize the Table Validation Results Records nonzero values */
     for (i=0; i<CFE_PLATFORM_TBL_MAX_NUM_VALIDATIONS; i++)
     {
-        CFE_TBL_TaskData.ValidationResults[i].State = CFE_TBL_VALIDATION_FREE;
-        CFE_TBL_TaskData.ValidationResults[i].CrcOfTable = 0;
-        CFE_TBL_TaskData.ValidationResults[i].Result = 0;
-        CFE_TBL_TaskData.ValidationResults[i].ActiveBuffer = false;
-        CFE_TBL_TaskData.ValidationResults[i].TableName[0] = '\0';
+        CFE_TBL_Global.ValidationResults[i].State = CFE_TBL_VALIDATION_FREE;
     }
 
-    /* Initialize the Dump-Only Table Dump Control Blocks */
+    /* Initialize the Dump-Only Table Dump Control Blocks nonzero values */
     for (i=0; i<CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS; i++)
     {
-        CFE_TBL_TaskData.DumpControlBlocks[i].State = CFE_TBL_DUMP_FREE;
-        CFE_TBL_TaskData.DumpControlBlocks[i].DumpBufferPtr = NULL;
-        CFE_TBL_TaskData.DumpControlBlocks[i].Size = 0;
-        CFE_TBL_TaskData.DumpControlBlocks[i].TableName[0] = '\0';
+        CFE_TBL_Global.DumpControlBlocks[i].State = CFE_TBL_DUMP_FREE;
         
         /* Prevent Shared Buffers from being used until successfully allocated */
-        CFE_TBL_TaskData.LoadBuffs[i].Taken = true;
+        CFE_TBL_Global.LoadBuffs[i].Taken = true;
     }
 
-    CFE_TBL_TaskData.ValidationCounter = 0;
-
-    CFE_TBL_TaskData.HkTlmTblRegIndex = CFE_TBL_NOT_FOUND;
-    CFE_TBL_TaskData.LastTblUpdated = CFE_TBL_NOT_FOUND;
+    CFE_TBL_Global.HkTlmTblRegIndex = CFE_TBL_NOT_FOUND;
+    CFE_TBL_Global.LastTblUpdated = CFE_TBL_NOT_FOUND;
     
     /*
     ** Create table registry access mutex
     */
-    Status = OS_MutSemCreate(&CFE_TBL_TaskData.RegistryMutex,
+    Status = OS_MutSemCreate(&CFE_TBL_Global.RegistryMutex,
                               CFE_TBL_MUT_REG_NAME,
                               CFE_TBL_MUT_REG_VALUE);
     if(Status != OS_SUCCESS)
@@ -131,7 +119,7 @@ int32 CFE_TBL_EarlyInit (void)
     /*
     ** Create working buffer access mutex
     */
-    Status = OS_MutSemCreate(&CFE_TBL_TaskData.WorkBufMutex,
+    Status = OS_MutSemCreate(&CFE_TBL_Global.WorkBufMutex,
                               CFE_TBL_MUT_WORK_NAME,
                               CFE_TBL_MUT_WORK_VALUE);
     if(Status != OS_SUCCESS)
@@ -142,21 +130,21 @@ int32 CFE_TBL_EarlyInit (void)
     /*
     ** Initialize housekeeping packet (clear user data area)...
     */
-    CFE_MSG_Init(&CFE_TBL_TaskData.HkPacket.TlmHeader.Msg,
+    CFE_MSG_Init(&CFE_TBL_Global.HkPacket.TlmHeader.Msg,
                  CFE_SB_ValueToMsgId(CFE_TBL_HK_TLM_MID),
-                 sizeof(CFE_TBL_TaskData.HkPacket));
+                 sizeof(CFE_TBL_Global.HkPacket));
 
     /*
     ** Initialize table registry report packet (clear user data area)...
     */
-    CFE_MSG_Init(&CFE_TBL_TaskData.TblRegPacket.TlmHeader.Msg,
+    CFE_MSG_Init(&CFE_TBL_Global.TblRegPacket.TlmHeader.Msg,
                  CFE_SB_ValueToMsgId(CFE_TBL_REG_TLM_MID),
-                 sizeof(CFE_TBL_TaskData.TblRegPacket));
+                 sizeof(CFE_TBL_Global.TblRegPacket));
 
     /* Initialize memory partition and allocate shared table buffers. */
-    Status = CFE_ES_PoolCreate(&CFE_TBL_TaskData.Buf.PoolHdl,
-                                CFE_TBL_TaskData.Buf.Partition.Data,
-                                sizeof(CFE_TBL_TaskData.Buf.Partition));
+    Status = CFE_ES_PoolCreate(&CFE_TBL_Global.Buf.PoolHdl,
+                                CFE_TBL_Global.Buf.Partition.Data,
+                                sizeof(CFE_TBL_Global.Buf.Partition));
 
     if(Status < 0)
     {
@@ -169,8 +157,8 @@ int32 CFE_TBL_EarlyInit (void)
         do
         {
             /* Allocate memory for shared load buffers */
-            Status = CFE_ES_GetPoolBuf(&CFE_TBL_TaskData.LoadBuffs[j].BufferPtr,
-                                       CFE_TBL_TaskData.Buf.PoolHdl,
+            Status = CFE_ES_GetPoolBuf(&CFE_TBL_Global.LoadBuffs[j].BufferPtr,
+                                       CFE_TBL_Global.Buf.PoolHdl,
                                        CFE_PLATFORM_TBL_MAX_SNGL_TABLE_SIZE);
 
             if (Status < CFE_PLATFORM_TBL_MAX_SNGL_TABLE_SIZE)
@@ -180,11 +168,7 @@ int32 CFE_TBL_EarlyInit (void)
             else
             {
                 /* The buffer is successfully created, so allow it to be used */
-                CFE_TBL_TaskData.LoadBuffs[j].Taken = false;
-                
-                memset(CFE_TBL_TaskData.LoadBuffs[j].DataSource, 0, OS_MAX_PATH_LEN);
-                CFE_TBL_TaskData.LoadBuffs[j].FileCreateTimeSecs = 0;
-                CFE_TBL_TaskData.LoadBuffs[j].FileCreateTimeSubSecs = 0;
+                CFE_TBL_Global.LoadBuffs[j].Taken = false;
             }
 
             j++;
@@ -193,27 +177,20 @@ int32 CFE_TBL_EarlyInit (void)
     }
     
     /* Try to obtain a previous image of the Critical Table Registry from the Critical Data Store */
-    Status = CFE_ES_RegisterCDSEx(&CFE_TBL_TaskData.CritRegHandle, 
+    Status = CFE_ES_RegisterCDSEx(&CFE_TBL_Global.CritRegHandle,
                                   (sizeof(CFE_TBL_CritRegRec_t)*CFE_PLATFORM_TBL_MAX_CRITICAL_TABLES),
                                   "CFE_TBL.CritReg", true);
                                 
     /* Assume for the moment that nothing is already in the CDS and zero out the Critical Table Registry */
     for (i=0; i<CFE_PLATFORM_TBL_MAX_CRITICAL_TABLES; i++)
     {
-        CFE_TBL_TaskData.CritReg[i].CDSHandle = CFE_ES_CDS_BAD_HANDLE;
-        CFE_TBL_TaskData.CritReg[i].FileCreateTimeSecs = 0;
-        CFE_TBL_TaskData.CritReg[i].FileCreateTimeSubSecs = 0;
-        CFE_TBL_TaskData.CritReg[i].LastFileLoaded[0] = '\0';
-        CFE_TBL_TaskData.CritReg[i].TimeOfLastUpdate.Seconds = 0;
-        CFE_TBL_TaskData.CritReg[i].TimeOfLastUpdate.Subseconds = 0;
-        CFE_TBL_TaskData.CritReg[i].TableLoadedOnce = false;
-
+        CFE_TBL_Global.CritReg[i].CDSHandle = CFE_ES_CDS_BAD_HANDLE;
     }
     
     if (Status == CFE_ES_CDS_ALREADY_EXISTS)
     {
         /* Try to recover the Critical Table Registry from the CDS */
-        Status = CFE_ES_RestoreFromCDS(CFE_TBL_TaskData.CritReg, CFE_TBL_TaskData.CritRegHandle);
+        Status = CFE_ES_RestoreFromCDS(CFE_TBL_Global.CritReg, CFE_TBL_Global.CritRegHandle);
         
         if (Status != CFE_SUCCESS)
         {
@@ -236,7 +213,7 @@ int32 CFE_TBL_EarlyInit (void)
     else
     {
         /* Save the initial version of the Critical Table Registry in the CDS */
-        Status = CFE_ES_CopyToCDS(CFE_TBL_TaskData.CritRegHandle, CFE_TBL_TaskData.CritReg);
+        Status = CFE_ES_CopyToCDS(CFE_TBL_Global.CritRegHandle, CFE_TBL_Global.CritReg);
         
         if (Status != CFE_SUCCESS)
         {
@@ -260,46 +237,18 @@ int32 CFE_TBL_EarlyInit (void)
 **
 ** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
 ********************************************************************/
-
-
 void CFE_TBL_InitRegistryRecord (CFE_TBL_RegistryRec_t *RegRecPtr)
 {
+    memset(RegRecPtr, 0, sizeof(*RegRecPtr));
+
     RegRecPtr->OwnerAppId = CFE_TBL_NOT_OWNED;
-    RegRecPtr->Size = 0;
     RegRecPtr->NotificationMsgId = CFE_SB_INVALID_MSG_ID;
-    RegRecPtr->NotificationCC = 0;
-    RegRecPtr->NotificationParam = 0;
-    RegRecPtr->Buffers[0].BufferPtr = NULL;
-    RegRecPtr->Buffers[0].FileCreateTimeSecs = 0;
-    RegRecPtr->Buffers[0].FileCreateTimeSubSecs = 0;
-    RegRecPtr->Buffers[0].Crc = 0;
-    RegRecPtr->Buffers[0].Taken = false;
-    RegRecPtr->Buffers[0].DataSource[0] = '\0';
-    RegRecPtr->Buffers[1].BufferPtr = NULL;
-    RegRecPtr->Buffers[1].FileCreateTimeSecs = 0;
-    RegRecPtr->Buffers[1].FileCreateTimeSubSecs = 0;
-    RegRecPtr->Buffers[1].Crc = 0;
-    RegRecPtr->Buffers[1].Taken = false;
-    RegRecPtr->Buffers[1].DataSource[0] = '\0';
-    RegRecPtr->ValidationFuncPtr = NULL;
-    RegRecPtr->TimeOfLastUpdate.Seconds = 0;
-    RegRecPtr->TimeOfLastUpdate.Subseconds = 0;
     RegRecPtr->HeadOfAccessList = CFE_TBL_END_OF_LIST;
     RegRecPtr->LoadInProgress =  CFE_TBL_NO_LOAD_IN_PROGRESS;
     RegRecPtr->ValidateActiveIndex = CFE_TBL_NO_VALIDATION_PENDING;
     RegRecPtr->ValidateInactiveIndex = CFE_TBL_NO_VALIDATION_PENDING;
     RegRecPtr->CDSHandle = CFE_ES_CDS_BAD_HANDLE;
-    RegRecPtr->CriticalTable = false;
-    RegRecPtr->TableLoadedOnce = false;
-    RegRecPtr->LoadPending = false;
-    RegRecPtr->DumpOnly = false;
     RegRecPtr->DumpControlIndex = CFE_TBL_NO_DUMP_PENDING;
-    RegRecPtr->UserDefAddr = false;
-    RegRecPtr->DoubleBuffered = false;
-    RegRecPtr->NotifyByMsg = false;
-    RegRecPtr->ActiveBufferIndex = 0;
-    RegRecPtr->Name[0] = '\0';
-    RegRecPtr->LastFileLoaded[0] = '\0';
 } /* End CFE_TBL_InitRegistryRecord */
 
 
@@ -321,7 +270,7 @@ int32 CFE_TBL_ValidateHandle(CFE_TBL_Handle_t TblHandle)
     else
     {
         /* Check to see if the Handle is no longer valid for this Table */
-        if (CFE_TBL_TaskData.Handles[TblHandle].UsedFlag == false)
+        if (CFE_TBL_Global.Handles[TblHandle].UsedFlag == false)
         {
             return CFE_TBL_ERR_INVALID_HANDLE;
         }
@@ -373,11 +322,11 @@ int32 CFE_TBL_CheckAccessRights(CFE_TBL_Handle_t TblHandle, CFE_ES_ResourceID_t 
 {
     int32 Status = CFE_SUCCESS;
 
-    if (!CFE_ES_ResourceID_Equal(ThisAppId, CFE_TBL_TaskData.Handles[TblHandle].AppId))
+    if (!CFE_ES_ResourceID_Equal(ThisAppId, CFE_TBL_Global.Handles[TblHandle].AppId))
     {
         /* The Table Service Task always has access rights so that tables */
         /* can be manipulated via ground command                          */
-        if (!CFE_ES_ResourceID_Equal(ThisAppId, CFE_TBL_TaskData.TableTaskAppId))
+        if (!CFE_ES_ResourceID_Equal(ThisAppId, CFE_TBL_Global.TableTaskAppId))
         {
             Status = CFE_TBL_ERR_NO_ACCESS;
         }
@@ -396,8 +345,8 @@ int32 CFE_TBL_CheckAccessRights(CFE_TBL_Handle_t TblHandle, CFE_ES_ResourceID_t 
 int32 CFE_TBL_RemoveAccessLink(CFE_TBL_Handle_t TblHandle)
 {
     int32 Status = CFE_SUCCESS;
-    CFE_TBL_AccessDescriptor_t *AccessDescPtr = &CFE_TBL_TaskData.Handles[TblHandle];
-    CFE_TBL_RegistryRec_t      *RegRecPtr     = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+    CFE_TBL_AccessDescriptor_t *AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle];
+    CFE_TBL_RegistryRec_t      *RegRecPtr     = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
 
     /* Lock Access to the table while we modify the linked list */
     CFE_TBL_LockRegistry();
@@ -411,19 +360,19 @@ int32 CFE_TBL_RemoveAccessLink(CFE_TBL_Handle_t TblHandle)
         /* Update the next link, if there is one, to be the new head of the list */
         if (AccessDescPtr->NextLink != CFE_TBL_END_OF_LIST)
         {
-            CFE_TBL_TaskData.Handles[AccessDescPtr->NextLink].PrevLink = CFE_TBL_END_OF_LIST;
+            CFE_TBL_Global.Handles[AccessDescPtr->NextLink].PrevLink = CFE_TBL_END_OF_LIST;
         }
     }
     else /* Access Descriptor is not the head of the list */
     {
         /* Set the next link on the previous link to the next link of the link being removed */
-        CFE_TBL_TaskData.Handles[AccessDescPtr->PrevLink].NextLink = AccessDescPtr->NextLink;
+        CFE_TBL_Global.Handles[AccessDescPtr->PrevLink].NextLink = AccessDescPtr->NextLink;
 
         /* If this link is not the end of the list, then complete two way linkage */
         /* by setting the next link's previous link to the previous link of the link being removed */
         if (AccessDescPtr->NextLink != CFE_TBL_END_OF_LIST)
         {
-            CFE_TBL_TaskData.Handles[AccessDescPtr->NextLink].PrevLink = AccessDescPtr->PrevLink;
+            CFE_TBL_Global.Handles[AccessDescPtr->NextLink].PrevLink = AccessDescPtr->PrevLink;
         }
     }
 
@@ -437,25 +386,25 @@ int32 CFE_TBL_RemoveAccessLink(CFE_TBL_Handle_t TblHandle)
         if (RegRecPtr->UserDefAddr == false)
         {
             /* Free memory allocated to buffers */
-            Status = CFE_ES_PutPoolBuf(CFE_TBL_TaskData.Buf.PoolHdl, RegRecPtr->Buffers[0].BufferPtr);
+            Status = CFE_ES_PutPoolBuf(CFE_TBL_Global.Buf.PoolHdl, RegRecPtr->Buffers[0].BufferPtr);
             RegRecPtr->Buffers[0].BufferPtr = NULL;
 
             if (Status < 0)
             {
                 CFE_ES_WriteToSysLog("CFE_TBL:RemoveAccessLink-PutPoolBuf[0] Fail Stat=0x%08X, Hndl=0x%08lX, Buf=0x%08lX\n",
-                        (unsigned int)Status, CFE_ES_ResourceID_ToInteger(CFE_TBL_TaskData.Buf.PoolHdl), (unsigned long)RegRecPtr->Buffers[0].BufferPtr);
+                        (unsigned int)Status, CFE_ES_ResourceID_ToInteger(CFE_TBL_Global.Buf.PoolHdl), (unsigned long)RegRecPtr->Buffers[0].BufferPtr);
             }
 
             /* If a double buffered table, then free the second buffer as well */
             if (RegRecPtr->DoubleBuffered)
             {
-                Status = CFE_ES_PutPoolBuf(CFE_TBL_TaskData.Buf.PoolHdl, RegRecPtr->Buffers[1].BufferPtr);
+                Status = CFE_ES_PutPoolBuf(CFE_TBL_Global.Buf.PoolHdl, RegRecPtr->Buffers[1].BufferPtr);
                 RegRecPtr->Buffers[1].BufferPtr = NULL;
 
                 if (Status < 0)
                 {
                     CFE_ES_WriteToSysLog("CFE_TBL:RemoveAccessLink-PutPoolBuf[1] Fail Stat=0x%08X, Hndl=0x%08lX, Buf=0x%08lX\n",
-                            (unsigned int)Status, CFE_ES_ResourceID_ToInteger(CFE_TBL_TaskData.Buf.PoolHdl), (unsigned long)RegRecPtr->Buffers[1].BufferPtr);
+                            (unsigned int)Status, CFE_ES_ResourceID_ToInteger(CFE_TBL_Global.Buf.PoolHdl), (unsigned long)RegRecPtr->Buffers[1].BufferPtr);
                 }
             }
             else
@@ -464,7 +413,7 @@ int32 CFE_TBL_RemoveAccessLink(CFE_TBL_Handle_t TblHandle)
                 if (RegRecPtr->LoadInProgress != CFE_TBL_NO_LOAD_IN_PROGRESS)
                 {
                     /* Free the working buffer */
-                    CFE_TBL_TaskData.LoadBuffs[RegRecPtr->LoadInProgress].Taken = false;
+                    CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].Taken = false;
                     RegRecPtr->LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
                 }
             }
@@ -498,7 +447,7 @@ int32 CFE_TBL_GetAddressInternal(void **TblPtr, CFE_TBL_Handle_t TblHandle, CFE_
     if (Status == CFE_SUCCESS)
     {
         /* Get a pointer to the Access Descriptor */
-        AccessDescPtr = &CFE_TBL_TaskData.Handles[TblHandle];
+        AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle];
 
         /* Verify that we are allowed access to the table */
         Status = CFE_TBL_CheckAccessRights(TblHandle, ThisAppId);
@@ -506,7 +455,7 @@ int32 CFE_TBL_GetAddressInternal(void **TblPtr, CFE_TBL_Handle_t TblHandle, CFE_
         if (Status == CFE_SUCCESS)
         {
             /* Get a pointer to the Table Registry entry */
-            RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+            RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
 
             /* If table is unowned, then owner must have unregistered it when we weren't looking */
             if (CFE_ES_ResourceID_Equal(RegRecPtr->OwnerAppId, CFE_TBL_NOT_OWNED))
@@ -561,8 +510,8 @@ int32 CFE_TBL_GetAddressInternal(void **TblPtr, CFE_TBL_Handle_t TblHandle, CFE_
 int32 CFE_TBL_GetNextNotification(CFE_TBL_Handle_t TblHandle)
 {
     int32 Status = CFE_SUCCESS;
-    CFE_TBL_AccessDescriptor_t *AccessDescPtr = &CFE_TBL_TaskData.Handles[TblHandle];
-    CFE_TBL_RegistryRec_t *RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+    CFE_TBL_AccessDescriptor_t *AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle];
+    CFE_TBL_RegistryRec_t *RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
 
     if (!RegRecPtr->TableLoadedOnce)
     {
@@ -597,10 +546,10 @@ int16 CFE_TBL_FindTableInRegistry(const char *TblName)
         i++;
 
         /* Check to see if the record is currently being used */
-        if ( !CFE_ES_ResourceID_Equal(CFE_TBL_TaskData.Registry[i].OwnerAppId, CFE_TBL_NOT_OWNED) )
+        if ( !CFE_ES_ResourceID_Equal(CFE_TBL_Global.Registry[i].OwnerAppId, CFE_TBL_NOT_OWNED) )
         {
             /* Perform a case sensitive name comparison */
-            if (strcmp(TblName, CFE_TBL_TaskData.Registry[i].Name) == 0)
+            if (strcmp(TblName, CFE_TBL_Global.Registry[i].Name) == 0)
             {
                 /* If the names match, then return the index */
                 RegIndx = i;
@@ -628,8 +577,8 @@ int16 CFE_TBL_FindFreeRegistryEntry(void)
     {
         /* A Table Registry is only "Free" when there isn't an owner AND */
         /* all other applications are not sharing or locking the table   */
-        if (CFE_ES_ResourceID_Equal(CFE_TBL_TaskData.Registry[i].OwnerAppId, CFE_TBL_NOT_OWNED) &&
-            (CFE_TBL_TaskData.Registry[i].HeadOfAccessList == CFE_TBL_END_OF_LIST))
+        if (CFE_ES_ResourceID_Equal(CFE_TBL_Global.Registry[i].OwnerAppId, CFE_TBL_NOT_OWNED) &&
+            (CFE_TBL_Global.Registry[i].HeadOfAccessList == CFE_TBL_END_OF_LIST))
         {
             RegIndx = i;
         }
@@ -657,7 +606,7 @@ CFE_TBL_Handle_t CFE_TBL_FindFreeHandle(void)
 
     while ((HandleIndx == CFE_TBL_END_OF_LIST) && (i < CFE_PLATFORM_TBL_MAX_NUM_HANDLES))
     {
-        if (CFE_TBL_TaskData.Handles[i].UsedFlag == false)
+        if (CFE_TBL_Global.Handles[i].UsedFlag == false)
         {
             HandleIndx = i;
         }
@@ -705,7 +654,7 @@ int32 CFE_TBL_LockRegistry(void)
 {
     int32   Status;
 
-    Status = OS_MutSemTake(CFE_TBL_TaskData.RegistryMutex);
+    Status = OS_MutSemTake(CFE_TBL_Global.RegistryMutex);
 
     if (Status == OS_SUCCESS)
     {
@@ -729,7 +678,7 @@ int32 CFE_TBL_UnlockRegistry(void)
 {
     int32   Status;
 
-    Status = OS_MutSemGive(CFE_TBL_TaskData.RegistryMutex);
+    Status = OS_MutSemGive(CFE_TBL_Global.RegistryMutex);
 
     if (Status == OS_SUCCESS)
     {
@@ -770,7 +719,7 @@ int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr,
         }
         else
         {
-            *WorkingBufferPtr = &CFE_TBL_TaskData.LoadBuffs[RegRecPtr->LoadInProgress];
+            *WorkingBufferPtr = &CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress];
         }
     }
     else
@@ -803,17 +752,17 @@ int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr,
                 AccessIterator = RegRecPtr->HeadOfAccessList;
                 while ((AccessIterator != CFE_TBL_END_OF_LIST) && (Status == CFE_SUCCESS))
                 {
-                    if ((CFE_TBL_TaskData.Handles[AccessIterator].BufferIndex == InactiveBufferIndex) &&
-		                (CFE_TBL_TaskData.Handles[AccessIterator].LockFlag))
+                    if ((CFE_TBL_Global.Handles[AccessIterator].BufferIndex == InactiveBufferIndex) &&
+		                (CFE_TBL_Global.Handles[AccessIterator].LockFlag))
                     {
                         Status = CFE_TBL_ERR_NO_BUFFER_AVAIL;
 
                         CFE_ES_WriteToSysLog("CFE_TBL:GetWorkingBuffer-Inactive Dbl Buff Locked for '%s' by AppId=%lu\n",
-                                             RegRecPtr->Name, CFE_ES_ResourceID_ToInteger(CFE_TBL_TaskData.Handles[AccessIterator].AppId));
+                                             RegRecPtr->Name, CFE_ES_ResourceID_ToInteger(CFE_TBL_Global.Handles[AccessIterator].AppId));
                     }
 
                     /* Move to next access descriptor in linked list */
-                    AccessIterator = CFE_TBL_TaskData.Handles[AccessIterator].NextLink;
+                    AccessIterator = CFE_TBL_Global.Handles[AccessIterator].NextLink;
                 }
 
                 /* If buffer is free, then return the pointer to it */
@@ -827,7 +776,7 @@ int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr,
             {
                 /* Take Mutex to make sure we are not trying to grab a working buffer that some */
                 /* other application is also trying to grab. */
-                Status = OS_MutSemTake(CFE_TBL_TaskData.WorkBufMutex);
+                Status = OS_MutSemTake(CFE_TBL_Global.WorkBufMutex);
 
                 /* Make note of any errors but continue and hope for the best */
                 if (Status != OS_SUCCESS)
@@ -838,7 +787,7 @@ int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr,
 
                 /* Determine if there are any common buffers available */
                 i = 0;
-                while ((i < CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS) && (CFE_TBL_TaskData.LoadBuffs[i].Taken == true))
+                while ((i < CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS) && (CFE_TBL_Global.LoadBuffs[i].Taken == true))
                 {
                     i++;
                 }
@@ -846,8 +795,8 @@ int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr,
                 /* If a free buffer was found, then return the address to the associated shared buffer */
                 if (i < CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS)
                 {
-                    CFE_TBL_TaskData.LoadBuffs[i].Taken = true;
-                    *WorkingBufferPtr = &CFE_TBL_TaskData.LoadBuffs[i];
+                    CFE_TBL_Global.LoadBuffs[i].Taken = true;
+                    *WorkingBufferPtr = &CFE_TBL_Global.LoadBuffs[i];
                     RegRecPtr->LoadInProgress = i;
 
                     /* Translate OS_SUCCESS into CFE_SUCCESS */
@@ -861,7 +810,7 @@ int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr,
                 }
 
                 /* Allow others to obtain a shared working buffer */
-                OS_MutSemGive(CFE_TBL_TaskData.WorkBufMutex);
+                OS_MutSemGive(CFE_TBL_Global.WorkBufMutex);
             }
 
             if ((*WorkingBufferPtr) != NULL &&
@@ -903,7 +852,7 @@ int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBuffe
     if (FilenameLen > (OS_MAX_PATH_LEN-1))
     {
         CFE_EVS_SendEventWithAppID(CFE_TBL_LOAD_FILENAME_LONG_ERR_EID,
-            CFE_EVS_EventType_ERROR, CFE_TBL_TaskData.TableTaskAppId,
+            CFE_EVS_EventType_ERROR, CFE_TBL_Global.TableTaskAppId,
             "%s: Filename is too long ('%s' (%lu) > %lu)",
             AppName, Filename, (long unsigned int)FilenameLen,
             (long unsigned int)OS_MAX_PATH_LEN-1);
@@ -917,7 +866,7 @@ int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBuffe
     if (Status < 0)
     {
         CFE_EVS_SendEventWithAppID(CFE_TBL_FILE_ACCESS_ERR_EID,
-            CFE_EVS_EventType_ERROR, CFE_TBL_TaskData.TableTaskAppId,
+            CFE_EVS_EventType_ERROR, CFE_TBL_Global.TableTaskAppId,
             "%s: Unable to open file (FileDescriptor=%d)",
             AppName, (int)Status);
 
@@ -938,7 +887,7 @@ int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBuffe
     if (strcmp(RegRecPtr->Name, TblFileHeader.TableName) != 0)
     {
         CFE_EVS_SendEventWithAppID(CFE_TBL_LOAD_TBLNAME_MISMATCH_ERR_EID,
-            CFE_EVS_EventType_ERROR, CFE_TBL_TaskData.TableTaskAppId,
+            CFE_EVS_EventType_ERROR, CFE_TBL_Global.TableTaskAppId,
             "%s: Table name mismatch (exp=%s, tblfilhdr=%s)",
             AppName, RegRecPtr->Name, TblFileHeader.TableName);
 
@@ -949,7 +898,7 @@ int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBuffe
     if ((TblFileHeader.Offset + TblFileHeader.NumBytes) > RegRecPtr->Size)
     {
         CFE_EVS_SendEventWithAppID(CFE_TBL_LOAD_EXCEEDS_SIZE_ERR_EID,
-            CFE_EVS_EventType_ERROR, CFE_TBL_TaskData.TableTaskAppId,
+            CFE_EVS_EventType_ERROR, CFE_TBL_Global.TableTaskAppId,
             "%s: File reports size larger than expected (file=%lu, exp=%lu)",
             AppName,
             (long unsigned int)(TblFileHeader.Offset + TblFileHeader.NumBytes),
@@ -978,7 +927,7 @@ int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBuffe
     if (NumBytes != TblFileHeader.NumBytes)
     {
        CFE_EVS_SendEventWithAppID(CFE_TBL_FILE_INCOMPLETE_ERR_EID, CFE_EVS_EventType_ERROR,
-            CFE_TBL_TaskData.TableTaskAppId,
+            CFE_TBL_Global.TableTaskAppId,
             "%s: File load incomplete (exp=%lu, read=%lu)",
             AppName, (long unsigned int)TblFileHeader.NumBytes,
             (long unsigned int)NumBytes);
@@ -994,7 +943,7 @@ int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBuffe
     if (NumBytes == 1)
     {
         CFE_EVS_SendEventWithAppID(CFE_TBL_FILE_TOO_BIG_ERR_EID, CFE_EVS_EventType_ERROR,
-            CFE_TBL_TaskData.TableTaskAppId,
+            CFE_TBL_Global.TableTaskAppId,
             "%s: File load too long (file length > %lu)",
             AppName, (long unsigned int)TblFileHeader.NumBytes);
 
@@ -1071,9 +1020,9 @@ int32 CFE_TBL_UpdateInternal( CFE_TBL_Handle_t TblHandle,
             AccessIterator = RegRecPtr->HeadOfAccessList;
             while (AccessIterator != CFE_TBL_END_OF_LIST)
             {
-                LockStatus = (LockStatus || CFE_TBL_TaskData.Handles[AccessIterator].LockFlag);
+                LockStatus = (LockStatus || CFE_TBL_Global.Handles[AccessIterator].LockFlag);
 
-                AccessIterator = CFE_TBL_TaskData.Handles[AccessIterator].NextLink;
+                AccessIterator = CFE_TBL_Global.Handles[AccessIterator].NextLink;
             }
 
             if (LockStatus)
@@ -1086,34 +1035,34 @@ int32 CFE_TBL_UpdateInternal( CFE_TBL_Handle_t TblHandle,
             {
                 /* To update a single buffered table requires a memcpy from working buffer */
                 if (RegRecPtr->Buffers[0].BufferPtr !=
-                        CFE_TBL_TaskData.LoadBuffs[RegRecPtr->LoadInProgress].BufferPtr)
+                        CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].BufferPtr)
                 {
                     memcpy(RegRecPtr->Buffers[0].BufferPtr,
-                              CFE_TBL_TaskData.LoadBuffs[RegRecPtr->LoadInProgress].BufferPtr,
+                              CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].BufferPtr,
                               RegRecPtr->Size);
                 }
 
                 /* Save source description with active buffer */
                 strncpy(RegRecPtr->Buffers[0].DataSource,
-                        CFE_TBL_TaskData.LoadBuffs[RegRecPtr->LoadInProgress].DataSource,
+                        CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].DataSource,
                         sizeof(RegRecPtr->Buffers[0].DataSource)-1);
                 RegRecPtr->Buffers[0].DataSource[sizeof(RegRecPtr->Buffers[0].DataSource)-1] = 0;
                 strncpy(RegRecPtr->LastFileLoaded,
-                        CFE_TBL_TaskData.LoadBuffs[RegRecPtr->LoadInProgress].DataSource,
+                        CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].DataSource,
                         sizeof(RegRecPtr->LastFileLoaded)-1);
                 RegRecPtr->LastFileLoaded[sizeof(RegRecPtr->LastFileLoaded)-1] = 0;
                 
                 /* Save the file creation time from the loaded file into the Table Registry */
                 RegRecPtr->Buffers[0].FileCreateTimeSecs = 
-                    CFE_TBL_TaskData.LoadBuffs[RegRecPtr->LoadInProgress].FileCreateTimeSecs;
+                    CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].FileCreateTimeSecs;
                 RegRecPtr->Buffers[0].FileCreateTimeSubSecs = 
-                    CFE_TBL_TaskData.LoadBuffs[RegRecPtr->LoadInProgress].FileCreateTimeSubSecs;
+                    CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].FileCreateTimeSubSecs;
                 
                 /* Save the previously computed CRC into the new buffer */
-                RegRecPtr->Buffers[0].Crc = CFE_TBL_TaskData.LoadBuffs[RegRecPtr->LoadInProgress].Crc;
+                RegRecPtr->Buffers[0].Crc = CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].Crc;
 
                 /* Free the working buffer */
-                CFE_TBL_TaskData.LoadBuffs[RegRecPtr->LoadInProgress].Taken = false;
+                CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].Taken = false;
 
                 CFE_TBL_NotifyTblUsersOfUpdate(RegRecPtr);
             
@@ -1151,9 +1100,9 @@ void CFE_TBL_NotifyTblUsersOfUpdate(CFE_TBL_RegistryRec_t *RegRecPtr)
     AccessIterator = RegRecPtr->HeadOfAccessList;
     while (AccessIterator != CFE_TBL_END_OF_LIST)
     {
-        CFE_TBL_TaskData.Handles[AccessIterator].Updated = true;
+        CFE_TBL_Global.Handles[AccessIterator].Updated = true;
 
-        AccessIterator = CFE_TBL_TaskData.Handles[AccessIterator].NextLink;
+        AccessIterator = CFE_TBL_Global.Handles[AccessIterator].NextLink;
     }
 } /* End of CFE_TBL_NotifyTblUsersOfUpdate() */
 
@@ -1191,7 +1140,7 @@ int32 CFE_TBL_ReadHeaders( osal_id_t FileDescriptor,
     {
         CFE_EVS_SendEventWithAppID(CFE_TBL_FILE_STD_HDR_ERR_EID,
                                    CFE_EVS_EventType_ERROR,
-                                   CFE_TBL_TaskData.TableTaskAppId,
+                                   CFE_TBL_Global.TableTaskAppId,
                                    "Unable to read std header for '%s', Status = 0x%08X",
                                    LoadFilename, (unsigned int)Status);
 
@@ -1204,7 +1153,7 @@ int32 CFE_TBL_ReadHeaders( osal_id_t FileDescriptor,
         {
             CFE_EVS_SendEventWithAppID(CFE_TBL_FILE_TYPE_ERR_EID,
                                        CFE_EVS_EventType_ERROR,
-                                       CFE_TBL_TaskData.TableTaskAppId,
+                                       CFE_TBL_Global.TableTaskAppId,
                                        "File '%s' is not a cFE file type, ContentType = 0x%08X",
                                        LoadFilename, (unsigned int)StdFileHeaderPtr->ContentType);
 
@@ -1217,7 +1166,7 @@ int32 CFE_TBL_ReadHeaders( osal_id_t FileDescriptor,
             {
                 CFE_EVS_SendEventWithAppID(CFE_TBL_FILE_SUBTYPE_ERR_EID,
                                            CFE_EVS_EventType_ERROR,
-                                           CFE_TBL_TaskData.TableTaskAppId,
+                                           CFE_TBL_Global.TableTaskAppId,
                                            "File subtype for '%s' is wrong. Subtype = 0x%08X",
                                            LoadFilename, (unsigned int)StdFileHeaderPtr->SubType);
 
@@ -1232,7 +1181,7 @@ int32 CFE_TBL_ReadHeaders( osal_id_t FileDescriptor,
                 {
                     CFE_EVS_SendEventWithAppID(CFE_TBL_FILE_TBL_HDR_ERR_EID,
                                                CFE_EVS_EventType_ERROR,
-                                               CFE_TBL_TaskData.TableTaskAppId,
+                                               CFE_TBL_Global.TableTaskAppId,
                                                "Unable to read tbl header for '%s', Status = 0x%08X",
                                                LoadFilename, (unsigned int)Status);
 
@@ -1276,7 +1225,7 @@ int32 CFE_TBL_ReadHeaders( osal_id_t FileDescriptor,
                         {
                             CFE_EVS_SendEventWithAppID(CFE_TBL_SPACECRAFT_ID_ERR_EID,
                                                        CFE_EVS_EventType_ERROR,
-                                                       CFE_TBL_TaskData.TableTaskAppId,
+                                                       CFE_TBL_Global.TableTaskAppId,
                                                        "Unable to verify Spacecraft ID for '%s', ID = 0x%08X",
                                                        LoadFilename, (unsigned int)StdFileHeaderPtr->SpacecraftID);
                         }
@@ -1300,7 +1249,7 @@ int32 CFE_TBL_ReadHeaders( osal_id_t FileDescriptor,
                         {
                             CFE_EVS_SendEventWithAppID(CFE_TBL_PROCESSOR_ID_ERR_EID,
                                                        CFE_EVS_EventType_ERROR,
-                                                       CFE_TBL_TaskData.TableTaskAppId,
+                                                       CFE_TBL_Global.TableTaskAppId,
                                                        "Unable to verify Processor ID for '%s', ID = 0x%08X",
                                                        LoadFilename, (unsigned int)StdFileHeaderPtr->ProcessorID);
                         }
@@ -1367,11 +1316,11 @@ int32 CFE_TBL_CleanUpApp(CFE_ES_ResourceID_t AppId)
     for (i=0; i<CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS; i++)
     {
         /* Check to see if the table to be dumped is owned by the App to be deleted */
-        if ((CFE_TBL_TaskData.DumpControlBlocks[i].State != CFE_TBL_DUMP_FREE) && 
-                CFE_ES_ResourceID_Equal(CFE_TBL_TaskData.DumpControlBlocks[i].RegRecPtr->OwnerAppId, AppId))
+        if ((CFE_TBL_Global.DumpControlBlocks[i].State != CFE_TBL_DUMP_FREE) &&
+                CFE_ES_ResourceID_Equal(CFE_TBL_Global.DumpControlBlocks[i].RegRecPtr->OwnerAppId, AppId))
         {
             /* If so, then remove the dump request */
-            CFE_TBL_TaskData.DumpControlBlocks[i].State = CFE_TBL_DUMP_FREE;
+            CFE_TBL_Global.DumpControlBlocks[i].State = CFE_TBL_DUMP_FREE;
         }
     }
     
@@ -1379,15 +1328,15 @@ int32 CFE_TBL_CleanUpApp(CFE_ES_ResourceID_t AppId)
     for (i=0; i<CFE_PLATFORM_TBL_MAX_NUM_HANDLES; i++)
     {
         /* Check to see if the Handle belongs to the Application being deleted */
-        if (CFE_ES_ResourceID_Equal(CFE_TBL_TaskData.Handles[i].AppId, AppId) &&
-                CFE_TBL_TaskData.Handles[i].UsedFlag == true)
+        if (CFE_ES_ResourceID_Equal(CFE_TBL_Global.Handles[i].AppId, AppId) &&
+                CFE_TBL_Global.Handles[i].UsedFlag == true)
         {
             /* Delete the handle (and the table, if the App owned it) */
             /* Get a pointer to the relevant Access Descriptor */
-            AccessDescPtr = &CFE_TBL_TaskData.Handles[i];
+            AccessDescPtr = &CFE_TBL_Global.Handles[i];
 
             /* Get a pointer to the relevant entry in the registry */
-            RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+            RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
 
             /* Determine if the Application owned this particular table */
             if (CFE_ES_ResourceID_Equal(RegRecPtr->OwnerAppId, AppId))
@@ -1408,7 +1357,7 @@ int32 CFE_TBL_CleanUpApp(CFE_ES_ResourceID_t AppId)
             /*       memory buffers are set free as well.         */
             CFE_TBL_RemoveAccessLink(i);
 	    
-            CFE_TBL_TaskData.Handles[i].AppId = CFE_TBL_NOT_OWNED;
+            CFE_TBL_Global.Handles[i].AppId = CFE_TBL_NOT_OWNED;
 
         }
     }
@@ -1432,9 +1381,9 @@ void CFE_TBL_FindCriticalTblInfo(CFE_TBL_CritRegRec_t **CritRegRecPtr, CFE_ES_CD
     
     for (i=0; i<CFE_PLATFORM_TBL_MAX_CRITICAL_TABLES; i++)
     {
-        if ( CFE_ES_ResourceID_Equal(CFE_TBL_TaskData.CritReg[i].CDSHandle, CDSHandleToFind) )
+        if ( CFE_ES_ResourceID_Equal(CFE_TBL_Global.CritReg[i].CDSHandle, CDSHandleToFind) )
         {
-            *CritRegRecPtr = &CFE_TBL_TaskData.CritReg[i];
+            *CritRegRecPtr = &CFE_TBL_Global.CritReg[i];
             break;
         }
     }
@@ -1477,7 +1426,7 @@ void CFE_TBL_UpdateCriticalTblCDS(CFE_TBL_RegistryRec_t *RegRecPtr)
             CritRegRecPtr->TableLoadedOnce = RegRecPtr->TableLoadedOnce;
             
             /* Update copy of Critical Table Registry in the CDS */
-            Status = CFE_ES_CopyToCDS(CFE_TBL_TaskData.CritRegHandle, CFE_TBL_TaskData.CritReg);
+            Status = CFE_ES_CopyToCDS(CFE_TBL_Global.CritRegHandle, CFE_TBL_Global.CritReg);
             
             if (Status != CFE_SUCCESS)
             {
@@ -1513,18 +1462,18 @@ int32 CFE_TBL_SendNotificationMsg(CFE_TBL_RegistryRec_t *RegRecPtr)
         /*
         ** Initialize notification message packet (clear user data area)...
         */
-        CFE_MSG_Init(&CFE_TBL_TaskData.NotifyMsg.CmdHeader.Msg,
+        CFE_MSG_Init(&CFE_TBL_Global.NotifyMsg.CmdHeader.Msg,
                      RegRecPtr->NotificationMsgId,
-                     sizeof(CFE_TBL_TaskData.NotifyMsg));
+                     sizeof(CFE_TBL_Global.NotifyMsg));
         
         /* Set the command code */
-        CFE_MSG_SetFcnCode(&CFE_TBL_TaskData.NotifyMsg.CmdHeader.Msg, RegRecPtr->NotificationCC);
+        CFE_MSG_SetFcnCode(&CFE_TBL_Global.NotifyMsg.CmdHeader.Msg, RegRecPtr->NotificationCC);
         
         /* Set the command parameter */
-        CFE_TBL_TaskData.NotifyMsg.Payload.Parameter = RegRecPtr->NotificationParam;
+        CFE_TBL_Global.NotifyMsg.Payload.Parameter = RegRecPtr->NotificationParam;
     
-        CFE_SB_TimeStampMsg(&CFE_TBL_TaskData.NotifyMsg.CmdHeader.Msg);
-        Status = CFE_SB_TransmitMsg(&CFE_TBL_TaskData.NotifyMsg.CmdHeader.Msg, false);
+        CFE_SB_TimeStampMsg(&CFE_TBL_Global.NotifyMsg.CmdHeader.Msg);
+        Status = CFE_SB_TransmitMsg(&CFE_TBL_Global.NotifyMsg.CmdHeader.Msg, false);
     
         if (Status != CFE_SUCCESS)
         {

--- a/fsw/cfe-core/src/tbl/cfe_tbl_internal.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_internal.h
@@ -582,7 +582,7 @@ extern void CFE_TBL_ByteSwapUint32(uint32 *Uint32ToSwapPtr);
 /*
 ** Globals specific to the TBL module
 */
-extern CFE_TBL_TaskData_t CFE_TBL_TaskData;
+extern CFE_TBL_Global_t CFE_TBL_Global;
 
 
 

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task.c
@@ -47,7 +47,7 @@
 /*
 ** Table task global data
 */
-CFE_TBL_TaskData_t    CFE_TBL_TaskData;
+CFE_TBL_Global_t    CFE_TBL_Global;
 
 /*
  * Macros to assist in building the CFE_TBL_CmdHandlerTbl -
@@ -124,7 +124,7 @@ void CFE_TBL_TaskMain(void)
 
         /* Pend on receipt of packet */
         Status = CFE_SB_ReceiveBuffer( &SBBufPtr,
-                                CFE_TBL_TaskData.CmdPipe,
+                                CFE_TBL_Global.CmdPipe,
                                 CFE_SB_PEND_FOREVER);
 
         CFE_ES_PerfLogEntry(CFE_MISSION_TBL_MAIN_PERF_ID);
@@ -181,7 +181,7 @@ int32 CFE_TBL_TaskInit(void)
     /*
     ** Create Software Bus message pipe
     */
-    Status = CFE_SB_CreatePipe(&CFE_TBL_TaskData.CmdPipe, CFE_TBL_TASK_PIPE_DEPTH, CFE_TBL_TASK_PIPE_NAME);
+    Status = CFE_SB_CreatePipe(&CFE_TBL_Global.CmdPipe, CFE_TBL_TASK_PIPE_DEPTH, CFE_TBL_TASK_PIPE_NAME);
     if(Status != CFE_SUCCESS)
     {
       CFE_ES_WriteToSysLog("TBL:Error creating cmd pipe:RC=0x%08X\n",(unsigned int)Status);
@@ -191,7 +191,7 @@ int32 CFE_TBL_TaskInit(void)
     /*
     ** Subscribe to Housekeeping request commands
     */
-    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TBL_SEND_HK_MID), CFE_TBL_TaskData.CmdPipe);
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TBL_SEND_HK_MID), CFE_TBL_Global.CmdPipe);
 
     if(Status != CFE_SUCCESS)
     {
@@ -202,7 +202,7 @@ int32 CFE_TBL_TaskInit(void)
     /*
     ** Subscribe to Table task ground command packets
     */
-    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TBL_CMD_MID), CFE_TBL_TaskData.CmdPipe);
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TBL_CMD_MID), CFE_TBL_Global.CmdPipe);
 
     if(Status != CFE_SUCCESS)
     {
@@ -230,23 +230,18 @@ int32 CFE_TBL_TaskInit(void)
 
 void CFE_TBL_InitData(void)
 {
-    /* Initialize Counters */
-    CFE_TBL_TaskData.CommandCounter = 0;
-    CFE_TBL_TaskData.CommandErrorCounter = 0;
-    CFE_TBL_TaskData.SuccessValCounter = 0;
-    CFE_TBL_TaskData.FailedValCounter = 0;
 
     /* Get the assigned Application ID for the Table Services Task */
-    CFE_ES_GetAppID(&CFE_TBL_TaskData.TableTaskAppId);
+    CFE_ES_GetAppID(&CFE_TBL_Global.TableTaskAppId);
 
     /* Initialize Packet Headers */
-    CFE_MSG_Init(&CFE_TBL_TaskData.HkPacket.TlmHeader.Msg,
+    CFE_MSG_Init(&CFE_TBL_Global.HkPacket.TlmHeader.Msg,
                  CFE_SB_ValueToMsgId(CFE_TBL_HK_TLM_MID),
-                 sizeof(CFE_TBL_TaskData.HkPacket));
+                 sizeof(CFE_TBL_Global.HkPacket));
 
-    CFE_MSG_Init(&CFE_TBL_TaskData.TblRegPacket.TlmHeader.Msg,
+    CFE_MSG_Init(&CFE_TBL_Global.TblRegPacket.TlmHeader.Msg,
                  CFE_SB_ValueToMsgId(CFE_TBL_REG_TLM_MID),
-                 sizeof(CFE_TBL_TaskData.TblRegPacket));
+                 sizeof(CFE_TBL_Global.TblRegPacket));
 
 } /* End of CFE_TBL_InitData() */
 
@@ -291,11 +286,11 @@ void CFE_TBL_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
         {
             if (CmdStatus == CFE_TBL_INC_CMD_CTR)
             {
-                CFE_TBL_TaskData.CommandCounter++;
+                CFE_TBL_Global.CommandCounter++;
             }
             else if (CmdStatus == CFE_TBL_INC_ERR_CTR)
             {
-                CFE_TBL_TaskData.CommandErrorCounter++;
+                CFE_TBL_Global.CommandErrorCounter++;
             }
         }
     }
@@ -311,7 +306,7 @@ void CFE_TBL_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
                               (unsigned int)CommandCode);
 
             /* Update the command error counter */
-            CFE_TBL_TaskData.CommandErrorCounter++;
+            CFE_TBL_Global.CommandErrorCounter++;
         }
         else  /* CmdIndx == CFE_TBL_BAD_MSG_ID */
         {

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task.h
@@ -336,7 +336,7 @@ typedef struct
   CFE_TBL_ValidationResult_t  ValidationResults[CFE_PLATFORM_TBL_MAX_NUM_VALIDATIONS]; /**< \brief Array of Table Validation Requests */
   CFE_TBL_DumpControl_t       DumpControlBlocks[CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS]; /**< \brief Array of Dump-Only Dump Control Blocks */
 
-} CFE_TBL_TaskData_t;
+} CFE_TBL_Global_t;
 
 
 /*************************************************************************/

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task_cmds.h
@@ -101,11 +101,11 @@ extern  void CFE_TBL_GetHkData(void);
 **
 ** \par Description
 **        Extracts the Table Registry information for the table specified by the
-**        #CFE_TBL_TaskData_t::HkTlmTblRegIndex variable.  It then formats the
+**        #CFE_TBL_Global_t::HkTlmTblRegIndex variable.  It then formats the
 **        Registry contents into a format appropriate for downlink.
 **
 ** \par Assumptions, External Events, and Notes:
-**        #CFE_TBL_TaskData_t::HkTlmTblRegIndex is assumed to be a valid index into
+**        #CFE_TBL_Global_t::HkTlmTblRegIndex is assumed to be a valid index into
 **           the Table Registry.
 **
 ** 

--- a/fsw/cfe-core/src/time/cfe_time_api.c
+++ b/fsw/cfe-core/src/time/cfe_time_api.c
@@ -200,42 +200,42 @@ uint16 CFE_TIME_GetClockInfo(void)
     /*
     ** Clock source set to "internal"...
     */
-    if (CFE_TIME_TaskData.ClockSource == CFE_TIME_SourceSelect_INTERNAL)
+    if (CFE_TIME_Global.ClockSource == CFE_TIME_SourceSelect_INTERNAL)
     {
         StateFlags |= CFE_TIME_FLAG_SRCINT;
     }
     /*
     ** Clock signal set to "primary"...
     */
-    if (CFE_TIME_TaskData.ClockSignal == CFE_TIME_ToneSignalSelect_PRIMARY)
+    if (CFE_TIME_Global.ClockSignal == CFE_TIME_ToneSignalSelect_PRIMARY)
     {
         StateFlags |= CFE_TIME_FLAG_SIGPRI;
     }
     /*
     ** Time Server is in FLYWHEEL mode...
     */
-    if (CFE_TIME_TaskData.ServerFlyState == CFE_TIME_FlywheelState_IS_FLY)
+    if (CFE_TIME_Global.ServerFlyState == CFE_TIME_FlywheelState_IS_FLY)
     {
         StateFlags |= CFE_TIME_FLAG_SRVFLY;
     }
     /*
     ** This instance of Time Services commanded into FLYWHEEL...
     */
-    if (CFE_TIME_TaskData.Forced2Fly)
+    if (CFE_TIME_Global.Forced2Fly)
     {
         StateFlags |= CFE_TIME_FLAG_CMDFLY;
     }
     /*
     ** One time STCF adjustment direction...
     */
-    if (CFE_TIME_TaskData.OneTimeDirection == CFE_TIME_AdjustDirection_ADD)
+    if (CFE_TIME_Global.OneTimeDirection == CFE_TIME_AdjustDirection_ADD)
     {
         StateFlags |= CFE_TIME_FLAG_ADDADJ;
     }
     /*
     ** 1 Hz STCF adjustment direction...
     */
-    if (CFE_TIME_TaskData.OneHzDirection == CFE_TIME_AdjustDirection_ADD)
+    if (CFE_TIME_Global.OneHzDirection == CFE_TIME_AdjustDirection_ADD)
     {
         StateFlags |= CFE_TIME_FLAG_ADD1HZ;
     }
@@ -256,7 +256,7 @@ uint16 CFE_TIME_GetClockInfo(void)
     /* 
     ** The tone is good 
     */
-    if (CFE_TIME_TaskData.IsToneGood == true)
+    if (CFE_TIME_Global.IsToneGood == true)
     {
         StateFlags |= CFE_TIME_FLAG_GDTONE;
     }   
@@ -701,14 +701,14 @@ int32  CFE_TIME_RegisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPt
         if (Status == CFE_SUCCESS)
         {
 
-            if (AppIndex >= (sizeof(CFE_TIME_TaskData.SynchCallback) / sizeof(CFE_TIME_TaskData.SynchCallback[0])) ||
-                CFE_TIME_TaskData.SynchCallback[AppIndex].Ptr != NULL)
+            if (AppIndex >= (sizeof(CFE_TIME_Global.SynchCallback) / sizeof(CFE_TIME_Global.SynchCallback[0])) ||
+                CFE_TIME_Global.SynchCallback[AppIndex].Ptr != NULL)
             {
                 Status = CFE_TIME_TOO_MANY_SYNCH_CALLBACKS;
             }
             else
             {
-                CFE_TIME_TaskData.SynchCallback[AppIndex].Ptr = CallbackFuncPtr;
+                CFE_TIME_Global.SynchCallback[AppIndex].Ptr = CallbackFuncPtr;
             }
         }
     }
@@ -737,14 +737,14 @@ int32  CFE_TIME_UnregisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFunc
         return Status;
     }
 
-    if (AppIndex >= (sizeof(CFE_TIME_TaskData.SynchCallback) / sizeof(CFE_TIME_TaskData.SynchCallback[0])) ||
-            CFE_TIME_TaskData.SynchCallback[AppIndex].Ptr != CallbackFuncPtr)
+    if (AppIndex >= (sizeof(CFE_TIME_Global.SynchCallback) / sizeof(CFE_TIME_Global.SynchCallback[0])) ||
+            CFE_TIME_Global.SynchCallback[AppIndex].Ptr != CallbackFuncPtr)
     {
         Status = CFE_TIME_CALLBACK_NOT_REGISTERED;
     }
     else
     {
-        CFE_TIME_TaskData.SynchCallback[AppIndex].Ptr = NULL;
+        CFE_TIME_Global.SynchCallback[AppIndex].Ptr = NULL;
     }
     
     return Status;

--- a/fsw/cfe-core/src/time/cfe_time_task.c
+++ b/fsw/cfe-core/src/time/cfe_time_task.c
@@ -40,7 +40,7 @@
 /*
 ** Time task global data...
 */
-CFE_TIME_TaskData_t CFE_TIME_TaskData;
+CFE_TIME_Global_t CFE_TIME_Global;
 
 
 /*
@@ -118,7 +118,7 @@ int32 CFE_TIME_SubDelayCmd(const CFE_TIME_SubDelayCmd_t *data);
 int32 CFE_TIME_EarlyInit(void)
 {
     /*
-    ** Initialize global Time Services data...
+    ** Initialize global Time Services nonzero data...
     */
     CFE_TIME_InitData();
 
@@ -169,7 +169,7 @@ void CFE_TIME_TaskMain(void)
   
       /* Pend on receipt of packet */
       Status = CFE_SB_ReceiveBuffer(&SBBufPtr,
-                              CFE_TIME_TaskData.CmdPipe,
+                              CFE_TIME_Global.CmdPipe,
                               CFE_SB_PEND_FOREVER);
   
       CFE_ES_PerfLogEntry(CFE_MISSION_TIME_MAIN_PERF_ID);
@@ -216,7 +216,7 @@ int32 CFE_TIME_TaskInit(void)
       return Status;
     }/* end if */
     
-    Status = OS_BinSemCreate(&CFE_TIME_TaskData.ToneSemaphore,
+    Status = OS_BinSemCreate(&CFE_TIME_Global.ToneSemaphore,
                               CFE_TIME_SEM_TONE_NAME,
                               CFE_TIME_SEM_VALUE,
                               CFE_TIME_SEM_OPTIONS);
@@ -226,7 +226,7 @@ int32 CFE_TIME_TaskInit(void)
       return Status;
     }/* end if */        
     
-    Status = OS_BinSemCreate(&CFE_TIME_TaskData.LocalSemaphore,
+    Status = OS_BinSemCreate(&CFE_TIME_Global.LocalSemaphore,
                               CFE_TIME_SEM_1HZ_NAME,
                               CFE_TIME_SEM_VALUE,
                               CFE_TIME_SEM_OPTIONS);
@@ -237,7 +237,7 @@ int32 CFE_TIME_TaskInit(void)
     }/* end if */
     
     
-    Status = CFE_ES_CreateChildTask(&CFE_TIME_TaskData.ToneTaskID,
+    Status = CFE_ES_CreateChildTask(&CFE_TIME_Global.ToneTaskID,
                                      CFE_TIME_TASK_TONE_NAME,
                                      CFE_TIME_Tone1HzTask,
                                      CFE_TIME_TASK_STACK_PTR,
@@ -251,7 +251,7 @@ int32 CFE_TIME_TaskInit(void)
     }/* end if */
     
         
-    Status = CFE_ES_CreateChildTask(&CFE_TIME_TaskData.LocalTaskID,
+    Status = CFE_ES_CreateChildTask(&CFE_TIME_Global.LocalTaskID,
                                      CFE_TIME_TASK_1HZ_NAME,
                                      CFE_TIME_Local1HzTask,
                                      CFE_TIME_TASK_STACK_PTR,
@@ -265,7 +265,7 @@ int32 CFE_TIME_TaskInit(void)
     }/* end if */
 
 
-    Status = CFE_SB_CreatePipe(&CFE_TIME_TaskData.CmdPipe, CFE_TIME_TASK_PIPE_DEPTH, CFE_TIME_TASK_PIPE_NAME);
+    Status = CFE_SB_CreatePipe(&CFE_TIME_Global.CmdPipe, CFE_TIME_TASK_PIPE_DEPTH, CFE_TIME_TASK_PIPE_NAME);
     if(Status != CFE_SUCCESS)
     {
       CFE_ES_WriteToSysLog("TIME:Error creating cmd pipe:RC=0x%08X\n",(unsigned int)Status);
@@ -274,7 +274,7 @@ int32 CFE_TIME_TaskInit(void)
 
 
     Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_SEND_HK_MID),
-                              CFE_TIME_TaskData.CmdPipe);
+                              CFE_TIME_Global.CmdPipe);
     if(Status != CFE_SUCCESS)
     {
       CFE_ES_WriteToSysLog("TIME:Error subscribing to HK Request:RC=0x%08X\n",(unsigned int)Status);
@@ -287,12 +287,12 @@ int32 CFE_TIME_TaskInit(void)
     */
     #if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
     Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_TONE_CMD_MID),
-                              CFE_TIME_TaskData.CmdPipe);
+                              CFE_TIME_Global.CmdPipe);
     #endif
     
     #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
     Status = CFE_SB_SubscribeLocal(CFE_SB_ValueToMsgId(CFE_TIME_TONE_CMD_MID),
-                              CFE_TIME_TaskData.CmdPipe,4);
+                              CFE_TIME_Global.CmdPipe,4);
     #endif
     if(Status != CFE_SUCCESS)
     {
@@ -306,12 +306,12 @@ int32 CFE_TIME_TaskInit(void)
     */
     #if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
     Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_DATA_CMD_MID),
-                              CFE_TIME_TaskData.CmdPipe);
+                              CFE_TIME_Global.CmdPipe);
     #endif
     
     #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
     Status = CFE_SB_SubscribeLocal(CFE_SB_ValueToMsgId(CFE_TIME_DATA_CMD_MID),
-                              CFE_TIME_TaskData.CmdPipe,4);
+                              CFE_TIME_Global.CmdPipe,4);
     #endif
     if(Status != CFE_SUCCESS)
     {
@@ -325,12 +325,12 @@ int32 CFE_TIME_TaskInit(void)
     */
     #if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
     Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_1HZ_CMD_MID),
-                              CFE_TIME_TaskData.CmdPipe);
+                              CFE_TIME_Global.CmdPipe);
     #endif
     
     #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
     Status = CFE_SB_SubscribeLocal(CFE_SB_ValueToMsgId(CFE_TIME_1HZ_CMD_MID),
-                                   CFE_TIME_TaskData.CmdPipe,4);
+                                   CFE_TIME_Global.CmdPipe,4);
     #endif
     
     if(Status != CFE_SUCCESS)
@@ -345,7 +345,7 @@ int32 CFE_TIME_TaskInit(void)
     */
     #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
     Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_SEND_CMD_MID),
-                                  CFE_TIME_TaskData.CmdPipe);
+                                  CFE_TIME_Global.CmdPipe);
     if(Status != CFE_SUCCESS)
     {
       CFE_ES_WriteToSysLog("TIME:Error subscribing to time at the tone request data cmds:RC=0x%08X\n",(unsigned int)Status);
@@ -357,7 +357,7 @@ int32 CFE_TIME_TaskInit(void)
     ** Subscribe to Time task ground command packets...
     */
     Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_CMD_MID),
-                              CFE_TIME_TaskData.CmdPipe);
+                              CFE_TIME_Global.CmdPipe);
     if(Status != CFE_SUCCESS)
     {
       CFE_ES_WriteToSysLog("TIME:Error subscribing to time task gnd cmds:RC=0x%08X\n",(unsigned int)Status);
@@ -378,7 +378,7 @@ int32 CFE_TIME_TaskInit(void)
     ** Select primary vs redundant tone interrupt signal...
     */
     #if (CFE_PLATFORM_TIME_CFG_SIGNAL == true)
-    OS_SelectTone(CFE_TIME_TaskData.ClockSignal);
+    OS_SelectTone(CFE_TIME_Global.ClockSignal);
     #endif
 
     /*
@@ -448,7 +448,7 @@ bool CFE_TIME_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
                           (unsigned int)CFE_SB_MsgIdToValue(MsgId), (unsigned int)FcnCode,
                           (unsigned int)ActualLength, (unsigned int)ExpectedLength);
         result = false;
-        ++CFE_TIME_TaskData.CommandErrorCounter;
+        ++CFE_TIME_Global.CommandErrorCounter;
     }
 
     return(result);
@@ -636,7 +636,7 @@ void CFE_TIME_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
 
                 default:
 
-                    CFE_TIME_TaskData.CommandErrorCounter++;
+                    CFE_TIME_Global.CommandErrorCounter++;
                     CFE_EVS_SendEvent(CFE_TIME_CC_ERR_EID, CFE_EVS_EventType_ERROR,
                              "Invalid command code -- ID = 0x%X, CC = %d",
                                       (unsigned int)CFE_SB_MsgIdToValue(MessageID), 
@@ -691,8 +691,8 @@ int32 CFE_TIME_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
     /*
     ** Send housekeeping telemetry packet...
     */
-    CFE_SB_TimeStampMsg(&CFE_TIME_TaskData.HkPacket.TlmHeader.Msg);
-    CFE_SB_TransmitMsg(&CFE_TIME_TaskData.HkPacket.TlmHeader.Msg, true);
+    CFE_SB_TimeStampMsg(&CFE_TIME_Global.HkPacket.TlmHeader.Msg);
+    CFE_SB_TransmitMsg(&CFE_TIME_Global.HkPacket.TlmHeader.Msg, true);
 
     /*
     ** Note: we only increment the command execution counter when
@@ -816,7 +816,7 @@ int32 CFE_TIME_ToneSendCmd(const CFE_TIME_FakeToneCmd_t *data)
 int32 CFE_TIME_NoopCmd(const CFE_TIME_NoopCmd_t *data)
 {
 
-    CFE_TIME_TaskData.CommandCounter++;
+    CFE_TIME_Global.CommandCounter++;
 
     CFE_EVS_SendEvent(CFE_TIME_NOOP_EID, CFE_EVS_EventType_INFORMATION,
                      "No-op command.%s", CFE_VERSION_STRING);
@@ -835,31 +835,31 @@ int32 CFE_TIME_NoopCmd(const CFE_TIME_NoopCmd_t *data)
 int32 CFE_TIME_ResetCountersCmd(const CFE_TIME_ResetCountersCmd_t *data)
 {
 
-    CFE_TIME_TaskData.CommandCounter = 0;
-    CFE_TIME_TaskData.CommandErrorCounter = 0;
+    CFE_TIME_Global.CommandCounter = 0;
+    CFE_TIME_Global.CommandErrorCounter = 0;
 
-    CFE_TIME_TaskData.ToneMatchCounter  = 0;
-    CFE_TIME_TaskData.ToneMatchErrorCounter = 0;
+    CFE_TIME_Global.ToneMatchCounter  = 0;
+    CFE_TIME_Global.ToneMatchErrorCounter = 0;
 
-    CFE_TIME_TaskData.ToneSignalCounter = 0;
-    CFE_TIME_TaskData.ToneDataCounter   = 0;
+    CFE_TIME_Global.ToneSignalCounter = 0;
+    CFE_TIME_Global.ToneDataCounter   = 0;
 
-    CFE_TIME_TaskData.ToneIntCounter    = 0;
-    CFE_TIME_TaskData.ToneIntErrorCounter   = 0;
-    CFE_TIME_TaskData.ToneTaskCounter   = 0;
+    CFE_TIME_Global.ToneIntCounter    = 0;
+    CFE_TIME_Global.ToneIntErrorCounter   = 0;
+    CFE_TIME_Global.ToneTaskCounter   = 0;
 
     /*
      * Note: Not resetting "LastVersion" counter here, that might
      * disturb access to the time reference data by other tasks
      */
-    CFE_TIME_TaskData.ResetVersionCounter =
-            CFE_TIME_TaskData.LastVersionCounter;
+    CFE_TIME_Global.ResetVersionCounter =
+            CFE_TIME_Global.LastVersionCounter;
 
-    CFE_TIME_TaskData.LocalIntCounter   = 0;
-    CFE_TIME_TaskData.LocalTaskCounter  = 0;
+    CFE_TIME_Global.LocalIntCounter   = 0;
+    CFE_TIME_Global.LocalTaskCounter  = 0;
 
-    CFE_TIME_TaskData.InternalCount   = 0;
-    CFE_TIME_TaskData.ExternalCount   = 0;
+    CFE_TIME_Global.InternalCount   = 0;
+    CFE_TIME_Global.ExternalCount   = 0;
 
     CFE_EVS_SendEvent(CFE_TIME_RESET_EID, CFE_EVS_EventType_DEBUG,
                      "Reset Counters command");
@@ -877,7 +877,7 @@ int32 CFE_TIME_ResetCountersCmd(const CFE_TIME_ResetCountersCmd_t *data)
 
 int32 CFE_TIME_SendDiagnosticTlm(const CFE_TIME_SendDiagnosticCmd_t *data)
 {
-    CFE_TIME_TaskData.CommandCounter++;
+    CFE_TIME_Global.CommandCounter++;
 
     /*
     ** Collect diagnostics data from Time Services utilities...
@@ -887,8 +887,8 @@ int32 CFE_TIME_SendDiagnosticTlm(const CFE_TIME_SendDiagnosticCmd_t *data)
     /*
     ** Send diagnostics telemetry packet...
     */
-    CFE_SB_TimeStampMsg(&CFE_TIME_TaskData.DiagPacket.TlmHeader.Msg);
-    CFE_SB_TransmitMsg(&CFE_TIME_TaskData.DiagPacket.TlmHeader.Msg, true);
+    CFE_SB_TimeStampMsg(&CFE_TIME_Global.DiagPacket.TlmHeader.Msg);
+    CFE_SB_TransmitMsg(&CFE_TIME_Global.DiagPacket.TlmHeader.Msg, true);
 
     CFE_EVS_SendEvent(CFE_TIME_DIAG_EID, CFE_EVS_EventType_DEBUG,
                      "Request diagnostics command");
@@ -934,13 +934,13 @@ int32 CFE_TIME_SetStateCmd(const CFE_TIME_SetStateCmd_t *data)
             ClockStateText = "FLYWHEEL";
         }
 
-        CFE_TIME_TaskData.CommandCounter++;
+        CFE_TIME_Global.CommandCounter++;
         CFE_EVS_SendEvent(CFE_TIME_STATE_EID, CFE_EVS_EventType_INFORMATION,
                          "Set Clock State = %s", ClockStateText);
     }
     else
     {
-        CFE_TIME_TaskData.CommandErrorCounter++;
+        CFE_TIME_Global.CommandErrorCounter++;
         CFE_EVS_SendEvent(CFE_TIME_STATE_ERR_EID, CFE_EVS_EventType_ERROR,
                          "Invalid Clock State = 0x%X", (unsigned int)CommandPtr->ClockState);
     }
@@ -974,7 +974,7 @@ int32 CFE_TIME_SetSourceCmd(const CFE_TIME_SetSourceCmd_t *data)
         /*
         ** Only systems configured to select source of time data...
         */
-        CFE_TIME_TaskData.CommandCounter++;
+        CFE_TIME_Global.CommandCounter++;
 
         CFE_TIME_SetSource(CommandPtr->TimeSource);
 
@@ -998,7 +998,7 @@ int32 CFE_TIME_SetSourceCmd(const CFE_TIME_SetSourceCmd_t *data)
         /*
         ** We want to know if disabled commands are being sent...
         */
-        CFE_TIME_TaskData.CommandErrorCounter++;
+        CFE_TIME_Global.CommandErrorCounter++;
 
         CFE_EVS_SendEvent(CFE_TIME_SOURCE_CFG_EID, CFE_EVS_EventType_ERROR,
         "Set Source commands invalid without CFE_PLATFORM_TIME_CFG_SOURCE set to TRUE");
@@ -1010,7 +1010,7 @@ int32 CFE_TIME_SetSourceCmd(const CFE_TIME_SetSourceCmd_t *data)
         /*
         ** Ground system database will prevent most of these errors...
         */
-        CFE_TIME_TaskData.CommandErrorCounter++;
+        CFE_TIME_Global.CommandErrorCounter++;
 
         CFE_EVS_SendEvent(CFE_TIME_SOURCE_ERR_EID, CFE_EVS_EventType_ERROR,
                          "Invalid Time Source = 0x%X", (unsigned int)CommandPtr->TimeSource);
@@ -1044,7 +1044,7 @@ int32 CFE_TIME_SetSignalCmd(const CFE_TIME_SetSignalCmd_t *data)
         /*
         ** Only systems configured to select tone signal...
         */
-        CFE_TIME_TaskData.CommandCounter++;
+        CFE_TIME_Global.CommandCounter++;
 
         CFE_TIME_SetSignal(CommandPtr->ToneSource);
 
@@ -1068,7 +1068,7 @@ int32 CFE_TIME_SetSignalCmd(const CFE_TIME_SetSignalCmd_t *data)
         /*
         ** We want to know if disabled commands are being sent...
         */
-        CFE_TIME_TaskData.CommandErrorCounter++;
+        CFE_TIME_Global.CommandErrorCounter++;
 
         CFE_EVS_SendEvent(CFE_TIME_SIGNAL_CFG_EID, CFE_EVS_EventType_ERROR,
            "Set Signal commands invalid without CFE_PLATFORM_TIME_CFG_SIGNAL set to TRUE");
@@ -1080,7 +1080,7 @@ int32 CFE_TIME_SetSignalCmd(const CFE_TIME_SetSignalCmd_t *data)
         /*
         ** Ground system database will prevent most of these errors...
         */
-        CFE_TIME_TaskData.CommandErrorCounter++;
+        CFE_TIME_Global.CommandErrorCounter++;
 
         CFE_EVS_SendEvent(CFE_TIME_SIGNAL_ERR_EID, CFE_EVS_EventType_ERROR,
                          "Invalid Tone Source = 0x%X", (unsigned int)CommandPtr->ToneSource);
@@ -1113,7 +1113,7 @@ void CFE_TIME_SetDelayImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIM
 
         CFE_TIME_SetDelay(Delay, Direction);
 
-        CFE_TIME_TaskData.CommandCounter++;
+        CFE_TIME_Global.CommandCounter++;
         CFE_EVS_SendEvent(CFE_TIME_DELAY_EID, CFE_EVS_EventType_INFORMATION,
            "Set Tone Delay -- secs = %u, usecs = %u, ssecs = 0x%X, dir = %d",
            (unsigned int)CommandPtr->Seconds, (unsigned int)CommandPtr->MicroSeconds,
@@ -1124,7 +1124,7 @@ void CFE_TIME_SetDelayImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIM
         /*
         ** We want to know if disabled commands are being sent...
         */
-        CFE_TIME_TaskData.CommandErrorCounter++;
+        CFE_TIME_Global.CommandErrorCounter++;
 
         CFE_EVS_SendEvent(CFE_TIME_DELAY_CFG_EID, CFE_EVS_EventType_ERROR,
         "Set Delay commands invalid without CFE_PLATFORM_TIME_CFG_CLIENT set to TRUE");
@@ -1133,7 +1133,7 @@ void CFE_TIME_SetDelayImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIM
     }
     else
     {
-        CFE_TIME_TaskData.CommandErrorCounter++;
+        CFE_TIME_Global.CommandErrorCounter++;
         CFE_EVS_SendEvent(CFE_TIME_DELAY_ERR_EID, CFE_EVS_EventType_ERROR,
                "Invalid Tone Delay -- secs = %u, usecs = %u",
                (unsigned int)CommandPtr->Seconds, (unsigned int)CommandPtr->MicroSeconds);
@@ -1184,7 +1184,7 @@ int32 CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data)
 
         CFE_TIME_SetTime(NewTime);
 
-        CFE_TIME_TaskData.CommandCounter++;
+        CFE_TIME_Global.CommandCounter++;
         CFE_EVS_SendEvent(CFE_TIME_TIME_EID, CFE_EVS_EventType_INFORMATION,
                          "Set Time -- secs = %u, usecs = %u, ssecs = 0x%X",
                           (unsigned int)CommandPtr->Seconds, (unsigned int)CommandPtr->MicroSeconds,
@@ -1194,7 +1194,7 @@ int32 CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data)
         /*
         ** We want to know if disabled commands are being sent...
         */
-        CFE_TIME_TaskData.CommandErrorCounter++;
+        CFE_TIME_Global.CommandErrorCounter++;
 
         CFE_EVS_SendEvent(CFE_TIME_TIME_CFG_EID, CFE_EVS_EventType_ERROR,
            "Set Time commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to TRUE");
@@ -1203,7 +1203,7 @@ int32 CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data)
     }
     else
     {
-        CFE_TIME_TaskData.CommandErrorCounter++;
+        CFE_TIME_Global.CommandErrorCounter++;
         CFE_EVS_SendEvent(CFE_TIME_TIME_ERR_EID, CFE_EVS_EventType_ERROR,
                          "Invalid Time -- secs = %u, usecs = %u",
                          (unsigned int)CommandPtr->Seconds, (unsigned int)CommandPtr->MicroSeconds);
@@ -1243,7 +1243,7 @@ int32 CFE_TIME_SetMETCmd(const CFE_TIME_SetMETCmd_t *data)
 
         CFE_TIME_SetMET(NewMET);
 
-        CFE_TIME_TaskData.CommandCounter++;
+        CFE_TIME_Global.CommandCounter++;
         CFE_EVS_SendEvent(CFE_TIME_MET_EID, CFE_EVS_EventType_INFORMATION,
                          "Set MET -- secs = %u, usecs = %u, ssecs = 0x%X",
                           (unsigned int)CommandPtr->Seconds, (unsigned int)CommandPtr->MicroSeconds,
@@ -1253,7 +1253,7 @@ int32 CFE_TIME_SetMETCmd(const CFE_TIME_SetMETCmd_t *data)
         /*
         ** We want to know if disabled commands are being sent...
         */
-        CFE_TIME_TaskData.CommandErrorCounter++;
+        CFE_TIME_Global.CommandErrorCounter++;
 
         CFE_EVS_SendEvent(CFE_TIME_MET_CFG_EID, CFE_EVS_EventType_ERROR,
            "Set MET commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to TRUE");
@@ -1262,7 +1262,7 @@ int32 CFE_TIME_SetMETCmd(const CFE_TIME_SetMETCmd_t *data)
     }
     else
     {
-        CFE_TIME_TaskData.CommandErrorCounter++;
+        CFE_TIME_Global.CommandErrorCounter++;
         CFE_EVS_SendEvent(CFE_TIME_MET_ERR_EID, CFE_EVS_EventType_ERROR,
                          "Invalid MET -- secs = %u, usecs = %u",
                          (unsigned int)CommandPtr->Seconds, (unsigned int)CommandPtr->MicroSeconds);
@@ -1297,7 +1297,7 @@ int32 CFE_TIME_SetSTCFCmd(const CFE_TIME_SetSTCFCmd_t *data)
 
         CFE_TIME_SetSTCF(NewSTCF);
 
-        CFE_TIME_TaskData.CommandCounter++;
+        CFE_TIME_Global.CommandCounter++;
         CFE_EVS_SendEvent(CFE_TIME_STCF_EID, CFE_EVS_EventType_INFORMATION,
                          "Set STCF -- secs = %u, usecs = %u, ssecs = 0x%X",
                          (unsigned int)CommandPtr->Seconds, (unsigned int)CommandPtr->MicroSeconds,
@@ -1307,7 +1307,7 @@ int32 CFE_TIME_SetSTCFCmd(const CFE_TIME_SetSTCFCmd_t *data)
         /*
         ** We want to know if disabled commands are being sent...
         */
-        CFE_TIME_TaskData.CommandErrorCounter++;
+        CFE_TIME_Global.CommandErrorCounter++;
 
         CFE_EVS_SendEvent(CFE_TIME_STCF_CFG_EID, CFE_EVS_EventType_ERROR,
            "Set STCF commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to TRUE");
@@ -1316,7 +1316,7 @@ int32 CFE_TIME_SetSTCFCmd(const CFE_TIME_SetSTCFCmd_t *data)
     }
     else
     {
-        CFE_TIME_TaskData.CommandErrorCounter++;
+        CFE_TIME_Global.CommandErrorCounter++;
         CFE_EVS_SendEvent(CFE_TIME_STCF_ERR_EID, CFE_EVS_EventType_ERROR,
                          "Invalid STCF -- secs = %u, usecs = %u",
                          (unsigned int)CommandPtr->Seconds, (unsigned int)CommandPtr->MicroSeconds);
@@ -1344,7 +1344,7 @@ int32 CFE_TIME_SetLeapSecondsCmd(const CFE_TIME_SetLeapSecondsCmd_t *data)
     */
     CFE_TIME_SetLeapSeconds(CommandPtr->LeapSeconds);
 
-    CFE_TIME_TaskData.CommandCounter++;
+    CFE_TIME_Global.CommandCounter++;
 
     CFE_EVS_SendEvent(CFE_TIME_LEAPS_EID, CFE_EVS_EventType_INFORMATION,
                      "Set Leap Seconds = %d", (int)CommandPtr->LeapSeconds);
@@ -1353,7 +1353,7 @@ int32 CFE_TIME_SetLeapSecondsCmd(const CFE_TIME_SetLeapSecondsCmd_t *data)
     /*
     ** We want to know if disabled commands are being sent...
     */
-    CFE_TIME_TaskData.CommandErrorCounter++;
+    CFE_TIME_Global.CommandErrorCounter++;
 
     CFE_EVS_SendEvent(CFE_TIME_LEAPS_CFG_EID, CFE_EVS_EventType_ERROR,
        "Set Leaps commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to TRUE");
@@ -1387,7 +1387,7 @@ void CFE_TIME_AdjustImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_
 
         CFE_TIME_SetAdjust(Adjust, Direction);
 
-        CFE_TIME_TaskData.CommandCounter++;
+        CFE_TIME_Global.CommandCounter++;
         CFE_EVS_SendEvent(CFE_TIME_DELTA_EID, CFE_EVS_EventType_INFORMATION,
            "STCF Adjust -- secs = %u, usecs = %u, ssecs = 0x%X, dir[1=Pos, 2=Neg] = %d",
            (unsigned int)CommandPtr->Seconds, (unsigned int)CommandPtr->MicroSeconds,
@@ -1398,7 +1398,7 @@ void CFE_TIME_AdjustImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_
         /*
         ** We want to know if disabled commands are being sent...
         */
-        CFE_TIME_TaskData.CommandErrorCounter++;
+        CFE_TIME_Global.CommandErrorCounter++;
 
         CFE_EVS_SendEvent(CFE_TIME_DELTA_CFG_EID, CFE_EVS_EventType_ERROR,
            "STCF Adjust commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to TRUE");
@@ -1407,7 +1407,7 @@ void CFE_TIME_AdjustImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_
     }
     else
     {
-        CFE_TIME_TaskData.CommandErrorCounter++;
+        CFE_TIME_Global.CommandErrorCounter++;
         CFE_EVS_SendEvent(CFE_TIME_DELTA_ERR_EID, CFE_EVS_EventType_ERROR,
            "Invalid STCF Adjust -- secs = %u, usecs = %u, dir[1=Pos, 2=Neg] = %d",
            (unsigned int)CommandPtr->Seconds, (unsigned int)CommandPtr->MicroSeconds, (int)Direction);
@@ -1462,7 +1462,7 @@ void CFE_TIME_1HzAdjImpl(const CFE_TIME_OneHzAdjustmentCmd_Payload_t *CommandPtr
 
     CFE_TIME_Set1HzAdj(Adjust, Direction);
 
-    CFE_TIME_TaskData.CommandCounter++;
+    CFE_TIME_Global.CommandCounter++;
     CFE_EVS_SendEvent(CFE_TIME_1HZ_EID, CFE_EVS_EventType_INFORMATION,
        "STCF 1Hz Adjust -- secs = %d, ssecs = 0x%X, dir[1=Pos, 2=Neg] = %d",
                       (int)CommandPtr->Seconds, (unsigned int)CommandPtr->Subseconds, (int)Direction);
@@ -1471,7 +1471,7 @@ void CFE_TIME_1HzAdjImpl(const CFE_TIME_OneHzAdjustmentCmd_Payload_t *CommandPtr
     /*
     ** We want to know if disabled commands are being sent...
     */
-    CFE_TIME_TaskData.CommandErrorCounter++;
+    CFE_TIME_Global.CommandErrorCounter++;
 
     CFE_EVS_SendEvent(CFE_TIME_1HZ_CFG_EID, CFE_EVS_EventType_ERROR,
        "1Hz Adjust commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to TRUE");

--- a/fsw/cfe-core/src/time/cfe_time_tone.c
+++ b/fsw/cfe-core/src/time/cfe_time_tone.c
@@ -95,7 +95,7 @@ void CFE_TIME_ToneSend(void)
         ** MET seconds is the count of tone interrupts...
         */
         #if (CFE_PLATFORM_TIME_CFG_VIRTUAL == true)
-        NewMET.Seconds = CFE_TIME_TaskData.VirtualMET;
+        NewMET.Seconds = CFE_TIME_Global.VirtualMET;
         #endif
 
         /*
@@ -133,17 +133,17 @@ void CFE_TIME_ToneSend(void)
     ** Payload must be big-endian.
     */
 
-    CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneMET.Seconds =
+    CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Seconds =
         CFE_MAKE_BIG32(NewMET.Seconds);
-    CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneMET.Subseconds =
+    CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Subseconds =
         CFE_MAKE_BIG32(NewMET.Subseconds);
-    CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneSTCF.Seconds =
+    CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF.Seconds =
         CFE_MAKE_BIG32(Reference.AtToneSTCF.Seconds);
-    CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneSTCF.Subseconds =
+    CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF.Subseconds =
         CFE_MAKE_BIG32(Reference.AtToneSTCF.Subseconds);
-    CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneLeapSeconds = 
+    CFE_TIME_Global.ToneDataCmd.Payload.AtToneLeapSeconds =
         CFE_MAKE_BIG16(Reference.AtToneLeapSeconds);
-    CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneState = 
+    CFE_TIME_Global.ToneDataCmd.Payload.AtToneState =
         CFE_MAKE_BIG16(AtToneState);
 
     #else /* !CFE_PLATFORM_TIME_CFG_BIGENDIAN */
@@ -151,26 +151,26 @@ void CFE_TIME_ToneSend(void)
     /*
     ** Remainder of time values are unchanged...
     */
-    CFE_TIME_Copy(&CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneMET, &NewMET);
-    CFE_TIME_Copy(&CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneSTCF, &Reference.AtToneSTCF);
-    CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneLeapSeconds = Reference.AtToneLeapSeconds;
+    CFE_TIME_Copy(&CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET, &NewMET);
+    CFE_TIME_Copy(&CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF, &Reference.AtToneSTCF);
+    CFE_TIME_Global.ToneDataCmd.Payload.AtToneLeapSeconds = Reference.AtToneLeapSeconds;
 
     /*
     ** Current clock state is a combination of factors...
     */
-    CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneState = CFE_TIME_CalculateState(&Reference);
+    CFE_TIME_Global.ToneDataCmd.Payload.AtToneState = CFE_TIME_CalculateState(&Reference);
 
     #endif /* CFE_PLATFORM_TIME_CFG_BIGENDIAN */
 
     /*
     ** Send "time at the tone" command data packet...
     */
-    CFE_SB_TransmitMsg(&CFE_TIME_TaskData.ToneDataCmd.CmdHeader.Msg, false);
+    CFE_SB_TransmitMsg(&CFE_TIME_Global.ToneDataCmd.CmdHeader.Msg, false);
 
     /*
     ** Count of "time at the tone" commands sent with internal data...
     */
-    CFE_TIME_TaskData.InternalCount++;
+    CFE_TIME_Global.InternalCount++;
 
     return;
 
@@ -213,7 +213,7 @@ int32 CFE_TIME_ToneSendMET(CFE_TIME_SysTime_t NewMET)
     /*
     ** Ignore external time data if commanded to use local MET...
     */
-    if (CFE_TIME_TaskData.ClockSource == CFE_TIME_SourceSelect_INTERNAL)
+    if (CFE_TIME_Global.ClockSource == CFE_TIME_SourceSelect_INTERNAL)
     {
         Result = CFE_TIME_INTERNAL_ONLY;
 
@@ -245,8 +245,8 @@ int32 CFE_TIME_ToneSendMET(CFE_TIME_SysTime_t NewMET)
         /*
         ** Compute minimum and maximum values for valid MET...
         */
-        MinValid = CFE_TIME_Subtract(Expected, CFE_TIME_TaskData.MaxDelta);
-        MaxValid = CFE_TIME_Add(Expected, CFE_TIME_TaskData.MaxDelta);
+        MinValid = CFE_TIME_Subtract(Expected, CFE_TIME_Global.MaxDelta);
+        MaxValid = CFE_TIME_Add(Expected, CFE_TIME_Global.MaxDelta);
 
         /*
         ** Compare new MET to minimum and maximum MET...
@@ -280,37 +280,37 @@ int32 CFE_TIME_ToneSendMET(CFE_TIME_SysTime_t NewMET)
             /*
             ** Payload must be big-endian.
             */
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneMET.Seconds =
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Seconds =
                 CFE_MAKE_BIG32(NewMET.Seconds);
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneMET.Subseconds =
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Subseconds =
                 CFE_MAKE_BIG32(NewMET.Subseconds);
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneSTCF.Seconds =
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF.Seconds =
                 CFE_MAKE_BIG32(Reference.AtToneSTCF.Seconds);
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneSTCF.Subseconds =
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF.Subseconds =
                 CFE_MAKE_BIG32(Reference.AtToneSTCF.Subseconds);
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneLeapSeconds = 
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneLeapSeconds =
                 CFE_MAKE_BIG16(Reference.AtToneLeapSeconds);
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneState = 
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneState =
                 CFE_MAKE_BIG16(ClockState);
 
             #else /* !CFE_PLATFORM_TIME_CFG_BIGENDIAN */
 
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneMET   = NewMET;
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneSTCF  = Reference.AtToneSTCF;
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneLeapSeconds = Reference.AtToneLeapSeconds;
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneState = ClockState;
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET   = NewMET;
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF  = Reference.AtToneSTCF;
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneLeapSeconds = Reference.AtToneLeapSeconds;
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneState = ClockState;
 
             #endif /* CFE_PLATFORM_TIME_CFG_BIGENDIAN */
 
             /*
             ** Send "time at the tone" command data packet...
             */
-            CFE_SB_TransmitMsg(&CFE_TIME_TaskData.ToneDataCmd.CmdHeader.Msg, false);
+            CFE_SB_TransmitMsg(&CFE_TIME_Global.ToneDataCmd.CmdHeader.Msg, false);
 
             /*
             ** Count of "time at the tone" commands sent with external data...
             */
-            CFE_TIME_TaskData.ExternalCount++;
+            CFE_TIME_Global.ExternalCount++;
         }
     }
 
@@ -356,7 +356,7 @@ int32 CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps)
     /*
     ** Ignore external time data if commanded to use local MET...
     */
-    if (CFE_TIME_TaskData.ClockSource == CFE_TIME_SourceSelect_INTERNAL)
+    if (CFE_TIME_Global.ClockSource == CFE_TIME_SourceSelect_INTERNAL)
     {
         Result = CFE_TIME_INTERNAL_ONLY;
 
@@ -400,8 +400,8 @@ int32 CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps)
         /*
         ** Compute minimum and maximum values for valid STCF...
         */
-        MinValid = CFE_TIME_Subtract(Reference.AtToneSTCF, CFE_TIME_TaskData.MaxDelta);
-        MaxValid = CFE_TIME_Add(Reference.AtToneSTCF, CFE_TIME_TaskData.MaxDelta);
+        MinValid = CFE_TIME_Subtract(Reference.AtToneSTCF, CFE_TIME_Global.MaxDelta);
+        MaxValid = CFE_TIME_Add(Reference.AtToneSTCF, CFE_TIME_Global.MaxDelta);
 
         /*
         ** Compare new STCF to minimum and maximum STCF...
@@ -434,37 +434,37 @@ int32 CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps)
             /*
             ** Payload must be big-endian.
             */
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneMET.Seconds =
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Seconds =
                 CFE_MAKE_BIG32(NewMET.Seconds);
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneMET.Subseconds =
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Subseconds =
                 CFE_MAKE_BIG32(NewMET.Subseconds);
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneSTCF.Seconds =
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF.Seconds =
                 CFE_MAKE_BIG32(NewSTCF.Seconds);
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneSTCF.Subseconds =
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF.Subseconds =
                 CFE_MAKE_BIG32(NewSTCF.Subseconds);
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneLeapSeconds = 
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneLeapSeconds =
                 CFE_MAKE_BIG16(NewLeaps);
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneState = 
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneState =
                 CFE_MAKE_BIG16(ClockState);
 
             #else /* !CFE_PLATFORM_TIME_CFG_BIGENDIAN */
 
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneMET   = NewMET;
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneSTCF  = NewSTCF;
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneLeapSeconds = NewLeaps;
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneState = ClockState;
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET   = NewMET;
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF  = NewSTCF;
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneLeapSeconds = NewLeaps;
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneState = ClockState;
 
             #endif /* CFE_PLATFORM_TIME_CFG_BIGENDIAN */
 
             /*
             ** Send "time at the tone" command data packet...
             */
-            CFE_SB_TransmitMsg(&CFE_TIME_TaskData.ToneDataCmd.CmdHeader.Msg, false);
+            CFE_SB_TransmitMsg(&CFE_TIME_Global.ToneDataCmd.CmdHeader.Msg, false);
 
             /*
             ** Count of "time at the tone" commands sent with external data...
             */
-            CFE_TIME_TaskData.ExternalCount++;
+            CFE_TIME_Global.ExternalCount++;
         }
     }
 
@@ -507,7 +507,7 @@ int32 CFE_TIME_ToneSendTime(CFE_TIME_SysTime_t NewTime)
     /*
     ** Ignore external time data if commanded to use local MET...
     */
-    if (CFE_TIME_TaskData.ClockSource == CFE_TIME_SourceSelect_INTERNAL)
+    if (CFE_TIME_Global.ClockSource == CFE_TIME_SourceSelect_INTERNAL)
     {
         Result = CFE_TIME_INTERNAL_ONLY;
 
@@ -551,8 +551,8 @@ int32 CFE_TIME_ToneSendTime(CFE_TIME_SysTime_t NewTime)
         /*
         ** Compute minimum and maximum values for valid STCF...
         */
-        MinValid = CFE_TIME_Subtract(Reference.AtToneSTCF, CFE_TIME_TaskData.MaxDelta);
-        MaxValid = CFE_TIME_Add(Reference.AtToneSTCF, CFE_TIME_TaskData.MaxDelta);
+        MinValid = CFE_TIME_Subtract(Reference.AtToneSTCF, CFE_TIME_Global.MaxDelta);
+        MaxValid = CFE_TIME_Add(Reference.AtToneSTCF, CFE_TIME_Global.MaxDelta);
 
         /*
         ** Compare new STCF to minimum and maximum STCF...
@@ -587,37 +587,37 @@ int32 CFE_TIME_ToneSendTime(CFE_TIME_SysTime_t NewTime)
             ** Payload must be big-endian.
             */
 
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneMET.Seconds =
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Seconds =
                 CFE_MAKE_BIG32(NewMET.Seconds);
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneMET.Subseconds =
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Subseconds =
                 CFE_MAKE_BIG32(NewMET.Subseconds);
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneSTCF.Seconds =
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF.Seconds =
                 CFE_MAKE_BIG32(NewSTCF.Seconds);
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneSTCF.Subseconds =
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF.Subseconds =
                 CFE_MAKE_BIG32(NewSTCF.Subseconds);
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneLeapSeconds = 
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneLeapSeconds =
                 CFE_MAKE_BIG16(Reference.AtToneLeapSeconds);
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneState = 
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneState =
                 CFE_MAKE_BIG16(ClockState);
 
             #else /* !CFE_PLATFORM_TIME_CFG_BIGENDIAN */
 
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneMET   = NewMET;
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneSTCF  = NewSTCF;
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneLeapSeconds = Reference.AtToneLeapSeconds;
-            CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneState = ClockState;
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET   = NewMET;
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF  = NewSTCF;
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneLeapSeconds = Reference.AtToneLeapSeconds;
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneState = ClockState;
 
             #endif /* CFE_PLATFORM_TIME_CFG_BIGENDIAN */
 
             /*
             ** Send "time at the tone" command data packet...
             */
-            CFE_SB_TransmitMsg(&CFE_TIME_TaskData.ToneDataCmd.CmdHeader.Msg, false);
+            CFE_SB_TransmitMsg(&CFE_TIME_Global.ToneDataCmd.CmdHeader.Msg, false);
 
             /*
             ** Count of "time at the tone" commands sent with external data...
             */
-            CFE_TIME_TaskData.ExternalCount++;
+            CFE_TIME_Global.ExternalCount++;
         }
     }
 
@@ -638,7 +638,7 @@ void CFE_TIME_ToneData(const CFE_TIME_ToneDataCmd_Payload_t *ToneDataCmd)
     /*
     ** Save the time when the data packet was received...
     */
-    CFE_TIME_TaskData.ToneDataLatch   = CFE_TIME_LatchClock();
+    CFE_TIME_Global.ToneDataLatch   = CFE_TIME_LatchClock();
 
     /*
     ** Save the data packet (may be a while before the data is used)...
@@ -649,23 +649,23 @@ void CFE_TIME_ToneData(const CFE_TIME_ToneDataCmd_Payload_t *ToneDataCmd)
     /*
     ** Tone data will be big-endian, convert to platform-endian.
     */
-    CFE_TIME_TaskData.PendingMET.Seconds =
+    CFE_TIME_Global.PendingMET.Seconds =
         CFE_MAKE_BIG32(ToneDataCmd->AtToneMET.Seconds);
-    CFE_TIME_TaskData.PendingMET.Subseconds =
+    CFE_TIME_Global.PendingMET.Subseconds =
         CFE_MAKE_BIG32(ToneDataCmd->AtToneMET.Subseconds);
-    CFE_TIME_TaskData.PendingSTCF.Seconds =
+    CFE_TIME_Global.PendingSTCF.Seconds =
         CFE_MAKE_BIG32(ToneDataCmd->AtToneSTCF.Seconds);
-    CFE_TIME_TaskData.PendingSTCF.Subseconds =
+    CFE_TIME_Global.PendingSTCF.Subseconds =
         CFE_MAKE_BIG32(ToneDataCmd->AtToneSTCF.Subseconds);
-    CFE_TIME_TaskData.PendingLeaps = CFE_MAKE_BIG16(ToneDataCmd->AtToneLeapSeconds);
-    CFE_TIME_TaskData.PendingState = CFE_MAKE_BIG16(ToneDataCmd->AtToneState);
+    CFE_TIME_Global.PendingLeaps = CFE_MAKE_BIG16(ToneDataCmd->AtToneLeapSeconds);
+    CFE_TIME_Global.PendingState = CFE_MAKE_BIG16(ToneDataCmd->AtToneState);
 
     #else /* !CFE_PLATFORM_TIME_CFG_BIGENDIAN */
 
-    CFE_TIME_Copy(&CFE_TIME_TaskData.PendingMET, &ToneDataCmd->AtToneMET);
-    CFE_TIME_Copy(&CFE_TIME_TaskData.PendingSTCF, &ToneDataCmd->AtToneSTCF);
-    CFE_TIME_TaskData.PendingLeaps = ToneDataCmd->AtToneLeapSeconds;
-    CFE_TIME_TaskData.PendingState = ToneDataCmd->AtToneState;
+    CFE_TIME_Copy(&CFE_TIME_Global.PendingMET, &ToneDataCmd->AtToneMET);
+    CFE_TIME_Copy(&CFE_TIME_Global.PendingSTCF, &ToneDataCmd->AtToneSTCF);
+    CFE_TIME_Global.PendingLeaps = ToneDataCmd->AtToneLeapSeconds;
+    CFE_TIME_Global.PendingState = ToneDataCmd->AtToneState;
 
     #endif /* CFE_PLATFORM_TIME_CFG_BIGENDIAN */
 
@@ -677,8 +677,8 @@ void CFE_TIME_ToneData(const CFE_TIME_ToneDataCmd_Payload_t *ToneDataCmd)
     **    now start using the new data to compute time.
     */
     #if (CFE_MISSION_TIME_AT_TONE_WAS == true)
-    CFE_TIME_ToneVerify(CFE_TIME_TaskData.ToneSignalLatch,
-                        CFE_TIME_TaskData.ToneDataLatch);
+    CFE_TIME_ToneVerify(CFE_TIME_Global.ToneSignalLatch,
+                        CFE_TIME_Global.ToneDataLatch);
     #endif
 
     /*
@@ -697,7 +697,7 @@ void CFE_TIME_ToneData(const CFE_TIME_ToneDataCmd_Payload_t *ToneDataCmd)
     /*
     ** Maintain a count of tone data packets...
     */
-    CFE_TIME_TaskData.ToneDataCounter++;
+    CFE_TIME_Global.ToneDataCounter++;
 
     return;
 
@@ -749,14 +749,14 @@ void CFE_TIME_ToneSignal(void)
     **    now start using the new data to compute time.
     */
     #if (CFE_MISSION_TIME_AT_TONE_WILL_BE == true)
-    CFE_TIME_ToneVerify(CFE_TIME_TaskData.ToneDataLatch,
-                        CFE_TIME_TaskData.ToneSignalLatch);
+    CFE_TIME_ToneVerify(CFE_TIME_Global.ToneDataLatch,
+                        CFE_TIME_Global.ToneSignalLatch);
     #endif
 
     /*
     ** Maintain a count of tone signal packets...
     */
-    CFE_TIME_TaskData.ToneSignalCounter++;
+    CFE_TIME_Global.ToneSignalCounter++;
 
     return;
 
@@ -798,14 +798,14 @@ void CFE_TIME_ToneVerify(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2)
     result = CFE_TIME_Compare(PrevTime1, Time1);
     if (result == CFE_TIME_EQUAL)
     {
-        CFE_TIME_TaskData.ToneMatchErrorCounter++;
+        CFE_TIME_Global.ToneMatchErrorCounter++;
     }
     else
     {
         result = CFE_TIME_Compare(PrevTime2, Time2);
         if (result == CFE_TIME_EQUAL)
         {
-            CFE_TIME_TaskData.ToneMatchErrorCounter++;
+            CFE_TIME_Global.ToneMatchErrorCounter++;
         }
         else
         {
@@ -818,7 +818,7 @@ void CFE_TIME_ToneVerify(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2)
                 /*
                 ** Local clock has rolled over...
                 */
-                elapsed = CFE_TIME_Subtract(CFE_TIME_TaskData.MaxLocalClock, Time1);
+                elapsed = CFE_TIME_Subtract(CFE_TIME_Global.MaxLocalClock, Time1);
                 elapsed = CFE_TIME_Add(elapsed, Time2);
             }
             else
@@ -833,22 +833,22 @@ void CFE_TIME_ToneVerify(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2)
             ** Ensure that time between packet and tone is within limits...
             */
             if ((elapsed.Seconds != 0) ||
-                (elapsed.Subseconds < CFE_TIME_TaskData.MinElapsed) ||
-                (elapsed.Subseconds > CFE_TIME_TaskData.MaxElapsed))
+                (elapsed.Subseconds < CFE_TIME_Global.MinElapsed) ||
+                (elapsed.Subseconds > CFE_TIME_Global.MaxElapsed))
             {
                 /*
                 ** Maintain count of tone vs data packet mis-matches...
                 */
-                CFE_TIME_TaskData.ToneMatchErrorCounter++;
+                CFE_TIME_Global.ToneMatchErrorCounter++;
             }
             else
             {
-                CFE_TIME_TaskData.ToneMatchCounter++;
+                CFE_TIME_Global.ToneMatchCounter++;
 
                 /*
                 ** Skip tone packet update if commanded into "flywheel" mode...
                 */
-                if (!CFE_TIME_TaskData.Forced2Fly)
+                if (!CFE_TIME_Global.Forced2Fly)
                 {
                     /*
                     ** Process "matching" tone and data packet...
@@ -914,9 +914,9 @@ void CFE_TIME_ToneUpdate(void)
     **    external data and a local h/w MET - so we don't need
     **    to worry about updating a local MET to external time.
     */
-    NextState->AtToneLatch = CFE_TIME_TaskData.ToneSignalLatch;
+    NextState->AtToneLatch = CFE_TIME_Global.ToneSignalLatch;
 
-    if (CFE_TIME_TaskData.ClockSource == CFE_TIME_SourceSelect_INTERNAL)
+    if (CFE_TIME_Global.ClockSource == CFE_TIME_SourceSelect_INTERNAL)
     {
         /*
         ** If we have been flywheeling, VirtualMET may be incorrect
@@ -924,7 +924,7 @@ void CFE_TIME_ToneUpdate(void)
         */
         if (NextState->ClockFlyState == CFE_TIME_FlywheelState_IS_FLY)
         {
-            CFE_TIME_TaskData.VirtualMET = Reference.CurrentMET.Seconds;
+            CFE_TIME_Global.VirtualMET = Reference.CurrentMET.Seconds;
         }
 
         /*
@@ -933,7 +933,7 @@ void CFE_TIME_ToneUpdate(void)
         ** Note: It is OK to not bother with reading the h/w MET
         **       since we sync'ed them at the moment of the tone.
         */
-        NextState->AtToneMET.Seconds = CFE_TIME_TaskData.VirtualMET;
+        NextState->AtToneMET.Seconds = CFE_TIME_Global.VirtualMET;
         NextState->AtToneMET.Subseconds = 0;
     }
     else
@@ -942,8 +942,8 @@ void CFE_TIME_ToneUpdate(void)
         ** Update "time at tone" with external MET data...
         */
         #if (CFE_PLATFORM_TIME_CFG_SRC_MET == true)
-        NextState->AtToneMET  = CFE_TIME_TaskData.PendingMET;
-        CFE_TIME_TaskData.VirtualMET = CFE_TIME_TaskData.PendingMET.Seconds;
+        NextState->AtToneMET  = CFE_TIME_Global.PendingMET;
+        CFE_TIME_Global.VirtualMET = CFE_TIME_Global.PendingMET.Seconds;
         #endif
 
         /*
@@ -960,10 +960,10 @@ void CFE_TIME_ToneUpdate(void)
         **    set time commands...
         */
         #if (CFE_PLATFORM_TIME_CFG_SRC_GPS == true)
-        NextState->AtToneMET.Seconds = CFE_TIME_TaskData.VirtualMET;
+        NextState->AtToneMET.Seconds = CFE_TIME_Global.VirtualMET;
         NextState->AtToneMET.Subseconds = 0;
-        NextState->AtToneSTCF  = CFE_TIME_TaskData.PendingSTCF;
-        NextState->AtToneLeapSeconds = CFE_TIME_TaskData.PendingLeaps;
+        NextState->AtToneSTCF  = CFE_TIME_Global.PendingSTCF;
+        NextState->AtToneLeapSeconds = CFE_TIME_Global.PendingLeaps;
         #endif
 
         /*
@@ -972,9 +972,9 @@ void CFE_TIME_ToneUpdate(void)
         **  STCF = external time at the tone - local MET at the tone
         */
         #if (CFE_PLATFORM_TIME_CFG_SRC_TIME == true)
-        NextState->AtToneMET.Seconds = CFE_TIME_TaskData.VirtualMET;
+        NextState->AtToneMET.Seconds = CFE_TIME_Global.VirtualMET;
         NextState->AtToneMET.Subseconds = 0;
-        NextState->AtToneSTCF = CFE_TIME_TaskData.PendingSTCF;
+        NextState->AtToneSTCF = CFE_TIME_Global.PendingSTCF;
         #endif
     }
 
@@ -985,7 +985,7 @@ void CFE_TIME_ToneUpdate(void)
     if (NextState->ClockFlyState == CFE_TIME_FlywheelState_IS_FLY)
     {
         NextState->ClockFlyState = CFE_TIME_FlywheelState_NO_FLY;
-        CFE_TIME_TaskData.ServerFlyState = CFE_TIME_FlywheelState_NO_FLY;
+        CFE_TIME_Global.ServerFlyState = CFE_TIME_FlywheelState_NO_FLY;
         NewFlywheelStatus = true;
     }
     #endif /* CFE_PLATFORM_TIME_CFG_SERVER */
@@ -994,22 +994,22 @@ void CFE_TIME_ToneUpdate(void)
     /*
     ** Set local clock latch time that matches the tone...
     */
-    NextState->AtToneLatch = CFE_TIME_TaskData.ToneSignalLatch;
+    NextState->AtToneLatch = CFE_TIME_Global.ToneSignalLatch;
 
     /*
     ** Time clients need all the "time at the tone" command data...
     */
-    NextState->AtToneMET   = CFE_TIME_TaskData.PendingMET;
-    NextState->AtToneSTCF  = CFE_TIME_TaskData.PendingSTCF;
-    NextState->AtToneLeapSeconds = CFE_TIME_TaskData.PendingLeaps;
+    NextState->AtToneMET   = CFE_TIME_Global.PendingMET;
+    NextState->AtToneSTCF  = CFE_TIME_Global.PendingSTCF;
+    NextState->AtToneLeapSeconds = CFE_TIME_Global.PendingLeaps;
 
     /*
     ** Convert the server clock state into its component parts...
     */
-    if (CFE_TIME_TaskData.PendingState == CFE_TIME_ClockState_INVALID)
+    if (CFE_TIME_Global.PendingState == CFE_TIME_ClockState_INVALID)
     {
         NextState->ClockSetState  = CFE_TIME_SetState_NOT_SET;
-        CFE_TIME_TaskData.ServerFlyState = CFE_TIME_FlywheelState_NO_FLY;
+        CFE_TIME_Global.ServerFlyState = CFE_TIME_FlywheelState_NO_FLY;
     }
     else
     {
@@ -1019,13 +1019,13 @@ void CFE_TIME_ToneUpdate(void)
         ** If the server is fly-wheel then the client must also
         **    report fly-wheel (even if it is not)...
         */
-        if (CFE_TIME_TaskData.PendingState == CFE_TIME_ClockState_FLYWHEEL)
+        if (CFE_TIME_Global.PendingState == CFE_TIME_ClockState_FLYWHEEL)
         {
-            CFE_TIME_TaskData.ServerFlyState = CFE_TIME_FlywheelState_IS_FLY;
+            CFE_TIME_Global.ServerFlyState = CFE_TIME_FlywheelState_IS_FLY;
         }
         else
         {
-            CFE_TIME_TaskData.ServerFlyState = CFE_TIME_FlywheelState_NO_FLY;
+            CFE_TIME_Global.ServerFlyState = CFE_TIME_FlywheelState_NO_FLY;
         }
     }
 
@@ -1101,15 +1101,15 @@ void CFE_TIME_Tone1HzISR(void)
     ** Compute elapsed time since the previous tone signal...
     */
     Result = CFE_TIME_Compare(ToneSignalLatch,
-                              CFE_TIME_TaskData.ToneSignalLatch);
+                              CFE_TIME_Global.ToneSignalLatch);
 
     if (Result == CFE_TIME_A_LT_B)
     {
         /*
         ** Local clock has rolled over...
         */
-        Elapsed = CFE_TIME_Subtract(CFE_TIME_TaskData.MaxLocalClock,
-                                    CFE_TIME_TaskData.ToneSignalLatch);
+        Elapsed = CFE_TIME_Subtract(CFE_TIME_Global.MaxLocalClock,
+                                    CFE_TIME_Global.ToneSignalLatch);
         Elapsed = CFE_TIME_Add(Elapsed, ToneSignalLatch);
     }
     else
@@ -1117,45 +1117,45 @@ void CFE_TIME_Tone1HzISR(void)
         /*
         ** Normal case...
         */
-        Elapsed = CFE_TIME_Subtract(ToneSignalLatch, CFE_TIME_TaskData.ToneSignalLatch);
+        Elapsed = CFE_TIME_Subtract(ToneSignalLatch, CFE_TIME_Global.ToneSignalLatch);
     }
 
     /*
     ** Verify that tone occurred ~1 second after previous tone...
     */
-    if (((Elapsed.Seconds == 1) && (Elapsed.Subseconds < CFE_TIME_TaskData.ToneOverLimit)) ||
-        ((Elapsed.Seconds == 0) && (Elapsed.Subseconds > CFE_TIME_TaskData.ToneUnderLimit)))
+    if (((Elapsed.Seconds == 1) && (Elapsed.Subseconds < CFE_TIME_Global.ToneOverLimit)) ||
+        ((Elapsed.Seconds == 0) && (Elapsed.Subseconds > CFE_TIME_Global.ToneUnderLimit)))
     {
         /*
         ** Maintain count of valid tone signal interrupts...
         **   (set to zero by reset command)
         */
-        CFE_TIME_TaskData.ToneIntCounter++;
+        CFE_TIME_Global.ToneIntCounter++;
 
         /* Since the tone occured ~1 seonds after the previous one, we
         ** can mark this tone as 'good'
         */
-        CFE_TIME_TaskData.IsToneGood = true;
+        CFE_TIME_Global.IsToneGood = true;
 
         /*
         ** Maintain virtual MET as count of valid tone signal interrupts...
         **   (not set to zero by reset command)
         */
         #if (CFE_PLATFORM_TIME_CFG_VIRTUAL == true)
-        CFE_TIME_TaskData.VirtualMET++;
+        CFE_TIME_Global.VirtualMET++;
         #endif
 
         /*
         ** Maintain virtual MET as count read from h/w MET register...
         */
         #if (CFE_PLATFORM_TIME_CFG_VIRTUAL != true)
-        OS_GetLocalMET(&CFE_TIME_TaskData.VirtualMET);
+        OS_GetLocalMET(&CFE_TIME_Global.VirtualMET);
         #endif
 
         /*
         ** Enable tone task (we can't send a SB message from here)...
         */
-        OS_BinSemGive(CFE_TIME_TaskData.ToneSemaphore);
+        OS_BinSemGive(CFE_TIME_Global.ToneSemaphore);
     }
     else
     {
@@ -1163,18 +1163,18 @@ void CFE_TIME_Tone1HzISR(void)
         ** Maintain count of invalid tone signal interrupts...
         **   (set to zero by reset command)
         */
-        CFE_TIME_TaskData.ToneIntErrorCounter++;
+        CFE_TIME_Global.ToneIntErrorCounter++;
         
         /* Since the tone didn't occur ~1 seonds after the previous one, we
         ** can mark this tone as 'not good'
         */
-        CFE_TIME_TaskData.IsToneGood = false;
+        CFE_TIME_Global.IsToneGood = false;
     }
 
     /*
     ** Save local time latch of most recent tone signal...
     */
-    CFE_TIME_TaskData.ToneSignalLatch = ToneSignalLatch;
+    CFE_TIME_Global.ToneSignalLatch = ToneSignalLatch;
     
     /* Notify registered time synchronization applications */
     CFE_TIME_NotifyTimeSynchApps();
@@ -1207,7 +1207,7 @@ void CFE_TIME_Tone1HzTask(void)
         /*
         ** Pend on semaphore given by tone ISR (above)...
         */
-        Result = OS_BinSemTake(CFE_TIME_TaskData.ToneSemaphore);
+        Result = OS_BinSemTake(CFE_TIME_Global.ToneSemaphore);
         
         /* Start Performance Monitoring */
         CFE_ES_PerfLogEntry(CFE_MISSION_TIME_TONE1HZTASK_PERF_ID);
@@ -1217,7 +1217,7 @@ void CFE_TIME_Tone1HzTask(void)
             /*
             ** Send tone signal command packet...
             */
-            CFE_SB_TransmitMsg(&CFE_TIME_TaskData.ToneSignalCmd.CmdHeader.Msg, false);
+            CFE_SB_TransmitMsg(&CFE_TIME_Global.ToneSignalCmd.CmdHeader.Msg, false);
 
 #if (CFE_MISSION_TIME_CFG_FAKE_TONE == true)
             /*
@@ -1225,13 +1225,13 @@ void CFE_TIME_Tone1HzTask(void)
             ** to send the tone to other time clients.
             ** (this is done by scheduler in non-fake mode)
             */
-            CFE_SB_TransmitMsg(&CFE_TIME_TaskData.ToneSendCmd.CmdHeader.Msg, false);
+            CFE_SB_TransmitMsg(&CFE_TIME_Global.ToneSendCmd.CmdHeader.Msg, false);
 #endif
 
             /*
             ** Maintain count of tone task wake-ups...
             */
-            CFE_TIME_TaskData.ToneTaskCounter++;
+            CFE_TIME_Global.ToneTaskCounter++;
         }
 
         /* Exit performance monitoring */
@@ -1273,21 +1273,21 @@ void CFE_TIME_Local1HzStateMachine(void)
     ** Apply 1Hz adjustment to STCF...
     */
     #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
-    if ((CFE_TIME_TaskData.OneHzAdjust.Seconds != 0) ||
-        (CFE_TIME_TaskData.OneHzAdjust.Subseconds != 0))
+    if ((CFE_TIME_Global.OneHzAdjust.Seconds != 0) ||
+        (CFE_TIME_Global.OneHzAdjust.Subseconds != 0))
     {
         CFE_TIME_SysTime_t NewSTCF;
         NextState = CFE_TIME_StartReferenceUpdate();
 
-        if (CFE_TIME_TaskData.OneHzDirection == CFE_TIME_AdjustDirection_ADD)
+        if (CFE_TIME_Global.OneHzDirection == CFE_TIME_AdjustDirection_ADD)
         {
             NewSTCF = CFE_TIME_Add(NextState->AtToneSTCF,
-                                CFE_TIME_TaskData.OneHzAdjust);
+                                CFE_TIME_Global.OneHzAdjust);
         }
         else
         {
             NewSTCF = CFE_TIME_Subtract(NextState->AtToneSTCF,
-                                     CFE_TIME_TaskData.OneHzAdjust);
+                                     CFE_TIME_Global.OneHzAdjust);
         }
 
         NextState->AtToneSTCF = NewSTCF;
@@ -1319,10 +1319,10 @@ void CFE_TIME_Local1HzStateMachine(void)
             */
             NextState->ClockFlyState = CFE_TIME_FlywheelState_IS_FLY;
             #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
-            CFE_TIME_TaskData.ServerFlyState = CFE_TIME_FlywheelState_IS_FLY;
+            CFE_TIME_Global.ServerFlyState = CFE_TIME_FlywheelState_IS_FLY;
             #endif
 
-            CFE_TIME_TaskData.AutoStartFly = true;
+            CFE_TIME_Global.AutoStartFly = true;
 
             /*
             ** Force anyone currently reading time to retry...
@@ -1375,12 +1375,12 @@ void CFE_TIME_Local1HzStateMachine(void)
 void CFE_TIME_Local1HzISR(void)
 {
 
-    CFE_TIME_TaskData.LocalIntCounter++;
+    CFE_TIME_Global.LocalIntCounter++;
 
     /*
     ** Enable 1Hz task (we can't send a SB message from here)...
     */
-    OS_BinSemGive(CFE_TIME_TaskData.LocalSemaphore);
+    OS_BinSemGive(CFE_TIME_Global.LocalSemaphore);
 
     return;
 
@@ -1410,7 +1410,7 @@ void CFE_TIME_Local1HzTask(void)
         /*
         ** Pend on the 1HZ semaphore (given by local 1Hz ISR)...
         */
-        Result = OS_BinSemTake(CFE_TIME_TaskData.LocalSemaphore);
+        Result = OS_BinSemTake(CFE_TIME_Global.LocalSemaphore);
                 
         /* Start Performance Monitoring */
         CFE_ES_PerfLogEntry(CFE_MISSION_TIME_LOCAL1HZTASK_PERF_ID);
@@ -1420,9 +1420,9 @@ void CFE_TIME_Local1HzTask(void)
             /*
             ** Send "info" event if we just started flywheel mode...
             */
-            if (CFE_TIME_TaskData.AutoStartFly)
+            if (CFE_TIME_Global.AutoStartFly)
             {
-                CFE_TIME_TaskData.AutoStartFly = false;
+                CFE_TIME_Global.AutoStartFly = false;
 
                 CFE_EVS_SendEvent(CFE_TIME_FLY_ON_EID,
                                   CFE_EVS_EventType_INFORMATION,
@@ -1434,9 +1434,9 @@ void CFE_TIME_Local1HzTask(void)
             ** This used to be optional in previous CFE versions, but it is now required
             ** as TIME subscribes to this itself to do state machine tasks.
             */
-            CFE_SB_TransmitMsg(&CFE_TIME_TaskData.Local1HzCmd.CmdHeader.Msg, false);
+            CFE_SB_TransmitMsg(&CFE_TIME_Global.Local1HzCmd.CmdHeader.Msg, false);
 
-            CFE_TIME_TaskData.LocalTaskCounter++;
+            CFE_TIME_Global.LocalTaskCounter++;
         }
 
         /* Exit performance monitoring */
@@ -1467,15 +1467,15 @@ void  CFE_TIME_NotifyTimeSynchApps(void)
     /*
     ** Notify applications that have requested tone synchronization
     */
-    if (CFE_TIME_TaskData.IsToneGood)
+    if (CFE_TIME_Global.IsToneGood)
     {
-        for (i=0; i < (sizeof(CFE_TIME_TaskData.SynchCallback) / sizeof(CFE_TIME_TaskData.SynchCallback[0])); ++i)
+        for (i=0; i < (sizeof(CFE_TIME_Global.SynchCallback) / sizeof(CFE_TIME_Global.SynchCallback[0])); ++i)
         {
             /* IMPORTANT:
              * Read the global pointer only once, since a thread could be unregistering
              * the same pointer in parallel with this action.
              */
-            Func = CFE_TIME_TaskData.SynchCallback[i].Ptr;
+            Func = CFE_TIME_Global.SynchCallback[i].Ptr;
             if (Func != NULL)
             {
                 Func();

--- a/fsw/cfe-core/src/time/cfe_time_utils.h
+++ b/fsw/cfe-core/src/time/cfe_time_utils.h
@@ -327,12 +327,12 @@ typedef struct
   */
   CFE_TIME_SynchCallbackRegEntry_t SynchCallback[CFE_PLATFORM_ES_MAX_APPLICATIONS];
 
-} CFE_TIME_TaskData_t;
+} CFE_TIME_Global_t;
 
 /*
 ** Time task global data (from "cfe_time_task.c")...
 */
-extern CFE_TIME_TaskData_t CFE_TIME_TaskData;
+extern CFE_TIME_Global_t CFE_TIME_Global;
 
 
 /*************************************************************************/
@@ -424,7 +424,7 @@ volatile CFE_TIME_ReferenceState_t *CFE_TIME_StartReferenceUpdate(void);
  */
 static inline void CFE_TIME_FinishReferenceUpdate(volatile CFE_TIME_ReferenceState_t *NextState)
 {
-    CFE_TIME_TaskData.LastVersionCounter = NextState->StateVersion;
+    CFE_TIME_Global.LastVersionCounter = NextState->StateVersion;
 }
 
 /*
@@ -434,8 +434,8 @@ static inline void CFE_TIME_FinishReferenceUpdate(volatile CFE_TIME_ReferenceSta
  */
 static inline volatile CFE_TIME_ReferenceState_t *CFE_TIME_GetReferenceState(void)
 {
-    return &CFE_TIME_TaskData.ReferenceState
-            [CFE_TIME_TaskData.LastVersionCounter & CFE_TIME_REFERENCE_BUF_MASK];
+    return &CFE_TIME_Global.ReferenceState
+            [CFE_TIME_Global.LastVersionCounter & CFE_TIME_REFERENCE_BUF_MASK];
 }
 
 /*

--- a/fsw/cfe-core/unit-test/evs_UT.c
+++ b/fsw/cfe-core/unit-test/evs_UT.c
@@ -365,10 +365,10 @@ void Test_Init(void)
     /* Test early initialization, clearing the event log (log mode path) */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetResetType), 1, -1);
-    CFE_EVS_GlobalData.EVS_LogPtr->LogMode = CFE_EVS_LogMode_OVERWRITE +
+    CFE_EVS_Global.EVS_LogPtr->LogMode = CFE_EVS_LogMode_OVERWRITE +
                                              CFE_EVS_LogMode_DISCARD + 1;
-    CFE_EVS_GlobalData.EVS_LogPtr->LogFullFlag = false;
-    CFE_EVS_GlobalData.EVS_LogPtr->Next = CFE_PLATFORM_EVS_LOG_MAX - 1;
+    CFE_EVS_Global.EVS_LogPtr->LogFullFlag = false;
+    CFE_EVS_Global.EVS_LogPtr->Next = CFE_PLATFORM_EVS_LOG_MAX - 1;
     CFE_EVS_EarlyInit();
     UT_Report(__FILE__, __LINE__,
               UT_SyslogIsInHistory(EVS_SYSLOG_MSGS[5]),
@@ -378,9 +378,9 @@ void Test_Init(void)
     /* Test early initialization, clearing the event log (log full path) */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetResetType), 1, -1);
-    CFE_EVS_GlobalData.EVS_LogPtr->LogMode = CFE_EVS_LogMode_DISCARD;
-    CFE_EVS_GlobalData.EVS_LogPtr->LogFullFlag = 2;
-    CFE_EVS_GlobalData.EVS_LogPtr->Next = CFE_PLATFORM_EVS_LOG_MAX - 1;
+    CFE_EVS_Global.EVS_LogPtr->LogMode = CFE_EVS_LogMode_DISCARD;
+    CFE_EVS_Global.EVS_LogPtr->LogFullFlag = 2;
+    CFE_EVS_Global.EVS_LogPtr->Next = CFE_PLATFORM_EVS_LOG_MAX - 1;
     CFE_EVS_EarlyInit();
     UT_Report(__FILE__, __LINE__,
               UT_SyslogIsInHistory(EVS_SYSLOG_MSGS[5]),
@@ -390,9 +390,9 @@ void Test_Init(void)
     /* Test early initialization, clearing the event log (next log path) */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetResetType), 1, -1);
-    CFE_EVS_GlobalData.EVS_LogPtr->LogMode = CFE_EVS_LogMode_OVERWRITE;
-    CFE_EVS_GlobalData.EVS_LogPtr->LogFullFlag = true;
-    CFE_EVS_GlobalData.EVS_LogPtr->Next = CFE_PLATFORM_EVS_LOG_MAX;
+    CFE_EVS_Global.EVS_LogPtr->LogMode = CFE_EVS_LogMode_OVERWRITE;
+    CFE_EVS_Global.EVS_LogPtr->LogFullFlag = true;
+    CFE_EVS_Global.EVS_LogPtr->Next = CFE_PLATFORM_EVS_LOG_MAX;
     CFE_EVS_EarlyInit();
     UT_Report(__FILE__, __LINE__,
               UT_SyslogIsInHistory(EVS_SYSLOG_MSGS[5]),
@@ -696,8 +696,8 @@ void Test_FilterRegistration(void)
 
     UtPrintf("Begin Test Filter Registration");
 
-    CFE_EVS_GlobalData.EVS_AppID = AppID;
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
+    CFE_EVS_Global.EVS_AppID = AppID;
+    CFE_EVS_Global.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
 
     /* Test filter registration using an invalid filter option */
     UT_InitData();
@@ -938,7 +938,7 @@ void Test_Format(void)
 
     UtPrintf("Begin Test Format");
 
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
+    CFE_EVS_Global.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
 
     /* Enable DEBUG message output */
     UT_InitData();
@@ -1083,7 +1083,7 @@ void Test_Ports(void)
 
     UtPrintf("Begin Test Ports");
 
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
+    CFE_EVS_Global.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
 
     /* Test enabling all ports; reports implicitly via port output */
     UT_InitData();
@@ -1225,11 +1225,11 @@ void Test_Logging(void)
 
     UtPrintf("Begin Test Logging");
 
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
+    CFE_EVS_Global.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
 
     /* Test setting the logging mode with logging disabled */
     UT_InitData();
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.LogEnabled = false;
+    CFE_EVS_Global.EVS_TlmPkt.Payload.LogEnabled = false;
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.modecmd.Payload.LogMode = 0xff;
     UT_EVS_DoDispatchCheckEvents(&CmdBuf.modecmd, sizeof(CmdBuf.modecmd),
@@ -1241,13 +1241,13 @@ void Test_Logging(void)
               "Set log mode command: event log disabled");
 
     /* Re-enable logging and set conditions to allow complete code coverage */
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.LogEnabled = true;
+    CFE_EVS_Global.EVS_TlmPkt.Payload.LogEnabled = true;
     UT_SetSizeofESResetArea(sizeof(CFE_ES_ResetData_t));
     UT_SetDeferredRetcode(UT_KEY(OS_MutSemCreate), 1, OS_SUCCESS);
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetResetType), 1, CFE_PSP_RST_TYPE_POWERON);
     CFE_PSP_GetResetArea(&TempAddr, &resetAreaSize);
     CFE_EVS_ResetDataPtr = (CFE_ES_ResetData_t *)TempAddr;
-    CFE_EVS_GlobalData.EVS_LogPtr = &CFE_EVS_ResetDataPtr->EVS_Log;
+    CFE_EVS_Global.EVS_LogPtr = &CFE_EVS_ResetDataPtr->EVS_Log;
 
     /* Test setting the logging mode using an invalid mode */
     UT_InitData();
@@ -1285,8 +1285,8 @@ void Test_Logging(void)
 
     CFE_EVS_SendEvent(0, CFE_EVS_EventType_INFORMATION, "Log overfill event discard");
     UT_Report(__FILE__, __LINE__,
-              CFE_EVS_GlobalData.EVS_LogPtr->LogFullFlag == true &&
-              CFE_EVS_GlobalData.EVS_LogPtr->LogMode == CFE_EVS_LogMode_DISCARD,
+              CFE_EVS_Global.EVS_LogPtr->LogFullFlag == true &&
+              CFE_EVS_Global.EVS_LogPtr->LogMode == CFE_EVS_LogMode_DISCARD,
               "CFE_EVS_SendEvent",
               "Log overfill event (discard mode)");
 
@@ -1298,14 +1298,14 @@ void Test_Logging(void)
                &UT_EVS_EventBuf);
     CFE_EVS_SendEvent(0, CFE_EVS_EventType_INFORMATION, "Log overfill event overwrite");
     UT_Report(__FILE__, __LINE__,
-              CFE_EVS_GlobalData.EVS_LogPtr->LogFullFlag == true &&
-              CFE_EVS_GlobalData.EVS_LogPtr->LogMode == CFE_EVS_LogMode_OVERWRITE,
+              CFE_EVS_Global.EVS_LogPtr->LogFullFlag == true &&
+              CFE_EVS_Global.EVS_LogPtr->LogMode == CFE_EVS_LogMode_OVERWRITE,
               "CFE_EVS_SetLogModeCmd",
               "Log overfill event (overwrite mode)");
 
     /* Test writing to the log while it is disabled */
     UT_InitData();
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.LogEnabled = false;
+    CFE_EVS_Global.EVS_TlmPkt.Payload.LogEnabled = false;
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_EVS_DoDispatchCheckEvents(&CmdBuf.logfilecmd, sizeof(CmdBuf.logfilecmd),
                UT_TPID_CFE_EVS_CMD_WRITE_LOG_DATA_FILE_CC,
@@ -1337,12 +1337,12 @@ void Test_Logging(void)
 
     /* Clear log for next test */
     UT_InitData();
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.LogEnabled = true;
+    CFE_EVS_Global.EVS_TlmPkt.Payload.LogEnabled = true;
     UT_EVS_DoDispatchCheckEvents(&CmdBuf.cmd, sizeof(CmdBuf.cmd),
                UT_TPID_CFE_EVS_CMD_CLEAR_LOG_CC,
                &UT_EVS_EventBuf);
     UT_Report(__FILE__, __LINE__,
-              CFE_EVS_GlobalData.EVS_LogPtr->LogFullFlag == false,
+              CFE_EVS_Global.EVS_LogPtr->LogFullFlag == false,
               "EVS_ClearLog",
               "Clear log");
 
@@ -1354,7 +1354,7 @@ void Test_Logging(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetResetType), 1, CFE_PSP_RST_TYPE_POWERON);
     CFE_PSP_GetResetArea(&TempAddr, &resetAreaSize);
     CFE_EVS_ResetDataPtr = (CFE_ES_ResetData_t *)TempAddr;
-    CFE_EVS_GlobalData.EVS_LogPtr = &CFE_EVS_ResetDataPtr->EVS_Log;
+    CFE_EVS_Global.EVS_LogPtr = &CFE_EVS_ResetDataPtr->EVS_Log;
     CmdBuf.modecmd.Payload.LogMode = CFE_EVS_LogMode_OVERWRITE;
     UT_Report(__FILE__, __LINE__,
               CFE_EVS_SetLogModeCmd(&CmdBuf.modecmd) == CFE_SUCCESS,
@@ -1385,7 +1385,7 @@ void Test_Logging(void)
     /* Test successfully writing all log entries */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(OS_MutSemCreate), 1, OS_SUCCESS);
-    CFE_EVS_GlobalData.EVS_LogPtr->LogCount = CFE_PLATFORM_EVS_LOG_MAX;
+    CFE_EVS_Global.EVS_LogPtr->LogCount = CFE_PLATFORM_EVS_LOG_MAX;
     UT_Report(__FILE__, __LINE__,
               CFE_EVS_WriteLogDataFileCmd(&CmdBuf.logfilecmd) == CFE_SUCCESS,
               "CFE_EVS_WriteLogDataFileCmd",
@@ -1395,7 +1395,7 @@ void Test_Logging(void)
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(OS_MutSemCreate), 1, OS_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(OS_write), OS_ERROR);
-    CFE_EVS_GlobalData.EVS_LogPtr->LogCount = CFE_PLATFORM_EVS_LOG_MAX;
+    CFE_EVS_Global.EVS_LogPtr->LogCount = CFE_PLATFORM_EVS_LOG_MAX;
     UT_Report(__FILE__, __LINE__,
               CFE_EVS_WriteLogDataFileCmd(&CmdBuf.logfilecmd) != CFE_SUCCESS,
               "CFE_EVS_WriteLogDataFileCmd",
@@ -1440,7 +1440,7 @@ void Test_WriteApp(void)
 
     UtPrintf("Begin Test Write App");
 
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
+    CFE_EVS_Global.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
 
     /* Enable DEBUG message output */
     UT_InitData();
@@ -1545,7 +1545,7 @@ void Test_BadAppCmd(void)
 
     UtPrintf("Begin Test Bad App Command");
 
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
+    CFE_EVS_Global.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
 
     UT_InitData();
 
@@ -1962,7 +1962,7 @@ void Test_EventCmd(void)
 
     UtPrintf("Begin Test Event Command");
 
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
+    CFE_EVS_Global.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
 
     UT_InitData();
 
@@ -2205,7 +2205,7 @@ void Test_FilterCmd(void)
 
     UtPrintf("Begin Test Filter Command");
 
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
+    CFE_EVS_Global.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
 
     UT_InitData();
 
@@ -2649,7 +2649,7 @@ void Test_InvalidCmd(void)
 
     /* Test invalid command length with write log data command */
     UT_InitData();
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.LogEnabled = true;
+    CFE_EVS_Global.EVS_TlmPkt.Payload.LogEnabled = true;
     UT_EVS_DoDispatchCheckEvents(&cmd, 0, 
                UT_TPID_CFE_EVS_CMD_WRITE_LOG_DATA_FILE_CC,
                &UT_EVS_EventBuf);
@@ -2706,8 +2706,8 @@ void Test_Misc(void)
     UtPrintf("Begin Test Miscellaneous");
 
     memset(&PktBuf, 0, sizeof(PktBuf));
-    CFE_EVS_GlobalData.EVS_AppID = AppID;
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
+    CFE_EVS_Global.EVS_AppID = AppID;
+    CFE_EVS_Global.EVS_TlmPkt.Payload.MessageFormatMode = CFE_EVS_MsgFormat_LONG;
 
     /* Test successful log data file write */
     UT_InitData();
@@ -2731,7 +2731,7 @@ void Test_Misc(void)
 
     /* Test housekeeping report with log enabled */
     UT_InitData();
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.LogEnabled = true;
+    CFE_EVS_Global.EVS_TlmPkt.Payload.LogEnabled = true;
     HK_SnapshotData.Count = 0;
     UT_SetHookFunction(UT_KEY(CFE_SB_TransmitMsg), UT_SoftwareBusSnapshotHook, &HK_SnapshotData);
     UT_CallTaskPipe(CFE_EVS_ProcessCommandPacket, &PktBuf.msg, sizeof(PktBuf.cmd),
@@ -2757,7 +2757,7 @@ void Test_Misc(void)
 
     /* Test housekeeping report with log disabled */
     UT_InitData();
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.LogEnabled = false;
+    CFE_EVS_Global.EVS_TlmPkt.Payload.LogEnabled = false;
     HK_SnapshotData.Count = 0;
     UT_SetHookFunction(UT_KEY(CFE_SB_TransmitMsg), UT_SoftwareBusSnapshotHook, &HK_SnapshotData);
     UT_CallTaskPipe(CFE_EVS_ProcessCommandPacket, &PktBuf.msg, sizeof(PktBuf.cmd),
@@ -2771,12 +2771,12 @@ void Test_Misc(void)
      * at their maximum allowed values
      */
     UT_InitData();
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageSendCounter =
+    CFE_EVS_Global.EVS_TlmPkt.Payload.MessageSendCounter =
         CFE_EVS_MAX_EVENT_SEND_COUNT;
     AppDataPtr->EventCount = CFE_EVS_MAX_EVENT_SEND_COUNT;
     EVS_SendEvent(0, 0, "Max Event Count");
     UT_Report(__FILE__, __LINE__,
-              CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageSendCounter ==
+              CFE_EVS_Global.EVS_TlmPkt.Payload.MessageSendCounter ==
                   CFE_EVS_MAX_EVENT_SEND_COUNT &&
               AppDataPtr->EventCount ==
                   CFE_EVS_MAX_EVENT_SEND_COUNT,
@@ -2794,14 +2794,14 @@ void Test_Misc(void)
     }
 
     msg[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH] = '\0';
-    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageTruncCounter = 0;
+    CFE_EVS_Global.EVS_TlmPkt.Payload.MessageTruncCounter = 0;
     EVS_AppDataSetUsed(AppDataPtr, AppID);
     AppDataPtr->ActiveFlag = true;
     AppDataPtr->EventTypesActiveFlag |=
         CFE_EVS_INFORMATION_BIT;
     EVS_SendEvent(0, CFE_EVS_EventType_INFORMATION, msg);
     UT_Report(__FILE__, __LINE__,
-              CFE_EVS_GlobalData.EVS_TlmPkt.Payload.MessageTruncCounter == 1,
+              CFE_EVS_Global.EVS_TlmPkt.Payload.MessageTruncCounter == 1,
               "EVS_SendEvent",
               "Maximum message length exceeded");
 }

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -234,7 +234,7 @@ void Test_SB_AppInit_EVSSendEvtFail(void)
 
     EVTCNT(4);
 
-    TEARDOWN(CFE_SB_DeletePipe(CFE_SB.CmdPipe));
+    TEARDOWN(CFE_SB_DeletePipe(CFE_SB_Global.CmdPipe));
 
 } /* end Test_SB_AppInit_EVSSendEvtFail */
 
@@ -267,7 +267,7 @@ void Test_SB_AppInit_Sub1Fail(void)
 
     EVTSENT(CFE_SB_DEST_BLK_ERR_EID);
 
-    TEARDOWN(CFE_SB_DeletePipe(CFE_SB.CmdPipe));
+    TEARDOWN(CFE_SB_DeletePipe(CFE_SB_Global.CmdPipe));
 
 } /* end Test_SB_AppInit_Sub1Fail */
 
@@ -283,7 +283,7 @@ void Test_SB_AppInit_Sub2Fail(void)
 
     EVTSENT(CFE_SB_DEST_BLK_ERR_EID);
 
-    TEARDOWN(CFE_SB_DeletePipe(CFE_SB.CmdPipe));
+    TEARDOWN(CFE_SB_DeletePipe(CFE_SB_Global.CmdPipe));
 
 } /* end Test_SB_AppInit_Sub2Fail */
 
@@ -300,7 +300,7 @@ void Test_SB_AppInit_GetPoolFail(void)
 
     EVTCNT(4);
 
-    TEARDOWN(CFE_SB_DeletePipe(CFE_SB.CmdPipe));
+    TEARDOWN(CFE_SB_DeletePipe(CFE_SB_Global.CmdPipe));
 
 } /* end Test_SB_AppInit_GetPoolFail */
 
@@ -317,7 +317,7 @@ void Test_SB_AppInit_PutPoolFail(void)
 
     EVTCNT(4);
 
-    TEARDOWN(CFE_SB_DeletePipe(CFE_SB.CmdPipe));
+    TEARDOWN(CFE_SB_DeletePipe(CFE_SB_Global.CmdPipe));
 
 } /* end Test_SB_AppInit_PutPoolFail */
 
@@ -344,7 +344,7 @@ void Test_SB_Main_RcvErr(void)
 
     EVTSENT(CFE_SB_Q_RD_ERR_EID);
 
-    TEARDOWN(CFE_SB_DeletePipe(CFE_SB.CmdPipe));
+    TEARDOWN(CFE_SB_DeletePipe(CFE_SB_Global.CmdPipe));
 
 } /* end Test_SB_Main_RcvErr */
 
@@ -358,7 +358,7 @@ void Test_SB_Main_InitErr(void)
 
     EVTCNT(4);
 
-    TEARDOWN(CFE_SB_DeletePipe(CFE_SB.CmdPipe));
+    TEARDOWN(CFE_SB_DeletePipe(CFE_SB_Global.CmdPipe));
 
 } /* end Test_SB_Main_InitErr */
 
@@ -471,7 +471,7 @@ void Test_SB_Cmds_Stats(void)
 
     /* For internal TransmitMsg call */
     MsgId = CFE_SB_ValueToMsgId(CFE_SB_STATS_TLM_MID);
-    Size = sizeof(CFE_SB.StatTlmMsg);
+    Size = sizeof(CFE_SB_Global.StatTlmMsg);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
 
@@ -526,7 +526,7 @@ void Test_SB_Cmds_RoutingInfoDef(void)
 
     EVTSENT(CFE_SB_SND_RTG_EID);
 
-    TEARDOWN(CFE_SB_DeletePipe(CFE_SB.CmdPipe));
+    TEARDOWN(CFE_SB_DeletePipe(CFE_SB_Global.CmdPipe));
 
 } /* end Test_SB_Cmds_RoutingInfoDef */
 
@@ -629,7 +629,7 @@ void Test_SB_Cmds_RoutingInfoWriteFail(void)
 
     EVTSENT(CFE_SB_FILEWRITE_ERR_EID);
 
-    TEARDOWN(CFE_SB_DeletePipe(CFE_SB.CmdPipe));
+    TEARDOWN(CFE_SB_DeletePipe(CFE_SB_Global.CmdPipe));
 
 } /* end Test_SB_Cmds_RoutingInfoWriteFail */
 
@@ -1274,7 +1274,7 @@ void Test_SB_Cmds_SendHK(void)
 
     /* For internal TransmitMsg call */
     MsgIdCmd = CFE_SB_ValueToMsgId(CFE_SB_HK_TLM_MID);
-    Size = sizeof(CFE_SB.HKTlmMsg);
+    Size = sizeof(CFE_SB_Global.HKTlmMsg);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
 
@@ -1338,7 +1338,7 @@ void Test_SB_Cmds_SendPrevSubs(void)
 
     /* For 3 internal TransmitMsg calls */
     MsgIdCmd = CFE_SB_ValueToMsgId(CFE_SB_ALLSUBS_TLM_MID);
-    Size = sizeof(CFE_SB.PrevSubMsg);
+    Size = sizeof(CFE_SB_Global.PrevSubMsg);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
@@ -1380,7 +1380,7 @@ void Test_SB_Cmds_SendPrevSubs(void)
 
     /* For 3 internal TransmitMsg calls */
     MsgIdCmd = CFE_SB_ValueToMsgId(CFE_SB_ALLSUBS_TLM_MID);
-    Size = sizeof(CFE_SB.PrevSubMsg);
+    Size = sizeof(CFE_SB_Global.PrevSubMsg);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
@@ -2001,8 +2001,8 @@ void Test_GetPipeIdByName(void)
 
     UT_SetDataBuffer(
         UT_KEY(OS_QueueGetIdByName),
-        &(CFE_SB.PipeTbl[0].SysQueueId),
-        sizeof(CFE_SB.PipeTbl[0].SysQueueId),
+        &(CFE_SB_Global.PipeTbl[0].SysQueueId),
+        sizeof(CFE_SB_Global.PipeTbl[0].SysQueueId),
         false);
 
     ASSERT(CFE_SB_GetPipeIdByName(&PipeIdOut, "TestPipe1"));
@@ -2377,7 +2377,7 @@ void Test_Subscribe_SendPrevSubs(void)
 
     /* For internal TransmitMsg call */
     MsgIdCmd = CFE_SB_ValueToMsgId(CFE_SB_ALLSUBS_TLM_MID);
-    Size = sizeof(CFE_SB.PrevSubMsg);
+    Size = sizeof(CFE_SB_Global.PrevSubMsg);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
 
@@ -2439,7 +2439,7 @@ void Test_Subscribe_SubscriptionReporting(void)
     SETUP(CFE_SB_Unsubscribe(MsgId, PipeId));
 
     /* Subscribe to message: LOCAL */
-    ASSERT(CFE_SB_SubscribeFull(MsgId, PipeId, Quality, CFE_PLATFORM_SB_DEFAULT_MSG_LIMIT, CFE_SB_LOCAL));
+    ASSERT(CFE_SB_SubscribeFull(MsgId, PipeId, Quality, CFE_PLATFORM_SB_DEFAULT_MSG_LIMIT, CFE_SB_MSG_LOCAL));
 
     EVTCNT(6);
 
@@ -2569,7 +2569,7 @@ void Test_Unsubscribe_InvalParam(void)
     ASSERT(CFE_ES_GetAppID(&CallerId));
 
     /* Perform test using a bad scope value */
-    ASSERT_EQ(CFE_SB_UnsubscribeFull(SB_UT_FIRST_VALID_MID, TestPipe, CFE_SB_LOCAL + 1, CallerId), CFE_SB_BAD_ARGUMENT);
+    ASSERT_EQ(CFE_SB_UnsubscribeFull(SB_UT_FIRST_VALID_MID, TestPipe, CFE_SB_MSG_LOCAL + 1, CallerId), CFE_SB_BAD_ARGUMENT);
 
     /* Perform test using an invalid pipe ID for branch path coverage.
      * This situation cannot happen in normal circumstances since the
@@ -3124,19 +3124,19 @@ void Test_TransmitMsg_ZeroCopyGetPtr(void)
     /* Increase the peak memory and buffers in use above the expected values in
      * order to exercise branch paths
      */
-    CFE_SB.StatTlmMsg.Payload.MemInUse = 0;
-    CFE_SB.StatTlmMsg.Payload.PeakMemInUse = sizeof(CFE_SB_ZeroCopyD_t) + MsgSize +
+    CFE_SB_Global.StatTlmMsg.Payload.MemInUse = 0;
+    CFE_SB_Global.StatTlmMsg.Payload.PeakMemInUse = sizeof(CFE_SB_ZeroCopyD_t) + MsgSize +
                                               sizeof(CFE_SB_BufferD_t) + 1;
-    CFE_SB.StatTlmMsg.Payload.PeakSBBuffersInUse =
-      CFE_SB.StatTlmMsg.Payload.SBBuffersInUse + 2;
+    CFE_SB_Global.StatTlmMsg.Payload.PeakSBBuffersInUse =
+      CFE_SB_Global.StatTlmMsg.Payload.SBBuffersInUse + 2;
     ASSERT_TRUE((cpuaddr) CFE_SB_ZeroCopyGetPtr(MsgSize, &ZeroCpyBufHndl) != (cpuaddr) NULL);
 
-    ASSERT_EQ(CFE_SB.StatTlmMsg.Payload.PeakMemInUse, sizeof(CFE_SB_ZeroCopyD_t) + MsgSize +
+    ASSERT_EQ(CFE_SB_Global.StatTlmMsg.Payload.PeakMemInUse, sizeof(CFE_SB_ZeroCopyD_t) + MsgSize +
         sizeof(CFE_SB_BufferD_t) + 1);
-    ASSERT_EQ(CFE_SB.StatTlmMsg.Payload.MemInUse, sizeof(CFE_SB_ZeroCopyD_t) + MsgSize +
+    ASSERT_EQ(CFE_SB_Global.StatTlmMsg.Payload.MemInUse, sizeof(CFE_SB_ZeroCopyD_t) + MsgSize +
         sizeof(CFE_SB_BufferD_t));
 
-    ASSERT_EQ(CFE_SB.StatTlmMsg.Payload.PeakSBBuffersInUse, CFE_SB.StatTlmMsg.Payload.SBBuffersInUse + 1);
+    ASSERT_EQ(CFE_SB_Global.StatTlmMsg.Payload.PeakSBBuffersInUse, CFE_SB_Global.StatTlmMsg.Payload.SBBuffersInUse + 1);
 
     EVTCNT(0);
 
@@ -3581,10 +3581,10 @@ void Test_CleanupApp_API(void)
     CFE_SB_ZeroCopyGetPtr(PipeDepth, &ZeroCpyBufHndl);
 
     /* Set second application ID to provide complete branch path coverage */
-    CFE_SB.PipeTbl[1].PipeId = SB_UT_PIPEID_1;
-    CFE_SB.PipeTbl[1].AppId = AppID;
+    CFE_SB_Global.PipeTbl[1].PipeId = SB_UT_PIPEID_1;
+    CFE_SB_Global.PipeTbl[1].AppId = AppID;
 
-    ASSERT_TRUE(CFE_SB.ZeroCopyTail != NULL);
+    ASSERT_TRUE(CFE_SB_Global.ZeroCopyTail != NULL);
 
     /* Attempt with a bad application ID first in order to get full branch path
      * coverage in CFE_SB_ZeroCopyReleaseAppId
@@ -3594,7 +3594,7 @@ void Test_CleanupApp_API(void)
     /* Attempt again with a valid application ID */
     CFE_SB_CleanUpApp(AppID);
 
-    ASSERT_TRUE(CFE_SB.ZeroCopyTail == NULL);
+    ASSERT_TRUE(CFE_SB_Global.ZeroCopyTail == NULL);
 
     EVTCNT(2);
 
@@ -3858,7 +3858,7 @@ void Test_ReqToSendEvent_ErrLogic(void)
      * the specified task
      */
     CFE_ES_GetTaskID(&TaskId);
-    CFE_SB.StopRecurseFlags[0] = 0x0000;
+    CFE_SB_Global.StopRecurseFlags[0] = 0x0000;
     ASSERT_EQ(CFE_SB_RequestToSendEvent(TaskId, Bit), CFE_SB_GRANTED);
 
     /* Call the function a second time; the result should indicate that the
@@ -3891,18 +3891,18 @@ void Test_CFE_SB_Buffers(void)
 
     CFE_SB_BufferD_t *bd;
 
-    CFE_SB.StatTlmMsg.Payload.MemInUse = 0;
-    CFE_SB.StatTlmMsg.Payload.PeakMemInUse = sizeof(CFE_SB_BufferD_t) * 4;
+    CFE_SB_Global.StatTlmMsg.Payload.MemInUse = 0;
+    CFE_SB_Global.StatTlmMsg.Payload.PeakMemInUse = sizeof(CFE_SB_BufferD_t) * 4;
     bd = CFE_SB_GetBufferFromPool(SB_UT_FIRST_VALID_MID, 0);
 
-    ASSERT_EQ(CFE_SB.StatTlmMsg.Payload.PeakMemInUse, sizeof(CFE_SB_BufferD_t) * 4);
+    ASSERT_EQ(CFE_SB_Global.StatTlmMsg.Payload.PeakMemInUse, sizeof(CFE_SB_BufferD_t) * 4);
 
     EVTCNT(0);
 
-    ExpRtn = CFE_SB.StatTlmMsg.Payload.SBBuffersInUse;
+    ExpRtn = CFE_SB_Global.StatTlmMsg.Payload.SBBuffersInUse;
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_PutPoolBuf), 1, -1);
     CFE_SB_ReturnBufferToPool(bd);
-    ASSERT_EQ(CFE_SB.StatTlmMsg.Payload.SBBuffersInUse, ExpRtn);
+    ASSERT_EQ(CFE_SB_Global.StatTlmMsg.Payload.SBBuffersInUse, ExpRtn);
 
     EVTCNT(0);
 
@@ -3913,10 +3913,10 @@ void Test_CFE_SB_Buffers(void)
     EVTCNT(0);
 
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_PutPoolBuf), 1, -1);
-    CFE_SB.StatTlmMsg.Payload.MemInUse = 0;
+    CFE_SB_Global.StatTlmMsg.Payload.MemInUse = 0;
     CFE_SB_PutDestinationBlk((CFE_SB_DestinationD_t *) bd);
 
-    ASSERT_EQ(CFE_SB.StatTlmMsg.Payload.MemInUse, 0);
+    ASSERT_EQ(CFE_SB_Global.StatTlmMsg.Payload.MemInUse, 0);
 
     EVTCNT(0);
 
@@ -3975,7 +3975,7 @@ void Test_SB_TransmitMsgPaths_Nominal(void)
 
     /* For internal send message call */
     MsgId = CFE_SB_ValueToMsgId(CFE_SB_HK_TLM_MID);
-    Size = sizeof(CFE_SB.HKTlmMsg);
+    Size = sizeof(CFE_SB_Global.HKTlmMsg);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
 
@@ -3984,21 +3984,21 @@ void Test_SB_TransmitMsgPaths_Nominal(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
 
     /* Repress sending the no subscriptions event and process request */
-    CFE_SB.HKTlmMsg.Payload.NoSubscribersCounter = 0;
-    CFE_SB.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_SEND_NO_SUBS_EID_BIT);
+    CFE_SB_Global.HKTlmMsg.Payload.NoSubscribersCounter = 0;
+    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_SEND_NO_SUBS_EID_BIT);
     CFE_SB_ProcessCmdPipePkt(&Housekeeping.SBBuf);
 
     /* The no subs event should not be in history but count should increment */
     ASSERT_TRUE(!UT_EventIsInHistory(CFE_SB_SEND_NO_SUBS_EID));
-    ASSERT_EQ(CFE_SB.HKTlmMsg.Payload.NoSubscribersCounter, 1);
+    ASSERT_EQ(CFE_SB_Global.HKTlmMsg.Payload.NoSubscribersCounter, 1);
 
     /* Repress get buffer error */
-    CFE_SB.HKTlmMsg.Payload.MsgSendErrorCounter = 0;
-    CFE_SB.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_GET_BUF_ERR_EID_BIT);
+    CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter = 0;
+    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_GET_BUF_ERR_EID_BIT);
 
     /* For internal send message call */
     MsgId = CFE_SB_ValueToMsgId(CFE_SB_HK_TLM_MID);
-    Size = sizeof(CFE_SB.HKTlmMsg);
+    Size = sizeof(CFE_SB_Global.HKTlmMsg);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
 
@@ -4008,13 +4008,13 @@ void Test_SB_TransmitMsgPaths_Nominal(void)
 
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetPoolBuf), 1, CFE_ES_ERR_MEM_BLOCK_SIZE);
     CFE_SB_ProcessCmdPipePkt(&Housekeeping.SBBuf);
-    ASSERT_EQ(CFE_SB.HKTlmMsg.Payload.MsgSendErrorCounter, 0);
+    ASSERT_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter, 0);
 
     ASSERT_TRUE(!UT_EventIsInHistory(CFE_SB_GET_BUF_ERR_EID));
 
     EVTCNT(0);
 
-    CFE_SB.StopRecurseFlags[1] = 0;
+    CFE_SB_Global.StopRecurseFlags[1] = 0;
 
     /* Create a message ID with the command bit set and disable reporting */
     MsgId = SB_UT_CMD_MID;
@@ -4063,9 +4063,9 @@ void Test_SB_TransmitMsgPaths_LimitErr(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
 
-    CFE_SB.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_MSGID_LIM_ERR_EID_BIT);
+    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_MSGID_LIM_ERR_EID_BIT);
     ASSERT(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
-    CFE_SB.StopRecurseFlags[1] = 0;
+    CFE_SB_Global.StopRecurseFlags[1] = 0;
 
     ASSERT_TRUE(!UT_EventIsInHistory(CFE_SB_MSGID_LIM_ERR_EID));
 
@@ -4101,9 +4101,9 @@ void Test_SB_TransmitMsgPaths_FullErr(void)
 
     /* Tell the QueuePut stub to return OS_QUEUE_FULL on its next call */
     UT_SetDeferredRetcode(UT_KEY(OS_QueuePut), 1, OS_QUEUE_FULL);
-    CFE_SB.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_Q_FULL_ERR_EID_BIT);
+    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_Q_FULL_ERR_EID_BIT);
     ASSERT(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
-    CFE_SB.StopRecurseFlags[1] = 0;
+    CFE_SB_Global.StopRecurseFlags[1] = 0;
 
     ASSERT_TRUE(!UT_EventIsInHistory(CFE_SB_Q_FULL_ERR_EID_BIT));
 
@@ -4131,9 +4131,9 @@ void Test_SB_TransmitMsgPaths_WriteErr(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
 
-    CFE_SB.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_Q_WR_ERR_EID_BIT);
+    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_Q_WR_ERR_EID_BIT);
     ASSERT(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
-    CFE_SB.StopRecurseFlags[1] = 0;
+    CFE_SB_Global.StopRecurseFlags[1] = 0;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);

--- a/fsw/cfe-core/unit-test/tbl_UT.c
+++ b/fsw/cfe-core/unit-test/tbl_UT.c
@@ -44,7 +44,7 @@
 ** External global variables
 */
 
-extern CFE_TBL_TaskData_t CFE_TBL_TaskData;
+extern CFE_TBL_Global_t CFE_TBL_Global;
 
 /*
 ** Global variables
@@ -167,9 +167,9 @@ void UT_InitializeTableRegistryNames()
 
     for (i = 0; i < CFE_PLATFORM_TBL_MAX_NUM_TABLES; i++)
     {
-        snprintf(CFE_TBL_TaskData.Registry[i].Name,
+        snprintf(CFE_TBL_Global.Registry[i].Name,
                  CFE_TBL_MAX_FULL_NAME_LEN, "%d", i);
-        CFE_TBL_TaskData.Registry[i].OwnerAppId = UT_TBL_APPID_2;
+        CFE_TBL_Global.Registry[i].OwnerAppId = UT_TBL_APPID_2;
     }
 }
 
@@ -182,47 +182,47 @@ void UT_ResetTableRegistry(void)
 
     for (i = 0; i < CFE_PLATFORM_TBL_MAX_NUM_TABLES; i++)
     {
-        CFE_TBL_InitRegistryRecord(&CFE_TBL_TaskData.Registry[i]);
+        CFE_TBL_InitRegistryRecord(&CFE_TBL_Global.Registry[i]);
     }
 
     /* Initialize the table access descriptors */
     for (i = 0; i < CFE_PLATFORM_TBL_MAX_NUM_HANDLES; i++)
     {
-        CFE_TBL_TaskData.Handles[i].AppId = CFE_TBL_NOT_OWNED;
-        CFE_TBL_TaskData.Handles[i].RegIndex = 0;
-        CFE_TBL_TaskData.Handles[i].PrevLink = CFE_TBL_END_OF_LIST;
-        CFE_TBL_TaskData.Handles[i].NextLink = CFE_TBL_END_OF_LIST;
-        CFE_TBL_TaskData.Handles[i].UsedFlag = false;
-        CFE_TBL_TaskData.Handles[i].LockFlag = false;
-        CFE_TBL_TaskData.Handles[i].Updated = false;
-        CFE_TBL_TaskData.Handles[i].BufferIndex = 0;
+        CFE_TBL_Global.Handles[i].AppId = CFE_TBL_NOT_OWNED;
+        CFE_TBL_Global.Handles[i].RegIndex = 0;
+        CFE_TBL_Global.Handles[i].PrevLink = CFE_TBL_END_OF_LIST;
+        CFE_TBL_Global.Handles[i].NextLink = CFE_TBL_END_OF_LIST;
+        CFE_TBL_Global.Handles[i].UsedFlag = false;
+        CFE_TBL_Global.Handles[i].LockFlag = false;
+        CFE_TBL_Global.Handles[i].Updated = false;
+        CFE_TBL_Global.Handles[i].BufferIndex = 0;
     }
 
     /* Initialize the table validation results records */
     for (i = 0; i < CFE_PLATFORM_TBL_MAX_NUM_VALIDATIONS; i++)
     {
-        CFE_TBL_TaskData.ValidationResults[i].State = CFE_TBL_VALIDATION_FREE;
-        CFE_TBL_TaskData.ValidationResults[i].CrcOfTable = 0;
-        CFE_TBL_TaskData.ValidationResults[i].Result = 0;
-        CFE_TBL_TaskData.ValidationResults[i].ActiveBuffer = false;
-        CFE_TBL_TaskData.ValidationResults[i].TableName[0] = '\0';
+        CFE_TBL_Global.ValidationResults[i].State = CFE_TBL_VALIDATION_FREE;
+        CFE_TBL_Global.ValidationResults[i].CrcOfTable = 0;
+        CFE_TBL_Global.ValidationResults[i].Result = 0;
+        CFE_TBL_Global.ValidationResults[i].ActiveBuffer = false;
+        CFE_TBL_Global.ValidationResults[i].TableName[0] = '\0';
     }
 
     /* Initialize the dump-only table dump control blocks */
     for (i = 0; i < CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS; i++)
     {
-        CFE_TBL_TaskData.DumpControlBlocks[i].State = CFE_TBL_DUMP_FREE;
-        CFE_TBL_TaskData.DumpControlBlocks[i].DumpBufferPtr = NULL;
-        CFE_TBL_TaskData.DumpControlBlocks[i].Size = 0;
-        CFE_TBL_TaskData.DumpControlBlocks[i].TableName[0] = '\0';
+        CFE_TBL_Global.DumpControlBlocks[i].State = CFE_TBL_DUMP_FREE;
+        CFE_TBL_Global.DumpControlBlocks[i].DumpBufferPtr = NULL;
+        CFE_TBL_Global.DumpControlBlocks[i].Size = 0;
+        CFE_TBL_Global.DumpControlBlocks[i].TableName[0] = '\0';
 
         /* Free all shared buffers */
-        CFE_TBL_TaskData.LoadBuffs[i].Taken = false;
+        CFE_TBL_Global.LoadBuffs[i].Taken = false;
     }
 
-    CFE_TBL_TaskData.ValidationCounter = 0;
-    CFE_TBL_TaskData.HkTlmTblRegIndex = CFE_TBL_NOT_FOUND;
-    CFE_TBL_TaskData.LastTblUpdated = CFE_TBL_NOT_FOUND;
+    CFE_TBL_Global.ValidationCounter = 0;
+    CFE_TBL_Global.HkTlmTblRegIndex = CFE_TBL_NOT_FOUND;
+    CFE_TBL_Global.LastTblUpdated = CFE_TBL_NOT_FOUND;
 }
 
 /*
@@ -361,14 +361,14 @@ void Test_CFE_TBL_TaskInit(void)
     /* Test command pipe messages handler response to other errors */
     /* Test command pipe messages handler response to "message type" message */
     UT_InitData();
-    CFE_TBL_TaskData.CommandCounter = 0;
-    CFE_TBL_TaskData.CommandErrorCounter = 0;
+    CFE_TBL_Global.CommandCounter = 0;
+    CFE_TBL_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TBL_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.NoArgsCmd), 
             UT_TPID_CFE_TBL_INVALID_MID);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TBL_MID_ERR_EID) &&
-                  CFE_TBL_TaskData.CommandCounter == 0 &&
-                  CFE_TBL_TaskData.CommandErrorCounter == 0,
+                  CFE_TBL_Global.CommandCounter == 0 &&
+                  CFE_TBL_Global.CommandErrorCounter == 0,
               "CFE_TBL_TaskPipe",
               "'Message' type message");
 
@@ -378,8 +378,8 @@ void Test_CFE_TBL_TaskInit(void)
             UT_TPID_CFE_TBL_CMD_RESET_COUNTERS_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TBL_RESET_INF_EID) &&
-                  CFE_TBL_TaskData.CommandCounter == 0 &&
-                  CFE_TBL_TaskData.CommandErrorCounter == 0,
+                  CFE_TBL_Global.CommandCounter == 0 &&
+                  CFE_TBL_Global.CommandErrorCounter == 0,
               "CFE_TBL_TaskPipe",
               "'Command' type message");
 }
@@ -477,7 +477,7 @@ void Test_CFE_TBL_DeleteCDSCmd(void)
 
     for (j = CFE_PLATFORM_TBL_MAX_NUM_TABLES; j < k; j++)
     {
-        snprintf(CFE_TBL_TaskData.CritReg[j - CFE_PLATFORM_TBL_MAX_NUM_TABLES].Name,
+        snprintf(CFE_TBL_Global.CritReg[j - CFE_PLATFORM_TBL_MAX_NUM_TABLES].Name,
                  CFE_TBL_MAX_FULL_NAME_LEN, "%d", j);
     }
 
@@ -556,7 +556,7 @@ void Test_CFE_TBL_TlmRegCmd(void)
     /* Registry[0].Name used because it is confirmed to be a registered
      * table name
      */
-    strncpy(TlmRegCmd.Payload.TableName, CFE_TBL_TaskData.Registry[0].Name,
+    strncpy(TlmRegCmd.Payload.TableName, CFE_TBL_Global.Registry[0].Name,
             sizeof(TlmRegCmd.Payload.TableName) - 1);
     TlmRegCmd.Payload.TableName[sizeof(TlmRegCmd.Payload.TableName) - 1] = '\0';
     UT_Report(__FILE__, __LINE__,
@@ -582,7 +582,7 @@ void Test_CFE_TBL_TlmRegCmd(void)
 */
 void Test_CFE_TBL_AbortLoadCmd(void)
 {
-    int                    load = (int) CFE_TBL_TaskData.Registry[0].LoadInProgress;
+    int                    load = (int) CFE_TBL_Global.Registry[0].LoadInProgress;
     CFE_TBL_AbortLoadCmd_t AbortLdCmd;
 
     UtPrintf("Begin Test Abort Load Command");
@@ -593,10 +593,10 @@ void Test_CFE_TBL_AbortLoadCmd(void)
     /* Entering the if statement with a table name that has to be in
      * the registry
      */
-    strncpy(AbortLdCmd.Payload.TableName, CFE_TBL_TaskData.Registry[0].Name,
+    strncpy(AbortLdCmd.Payload.TableName, CFE_TBL_Global.Registry[0].Name,
             sizeof(AbortLdCmd.Payload.TableName) - 1);
     AbortLdCmd.Payload.TableName[sizeof(AbortLdCmd.Payload.TableName) - 1] = '\0';
-    CFE_TBL_TaskData.Registry[0].LoadInProgress = 1;
+    CFE_TBL_Global.Registry[0].LoadInProgress = 1;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_AbortLoadCmd(&AbortLdCmd) ==
                 CFE_TBL_INC_CMD_CTR,
@@ -605,7 +605,7 @@ void Test_CFE_TBL_AbortLoadCmd(void)
 
     /* Test when table name does exist but no table load is in progress */
     UT_InitData();
-    CFE_TBL_TaskData.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
+    CFE_TBL_Global.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_AbortLoadCmd(&AbortLdCmd) ==
                 CFE_TBL_INC_ERR_CTR,
@@ -616,8 +616,8 @@ void Test_CFE_TBL_AbortLoadCmd(void)
      * table is dump only
      */
     UT_InitData();
-    CFE_TBL_TaskData.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
-    CFE_TBL_TaskData.Registry[0].DumpOnly = true;
+    CFE_TBL_Global.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
+    CFE_TBL_Global.Registry[0].DumpOnly = true;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_AbortLoadCmd(&AbortLdCmd) ==
                 CFE_TBL_INC_ERR_CTR,
@@ -636,17 +636,17 @@ void Test_CFE_TBL_AbortLoadCmd(void)
 
     /* Test when table is double buffered */
     UT_InitData();
-    CFE_TBL_TaskData.Registry[0].DoubleBuffered = true;
-    CFE_TBL_TaskData.LoadBuffs[0].Taken = true;
-    CFE_TBL_AbortLoad(&CFE_TBL_TaskData.Registry[0]);
+    CFE_TBL_Global.Registry[0].DoubleBuffered = true;
+    CFE_TBL_Global.LoadBuffs[0].Taken = true;
+    CFE_TBL_AbortLoad(&CFE_TBL_Global.Registry[0]);
     UT_Report(__FILE__, __LINE__,
-              CFE_TBL_TaskData.LoadBuffs[0].Taken == true,
+              CFE_TBL_Global.LoadBuffs[0].Taken == true,
               "CFE_TBL_AbortLoad",
               "Table is double buffered");
 
     /* Restore values for subsequent tests */
-    CFE_TBL_TaskData.Registry[0].LoadInProgress = load;
-    CFE_TBL_TaskData.LoadBuffs[0].Taken = false;
+    CFE_TBL_Global.Registry[0].LoadInProgress = load;
+    CFE_TBL_Global.LoadBuffs[0].Taken = false;
 }
 
 /*
@@ -654,14 +654,14 @@ void Test_CFE_TBL_AbortLoadCmd(void)
 */
 void Test_CFE_TBL_ActivateCmd(void)
 {
-    int                   load = (int) CFE_TBL_TaskData.Registry[0].LoadInProgress;
-    uint8                 dump = CFE_TBL_TaskData.Registry[0].DumpOnly;
+    int                   load = (int) CFE_TBL_Global.Registry[0].LoadInProgress;
+    uint8                 dump = CFE_TBL_Global.Registry[0].DumpOnly;
     CFE_TBL_ActivateCmd_t ActivateCmd;
 
     UtPrintf("Begin Test Activate Command");
 
     /* Enter the if statement with a table name that is in the registry */
-    strncpy(ActivateCmd.Payload.TableName, CFE_TBL_TaskData.Registry[0].Name,
+    strncpy(ActivateCmd.Payload.TableName, CFE_TBL_Global.Registry[0].Name,
             sizeof(ActivateCmd.Payload.TableName) - 1);
     ActivateCmd.Payload.TableName[sizeof(ActivateCmd.Payload.TableName) - 1] = '\0';
 
@@ -669,7 +669,7 @@ void Test_CFE_TBL_ActivateCmd(void)
      * table
      */
     UT_InitData();
-    CFE_TBL_TaskData.Registry[0].DumpOnly = true;
+    CFE_TBL_Global.Registry[0].DumpOnly = true;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_ActivateCmd(&ActivateCmd) ==
                                       CFE_TBL_INC_ERR_CTR,
@@ -680,9 +680,9 @@ void Test_CFE_TBL_ActivateCmd(void)
      * progress, and the table is double-buffered
      */
     UT_InitData();
-    CFE_TBL_TaskData.Registry[0].DumpOnly = false;
-    CFE_TBL_TaskData.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
-    CFE_TBL_TaskData.Registry[0].DoubleBuffered = true;
+    CFE_TBL_Global.Registry[0].DumpOnly = false;
+    CFE_TBL_Global.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
+    CFE_TBL_Global.Registry[0].DoubleBuffered = true;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_ActivateCmd(&ActivateCmd) ==
                 CFE_TBL_INC_ERR_CTR,
@@ -694,8 +694,8 @@ void Test_CFE_TBL_ActivateCmd(void)
      * progress, the table isn't double-buffered, and ValidationStatus = true
      */
     UT_InitData();
-    CFE_TBL_TaskData.Registry[0].DoubleBuffered = false;
-    CFE_TBL_TaskData.LoadBuffs[CFE_TBL_TaskData.Registry[0].LoadInProgress].Validated = true;
+    CFE_TBL_Global.Registry[0].DoubleBuffered = false;
+    CFE_TBL_Global.LoadBuffs[CFE_TBL_Global.Registry[0].LoadInProgress].Validated = true;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_ActivateCmd(&ActivateCmd) ==
                 CFE_TBL_INC_CMD_CTR,
@@ -707,8 +707,8 @@ void Test_CFE_TBL_ActivateCmd(void)
      * progress, and no notification message should be sent
      */
     UT_InitData();
-    CFE_TBL_TaskData.Registry[0].NotifyByMsg = false;
-    CFE_TBL_TaskData.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
+    CFE_TBL_Global.Registry[0].NotifyByMsg = false;
+    CFE_TBL_Global.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_ActivateCmd(&ActivateCmd) ==
                 CFE_TBL_INC_ERR_CTR,
@@ -721,8 +721,8 @@ void Test_CFE_TBL_ActivateCmd(void)
      */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_TransmitMsg), 1, CFE_SB_INTERNAL_ERR);
-    CFE_TBL_TaskData.Registry[0].NotifyByMsg = true;
-    CFE_TBL_TaskData.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
+    CFE_TBL_Global.Registry[0].NotifyByMsg = true;
+    CFE_TBL_Global.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_ActivateCmd(&ActivateCmd) ==
                 CFE_TBL_INC_CMD_CTR,
@@ -741,8 +741,8 @@ void Test_CFE_TBL_ActivateCmd(void)
               "Table registry entry doesn't exist");
 
     /* Restore original values */
-    CFE_TBL_TaskData.Registry[0].LoadInProgress = load;
-    CFE_TBL_TaskData.Registry[0].DumpOnly = dump;
+    CFE_TBL_Global.Registry[0].LoadInProgress = load;
+    CFE_TBL_Global.Registry[0].DumpOnly = dump;
 }
 
 /*
@@ -857,17 +857,17 @@ void Test_CFE_TBL_ValidateCmd(void)
      * have been requested
      */
     UT_InitData();
-    strncpy(ValidateCmd.Payload.TableName, CFE_TBL_TaskData.Registry[0].Name,
+    strncpy(ValidateCmd.Payload.TableName, CFE_TBL_Global.Registry[0].Name,
             sizeof(ValidateCmd.Payload.TableName) - 1);
     ValidateCmd.Payload.TableName[sizeof(ValidateCmd.Payload.TableName) - 1] = '\0';
     ValidateCmd.Payload.ActiveTableFlag = CFE_TBL_BufferSelect_ACTIVE;
-    CFE_TBL_TaskData.Registry[0].
-      Buffers[CFE_TBL_TaskData.Registry[0].ActiveBufferIndex].
+    CFE_TBL_Global.Registry[0].
+      Buffers[CFE_TBL_Global.Registry[0].ActiveBufferIndex].
         BufferPtr = BuffPtr;
 
     for (i = 0; i < CFE_PLATFORM_TBL_MAX_NUM_VALIDATIONS; i++)
     {
-        CFE_TBL_TaskData.ValidationResults[i].State =
+        CFE_TBL_Global.ValidationResults[i].State =
             CFE_TBL_VALIDATION_PENDING;
     }
 
@@ -882,8 +882,8 @@ void Test_CFE_TBL_ValidateCmd(void)
      * function pointer
      */
     UT_InitData();
-    CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_FREE;
-    CFE_TBL_TaskData.Registry[0].ValidationFuncPtr = NULL;
+    CFE_TBL_Global.ValidationResults[0].State = CFE_TBL_VALIDATION_FREE;
+    CFE_TBL_Global.Registry[0].ValidationFuncPtr = NULL;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_ValidateCmd(&ValidateCmd) ==
                 CFE_TBL_INC_CMD_CTR,
@@ -894,8 +894,8 @@ void Test_CFE_TBL_ValidateCmd(void)
      * exists, and the active table flag is set
      */
     UT_InitData();
-    CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_FREE;
-    CFE_TBL_TaskData.Registry[0].ValidationFuncPtr = ValFuncPtr;
+    CFE_TBL_Global.ValidationResults[0].State = CFE_TBL_VALIDATION_FREE;
+    CFE_TBL_Global.Registry[0].ValidationFuncPtr = ValFuncPtr;
     ValidateCmd.Payload.ActiveTableFlag = true;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_ValidateCmd(&ValidateCmd) ==
@@ -909,10 +909,10 @@ void Test_CFE_TBL_ValidateCmd(void)
      */
     UT_InitData();
     ValidateCmd.Payload.ActiveTableFlag = CFE_TBL_BufferSelect_INACTIVE;
-    CFE_TBL_TaskData.Registry[0].DoubleBuffered = true;
-    CFE_TBL_TaskData.Registry[0].Buffers[1 - CFE_TBL_TaskData.Registry[0].ActiveBufferIndex].BufferPtr = BuffPtr;
-    CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_FREE;
-    CFE_TBL_TaskData.Registry[0].ValidationFuncPtr = ValFuncPtr;
+    CFE_TBL_Global.Registry[0].DoubleBuffered = true;
+    CFE_TBL_Global.Registry[0].Buffers[1 - CFE_TBL_Global.Registry[0].ActiveBufferIndex].BufferPtr = BuffPtr;
+    CFE_TBL_Global.ValidationResults[0].State = CFE_TBL_VALIDATION_FREE;
+    CFE_TBL_Global.Registry[0].ValidationFuncPtr = ValFuncPtr;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_ValidateCmd(&ValidateCmd) ==
                 CFE_TBL_INC_CMD_CTR,
@@ -925,11 +925,11 @@ void Test_CFE_TBL_ValidateCmd(void)
      * notification message should be sent
      */
     UT_InitData();
-    CFE_TBL_TaskData.Registry[0].NotifyByMsg = false;
-    CFE_TBL_TaskData.Registry[0].DoubleBuffered = false;
-    CFE_TBL_TaskData.LoadBuffs[CFE_TBL_TaskData.Registry[0].LoadInProgress].BufferPtr = BuffPtr;
-    CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_FREE;
-    CFE_TBL_TaskData.Registry[0].LoadInProgress =
+    CFE_TBL_Global.Registry[0].NotifyByMsg = false;
+    CFE_TBL_Global.Registry[0].DoubleBuffered = false;
+    CFE_TBL_Global.LoadBuffs[CFE_TBL_Global.Registry[0].LoadInProgress].BufferPtr = BuffPtr;
+    CFE_TBL_Global.ValidationResults[0].State = CFE_TBL_VALIDATION_FREE;
+    CFE_TBL_Global.Registry[0].LoadInProgress =
         CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_ValidateCmd(&ValidateCmd) ==
@@ -944,11 +944,11 @@ void Test_CFE_TBL_ValidateCmd(void)
      */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_TransmitMsg), 1, CFE_SB_INTERNAL_ERR);
-    CFE_TBL_TaskData.Registry[0].NotifyByMsg = true;
-    CFE_TBL_TaskData.Registry[0].DoubleBuffered = false;
-    CFE_TBL_TaskData.LoadBuffs[CFE_TBL_TaskData.Registry[0].LoadInProgress].BufferPtr = BuffPtr;
-    CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_FREE;
-    CFE_TBL_TaskData.Registry[0].LoadInProgress =
+    CFE_TBL_Global.Registry[0].NotifyByMsg = true;
+    CFE_TBL_Global.Registry[0].DoubleBuffered = false;
+    CFE_TBL_Global.LoadBuffs[CFE_TBL_Global.Registry[0].LoadInProgress].BufferPtr = BuffPtr;
+    CFE_TBL_Global.ValidationResults[0].State = CFE_TBL_VALIDATION_FREE;
+    CFE_TBL_Global.Registry[0].LoadInProgress =
         CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_ValidateCmd(&ValidateCmd) ==
@@ -961,7 +961,7 @@ void Test_CFE_TBL_ValidateCmd(void)
      * load in progress)
      */
     UT_InitData();
-    CFE_TBL_TaskData.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
+    CFE_TBL_Global.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_ValidateCmd(&ValidateCmd) ==
                 CFE_TBL_INC_ERR_CTR,
@@ -1004,36 +1004,36 @@ void Test_CFE_TBL_GetTblRegData(void)
 
     /* Test using a double buffered table */
     UT_InitData();
-    CFE_TBL_TaskData.TblRegPacket.Payload.InactiveBufferAddr = CFE_ES_MEMADDRESS_C(0);
-    CFE_TBL_TaskData.Registry[CFE_TBL_TaskData.HkTlmTblRegIndex].DoubleBuffered = true;
+    CFE_TBL_Global.TblRegPacket.Payload.InactiveBufferAddr = CFE_ES_MEMADDRESS_C(0);
+    CFE_TBL_Global.Registry[CFE_TBL_Global.HkTlmTblRegIndex].DoubleBuffered = true;
     CFE_TBL_GetTblRegData();
     UT_Report(__FILE__, __LINE__,
-              CFE_TBL_TaskData.TblRegPacket.Payload.InactiveBufferAddr != 0,
+              CFE_TBL_Global.TblRegPacket.Payload.InactiveBufferAddr != 0,
               "CFE_TBL_GetTblRegData",
               "Double buffered table");
 
     /* Test using a single buffered table and the buffer is inactive */
     UT_InitData();
-    CFE_TBL_TaskData.TblRegPacket.Payload.InactiveBufferAddr = CFE_ES_MEMADDRESS_C(0);
-    CFE_TBL_TaskData.Registry[CFE_TBL_TaskData.HkTlmTblRegIndex].DoubleBuffered = false;
-    CFE_TBL_TaskData.
-      Registry[CFE_TBL_TaskData.HkTlmTblRegIndex].
+    CFE_TBL_Global.TblRegPacket.Payload.InactiveBufferAddr = CFE_ES_MEMADDRESS_C(0);
+    CFE_TBL_Global.Registry[CFE_TBL_Global.HkTlmTblRegIndex].DoubleBuffered = false;
+    CFE_TBL_Global.
+      Registry[CFE_TBL_Global.HkTlmTblRegIndex].
         LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
     CFE_TBL_GetTblRegData();
     UT_Report(__FILE__, __LINE__,
-              CFE_TBL_TaskData.TblRegPacket.Payload.InactiveBufferAddr != 0,
+              CFE_TBL_Global.TblRegPacket.Payload.InactiveBufferAddr != 0,
               "CFE_TBL_GetTblRegData",
               "Single buffered table - inactive buffer");
 
     /* Test with no inactive buffer */
     UT_InitData();
-    CFE_TBL_TaskData.TblRegPacket.Payload.InactiveBufferAddr = CFE_ES_MEMADDRESS_C(0);
-    CFE_TBL_TaskData.
-      Registry[CFE_TBL_TaskData.HkTlmTblRegIndex].LoadInProgress =
+    CFE_TBL_Global.TblRegPacket.Payload.InactiveBufferAddr = CFE_ES_MEMADDRESS_C(0);
+    CFE_TBL_Global.
+      Registry[CFE_TBL_Global.HkTlmTblRegIndex].LoadInProgress =
           CFE_TBL_NO_LOAD_IN_PROGRESS;
     CFE_TBL_GetTblRegData();
     UT_Report(__FILE__, __LINE__,
-              CFE_TBL_TaskData.TblRegPacket.Payload.InactiveBufferAddr == 0,
+              CFE_TBL_Global.TblRegPacket.Payload.InactiveBufferAddr == 0,
               "CFE_TBL_GetTblRegData",
               "No inactive buffer");
 }
@@ -1057,80 +1057,80 @@ void Test_CFE_TBL_GetHkData(void)
 
     for (i = 0; i < CFE_PLATFORM_TBL_MAX_NUM_TABLES; i++)
     {
-        CFE_TBL_TaskData.Registry[i].LoadPending = false;
+        CFE_TBL_Global.Registry[i].LoadPending = false;
     }
 
     /* Test raising the count of load pending tables */
     UT_InitData();
-    CFE_TBL_TaskData.Registry[NumLoadPendingIndex].LoadPending = true;
-    CFE_TBL_TaskData.Registry[NumLoadPendingIndex].OwnerAppId = AppID;
+    CFE_TBL_Global.Registry[NumLoadPendingIndex].LoadPending = true;
+    CFE_TBL_Global.Registry[NumLoadPendingIndex].OwnerAppId = AppID;
     CFE_TBL_GetHkData();
     UT_Report(__FILE__, __LINE__,
-              CFE_TBL_TaskData.HkPacket.Payload.NumLoadPending == 1,
+              CFE_TBL_Global.HkPacket.Payload.NumLoadPending == 1,
               "CFE_TBL_GetHkData",
               "Raise load pending table count");
 
     /* Test lowering the count of free shared buffers */
     UT_InitData();
-    CFE_TBL_TaskData.LoadBuffs[FreeSharedBuffIndex].Taken = true;
+    CFE_TBL_Global.LoadBuffs[FreeSharedBuffIndex].Taken = true;
     CFE_TBL_GetHkData();
     UT_Report(__FILE__, __LINE__,
-              CFE_TBL_TaskData.HkPacket.Payload.NumFreeSharedBufs ==
+              CFE_TBL_Global.HkPacket.Payload.NumFreeSharedBufs ==
                   CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS - 1,
               "CFE_TBL_GetHkData",
               "Lower free shared buffer count");
 
     /* Test making a ValPtr with result = CFE_SUCCESS */
     UT_InitData();
-    CFE_TBL_TaskData.SuccessValCounter = 0;
-    CFE_TBL_TaskData.ValidationResults[ValTableIndex].State =
+    CFE_TBL_Global.SuccessValCounter = 0;
+    CFE_TBL_Global.ValidationResults[ValTableIndex].State =
         CFE_TBL_VALIDATION_PERFORMED;
-    CFE_TBL_TaskData.ValidationResults[ValTableIndex].Result = CFE_SUCCESS;
+    CFE_TBL_Global.ValidationResults[ValTableIndex].Result = CFE_SUCCESS;
     CFE_TBL_GetHkData();
     UT_Report(__FILE__, __LINE__,
-              CFE_TBL_TaskData.SuccessValCounter == 1,
+              CFE_TBL_Global.SuccessValCounter == 1,
               "CFE_TBL_GetHkData",
               "ValPtr result CFE_SUCCESS");
 
     /* Test making a ValPtr without result = CFE_SUCCESS */
     UT_InitData();
-    CFE_TBL_TaskData.FailedValCounter = 0;
-    CFE_TBL_TaskData.ValidationResults[ValTableIndex].State =
+    CFE_TBL_Global.FailedValCounter = 0;
+    CFE_TBL_Global.ValidationResults[ValTableIndex].State =
         CFE_TBL_VALIDATION_PERFORMED;
-    CFE_TBL_TaskData.ValidationResults[ValTableIndex].Result = CFE_SUCCESS - 1;
+    CFE_TBL_Global.ValidationResults[ValTableIndex].Result = CFE_SUCCESS - 1;
     CFE_TBL_GetHkData();
     UT_Report(__FILE__, __LINE__,
-              CFE_TBL_TaskData.FailedValCounter == 1,
+              CFE_TBL_Global.FailedValCounter == 1,
               "CFE_TBL_GetHkData",
               "ValPtr result != CFE_SUCCESS");
 
     /* Test with an invalid registry entry */
     UT_InitData();
-    CFE_TBL_TaskData.Registry[CFE_TBL_TaskData.LastTblUpdated].OwnerAppId = CFE_TBL_NOT_OWNED;
-    CFE_TBL_TaskData.HkPacket.Payload.LastUpdateTime.Seconds = 19283;
+    CFE_TBL_Global.Registry[CFE_TBL_Global.LastTblUpdated].OwnerAppId = CFE_TBL_NOT_OWNED;
+    CFE_TBL_Global.HkPacket.Payload.LastUpdateTime.Seconds = 19283;
     CFE_TBL_GetHkData();
     UT_Report(__FILE__, __LINE__,
-              CFE_TBL_TaskData.HkPacket.Payload.LastUpdateTime.Seconds == 19283,
+              CFE_TBL_Global.HkPacket.Payload.LastUpdateTime.Seconds == 19283,
               "CFE_TBL_GetHkData",
               "Invalid registry entry");
 
     /* Test with invalid last valid table updated out of range (low) */
     UT_InitData();
-    CFE_TBL_TaskData.LastTblUpdated = -1;
-    CFE_TBL_TaskData.HkPacket.Payload.LastUpdateTime.Seconds = 12345;
+    CFE_TBL_Global.LastTblUpdated = -1;
+    CFE_TBL_Global.HkPacket.Payload.LastUpdateTime.Seconds = 12345;
     CFE_TBL_GetHkData();
     UT_Report(__FILE__, __LINE__,
-              CFE_TBL_TaskData.HkPacket.Payload.LastUpdateTime.Seconds == 12345,
+              CFE_TBL_Global.HkPacket.Payload.LastUpdateTime.Seconds == 12345,
               "CFE_TBL_GetHkData",
               "Last valid table updated out of range (low)");
 
     /* Test with invalid last valid table updated out of range (high) */
     UT_InitData();
-    CFE_TBL_TaskData.LastTblUpdated = CFE_PLATFORM_TBL_MAX_NUM_TABLES;
-    CFE_TBL_TaskData.HkPacket.Payload.LastUpdateTime.Seconds = 54321;
+    CFE_TBL_Global.LastTblUpdated = CFE_PLATFORM_TBL_MAX_NUM_TABLES;
+    CFE_TBL_Global.HkPacket.Payload.LastUpdateTime.Seconds = 54321;
     CFE_TBL_GetHkData();
     UT_Report(__FILE__, __LINE__,
-              CFE_TBL_TaskData.HkPacket.Payload.LastUpdateTime.Seconds == 54321,
+              CFE_TBL_Global.HkPacket.Payload.LastUpdateTime.Seconds == 54321,
               "CFE_TBL_GetHkData",
               "Last valid table updated out of range (high)");
 }
@@ -1153,7 +1153,7 @@ void Test_CFE_TBL_DumpRegCmd(void)
 
     for (q = 0; q < CFE_PLATFORM_TBL_MAX_NUM_TABLES; q++)
     {
-        CFE_TBL_TaskData.Registry[q].HeadOfAccessList = CFE_TBL_END_OF_LIST;
+        CFE_TBL_Global.Registry[q].HeadOfAccessList = CFE_TBL_END_OF_LIST;
     }
 
     /* Test with an error creating the dump file */
@@ -1180,11 +1180,11 @@ void Test_CFE_TBL_DumpRegCmd(void)
      */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_WriteHeader), 10, sizeof(CFE_FS_Header_t));
-    CFE_TBL_TaskData.Registry[0].OwnerAppId = AppID;
-    CFE_TBL_TaskData.Registry[0].HeadOfAccessList = CFE_TBL_END_OF_LIST;
-    CFE_TBL_TaskData.Registry[1].OwnerAppId = CFE_TBL_NOT_OWNED;
-    CFE_TBL_TaskData.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
-    CFE_TBL_TaskData.Registry[0].DoubleBuffered = true;
+    CFE_TBL_Global.Registry[0].OwnerAppId = AppID;
+    CFE_TBL_Global.Registry[0].HeadOfAccessList = CFE_TBL_END_OF_LIST;
+    CFE_TBL_Global.Registry[1].OwnerAppId = CFE_TBL_NOT_OWNED;
+    CFE_TBL_Global.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
+    CFE_TBL_Global.Registry[0].DoubleBuffered = true;
     UT_SetDeferredRetcode(UT_KEY(OS_OpenCreate), 1, OS_ERROR);
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DumpRegistryCmd(&DumpRegCmd) ==
@@ -1197,7 +1197,7 @@ void Test_CFE_TBL_DumpRegCmd(void)
      * overwritten
      */
     UT_InitData();
-    CFE_TBL_TaskData.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
+    CFE_TBL_Global.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DumpRegistryCmd(&DumpRegCmd) ==
                 CFE_TBL_INC_CMD_CTR,
@@ -1209,9 +1209,9 @@ void Test_CFE_TBL_DumpRegCmd(void)
      */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(OS_write), 1, sizeof(CFE_TBL_RegDumpRec_t) - 1);
-    CFE_TBL_TaskData.Registry[0].OwnerAppId = CFE_TBL_NOT_OWNED;
-    CFE_TBL_TaskData.Registry[0].HeadOfAccessList = 2;
-    CFE_TBL_TaskData.Handles[2].NextLink = CFE_TBL_END_OF_LIST;
+    CFE_TBL_Global.Registry[0].OwnerAppId = CFE_TBL_NOT_OWNED;
+    CFE_TBL_Global.Registry[0].HeadOfAccessList = 2;
+    CFE_TBL_Global.Handles[2].NextLink = CFE_TBL_END_OF_LIST;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DumpRegistryCmd(&DumpRegCmd) ==
                 CFE_TBL_INC_ERR_CTR,
@@ -1262,28 +1262,28 @@ void Test_CFE_TBL_DumpCmd(void)
      * working buffer; load in progress, single-buffered
      */
     UT_InitData();
-    strncpy(CFE_TBL_TaskData.Registry[2].Name, "DumpCmdTest",
-            sizeof(CFE_TBL_TaskData.Registry[2].Name) - 1);
-    CFE_TBL_TaskData.Registry[2].Name[sizeof(CFE_TBL_TaskData.Registry[2].Name) - 1] = '\0';
-    CFE_TBL_TaskData.Registry[2].OwnerAppId = AppID;
-    strncpy(DumpCmd.Payload.TableName, CFE_TBL_TaskData.Registry[2].Name,
+    strncpy(CFE_TBL_Global.Registry[2].Name, "DumpCmdTest",
+            sizeof(CFE_TBL_Global.Registry[2].Name) - 1);
+    CFE_TBL_Global.Registry[2].Name[sizeof(CFE_TBL_Global.Registry[2].Name) - 1] = '\0';
+    CFE_TBL_Global.Registry[2].OwnerAppId = AppID;
+    strncpy(DumpCmd.Payload.TableName, CFE_TBL_Global.Registry[2].Name,
             sizeof(DumpCmd.Payload.TableName) - 1);
     DumpCmd.Payload.TableName[sizeof(DumpCmd.Payload.TableName) - 1] = '\0';
     DumpCmd.Payload.ActiveTableFlag = CFE_TBL_BufferSelect_ACTIVE;
-    CFE_TBL_TaskData.Registry[2].Buffers[CFE_TBL_TaskData.Registry[2].ActiveBufferIndex].BufferPtr = BuffPtr;
+    CFE_TBL_Global.Registry[2].Buffers[CFE_TBL_Global.Registry[2].ActiveBufferIndex].BufferPtr = BuffPtr;
 
     for (i = 0; i < CFE_PLATFORM_TBL_MAX_NUM_TABLES; i++)
     {
-        CFE_TBL_TaskData.Registry[i].DumpOnly = true;
+        CFE_TBL_Global.Registry[i].DumpOnly = true;
     }
 
-    CFE_TBL_TaskData.DumpControlBlocks[2].State = CFE_TBL_DUMP_PENDING;
-    CFE_TBL_TaskData.DumpControlBlocks[3].State = CFE_TBL_DUMP_FREE;
-    CFE_TBL_TaskData.Registry[2].DumpControlIndex = CFE_TBL_NO_DUMP_PENDING;
-    CFE_TBL_TaskData.Registry[2].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
-    CFE_TBL_TaskData.Registry[2].DoubleBuffered = false;
-    CFE_TBL_TaskData.LoadBuffs[CFE_TBL_TaskData.Registry[2].LoadInProgress] = Load;
-    CFE_TBL_TaskData.Registry[2].NotifyByMsg = true;
+    CFE_TBL_Global.DumpControlBlocks[2].State = CFE_TBL_DUMP_PENDING;
+    CFE_TBL_Global.DumpControlBlocks[3].State = CFE_TBL_DUMP_FREE;
+    CFE_TBL_Global.Registry[2].DumpControlIndex = CFE_TBL_NO_DUMP_PENDING;
+    CFE_TBL_Global.Registry[2].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
+    CFE_TBL_Global.Registry[2].DoubleBuffered = false;
+    CFE_TBL_Global.LoadBuffs[CFE_TBL_Global.Registry[2].LoadInProgress] = Load;
+    CFE_TBL_Global.Registry[2].NotifyByMsg = true;
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_TransmitMsg), 1, CFE_SB_INTERNAL_ERR);
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DumpCmd(&DumpCmd) ==
@@ -1298,18 +1298,18 @@ void Test_CFE_TBL_DumpCmd(void)
      * available
      */
     UT_InitData();
-    CFE_TBL_TaskData.DumpControlBlocks[2].State = CFE_TBL_DUMP_FREE;
-    CFE_TBL_TaskData.Registry[2].DumpControlIndex = CFE_TBL_NO_DUMP_PENDING;
-    CFE_TBL_TaskData.Registry[2].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
-    CFE_TBL_TaskData.Registry[2].TableLoadedOnce = true;
-    CFE_TBL_TaskData.Registry[2].DoubleBuffered = false;
+    CFE_TBL_Global.DumpControlBlocks[2].State = CFE_TBL_DUMP_FREE;
+    CFE_TBL_Global.Registry[2].DumpControlIndex = CFE_TBL_NO_DUMP_PENDING;
+    CFE_TBL_Global.Registry[2].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
+    CFE_TBL_Global.Registry[2].TableLoadedOnce = true;
+    CFE_TBL_Global.Registry[2].DoubleBuffered = false;
 
     for (u = 0; u < CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS; u++)
     {
-        CFE_TBL_TaskData.LoadBuffs[u].Taken = true;
+        CFE_TBL_Global.LoadBuffs[u].Taken = true;
     }
 
-    CFE_TBL_TaskData.Registry[2].NotifyByMsg = true;
+    CFE_TBL_Global.Registry[2].NotifyByMsg = true;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DumpCmd(&DumpCmd) ==
                 CFE_TBL_INC_ERR_CTR,
@@ -1323,14 +1323,14 @@ void Test_CFE_TBL_DumpCmd(void)
      * dump only table dumps have been requested
      */
     UT_InitData();
-    CFE_TBL_TaskData.Registry[2].DumpControlIndex = CFE_TBL_NO_DUMP_PENDING;
+    CFE_TBL_Global.Registry[2].DumpControlIndex = CFE_TBL_NO_DUMP_PENDING;
 
     for (k = 0; k < CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS; k++)
     {
-        CFE_TBL_TaskData.DumpControlBlocks[k].State = CFE_TBL_DUMP_PENDING;
+        CFE_TBL_Global.DumpControlBlocks[k].State = CFE_TBL_DUMP_PENDING;
     }
 
-    CFE_TBL_TaskData.Registry[2].NotifyByMsg = true;
+    CFE_TBL_Global.Registry[2].NotifyByMsg = true;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DumpCmd(&DumpCmd) ==
                 CFE_TBL_INC_ERR_CTR,
@@ -1344,9 +1344,9 @@ void Test_CFE_TBL_DumpCmd(void)
      */
     UT_InitData();
     DumpCmd.Payload.ActiveTableFlag = CFE_TBL_BufferSelect_INACTIVE;
-    CFE_TBL_TaskData.Registry[2].DoubleBuffered = true;
-    CFE_TBL_TaskData.Registry[2].Buffers[(1 - CFE_TBL_TaskData.Registry[2].ActiveBufferIndex)].BufferPtr = BuffPtr;
-    CFE_TBL_TaskData.Registry[2].DumpControlIndex = CFE_TBL_NO_DUMP_PENDING +
+    CFE_TBL_Global.Registry[2].DoubleBuffered = true;
+    CFE_TBL_Global.Registry[2].Buffers[(1 - CFE_TBL_Global.Registry[2].ActiveBufferIndex)].BufferPtr = BuffPtr;
+    CFE_TBL_Global.Registry[2].DumpControlIndex = CFE_TBL_NO_DUMP_PENDING +
                                                     1;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DumpCmd(&DumpCmd) ==
@@ -1359,11 +1359,11 @@ void Test_CFE_TBL_DumpCmd(void)
      * dump only table
      */
     UT_InitData();
-    CFE_TBL_TaskData.Registry[2].DoubleBuffered = false;
-    CFE_TBL_TaskData.Registry[2].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
-    CFE_TBL_TaskData.LoadBuffs[CFE_TBL_TaskData.Registry[2].LoadInProgress].BufferPtr = BuffPtr;
-    CFE_TBL_TaskData.Registry[2].DumpOnly = false;
-    strncpy(DumpCmd.Payload.DumpFilename, CFE_TBL_TaskData.Registry[2].LastFileLoaded,
+    CFE_TBL_Global.Registry[2].DoubleBuffered = false;
+    CFE_TBL_Global.Registry[2].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
+    CFE_TBL_Global.LoadBuffs[CFE_TBL_Global.Registry[2].LoadInProgress].BufferPtr = BuffPtr;
+    CFE_TBL_Global.Registry[2].DumpOnly = false;
+    strncpy(DumpCmd.Payload.DumpFilename, CFE_TBL_Global.Registry[2].LastFileLoaded,
             sizeof(DumpCmd.Payload.DumpFilename) - 1);
     DumpCmd.Payload.DumpFilename[sizeof(DumpCmd.Payload.DumpFilename) - 1] = '\0';
     UT_Report(__FILE__, __LINE__,
@@ -1377,7 +1377,7 @@ void Test_CFE_TBL_DumpCmd(void)
      * table due to load in progress
      */
     UT_InitData();
-    CFE_TBL_TaskData.Registry[2].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
+    CFE_TBL_Global.Registry[2].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DumpCmd(&DumpCmd) ==
                 CFE_TBL_INC_ERR_CTR,
@@ -1389,8 +1389,8 @@ void Test_CFE_TBL_DumpCmd(void)
      * table due to user defined address
      */
     UT_InitData();
-    CFE_TBL_TaskData.Registry[2].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
-    CFE_TBL_TaskData.Registry[2].UserDefAddr = true;
+    CFE_TBL_Global.Registry[2].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
+    CFE_TBL_Global.Registry[2].UserDefAddr = true;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_DumpCmd(&DumpCmd) ==
                 CFE_TBL_INC_ERR_CTR,
@@ -1417,7 +1417,7 @@ void Test_CFE_TBL_LoadCmd(void)
     int                 i, j;
     CFE_TBL_File_Hdr_t  TblFileHeader;
     CFE_FS_Header_t     StdFileHeader;
-    CFE_TBL_LoadBuff_t  BufferPtr = CFE_TBL_TaskData.LoadBuffs[0];
+    CFE_TBL_LoadBuff_t  BufferPtr = CFE_TBL_Global.LoadBuffs[0];
     CFE_TBL_LoadCmd_t   LoadCmd;
     CFE_ES_ResourceID_t AppID;
 
@@ -1445,11 +1445,11 @@ void Test_CFE_TBL_LoadCmd(void)
 
     for (i = 0; i < CFE_PLATFORM_TBL_MAX_NUM_TABLES; i++)
     {
-        CFE_TBL_TaskData.Registry[i].OwnerAppId = CFE_TBL_NOT_OWNED;
-        CFE_TBL_TaskData.Registry[i].LoadPending = false;
+        CFE_TBL_Global.Registry[i].OwnerAppId = CFE_TBL_NOT_OWNED;
+        CFE_TBL_Global.Registry[i].LoadPending = false;
     }
 
-    strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
+    strncpy(TblFileHeader.TableName, CFE_TBL_Global.Registry[0].Name,
             sizeof(TblFileHeader.TableName) - 1);
     TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     strncpy(StdFileHeader.Description, "FS header description",
@@ -1467,11 +1467,11 @@ void Test_CFE_TBL_LoadCmd(void)
 
     /* Test attempt to load a dump only table */
     UT_InitData();
-    CFE_TBL_TaskData.Registry[0].OwnerAppId = AppID;
+    CFE_TBL_Global.Registry[0].OwnerAppId = AppID;
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
-    CFE_TBL_TaskData.Registry[0].Size = sizeof(CFE_TBL_File_Hdr_t) + 1;
-    CFE_TBL_TaskData.Registry[0].DumpOnly = true;
+    CFE_TBL_Global.Registry[0].Size = sizeof(CFE_TBL_File_Hdr_t) + 1;
+    CFE_TBL_Global.Registry[0].DumpOnly = true;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_LoadCmd(&LoadCmd) ==
                 CFE_TBL_INC_ERR_CTR,
@@ -1480,18 +1480,18 @@ void Test_CFE_TBL_LoadCmd(void)
 
     /* Test attempt to load a table with a load already pending */
     UT_InitData();
-    CFE_TBL_TaskData.Registry[0].OwnerAppId = AppID;
+    CFE_TBL_Global.Registry[0].OwnerAppId = AppID;
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
-    CFE_TBL_TaskData.Registry[0].Size = sizeof(CFE_TBL_File_Hdr_t) + 1;
-    CFE_TBL_TaskData.Registry[0].DumpOnly = false;
-    CFE_TBL_TaskData.Registry[0].LoadPending = true;
+    CFE_TBL_Global.Registry[0].Size = sizeof(CFE_TBL_File_Hdr_t) + 1;
+    CFE_TBL_Global.Registry[0].DumpOnly = false;
+    CFE_TBL_Global.Registry[0].LoadPending = true;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_LoadCmd(&LoadCmd) ==
                 CFE_TBL_INC_ERR_CTR,
               "CFE_TBL_LoadCmd",
               "Attempting to load a table with load already pending");
-    CFE_TBL_TaskData.Registry[0].LoadPending = false;
+    CFE_TBL_Global.Registry[0].LoadPending = false;
 
     /* Test where the file isn't dump only and passes table checks, get a
      * working buffer, and there is an extra byte (more data than header
@@ -1499,16 +1499,16 @@ void Test_CFE_TBL_LoadCmd(void)
      */
     UT_InitData();
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(CFE_TBL_File_Hdr_t));
-    CFE_TBL_TaskData.Registry[0].TableLoadedOnce = true;
+    CFE_TBL_Global.Registry[0].TableLoadedOnce = true;
 
-    CFE_TBL_TaskData.Registry[0].Size = sizeof(CFE_TBL_File_Hdr_t);
-    CFE_TBL_TaskData.Registry[0].LoadInProgress =
+    CFE_TBL_Global.Registry[0].Size = sizeof(CFE_TBL_File_Hdr_t);
+    CFE_TBL_Global.Registry[0].LoadInProgress =
         CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
-    CFE_TBL_TaskData.Registry[0].DoubleBuffered = false;
-    CFE_TBL_TaskData.LoadBuffs[CFE_TBL_TaskData.Registry[0].LoadInProgress].BufferPtr = (uint8 *) &BufferPtr;
+    CFE_TBL_Global.Registry[0].DoubleBuffered = false;
+    CFE_TBL_Global.LoadBuffs[CFE_TBL_Global.Registry[0].LoadInProgress].BufferPtr = (uint8 *) &BufferPtr;
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
-    CFE_TBL_TaskData.Registry[0].DumpOnly = false;
+    CFE_TBL_Global.Registry[0].DumpOnly = false;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_LoadCmd(&LoadCmd) ==
                 CFE_TBL_INC_ERR_CTR,
@@ -1520,7 +1520,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(CFE_TBL_File_Hdr_t));
 
     UT_SetDeferredRetcode(UT_KEY(OS_read), 3, 0);
-    strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
+    strncpy(TblFileHeader.TableName, CFE_TBL_Global.Registry[0].Name,
             sizeof(TblFileHeader.TableName) - 1);
     TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -1540,7 +1540,7 @@ void Test_CFE_TBL_LoadCmd(void)
         CFE_TBL_ByteSwapUint32(&TblFileHeader.NumBytes);
     }
 
-    strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
+    strncpy(TblFileHeader.TableName, CFE_TBL_Global.Registry[0].Name,
             sizeof(TblFileHeader.TableName) - 1);
     TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetDeferredRetcode(UT_KEY(OS_read), 2, 0);
@@ -1554,17 +1554,17 @@ void Test_CFE_TBL_LoadCmd(void)
 
     /* Test with no working buffers available */
     UT_InitData();
-    CFE_TBL_TaskData.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
-    CFE_TBL_TaskData.Registry[0].TableLoadedOnce = true;
-    CFE_TBL_TaskData.Registry[0].DoubleBuffered = false;
-    CFE_TBL_TaskData.Registry[0].Buffers[CFE_TBL_TaskData.Registry[0].ActiveBufferIndex] = BufferPtr;
+    CFE_TBL_Global.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
+    CFE_TBL_Global.Registry[0].TableLoadedOnce = true;
+    CFE_TBL_Global.Registry[0].DoubleBuffered = false;
+    CFE_TBL_Global.Registry[0].Buffers[CFE_TBL_Global.Registry[0].ActiveBufferIndex] = BufferPtr;
 
     for (j = 0; j < CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS; j++)
     {
-        CFE_TBL_TaskData.LoadBuffs[j].Taken = true;
+        CFE_TBL_Global.LoadBuffs[j].Taken = true;
     }
 
-    strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
+    strncpy(TblFileHeader.TableName, CFE_TBL_Global.Registry[0].Name,
             sizeof(TblFileHeader.TableName) - 1);
     TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -1579,8 +1579,8 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_InitData();
     UT_TBL_SetupHeader(&TblFileHeader, 0, sizeof(CFE_TBL_File_Hdr_t));
 
-    CFE_TBL_TaskData.Registry[0].Size = sizeof(CFE_TBL_File_Hdr_t) - 1;
-    strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
+    CFE_TBL_Global.Registry[0].Size = sizeof(CFE_TBL_File_Hdr_t) - 1;
+    strncpy(TblFileHeader.TableName, CFE_TBL_Global.Registry[0].Name,
             sizeof(TblFileHeader.TableName) - 1);
     TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -1595,7 +1595,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_InitData();
     UT_TBL_SetupHeader(&TblFileHeader, 0, 0);
 
-    strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
+    strncpy(TblFileHeader.TableName, CFE_TBL_Global.Registry[0].Name,
             sizeof(TblFileHeader.TableName) - 1);
     TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -1612,10 +1612,10 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_InitData();
     UT_TBL_SetupHeader(&TblFileHeader, 1, 1);
 
-    CFE_TBL_TaskData.Registry[0].TableLoadedOnce = false;
+    CFE_TBL_Global.Registry[0].TableLoadedOnce = false;
 
-    CFE_TBL_TaskData.Registry[0].Size = sizeof(CFE_TBL_File_Hdr_t);
-    strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
+    CFE_TBL_Global.Registry[0].Size = sizeof(CFE_TBL_File_Hdr_t);
+    strncpy(TblFileHeader.TableName, CFE_TBL_Global.Registry[0].Name,
             sizeof(TblFileHeader.TableName) - 1);
     TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -1633,10 +1633,10 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_InitData();
     UT_TBL_SetupHeader(&TblFileHeader, 0, 1);
 
-    CFE_TBL_TaskData.Registry[0].TableLoadedOnce = false;
+    CFE_TBL_Global.Registry[0].TableLoadedOnce = false;
 
-    CFE_TBL_TaskData.Registry[0].Size = sizeof(CFE_TBL_File_Hdr_t);
-    strncpy(TblFileHeader.TableName, CFE_TBL_TaskData.Registry[0].Name,
+    CFE_TBL_Global.Registry[0].Size = sizeof(CFE_TBL_File_Hdr_t);
+    strncpy(TblFileHeader.TableName, CFE_TBL_Global.Registry[0].Name,
             sizeof(TblFileHeader.TableName) - 1);
     TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
@@ -1682,13 +1682,13 @@ void Test_CFE_TBL_HousekeepingCmd(void)
      * to send Hk packet
      */
     UT_InitData();
-    strncpy(CFE_TBL_TaskData.DumpControlBlocks[0].TableName,
-           "housekeepingtest", sizeof(CFE_TBL_TaskData.DumpControlBlocks[0].TableName) - 1);
-    CFE_TBL_TaskData.DumpControlBlocks[0].TableName[sizeof(CFE_TBL_TaskData.DumpControlBlocks[0].TableName) - 1] = '\0';
-    CFE_TBL_TaskData.DumpControlBlocks[0].Size = 10;
+    strncpy(CFE_TBL_Global.DumpControlBlocks[0].TableName,
+           "housekeepingtest", sizeof(CFE_TBL_Global.DumpControlBlocks[0].TableName) - 1);
+    CFE_TBL_Global.DumpControlBlocks[0].TableName[sizeof(CFE_TBL_Global.DumpControlBlocks[0].TableName) - 1] = '\0';
+    CFE_TBL_Global.DumpControlBlocks[0].Size = 10;
     LoadInProg = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
     RegRecPtr.LoadInProgress = LoadInProg;
-    CFE_TBL_TaskData.DumpControlBlocks[0].RegRecPtr = &RegRecPtr;
+    CFE_TBL_Global.DumpControlBlocks[0].RegRecPtr = &RegRecPtr;
     DumpBuffPtr->Taken = true;
     DumpBuffPtr->Validated = true;
     DumpBuffPtr->BufferPtr = BuffPtr;
@@ -1696,16 +1696,16 @@ void Test_CFE_TBL_HousekeepingCmd(void)
     DumpBuffPtr->FileCreateTimeSubSecs = SubSecs;
     strncpy(DumpBuffPtr->DataSource, "hkSource", sizeof(DumpBuffPtr->DataSource) - 1);
     DumpBuffPtr->DataSource[sizeof(DumpBuffPtr->DataSource) - 1] = '\0';
-    CFE_TBL_TaskData.DumpControlBlocks[0].DumpBufferPtr = DumpBuffPtr;
-    CFE_TBL_TaskData.DumpControlBlocks[0].State = CFE_TBL_DUMP_PERFORMED;
+    CFE_TBL_Global.DumpControlBlocks[0].DumpBufferPtr = DumpBuffPtr;
+    CFE_TBL_Global.DumpControlBlocks[0].State = CFE_TBL_DUMP_PERFORMED;
 
     for (i = 1; i < CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS; i++)
     {
-        CFE_TBL_TaskData.DumpControlBlocks[i].State = CFE_TBL_DUMP_PENDING;
+        CFE_TBL_Global.DumpControlBlocks[i].State = CFE_TBL_DUMP_PENDING;
     }
 
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_TransmitMsg), 1, CFE_SUCCESS - 1);
-    CFE_TBL_TaskData.HkTlmTblRegIndex = CFE_TBL_NOT_FOUND + 1;
+    CFE_TBL_Global.HkTlmTblRegIndex = CFE_TBL_NOT_FOUND + 1;
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_HousekeepingCmd(NULL) == CFE_TBL_DONT_INC_CTR,
               "CFE_TBL_HousekeepingCmd",
@@ -1713,16 +1713,16 @@ void Test_CFE_TBL_HousekeepingCmd(void)
 
     for (i = 1; i < CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS; i++)
     {
-        CFE_TBL_TaskData.DumpControlBlocks[i].State = CFE_TBL_DUMP_PENDING;
+        CFE_TBL_Global.DumpControlBlocks[i].State = CFE_TBL_DUMP_PENDING;
     }
 
     RegRecPtr.LoadInProgress = LoadInProg;
-    CFE_TBL_TaskData.DumpControlBlocks[0].RegRecPtr = &RegRecPtr;
+    CFE_TBL_Global.DumpControlBlocks[0].RegRecPtr = &RegRecPtr;
 
     /* Test response to inability to open dump file */
     UT_InitData();
-    CFE_TBL_TaskData.DumpControlBlocks[0].State = CFE_TBL_DUMP_PERFORMED;
-    CFE_TBL_TaskData.HkTlmTblRegIndex = CFE_TBL_NOT_FOUND + 1;
+    CFE_TBL_Global.DumpControlBlocks[0].State = CFE_TBL_DUMP_PERFORMED;
+    CFE_TBL_Global.HkTlmTblRegIndex = CFE_TBL_NOT_FOUND + 1;
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_HousekeepingCmd(NULL) == CFE_TBL_DONT_INC_CTR,
@@ -1731,8 +1731,8 @@ void Test_CFE_TBL_HousekeepingCmd(void)
 
     /* Test response to an invalid table and a dump file create failure */
     UT_InitData();
-    CFE_TBL_TaskData.HkTlmTblRegIndex = CFE_TBL_NOT_FOUND;
-    CFE_TBL_TaskData.DumpControlBlocks[0].State = CFE_TBL_DUMP_PERFORMED;
+    CFE_TBL_Global.HkTlmTblRegIndex = CFE_TBL_NOT_FOUND;
+    CFE_TBL_Global.DumpControlBlocks[0].State = CFE_TBL_DUMP_PERFORMED;
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_HousekeepingCmd(NULL) == CFE_TBL_DONT_INC_CTR,
@@ -1741,7 +1741,7 @@ void Test_CFE_TBL_HousekeepingCmd(void)
 
     /* Test response to a file time stamp failure */
     UT_InitData();
-    CFE_TBL_TaskData.DumpControlBlocks[0].State = CFE_TBL_DUMP_PERFORMED;
+    CFE_TBL_Global.DumpControlBlocks[0].State = CFE_TBL_DUMP_PERFORMED;
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_SetTimestamp), 1, OS_SUCCESS - 1);
     UT_Report(__FILE__, __LINE__,
               CFE_TBL_HousekeepingCmd(NULL) == CFE_TBL_DONT_INC_CTR,
@@ -1756,7 +1756,7 @@ void Test_CFE_TBL_ApiInit(void)
 {
     UT_ResetCDS();
     CFE_TBL_EarlyInit();
-    CFE_TBL_TaskData.TableTaskAppId = UT_TBL_APPID_10;
+    CFE_TBL_Global.TableTaskAppId = UT_TBL_APPID_10;
 }
 
 /*
@@ -2133,7 +2133,7 @@ void Test_CFE_TBL_Register(void)
     /* a. Perform test */
     UT_ClearEventHistory();
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_RegisterCDSEx), 1, CFE_ES_CDS_ALREADY_EXISTS);
-    CFE_TBL_TaskData.CritReg[0].TableLoadedOnce = true;
+    CFE_TBL_Global.CritReg[0].TableLoadedOnce = true;
     RtnCode = CFE_TBL_Register(&TblHandle1, "UT_Table1",
                                sizeof(UT_Table1_t),
                                CFE_TBL_OPT_CRITICAL, NULL);
@@ -2160,7 +2160,7 @@ void Test_CFE_TBL_Register(void)
     /* a. Perform test */
     UT_ClearEventHistory();
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_RegisterCDSEx), 1, CFE_ES_CDS_ALREADY_EXISTS);
-    CFE_TBL_TaskData.CritReg[0].TableLoadedOnce = false;
+    CFE_TBL_Global.CritReg[0].TableLoadedOnce = false;
     RtnCode = CFE_TBL_Register(&TblHandle1, "UT_Table1",
                                sizeof(UT_Table1_t),
                                CFE_TBL_OPT_CRITICAL, NULL);
@@ -2220,7 +2220,7 @@ void Test_CFE_TBL_Register(void)
     /* Remove all entries from critical table registry */
     for (i = 0; i < CFE_PLATFORM_TBL_MAX_CRITICAL_TABLES; i++)
     {
-        CFE_TBL_TaskData.CritReg[i].CDSHandle = CFE_ES_CDS_BAD_HANDLE;
+        CFE_TBL_Global.CritReg[i].CDSHandle = CFE_ES_CDS_BAD_HANDLE;
     }
 
     RtnCode = CFE_TBL_Register(&TblHandle1, "UT_Table1",
@@ -2254,7 +2254,7 @@ void Test_CFE_TBL_Register(void)
     /* a. Perform test */
     for (i = 0; i < CFE_PLATFORM_TBL_MAX_CRITICAL_TABLES; i++)
     {
-        CFE_TBL_TaskData.CritReg[i].CDSHandle = CFE_ES_RESOURCEID_UNDEFINED;
+        CFE_TBL_Global.CritReg[i].CDSHandle = CFE_ES_RESOURCEID_UNDEFINED;
     }
 
     RtnCode = CFE_TBL_Register(&TblHandle1, "UT_Table1",
@@ -2404,7 +2404,7 @@ void Test_CFE_TBL_Register(void)
 
     /* Test attempt to register a table with UsedFlag = false */
     UT_InitData();
-    CFE_TBL_TaskData.Handles[0].UsedFlag = false;
+    CFE_TBL_Global.Handles[0].UsedFlag = false;
     RtnCode = CFE_TBL_Register(&TblHandle2, "UT_Table1",
                                sizeof(UT_Table1_t),
                                CFE_TBL_OPT_DBL_BUFFER, NULL);
@@ -2417,8 +2417,8 @@ void Test_CFE_TBL_Register(void)
 
     /* Test attempt to register a table with an invalid registry index */
     UT_InitData();
-    CFE_TBL_TaskData.Handles[0].UsedFlag = true;
-    CFE_TBL_TaskData.Handles[0].RegIndex = -1;
+    CFE_TBL_Global.Handles[0].UsedFlag = true;
+    CFE_TBL_Global.Handles[0].RegIndex = -1;
     RtnCode = CFE_TBL_Register(&TblHandle2, "UT_Table1",
                                sizeof(UT_Table1_t),
                                CFE_TBL_OPT_DBL_BUFFER, NULL);
@@ -2434,7 +2434,7 @@ void Test_CFE_TBL_Register(void)
 
    for (i = 0; i < CFE_PLATFORM_TBL_MAX_NUM_TABLES; i++)
    {
-       CFE_TBL_TaskData.Registry[i].HeadOfAccessList = CFE_TBL_END_OF_LIST;
+       CFE_TBL_Global.Registry[i].HeadOfAccessList = CFE_TBL_END_OF_LIST;
    }
 
    RtnCode = CFE_TBL_Register(&TblHandle2, "UT_Table1",
@@ -2454,19 +2454,19 @@ void Test_CFE_TBL_Register(void)
    UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetPoolBuf), 1, CFE_SEVERITY_ERROR);
    snprintf(TblName, CFE_MISSION_TBL_MAX_NAME_LENGTH, "UT_Table%d",
             CFE_PLATFORM_TBL_MAX_NUM_TABLES);
-   CFE_TBL_TaskData.Handles[0].UsedFlag = false;
+   CFE_TBL_Global.Handles[0].UsedFlag = false;
    RtnCode = CFE_TBL_Register(&TblHandle2, TblName,
                               sizeof(UT_Table1_t) + 1,
                               CFE_TBL_OPT_DBL_BUFFER, NULL);
-   AccessDescPtr = &CFE_TBL_TaskData.Handles[TblHandle2];
-   RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+   AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle2];
+   RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
    EventsCorrect = RegRecPtr->DoubleBuffered == false &&
                    RegRecPtr->ActiveBufferIndex == 0;
    UT_Report(__FILE__, __LINE__,
               RtnCode == CFE_SEVERITY_ERROR && EventsCorrect,
              "CFE_TBL_Register",
              "Register a double buffered table with pool buffer error");
-   CFE_TBL_TaskData.Handles[0].UsedFlag = true;
+   CFE_TBL_Global.Handles[0].UsedFlag = true;
 }
 
 /*
@@ -2638,8 +2638,8 @@ void Test_CFE_TBL_NotifyByMessage(void)
 
     /* Set up notify by message tests */
     UT_InitData();
+    Test_CFE_TBL_ApiInit();
     UT_SetAppID(UT_TBL_APPID_1);
-    CFE_TBL_EarlyInit();
     UT_ResetPoolBufferIndex();
 
     RtnCode = CFE_TBL_Register(&App1TblHandle1, "NBMsg_Tbl",
@@ -2664,7 +2664,7 @@ void Test_CFE_TBL_NotifyByMessage(void)
      * own the table handle
      */
     UT_InitData();
-    CFE_TBL_TaskData.Registry[0].OwnerAppId = CFE_TBL_NOT_OWNED;
+    CFE_TBL_Global.Registry[0].OwnerAppId = CFE_TBL_NOT_OWNED;
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     RtnCode = CFE_TBL_NotifyByMessage(App1TblHandle1, CFE_SB_ValueToMsgId(1), 1, 1);
     UT_Report(__FILE__, __LINE__,
@@ -2752,8 +2752,8 @@ void Test_CFE_TBL_Load(void)
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UT_SetDeferredRetcode(UT_KEY(OS_read), 3, 0);
-    AccessDescPtr = &CFE_TBL_TaskData.Handles[App1TblHandle1];
-    RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+    AccessDescPtr = &CFE_TBL_Global.Handles[App1TblHandle1];
+    RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
     RegRecPtr->UserDefAddr = true;
     RegRecPtr->TableLoadedOnce = true;
     RtnCode = CFE_TBL_Load(App1TblHandle1,
@@ -2826,8 +2826,8 @@ void Test_CFE_TBL_Load(void)
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UT_SetDeferredRetcode(UT_KEY(OS_read), 3, 0);
-    AccessDescPtr = &CFE_TBL_TaskData.Handles[App1TblHandle2];
-    RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+    AccessDescPtr = &CFE_TBL_Global.Handles[App1TblHandle2];
+    RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
     RegRecPtr->DoubleBuffered = true;
     RegRecPtr->TableLoadedOnce = true;
     RtnCode = CFE_TBL_Load(App1TblHandle2,
@@ -2931,8 +2931,8 @@ void Test_CFE_TBL_Load(void)
 
     /* Test attempt to load a dump-only table with the table already loaded */
     UT_InitData();
-    AccessDescPtr = &CFE_TBL_TaskData.Handles[DumpOnlyTblHandle];
-    RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+    AccessDescPtr = &CFE_TBL_Global.Handles[DumpOnlyTblHandle];
+    RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
     RegRecPtr->UserDefAddr = true;
     RegRecPtr->TableLoadedOnce = true;
     RtnCode = CFE_TBL_Load(DumpOnlyTblHandle,
@@ -3263,7 +3263,7 @@ void Test_CFE_TBL_Manage(void)
 
     /* "Load" image into inactive buffer for table */
     RegIndex = CFE_TBL_FindTableInRegistry("ut_cfe_tbl.UT_Table1");
-    RegRecPtr = &CFE_TBL_TaskData.Registry[RegIndex];
+    RegRecPtr = &CFE_TBL_Global.Registry[RegIndex];
     RtnCode = CFE_TBL_GetWorkingBuffer(&WorkingBufferPtr, RegRecPtr, false);
     UT_SetAppID(UT_TBL_APPID_1);
     RtnCode = CFE_TBL_Load(App1TblHandle1, CFE_TBL_SRC_ADDRESS, &TestTable1);
@@ -3280,13 +3280,13 @@ void Test_CFE_TBL_Manage(void)
     UT_InitData();
 
     /* Configure table for validation */
-    CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
-    CFE_TBL_TaskData.ValidationResults[0].Result = 0;
-    strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
-    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
-    CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
-    CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = false;
+    CFE_TBL_Global.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
+    CFE_TBL_Global.ValidationResults[0].Result = 0;
+    strncpy(CFE_TBL_Global.ValidationResults[0].TableName,
+            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_Global.ValidationResults[0].TableName) - 1);
+    CFE_TBL_Global.ValidationResults[0].TableName[sizeof(CFE_TBL_Global.ValidationResults[0].TableName) - 1] = '\0';
+    CFE_TBL_Global.ValidationResults[0].CrcOfTable = 0;
+    CFE_TBL_Global.ValidationResults[0].ActiveBuffer = false;
     RegRecPtr->ValidateInactiveIndex = 0;
 
     /* Perform validation via manage call */
@@ -3296,7 +3296,7 @@ void Test_CFE_TBL_Manage(void)
                      UT_GetNumEventsSent() == 1);
     UT_Report(__FILE__, __LINE__,
               RtnCode == CFE_SUCCESS && EventsCorrect &&
-              CFE_TBL_TaskData.ValidationResults[0].Result == -1,
+              CFE_TBL_Global.ValidationResults[0].Result == -1,
               "CFE_TBL_Manage",
               "Manage table that has a failed validation pending on "
                 "inactive buffer (valid function return code)");
@@ -3307,13 +3307,13 @@ void Test_CFE_TBL_Manage(void)
     UT_InitData();
 
     /* Configure table for validation */
-    CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
-    CFE_TBL_TaskData.ValidationResults[0].Result = 0;
-    strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
-    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
-    CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
-    CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = false;
+    CFE_TBL_Global.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
+    CFE_TBL_Global.ValidationResults[0].Result = 0;
+    strncpy(CFE_TBL_Global.ValidationResults[0].TableName,
+            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_Global.ValidationResults[0].TableName) - 1);
+    CFE_TBL_Global.ValidationResults[0].TableName[sizeof(CFE_TBL_Global.ValidationResults[0].TableName) - 1] = '\0';
+    CFE_TBL_Global.ValidationResults[0].CrcOfTable = 0;
+    CFE_TBL_Global.ValidationResults[0].ActiveBuffer = false;
     RegRecPtr->ValidateInactiveIndex = 0;
 
     /* Perform validation via manage call */
@@ -3323,7 +3323,7 @@ void Test_CFE_TBL_Manage(void)
                      UT_GetNumEventsSent() == 1);
     UT_Report(__FILE__, __LINE__,
               RtnCode == CFE_SUCCESS && EventsCorrect &&
-              CFE_TBL_TaskData.ValidationResults[0].Result == 1,
+              CFE_TBL_Global.ValidationResults[0].Result == 1,
               "CFE_TBL_Manage",
               "Manage table that has a failed validation pending on "
                 "inactive buffer (invalid function return code)");
@@ -3334,13 +3334,13 @@ void Test_CFE_TBL_Manage(void)
     UT_InitData();
 
     /* Configure table for validation */
-    CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
-    CFE_TBL_TaskData.ValidationResults[0].Result = 1;
-    strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
-    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
-    CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
-    CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = false;
+    CFE_TBL_Global.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
+    CFE_TBL_Global.ValidationResults[0].Result = 1;
+    strncpy(CFE_TBL_Global.ValidationResults[0].TableName,
+            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_Global.ValidationResults[0].TableName) - 1);
+    CFE_TBL_Global.ValidationResults[0].TableName[sizeof(CFE_TBL_Global.ValidationResults[0].TableName) - 1] = '\0';
+    CFE_TBL_Global.ValidationResults[0].CrcOfTable = 0;
+    CFE_TBL_Global.ValidationResults[0].ActiveBuffer = false;
     RegRecPtr->ValidateInactiveIndex = 0;
 
     /* Perform validation via manage call */
@@ -3350,7 +3350,7 @@ void Test_CFE_TBL_Manage(void)
                      UT_GetNumEventsSent() == 1);
     UT_Report(__FILE__, __LINE__,
               RtnCode == CFE_SUCCESS && EventsCorrect &&
-              CFE_TBL_TaskData.ValidationResults[0].Result == 0,
+              CFE_TBL_Global.ValidationResults[0].Result == 0,
               "CFE_TBL_Manage",
               "Manage table that has a successful validation pending on "
                 "an inactive buffer");
@@ -3361,13 +3361,13 @@ void Test_CFE_TBL_Manage(void)
     UT_InitData();
 
     /* Configure table for validation */
-    CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
-    CFE_TBL_TaskData.ValidationResults[0].Result = 0;
-    strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
-    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
-    CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
-    CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = true;
+    CFE_TBL_Global.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
+    CFE_TBL_Global.ValidationResults[0].Result = 0;
+    strncpy(CFE_TBL_Global.ValidationResults[0].TableName,
+            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_Global.ValidationResults[0].TableName) - 1);
+    CFE_TBL_Global.ValidationResults[0].TableName[sizeof(CFE_TBL_Global.ValidationResults[0].TableName) - 1] = '\0';
+    CFE_TBL_Global.ValidationResults[0].CrcOfTable = 0;
+    CFE_TBL_Global.ValidationResults[0].ActiveBuffer = true;
     RegRecPtr->ValidateActiveIndex = 0;
 
     /* Perform validation via manage call */
@@ -3377,7 +3377,7 @@ void Test_CFE_TBL_Manage(void)
                      UT_GetNumEventsSent() == 1);
     UT_Report(__FILE__, __LINE__,
               RtnCode == CFE_SUCCESS && EventsCorrect &&
-              CFE_TBL_TaskData.ValidationResults[0].Result == -1,
+              CFE_TBL_Global.ValidationResults[0].Result == -1,
               "CFE_TBL_Manage",
               "Manage table that has an unsuccessful validation pending on "
                 "an active buffer");
@@ -3388,13 +3388,13 @@ void Test_CFE_TBL_Manage(void)
     UT_InitData();
 
     /* Configure table for validation */
-    CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
-    CFE_TBL_TaskData.ValidationResults[0].Result = 0;
-    strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
-    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
-    CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
-    CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = true;
+    CFE_TBL_Global.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
+    CFE_TBL_Global.ValidationResults[0].Result = 0;
+    strncpy(CFE_TBL_Global.ValidationResults[0].TableName,
+            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_Global.ValidationResults[0].TableName) - 1);
+    CFE_TBL_Global.ValidationResults[0].TableName[sizeof(CFE_TBL_Global.ValidationResults[0].TableName) - 1] = '\0';
+    CFE_TBL_Global.ValidationResults[0].CrcOfTable = 0;
+    CFE_TBL_Global.ValidationResults[0].ActiveBuffer = true;
     RegRecPtr->ValidateActiveIndex = 0;
 
     /* Perform validation via manage call */
@@ -3404,7 +3404,7 @@ void Test_CFE_TBL_Manage(void)
                      UT_GetNumEventsSent() == 1);
     UT_Report(__FILE__, __LINE__,
               RtnCode == CFE_SUCCESS && EventsCorrect &&
-              CFE_TBL_TaskData.ValidationResults[0].Result == 1,
+              CFE_TBL_Global.ValidationResults[0].Result == 1,
               "CFE_TBL_Manage",
               "Manage table that has an unsuccessful validation pending "
                 "on an active buffer");
@@ -3415,13 +3415,13 @@ void Test_CFE_TBL_Manage(void)
     UT_InitData();
 
     /* Configure table for validation */
-    CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
-    CFE_TBL_TaskData.ValidationResults[0].Result = 1;
-    strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
-    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
-    CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
-    CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = true;
+    CFE_TBL_Global.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
+    CFE_TBL_Global.ValidationResults[0].Result = 1;
+    strncpy(CFE_TBL_Global.ValidationResults[0].TableName,
+            "ut_cfe_tbl.UT_Table1", sizeof(CFE_TBL_Global.ValidationResults[0].TableName) - 1);
+    CFE_TBL_Global.ValidationResults[0].TableName[sizeof(CFE_TBL_Global.ValidationResults[0].TableName) - 1] = '\0';
+    CFE_TBL_Global.ValidationResults[0].CrcOfTable = 0;
+    CFE_TBL_Global.ValidationResults[0].ActiveBuffer = true;
     RegRecPtr->ValidateActiveIndex = 0;
 
     /* Perform validation via manage call */
@@ -3431,7 +3431,7 @@ void Test_CFE_TBL_Manage(void)
                      UT_GetNumEventsSent() == 1);
     UT_Report(__FILE__, __LINE__,
               RtnCode == CFE_SUCCESS && EventsCorrect &&
-              CFE_TBL_TaskData.ValidationResults[0].Result == 0,
+              CFE_TBL_Global.ValidationResults[0].Result == 0,
               "CFE_TBL_Manage",
               "Manage table that has a successful validation pending on "
                 "an active buffer");
@@ -3469,8 +3469,8 @@ void Test_CFE_TBL_Manage(void)
               "Process an update request on a locked table");
 
     /* Save the previous table's information for a subsequent test */
-    AccessDescPtr = &CFE_TBL_TaskData.Handles[App1TblHandle1];
-    RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+    AccessDescPtr = &CFE_TBL_Global.Handles[App1TblHandle1];
+    RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
     AccessIterator = RegRecPtr->HeadOfAccessList;
 
     /* Test unlocking a table by releasing the address */
@@ -3508,17 +3508,17 @@ void Test_CFE_TBL_Manage(void)
     /* Reset the current table entry pointer to a previous table in order to
      * exercise the path where no buffer is available
      */
-    AccessDescPtr = &CFE_TBL_TaskData.Handles[App1TblHandle2];
-    RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
-    CFE_TBL_TaskData.Handles[AccessIterator].NextLink = RegRecPtr->HeadOfAccessList;
-    CFE_TBL_TaskData.Handles[AccessIterator].AppId = UT_TBL_APPID_2;
+    AccessDescPtr = &CFE_TBL_Global.Handles[App1TblHandle2];
+    RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
+    CFE_TBL_Global.Handles[AccessIterator].NextLink = RegRecPtr->HeadOfAccessList;
+    CFE_TBL_Global.Handles[AccessIterator].AppId = UT_TBL_APPID_2;
     RegRecPtr->HeadOfAccessList = AccessIterator;
-    CFE_TBL_TaskData.Handles[AccessIterator].BufferIndex = 1;
-    CFE_TBL_TaskData.Handles[AccessIterator].LockFlag = true;
+    CFE_TBL_Global.Handles[AccessIterator].BufferIndex = 1;
+    CFE_TBL_Global.Handles[AccessIterator].LockFlag = true;
 
     /* Attempt to "load" image into inactive buffer for table */
     RegIndex = CFE_TBL_FindTableInRegistry("ut_cfe_tbl.UT_Table2");
-    RegRecPtr = &CFE_TBL_TaskData.Registry[RegIndex];
+    RegRecPtr = &CFE_TBL_Global.Registry[RegIndex];
     RtnCode = CFE_TBL_GetWorkingBuffer(&WorkingBufferPtr, RegRecPtr, false);
     UT_Report(__FILE__, __LINE__,
               RtnCode == CFE_TBL_ERR_NO_BUFFER_AVAIL,
@@ -3526,20 +3526,20 @@ void Test_CFE_TBL_Manage(void)
               "No buffer available");
 
     /* Reset the table information for subsequent tests */
-    CFE_TBL_TaskData.Handles[AccessIterator].BufferIndex = 1;
-    CFE_TBL_TaskData.Handles[AccessIterator].LockFlag = false;
+    CFE_TBL_Global.Handles[AccessIterator].BufferIndex = 1;
+    CFE_TBL_Global.Handles[AccessIterator].LockFlag = false;
 
     /* Successfully "load" image into inactive buffer for table */
     RtnCode = CFE_TBL_GetWorkingBuffer(&WorkingBufferPtr, RegRecPtr, false);
 
     /* Configure table for validation */
-    CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
-    CFE_TBL_TaskData.ValidationResults[0].Result = 0;
-    strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table2", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
-    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
-    CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
-    CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = false;
+    CFE_TBL_Global.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
+    CFE_TBL_Global.ValidationResults[0].Result = 0;
+    strncpy(CFE_TBL_Global.ValidationResults[0].TableName,
+            "ut_cfe_tbl.UT_Table2", sizeof(CFE_TBL_Global.ValidationResults[0].TableName) - 1);
+    CFE_TBL_Global.ValidationResults[0].TableName[sizeof(CFE_TBL_Global.ValidationResults[0].TableName) - 1] = '\0';
+    CFE_TBL_Global.ValidationResults[0].CrcOfTable = 0;
+    CFE_TBL_Global.ValidationResults[0].ActiveBuffer = false;
     RegRecPtr->ValidateInactiveIndex = 0;
 
     /* Perform validation via manage call */
@@ -3549,7 +3549,7 @@ void Test_CFE_TBL_Manage(void)
                      UT_GetNumEventsSent() == 1);
     UT_Report(__FILE__, __LINE__,
               RtnCode == CFE_SUCCESS && EventsCorrect &&
-              CFE_TBL_TaskData.ValidationResults[0].Result == -1,
+              CFE_TBL_Global.ValidationResults[0].Result == -1,
               "CFE_TBL_Manage",
               "Manage table that has a failed validation pending on an "
                 "inactive buffer (double buffered)");
@@ -3560,13 +3560,13 @@ void Test_CFE_TBL_Manage(void)
     UT_InitData();
 
     /* Configure table for validation */
-    CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
-    CFE_TBL_TaskData.ValidationResults[0].Result = 1;
-    strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table2", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
-    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
-    CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
-    CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = false;
+    CFE_TBL_Global.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
+    CFE_TBL_Global.ValidationResults[0].Result = 1;
+    strncpy(CFE_TBL_Global.ValidationResults[0].TableName,
+            "ut_cfe_tbl.UT_Table2", sizeof(CFE_TBL_Global.ValidationResults[0].TableName) - 1);
+    CFE_TBL_Global.ValidationResults[0].TableName[sizeof(CFE_TBL_Global.ValidationResults[0].TableName) - 1] = '\0';
+    CFE_TBL_Global.ValidationResults[0].CrcOfTable = 0;
+    CFE_TBL_Global.ValidationResults[0].ActiveBuffer = false;
     RegRecPtr->ValidateInactiveIndex = 0;
 
     /* Perform validation via manage call */
@@ -3576,7 +3576,7 @@ void Test_CFE_TBL_Manage(void)
                      UT_GetNumEventsSent() == 1);
     UT_Report(__FILE__, __LINE__,
               RtnCode == CFE_SUCCESS && EventsCorrect &&
-              CFE_TBL_TaskData.ValidationResults[0].Result == 0,
+              CFE_TBL_Global.ValidationResults[0].Result == 0,
               "CFE_TBL_Manage",
               "Manage table that has a successful validation pending on an "
                 "inactive buffer (double buffered)");
@@ -3587,13 +3587,13 @@ void Test_CFE_TBL_Manage(void)
     UT_InitData();
 
     /* Configure table for validation */
-    CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
-    CFE_TBL_TaskData.ValidationResults[0].Result = 0;
-    strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table2", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
-    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
-    CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
-    CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = true;
+    CFE_TBL_Global.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
+    CFE_TBL_Global.ValidationResults[0].Result = 0;
+    strncpy(CFE_TBL_Global.ValidationResults[0].TableName,
+            "ut_cfe_tbl.UT_Table2", sizeof(CFE_TBL_Global.ValidationResults[0].TableName) - 1);
+    CFE_TBL_Global.ValidationResults[0].TableName[sizeof(CFE_TBL_Global.ValidationResults[0].TableName) - 1] = '\0';
+    CFE_TBL_Global.ValidationResults[0].CrcOfTable = 0;
+    CFE_TBL_Global.ValidationResults[0].ActiveBuffer = true;
     RegRecPtr->ValidateActiveIndex = 0;
 
     /* Perform validation via manage call */
@@ -3603,7 +3603,7 @@ void Test_CFE_TBL_Manage(void)
                      UT_GetNumEventsSent() == 1);
     UT_Report(__FILE__, __LINE__,
               RtnCode == CFE_SUCCESS && EventsCorrect &&
-              CFE_TBL_TaskData.ValidationResults[0].Result == -1,
+              CFE_TBL_Global.ValidationResults[0].Result == -1,
               "CFE_TBL_Manage",
               "Manage table that has an unsuccessful validation pending on an "
                 "active buffer (double buffered)");
@@ -3614,13 +3614,13 @@ void Test_CFE_TBL_Manage(void)
     UT_InitData();
 
     /* Configure table for validation */
-    CFE_TBL_TaskData.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
-    CFE_TBL_TaskData.ValidationResults[0].Result = 1;
-    strncpy(CFE_TBL_TaskData.ValidationResults[0].TableName,
-            "ut_cfe_tbl.UT_Table2", sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1);
-    CFE_TBL_TaskData.ValidationResults[0].TableName[sizeof(CFE_TBL_TaskData.ValidationResults[0].TableName) - 1] = '\0';
-    CFE_TBL_TaskData.ValidationResults[0].CrcOfTable = 0;
-    CFE_TBL_TaskData.ValidationResults[0].ActiveBuffer = true;
+    CFE_TBL_Global.ValidationResults[0].State = CFE_TBL_VALIDATION_PENDING;
+    CFE_TBL_Global.ValidationResults[0].Result = 1;
+    strncpy(CFE_TBL_Global.ValidationResults[0].TableName,
+            "ut_cfe_tbl.UT_Table2", sizeof(CFE_TBL_Global.ValidationResults[0].TableName) - 1);
+    CFE_TBL_Global.ValidationResults[0].TableName[sizeof(CFE_TBL_Global.ValidationResults[0].TableName) - 1] = '\0';
+    CFE_TBL_Global.ValidationResults[0].CrcOfTable = 0;
+    CFE_TBL_Global.ValidationResults[0].ActiveBuffer = true;
     RegRecPtr->ValidateActiveIndex = 0;
 
     /* Perform validation via manage call */
@@ -3630,7 +3630,7 @@ void Test_CFE_TBL_Manage(void)
                      UT_GetNumEventsSent() == 1);
     UT_Report(__FILE__, __LINE__,
               RtnCode == CFE_SUCCESS && EventsCorrect &&
-              CFE_TBL_TaskData.ValidationResults[0].Result == 0,
+              CFE_TBL_Global.ValidationResults[0].Result == 0,
               "CFE_TBL_Manage",
               "Manage table that has a successful validation pending on an "
                 "active buffer (double buffered)");
@@ -3638,21 +3638,21 @@ void Test_CFE_TBL_Manage(void)
     /* Test successfully processing a table dump request */
     UT_InitData();
     RtnCode = CFE_TBL_GetWorkingBuffer(&WorkingBufferPtr, RegRecPtr, false);
-    CFE_TBL_TaskData.DumpControlBlocks[0].State = CFE_TBL_DUMP_PENDING;
-    CFE_TBL_TaskData.DumpControlBlocks[0].RegRecPtr = RegRecPtr;
+    CFE_TBL_Global.DumpControlBlocks[0].State = CFE_TBL_DUMP_PENDING;
+    CFE_TBL_Global.DumpControlBlocks[0].RegRecPtr = RegRecPtr;
 
     /* Save the name of the desired dump filename, table name, and size for
      * later
      */
-    CFE_TBL_TaskData.DumpControlBlocks[0].DumpBufferPtr = WorkingBufferPtr;
-    strncpy(CFE_TBL_TaskData.DumpControlBlocks[0].DumpBufferPtr->DataSource,
-            "MyDumpFilename", sizeof(CFE_TBL_TaskData.DumpControlBlocks[0].DumpBufferPtr->DataSource) - 1);
-    CFE_TBL_TaskData.DumpControlBlocks[0].DumpBufferPtr->DataSource[
-            sizeof(CFE_TBL_TaskData.DumpControlBlocks[0].DumpBufferPtr->DataSource) - 1] = 0;
-    strncpy(CFE_TBL_TaskData.DumpControlBlocks[0].TableName, "ut_cfe_tbl.UT_Table2",
-            sizeof(CFE_TBL_TaskData.DumpControlBlocks[0].TableName) - 1);
-    CFE_TBL_TaskData.DumpControlBlocks[0].TableName[sizeof(CFE_TBL_TaskData.DumpControlBlocks[0].TableName) - 1] = 0;
-    CFE_TBL_TaskData.DumpControlBlocks[0].Size = RegRecPtr->Size;
+    CFE_TBL_Global.DumpControlBlocks[0].DumpBufferPtr = WorkingBufferPtr;
+    strncpy(CFE_TBL_Global.DumpControlBlocks[0].DumpBufferPtr->DataSource,
+            "MyDumpFilename", sizeof(CFE_TBL_Global.DumpControlBlocks[0].DumpBufferPtr->DataSource) - 1);
+    CFE_TBL_Global.DumpControlBlocks[0].DumpBufferPtr->DataSource[
+            sizeof(CFE_TBL_Global.DumpControlBlocks[0].DumpBufferPtr->DataSource) - 1] = 0;
+    strncpy(CFE_TBL_Global.DumpControlBlocks[0].TableName, "ut_cfe_tbl.UT_Table2",
+            sizeof(CFE_TBL_Global.DumpControlBlocks[0].TableName) - 1);
+    CFE_TBL_Global.DumpControlBlocks[0].TableName[sizeof(CFE_TBL_Global.DumpControlBlocks[0].TableName) - 1] = 0;
+    CFE_TBL_Global.DumpControlBlocks[0].Size = RegRecPtr->Size;
     RegRecPtr->DumpControlIndex = 0;
     RtnCode = CFE_TBL_Manage(App1TblHandle2);
     EventsCorrect = (UT_GetNumEventsSent() == 0);
@@ -3809,8 +3809,8 @@ void Test_CFE_TBL_TblMod(void)
      */
     /* a. Test setup */
     UT_InitData();
+    Test_CFE_TBL_ApiInit();
     UT_SetAppID(UT_TBL_APPID_1);
-    CFE_TBL_EarlyInit();
     UT_ResetPoolBufferIndex();
 
     /* Test setup for CFE_TBL_Modified; register a non critical table */
@@ -3883,8 +3883,8 @@ void Test_CFE_TBL_TblMod(void)
                 "been updated by application");
 
     /* Save the previous table's information for a subsequent test */
-    AccessDescPtr = &CFE_TBL_TaskData.Handles[App1TblHandle1];
-    RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+    AccessDescPtr = &CFE_TBL_Global.Handles[App1TblHandle1];
+    RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
     AccessIterator = RegRecPtr->HeadOfAccessList;
 
     /* Test response to adding a TBL API for notifying table services that
@@ -3907,10 +3907,10 @@ void Test_CFE_TBL_TblMod(void)
     /* Reset the current table entry pointer to a previous table in order to
      * exercise the path where one of the application IDs don't match
      */
-    AccessDescPtr = &CFE_TBL_TaskData.Handles[App1TblHandle1];
-    RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
-    CFE_TBL_TaskData.Handles[AccessIterator].NextLink = RegRecPtr->HeadOfAccessList;
-    CFE_TBL_TaskData.Handles[AccessIterator].AppId = UT_TBL_APPID_2;
+    AccessDescPtr = &CFE_TBL_Global.Handles[App1TblHandle1];
+    RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
+    CFE_TBL_Global.Handles[AccessIterator].NextLink = RegRecPtr->HeadOfAccessList;
+    CFE_TBL_Global.Handles[AccessIterator].AppId = UT_TBL_APPID_2;
     RegRecPtr->HeadOfAccessList = AccessIterator;
 
     /* Configure for successful file read to initialize table */
@@ -4006,8 +4006,8 @@ void Test_CFE_TBL_Internal(void)
 
     /* Test successful initial load of double buffered table */
     UT_InitData();
-    AccessDescPtr = &CFE_TBL_TaskData.Handles[App1TblHandle2];
-    RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+    AccessDescPtr = &CFE_TBL_Global.Handles[App1TblHandle2];
+    RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
     strncpy(RegRecPtr->Name, "ut_cfe_tbl.UT_Table3",
             sizeof(RegRecPtr->Name) - 1);
     RegRecPtr->Name[sizeof(RegRecPtr->Name) - 1] = '\0';
@@ -4027,8 +4027,8 @@ void Test_CFE_TBL_Internal(void)
      */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(OS_MutSemTake), 1, OS_ERROR);
-    AccessDescPtr = &CFE_TBL_TaskData.Handles[App1TblHandle1];
-    RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+    AccessDescPtr = &CFE_TBL_Global.Handles[App1TblHandle1];
+    RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
     RtnCode = CFE_TBL_GetWorkingBuffer(&WorkingBufferPtr, RegRecPtr, false);
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     UT_Report(__FILE__, __LINE__,
@@ -4635,14 +4635,14 @@ void Test_CFE_TBL_Internal(void)
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UT_SetDeferredRetcode(UT_KEY(OS_read), 3, 0);
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_CopyToCDS), 2, CFE_ES_ERR_RESOURCEID_NOT_VALID);
-    AccessDescPtr = &CFE_TBL_TaskData.Handles[App1TblHandle2];
-    RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+    AccessDescPtr = &CFE_TBL_Global.Handles[App1TblHandle2];
+    RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
 
     for (i = 0; i < CFE_PLATFORM_TBL_MAX_CRITICAL_TABLES; i++)
     {
-        if ( CFE_ES_ResourceID_Equal(CFE_TBL_TaskData.CritReg[i].CDSHandle, RegRecPtr->CDSHandle) )
+        if ( CFE_ES_ResourceID_Equal(CFE_TBL_Global.CritReg[i].CDSHandle, RegRecPtr->CDSHandle) )
         {
-            CFE_TBL_TaskData.CritReg[i].CDSHandle = CFE_ES_RESOURCEID_RESERVED;
+            CFE_TBL_Global.CritReg[i].CDSHandle = CFE_ES_RESOURCEID_RESERVED;
         }
     }
 
@@ -4659,7 +4659,7 @@ void Test_CFE_TBL_Internal(void)
     /* Test unregistering a shared table */
     /* a. Share table */
     UT_InitData();
-    CFE_TBL_TaskData.CritReg[0].CDSHandle = RegRecPtr->CDSHandle;
+    CFE_TBL_Global.CritReg[0].CDSHandle = RegRecPtr->CDSHandle;
     UT_SetAppID(UT_TBL_APPID_2);
     RtnCode = CFE_TBL_Share(&App2TblHandle1, "ut_cfe_tbl.UT_Table1");
     UT_Report(__FILE__, __LINE__,
@@ -4680,18 +4680,18 @@ void Test_CFE_TBL_Internal(void)
     UT_InitData();
     UT_SetAppID(UT_TBL_APPID_1);
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_PutPoolBuf), -1);
-    AccessDescPtr = &CFE_TBL_TaskData.Handles[App1TblHandle1];
-    RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
-    CFE_TBL_TaskData.DumpControlBlocks[3].State = CFE_TBL_DUMP_PENDING;
-    CFE_TBL_TaskData.DumpControlBlocks[3].RegRecPtr = RegRecPtr;
+    AccessDescPtr = &CFE_TBL_Global.Handles[App1TblHandle1];
+    RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
+    CFE_TBL_Global.DumpControlBlocks[3].State = CFE_TBL_DUMP_PENDING;
+    CFE_TBL_Global.DumpControlBlocks[3].RegRecPtr = RegRecPtr;
     RegRecPtr->LoadInProgress = 1;
-    CFE_TBL_TaskData.LoadBuffs[1].Taken = true;
+    CFE_TBL_Global.LoadBuffs[1].Taken = true;
     CFE_TBL_CleanUpApp(UT_TBL_APPID_1);
     UT_Report(__FILE__, __LINE__,
-              CFE_TBL_TaskData.DumpControlBlocks[3].State ==
+              CFE_TBL_Global.DumpControlBlocks[3].State ==
                   CFE_TBL_DUMP_FREE &&
               CFE_ES_ResourceID_Equal(RegRecPtr->OwnerAppId, CFE_TBL_NOT_OWNED) &&
-              CFE_TBL_TaskData.LoadBuffs[RegRecPtr->LoadInProgress].Taken ==
+              CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].Taken ==
                   false &&
               RegRecPtr->LoadInProgress == CFE_TBL_NO_LOAD_IN_PROGRESS,
               "CFE_TBL_CleanUpApp",
@@ -4735,7 +4735,7 @@ void Test_CFE_TBL_Internal(void)
      * the table task application ID
      */
     UT_InitData();
-    CFE_TBL_TaskData.TableTaskAppId = UT_TBL_APPID_1;
+    CFE_TBL_Global.TableTaskAppId = UT_TBL_APPID_1;
     RtnCode = CFE_TBL_CheckAccessRights(App2TblHandle1, UT_TBL_APPID_1);
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     UT_Report(__FILE__, __LINE__,
@@ -4747,8 +4747,8 @@ void Test_CFE_TBL_Internal(void)
      * not owned but is not at the end of the list
      */
     UT_InitData();
-    CFE_TBL_TaskData.Registry[0].OwnerAppId = CFE_TBL_NOT_OWNED;
-    CFE_TBL_TaskData.Registry[0].HeadOfAccessList = CFE_TBL_END_OF_LIST + 1;
+    CFE_TBL_Global.Registry[0].OwnerAppId = CFE_TBL_NOT_OWNED;
+    CFE_TBL_Global.Registry[0].HeadOfAccessList = CFE_TBL_END_OF_LIST + 1;
     RtnCode = CFE_TBL_FindFreeRegistryEntry();
     EventsCorrect = (UT_GetNumEventsSent() == 0);
     UT_Report(__FILE__, __LINE__,
@@ -4793,8 +4793,8 @@ void Test_CFE_TBL_Internal(void)
      * be copied but a load is in progress
      */
     UT_InitData();
-    AccessDescPtr = &CFE_TBL_TaskData.Handles[App1TblHandle2];
-    RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+    AccessDescPtr = &CFE_TBL_Global.Handles[App1TblHandle2];
+    RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
     RegRecPtr->LoadPending = true;
     RegRecPtr->LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
     RtnCode = CFE_TBL_UpdateInternal(App1TblHandle2, RegRecPtr, AccessDescPtr);
@@ -4808,8 +4808,8 @@ void Test_CFE_TBL_Internal(void)
      * be copied but a load is in progress
      */
     UT_InitData();
-    AccessDescPtr = &CFE_TBL_TaskData.Handles[App1TblHandle2];
-    RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+    AccessDescPtr = &CFE_TBL_Global.Handles[App1TblHandle2];
+    RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
     RegRecPtr->LoadPending = true;
     RegRecPtr->LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
     RegRecPtr->CriticalTable = false;
@@ -4827,8 +4827,8 @@ void Test_CFE_TBL_Internal(void)
      * source and dest are not equal
      */
     UT_InitData();
-    AccessDescPtr = &CFE_TBL_TaskData.Handles[App1TblHandle2];
-    RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+    AccessDescPtr = &CFE_TBL_Global.Handles[App1TblHandle2];
+    RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
     RegRecPtr->LoadPending = true;
     RegRecPtr->LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
     RegRecPtr->DoubleBuffered = false;
@@ -4845,15 +4845,15 @@ void Test_CFE_TBL_Internal(void)
     UT_InitData();
     UT_SetAppID(UT_TBL_APPID_1);
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_PutPoolBuf), -1);
-    CFE_TBL_TaskData.Handles[0].AppId = UT_TBL_APPID_1;
-    AccessDescPtr = &CFE_TBL_TaskData.Handles[App1TblHandle2];
-    RegRecPtr = &CFE_TBL_TaskData.Registry[AccessDescPtr->RegIndex];
+    CFE_TBL_Global.Handles[0].AppId = UT_TBL_APPID_1;
+    AccessDescPtr = &CFE_TBL_Global.Handles[App1TblHandle2];
+    RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
     RegRecPtr->OwnerAppId = CFE_TBL_NOT_OWNED;
-    CFE_TBL_TaskData.DumpControlBlocks[3].State = CFE_TBL_DUMP_PENDING;
-    CFE_TBL_TaskData.DumpControlBlocks[3].RegRecPtr = RegRecPtr;
+    CFE_TBL_Global.DumpControlBlocks[3].State = CFE_TBL_DUMP_PENDING;
+    CFE_TBL_Global.DumpControlBlocks[3].RegRecPtr = RegRecPtr;
     CFE_TBL_CleanUpApp(UT_TBL_APPID_1);
     UT_Report(__FILE__, __LINE__,
-              CFE_TBL_TaskData.DumpControlBlocks[3].State ==
+              CFE_TBL_Global.DumpControlBlocks[3].State ==
             CFE_TBL_DUMP_PENDING &&
               CFE_ES_ResourceID_Equal(RegRecPtr->OwnerAppId, CFE_TBL_NOT_OWNED),
               "CFE_TBL_CleanUpApp",

--- a/fsw/cfe-core/unit-test/time_UT.c
+++ b/fsw/cfe-core/unit-test/time_UT.c
@@ -527,7 +527,7 @@ void Test_GetTime(void)
 
     UtPrintf("Begin Test Get Time");
 
-    CFE_TIME_TaskData.LastVersionCounter = 0x1000;
+    CFE_TIME_Global.LastVersionCounter = 0x1000;
 
     /* Test successfully retrieving the mission elapsed time */
     UT_InitData();
@@ -666,14 +666,14 @@ void Test_GetTime(void)
     RefState = CFE_TIME_StartReferenceUpdate();
     RefState->ClockSetState = CFE_TIME_SetState_NOT_SET;
     RefState->ClockFlyState = CFE_TIME_FlywheelState_NO_FLY;
-    CFE_TIME_TaskData.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
-    CFE_TIME_TaskData.ClockSignal = CFE_TIME_ToneSignalSelect_REDUNDANT;
-    CFE_TIME_TaskData.ServerFlyState = CFE_TIME_FlywheelState_NO_FLY;
-    CFE_TIME_TaskData.Forced2Fly = false;
-    CFE_TIME_TaskData.OneTimeDirection = CFE_TIME_AdjustDirection_SUBTRACT;
-    CFE_TIME_TaskData.OneHzDirection = CFE_TIME_AdjustDirection_SUBTRACT;
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
+    CFE_TIME_Global.ClockSignal = CFE_TIME_ToneSignalSelect_REDUNDANT;
+    CFE_TIME_Global.ServerFlyState = CFE_TIME_FlywheelState_NO_FLY;
+    CFE_TIME_Global.Forced2Fly = false;
+    CFE_TIME_Global.OneTimeDirection = CFE_TIME_AdjustDirection_SUBTRACT;
+    CFE_TIME_Global.OneHzDirection = CFE_TIME_AdjustDirection_SUBTRACT;
     RefState->DelayDirection = CFE_TIME_AdjustDirection_SUBTRACT;
-    CFE_TIME_TaskData.IsToneGood = false;
+    CFE_TIME_Global.IsToneGood = false;
     CFE_TIME_FinishReferenceUpdate(RefState);
     ActFlags = CFE_TIME_GetClockInfo();
     StateFlags = 0;
@@ -696,13 +696,13 @@ void Test_GetTime(void)
     RefState->ClockFlyState = CFE_TIME_FlywheelState_IS_FLY;
     RefState->DelayDirection = CFE_TIME_AdjustDirection_ADD;
     CFE_TIME_FinishReferenceUpdate(RefState);
-    CFE_TIME_TaskData.ClockSource = CFE_TIME_SourceSelect_INTERNAL;
-    CFE_TIME_TaskData.ClockSignal = CFE_TIME_ToneSignalSelect_PRIMARY;
-    CFE_TIME_TaskData.ServerFlyState = CFE_TIME_FlywheelState_IS_FLY;
-    CFE_TIME_TaskData.Forced2Fly = true;
-    CFE_TIME_TaskData.OneTimeDirection = CFE_TIME_AdjustDirection_ADD;
-    CFE_TIME_TaskData.OneHzDirection = CFE_TIME_AdjustDirection_ADD;
-    CFE_TIME_TaskData.IsToneGood = true;
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_INTERNAL;
+    CFE_TIME_Global.ClockSignal = CFE_TIME_ToneSignalSelect_PRIMARY;
+    CFE_TIME_Global.ServerFlyState = CFE_TIME_FlywheelState_IS_FLY;
+    CFE_TIME_Global.Forced2Fly = true;
+    CFE_TIME_Global.OneTimeDirection = CFE_TIME_AdjustDirection_ADD;
+    CFE_TIME_Global.OneHzDirection = CFE_TIME_AdjustDirection_ADD;
+    CFE_TIME_Global.IsToneGood = true;
 
     StateFlags = CFE_TIME_FLAG_CLKSET |
                  CFE_TIME_FLAG_FLYING |
@@ -1201,7 +1201,7 @@ void Test_RegisterSyncCallbackTrue(void)
 
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppID), 1, -1);
-    CFE_TIME_TaskData.SynchCallback[0].Ptr = NULL;
+    CFE_TIME_Global.SynchCallback[0].Ptr = NULL;
 
     Result = CFE_TIME_RegisterSynchCallback(&ut_time_MyCallbackFunc);
     UT_Report(__FILE__, __LINE__,
@@ -1265,12 +1265,12 @@ void Test_ExternalTone(void)
 
     UT_InitData();
     UT_SetBSP_Time(123, 0);
-    CFE_TIME_TaskData.ToneSignalLatch.Seconds = 0;
-    CFE_TIME_TaskData.ToneSignalLatch.Subseconds = 0;
+    CFE_TIME_Global.ToneSignalLatch.Seconds = 0;
+    CFE_TIME_Global.ToneSignalLatch.Subseconds = 0;
     CFE_TIME_ExternalTone();
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ToneSignalLatch.Seconds == 123 &&
-              CFE_TIME_TaskData.ToneSignalLatch.Subseconds == 0,
+              CFE_TIME_Global.ToneSignalLatch.Seconds == 123 &&
+              CFE_TIME_Global.ToneSignalLatch.Subseconds == 0,
               "CFE_TIME_ExternalTone",
               "External tone");
 }
@@ -1294,14 +1294,14 @@ void Test_External(void)
      * state not set
      */
     UT_InitData();
-    CFE_TIME_TaskData.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
-    CFE_TIME_TaskData.ClockSetState = CFE_TIME_SetState_NOT_SET;
-    CFE_TIME_TaskData.ExternalCount = 0;
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
+    CFE_TIME_Global.ClockSetState = CFE_TIME_SetState_NOT_SET;
+    CFE_TIME_Global.ExternalCount = 0;
     settime.Seconds = 0;
     settime.Subseconds = 0;
     CFE_TIME_ExternalMET(settime);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ExternalCount == 1,
+              CFE_TIME_Global.ExternalCount == 1,
               "CFE_TIME_ExternalMET",
               "External MET - external source and clock state not set");
 
@@ -1309,25 +1309,25 @@ void Test_External(void)
      * state set and time less than the minimum
      */
     UT_InitData();
-    CFE_TIME_TaskData.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
-    CFE_TIME_TaskData.ClockSetState = CFE_TIME_SetState_WAS_SET;
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
+    CFE_TIME_Global.ClockSetState = CFE_TIME_SetState_WAS_SET;
     settime.Seconds = 0;
     settime.Subseconds = 0;
-    CFE_TIME_TaskData.InternalCount = 0;
-    CFE_TIME_TaskData.AtToneMET.Seconds = 10;
-    CFE_TIME_TaskData.AtToneMET.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneDelay.Seconds = 0;
-    CFE_TIME_TaskData.AtToneDelay.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneLatch.Seconds = 0;
-    CFE_TIME_TaskData.AtToneLatch.Subseconds = 0;
-    CFE_TIME_TaskData.MaxDelta.Seconds = 0;
-    CFE_TIME_TaskData.MaxDelta.Subseconds = 1;
-    CFE_TIME_TaskData.MaxLocalClock.Seconds = 0;
-    CFE_TIME_TaskData.MaxLocalClock.Subseconds = 0;
+    CFE_TIME_Global.InternalCount = 0;
+    CFE_TIME_Global.AtToneMET.Seconds = 10;
+    CFE_TIME_Global.AtToneMET.Subseconds = 0;
+    CFE_TIME_Global.AtToneDelay.Seconds = 0;
+    CFE_TIME_Global.AtToneDelay.Subseconds = 0;
+    CFE_TIME_Global.AtToneLatch.Seconds = 0;
+    CFE_TIME_Global.AtToneLatch.Subseconds = 0;
+    CFE_TIME_Global.MaxDelta.Seconds = 0;
+    CFE_TIME_Global.MaxDelta.Subseconds = 1;
+    CFE_TIME_Global.MaxLocalClock.Seconds = 0;
+    CFE_TIME_Global.MaxLocalClock.Subseconds = 0;
     UT_SetBSP_Time(0, 0);
     CFE_TIME_ExternalMET(settime);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.InternalCount == 1,
+              CFE_TIME_Global.InternalCount == 1,
               "CFE_TIME_ExternalMET",
               "External MET - external source and time out of range (low)");
 
@@ -1335,59 +1335,59 @@ void Test_External(void)
      * state set and time greater than the maximum
      */
     UT_InitData();
-    CFE_TIME_TaskData.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
-    CFE_TIME_TaskData.ClockSetState = CFE_TIME_SetState_WAS_SET;
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
+    CFE_TIME_Global.ClockSetState = CFE_TIME_SetState_WAS_SET;
     settime.Seconds = 20;
     settime.Subseconds = 0;
-    CFE_TIME_TaskData.InternalCount = 0;
-    CFE_TIME_TaskData.AtToneMET.Seconds = 10;
-    CFE_TIME_TaskData.AtToneMET.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneDelay.Seconds = 0;
-    CFE_TIME_TaskData.AtToneDelay.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneLatch.Seconds = 0;
-    CFE_TIME_TaskData.AtToneLatch.Subseconds = 0;
-    CFE_TIME_TaskData.MaxDelta.Seconds = 0;
-    CFE_TIME_TaskData.MaxDelta.Subseconds = 1;
-    CFE_TIME_TaskData.MaxLocalClock.Seconds = 0;
-    CFE_TIME_TaskData.MaxLocalClock.Subseconds = 0;
+    CFE_TIME_Global.InternalCount = 0;
+    CFE_TIME_Global.AtToneMET.Seconds = 10;
+    CFE_TIME_Global.AtToneMET.Subseconds = 0;
+    CFE_TIME_Global.AtToneDelay.Seconds = 0;
+    CFE_TIME_Global.AtToneDelay.Subseconds = 0;
+    CFE_TIME_Global.AtToneLatch.Seconds = 0;
+    CFE_TIME_Global.AtToneLatch.Subseconds = 0;
+    CFE_TIME_Global.MaxDelta.Seconds = 0;
+    CFE_TIME_Global.MaxDelta.Subseconds = 1;
+    CFE_TIME_Global.MaxLocalClock.Seconds = 0;
+    CFE_TIME_Global.MaxLocalClock.Subseconds = 0;
     UT_SetBSP_Time(0, 0);
     CFE_TIME_ExternalMET(settime);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.InternalCount == 1,
+              CFE_TIME_Global.InternalCount == 1,
               "CFE_TIME_ExternalMET",
               "External MET - external source and time out of range (high)");
 
     /* Test setting time data from MET (external source, state set) */
     UT_InitData();
-    CFE_TIME_TaskData.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
-    CFE_TIME_TaskData.ClockSetState = CFE_TIME_SetState_WAS_SET;
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
+    CFE_TIME_Global.ClockSetState = CFE_TIME_SetState_WAS_SET;
     settime.Seconds = 10;
     settime.Subseconds = 0;
-    CFE_TIME_TaskData.ExternalCount = 0;
-    CFE_TIME_TaskData.AtToneMET.Seconds = 10;
-    CFE_TIME_TaskData.AtToneMET.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneDelay.Seconds = 0;
-    CFE_TIME_TaskData.AtToneDelay.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneLatch.Seconds = 0;
-    CFE_TIME_TaskData.AtToneLatch.Subseconds = 0;
-    CFE_TIME_TaskData.MaxDelta.Seconds = 0;
-    CFE_TIME_TaskData.MaxDelta.Subseconds = 1;
-    CFE_TIME_TaskData.MaxLocalClock.Seconds = 0;
-    CFE_TIME_TaskData.MaxLocalClock.Subseconds = 0;
+    CFE_TIME_Global.ExternalCount = 0;
+    CFE_TIME_Global.AtToneMET.Seconds = 10;
+    CFE_TIME_Global.AtToneMET.Subseconds = 0;
+    CFE_TIME_Global.AtToneDelay.Seconds = 0;
+    CFE_TIME_Global.AtToneDelay.Subseconds = 0;
+    CFE_TIME_Global.AtToneLatch.Seconds = 0;
+    CFE_TIME_Global.AtToneLatch.Subseconds = 0;
+    CFE_TIME_Global.MaxDelta.Seconds = 0;
+    CFE_TIME_Global.MaxDelta.Subseconds = 1;
+    CFE_TIME_Global.MaxLocalClock.Seconds = 0;
+    CFE_TIME_Global.MaxLocalClock.Subseconds = 0;
     UT_SetBSP_Time(0, 0);
     CFE_TIME_ExternalMET(settime);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ExternalCount == 1,
+              CFE_TIME_Global.ExternalCount == 1,
               "CFE_TIME_ExternalMET",
               "External MET - external source and time in range");
 
     /* Test setting time data from MET (internal source) */
     UT_InitData();
-    CFE_TIME_TaskData.ClockSource = CFE_TIME_SourceSelect_INTERNAL;
-    CFE_TIME_TaskData.InternalCount = 0;
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_INTERNAL;
+    CFE_TIME_Global.InternalCount = 0;
     CFE_TIME_ExternalMET(settime);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.InternalCount == 1,
+              CFE_TIME_Global.InternalCount == 1,
               "CFE_TIME_ExternalMET",
               "External MET (internal source)");
 #else
@@ -1425,14 +1425,14 @@ void Test_External(void)
      * state not set
      */
     UT_InitData();
-    CFE_TIME_TaskData.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
-    CFE_TIME_TaskData.ClockSetState = CFE_TIME_SetState_NOT_SET;
-    CFE_TIME_TaskData.ExternalCount = 0;
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
+    CFE_TIME_Global.ClockSetState = CFE_TIME_SetState_NOT_SET;
+    CFE_TIME_Global.ExternalCount = 0;
     settime.Seconds = 0;
     settime.Subseconds = 0;
     CFE_TIME_ExternalGPS(settime, 0);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ExternalCount == 1,
+              CFE_TIME_Global.ExternalCount == 1,
               "CFE_TIME_ExternalGPS",
               "External GPS - external source and clock state not set");
 
@@ -1440,27 +1440,27 @@ void Test_External(void)
      * state set and time less than the minimum
      */
     UT_InitData();
-    CFE_TIME_TaskData.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
-    CFE_TIME_TaskData.ClockSetState = CFE_TIME_SetState_WAS_SET;
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
+    CFE_TIME_Global.ClockSetState = CFE_TIME_SetState_WAS_SET;
     settime.Seconds = 0;
     settime.Subseconds = 0;
-    CFE_TIME_TaskData.InternalCount = 0;
-    CFE_TIME_TaskData.AtToneMET.Seconds = 0;
-    CFE_TIME_TaskData.AtToneMET.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneSTCF.Seconds = 10;
-    CFE_TIME_TaskData.AtToneSTCF.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneDelay.Seconds = 0;
-    CFE_TIME_TaskData.AtToneDelay.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneLatch.Seconds = 0;
-    CFE_TIME_TaskData.AtToneLatch.Subseconds = 0;
-    CFE_TIME_TaskData.MaxDelta.Seconds = 0;
-    CFE_TIME_TaskData.MaxDelta.Subseconds = 1;
-    CFE_TIME_TaskData.MaxLocalClock.Seconds = 0;
-    CFE_TIME_TaskData.MaxLocalClock.Subseconds = 0;
+    CFE_TIME_Global.InternalCount = 0;
+    CFE_TIME_Global.AtToneMET.Seconds = 0;
+    CFE_TIME_Global.AtToneMET.Subseconds = 0;
+    CFE_TIME_Global.AtToneSTCF.Seconds = 10;
+    CFE_TIME_Global.AtToneSTCF.Subseconds = 0;
+    CFE_TIME_Global.AtToneDelay.Seconds = 0;
+    CFE_TIME_Global.AtToneDelay.Subseconds = 0;
+    CFE_TIME_Global.AtToneLatch.Seconds = 0;
+    CFE_TIME_Global.AtToneLatch.Subseconds = 0;
+    CFE_TIME_Global.MaxDelta.Seconds = 0;
+    CFE_TIME_Global.MaxDelta.Subseconds = 1;
+    CFE_TIME_Global.MaxLocalClock.Seconds = 0;
+    CFE_TIME_Global.MaxLocalClock.Subseconds = 0;
     UT_SetBSP_Time(0, 0);
     CFE_TIME_ExternalGPS(settime, 0);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.InternalCount == 1,
+              CFE_TIME_Global.InternalCount == 1,
               "CFE_TIME_ExternalGPS",
               "External GPS - external source and time out of range (low)");
 
@@ -1468,63 +1468,63 @@ void Test_External(void)
      * state set and time greater than the maximum
      */
     UT_InitData();
-    CFE_TIME_TaskData.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
-    CFE_TIME_TaskData.ClockSetState = CFE_TIME_SetState_WAS_SET;
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
+    CFE_TIME_Global.ClockSetState = CFE_TIME_SetState_WAS_SET;
     settime.Seconds = 20;
     settime.Subseconds = 0;
-    CFE_TIME_TaskData.InternalCount = 0;
-    CFE_TIME_TaskData.AtToneMET.Seconds = 0;
-    CFE_TIME_TaskData.AtToneMET.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneSTCF.Seconds = 10;
-    CFE_TIME_TaskData.AtToneSTCF.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneDelay.Seconds = 0;
-    CFE_TIME_TaskData.AtToneDelay.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneLatch.Seconds = 0;
-    CFE_TIME_TaskData.AtToneLatch.Subseconds = 0;
-    CFE_TIME_TaskData.MaxDelta.Seconds = 0;
-    CFE_TIME_TaskData.MaxDelta.Subseconds = 1;
-    CFE_TIME_TaskData.MaxLocalClock.Seconds = 0;
-    CFE_TIME_TaskData.MaxLocalClock.Subseconds = 0;
+    CFE_TIME_Global.InternalCount = 0;
+    CFE_TIME_Global.AtToneMET.Seconds = 0;
+    CFE_TIME_Global.AtToneMET.Subseconds = 0;
+    CFE_TIME_Global.AtToneSTCF.Seconds = 10;
+    CFE_TIME_Global.AtToneSTCF.Subseconds = 0;
+    CFE_TIME_Global.AtToneDelay.Seconds = 0;
+    CFE_TIME_Global.AtToneDelay.Subseconds = 0;
+    CFE_TIME_Global.AtToneLatch.Seconds = 0;
+    CFE_TIME_Global.AtToneLatch.Subseconds = 0;
+    CFE_TIME_Global.MaxDelta.Seconds = 0;
+    CFE_TIME_Global.MaxDelta.Subseconds = 1;
+    CFE_TIME_Global.MaxLocalClock.Seconds = 0;
+    CFE_TIME_Global.MaxLocalClock.Subseconds = 0;
     UT_SetBSP_Time(0, 0);
     CFE_TIME_ExternalGPS(settime, 0);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.InternalCount == 1,
+              CFE_TIME_Global.InternalCount == 1,
               "CFE_TIME_ExternalGPS",
               "External GPS - external source and time out of range (high)");
 
     /* Test setting time data from GPS (external source, state set) */
     UT_InitData();
-    CFE_TIME_TaskData.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
-    CFE_TIME_TaskData.ClockSetState = CFE_TIME_SetState_WAS_SET;
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
+    CFE_TIME_Global.ClockSetState = CFE_TIME_SetState_WAS_SET;
     settime.Seconds = 10;
     settime.Subseconds = 0;
-    CFE_TIME_TaskData.ExternalCount = 0;
-    CFE_TIME_TaskData.AtToneMET.Seconds = 0;
-    CFE_TIME_TaskData.AtToneMET.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneSTCF.Seconds = 10;
-    CFE_TIME_TaskData.AtToneSTCF.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneDelay.Seconds = 0;
-    CFE_TIME_TaskData.AtToneDelay.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneLatch.Seconds = 0;
-    CFE_TIME_TaskData.AtToneLatch.Subseconds = 0;
-    CFE_TIME_TaskData.MaxDelta.Seconds = 0;
-    CFE_TIME_TaskData.MaxDelta.Subseconds = 1;
-    CFE_TIME_TaskData.MaxLocalClock.Seconds = 0;
-    CFE_TIME_TaskData.MaxLocalClock.Subseconds = 0;
+    CFE_TIME_Global.ExternalCount = 0;
+    CFE_TIME_Global.AtToneMET.Seconds = 0;
+    CFE_TIME_Global.AtToneMET.Subseconds = 0;
+    CFE_TIME_Global.AtToneSTCF.Seconds = 10;
+    CFE_TIME_Global.AtToneSTCF.Subseconds = 0;
+    CFE_TIME_Global.AtToneDelay.Seconds = 0;
+    CFE_TIME_Global.AtToneDelay.Subseconds = 0;
+    CFE_TIME_Global.AtToneLatch.Seconds = 0;
+    CFE_TIME_Global.AtToneLatch.Subseconds = 0;
+    CFE_TIME_Global.MaxDelta.Seconds = 0;
+    CFE_TIME_Global.MaxDelta.Subseconds = 1;
+    CFE_TIME_Global.MaxLocalClock.Seconds = 0;
+    CFE_TIME_Global.MaxLocalClock.Subseconds = 0;
     UT_SetBSP_Time(0, 0);
     CFE_TIME_ExternalGPS(settime, 0);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ExternalCount == 1,
+              CFE_TIME_Global.ExternalCount == 1,
               "CFE_TIME_ExternalGPS",
               "External GPS - external source and time in range");
 
     /* Test setting time data from GPS (internal source) */
     UT_InitData();
-    CFE_TIME_TaskData.ClockSource = CFE_TIME_SourceSelect_INTERNAL;
-    CFE_TIME_TaskData.InternalCount = 0;
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_INTERNAL;
+    CFE_TIME_Global.InternalCount = 0;
     CFE_TIME_ExternalGPS(settime, 0);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.InternalCount == 1,
+              CFE_TIME_Global.InternalCount == 1,
               "CFE_TIME_ExternalGPS",
               "External GPS (internal source)");
 #else
@@ -1562,14 +1562,14 @@ void Test_External(void)
      * state not set
      */
     UT_InitData();
-    CFE_TIME_TaskData.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
-    CFE_TIME_TaskData.ClockSetState = CFE_TIME_SetState_NOT_SET;
-    CFE_TIME_TaskData.ExternalCount = 0;
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
+    CFE_TIME_Global.ClockSetState = CFE_TIME_SetState_NOT_SET;
+    CFE_TIME_Global.ExternalCount = 0;
     settime.Seconds = 0;
     settime.Subseconds = 0;
     CFE_TIME_ExternalTime(settime);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ExternalCount == 1,
+              CFE_TIME_Global.ExternalCount == 1,
               "CFE_TIME_ExternalTime",
               "External Time - external source and clock state not set");
 
@@ -1577,27 +1577,27 @@ void Test_External(void)
      * state set and time less than the minimum
      */
     UT_InitData();
-    CFE_TIME_TaskData.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
-    CFE_TIME_TaskData.ClockSetState = CFE_TIME_SetState_WAS_SET;
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
+    CFE_TIME_Global.ClockSetState = CFE_TIME_SetState_WAS_SET;
     settime.Seconds = 0;
     settime.Subseconds = 0;
-    CFE_TIME_TaskData.InternalCount = 0;
-    CFE_TIME_TaskData.AtToneMET.Seconds = 0;
-    CFE_TIME_TaskData.AtToneMET.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneSTCF.Seconds = 10;
-    CFE_TIME_TaskData.AtToneSTCF.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneDelay.Seconds = 0;
-    CFE_TIME_TaskData.AtToneDelay.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneLatch.Seconds = 0;
-    CFE_TIME_TaskData.AtToneLatch.Subseconds = 0;
-    CFE_TIME_TaskData.MaxDelta.Seconds = 0;
-    CFE_TIME_TaskData.MaxDelta.Subseconds = 1;
-    CFE_TIME_TaskData.MaxLocalClock.Seconds = 0;
-    CFE_TIME_TaskData.MaxLocalClock.Subseconds = 0;
+    CFE_TIME_Global.InternalCount = 0;
+    CFE_TIME_Global.AtToneMET.Seconds = 0;
+    CFE_TIME_Global.AtToneMET.Subseconds = 0;
+    CFE_TIME_Global.AtToneSTCF.Seconds = 10;
+    CFE_TIME_Global.AtToneSTCF.Subseconds = 0;
+    CFE_TIME_Global.AtToneDelay.Seconds = 0;
+    CFE_TIME_Global.AtToneDelay.Subseconds = 0;
+    CFE_TIME_Global.AtToneLatch.Seconds = 0;
+    CFE_TIME_Global.AtToneLatch.Subseconds = 0;
+    CFE_TIME_Global.MaxDelta.Seconds = 0;
+    CFE_TIME_Global.MaxDelta.Subseconds = 1;
+    CFE_TIME_Global.MaxLocalClock.Seconds = 0;
+    CFE_TIME_Global.MaxLocalClock.Subseconds = 0;
     UT_SetBSP_Time(0, 0);
     CFE_TIME_ExternalTime(settime);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.InternalCount == 1,
+              CFE_TIME_Global.InternalCount == 1,
               "CFE_TIME_ExternalTime",
               "External Time - external source and time out of range (low)");
 
@@ -1605,63 +1605,63 @@ void Test_External(void)
      * state set and time greater than the maximum
      */
     UT_InitData();
-    CFE_TIME_TaskData.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
-    CFE_TIME_TaskData.ClockSetState = CFE_TIME_SetState_WAS_SET;
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
+    CFE_TIME_Global.ClockSetState = CFE_TIME_SetState_WAS_SET;
     settime.Seconds = 20;
     settime.Subseconds = 0;
-    CFE_TIME_TaskData.InternalCount = 0;
-    CFE_TIME_TaskData.AtToneMET.Seconds = 0;
-    CFE_TIME_TaskData.AtToneMET.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneSTCF.Seconds = 10;
-    CFE_TIME_TaskData.AtToneSTCF.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneDelay.Seconds = 0;
-    CFE_TIME_TaskData.AtToneDelay.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneLatch.Seconds = 0;
-    CFE_TIME_TaskData.AtToneLatch.Subseconds = 0;
-    CFE_TIME_TaskData.MaxDelta.Seconds = 0;
-    CFE_TIME_TaskData.MaxDelta.Subseconds = 1;
-    CFE_TIME_TaskData.MaxLocalClock.Seconds = 0;
-    CFE_TIME_TaskData.MaxLocalClock.Subseconds = 0;
+    CFE_TIME_Global.InternalCount = 0;
+    CFE_TIME_Global.AtToneMET.Seconds = 0;
+    CFE_TIME_Global.AtToneMET.Subseconds = 0;
+    CFE_TIME_Global.AtToneSTCF.Seconds = 10;
+    CFE_TIME_Global.AtToneSTCF.Subseconds = 0;
+    CFE_TIME_Global.AtToneDelay.Seconds = 0;
+    CFE_TIME_Global.AtToneDelay.Subseconds = 0;
+    CFE_TIME_Global.AtToneLatch.Seconds = 0;
+    CFE_TIME_Global.AtToneLatch.Subseconds = 0;
+    CFE_TIME_Global.MaxDelta.Seconds = 0;
+    CFE_TIME_Global.MaxDelta.Subseconds = 1;
+    CFE_TIME_Global.MaxLocalClock.Seconds = 0;
+    CFE_TIME_Global.MaxLocalClock.Subseconds = 0;
     UT_SetBSP_Time(0, 0);
     CFE_TIME_ExternalTime(settime);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.InternalCount == 1,
+              CFE_TIME_Global.InternalCount == 1,
               "CFE_TIME_ExternalTime",
               "External Time - external source and time out of range (high)");
 
     /* Test setting time data from Time (external source, state set) */
     UT_InitData();
-    CFE_TIME_TaskData.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
-    CFE_TIME_TaskData.ClockSetState = CFE_TIME_SetState_WAS_SET;
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
+    CFE_TIME_Global.ClockSetState = CFE_TIME_SetState_WAS_SET;
     settime.Seconds = 10;
     settime.Subseconds = 0;
-    CFE_TIME_TaskData.ExternalCount = 0;
-    CFE_TIME_TaskData.AtToneMET.Seconds = 0;
-    CFE_TIME_TaskData.AtToneMET.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneSTCF.Seconds = 10;
-    CFE_TIME_TaskData.AtToneSTCF.Subseconds = 0;
-   CFE_TIME_TaskData.AtToneDelay.Seconds = 0;
-    CFE_TIME_TaskData.AtToneDelay.Subseconds = 0;
-    CFE_TIME_TaskData.AtToneLatch.Seconds = 0;
-    CFE_TIME_TaskData.AtToneLatch.Subseconds = 0;
-    CFE_TIME_TaskData.MaxDelta.Seconds = 0;
-    CFE_TIME_TaskData.MaxDelta.Subseconds = 1;
-    CFE_TIME_TaskData.MaxLocalClock.Seconds = 0;
-    CFE_TIME_TaskData.MaxLocalClock.Subseconds = 0;
+    CFE_TIME_Global.ExternalCount = 0;
+    CFE_TIME_Global.AtToneMET.Seconds = 0;
+    CFE_TIME_Global.AtToneMET.Subseconds = 0;
+    CFE_TIME_Global.AtToneSTCF.Seconds = 10;
+    CFE_TIME_Global.AtToneSTCF.Subseconds = 0;
+   CFE_TIME_Global.AtToneDelay.Seconds = 0;
+    CFE_TIME_Global.AtToneDelay.Subseconds = 0;
+    CFE_TIME_Global.AtToneLatch.Seconds = 0;
+    CFE_TIME_Global.AtToneLatch.Subseconds = 0;
+    CFE_TIME_Global.MaxDelta.Seconds = 0;
+    CFE_TIME_Global.MaxDelta.Subseconds = 1;
+    CFE_TIME_Global.MaxLocalClock.Seconds = 0;
+    CFE_TIME_Global.MaxLocalClock.Subseconds = 0;
     UT_SetBSP_Time(0, 0);
     CFE_TIME_ExternalTime(settime);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ExternalCount == 1,
+              CFE_TIME_Global.ExternalCount == 1,
               "CFE_TIME_ExternalTime",
               "External Time - external source and time in range");
 
     /* Test setting time data from Time (internal source) */
     UT_InitData();
-    CFE_TIME_TaskData.ClockSource = CFE_TIME_SourceSelect_INTERNAL;
-    CFE_TIME_TaskData.InternalCount = 0;
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_INTERNAL;
+    CFE_TIME_Global.InternalCount = 0;
     CFE_TIME_ExternalTime(settime);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.InternalCount == 1,
+              CFE_TIME_Global.InternalCount == 1,
               "CFE_TIME_ExternalTime",
               "External Time (internal source)");
 #else
@@ -1695,7 +1695,7 @@ void Test_External(void)
 #endif
 
     /* Reset to normal value for subsequent tests */
-    CFE_TIME_TaskData.ClockSource = CFE_TIME_SourceSelect_INTERNAL;
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_INTERNAL;
 }
 
 /*
@@ -1752,22 +1752,22 @@ void Test_PipeCmds(void)
     /* Test sending the time at the tone "signal" command */
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_TaskData.ToneSignalCounter = 0;
+    CFE_TIME_Global.ToneSignalCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.cmd),
             UT_TPID_CFE_TIME_TONE_CMD);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ToneSignalCounter == 1,
+              CFE_TIME_Global.ToneSignalCounter == 1,
               "CFE_TIME_ToneSignalCmd",
               "Time at tone signal");
 
     /* Test sending the time at the tone "data" command */
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_TaskData.ToneDataCounter = 0;
+    CFE_TIME_Global.ToneDataCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.tonedatacmd),
             UT_TPID_CFE_TIME_DATA_CMD);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ToneDataCounter == 1,
+              CFE_TIME_Global.ToneDataCounter == 1,
               "CFE_TIME_ToneDataCmd",
               "Time at tone data");
 
@@ -1775,12 +1775,12 @@ void Test_PipeCmds(void)
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_SetBSP_Time(123, 0);
-    CFE_TIME_TaskData.ToneSignalLatch.Seconds = 0;
-    CFE_TIME_TaskData.ToneSignalLatch.Subseconds = 0;
+    CFE_TIME_Global.ToneSignalLatch.Seconds = 0;
+    CFE_TIME_Global.ToneSignalLatch.Subseconds = 0;
     CFE_TIME_Tone1HzISR();
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ToneSignalLatch.Seconds == 123 &&
-              CFE_TIME_TaskData.ToneSignalLatch.Subseconds == 0,
+              CFE_TIME_Global.ToneSignalLatch.Seconds == 123 &&
+              CFE_TIME_Global.ToneSignalLatch.Subseconds == 0,
               "CFE_TIME_FakeToneCmd",
               "Simulated time at tone signal");
 
@@ -1789,7 +1789,7 @@ void Test_PipeCmds(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
 
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
-    count = CFE_TIME_TaskData.InternalCount;
+    count = CFE_TIME_Global.InternalCount;
 #endif
 
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.cmd),
@@ -1798,7 +1798,7 @@ void Test_PipeCmds(void)
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
     UT_Report(__FILE__, __LINE__,
               !UT_EventIsInHistory(CFE_TIME_ID_ERR_EID) &&
-              CFE_TIME_TaskData.InternalCount == count + 1,
+              CFE_TIME_Global.InternalCount == count + 1,
               "CFE_TIME_ToneSendCmd",
               "Request time at tone data");
 #else
@@ -1938,22 +1938,22 @@ void Test_PipeCmds(void)
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.signalcmd.Payload.ToneSource = CFE_TIME_ToneSignalSelect_PRIMARY;
-    CFE_TIME_TaskData.CommandCounter = 0;
-    CFE_TIME_TaskData.CommandErrorCounter = 0;
+    CFE_TIME_Global.CommandCounter = 0;
+    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.signalcmd),
             UT_TPID_CFE_TIME_CMD_SET_SIGNAL_CC);
 
 #if (CFE_PLATFORM_TIME_CFG_SIGNAL == true)
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_SIGNAL_EID) &&
-              CFE_TIME_TaskData.CommandCounter == 1 &&
-              CFE_TIME_TaskData.CommandErrorCounter == 0,
+              CFE_TIME_Global.CommandCounter == 1 &&
+              CFE_TIME_Global.CommandErrorCounter == 0,
               "CFE_TIME_SetSignalCmd",
               "Set tone signal source = primary");
 #else
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_SIGNAL_CFG_EID) &&
-              CFE_TIME_TaskData.CommandErrorCounter == 1,
+              CFE_TIME_Global.CommandErrorCounter == 1,
               "CFE_TIME_SetSignalCmd",
               "Set tone source = primary invalid");
 #endif
@@ -1962,22 +1962,22 @@ void Test_PipeCmds(void)
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.signalcmd.Payload.ToneSource = CFE_TIME_ToneSignalSelect_REDUNDANT;
-    CFE_TIME_TaskData.CommandCounter = 0;
-    CFE_TIME_TaskData.CommandErrorCounter = 0;
+    CFE_TIME_Global.CommandCounter = 0;
+    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.signalcmd),
             UT_TPID_CFE_TIME_CMD_SET_SIGNAL_CC);
 
 #if (CFE_PLATFORM_TIME_CFG_SIGNAL == true)
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_SIGNAL_EID) &&
-              CFE_TIME_TaskData.CommandCounter == 1 &&
-              CFE_TIME_TaskData.CommandErrorCounter == 0,
+              CFE_TIME_Global.CommandCounter == 1 &&
+              CFE_TIME_Global.CommandErrorCounter == 0,
               "CFE_TIME_SetSignalCmd",
               "Set tone signal source = redundant");
 #else
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_SIGNAL_CFG_EID) &&
-              CFE_TIME_TaskData.CommandErrorCounter == 1,
+              CFE_TIME_Global.CommandErrorCounter == 1,
               "CFE_TIME_SetSignalCmd",
               "Set tone signal source = redundant invalid");
 #endif
@@ -1988,12 +1988,12 @@ void Test_PipeCmds(void)
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.signalcmd.Payload.ToneSource = -1;
-    CFE_TIME_TaskData.CommandErrorCounter = 0;
+    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.signalcmd),
             UT_TPID_CFE_TIME_CMD_SET_SIGNAL_CC);
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_SIGNAL_ERR_EID) &&
-            CFE_TIME_TaskData.CommandErrorCounter == 1,
+            CFE_TIME_Global.CommandErrorCounter == 1,
               "CFE_TIME_SetSignalCmd",
               "Invalid tone source");
 
@@ -2002,23 +2002,23 @@ void Test_PipeCmds(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.adddelaycmd.Payload.MicroSeconds = 0;
     CmdBuf.adddelaycmd.Payload.Seconds = 0;
-    CFE_TIME_TaskData.CommandCounter = 0;
-    CFE_TIME_TaskData.CommandErrorCounter = 0;
+    CFE_TIME_Global.CommandCounter = 0;
+    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.adddelaycmd),
             UT_TPID_CFE_TIME_CMD_ADD_DELAY_CC);
 
 #if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_DELAY_EID) &&
-              CFE_TIME_TaskData.CommandCounter == 1 &&
-              CFE_TIME_TaskData.CommandErrorCounter == 0,
+              CFE_TIME_Global.CommandCounter == 1 &&
+              CFE_TIME_Global.CommandErrorCounter == 0,
               "CFE_TIME_SetDelayCmd",
               "Set tone add delay");
 #else
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_DELAY_CFG_EID) &&
-              CFE_TIME_TaskData.CommandCounter == 0 &&
-              CFE_TIME_TaskData.CommandErrorCounter == 1,
+              CFE_TIME_Global.CommandCounter == 0 &&
+              CFE_TIME_Global.CommandErrorCounter == 1,
               "CFE_TIME_SetDelayCmd",
               "Set tone add delay invalid");
 #endif
@@ -2026,23 +2026,23 @@ void Test_PipeCmds(void)
     /* Test sending a time tone subtract delay command */
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_TaskData.CommandCounter = 0;
-    CFE_TIME_TaskData.CommandErrorCounter = 0;
+    CFE_TIME_Global.CommandCounter = 0;
+    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.subdelaycmd),
             UT_TPID_CFE_TIME_CMD_SUB_DELAY_CC);
 
 #if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_DELAY_EID) &&
-              CFE_TIME_TaskData.CommandCounter == 1 &&
-              CFE_TIME_TaskData.CommandErrorCounter == 0,
+              CFE_TIME_Global.CommandCounter == 1 &&
+              CFE_TIME_Global.CommandErrorCounter == 0,
               "CFE_TIME_SetDelayCmd",
               "Set tone subtract delay");
 #else
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_DELAY_CFG_EID) &&
-              CFE_TIME_TaskData.CommandCounter == 0 &&
-              CFE_TIME_TaskData.CommandErrorCounter == 1,
+              CFE_TIME_Global.CommandCounter == 0 &&
+              CFE_TIME_Global.CommandErrorCounter == 1,
               "CFE_TIME_SetDelayCmd",
               "Set subtract delay invalid");
 #endif
@@ -2050,23 +2050,23 @@ void Test_PipeCmds(void)
     /* Test sending a set time command */
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_TaskData.CommandCounter = 0;
-    CFE_TIME_TaskData.CommandErrorCounter = 0;
+    CFE_TIME_Global.CommandCounter = 0;
+    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.settimecmd),
             UT_TPID_CFE_TIME_CMD_SET_TIME_CC);
 
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_TIME_EID) &&
-              CFE_TIME_TaskData.CommandCounter == 1 &&
-              CFE_TIME_TaskData.CommandErrorCounter == 0,
+              CFE_TIME_Global.CommandCounter == 1 &&
+              CFE_TIME_Global.CommandErrorCounter == 0,
               "CFE_TIME_SetTimeCmd",
               "Set time");
 #else
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_TIME_CFG_EID) &&
-              CFE_TIME_TaskData.CommandCounter == 0 &&
-              CFE_TIME_TaskData.CommandErrorCounter == 1,
+              CFE_TIME_Global.CommandCounter == 0 &&
+              CFE_TIME_Global.CommandErrorCounter == 1,
               "CFE_TIME_SetTimeCmd",
               "Set time invalid");
 #endif
@@ -2074,23 +2074,23 @@ void Test_PipeCmds(void)
     /* Test sending a set MET command */
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_TaskData.CommandCounter = 0;
-    CFE_TIME_TaskData.CommandErrorCounter = 0;
+    CFE_TIME_Global.CommandCounter = 0;
+    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.setmetcmd),
             UT_TPID_CFE_TIME_CMD_SET_MET_CC);
 
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_MET_EID) &&
-              CFE_TIME_TaskData.CommandCounter == 1 &&
-              CFE_TIME_TaskData.CommandErrorCounter == 0,
+              CFE_TIME_Global.CommandCounter == 1 &&
+              CFE_TIME_Global.CommandErrorCounter == 0,
               "CFE_TIME_SetMETCmd",
               "Set MET");
 #else
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_MET_CFG_EID) &&
-              CFE_TIME_TaskData.CommandCounter == 0 &&
-              CFE_TIME_TaskData.CommandErrorCounter == 1,
+              CFE_TIME_Global.CommandCounter == 0 &&
+              CFE_TIME_Global.CommandErrorCounter == 1,
               "CFE_TIME_SetMETCmd",
               "Set MET invalid");
 #endif
@@ -2098,23 +2098,23 @@ void Test_PipeCmds(void)
     /* Test sending a set STCF command */
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_TaskData.CommandCounter = 0;
-    CFE_TIME_TaskData.CommandErrorCounter = 0;
+    CFE_TIME_Global.CommandCounter = 0;
+    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.setstcfcmd),
             UT_TPID_CFE_TIME_CMD_SET_STCF_CC);
 
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_STCF_EID) &&
-              CFE_TIME_TaskData.CommandCounter == 1 &&
-              CFE_TIME_TaskData.CommandErrorCounter == 0,
+              CFE_TIME_Global.CommandCounter == 1 &&
+              CFE_TIME_Global.CommandErrorCounter == 0,
               "CFE_TIME_SetSTCFCmd",
               "Set STCF");
 #else
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_STCF_CFG_EID) &&
-              CFE_TIME_TaskData.CommandCounter == 0 &&
-              CFE_TIME_TaskData.CommandErrorCounter == 1,
+              CFE_TIME_Global.CommandCounter == 0 &&
+              CFE_TIME_Global.CommandErrorCounter == 1,
               "CFE_TIME_SetSTCFCmd",
               "Set STCF invalid");
 #endif
@@ -2122,23 +2122,23 @@ void Test_PipeCmds(void)
     /* Test sending an adjust STCF positive command */
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_TaskData.CommandCounter = 0;
-    CFE_TIME_TaskData.CommandErrorCounter = 0;
+    CFE_TIME_Global.CommandCounter = 0;
+    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.addadjcmd),
             UT_TPID_CFE_TIME_CMD_ADD_ADJUST_CC);
 
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_DELTA_EID) &&
-              CFE_TIME_TaskData.CommandCounter == 1 &&
-              CFE_TIME_TaskData.CommandErrorCounter == 0,
+              CFE_TIME_Global.CommandCounter == 1 &&
+              CFE_TIME_Global.CommandErrorCounter == 0,
               "CFE_TIME_AdjustCmd",
               "Set STCF adjust positive");
 #else
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_DELTA_CFG_EID) &&
-              CFE_TIME_TaskData.CommandCounter == 0 &&
-              CFE_TIME_TaskData.CommandErrorCounter == 1,
+              CFE_TIME_Global.CommandCounter == 0 &&
+              CFE_TIME_Global.CommandErrorCounter == 1,
               "CFE_TIME_AdjustCmd",
               "Set STCF adjust positive invalid");
 #endif
@@ -2146,23 +2146,23 @@ void Test_PipeCmds(void)
     /* Test sending an adjust STCF negative command */
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_TaskData.CommandCounter = 0;
-    CFE_TIME_TaskData.CommandErrorCounter = 0;
+    CFE_TIME_Global.CommandCounter = 0;
+    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.subadjcmd),
             UT_TPID_CFE_TIME_CMD_SUB_ADJUST_CC);
 
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_DELTA_EID) &&
-              CFE_TIME_TaskData.CommandCounter == 1 &&
-              CFE_TIME_TaskData.CommandErrorCounter == 0,
+              CFE_TIME_Global.CommandCounter == 1 &&
+              CFE_TIME_Global.CommandErrorCounter == 0,
               "CFE_TIME_AdjustCmd",
               "Set STCF adjust negative");
 #else
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_DELTA_CFG_EID) &&
-              CFE_TIME_TaskData.CommandCounter == 0 &&
-              CFE_TIME_TaskData.CommandErrorCounter == 1,
+              CFE_TIME_Global.CommandCounter == 0 &&
+              CFE_TIME_Global.CommandErrorCounter == 1,
               "CFE_TIME_AdjustCmd",
               "Set STCF adjust negative invalid");
 #endif
@@ -2170,23 +2170,23 @@ void Test_PipeCmds(void)
     /* Test sending an adjust STCF 1 Hz positive command */
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_TaskData.CommandCounter = 0;
-    CFE_TIME_TaskData.CommandErrorCounter = 0;
+    CFE_TIME_Global.CommandCounter = 0;
+    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.add1hzadjcmd),
             UT_TPID_CFE_TIME_CMD_ADD_1HZ_ADJUSTMENT_CC);
 
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_1HZ_EID) &&
-              CFE_TIME_TaskData.CommandCounter == 1 &&
-              CFE_TIME_TaskData.CommandErrorCounter == 0,
+              CFE_TIME_Global.CommandCounter == 1 &&
+              CFE_TIME_Global.CommandErrorCounter == 0,
               "CFE_TIME_1HzAdjCmd",
               "Set STCF 1Hz adjust positive");
 #else
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_1HZ_CFG_EID) &&
-              CFE_TIME_TaskData.CommandCounter == 0 &&
-              CFE_TIME_TaskData.CommandErrorCounter == 1,
+              CFE_TIME_Global.CommandCounter == 0 &&
+              CFE_TIME_Global.CommandErrorCounter == 1,
               "CFE_TIME_1HzAdjCmd",
               "Set STCF 1Hz adjust positive invalid");
 #endif
@@ -2194,23 +2194,23 @@ void Test_PipeCmds(void)
     /* Test sending an adjust STCF 1 Hz negative command */
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_TaskData.CommandCounter = 0;
-    CFE_TIME_TaskData.CommandErrorCounter = 0;
+    CFE_TIME_Global.CommandCounter = 0;
+    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.sub1hzadjcmd),
             UT_TPID_CFE_TIME_CMD_SUB_1HZ_ADJUSTMENT_CC);
 
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_1HZ_EID) &&
-              CFE_TIME_TaskData.CommandCounter == 1 &&
-              CFE_TIME_TaskData.CommandErrorCounter == 0,
+              CFE_TIME_Global.CommandCounter == 1 &&
+              CFE_TIME_Global.CommandErrorCounter == 0,
               "CFE_TIME_1HzAdjCmd",
               "Set STCF 1Hz adjust negative");
 #else
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_1HZ_CFG_EID) &&
-              CFE_TIME_TaskData.CommandCounter == 0 &&
-              CFE_TIME_TaskData.CommandErrorCounter == 1,
+              CFE_TIME_Global.CommandCounter == 0 &&
+              CFE_TIME_Global.CommandErrorCounter == 1,
               "CFE_TIME_1HzAdjCmd",
               "Set STCF 1Hz adjust negative invalid");
 #endif
@@ -2273,8 +2273,8 @@ void Test_PipeCmds(void)
     /* Test sending a set leap seconds commands */
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_TaskData.CommandCounter = 0;
-    CFE_TIME_TaskData.CommandErrorCounter = 0;
+    CFE_TIME_Global.CommandCounter = 0;
+    CFE_TIME_Global.CommandErrorCounter = 0;
     CmdBuf.leapscmd.Payload.LeapSeconds = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.leapscmd),
             UT_TPID_CFE_TIME_CMD_SET_LEAP_SECONDS_CC);
@@ -2282,15 +2282,15 @@ void Test_PipeCmds(void)
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_LEAPS_EID) &&
-            CFE_TIME_TaskData.CommandCounter == 1 &&
-            CFE_TIME_TaskData.CommandErrorCounter == 0,
+            CFE_TIME_Global.CommandCounter == 1 &&
+            CFE_TIME_Global.CommandErrorCounter == 0,
               "CFE_TIME_SetLeapSecondsCmd",
               "Set leap seconds");
 #else
     UT_Report(__FILE__, __LINE__,
               UT_EventIsInHistory(CFE_TIME_LEAPS_CFG_EID) &&
-              CFE_TIME_TaskData.CommandCounter == 0 &&
-              CFE_TIME_TaskData.CommandErrorCounter == 1,
+              CFE_TIME_Global.CommandCounter == 0 &&
+              CFE_TIME_Global.CommandErrorCounter == 1,
               "CFE_TIME_SetLeapSecondsCmd",
               "Set leap seconds invalid");
 #endif
@@ -2348,13 +2348,13 @@ void Test_ResetArea(void)
 
     /* Test successfully updating the reset area */
     UT_InitData();
-    CFE_TIME_TaskData.DataStoreStatus = CFE_TIME_RESET_AREA_EXISTING;
-    CFE_TIME_TaskData.ClockSignal = CFE_TIME_ToneSignalSelect_PRIMARY;
+    CFE_TIME_Global.DataStoreStatus = CFE_TIME_RESET_AREA_EXISTING;
+    CFE_TIME_Global.ClockSignal = CFE_TIME_ToneSignalSelect_PRIMARY;
     UT_GetResetDataPtr()->TimeResetVars.ClockSignal = CFE_TIME_ToneSignalSelect_REDUNDANT;
     CFE_TIME_UpdateResetVars(&Reference);
     UT_Report(__FILE__, __LINE__,
               UT_GetResetDataPtr()->TimeResetVars.ClockSignal ==
-              CFE_TIME_TaskData.ClockSignal,
+              CFE_TIME_Global.ClockSignal,
               "CFE_TIME_UpdateResetVars",
               "Successful update");
 
@@ -2364,7 +2364,7 @@ void Test_ResetArea(void)
                              CFE_TIME_ToneSignalSelect_PRIMARY);
     CFE_TIME_QueryResetVars();
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.DataStoreStatus ==
+              CFE_TIME_Global.DataStoreStatus ==
               CFE_TIME_RESET_AREA_EXISTING,
               "CFE_TIME_QueryResetVars",
               "Initialize times using an existing reset area; time tone PRI");
@@ -2375,7 +2375,7 @@ void Test_ResetArea(void)
                              CFE_TIME_ToneSignalSelect_REDUNDANT);
     CFE_TIME_QueryResetVars();
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.DataStoreStatus ==
+              CFE_TIME_Global.DataStoreStatus ==
               CFE_TIME_RESET_AREA_EXISTING,
               "CFE_TIME_QueryResetVars",
               "Initialize times using an existing reset area; time tone RED");
@@ -2386,7 +2386,7 @@ void Test_ResetArea(void)
                              CFE_TIME_ToneSignalSelect_PRIMARY);
     CFE_TIME_QueryResetVars();
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.DataStoreStatus == CFE_TIME_RESET_AREA_BAD,
+              CFE_TIME_Global.DataStoreStatus == CFE_TIME_RESET_AREA_BAD,
               "CFE_TIME_QueryResetVars",
               "Reset area error");
 
@@ -2396,7 +2396,7 @@ void Test_ResetArea(void)
                              CFE_TIME_ToneSignalSelect_PRIMARY);
     CFE_TIME_QueryResetVars();
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.DataStoreStatus == CFE_TIME_RESET_AREA_NEW,
+              CFE_TIME_Global.DataStoreStatus == CFE_TIME_RESET_AREA_NEW,
               "CFE_TIME_QueryResetVars",
               "Initialize to default values");
 
@@ -2406,32 +2406,32 @@ void Test_ResetArea(void)
                              CFE_TIME_ToneSignalSelect_REDUNDANT+1);
     CFE_TIME_QueryResetVars();
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.DataStoreStatus == CFE_TIME_RESET_AREA_NEW,
+              CFE_TIME_Global.DataStoreStatus == CFE_TIME_RESET_AREA_NEW,
               "CFE_TIME_QueryResetVars",
               "Bad clock signal selection");
 
     /* Test response to a reset area error */
     UT_InitData();
-    CFE_TIME_TaskData.DataStoreStatus = CFE_TIME_RESET_AREA_ERROR;
-    CFE_TIME_TaskData.ClockSignal = CFE_TIME_ToneSignalSelect_PRIMARY;
+    CFE_TIME_Global.DataStoreStatus = CFE_TIME_RESET_AREA_ERROR;
+    CFE_TIME_Global.ClockSignal = CFE_TIME_ToneSignalSelect_PRIMARY;
     UT_GetResetDataPtr()->TimeResetVars.ClockSignal = CFE_TIME_ToneSignalSelect_REDUNDANT;
     CFE_TIME_UpdateResetVars(&Reference);
     UT_Report(__FILE__, __LINE__,
               UT_GetResetDataPtr()->TimeResetVars.ClockSignal !=
-              CFE_TIME_TaskData.ClockSignal,
+              CFE_TIME_Global.ClockSignal,
               "CFE_TIME_UpdateResetVars",
               "Reset area error");
 
     /* Test failure to get reset area updating the reset area */
     UT_InitData();
     UT_SetStatusBSPResetArea(CFE_PSP_ERROR, 0, CFE_TIME_ToneSignalSelect_PRIMARY);
-    CFE_TIME_TaskData.DataStoreStatus = CFE_TIME_RESET_AREA_EXISTING;
-    CFE_TIME_TaskData.ClockSignal = CFE_TIME_ToneSignalSelect_PRIMARY;
+    CFE_TIME_Global.DataStoreStatus = CFE_TIME_RESET_AREA_EXISTING;
+    CFE_TIME_Global.ClockSignal = CFE_TIME_ToneSignalSelect_PRIMARY;
     UT_GetResetDataPtr()->TimeResetVars.ClockSignal = CFE_TIME_ToneSignalSelect_REDUNDANT;
     CFE_TIME_UpdateResetVars(&Reference);
     UT_Report(__FILE__, __LINE__,
               UT_GetResetDataPtr()->TimeResetVars.ClockSignal !=
-              CFE_TIME_TaskData.ClockSignal,
+              CFE_TIME_Global.ClockSignal,
               "CFE_TIME_UpdateResetVars",
               "Get reset area fail");
 }
@@ -2454,7 +2454,7 @@ void Test_State(void)
     UT_InitData();
     Reference.ClockSetState = CFE_TIME_SetState_WAS_SET;
     Reference.ClockFlyState = CFE_TIME_FlywheelState_NO_FLY;
-    CFE_TIME_TaskData.ServerFlyState = CFE_TIME_FlywheelState_NO_FLY;
+    CFE_TIME_Global.ServerFlyState = CFE_TIME_FlywheelState_NO_FLY;
     ExpState = CFE_TIME_ClockState_VALID;
     UT_Report(__FILE__, __LINE__,
               CFE_TIME_CalculateState(&Reference) == ExpState,
@@ -2467,7 +2467,7 @@ void Test_State(void)
     UT_InitData();
     Reference.ClockSetState = CFE_TIME_SetState_WAS_SET;
     Reference.ClockFlyState = CFE_TIME_FlywheelState_NO_FLY;
-    CFE_TIME_TaskData.ServerFlyState = CFE_TIME_FlywheelState_IS_FLY;
+    CFE_TIME_Global.ServerFlyState = CFE_TIME_FlywheelState_IS_FLY;
 #if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
     ExpState = CFE_TIME_ClockState_FLYWHEEL;
 #else
@@ -2527,12 +2527,12 @@ void Test_State(void)
               "CFE_TIME_GetStateFlags",
               "State data atomic update after finish");
 
-    CFE_TIME_TaskData.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
-    CFE_TIME_TaskData.ClockSignal = CFE_TIME_ToneSignalSelect_REDUNDANT;
-    CFE_TIME_TaskData.ServerFlyState = CFE_TIME_FlywheelState_NO_FLY;
-    CFE_TIME_TaskData.Forced2Fly = false;
-    CFE_TIME_TaskData.OneTimeDirection = CFE_TIME_AdjustDirection_SUBTRACT;
-    CFE_TIME_TaskData.OneHzDirection = CFE_TIME_AdjustDirection_SUBTRACT;
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
+    CFE_TIME_Global.ClockSignal = CFE_TIME_ToneSignalSelect_REDUNDANT;
+    CFE_TIME_Global.ServerFlyState = CFE_TIME_FlywheelState_NO_FLY;
+    CFE_TIME_Global.Forced2Fly = false;
+    CFE_TIME_Global.OneTimeDirection = CFE_TIME_AdjustDirection_SUBTRACT;
+    CFE_TIME_Global.OneHzDirection = CFE_TIME_AdjustDirection_SUBTRACT;
 
     flag = CFE_TIME_GetClockInfo();
     UT_Report(__FILE__, __LINE__,
@@ -2543,7 +2543,7 @@ void Test_State(void)
     RefState = CFE_TIME_StartReferenceUpdate();
     RefState->ClockFlyState = CFE_TIME_FlywheelState_IS_FLY;
     CFE_TIME_FinishReferenceUpdate(RefState);
-    CFE_TIME_TaskData.ClockSource = CFE_TIME_SourceSelect_INTERNAL;
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_INTERNAL;
 }
 
 /*
@@ -2565,8 +2565,8 @@ void Test_GetReference(void)
     RefState->AtToneDelay.Subseconds = 0;
     RefState->AtToneLatch.Seconds = 10;
     RefState->AtToneLatch.Subseconds = 0;
-    CFE_TIME_TaskData.MaxLocalClock.Seconds = 1000;
-    CFE_TIME_TaskData.MaxLocalClock.Subseconds = 0;
+    CFE_TIME_Global.MaxLocalClock.Seconds = 1000;
+    CFE_TIME_Global.MaxLocalClock.Subseconds = 0;
     CFE_TIME_FinishReferenceUpdate(RefState);
     UT_SetBSP_Time(0, 0);
     CFE_TIME_GetReference(&Reference);
@@ -2588,8 +2588,8 @@ void Test_GetReference(void)
     RefState->AtToneDelay.Subseconds = 0;
     RefState->AtToneLatch.Seconds = 10;
     RefState->AtToneLatch.Subseconds = 0;
-    CFE_TIME_TaskData.MaxLocalClock.Seconds = 0;
-    CFE_TIME_TaskData.MaxLocalClock.Subseconds = 0;
+    CFE_TIME_Global.MaxLocalClock.Seconds = 0;
+    CFE_TIME_Global.MaxLocalClock.Subseconds = 0;
     CFE_TIME_FinishReferenceUpdate(RefState);
     UT_SetBSP_Time(15, 0);
     CFE_TIME_GetReference(&Reference);
@@ -2617,8 +2617,8 @@ void Test_Tone(void)
     int virtualSeconds = 1234567;
 #endif
 
-    uint32 MinElapsed = CFE_TIME_TaskData.MinElapsed;
-    uint32 MaxElapsed = CFE_TIME_TaskData.MaxElapsed;
+    uint32 MinElapsed = CFE_TIME_Global.MinElapsed;
+    uint32 MaxElapsed = CFE_TIME_Global.MaxElapsed;
 
     UtPrintf("Begin Test Tone");
 
@@ -2635,9 +2635,9 @@ void Test_Tone(void)
     RefState->AtToneDelay.Subseconds = 0;
     RefState->AtToneLatch.Seconds = 0; /* 10.00000 */
     RefState->AtToneLatch.Subseconds = 0;
-    CFE_TIME_TaskData.VirtualMET = virtualSeconds;
-    CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneMET.Seconds = 0;
-    CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneMET.Subseconds = seconds;
+    CFE_TIME_Global.VirtualMET = virtualSeconds;
+    CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Seconds = 0;
+    CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Subseconds = seconds;
     CFE_TIME_FinishReferenceUpdate(RefState);
 
     CFE_TIME_ToneSend();
@@ -2648,14 +2648,14 @@ void Test_Tone(void)
 
 #ifdef CFE_PLATFORM_TIME_CFG_BIGENDIAN
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneMET.Seconds == CFE_MAKE_BIG32(seconds) &&
-              CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneMET.Subseconds == CFE_MAKE_BIG32(0), /* yes, I know, 0 is 0 in all endians */
+              CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Seconds == CFE_MAKE_BIG32(seconds) &&
+              CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Subseconds == CFE_MAKE_BIG32(0), /* yes, I know, 0 is 0 in all endians */
               "CFE_TIME_ToneSend",
               "Send tone, flywheel ON");
 #else /* !CFE_PLATFORM_TIME_CFG_BIGENDIAN */
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneMET.Seconds == seconds &&
-              CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneMET.Subseconds == 0,
+              CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Seconds == seconds &&
+              CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Subseconds == 0,
               "CFE_TIME_ToneSend",
               "Send tone, flywheel ON");
 #endif /* CFE_PLATFORM_TIME_CFG_BIGENDIAN */
@@ -2675,18 +2675,18 @@ void Test_Tone(void)
 #ifdef CFE_PLATFORM_TIME_CFG_BIGENDIAN
 
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneMET.Seconds ==
+              CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Seconds ==
                   CFE_MAKE_BIG32(virtualSeconds) &&
-              CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneMET.Subseconds == CFE_MAKE_BIG32(0), /* yes, I know, 0 is 0 in all endians */
+              CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Subseconds == CFE_MAKE_BIG32(0), /* yes, I know, 0 is 0 in all endians */
               "CFE_TIME_ToneSend",
               "Send tone, flywheel OFF");
 
 #else /* !CFE_PLATFORM_TIME_CFG_BIGENDIAN */
 
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneMET.Seconds ==
+              CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Seconds ==
                   virtualSeconds &&
-              CFE_TIME_TaskData.ToneDataCmd.Payload.AtToneMET.Subseconds == 0,
+              CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Subseconds == 0,
               "CFE_TIME_ToneSend",
               "Send tone, flywheel OFF");
 
@@ -2718,31 +2718,31 @@ void Test_Tone(void)
      * to known values
      */
     UT_InitData();
-    VersionSave = CFE_TIME_TaskData.LastVersionCounter; /* Verifies 'ForcedToFly' path */
-    CFE_TIME_TaskData.ToneMatchCounter = 0;
-    CFE_TIME_TaskData.Forced2Fly = false; /* Exercises '!ForcedToFly' path */
+    VersionSave = CFE_TIME_Global.LastVersionCounter; /* Verifies 'ForcedToFly' path */
+    CFE_TIME_Global.ToneMatchCounter = 0;
+    CFE_TIME_Global.Forced2Fly = false; /* Exercises '!ForcedToFly' path */
     CFE_TIME_ToneVerify(time1, time2);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.LastVersionCounter > VersionSave &&
-              CFE_TIME_TaskData.ToneMatchCounter == 1,
+              CFE_TIME_Global.LastVersionCounter > VersionSave &&
+              CFE_TIME_Global.ToneMatchCounter == 1,
               "CFE_TIME_ToneVerify",
               "Time 1 < time 2, Forced2Fly false");
 
     /* Test tone validation when time 1 equals the previous time 1 value */
     UT_InitData();
-    CFE_TIME_TaskData.ToneMatchErrorCounter = 0;
+    CFE_TIME_Global.ToneMatchErrorCounter = 0;
     CFE_TIME_ToneVerify(time1, time1);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ToneMatchErrorCounter == 1,
+              CFE_TIME_Global.ToneMatchErrorCounter == 1,
               "CFE_TIME_ToneVerify",
               "Time 1 same as previous time 1");
 
     /* Test tone validation when time 2 equals the previous time 2 value */
     UT_InitData();
-    CFE_TIME_TaskData.ToneMatchErrorCounter = 0;
+    CFE_TIME_Global.ToneMatchErrorCounter = 0;
     CFE_TIME_ToneVerify(time2, time1);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ToneMatchErrorCounter == 1,
+              CFE_TIME_Global.ToneMatchErrorCounter == 1,
               "CFE_TIME_ToneVerify",
               "Time 2 same as previous time 2");
 
@@ -2752,12 +2752,12 @@ void Test_Tone(void)
     time2.Seconds = 0;
     time1.Subseconds = 0;
     time2.Subseconds = 100;
-    CFE_TIME_TaskData.MaxLocalClock.Seconds = 20; /* 1000.00000 */
-    CFE_TIME_TaskData.MaxLocalClock.Subseconds = 0;
-    CFE_TIME_TaskData.ToneMatchCounter = 0;
+    CFE_TIME_Global.MaxLocalClock.Seconds = 20; /* 1000.00000 */
+    CFE_TIME_Global.MaxLocalClock.Subseconds = 0;
+    CFE_TIME_Global.ToneMatchCounter = 0;
     CFE_TIME_ToneVerify(time1, time2);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ToneMatchCounter == 1,
+              CFE_TIME_Global.ToneMatchCounter == 1,
               "CFE_TIME_ToneVerify",
               "Time 1 > time 2 (clock rollover)");
 
@@ -2769,10 +2769,10 @@ void Test_Tone(void)
     time2.Seconds = 11;
     time1.Subseconds = 0;
     time2.Subseconds = 0;
-    CFE_TIME_TaskData.ToneMatchErrorCounter = 0;
+    CFE_TIME_Global.ToneMatchErrorCounter = 0;
     CFE_TIME_ToneVerify(time2, time1);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ToneMatchErrorCounter == 1,
+              CFE_TIME_Global.ToneMatchErrorCounter == 1,
               "CFE_TIME_ToneVerify",
               "Elapsed time out of limits (seconds)");
 
@@ -2784,12 +2784,12 @@ void Test_Tone(void)
     time2.Seconds = 12;
     time1.Subseconds = 0;
     time2.Subseconds = 10;
-    CFE_TIME_TaskData.MinElapsed = 20;
-    CFE_TIME_TaskData.MaxElapsed = 30;
-    CFE_TIME_TaskData.ToneMatchErrorCounter = 0;
+    CFE_TIME_Global.MinElapsed = 20;
+    CFE_TIME_Global.MaxElapsed = 30;
+    CFE_TIME_Global.ToneMatchErrorCounter = 0;
     CFE_TIME_ToneVerify(time1, time2);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ToneMatchErrorCounter == 1,
+              CFE_TIME_Global.ToneMatchErrorCounter == 1,
               "CFE_TIME_ToneVerify",
               "Elapsed time out of limits (subseconds low)");
 
@@ -2801,17 +2801,17 @@ void Test_Tone(void)
     time2.Seconds = 13;
     time1.Subseconds = 0;
     time2.Subseconds = 40;
-    CFE_TIME_TaskData.MinElapsed = 20;
-    CFE_TIME_TaskData.MaxElapsed = 30;
-    CFE_TIME_TaskData.ToneMatchErrorCounter = 0;
+    CFE_TIME_Global.MinElapsed = 20;
+    CFE_TIME_Global.MaxElapsed = 30;
+    CFE_TIME_Global.ToneMatchErrorCounter = 0;
     CFE_TIME_ToneVerify(time1, time2);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ToneMatchErrorCounter == 1,
+              CFE_TIME_Global.ToneMatchErrorCounter == 1,
               "CFE_TIME_ToneVerify",
               "Elapsed time out of limits (subseconds high)");
 
-    CFE_TIME_TaskData.MinElapsed = MinElapsed;
-    CFE_TIME_TaskData.MaxElapsed = MaxElapsed;
+    CFE_TIME_Global.MinElapsed = MinElapsed;
+    CFE_TIME_Global.MaxElapsed = MaxElapsed;
 
     time1.Seconds = 10;
     time1.Subseconds = 0;
@@ -2822,42 +2822,42 @@ void Test_Tone(void)
      * false and the clock source is external
      */
     UT_InitData();
-    VersionSave = CFE_TIME_TaskData.LastVersionCounter; /* Verifies 'ForcedToFly' path */
-    CFE_TIME_TaskData.ToneMatchCounter = 0;
-    CFE_TIME_TaskData.Forced2Fly = false; /* Exercises '!ForcedToFly' path */
-    CFE_TIME_TaskData.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
-    CFE_TIME_TaskData.VirtualMET = 5;
-    CFE_TIME_TaskData.PendingMET.Seconds = CFE_TIME_TaskData.VirtualMET;
+    VersionSave = CFE_TIME_Global.LastVersionCounter; /* Verifies 'ForcedToFly' path */
+    CFE_TIME_Global.ToneMatchCounter = 0;
+    CFE_TIME_Global.Forced2Fly = false; /* Exercises '!ForcedToFly' path */
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
+    CFE_TIME_Global.VirtualMET = 5;
+    CFE_TIME_Global.PendingMET.Seconds = CFE_TIME_Global.VirtualMET;
     CFE_TIME_ToneVerify(time1, time2);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.LastVersionCounter > VersionSave &&
-              CFE_TIME_TaskData.ToneMatchCounter == 1 &&
-              CFE_TIME_TaskData.VirtualMET == 5,
+              CFE_TIME_Global.LastVersionCounter > VersionSave &&
+              CFE_TIME_Global.ToneMatchCounter == 1 &&
+              CFE_TIME_Global.VirtualMET == 5,
               "CFE_TIME_ToneVerify",
               "Time 1 < time 2, Forced2Fly false, Clock EXTERN");
 
-    CFE_TIME_TaskData.ClockSource = CFE_TIME_SourceSelect_INTERNAL;
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_INTERNAL;
 
 #if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
     /* Test tone update using an invalid pending state */
     UT_InitData();
-    CFE_TIME_TaskData.PendingState = CFE_TIME_ClockState_INVALID;
-    CFE_TIME_TaskData.ClockSetState  = CFE_TIME_SetState_WAS_SET;
-    CFE_TIME_TaskData.ServerFlyState = CFE_TIME_FlywheelState_IS_FLY;
+    CFE_TIME_Global.PendingState = CFE_TIME_ClockState_INVALID;
+    CFE_TIME_Global.ClockSetState  = CFE_TIME_SetState_WAS_SET;
+    CFE_TIME_Global.ServerFlyState = CFE_TIME_FlywheelState_IS_FLY;
     CFE_TIME_ToneUpdate();
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ClockSetState == CFE_TIME_SetState_NOT_SET &&
-              CFE_TIME_TaskData.ServerFlyState == CFE_TIME_FlywheelState_NO_FLY,
+              CFE_TIME_Global.ClockSetState == CFE_TIME_SetState_NOT_SET &&
+              CFE_TIME_Global.ServerFlyState == CFE_TIME_FlywheelState_NO_FLY,
               "CFE_TIME_ToneUpdate",
               "Invalid pending state");
 
     /* Test tone update using FLYWHEEL as the pending state */
     UT_InitData();
-    CFE_TIME_TaskData.PendingState = CFE_TIME_ClockState_FLYWHEEL;
-    CFE_TIME_TaskData.ServerFlyState = CFE_TIME_FlywheelState_NO_FLY;
+    CFE_TIME_Global.PendingState = CFE_TIME_ClockState_FLYWHEEL;
+    CFE_TIME_Global.ServerFlyState = CFE_TIME_FlywheelState_NO_FLY;
     CFE_TIME_ToneUpdate();
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ServerFlyState == CFE_TIME_FlywheelState_IS_FLY,
+              CFE_TIME_Global.ServerFlyState == CFE_TIME_FlywheelState_IS_FLY,
               "CFE_TIME_ToneUpdate",
               "Pending state is FLYWHEEL");
 
@@ -2933,18 +2933,18 @@ void Test_1Hz(void)
     UT_InitData();
     RefState = CFE_TIME_StartReferenceUpdate();
     RefState->ClockFlyState = CFE_TIME_FlywheelState_NO_FLY;
-    CFE_TIME_TaskData.AutoStartFly = false;
+    CFE_TIME_Global.AutoStartFly = false;
     RefState->AtToneLatch.Seconds = 1;
     RefState->AtToneLatch.Subseconds = 0;
-    CFE_TIME_TaskData.OneHzAdjust.Seconds = 1;
-    CFE_TIME_TaskData.OneHzAdjust.Subseconds = 0;
+    CFE_TIME_Global.OneHzAdjust.Seconds = 1;
+    CFE_TIME_Global.OneHzAdjust.Subseconds = 0;
     CFE_TIME_FinishReferenceUpdate(RefState);
     UT_SetBSP_Time(0, 0);
-    CFE_TIME_TaskData.MaxLocalClock.Seconds = CFE_PLATFORM_TIME_CFG_LATCH_FLY - 1;
-    CFE_TIME_TaskData.MaxLocalClock.Subseconds = 0;
+    CFE_TIME_Global.MaxLocalClock.Seconds = CFE_PLATFORM_TIME_CFG_LATCH_FLY - 1;
+    CFE_TIME_Global.MaxLocalClock.Subseconds = 0;
     CFE_TIME_Local1HzStateMachine();
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.AutoStartFly == true,
+              CFE_TIME_Global.AutoStartFly == true,
               "CFE_TIME_Local1HzISR",
               "Auto start flywheel (seconds)");
 
@@ -2959,13 +2959,13 @@ void Test_1Hz(void)
     RefState->AtToneDelay.Subseconds = 0;
     RefState->AtToneMET.Seconds = time1.Seconds;
     RefState->AtToneMET.Subseconds = 0;
-    CFE_TIME_TaskData.OneHzAdjust.Seconds = 0;
-    CFE_TIME_TaskData.OneHzAdjust.Subseconds = 0;
+    CFE_TIME_Global.OneHzAdjust.Seconds = 0;
+    CFE_TIME_Global.OneHzAdjust.Subseconds = 0;
     RefState->AtToneLatch.Seconds = time2.Seconds;
     RefState->AtToneLatch.Subseconds = 0;
     UT_SetBSP_Time(0, 0);
-    CFE_TIME_TaskData.MaxLocalClock.Seconds = CFE_PLATFORM_TIME_CFG_LATCH_FLY + delSec;
-    CFE_TIME_TaskData.MaxLocalClock.Subseconds = 0;
+    CFE_TIME_Global.MaxLocalClock.Seconds = CFE_PLATFORM_TIME_CFG_LATCH_FLY + delSec;
+    CFE_TIME_Global.MaxLocalClock.Subseconds = 0;
     RefState->ClockFlyState = CFE_TIME_FlywheelState_IS_FLY;
     CFE_TIME_FinishReferenceUpdate(RefState);
     CFE_TIME_Local1HzStateMachine();
@@ -2982,13 +2982,13 @@ void Test_1Hz(void)
      * the previous one
      */
     UT_InitData();
-    CFE_TIME_TaskData.IsToneGood = true;
+    CFE_TIME_Global.IsToneGood = true;
     UT_SetBSP_Time(0, 0);
-    CFE_TIME_TaskData.ToneSignalLatch.Seconds = 1;
-    CFE_TIME_TaskData.ToneSignalLatch.Subseconds = 0;
+    CFE_TIME_Global.ToneSignalLatch.Seconds = 1;
+    CFE_TIME_Global.ToneSignalLatch.Subseconds = 0;
     CFE_TIME_Tone1HzISR();
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.IsToneGood == false,
+              CFE_TIME_Global.IsToneGood == false,
               "CFE_TIME_Tone1HzISR",
               "Invalid tone signal interrupt");
 
@@ -2999,15 +2999,15 @@ void Test_1Hz(void)
     UT_InitData();
     UT_SetBSP_Time(1, 0);
     /* Set up the sync callback table with callbacks for 3 apps */
-    for (i = 0; i < (sizeof(CFE_TIME_TaskData.SynchCallback) / sizeof(CFE_TIME_TaskData.SynchCallback[0])); i++)
+    for (i = 0; i < (sizeof(CFE_TIME_Global.SynchCallback) / sizeof(CFE_TIME_Global.SynchCallback[0])); i++)
     {
         if (i < 3)
         {
-            CFE_TIME_TaskData.SynchCallback[i].Ptr = &ut_time_MyCallbackFunc;
+            CFE_TIME_Global.SynchCallback[i].Ptr = &ut_time_MyCallbackFunc;
         }
         else
         {
-            CFE_TIME_TaskData.SynchCallback[i].Ptr = NULL;
+            CFE_TIME_Global.SynchCallback[i].Ptr = NULL;
         }
     }
     ut_time_CallbackCalled = 0;
@@ -3021,12 +3021,12 @@ void Test_1Hz(void)
      * second call
      */
     UT_InitData();
-    CFE_TIME_TaskData.AutoStartFly = true;
-    CFE_TIME_TaskData.LocalTaskCounter = 0;
+    CFE_TIME_Global.AutoStartFly = true;
+    CFE_TIME_Global.LocalTaskCounter = 0;
     UT_SetDeferredRetcode(UT_KEY(OS_BinSemTake), 2, OS_ERROR);
     CFE_TIME_Local1HzTask();
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.LocalTaskCounter == 1,
+              CFE_TIME_Global.LocalTaskCounter == 1,
               "CFE_TIME_Local1HzTask",
               "Semaphore creation pass, then fail");
 
@@ -3034,49 +3034,49 @@ void Test_1Hz(void)
      * second call
      */
     UT_InitData();
-    CFE_TIME_TaskData.ToneTaskCounter = 0;
+    CFE_TIME_Global.ToneTaskCounter = 0;
     UT_SetDeferredRetcode(UT_KEY(OS_BinSemTake), 2, OS_ERROR);
     CFE_TIME_Tone1HzTask();
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.ToneTaskCounter == 1,
+              CFE_TIME_Global.ToneTaskCounter == 1,
               "CFE_TIME_Tone1HzTask",
               "Semaphore creation pass, then fail");
 
     /* Test the tone 1Hz task with the tone signal over the time limit */
     UT_InitData();
-    UT_SetBSP_Time(1, CFE_TIME_Sub2MicroSecs(CFE_TIME_TaskData.ToneOverLimit));
-    CFE_TIME_TaskData.IsToneGood = true;
-    CFE_TIME_TaskData.MaxLocalClock.Seconds = 0;
-    CFE_TIME_TaskData.MaxLocalClock.Subseconds = 0;
-    CFE_TIME_TaskData.ToneSignalLatch.Seconds = 0;
-    CFE_TIME_TaskData.ToneSignalLatch.Subseconds = 0;
+    UT_SetBSP_Time(1, CFE_TIME_Sub2MicroSecs(CFE_TIME_Global.ToneOverLimit));
+    CFE_TIME_Global.IsToneGood = true;
+    CFE_TIME_Global.MaxLocalClock.Seconds = 0;
+    CFE_TIME_Global.MaxLocalClock.Subseconds = 0;
+    CFE_TIME_Global.ToneSignalLatch.Seconds = 0;
+    CFE_TIME_Global.ToneSignalLatch.Subseconds = 0;
     CFE_TIME_Tone1HzISR();
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.IsToneGood == false,
+              CFE_TIME_Global.IsToneGood == false,
               "CFE_TIME_Tone1HzISR",
               "Invalid tone signal interrupt; tolerance over limit");
 
     /* Test the tone 1Hz task with the tone signal within the time limits */
     UT_InitData();
-    UT_SetBSP_Time(0, CFE_TIME_Sub2MicroSecs(CFE_TIME_TaskData.ToneUnderLimit) + 1);
-    CFE_TIME_TaskData.IsToneGood = false;
-    CFE_TIME_TaskData.ToneSignalLatch.Seconds = 0;
-    CFE_TIME_TaskData.ToneSignalLatch.Subseconds = 0;
+    UT_SetBSP_Time(0, CFE_TIME_Sub2MicroSecs(CFE_TIME_Global.ToneUnderLimit) + 1);
+    CFE_TIME_Global.IsToneGood = false;
+    CFE_TIME_Global.ToneSignalLatch.Seconds = 0;
+    CFE_TIME_Global.ToneSignalLatch.Subseconds = 0;
     CFE_TIME_Tone1HzISR();
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.IsToneGood == true,
+              CFE_TIME_Global.IsToneGood == true,
               "CFE_TIME_Tone1HzISR",
               "Valid tone signal interrupt, tolerance in limits");
 
     /* Test the tone 1Hz task with the tone signal under the time limit */
     UT_InitData();
-    UT_SetBSP_Time(0, CFE_TIME_Sub2MicroSecs(CFE_TIME_TaskData.ToneUnderLimit) - 1);
-    CFE_TIME_TaskData.IsToneGood = true;
-    CFE_TIME_TaskData.ToneSignalLatch.Seconds = 0;
-    CFE_TIME_TaskData.ToneSignalLatch.Subseconds = 0;
+    UT_SetBSP_Time(0, CFE_TIME_Sub2MicroSecs(CFE_TIME_Global.ToneUnderLimit) - 1);
+    CFE_TIME_Global.IsToneGood = true;
+    CFE_TIME_Global.ToneSignalLatch.Seconds = 0;
+    CFE_TIME_Global.ToneSignalLatch.Subseconds = 0;
     CFE_TIME_Tone1HzISR();
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.IsToneGood == false,
+              CFE_TIME_Global.IsToneGood == false,
               "CFE_TIME_Tone1HzISR",
               "Valid tone signal interrupt, tolerance under limits");
 
@@ -3086,16 +3086,16 @@ void Test_1Hz(void)
     UT_InitData();
     RefState = CFE_TIME_StartReferenceUpdate();
     RefState->ClockFlyState = CFE_TIME_FlywheelState_NO_FLY;
-    CFE_TIME_TaskData.AutoStartFly = false;
+    CFE_TIME_Global.AutoStartFly = false;
     RefState->AtToneLatch.Seconds = 1;
     RefState->AtToneLatch.Subseconds = 0;
-    CFE_TIME_TaskData.OneHzAdjust.Seconds = 0;
-    CFE_TIME_TaskData.OneHzAdjust.Subseconds = 1;
+    CFE_TIME_Global.OneHzAdjust.Seconds = 0;
+    CFE_TIME_Global.OneHzAdjust.Subseconds = 1;
     CFE_TIME_FinishReferenceUpdate(RefState);
     UT_SetBSP_Time(0, 0);
     CFE_TIME_Local1HzStateMachine();
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.AutoStartFly == true,
+              CFE_TIME_Global.AutoStartFly == true,
               "CFE_TIME_Local1HzISR",
               "Auto start flywheel (subseconds)");
 
@@ -3105,8 +3105,8 @@ void Test_1Hz(void)
     UT_InitData();
     RefState = CFE_TIME_StartReferenceUpdate();
     RefState->ClockFlyState = CFE_TIME_FlywheelState_NO_FLY;
-    CFE_TIME_TaskData.OneHzAdjust.Seconds = 0;
-    CFE_TIME_TaskData.OneHzAdjust.Subseconds = 0;
+    CFE_TIME_Global.OneHzAdjust.Seconds = 0;
+    CFE_TIME_Global.OneHzAdjust.Subseconds = 0;
     CFE_TIME_FinishReferenceUpdate(RefState);
     UT_SetBSP_Time(1, 0);
     CFE_TIME_Local1HzStateMachine();
@@ -3118,8 +3118,8 @@ void Test_1Hz(void)
 
     /* Test the local 1Hz task where auto start flywheel is disabled */
     UT_InitData();
-    CFE_TIME_TaskData.LocalTaskCounter = 0;
-    CFE_TIME_TaskData.AutoStartFly = false;
+    CFE_TIME_Global.LocalTaskCounter = 0;
+    CFE_TIME_Global.AutoStartFly = false;
     UT_SetDeferredRetcode(UT_KEY(OS_BinSemTake), 2, OS_ERROR);
     CFE_TIME_Local1HzTask();
     RefState = CFE_TIME_GetReferenceState();
@@ -3131,16 +3131,16 @@ void Test_1Hz(void)
 
     /* Test the CFE_TIME_Local1HzTimerCallback function */
     UT_InitData();
-    CFE_TIME_TaskData.LocalIntCounter = 1;
+    CFE_TIME_Global.LocalIntCounter = 1;
     RefState = CFE_TIME_StartReferenceUpdate();
     RefState->ClockFlyState = CFE_TIME_FlywheelState_NO_FLY;
-    CFE_TIME_TaskData.OneHzAdjust.Seconds = 0;
-    CFE_TIME_TaskData.OneHzAdjust.Subseconds = 0;
+    CFE_TIME_Global.OneHzAdjust.Seconds = 0;
+    CFE_TIME_Global.OneHzAdjust.Subseconds = 0;
     CFE_TIME_FinishReferenceUpdate(RefState);
     UT_SetBSP_Time(0, 0);
     CFE_TIME_Local1HzTimerCallback(OS_ObjectIdFromInteger(123), &Arg);
     UT_Report(__FILE__, __LINE__,
-              CFE_TIME_TaskData.LocalIntCounter == 2,
+              CFE_TIME_Global.LocalIntCounter == 2,
               "CFE_TIME_Local1HzTimerCallback",
               "Pass through to CFE_TIME_Local1HzISR");
 }
@@ -3165,15 +3165,15 @@ void Test_UnregisterSynchCallback(void)
 
 
     /* Set up the sync callback table with callbacks for 3 apps */
-    for (i = 0; i < (sizeof(CFE_TIME_TaskData.SynchCallback) / sizeof(CFE_TIME_TaskData.SynchCallback[0])); i++)
+    for (i = 0; i < (sizeof(CFE_TIME_Global.SynchCallback) / sizeof(CFE_TIME_Global.SynchCallback[0])); i++)
     {
         if (i < 3)
         {
-            CFE_TIME_TaskData.SynchCallback[i].Ptr = &ut_time_MyCallbackFunc;
+            CFE_TIME_Global.SynchCallback[i].Ptr = &ut_time_MyCallbackFunc;
         }
         else
         {
-            CFE_TIME_TaskData.SynchCallback[i].Ptr = NULL;
+            CFE_TIME_Global.SynchCallback[i].Ptr = NULL;
         }
     }
 
@@ -3219,10 +3219,10 @@ void Test_UnregisterSynchCallback(void)
 
     /* Test tone notification with an invalid time synch application */
     UT_InitData();
-    CFE_TIME_TaskData.IsToneGood = true;
-    for (i = 0; i < (sizeof(CFE_TIME_TaskData.SynchCallback) / sizeof(CFE_TIME_TaskData.SynchCallback[0])); i++)
+    CFE_TIME_Global.IsToneGood = true;
+    for (i = 0; i < (sizeof(CFE_TIME_Global.SynchCallback) / sizeof(CFE_TIME_Global.SynchCallback[0])); i++)
     {
-        CFE_TIME_TaskData.SynchCallback[i].Ptr = NULL;
+        CFE_TIME_Global.SynchCallback[i].Ptr = NULL;
     }
     CFE_TIME_NotifyTimeSynchApps();
     UT_Report(__FILE__, __LINE__,
@@ -3248,9 +3248,9 @@ void Test_CleanUpApp(void)
     CFE_ES_GetAppID(&TestAppId);
 
     /* Clear out the sync callback table */
-    for (i = 0; i < (sizeof(CFE_TIME_TaskData.SynchCallback) / sizeof(CFE_TIME_TaskData.SynchCallback[0])); i++)
+    for (i = 0; i < (sizeof(CFE_TIME_Global.SynchCallback) / sizeof(CFE_TIME_Global.SynchCallback[0])); i++)
     {
-        CFE_TIME_TaskData.SynchCallback[i].Ptr = NULL;
+        CFE_TIME_Global.SynchCallback[i].Ptr = NULL;
     }
 
     /* Add callbacks for 3 apps into callback registry table */
@@ -3274,9 +3274,9 @@ void Test_CleanUpApp(void)
               "Successful result");
 
     Count = 0;
-    for (i = 0; i < (sizeof(CFE_TIME_TaskData.SynchCallback) / sizeof(CFE_TIME_TaskData.SynchCallback[0])); i++)
+    for (i = 0; i < (sizeof(CFE_TIME_Global.SynchCallback) / sizeof(CFE_TIME_Global.SynchCallback[0])); i++)
     {
-        if (CFE_TIME_TaskData.SynchCallback[i].Ptr != NULL)
+        if (CFE_TIME_Global.SynchCallback[i].Ptr != NULL)
         {
             ++Count;
         }
@@ -3298,9 +3298,9 @@ void Test_CleanUpApp(void)
               "Successful result");
 
     Count = 0;
-    for (i = 0; i < (sizeof(CFE_TIME_TaskData.SynchCallback) / sizeof(CFE_TIME_TaskData.SynchCallback[0])); i++)
+    for (i = 0; i < (sizeof(CFE_TIME_Global.SynchCallback) / sizeof(CFE_TIME_Global.SynchCallback[0])); i++)
     {
-        if (CFE_TIME_TaskData.SynchCallback[i].Ptr != NULL)
+        if (CFE_TIME_Global.SynchCallback[i].Ptr != NULL)
         {
             ++Count;
         }


### PR DESCRIPTION
**Describe the contribution**
Fix #1036 - explicity memset the task data to zero at the start of EarlyInit.  Also standardizes the global typdef/variable names.

Might need a rebase based on the name changes.

**Testing performed**
Build and run unit tests, passed.

**Expected behavior changes**
None.

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
TBL global depends on `CFE_TBL_Global.TableTaskAppId` being set, which doesn't happen until the app starts (in `CFE_TBL_InitData`), so replaced where CFE_TBL_EarlyInit was being called to initialize the data with the test initialization function `Test_CFE_TBL_ApiInit`.  In the future these tests could be cleaned up by calling the initialization before each test, and ensuring there are no test configuration dependencies across tests.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC