### PR TITLE
Fix #1123, Convert global CFE_SB_Default_Qos to macro

### DIFF
--- a/docs/src/cfe_sb.dox
+++ b/docs/src/cfe_sb.dox
@@ -445,12 +445,10 @@
   Quality of Service (QOS) for off-board routing and is of the type #CFE_SB_Qos_t. This structure
   has two members named priority and reliability. The Quality parameter is currently unused by
   the software bus. It is a placeholder to be used with the future software bus capability of
-  inter-processor communication. Although currently the software bus does not read the Quality
-  values, it would be best to set this parameter to the value defined as #CFE_SB_Default_Qos.
-  This value is set internally by the software bus with values of zero for priority and
-  reliability. The values of zero will correspond to low priority and low reliability. Setting
-  the QOS value to the #CFE_SB_Default_Qos will ensure seamless integration when the software
-  bus is expanded to support inter-processor communication.
+  inter-processor communication. Although currently the software bus does not implement quality
+  of service.
+
+  A default quality of services is provided via the #CFE_SB_DEFAULT_QOS macro.
 
   Next: \ref cfesbugknwnprob <BR>
   Prev: \ref cfesbugroutcntrl <BR>
@@ -569,9 +567,8 @@
         </B><TR><TD WIDTH="5%"> &nbsp; <TD WIDTH="95%">
            The QOS parameter is currently unused by the software bus. It is a placeholder to be
            used with the future software bus capability of inter-processor communication. Setting
-           the QOS value to the SB defined #CFE_SB_Default_Qos (QOS.Priority=0,QOS.Reliability=0)
-           will ensure seamless integration when the software bus is expanded to support
-           inter-processor communication.
+           the QOS as #CFE_SB_DEFAULT_QOS will ensure seamless integration when the software bus
+           is expanded to support inter-processor communication.
         <TR><TD COLSPAN=2 WIDTH="100%"> <B>(Q)
            Can I confirm my software bus buffer was delivered?
         </B><TR><TD WIDTH="5%"> &nbsp; <TD WIDTH="95%">

--- a/fsw/cfe-core/src/inc/cfe_sb.h
+++ b/fsw/cfe-core/src/inc/cfe_sb.h
@@ -190,8 +190,10 @@ typedef  struct {
     uint8 Reliability;/**< \brief  Specify high(1) or low(0) message transfer reliability for off-board routing, currently unused */
 }CFE_SB_Qos_t;
 
-extern CFE_SB_Qos_t CFE_SB_Default_Qos;/**< \brief  Defines a default priority and reliabilty for off-board routing */
-
+#define CFE_SB_DEFAULT_QOS ((CFE_SB_Qos_t) {0}) /**< \brief Default Qos macro */
+#ifndef CFE_OMIT_DEPRECATED_6_8
+#define CFE_SB_Default_Qos CFE_SB_DEFAULT_QOS   /**< \deprecated use CFE_SB_DEFAULT_QOS */
+#endif
 
 /****************** Function Prototypes **********************/
 
@@ -397,7 +399,7 @@ CFE_Status_t  CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *Pip
 **                          should be sent to.
 **
 ** \param[in]  Quality      The requested Quality of Service (QoS) required of
-**                          the messages. Most callers will use #CFE_SB_Default_Qos
+**                          the messages. Most callers will use #CFE_SB_DEFAULT_QOS
 **                          for this parameter.
 **
 ** \param[in]  MsgLim       The maximum number of messages with this Message ID to
@@ -421,7 +423,7 @@ CFE_Status_t  CFE_SB_SubscribeEx(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, C
 ** \par Description
 **          This routine adds the specified pipe to the destination list for
 **          the specified message ID.  This is the same as #CFE_SB_SubscribeEx
-**          with the Quality field set to #CFE_SB_Default_Qos and MsgLim set
+**          with the Quality field set to #CFE_SB_DEFAULT_QOS and MsgLim set
 **          to #CFE_PLATFORM_SB_DEFAULT_MSG_LIMIT (4).
 **
 ** \par Assumptions, External Events, and Notes:
@@ -456,7 +458,7 @@ CFE_Status_t CFE_SB_Subscribe(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId);
 ** \par Description
 **          This routine adds the specified pipe to the destination list for
 **          the specified message ID.  This is similar to #CFE_SB_SubscribeEx
-**          with the Quality field set to #CFE_SB_Default_Qos and MsgLim set
+**          with the Quality field set to #CFE_SB_DEFAULT_QOS and MsgLim set
 **          to #CFE_PLATFORM_SB_DEFAULT_MSG_LIMIT, but will not report the subscription.
 **          Subscription Reporting is enabled for interprocessor communication
 **          by way of the Software Bus Network (SBN) Application.

--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -878,7 +878,7 @@ int32 CFE_SB_SubscribeLocal(CFE_SB_MsgId_t   MsgId,
                             CFE_SB_PipeId_t  PipeId,
                             uint16           MsgLim)
 {
-    return CFE_SB_SubscribeFull(MsgId,PipeId,CFE_SB_Default_Qos,MsgLim,
+    return CFE_SB_SubscribeFull(MsgId,PipeId,CFE_SB_DEFAULT_QOS,MsgLim,
                                 (uint8)CFE_SB_LOCAL);
 
 }/* end CFE_SB_SubscribeLocal */
@@ -889,7 +889,7 @@ int32 CFE_SB_SubscribeLocal(CFE_SB_MsgId_t   MsgId,
 int32 CFE_SB_Subscribe(CFE_SB_MsgId_t   MsgId,
                        CFE_SB_PipeId_t  PipeId)
 {
-    return CFE_SB_SubscribeFull(MsgId,PipeId,CFE_SB_Default_Qos,
+    return CFE_SB_SubscribeFull(MsgId,PipeId,CFE_SB_DEFAULT_QOS,
                                (uint16)CFE_PLATFORM_SB_DEFAULT_MSG_LIMIT,
                                (uint8)CFE_SB_GLOBAL);
 

--- a/fsw/cfe-core/src/sb/cfe_sb_init.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_init.c
@@ -90,9 +90,6 @@ int32 CFE_SB_EarlyInit (void) {
     /* ensure entire CFE_SB global data structure is purged first */
     memset(&CFE_SB, 0, sizeof(CFE_SB));
 
-    CFE_SB_Default_Qos.Priority    = CFE_SB_QOS_LOW_PRIORITY;
-    CFE_SB_Default_Qos.Reliability = CFE_SB_QOS_LOW_RELIABILITY;
-
     Stat = OS_MutSemCreate(&CFE_SB.SharedDataMutexId, "CFE_SB_DataMutex", 0);
     if(Stat != OS_SUCCESS){
       CFE_ES_WriteToSysLog("SB shared data mutex creation failed! RC=0x%08x\n",(unsigned int)Stat);

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.h
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.h
@@ -83,9 +83,6 @@
 #define CFE_SB_CMD_PIPE_NAME            "SB_CMD_PIPE"
 #define CFE_SB_MAX_CFG_FILE_EVENTS_TO_FILTER     8
 
-#define CFE_SB_QOS_LOW_PRIORITY         0
-#define CFE_SB_QOS_LOW_RELIABILITY      0
-
 #define CFE_SB_PIPE_OVERFLOW            (-1)
 #define CFE_SB_PIPE_WR_ERR              (-2)
 #define CFE_SB_USECNT_ERR               (-3)

--- a/fsw/cfe-core/src/sb/cfe_sb_task.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_task.c
@@ -46,7 +46,6 @@
 
 /*  Task Globals */
 cfe_sb_t                CFE_SB;
-CFE_SB_Qos_t            CFE_SB_Default_Qos;
 
 /* Local structure for file writing callbacks */
 typedef struct

--- a/fsw/cfe-core/unit-test/sb_UT.c
+++ b/fsw/cfe-core/unit-test/sb_UT.c
@@ -3034,7 +3034,7 @@ void Test_TransmitMsg_MsgLimitExceeded(void)
     SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "MsgLimTestPipe"));
 
     /* Set maximum allowed messages on the pipe at one time to 1 */
-    CFE_SB_SubscribeEx(MsgId, PipeId, CFE_SB_Default_Qos, 1);
+    CFE_SB_SubscribeEx(MsgId, PipeId, CFE_SB_DEFAULT_QOS, 1);
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
@@ -3930,7 +3930,6 @@ void Test_CFE_SB_BadPipeInfo(void)
     CFE_SB_PipeId_t PipeId;
     CFE_SB_PipeD_t  *PipeDscPtr;
     uint16          PipeDepth = 10;
-    CFE_SB_Qos_t    CFE_SB_Default_Qos;
     CFE_ES_ResourceID_t AppID;
 
     SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "TestPipe1"));
@@ -3946,7 +3945,7 @@ void Test_CFE_SB_BadPipeInfo(void)
     /* Reset the pipe ID and delete the pipe */
     PipeDscPtr->PipeId = PipeId;
 
-    ASSERT_EQ(CFE_SB_SubscribeFull(SB_UT_FIRST_VALID_MID , PipeId, CFE_SB_Default_Qos,
+    ASSERT_EQ(CFE_SB_SubscribeFull(SB_UT_FIRST_VALID_MID , PipeId, CFE_SB_DEFAULT_QOS,
                                   CFE_PLATFORM_SB_DEFAULT_MSG_LIMIT, 2), CFE_SB_BAD_ARGUMENT);
 
     EVTCNT(4);
@@ -4050,7 +4049,7 @@ void Test_SB_TransmitMsgPaths_LimitErr(void)
     SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "MsgLimTestPipe"));
 
     /* Set maximum allowed messages on the pipe at one time to 1 */
-    SETUP(CFE_SB_SubscribeEx(MsgId, PipeId, CFE_SB_Default_Qos, 1));
+    SETUP(CFE_SB_SubscribeEx(MsgId, PipeId, CFE_SB_DEFAULT_QOS, 1));
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);

--- a/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_sb_stubs.c
@@ -47,16 +47,6 @@ typedef struct
 
 } CFE_SB_StubMsg_MetaData_t;
 
-
-/*
-** Global variables
-**
-** NOTE: CFE_SB_Default_Qos is an oddball in that it is directly referenced by the code
-** in other applications.  Therefore the UT stub has to instantiate this in order to get
-** any dependent code to link.
-*/
-CFE_SB_Qos_t CFE_SB_Default_Qos;
-
 static CFE_SB_StubMsg_MetaData_t* CFE_SB_StubMsg_GetMetaData(const CFE_MSG_Message_t *MsgPtr)
 {
     CFE_SB_StubMsg_MetaData_t* MetaPtr;


### PR DESCRIPTION
**Describe the contribution**
Fix #1123 - deprecates CFE_SB_Default_Qos and replaces with CFE_SB_DEFAULT_QOS macro that avoids global variable exposure, and removed SB internal defines (they aren't implemented anywhere and are not used).  These can be added at the appropriate scope once requirements are defined.

**Testing performed**
Build and ran unit tests

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle integration candidate + this commit

**Additional context**
@ejtimmon - deprecation of CFE_SB_Default_Qos (coding standard all-caps for macros requires change)
Depends on #1126 to compile with OMIT_DEPRECATED

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC