### PR TITLE
Fix #1122, ES and EVS use default message limits

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_task.c
+++ b/fsw/cfe-core/src/es/cfe_es_task.c
@@ -272,8 +272,7 @@ int32 CFE_ES_TaskInit(void)
     /*
     ** Subscribe to Housekeeping request commands
     */
-    Status = CFE_SB_SubscribeEx(CFE_SB_ValueToMsgId(CFE_ES_SEND_HK_MID), CFE_ES_TaskData.CmdPipe,
-                                CFE_SB_Default_Qos, CFE_ES_LIMIT_HK);
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_ES_SEND_HK_MID), CFE_ES_TaskData.CmdPipe);
     if ( Status != CFE_SUCCESS )
     {
         CFE_ES_WriteToSysLog("ES:Cannot Subscribe to HK packet, RC = 0x%08X\n", (unsigned int)Status);
@@ -283,8 +282,7 @@ int32 CFE_ES_TaskInit(void)
     /*
     ** Subscribe to ES task ground command packets
     */
-    Status = CFE_SB_SubscribeEx(CFE_SB_ValueToMsgId(CFE_ES_CMD_MID), CFE_ES_TaskData.CmdPipe,
-                                CFE_SB_Default_Qos, CFE_ES_LIMIT_CMD);
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_ES_CMD_MID), CFE_ES_TaskData.CmdPipe);
     if ( Status != CFE_SUCCESS )
     {
         CFE_ES_WriteToSysLog("ES:Cannot Subscribe to ES ground commands, RC = 0x%08X\n", (unsigned int)Status);

--- a/fsw/cfe-core/src/es/cfe_es_task.h
+++ b/fsw/cfe-core/src/es/cfe_es_task.h
@@ -128,9 +128,6 @@ typedef struct
   /*
   ** ES Task initialization data (not reported in housekeeping)
   */
-  uint8                 LimitHK;
-  uint8                 LimitCmd;
-
   CFE_ES_BackgroundLogDumpGlobal_t  BackgroundERLogDumpState;
 
   /*

--- a/fsw/cfe-core/src/evs/cfe_evs_task.c
+++ b/fsw/cfe-core/src/evs/cfe_evs_task.c
@@ -316,16 +316,14 @@ int32 CFE_EVS_TaskInit ( void )
    }
       
    /* Subscribe to command and telemetry requests coming in on the command pipe */
-   Status = CFE_SB_SubscribeEx(CFE_SB_ValueToMsgId(CFE_EVS_CMD_MID), CFE_EVS_GlobalData.EVS_CommandPipe,
-                               CFE_SB_Default_Qos, CFE_EVS_MSG_LIMIT);
+   Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_EVS_CMD_MID), CFE_EVS_GlobalData.EVS_CommandPipe);
    if (Status != CFE_SUCCESS)
    {
       CFE_ES_WriteToSysLog("EVS:Subscribing to Cmds Failed:RC=0x%08X\n",(unsigned int)Status);
       return Status;
    }
   
-   Status = CFE_SB_SubscribeEx(CFE_SB_ValueToMsgId(CFE_EVS_SEND_HK_MID), CFE_EVS_GlobalData.EVS_CommandPipe,
-                               CFE_SB_Default_Qos, CFE_EVS_MSG_LIMIT);
+   Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_EVS_SEND_HK_MID), CFE_EVS_GlobalData.EVS_CommandPipe);
    if (Status != CFE_SUCCESS)
    {
       CFE_ES_WriteToSysLog("EVS:Subscribing to HK Request Failed:RC=0x%08X\n",(unsigned int)Status);

--- a/fsw/cfe-core/src/evs/cfe_evs_task.h
+++ b/fsw/cfe-core/src/evs/cfe_evs_task.h
@@ -59,7 +59,6 @@
 #define CFE_EVS_FREE_SLOT               (-1)
 #define CFE_EVS_NO_MASK                 0
 #define CFE_EVS_PIPE_DEPTH              32
-#define CFE_EVS_MSG_LIMIT               4
 #define CFE_EVS_MAX_EVENT_SEND_COUNT    65535
 #define CFE_EVS_MAX_FILTER_COUNT        65535
 #define CFE_EVS_PIPE_NAME               "EVS_CMD_PIPE"

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -2726,7 +2726,7 @@ void TestTask(void)
 
     /* Test task main process loop with a HK packet subscribe failure */
     ES_ResetUnitTest();
-    UT_SetDeferredRetcode(UT_KEY(CFE_SB_SubscribeEx), 1, -3);
+    UT_SetDeferredRetcode(UT_KEY(CFE_SB_Subscribe), 1, -3);
     UT_Report(__FILE__, __LINE__,
               CFE_ES_TaskInit() == -3,
               "CFE_ES_TaskInit",
@@ -2734,7 +2734,7 @@ void TestTask(void)
 
     /* Test task main process loop with a ground command subscribe failure */
     ES_ResetUnitTest();
-    UT_SetDeferredRetcode(UT_KEY(CFE_SB_SubscribeEx), 2, -4);
+    UT_SetDeferredRetcode(UT_KEY(CFE_SB_Subscribe), 2, -4);
     UT_Report(__FILE__, __LINE__,
               CFE_ES_TaskInit() == -4,
               "CFE_ES_TaskInit",

--- a/fsw/cfe-core/unit-test/evs_UT.c
+++ b/fsw/cfe-core/unit-test/evs_UT.c
@@ -448,7 +448,7 @@ void Test_Init(void)
 
     /* Test task initialization where command subscription fails */
     UT_InitData();
-    UT_SetDeferredRetcode(UT_KEY(CFE_SB_SubscribeEx), 1, -1);
+    UT_SetDeferredRetcode(UT_KEY(CFE_SB_Subscribe), 1, -1);
     CFE_EVS_TaskInit();
     UT_Report(__FILE__, __LINE__,
               UT_SyslogIsInHistory(EVS_SYSLOG_MSGS[13]),
@@ -457,7 +457,7 @@ void Test_Init(void)
 
     /* Test task initialization where HK request subscription fails */
     UT_InitData();
-    UT_SetDeferredRetcode(UT_KEY(CFE_SB_SubscribeEx), 2, -1);
+    UT_SetDeferredRetcode(UT_KEY(CFE_SB_Subscribe), 2, -1);
     CFE_EVS_TaskInit();
     UT_Report(__FILE__, __LINE__,
               UT_SyslogIsInHistory(EVS_SYSLOG_MSGS[14]),


### PR DESCRIPTION
**Describe the contribution**
Fix #1122 - ES and EVS used `CFE_SB_SubscribeEx` with no requirement or justification (all but one of the limits were default, and the non-default for ES HK was 2 vs 4).  Default limits should be fine unless required to be different.

**Testing performed**
Built and ran unit tests, passed

**Expected behavior changes**
None except it could queue a few more HK messages, but SCH loads after ES anyways.

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC