### PR TITLE
Fix #915, Check for file existence in CFE_ES_RestartApp

### DIFF
--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -3040,6 +3040,21 @@ void TestTask(void)
               "CFE_ES_RestartAppCmd",
               "Restart application initiated");
 
+    /* Test app restart with failed file check */
+    ES_ResetUnitTest();
+    memset(&CmdBuf, 0, sizeof(CmdBuf));
+    UT_SetDefaultReturnValue(UT_KEY(OS_stat), OS_ERROR);
+    ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
+    strncpy(CmdBuf.RestartAppCmd.Payload.Application, "CFE_ES",
+            sizeof(CmdBuf.RestartAppCmd.Payload.Application));
+    CmdBuf.RestartAppCmd.Payload.Application[sizeof(CmdBuf.RestartAppCmd.Payload.Application) - 1] = '\0';
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.RestartAppCmd),
+            UT_TPID_CFE_ES_CMD_RESTART_APP_CC);
+    UT_Report(__FILE__, __LINE__,
+              UT_EventIsInHistory(CFE_ES_RESTART_APP_ERR1_EID),
+              "CFE_ES_RestartAppCmd",
+              "Restart application failed");
+
     /* Test app restart with a bad app name */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
@@ -3053,12 +3068,26 @@ void TestTask(void)
               "CFE_ES_RestartAppCmd",
               "Restart application bad name");
 
-    /* Test failed app restart */
+    /* Test failed app restart, core app */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_WAITING, "CFE_ES", NULL, NULL);
+    ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
     strncpy(CmdBuf.RestartAppCmd.Payload.Application, "CFE_ES",
         sizeof(CmdBuf.RestartAppCmd.Payload.Application) - 1);
+    CmdBuf.RestartAppCmd.Payload.Application[sizeof(CmdBuf.RestartAppCmd.Payload.Application) - 1] = '\0';
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.RestartAppCmd),
+            UT_TPID_CFE_ES_CMD_RESTART_APP_CC);
+    UT_Report(__FILE__, __LINE__,
+              UT_EventIsInHistory(CFE_ES_RESTART_APP_ERR1_EID),
+              "CFE_ES_RestartAppCmd",
+              "Restart application failed");
+
+    /* Test failed app restart, not running */
+    ES_ResetUnitTest();
+    memset(&CmdBuf, 0, sizeof(CmdBuf));
+    ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_WAITING, "CFE_ES", NULL, NULL);
+    strncpy(CmdBuf.RestartAppCmd.Payload.Application, "CFE_ES",
+        sizeof(CmdBuf.RestartAppCmd.Payload.Application));
     CmdBuf.RestartAppCmd.Payload.Application[sizeof(CmdBuf.RestartAppCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.RestartAppCmd),
             UT_TPID_CFE_ES_CMD_RESTART_APP_CC);
@@ -3084,6 +3113,24 @@ void TestTask(void)
               "CFE_ES_ReloadAppCmd",
               "Reload application initiated");
 
+    /* Test app reload with missing file */
+    ES_ResetUnitTest();
+    memset(&CmdBuf, 0, sizeof(CmdBuf));
+    UT_SetDefaultReturnValue(UT_KEY(OS_stat), OS_ERROR);
+    ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
+    strncpy(CmdBuf.ReloadAppCmd.Payload.AppFileName, "New_Name",
+            sizeof(CmdBuf.ReloadAppCmd.Payload.AppFileName));
+    CmdBuf.ReloadAppCmd.Payload.AppFileName[sizeof(CmdBuf.ReloadAppCmd.Payload.AppFileName) - 1] = '\0';
+    strncpy(CmdBuf.ReloadAppCmd.Payload.Application, "CFE_ES",
+            sizeof(CmdBuf.ReloadAppCmd.Payload.Application));
+    CmdBuf.ReloadAppCmd.Payload.Application[sizeof(CmdBuf.ReloadAppCmd.Payload.Application) - 1] = '\0';
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.ReloadAppCmd),
+            UT_TPID_CFE_ES_CMD_RELOAD_APP_CC);
+    UT_Report(__FILE__, __LINE__,
+              UT_EventIsInHistory(CFE_ES_RELOAD_APP_ERR1_EID),
+              "CFE_ES_ReloadAppCmd",
+              "Reload application failed");
+
     /* Test app reload with a bad app name */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
@@ -3097,12 +3144,26 @@ void TestTask(void)
               "CFE_ES_ReloadAppCmd",
               "Reload application bad name");
 
-    /* Test failed app reload */
+    /* Test failed app reload, core app */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_WAITING, "CFE_ES", NULL, NULL);
+    ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
     strncpy(CmdBuf.ReloadAppCmd.Payload.Application, "CFE_ES",
-            sizeof(CmdBuf.ReloadAppCmd.Payload.Application) - 1);
+            sizeof(CmdBuf.ReloadAppCmd.Payload.Application));
+    CmdBuf.ReloadAppCmd.Payload.Application[sizeof(CmdBuf.ReloadAppCmd.Payload.Application) - 1] = '\0';
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.ReloadAppCmd),
+            UT_TPID_CFE_ES_CMD_RELOAD_APP_CC);
+    UT_Report(__FILE__, __LINE__,
+              UT_EventIsInHistory(CFE_ES_RELOAD_APP_ERR1_EID),
+              "CFE_ES_ReloadAppCmd",
+              "Reload application failed");
+
+    /* Test failed app reload, not RUNNING */
+    ES_ResetUnitTest();
+    memset(&CmdBuf, 0, sizeof(CmdBuf));
+    ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_WAITING, "CFE_ES", NULL, NULL);
+    strncpy(CmdBuf.ReloadAppCmd.Payload.Application, "CFE_ES",
+            sizeof(CmdBuf.ReloadAppCmd.Payload.Application));
     CmdBuf.ReloadAppCmd.Payload.Application[sizeof(CmdBuf.ReloadAppCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.ReloadAppCmd),
             UT_TPID_CFE_ES_CMD_RELOAD_APP_CC);


### PR DESCRIPTION
**Describe the contribution**
Fix #915 - `CFE_ES_RestartApp` now checkes for file existence as part of command processing.  Avoids removing the app if the file doesn't exist (just avoids one error case). 

**Testing performed**
Build and ran unit tests, passed.  Also ran cFE and tested with valid and invalid file (moved good file), confirmed error counter increment (and command rejected so app remained running).

**Expected behavior changes**
Now rejects command and increments command error counter if file is missing

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
#915

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC