### PR TITLE
Fix #609, Remove CFE_PLATFORM_EVS_LOG_ON undefined option to diasble log

### DIFF
--- a/cmake/sample_defs/cpu1_platform_cfg.h
+++ b/cmake/sample_defs/cpu1_platform_cfg.h
@@ -1456,20 +1456,6 @@
 
 
 /**
-**  \cfeevscfg Enable or Disable EVS Local Event Log
-**
-**  \par Description:
-**       The CFE_PLATFORM_EVS_LOG_ON configuration parameter must be defined to enable EVS
-**       event logging. In order to disable the local event log this definition needs
-**       to be commented out.
-**
-**  \par Limits
-**       Not Applicable
-*/
-#define CFE_PLATFORM_EVS_LOG_ON
-
-
-/**
 **  \cfeevscfg Default Event Log Filename
 **
 **  \par Description:

--- a/fsw/cfe-core/src/evs/cfe_evs_task.c
+++ b/fsw/cfe-core/src/evs/cfe_evs_task.c
@@ -74,14 +74,10 @@ bool CFE_EVS_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength);
 int32 CFE_EVS_EarlyInit ( void )
 {
 
-#ifdef CFE_PLATFORM_EVS_LOG_ON
-
    int32                Status;
    uint32               resetAreaSize = 0;
    cpuaddr              resetAreaAddr;
    CFE_ES_ResetData_t  *CFE_EVS_ResetDataPtr = (CFE_ES_ResetData_t *) NULL;
-
-#endif
 
    memset(&CFE_EVS_GlobalData, 0, sizeof(CFE_EVS_GlobalData_t));
 
@@ -94,8 +90,6 @@ int32 CFE_EVS_EarlyInit ( void )
    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.OutputPort = CFE_PLATFORM_EVS_PORT_DEFAULT;
    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.LogFullFlag = false;
    CFE_EVS_GlobalData.EVS_TlmPkt.Payload.LogMode = CFE_PLATFORM_EVS_DEFAULT_LOG_MODE;
-
-#ifdef CFE_PLATFORM_EVS_LOG_ON
 
    /* Get a pointer to the CFE reset area from the BSP */
    Status = CFE_PSP_GetResetArea(&resetAreaAddr, &resetAreaSize);
@@ -162,8 +156,6 @@ int32 CFE_EVS_EarlyInit ( void )
          }
       }
    }
-
-#endif
 
    return(CFE_SUCCESS);
 

--- a/fsw/cfe-core/src/inc/cfe_evs_events.h
+++ b/fsw/cfe-core/src/inc/cfe_evs_events.h
@@ -541,12 +541,10 @@
 **  \par Cause:
 **
 **  This event message is generated upon receipt of a "Set Log Mode"
-**  command when the use of the Event Log has been disabled.  To enable
-**  the Event Log, the cFE code must be compiled for the target with
-**  the \b CFE_PLATFORM_EVS_LOG_ON macro defined.  The EVS task must also succeed
-**  during task initialization in acquiring a pointer to the cFE reset
-**  area and in the creation of a serializing semaphore to control
-**  access to the Event Log.
+**  command when the use of the Event Log has been disabled. The EVS task
+**  must succeed during task initialization in acquiring a pointer to
+**  the cFE reset area and in the creation of a serializing semaphore to
+**  control access to the Event Log.
 **/
 #define CFE_EVS_NO_LOGSET_EID             34
 
@@ -558,12 +556,10 @@
 **  \par Cause:
 **
 **  This event message is generated upon receipt of a "Clear Log"
-**  command when the use of the Event Log has been disabled.  To enable
-**  the Event Log, the cFE code must be compiled for the target with
-**  the \b CFE_PLATFORM_EVS_LOG_ON macro defined.  The EVS task must also succeed
-**  during task initialization in acquiring a pointer to the cFE reset
-**  area and in the creation of a serializing semaphore to control
-**  access to the Event Log.
+**  command when the use of the Event Log has been disabled. The EVS task
+**  must succeed during task initialization in acquiring a pointer to
+**  the cFE reset area and in the creation of a serializing semaphore to
+**  control access to the Event Log.
 **/
 #define CFE_EVS_NO_LOGCLR_EID             35
 
@@ -575,12 +571,10 @@
 **  \par Cause:
 **
 **  This event message is generated upon receipt of a "Write Log"
-**  command when the use of the Event Log has been disabled.  To enable
-**  the Event Log, the cFE code must be compiled for the target with
-**  the \b CFE_PLATFORM_EVS_LOG_ON macro defined.  The EVS task must also succeed
-**  during task initialization in acquiring a pointer to the cFE reset
-**  area and in the creation of a serializing semaphore to control
-**  access to the Event Log.
+**  command when the use of the Event Log has been disabled. The EVS task
+**  must succeed during task initialization in acquiring a pointer to
+**  the cFE reset area and in the creation of a serializing semaphore to
+**  control access to the Event Log.
 **/
 #define CFE_EVS_NO_LOGWR_EID              36
 

--- a/fsw/cfe-core/src/inc/private/cfe_es_resetdata_typedef.h
+++ b/fsw/cfe-core/src/inc/private/cfe_es_resetdata_typedef.h
@@ -37,7 +37,7 @@
 #include "cfe_es_erlog_typedef.h"      /* Required for CFE_ES_ERLog_t definition */
 #include "cfe_es_perfdata_typedef.h"   /* Required for CFE_ES_PerfData_t definition */
 #include "cfe_evs_log_typedef.h"       /* Required for CFE_EVS_Log_t definition */
-#include "cfe_platform_cfg.h"          /* CFE_PLATFORM_EVS_LOG_ON, CFE_PLATFORM_ES_ER_LOG_ENTRIES, CFE_PLATFORM_ES_SYSTEM_LOG_SIZE */
+#include "cfe_platform_cfg.h"          /* CFE_PLATFORM_ES_ER_LOG_ENTRIES, CFE_PLATFORM_ES_SYSTEM_LOG_SIZE */
 
 /*
 ** Reset Variables type
@@ -93,12 +93,10 @@ typedef struct
    */
    CFE_TIME_ResetVars_t TimeResetVars;
 
-#ifdef CFE_PLATFORM_EVS_LOG_ON
    /*
    ** EVS Log and associated variables. This needs to be preserved on a processor reset.
    */
    CFE_EVS_Log_t              EVS_Log;
-#endif
 
 } CFE_ES_ResetData_t;
 


### PR DESCRIPTION
**Describe the contribution**
Fix #609 - removes the ability to disable the log by not defining `CFE_PLATFORM_EVS_LOG_ON`

**Testing performed**
Build and run unit tests, passed

**Expected behavior changes**
No longer able to disable log completely, for minimum memory use define `CFE_PLATFORM_EVS_LOG_MAX` as 1

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
Could remove control based on LogEnabled, panic on reset area fail and limp along if sem create fails.
Needs requirements updates - #1131

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC