### PR TITLE
Fix #680, Remove table service exclusion logic

### DIFF
--- a/docs/src/cfe_tbl.dox
+++ b/docs/src/cfe_tbl.dox
@@ -22,43 +22,9 @@
     <LI> \subpage cfetblugregistry <BR>
     <LI> \subpage cfetblugtelemetry <BR>
     <LI> \subpage cfetblugprocreset <BR>
-    <LI> \subpage cfetblugdecouple <BR>
     <LI> \subpage cfetblugfaq <BR> 
   </UL>
 
-**/
-
-/**
-  \page cfetblugdecouple How To Remove cFE Table Services
-
-  It is possible to build the CFE without including Table Services.  This is only applicable if
-  the mission does not intend to use any CFS applications that require CFE type table services, or
-  if the mission intends to provide custom table services. If CFE Table Services are removed, the
-  CFE makefile will no longer try to make the Table Services application and the link makefile will
-  no longer include the Table Services object module in the CFE-CORE. Even if excluded from the build,
-  the Table Services source and header files will remain in the CFE source tree.
-
-  If EXCLUDE_CFE_TBL is defined (typically in the applicable *_platform_config.h file) Executive
-  services will not load or shut down table services. Note this option does not effect the build
-  and link of table services.
-
-  To remove table services from the build completely, remove "tbl" from the CFE_CORE_MODULES
-  in the cfe/fsw/cfe-core CMakeLists.txt directory (note this option also needs EXCLUDE_CFE_TBL defined
-  or executive services will try to load it).
-
-  Removing Table Services reduces the size of the CFE-CORE load file and also reduces the amount
-  of RAM memory required to load the cFE. Each development environment will have unique savings.
-  The numbers from an example default linux build are as follows:
-
-      Size of core cFE binary load file with Table Services:          963K
-      Size of core cFE binary load file w/o building Table services:  871K
-
-      RAM used after loading cFE with Table Services:        153K
-      RAM used after loading cFE w/o loading Table Services: 144M 
-
-  Next: \ref cfetblugfaq <BR>
-  Prev: \ref cfetblugprocreset <BR>
-  Up To: \ref cfetblovr
 **/
 
 /**
@@ -344,7 +310,7 @@
   contents of the table are automatically loaded into the table and the Application is notified that the
   table does not require additional initialization.
     
-  Next: \ref cfetblugdecouple <BR>
+  Next: \ref cfetblugfaq <BR>
   Prev: \ref cfetblugtelemetry <BR>
   Up To: \ref cfetblovr
 **/
@@ -441,7 +407,7 @@
 
     </TABLE>
     
-  Prev: \ref cfetblugdecouple <BR>
+  Prev: \ref cfetblugprocreset <BR>
   Up To: \ref cfetblovr
 **/
 

--- a/fsw/cfe-core/src/es/cfe_es_objtab.c
+++ b/fsw/cfe-core/src/es/cfe_es_objtab.c
@@ -98,18 +98,11 @@ CFE_ES_ObjectTable_t  CFE_ES_ObjectTable[CFE_PLATFORM_ES_OBJECT_TABLE_SIZE] =
    },
    {
            .ObjectType = CFE_ES_NULL_ENTRY },
-#ifndef EXCLUDE_CFE_TBL
    {
            .ObjectType = CFE_ES_FUNCTION_CALL,
            .ObjectName = "CFE_TBL_EarlyInit",
            .FuncPtrUnion.FunctionPtr = CFE_TBL_EarlyInit
    },
-
-#else
-   {
-           .ObjectType = CFE_ES_NULL_ENTRY
-   },
-#endif
    {
            .ObjectType = CFE_ES_NULL_ENTRY
    },
@@ -173,7 +166,6 @@ CFE_ES_ObjectTable_t  CFE_ES_ObjectTable[CFE_PLATFORM_ES_OBJECT_TABLE_SIZE] =
    {
            .ObjectType = CFE_ES_NULL_ENTRY
    },
-#ifndef EXCLUDE_CFE_TBL
    {
            .ObjectType = CFE_ES_CORE_TASK,
            .ObjectName = "CFE_TBL",
@@ -181,11 +173,6 @@ CFE_ES_ObjectTable_t  CFE_ES_ObjectTable[CFE_PLATFORM_ES_OBJECT_TABLE_SIZE] =
            .ObjectPriority = CFE_PLATFORM_TBL_START_TASK_PRIORITY,
            .ObjectSize = CFE_PLATFORM_TBL_START_TASK_STACK_SIZE
    },
-#else
-   {
-           .ObjectType = CFE_ES_NULL_ENTRY
-   },
-#endif
 
    /*
    ** Spare entries


### PR DESCRIPTION
**Describe the contribution**
Fix #680 - This removes the final remnants of the table service exclusion logic and documentation.

**Testing performed**
Build and run unit tests, passed.

**Expected behavior changes**
No affect to default behavior.  `EXCLUDE_CFE_TBL` no longer used, if define table services will still be started.

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
#972 will transition table service to a module that can be customized or implemented differently if desired.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC