### PR TITLE
Fix #723, CFE_EVS_Register const correct and report truncation

### DIFF
--- a/fsw/cfe-core/src/evs/cfe_evs.c
+++ b/fsw/cfe-core/src/evs/cfe_evs.c
@@ -50,7 +50,7 @@
 /*
 ** Function: CFE_EVS_Register - See API and header file for details
 */
-int32 CFE_EVS_Register (void *Filters, uint16 NumEventFilters, uint16 FilterScheme)
+int32 CFE_EVS_Register (const void *Filters, uint16 NumEventFilters, uint16 FilterScheme)
 {
    uint16 FilterLimit;
    uint16 i;
@@ -89,6 +89,8 @@ int32 CFE_EVS_Register (void *Filters, uint16 NumEventFilters, uint16 FilterSche
          else
          {
             FilterLimit = CFE_PLATFORM_EVS_MAX_EVENT_FILTERS;
+            CFE_ES_WriteToSysLog("CFE_EVS_Register: Filter limit truncated to %d\n",
+                                 (int)FilterLimit);
          }
 
          if (Filters != NULL)

--- a/fsw/cfe-core/src/inc/cfe_evs.h
+++ b/fsw/cfe-core/src/inc/cfe_evs.h
@@ -149,7 +149,7 @@ typedef struct CFE_EVS_BinFilter {
 ** \sa #CFE_EVS_Unregister
 **
 **/
-CFE_Status_t CFE_EVS_Register (void              *Filters,           /* Pointer to an array of filters */
+CFE_Status_t CFE_EVS_Register (const void              *Filters,           /* Pointer to an array of filters */
                         uint16               NumFilteredEvents,  /* How many elements in the array? */
                         uint16               FilterScheme);      /* Filtering Algorithm to be implemented */
 

--- a/fsw/cfe-core/ut-stubs/ut_evs_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_evs_stubs.c
@@ -201,7 +201,7 @@ int32 CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time,
 **        Returns either a user-defined status flag or CFE_SUCCESS.
 **
 ******************************************************************************/
-int32 CFE_EVS_Register(void *Filters,
+int32 CFE_EVS_Register(const void *Filters,
                        uint16 NumFilteredEvents,
                        uint16 FilterScheme)
 {


### PR DESCRIPTION
**Describe the contribution**
Fix #723 - Filters pointer now const in API and truncation is reported in the system log

**Testing performed**
Built and ran unit tests (already cover the truncation case), verified new system log message

**Expected behavior changes**
Reports truncation when registering filters with CFE_EVS_Register

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC