### PR TITLE
Fix #1134, Add UtDebug output to CFE_ES_WriteToSysLog stub

### DIFF
--- a/fsw/cfe-core/ut-stubs/ut_es_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_es_stubs.c
@@ -416,6 +416,21 @@ int32 CFE_ES_WriteToSysLog(const char *SpecStringPtr, ...)
 
     int32   status;
     va_list va;
+    char    str[128];
+    char   *newline;
+
+    va_start(va,SpecStringPtr);
+    vsnprintf(str, sizeof(str), SpecStringPtr, va);
+
+    /* Replace newline since UtDebug already adds one */
+    newline = strchr(str, '\n');
+    if (newline != NULL)
+    {
+        *newline = '\0';
+    }
+
+    UtDebug("CFE_ES_WriteToSysLog: %s", str);
+    va_end(va);
 
     va_start(va,SpecStringPtr);
     status = UT_DEFAULT_IMPL_VARARGS(CFE_ES_WriteToSysLog, va);


### PR DESCRIPTION
**Describe the contribution**
Fix #1134, Add UtDebug output to CFE_ES_WriteToSysLog stub

**Testing performed**
Build and run unit tests with -d flag to get debug output, passed and now reports CFE_ES_WriteToSysLog messages

**Expected behavior changes**
UT more informative, no FSW changes.

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None.

**Third party code**
None.

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC