### PR TITLE
Fix #1070, patch PSP include directory reference

### DIFF
--- a/cmake/arch_build.cmake
+++ b/cmake/arch_build.cmake
@@ -62,7 +62,7 @@ endfunction(initialize_globals)
 function(add_psp_module MOD_NAME MOD_SRC_FILES)
 
   # Include the PSP shared directory so it can get to cfe_psp_module.h
-  include_directories(${MISSION_SOURCE_DIR}/psp/fsw/shared)
+  include_directories(${MISSION_SOURCE_DIR}/psp/fsw/shared/inc)
   add_definitions(-D_CFE_PSP_MODULE_)
   
   # Create the module


### PR DESCRIPTION
**Describe the contribution**
Copy of #1072 but main target (Caelum development)

**Testing performed**
Nothing new, #1072 tested the fix

**Expected behavior changes**
PSP modules should be able to build again

**System(s) tested on**
NA, leveraging previous tests

**Additional context**
Maybe add a PSP module test into the matrix to catch issues like this?

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC