### PR TITLE
Fix #546 #547, api argument validation

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_mempool.c
+++ b/fsw/cfe-core/src/es/cfe_es_mempool.c
@@ -411,6 +411,11 @@ int32 CFE_ES_GetPoolBuf(CFE_ES_MemPoolBuf_t *BufPtr,
     CFE_ES_MemPoolRecord_t *PoolRecPtr;
     size_t   DataOffset;
 
+    if (BufPtr == NULL)
+    {
+        return CFE_ES_BAD_ARGUMENT;
+    }
+
     PoolRecPtr = CFE_ES_LocateMemPoolRecordByID(Handle);
 
     /* basic sanity check */
@@ -473,6 +478,11 @@ int32 CFE_ES_GetPoolBufInfo(CFE_ES_MemHandle_t   Handle,
     size_t   DataOffset;
     size_t   DataSize;
 
+    if (BufPtr == NULL)
+    {
+        return CFE_ES_BAD_ARGUMENT;
+    }
+
     PoolRecPtr = CFE_ES_LocateMemPoolRecordByID(Handle);
 
     /* basic sanity check */
@@ -526,6 +536,11 @@ int32 CFE_ES_PutPoolBuf(CFE_ES_MemHandle_t   Handle,
     size_t   DataSize;
     size_t   DataOffset;
     int32 Status;
+
+    if (BufPtr == NULL)
+    {
+        return CFE_ES_BAD_ARGUMENT;
+    }
 
     PoolRecPtr = CFE_ES_LocateMemPoolRecordByID(Handle);
 
@@ -604,6 +619,11 @@ int32 CFE_ES_GetMemPoolStats(CFE_ES_MemPoolStats_t *BufPtr,
     CFE_ES_MemPoolRecord_t *PoolRecPtr;
     uint16 NumBuckets;
     uint16 Idx;
+
+    if (BufPtr == NULL)
+    {
+        return CFE_ES_BAD_ARGUMENT;
+    }
 
     PoolRecPtr = CFE_ES_LocateMemPoolRecordByID(Handle);
 

--- a/fsw/cfe-core/src/evs/cfe_evs.c
+++ b/fsw/cfe-core/src/evs/cfe_evs.c
@@ -154,6 +154,10 @@ int32 CFE_EVS_SendEvent (uint16 EventID, uint16 EventType, const char *Spec, ...
    va_list            Ptr;
    EVS_AppData_t     *AppDataPtr;
 
+   if(Spec == NULL){
+      return CFE_EVS_INVALID_PARAMETER;
+   }
+
    /* Query and verify the caller's AppID */
    Status = EVS_GetCurrentContext(&AppDataPtr, &AppID);
    if (Status == CFE_SUCCESS)
@@ -190,6 +194,10 @@ int32 CFE_EVS_SendEventWithAppID (uint16 EventID, uint16 EventType, CFE_ES_AppId
    va_list            Ptr;
    EVS_AppData_t     *AppDataPtr;
 
+   if(Spec == NULL){
+      return CFE_EVS_INVALID_PARAMETER;
+   }
+
    AppDataPtr = EVS_GetAppDataByID (AppID);
    if (AppDataPtr == NULL)
    {
@@ -224,6 +232,10 @@ int32 CFE_EVS_SendTimedEvent (CFE_TIME_SysTime_t Time, uint16 EventID, uint16 Ev
    CFE_ES_AppId_t     AppID;
    va_list            Ptr;
    EVS_AppData_t     *AppDataPtr;
+
+   if(Spec == NULL){
+      return CFE_EVS_INVALID_PARAMETER;
+   }
 
    /* Query and verify the caller's AppID */
    Status = EVS_GetCurrentContext(&AppDataPtr, &AppID);

--- a/fsw/cfe-core/src/fs/cfe_fs_api.c
+++ b/fsw/cfe-core/src/fs/cfe_fs_api.c
@@ -50,6 +50,11 @@ int32 CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, osal_id_t FileDes)
 {
     int32   Result;
     int32   EndianCheck = 0x01020304;
+
+    if (Hdr == NULL)
+    {
+        return CFE_FS_BAD_ARGUMENT;
+    }
     
     /*
     ** Ensure that we are at the start of the file...
@@ -81,9 +86,16 @@ int32 CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, osal_id_t FileDes)
 */
 void CFE_FS_InitHeader(CFE_FS_Header_t *Hdr, const char *Description, uint32 SubType)
 {
-   memset(Hdr, 0, sizeof(CFE_FS_Header_t));
-   strncpy((char *)Hdr->Description, Description, sizeof(Hdr->Description) - 1);
-   Hdr->SubType = SubType;
+   if(Hdr == NULL || Description == NULL)
+   {
+        CFE_ES_WriteToSysLog("CFE_FS:InitHeader-Failed invalid arguments\n");
+   }
+   else
+   {
+        memset(Hdr, 0, sizeof(CFE_FS_Header_t));
+        strncpy((char *)Hdr->Description, Description, sizeof(Hdr->Description) - 1);
+        Hdr->SubType = SubType;
+   }
 }
 
 /*
@@ -95,6 +107,11 @@ int32 CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr)
     int32   Result;
     int32   EndianCheck = 0x01020304;
     CFE_ES_AppId_t AppID;
+
+    if (Hdr == NULL)
+	{
+		return CFE_FS_BAD_ARGUMENT;
+	}
 
     /*
     ** Ensure that we are at the start of the file...

--- a/fsw/cfe-core/src/inc/cfe_error.h
+++ b/fsw/cfe-core/src/inc/cfe_error.h
@@ -1285,7 +1285,16 @@ typedef int32 CFE_Status_t;
 **  Error code indicating that the TBL file could not be
 **  opened by the OS.
 */
-#define CFE_TBL_ERR_ACCESS ((CFE_Status_t)0xcc00002c)
+#define CFE_TBL_ERR_ACCESS              ((CFE_Status_t)0xcc00002c)
+
+/**
+ * @brief Bad Argument
+ *
+ *  A parameter given by a caller to a Table API did not pass 
+ *  validation checks.
+ *
+ */
+#define CFE_TBL_BAD_ARGUMENT            ((CFE_Status_t)0xcc00002d)
 
 /**
  * @brief Not Implemented
@@ -1360,6 +1369,15 @@ typedef int32 CFE_Status_t;
  *
  */
 #define CFE_TIME_CALLBACK_NOT_REGISTERED ((CFE_Status_t)0xce000004)
+
+/**
+ * @brief Bad Argument
+ *
+ *  A parameter given by a caller to a TIME Services API did not pass 
+ *  validation checks.
+ *
+ */
+#define CFE_TIME_BAD_ARGUMENT            ((CFE_Status_t)0xce000005)
 /**@}*/
 
 /* Compatibility for error names which have been updated */

--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -2131,6 +2131,7 @@ CFE_SB_Buffer_t *CFE_SB_ZeroCopyGetPtr(size_t MsgSize,
 
     if (BufferHandle == NULL)
     {
+        CFE_ES_WriteToSysLog(" CFE_SB:ZeroCopyGetPtr-BufferHandle is NULL\n");
         return NULL;
     }
 

--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -2128,6 +2128,11 @@ CFE_SB_Buffer_t *CFE_SB_ZeroCopyGetPtr(size_t MsgSize,
     AppId = CFE_ES_APPID_UNDEFINED;
     BufDscPtr = NULL;
     BufPtr = NULL;
+    if(MsgSize > CFE_MISSION_SB_MAX_SB_MSG_SIZE)
+    {
+        CFE_ES_WriteToSysLog(" CFE_SB:ZeroCopyGetPtr-Failed, MsgSize is too large\n");
+        return NULL;
+    }
 
     if (BufferHandle == NULL)
     {

--- a/fsw/cfe-core/src/sb/cfe_sb_util.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_util.c
@@ -160,7 +160,13 @@ void CFE_SB_SetUserDataLength(CFE_MSG_Message_t *MsgPtr, size_t DataLength)
         HdrSize = CFE_SB_MsgHdrSize(MsgPtr);
         TotalMsgSize = HdrSize + DataLength;
     
-        CFE_MSG_SetSize(MsgPtr, TotalMsgSize);
+        if(TotalMsgSize <= CFE_MISSION_SB_MAX_SB_MSG_SIZE){
+            CFE_MSG_SetSize(MsgPtr, TotalMsgSize);
+        }
+        else
+        {
+            CFE_ES_WriteToSysLog("CFE_SB:SetUserDataLength-Failed TotalMsgSize too large\n");  
+        }   
     }
 }/* end CFE_SB_SetUserDataLength */
 

--- a/fsw/cfe-core/src/tbl/cfe_tbl_api.c
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_api.c
@@ -66,6 +66,11 @@ int32 CFE_TBL_Register( CFE_TBL_Handle_t *TblHandlePtr,
     char                        TblName[CFE_TBL_MAX_FULL_NAME_LEN] = {""};
     CFE_TBL_Handle_t            AccessIndex;
 
+    if (TblHandlePtr == NULL || Name == NULL)
+    {
+        return CFE_TBL_BAD_ARGUMENT;
+    }
+
     /* Check to make sure calling application is legit */
     Status = CFE_ES_GetAppID(&ThisAppId);
 
@@ -522,6 +527,11 @@ int32 CFE_TBL_Share( CFE_TBL_Handle_t *TblHandlePtr,
     CFE_TBL_RegistryRec_t      *RegRecPtr = NULL;
     char    AppName[OS_MAX_API_NAME] = {"UNKNOWN"};
 
+    if (TblHandlePtr == NULL || TblName == NULL)
+    {
+        return CFE_TBL_BAD_ARGUMENT;
+    }
+    
     /* Get a valid Application ID for calling App */
     Status = CFE_ES_GetAppID(&ThisAppId);
 
@@ -691,6 +701,11 @@ int32 CFE_TBL_Load( CFE_TBL_Handle_t TblHandle,
     CFE_TBL_RegistryRec_t      *RegRecPtr;
     char                        AppName[OS_MAX_API_NAME] = {"UNKNOWN"};
     bool                        FirstTime = false;
+
+    if (SrcDataPtr == NULL)
+    {
+        return CFE_TBL_BAD_ARGUMENT;
+    }
 
     /* Verify access rights and get a valid Application ID for calling App */
     Status = CFE_TBL_ValidateAccess(TblHandle, &ThisAppId);
@@ -1000,6 +1015,11 @@ int32 CFE_TBL_GetAddress( void **TblPtr,
     int32   Status;
     CFE_ES_AppId_t  ThisAppId;
 
+    if (TblPtr == NULL)
+    {
+        return CFE_TBL_BAD_ARGUMENT;
+    }
+
     /* Assume failure at returning the table address */
     *TblPtr = NULL;
 
@@ -1065,6 +1085,11 @@ int32 CFE_TBL_GetAddresses( void **TblPtrs[],
     uint16  i;
     int32   Status;
     CFE_ES_AppId_t   ThisAppId;
+
+     if (TblPtrs == NULL)
+    {
+        return CFE_TBL_BAD_ARGUMENT;
+    }
 
     /* Assume failure at returning the table addresses */
     for (i=0; i<NumTables; i++)
@@ -1387,6 +1412,10 @@ int32 CFE_TBL_GetInfo( CFE_TBL_Info_t *TblInfoPtr, const char *TblName )
     int32                    NumAccessDescriptors = 0;
     CFE_TBL_RegistryRec_t   *RegRecPtr;
     CFE_TBL_Handle_t         HandleIterator;
+
+    if(TblInfoPtr == NULL || TblName == NULL){
+        return CFE_TBL_BAD_ARGUMENT;
+    }
 
     RegIndx = CFE_TBL_FindTableInRegistry(TblName);
 

--- a/fsw/cfe-core/src/time/cfe_time_api.c
+++ b/fsw/cfe-core/src/time/cfe_time_api.c
@@ -547,6 +547,12 @@ void CFE_TIME_Print(char *PrintBuffer, CFE_TIME_SysTime_t TimeToPrint)
 
     bool StillCountingYears = true;
 
+    if (PrintBuffer == NULL)
+    {
+        CFE_ES_WriteToSysLog("CFE_TIME:Print-Failed invalid arguments\n");
+        return;
+    }
+
     /*
     ** Convert the cFE time (offset from epoch) into calendar time...
     */
@@ -693,6 +699,11 @@ int32  CFE_TIME_RegisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPt
     CFE_ES_AppId_t AppId;
     uint32 AppIndex;
 
+    if (CallbackFuncPtr == NULL)
+    {
+        return CFE_TIME_BAD_ARGUMENT;
+    }
+
     Status = CFE_ES_GetAppID(&AppId);
     if (Status == CFE_SUCCESS)
     {
@@ -725,6 +736,11 @@ int32  CFE_TIME_UnregisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFunc
     int32  Status;
     CFE_ES_AppId_t AppId;
     uint32 AppIndex;
+
+    if (CallbackFuncPtr == NULL)
+    {
+        return CFE_TIME_BAD_ARGUMENT;
+    }
 
     Status = CFE_ES_GetAppID(&AppId);
     if (Status == CFE_SUCCESS)


### PR DESCRIPTION
**Describe the contribution**
Fixes #546 
Fixes #547
Add validation for method parameters. Mostly null pointer checks for #547 and a few size checks for #546

Fixes #1119
Returning the input instead of an error code 

**Testing performed**
Build and run unit test

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Additional Context** 
Here is the function list from #546 and the changes done 

cfe_es_api.c:CFE_ES_DeleteApp - Can get a segmentation fault if user tries to delete an APP greater than CFE_PLATFORM_ES_MAX_APPLICATIONS
	 CFE_ES_LocateAppRecordByID gets a pointer that is either valid or null

cfe_es_api.c:CFE_ES_ReloadApp - Can Result in Segmentation fault if APID is invalid
	CFE_ES_LocateAppRecordByID gets a pointer that is either valid or null

cfe_es_api.c:CFE_ES_CreateChildTask - Input Argument 'Flags' is not validated…also it does not appear to be used anywhere, consider removing
	Not changing functions in this task 

cfe_es_api.c:CFE_ES_GetAppName - Consider comparing BufferLength with OS_MAX_API_NAME prior to use.
	No invalid buffer length

cfe_es_api.c:CFE_ES_RegisterCDS - Consider checking if block size is less than CFE_PLATFORM_ES_MAX_BLOCK_SIZE
	CFE_ES_RegisterCDSEx checks BlockSize

cfe_es_perf.c:CFE_ES_PerfLogAdd - Should check if EntryExit is either a 0 or 1
	It's internal and the macro that calls it will only pass in valid values

cfe_fs_api.c:CFE_FS_InitHeader - SubType not checked
	The API doesn't have a limitation for SubType

cfe_sb_api.c:CFE_SB_SubscribeFull - Quality is not checked…consider checking that it is 0 or 1
	Quality is not nessacarly 1 or 0

cfe_sb_api.c:CFE_SB_ZeroCopyGetPtr - Is there a maximum message size? Consider verifying MsgSize prior to use.
	Checks MsgSize

cfe_sb_api.c:CFE_SB_SubscribeLocal - MsgLim is not checked…if a max limit does exist, should add argument validation
	a max limit doesn't exists

cfe_sb_util.c:CFE_SB_SetUserDataLength - Consider verifying Length of user data (if there exists a limit) and/or TotalMsgSize
	Checks TotalMsgSize
cfe_tbl_api.c:CFE_TBL_GetAddresses - Can result in Segmentation fault if NumTables grows larger than max number of tables.
	Needs to be enforced by user 

cfe_tbl_api.c:CFE_TBL_ReleaseAddresses - Should check to make sure NumTables is less than CFE_PLATFORM_TBL_MAX_NUM_TABLES
	Needs to be enforced by user 


Here is a list of the functions from #547 and their new current state 

cfe_es_api.c:CFE_ES_CalculateCRC
	checks for NULL 
cfe_es_api.c:CFE_ES_CopyToCDS
	checks for NULL
cfe_es_api.c:CFE_ES_CreateChildTask
	checks for NULL
cfe_es_api.c:CFE_ES_GetAppID
    checks for NULL
cfe_es_api.c:CFE_ES_GetAppName
	checks for NULL
cfe_es_api.c:CFE_ES_GetGenCounterIDByName
	checks for NULL
cfe_es_api.c:CFE_ES_GetTaskInfo
	checks for NULL
cfe_es_api.c:CFE_ES_ProcessCoreException
	Method no longer exists
cfe_es_api.c:CFE_ES_RegisterCDS
    checks for NULL
cfe_es_api.c:CFE_ES_RestoreFromCDS
    checks for NULL
cfe_es_api.c:CFE_ES_RunLoop
	Can be called with NULL
cfe_es_api.c:CFE_ES_WriteToSysLog
    checks for NULL
cfe_esmempool.c:CFE_ES_GetMemPoolStats
    checks for NULL
cfe_esmempool.c:CFE_ES_GetPoolBuf
    checks for NULL
cfe_esmempool.c:CFE_ES_GetPoolBufInfo
    checks for NULL
cfe_esmempool.c:CFE_ES_PoolCreate
	Calls CFE_ES_PoolCreateEx which checks for NULL
cfe_esmempool.c:CFE_ES_PoolCreateEx
    checks for NULL
cfe_esmempool.c:CFE_ES_PoolCreateNoSem
	Calls CFE_ES_PoolCreateEx which checks for NULL
cfe_esmempool.c:CFE_ES_PutPoolBuf
    checks for NULL
cfe_evs.c:CFE_EVS_SendEvent
	checks for NULL
cfe_evs.c:CFE_EVS_SendEventWithAppID
	checks for NULL
cfe_evs.c:CFE_EVS_SendTimedEvent
	checks for NULL
cfe_fs_api.c:CFE_FS_InitHeader
	checks for NULL
cfe_fs_api.c:CFE_FS_ReadHeader
	checks for NULL
cfe_fs_api.c:CFE_FS_SetTimestamp
	No pointer to check
cfe_fs_api.c:CFE_FS_WriteHeader
	checks for NULL	
cfe_sb_api.c:CFE_SB_CreatePipe
	checks for NULL
cfe_sb_api.c:CFE_SB_ZeroCopyGetPtr
	checks for NULL
cfe_sb_msg_id_util.c:CFE_SB_GetMsgId
	Deprecated
cfe_sb_msg_id_util.c:CFE_SB_SetMsgId
	Deprecated
cfe_sb_util.c:CFE_SB_GenerateChecksum
	Deprecated
cfe_sb_util.c:CFE_SB_GetChecksum
	Deprecated
cfe_sb_util.c:CFE_SB_GetCmdCode
	Deprecated
cfe_sb_util.c:CFE_SB_GetMsgTime
	Deprecated
cfe_sb_util.c:CFE_SB_GetTotalMsgLength
	Deprecated
cfe_sb_util.c:CFE_SB_GetUserData
	checks for NULL
cfe_sb_util.c:CFE_SB_GetUserDataLength
	checks for NULL
cfe_sb_util.c:CFE_SB_InitMsg
	Deprecated
cfe_sb_util.c:CFE_SB_MessageStringGet
	checks for NULL
cfe_sb_util.c:CFE_SB_MessageStringSet
	checks for NULL
cfe_sb_util.c:CFE_SB_MsgHdrSize
	checks for NULL
cfe_sb_util.c:CFE_SB_SetCmdCode
	Deprecated
cfe_sb_util.c:CFE_SB_SetMsgTime
	Deprecated
cfe_sb_util.c:CFE_SB_SetTotalMsgLength
	Deprecated
cfe_sb_util.c:CFE_SB_SetUserDataLength
	checks for NULL
cfe_sb_util.c:CFE_SB_TimeStampMsg
	calls CFE_MSG_SetMsgTime which checks for NULL
cfe_sb_util.c:CFE_SB_ValidateChecksum
	Deprecated
cfe_tbl_api.c:CFE_TBL_GetAddress
	checks for NULL
cfe_tbl_api.c:CFE_TBL_GetAddresses
	checks for NULL
cfe_tbl_api.c:CFE_TBL_GetInfo
	checks for NULL
cfe_tbl_api.c:CFE_TBL_Load
	checks for NULL
cfe_tbl_api.c:CFE_TBL_Register
	checks for NULL
cfe_tbl_api.c:CFE_TBL_Share
	checks for NULL
cfe_time_api:CFE_TIME_Print
	checks for NULL
cfe_time_api:CFE_TIME_RegisterSynchCallback
	checks for NULL

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC