### PR TITLE
Fix #1144, Add workflow action timeout

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,6 +12,7 @@ jobs:
   static-analysis:
     name: Run cppcheck
     runs-on: ubuntu-18.04
+    timeout-minutes: 15
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
**Describe the contribution**
Fix #1144 - Added a timeout to prevent excess resource utilization (default is 360 minutes)

**Testing performed**
Set timeout to 1 and added a sleep, confirmed workflow timed out

**Expected behavior changes**
None, just avoids log job runs

**System(s) tested on**
CI

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC