### PR TITLE
Fix #139, Do file writes in background

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_apps.h
+++ b/fsw/cfe-core/src/es/cfe_es_apps.h
@@ -249,9 +249,14 @@ bool CFE_ES_RunAppTableScan(uint32 ElapsedTime, void *Arg);
 bool CFE_ES_RunExceptionScan(uint32 ElapsedTime, void *Arg);
 
 /*
-** Check if ER log dump request is pending
-*/
-bool CFE_ES_RunERLogDump(uint32 ElapsedTime, void *Arg);
+ * Background file write data getter for ER log entry
+ */
+bool CFE_ES_BackgroundERLogFileDataGetter(void *Meta, uint32 RecordNum, void **Buffer, size_t *BufSize);
+
+/*
+ * Background file write event handler for ER log entry
+ */
+void CFE_ES_BackgroundERLogFileEventHandler(void *Meta, CFE_FS_FileWriteEvent_t Event, int32 Status, uint32 RecordNum, size_t BlockSize, size_t Position);
 
 /*
 ** Perform the requested control action for an application

--- a/fsw/cfe-core/src/es/cfe_es_backgroundtask.c
+++ b/fsw/cfe-core/src/es/cfe_es_backgroundtask.c
@@ -89,9 +89,9 @@ const CFE_ES_BackgroundJobEntry_t CFE_ES_BACKGROUND_JOB_TABLE[] =
                 .ActivePeriod = CFE_PLATFORM_ES_APP_SCAN_RATE,
                 .IdlePeriod = CFE_PLATFORM_ES_APP_SCAN_RATE
         },
-        {   /* Check for ER log write requests */
-                .RunFunc = CFE_ES_RunERLogDump,
-                .JobArg = &CFE_ES_TaskData.BackgroundERLogDumpState,
+        {   /* Call FS to handle background file writes */
+                .RunFunc = CFE_FS_RunBackgroundFileDump,
+                .JobArg = NULL,
                 .ActivePeriod = CFE_PLATFORM_ES_APP_SCAN_RATE,
                 .IdlePeriod = CFE_PLATFORM_ES_APP_SCAN_RATE
         }

--- a/fsw/cfe-core/src/es/cfe_es_task.h
+++ b/fsw/cfe-core/src/es/cfe_es_task.h
@@ -44,6 +44,7 @@
 #include "cfe_es_events.h"
 #include "cfe_es_msg.h"
 #include "cfe_es_perf.h"
+#include "private/cfe_es_erlog_typedef.h"
 
 /*************************************************************************/
 
@@ -90,8 +91,8 @@
  */
 typedef struct
 {
-    volatile bool   IsPending;
-    char            DataFileName[OS_MAX_PATH_LEN];
+    CFE_FS_FileWriteMetaData_t    FileWrite;   /**< FS state data - must be first */
+    CFE_ES_ERLog_FileEntry_t      EntryBuffer; /**< Temp holding area for record to write */
 } CFE_ES_BackgroundLogDumpGlobal_t;
 
 /*
@@ -164,7 +165,6 @@ void  CFE_ES_TaskPipe(CFE_SB_Buffer_t *SBBufPtr);
  */
 int32 CFE_ES_BackgroundInit(void);
 void  CFE_ES_BackgroundTask(void);
-void  CFE_ES_BackgroundWakeup(void);
 void  CFE_ES_BackgroundCleanup(void);
 
 /*

--- a/fsw/cfe-core/src/fs/cfe_fs_priv.h
+++ b/fsw/cfe-core/src/fs/cfe_fs_priv.h
@@ -44,10 +44,92 @@
 ** Macro Definitions
 */
 
+/*
+ * Max Number of file write requests that can be queued
+ * 
+ * This needs to be a power of two to simplify the masking/wraparound (bitwise AND).
+ */
+#define CFE_FS_MAX_BACKGROUND_FILE_WRITES   4
+
+
+/*
+ * Background file credit accumulation rate
+ * 
+ * The background file writer will limit the total bytes written over time.  This
+ * controls the amount of "credit" (bytes that can be written) per second
+ * of elapsed time.
+ * 
+ * This permits a file writing rate of up to 10kbytes/sec.
+ */
+#define CFE_FS_BACKGROUND_CREDIT_PER_SECOND    10000
+
+/*
+ * Maximum credit that the background write task can accumulate
+ * 
+ * The background file writer will limit the total bytes written over time, and
+ * will accumulate credit against this limit while no writes are in progress.
+ * This is an upper cap on the amount of credit that can be accumulated.
+ * 
+ * Without this limit, after a long period of inactivity without any file
+ * writes, a large credit would essentially bypass the rate limiting for
+ * the next file write command(s) once they are issued.
+ */
+#define CFE_FS_BACKGROUND_MAX_CREDIT    10000
 
 /*
 ** Type Definitions
 */
+
+/*
+ * Background file dump entry structure
+ *
+ * This structure is stored in global memory and keeps the state
+ * of the file dump from one iteration to the next.
+ */
+typedef struct
+{
+    CFE_ES_AppId_t              RequestorAppId;
+    CFE_FS_FileWriteMetaData_t *Meta;
+} CFE_FS_BackgroundFileDumpEntry_t;
+
+typedef struct
+{
+    osal_id_t Fd;
+    int32     Credit;
+    uint32    RecordNum;
+    size_t    FileSize;
+} CFE_FS_CurrentFileState_t;
+
+
+/**
+ * \brief Background file dump queue structure
+ *
+ * This structure is stored in global memory and keeps the state
+ * of the file dump from one iteration to the next.
+ * 
+ * Normally when idle the "RequestCount" and "CompleteCount" are the
+ * same value.  When an application requests a background file dump,
+ * the "RequestCount" is incremented accordingly, and when the background
+ * job finishes, the "CompleteCount" is incremented accordingly.  
+ */
+typedef struct
+{
+    uint32 RequestCount;    /**< Total Number of background file writes requested */
+    uint32 CompleteCount;   /**< Total Number of background file writes completed */
+
+    /**
+     * Data related to each background file write request
+     */
+    CFE_FS_BackgroundFileDumpEntry_t Entries[CFE_FS_MAX_BACKGROUND_FILE_WRITES];
+
+    /**
+     * Persistent storage for the current file write
+     * (reused for each file)
+     */
+    CFE_FS_CurrentFileState_t Current;
+
+} CFE_FS_BackgroundFileDumpState_t;
+
 
 /******************************************************************************
 **  Typedef: CFE_FS_Global_t
@@ -59,7 +141,12 @@ typedef struct
 {
     osal_id_t              SharedDataMutexId;
 
+    CFE_FS_BackgroundFileDumpState_t FileDump;
+
 } CFE_FS_Global_t;
+
+
+extern CFE_FS_Global_t CFE_FS_Global;
 
 /*
 ** FS Function Prototypes

--- a/fsw/cfe-core/src/inc/cfe_error.h
+++ b/fsw/cfe-core/src/inc/cfe_error.h
@@ -173,6 +173,15 @@ typedef int32 CFE_Status_t;
 #define CFE_STATUS_EXTERNAL_RESOURCE_FAIL  ((int32)0xc8000005)
 
 /**
+ * @brief Request already pending
+ *
+ *  Commands or requests are already pending or the pending request
+ *  limit has been reached.  No more requests can be made until
+ *  the current request(s) complete.
+ */
+#define CFE_STATUS_REQUEST_ALREADY_PENDING       ((int32)0xc8000006)
+
+/**
  * @brief Not Implemented
  *
  *  Current version does not have the function or the feature

--- a/fsw/cfe-core/src/inc/cfe_es.h
+++ b/fsw/cfe-core/src/inc/cfe_es.h
@@ -1107,6 +1107,26 @@ void CFE_ES_ExitChildTask(void);
 
 /*****************************************************************************/
 /**
+** \brief Wakes up the CFE background task
+**
+** \par Description
+**        Normally the ES background task wakes up at a periodic interval.
+**        Whenever new background work is added, this can be used to wake the task early, 
+**        which may reduce the delay between adding the job and the job getting processed.
+**
+** \par Assumptions, External Events, and Notes:
+**        Note the amount of work that the background task will perform is pro-rated
+**        based on the amount of time elapsed since the last wakeup.  Waking the task
+**        early will not cause the background task to do more work than it otherwise 
+**        would - it just reduces the delay before work starts initially.
+**
+**
+******************************************************************************/
+void  CFE_ES_BackgroundWakeup(void);
+
+
+/*****************************************************************************/
+/**
 ** \brief Write a string to the cFE System Log
 **
 ** \par Description

--- a/fsw/cfe-core/src/inc/cfe_fs.h
+++ b/fsw/cfe-core/src/inc/cfe_fs.h
@@ -42,6 +42,66 @@
 #include "common_types.h"
 #include "cfe_time.h"
 
+/*
+ * Because FS is a library not an app, it does not have its own context or
+ * event IDs.  The file writer runs in the context of the ES background task
+ * on behalf of whatever App requested the file write.
+ * 
+ * This is a list of abstract events associated with background file write jobs.
+ * An app requesting the file write must supply a callback function to translate
+ * these into its own event IDs for feedback (i.e. file complete, error conditions, etc).
+ */
+typedef enum
+{
+    CFE_FS_FileWriteEvent_UNDEFINED, /* placeholder, no-op, keep as 0 */
+
+    CFE_FS_FileWriteEvent_COMPLETE,             /**< File is completed successfully */
+    CFE_FS_FileWriteEvent_CREATE_ERROR,         /**< Unable to create/open file */
+    CFE_FS_FileWriteEvent_HEADER_WRITE_ERROR,   /**< Unable to write FS header */
+    CFE_FS_FileWriteEvent_RECORD_WRITE_ERROR,   /**< Unable to write data record */
+
+    CFE_FS_FileWriteEvent_MAX /* placeholder, no-op, keep last */
+
+} CFE_FS_FileWriteEvent_t;
+
+
+/**
+ * Data Getter routine provided by requester
+ * 
+ * Outputs a data block.  Should return true if the file is complete (last record/EOF), otherwise return false.
+ */
+typedef bool (*CFE_FS_FileWriteGetData_t)(void *Meta, uint32 RecordNum, void **Buffer, size_t *BufSize);
+
+/**
+ * Event generator routine provided by requester
+ * 
+ * Invoked from certain points in the file write process.  Implementation may invoke CFE_EVS_SendEvent() appropriately
+ * to inform of progress.
+ */
+typedef void (*CFE_FS_FileWriteOnEvent_t)(void *Meta, CFE_FS_FileWriteEvent_t Event, int32 Status, uint32 RecordNum, size_t BlockSize, size_t Position);
+
+/**
+ * \brief External Metadata/State object associated with background file writes
+ *
+ * Applications intending to schedule background file write jobs should instantiate
+ * this object in static/global data memory.  This keeps track of the state of the
+ * file write request(s).
+ */ 
+typedef struct CFE_FS_FileWriteMetaData
+{
+    volatile bool IsPending;            /**< Whether request is pending (volatile as it may be checked outside lock) */
+
+    char   FileName[OS_MAX_PATH_LEN];   /**< Name of file to write */
+
+    /* Data for FS header */
+    uint32 FileSubType;                          /**< Type of file to write (for FS header) */
+    char   Description[CFE_FS_HDR_DESC_MAX_LEN]; /**< Description of file (for FS header) */
+
+    CFE_FS_FileWriteGetData_t GetData;  /**< Application callback to get a data record */
+    CFE_FS_FileWriteOnEvent_t OnEvent;  /**< Application callback for abstract event processing */
+
+} CFE_FS_FileWriteMetaData_t;
+
 
 /** @defgroup CFEAPIFSHeader cFE File Header Management APIs
  * @{
@@ -183,6 +243,63 @@ CFE_Status_t CFE_FS_SetTimestamp(osal_id_t FileDes, CFE_TIME_SysTime_t NewTimest
 **
 ******************************************************************************/
 CFE_Status_t CFE_FS_ExtractFilenameFromPath(const char *OriginalPath, char *FileNameOnly);
+
+/*****************************************************************************/
+/**
+** \brief Register a background file dump request
+**
+** \par Description
+**        Puts the previously-initialized metadata into the pending request queue
+**
+** \par Assumptions, External Events, and Notes:
+**        Metadata structure should be stored in a static memory area (not on heap) as it
+**        must persist and be accessible by the file writer task throughout the asynchronous
+**        job operation.
+**
+** \param[inout] Meta        The background file write persistent state object
+**
+** \return Execution status, see \ref CFEReturnCodes
+**
+******************************************************************************/
+int32 CFE_FS_BackgroundFileDumpRequest(CFE_FS_FileWriteMetaData_t *Meta);
+
+/*****************************************************************************/
+/**
+** \brief Query if a background file write request is currently pending
+**
+** \par Description
+**        This returns "true" while the request is on the background work queue
+**        This returns "false" once the request is complete and removed from the queue.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \param[inout] Meta        The background file write persistent state object
+**
+** \return true if request is already pending, false if not
+**
+******************************************************************************/
+bool CFE_FS_BackgroundFileDumpIsPending(const CFE_FS_FileWriteMetaData_t *Meta);
+
+/*****************************************************************************/
+/**
+** \brief Execute the background file write job(s)
+**
+** \par Description
+**        Runs the state machine associated with background file write requests
+**
+** \par Assumptions, External Events, and Notes:
+**        This should only be invoked as a background job from the ES background task,
+**        it should not be invoked directly.
+**
+** \param[in] ElapsedTime       The amount of time passed since last invocation (ms)
+** \param[in] Arg               Not used/ignored
+**
+** \return true if jobs are pending, false if idle
+**
+******************************************************************************/
+bool CFE_FS_RunBackgroundFileDump(uint32 ElapsedTime, void *Arg);
+
 /**@}*/
 
 #endif /* _cfe_fs_ */

--- a/fsw/cfe-core/src/inc/cfe_sb_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_sb_msg.h
@@ -591,11 +591,11 @@ typedef struct CFE_SB_PipeDepthStats {
 
     CFE_SB_PipeId_t     PipeId;/**< \cfetlmmnemonic \SB_PDPIPEID
                                     \brief Pipe Id associated with the stats below */
-    uint16              Depth;/**< \cfetlmmnemonic \SB_PDDEPTH
+    uint16              MaxQueueDepth;/**< \cfetlmmnemonic \SB_PDDEPTH
                                    \brief Number of messages the pipe can hold */
-    uint16              InUse;/**< \cfetlmmnemonic \SB_PDINUSE
+    uint16              CurrentQueueDepth;/**< \cfetlmmnemonic \SB_PDINUSE
                                    \brief Number of messages currently on the pipe */
-    uint16              PeakInUse;/**< \cfetlmmnemonic \SB_PDPKINUSE
+    uint16              PeakQueueDepth;/**< \cfetlmmnemonic \SB_PDPKINUSE
                                        \brief Peak number of messages that have been on the pipe */
     uint16              Spare;/**< \cfetlmmnemonic \SB_PDSPARE
                                    \brief Spare word to ensure alignment */

--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -194,9 +194,9 @@ int32  CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16  Depth, const char *
     if (Status == CFE_SUCCESS)
     {
         /* fill in the pipe table fields */
-        PipeDscPtr->SysQueueId  = SysQueueId;
-        PipeDscPtr->QueueDepth  = Depth;
-        PipeDscPtr->AppId       = AppId;
+        PipeDscPtr->SysQueueId    = SysQueueId;
+        PipeDscPtr->MaxQueueDepth = Depth;
+        PipeDscPtr->AppId         = AppId;
 
         CFE_SB_PipeDescSetUsed(PipeDscPtr, PendingPipeId);
 
@@ -1692,10 +1692,10 @@ int32  CFE_SB_TransmitBufferFull(CFE_SB_BufferD_t *BufDscPtr,
 
             DestPtr->BuffCount++; /* used for checking MsgId2PipeLimit */
             DestPtr->DestCnt++;   /* used for statistics */
-            ++PipeDscPtr->QueueDepth;
-            if (PipeDscPtr->QueueDepth >= PipeDscPtr->PeakDepth)
+            ++PipeDscPtr->CurrentQueueDepth;
+            if (PipeDscPtr->CurrentQueueDepth >= PipeDscPtr->PeakQueueDepth)
             {
-                PipeDscPtr->PeakDepth = PipeDscPtr->QueueDepth;
+                PipeDscPtr->PeakQueueDepth = PipeDscPtr->CurrentQueueDepth;
             }
 
             Status = CFE_SUCCESS;
@@ -2001,9 +2001,9 @@ int32  CFE_SB_ReceiveBuffer(CFE_SB_Buffer_t **BufPtr,
                 DestPtr->BuffCount--;
             }
 
-            if (PipeDscPtr->CurrentDepth > 0)
+            if (PipeDscPtr->CurrentQueueDepth > 0)
             {
-                --PipeDscPtr->CurrentDepth;
+                --PipeDscPtr->CurrentQueueDepth;
             }
         }
         else

--- a/fsw/cfe-core/src/tbl/cfe_tbl_internal.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_internal.h
@@ -578,6 +578,15 @@ int32 CFE_TBL_SendNotificationMsg(CFE_TBL_RegistryRec_t *RegRecPtr);
 ******************************************************************************/
 extern void CFE_TBL_ByteSwapUint32(uint32 *Uint32ToSwapPtr);
 
+/*
+ * Internal helper functions for Table Registry dump
+ *
+ * These callbacks are used with the FS background write request API
+ * and are implemented per that specification.
+ */
+void CFE_TBL_DumpRegistryEventHandler(void *Meta, CFE_FS_FileWriteEvent_t Event, int32 Status, uint32 RecordNum, size_t BlockSize, size_t Position);
+bool CFE_TBL_DumpRegistryGetter(void *Meta, uint32 RecordNum, void **Buffer, size_t *BufSize);
+
 
 /*
 ** Globals specific to the TBL module

--- a/fsw/cfe-core/src/tbl/cfe_tbl_task.h
+++ b/fsw/cfe-core/src/tbl/cfe_tbl_task.h
@@ -272,6 +272,19 @@ typedef struct
 } CFE_TBL_RegDumpRec_t;
 
 /*******************************************************************************/
+/**   \brief Table Registry Dump background state information
+**
+**    State info for background table registry dump process and one temporary data record.
+*/
+typedef struct 
+{
+    CFE_FS_FileWriteMetaData_t FileWrite;   /**< FS state data - must be first */
+
+    bool                 FileExisted; /**< Set true if the file already existed at the time of request */
+    CFE_TBL_RegDumpRec_t DumpRecord;  /**< Current record buffer (reused each entry) */
+} CFE_TBL_RegDumpStateInfo_t;
+
+/*******************************************************************************/
 /**   \brief Table Task Global Data
 **
 **     Structure used to ensure Table Task Global Data is maintained as a single
@@ -335,6 +348,11 @@ typedef struct
   CFE_TBL_BufParams_t         Buf;                               /**< \brief Parameters associated with Table Task's Memory Pool */
   CFE_TBL_ValidationResult_t  ValidationResults[CFE_PLATFORM_TBL_MAX_NUM_VALIDATIONS]; /**< \brief Array of Table Validation Requests */
   CFE_TBL_DumpControl_t       DumpControlBlocks[CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS]; /**< \brief Array of Dump-Only Dump Control Blocks */
+
+  /*
+   * Registry dump state info (background job)
+   */
+  CFE_TBL_RegDumpStateInfo_t  RegDumpState;
 
 } CFE_TBL_Global_t;
 

--- a/fsw/cfe-core/unit-test/fs_UT.h
+++ b/fsw/cfe-core/unit-test/fs_UT.h
@@ -270,4 +270,17 @@ void Test_CFE_FS_Decompress(void);
 ******************************************************************************/
 void Test_CFE_FS_GetUncompressedFile(void);
 
+/*****************************************************************************/
+/**
+** \brief Tests for FS background file dump
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+**
+******************************************************************************/
+void Test_CFE_FS_BackgroundFileDump(void);
+
 #endif /* _es_ut_h_ */

--- a/fsw/cfe-core/unit-test/sb_UT.h
+++ b/fsw/cfe-core/unit-test/sb_UT.h
@@ -365,7 +365,7 @@ void Test_SB_Cmds_Stats(void);
 
 /*****************************************************************************/
 /**
-** \brief Test send routing information command using the default file name
+** \brief Test send routing information command default/nominal path
 **
 ** \par Description
 **        This function tests the send routing information command using the
@@ -381,7 +381,7 @@ void Test_SB_Cmds_RoutingInfoDef(void);
 
 /*****************************************************************************/
 /**
-** \brief Test send routing information command using a specified file name
+** \brief Test send routing information command with request already pending
 **
 ** \par Description
 **        This function tests the send routing information command using a
@@ -393,15 +393,11 @@ void Test_SB_Cmds_RoutingInfoDef(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SB_Cmds_RoutingInfoSpec(void);
+void Test_SB_Cmds_RoutingInfoAlreadyPending(void);
 
 /*****************************************************************************/
 /**
-** \brief Test send routing information command with a file creation failure
-**
-** \par Description
-**        This function tests the send routing information command with a file
-**        creation failure.
+** \brief Test routing information data getter
 **
 ** \par Assumptions, External Events, and Notes:
 **        None
@@ -409,7 +405,7 @@ void Test_SB_Cmds_RoutingInfoSpec(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SB_Cmds_RoutingInfoCreateFail(void);
+void Test_SB_Cmds_RoutingInfoDataGetter(void);
 
 /*****************************************************************************/
 /**
@@ -650,41 +646,7 @@ void Test_GetPipeIdByName(void);
 
 /*****************************************************************************/
 /**
-** \brief Test send routing information command with a file header
-**        write failure
-**
-** \par Description
-**        This function tests the send routing information command with a file
-**        header write failure.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-******************************************************************************/
-void Test_SB_Cmds_RoutingInfoHdrFail(void);
-
-/*****************************************************************************/
-/**
-** \brief Test send routing information command with a file header write
-**        failure on the second write
-**
-** \par Description
-**        This function tests the send routing information command with a file
-**        header write failure on the second write.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-******************************************************************************/
-void Test_SB_Cmds_RoutingInfoWriteFail(void);
-
-/*****************************************************************************/
-/**
-** \brief Test send pipe information command using the default file name
+** \brief Test send pipe information command default / nominal path
 **
 ** \par Description
 **        This function tests the send pipe information command using the
@@ -700,11 +662,7 @@ void Test_SB_Cmds_PipeInfoDef(void);
 
 /*****************************************************************************/
 /**
-** \brief Test send pipe information command using a specified file name
-**
-** \par Description
-**        This function tests the send pipe information command using a
-**        specified file name.
+** \brief Test send pipe information command when already pending
 **
 ** \par Assumptions, External Events, and Notes:
 **        None
@@ -712,15 +670,11 @@ void Test_SB_Cmds_PipeInfoDef(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SB_Cmds_PipeInfoSpec(void);
+void Test_SB_Cmds_PipeInfoAlreadyPending(void);
 
 /*****************************************************************************/
 /**
-** \brief Test send pipe information command with a file creation failure
-**
-** \par Description
-**        This function tests the send pipe information command with a file
-**        creation failure.
+** \brief Test pipe information data getter
 **
 ** \par Assumptions, External Events, and Notes:
 **        None
@@ -728,16 +682,11 @@ void Test_SB_Cmds_PipeInfoSpec(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SB_Cmds_PipeInfoCreateFail(void);
+void Test_SB_Cmds_PipeInfoDataGetter(void);
 
 /*****************************************************************************/
 /**
-** \brief Test send pipe information command with a file header
-**        write failure
-**
-** \par Description
-**        This function tests the send pipe information command with a file
-**        header write failure.
+** \brief Test background file writer event handler
 **
 ** \par Assumptions, External Events, and Notes:
 **        None
@@ -745,28 +694,11 @@ void Test_SB_Cmds_PipeInfoCreateFail(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SB_Cmds_PipeInfoHdrFail(void);
+void Test_SB_Cmds_BackgroundFileWriteEvents(void);
 
 /*****************************************************************************/
 /**
-** \brief Test send pipe information command with a file write failure on
-**        the second write
-**
-** \par Description
-**        This function tests the send pipe information command with a file
-**        write failure on the second write.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-******************************************************************************/
-void Test_SB_Cmds_PipeInfoWriteFail(void);
-
-/*****************************************************************************/
-/**
-** \brief Test send map information command using the default file name
+** \brief Test send map information command using the defaults / nominal path
 **
 ** \par Description
 **        This function tests the send map information command using the
@@ -782,7 +714,7 @@ void Test_SB_Cmds_MapInfoDef(void);
 
 /*****************************************************************************/
 /**
-** \brief Test send map information command using a specified file name
+** \brief Test send map information command when already pending
 **
 ** \par Description
 **        This function tests the send map information command using a
@@ -794,15 +726,11 @@ void Test_SB_Cmds_MapInfoDef(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SB_Cmds_MapInfoSpec(void);
+void Test_SB_Cmds_MapInfoAlreadyPending(void);
 
 /*****************************************************************************/
 /**
-** \brief Test send map information command with a file creation failure
-**
-** \par Description
-**        This function tests the send map information command with a file
-**        creation failure.
+** \brief Test map information data getter function
 **
 ** \par Assumptions, External Events, and Notes:
 **        None
@@ -810,40 +738,7 @@ void Test_SB_Cmds_MapInfoSpec(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_SB_Cmds_MapInfoCreateFail(void);
-
-/*****************************************************************************/
-/**
-** \brief Test send map information command with a file header write failure
-**
-** \par Description
-**        This function tests the send map information command with a file
-**        header write failure.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-******************************************************************************/
-void Test_SB_Cmds_MapInfoHdrFail(void);
-
-/*****************************************************************************/
-/**
-** \brief Test send map information command with a file write failure on
-**        the second write
-**
-** \par Description
-**        This function tests the send map information command with a file
-**        write failure on the second write.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-******************************************************************************/
-void Test_SB_Cmds_MapInfoWriteFail(void);
+void Test_SB_Cmds_MapInfoDataGetter(void);
 
 /*****************************************************************************/
 /**

--- a/fsw/cfe-core/ut-stubs/ut_es_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_es_stubs.c
@@ -1336,3 +1336,8 @@ int32 CFE_ES_TaskID_ToIndex(CFE_ES_TaskId_t TaskID, uint32 *Idx)
 
     return return_code;
 }
+
+void CFE_ES_BackgroundWakeup(void)
+{
+    UT_DEFAULT_IMPL(CFE_ES_BackgroundWakeup);
+}

--- a/fsw/cfe-core/ut-stubs/ut_fs_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_fs_stubs.c
@@ -304,3 +304,40 @@ int32 CFE_FS_ExtractFilenameFromPath(const char *OriginalPath, char *FileNameOnl
     return status;
 }
 
+
+bool CFE_FS_RunBackgroundFileDump(uint32 ElapsedTime, void *Arg)
+{
+    UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_FS_RunBackgroundFileDump), ElapsedTime);
+    UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_FS_RunBackgroundFileDump), Arg);
+
+    int32 status;
+
+    status = UT_DEFAULT_IMPL(CFE_FS_RunBackgroundFileDump);
+
+    return status;
+}
+
+int32 CFE_FS_BackgroundFileDumpRequest(CFE_FS_FileWriteMetaData_t *Meta)
+{
+    UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_FS_BackgroundFileDumpRequest), Meta);
+
+    int32 status;
+
+    status = UT_DEFAULT_IMPL(CFE_FS_BackgroundFileDumpRequest);
+
+    if (status == CFE_SUCCESS)
+    {
+        /* Snapshot the request, in case the UT test case wants to look */
+        UT_Stub_CopyFromLocal(UT_KEY(CFE_FS_BackgroundFileDumpRequest), Meta, sizeof(*Meta));
+    }
+
+    return status;
+}
+
+bool CFE_FS_BackgroundFileDumpIsPending(const CFE_FS_FileWriteMetaData_t *Meta)
+{
+    UT_Stub_RegisterContextGenericArg(UT_KEY(CFE_FS_BackgroundFileDumpIsPending), Meta);
+
+    return UT_DEFAULT_IMPL(CFE_FS_BackgroundFileDumpIsPending);
+
+}


### PR DESCRIPTION
**Describe the contribution**
Implement a generic FS facility to perform file writes as a background job.  

Applications wanting to use this facility need to instantiate a state object (metadata) in global memory, and two callback APIs- one to get a data record, another to send events. 

The following file requests are changed to use this facility:
- ES ER Log dump
- SB Pipe Info
- SB Message Map
- SB Route Info
- TBL Registry Dump

Fixes #139

**Testing performed**
First built and ran "main" branch (unchanged) and issued all file write commands before change to get a baseline/reference copy.
Then re-built with this change applied and re-issued all file write commands.
Compared old files to new files - confirmed that the new files are correct (but see note below!).

**Expected behavior changes**
Files are written in the context of the ES background task.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
While examining the diffs between the old files and new files, I noticed that the queue depth in the Pipe Info was actually wrong in the original/reference data.  This was due to some mismatches between Pipe Info fields where names were getting crossed.

In order to fix this and avoid it from happening in the future - this changes the internal SB member names to be consistently named:
 - `MaxQueueDepth` for maximum depth at queue creation time (previously was `QueueDepth` or `Depth` depending on context)
 - `CurrentQueueDepth` for the running count (previously was `InUse` or `CurrentDepth` depending on context)
 - `PeakQueueDepth` for the highest watermark (previously was `PeakInUse` or `PeakDepth` depending on context)

In particular the `Depth` and `CurrentDepth` were not (previously) being propagated to the file correctly - as the names got crossed in the implementation.  This PR fixes it by making the names consistent.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
