### PR TITLE
Fix #978, put task parameters into task record

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_apps.h
+++ b/fsw/cfe-core/src/es/cfe_es_apps.h
@@ -77,8 +77,7 @@ typedef struct
 */
 typedef struct
 {
-    char                  Name[OS_MAX_API_NAME];
-    char                  EntryPoint[OS_MAX_API_NAME];
+    char                  InitSymbolName[OS_MAX_API_NAME];
     char                  FileName[OS_MAX_PATH_LEN];
 
 } CFE_ES_ModuleLoadParams_t;
@@ -92,19 +91,31 @@ typedef struct
 */
 typedef struct
 {
-    cpuaddr               EntryAddress;
     osal_id_t             ModuleId;
+    cpuaddr               InitSymbolAddress;
 
 } CFE_ES_ModuleLoadStatus_t;
 
 
+/*
+** CFE_ES_TaskStartParams_t contains basic details about a CFE task
+** 
+** This information needs to be specified when starting a task and is
+** stored as part of the task record for future reference.
+*/
+typedef struct
+{
+    size_t                          StackSize;
+    CFE_ES_TaskPriority_Atom_t      Priority;
+
+} CFE_ES_TaskStartParams_t;
+
 
 /*
-** CFE_ES_AppStartParams_t is a structure of information used when an application is
-**   created in the system.
+** CFE_ES_AppStartParams_t contains basic details about a CFE app.
 **
 ** This is an extension of the CFE_ES_ModuleLoadParams_t which adds information
-** about the task stack size and priority.  It is only used for apps, as libraries
+** about the main task and exception action.  It is only used for apps, as libraries
 ** do not have a task associated.
 */
 typedef struct
@@ -112,16 +123,13 @@ typedef struct
     /*
      * Basic (static) information about the module
      */
-    CFE_ES_ModuleLoadParams_t       BasicInfo;
+    CFE_ES_ModuleLoadParams_t BasicInfo;
 
-    /*
-     * Extra information the pertains to applications only, not libraries.
-     */
-    size_t                          StackSize;
-    CFE_ES_TaskPriority_Atom_t      Priority;
-    CFE_ES_ExceptionAction_Enum_t   ExceptionAction;
+    CFE_ES_TaskStartParams_t      MainTaskInfo;
+    CFE_ES_ExceptionAction_Enum_t ExceptionAction;
 
 } CFE_ES_AppStartParams_t;
+
 
 /*
 ** CFE_ES_AppRecord_t is an internal structure used to keep track of
@@ -129,13 +137,14 @@ typedef struct
 */
 typedef struct
 {
-   CFE_ES_AppId_t             AppId;                 /* The actual AppID of this entry, or undefined */
-   CFE_ES_AppState_Enum_t     AppState;              /* Is the app running, or stopped, or waiting? */
-   CFE_ES_AppType_Enum_t      Type;                  /* The type of App: CORE or EXTERNAL */
-   CFE_ES_AppStartParams_t    StartParams;           /* The start parameters for an App */
-   CFE_ES_ModuleLoadStatus_t  ModuleInfo;            /* Runtime module information */
-   CFE_ES_ControlReq_t        ControlReq;            /* The Control Request Record for External cFE Apps */
-   CFE_ES_TaskId_t            MainTaskId;            /* The Application's Main Task ID */
+    CFE_ES_AppId_t            AppId;                    /* The actual AppID of this entry, or undefined */
+    char                      AppName[OS_MAX_API_NAME]; /* The name of the app */
+    CFE_ES_AppState_Enum_t    AppState;                 /* Is the app running, or stopped, or waiting? */
+    CFE_ES_AppType_Enum_t     Type;                     /* The type of App: CORE or EXTERNAL */
+    CFE_ES_AppStartParams_t   StartParams;              /* The start parameters for an App */
+    CFE_ES_ModuleLoadStatus_t LoadStatus;               /* Runtime module information */
+    CFE_ES_ControlReq_t       ControlReq;               /* The Control Request Record for External cFE Apps */
+    CFE_ES_TaskId_t           MainTaskId;               /* The Application's Main Task ID */
 
 } CFE_ES_AppRecord_t;
 
@@ -146,11 +155,12 @@ typedef struct
 */
 typedef struct
 {
-   CFE_ES_TaskId_t         TaskId;            /* The actual TaskID of this entry, or undefined */
-   CFE_ES_AppId_t          AppId;             /* The parent Application's App ID */
-   uint32    ExecutionCounter;                /* The execution counter for the Child task */
-   char      TaskName[OS_MAX_API_NAME];       /* Task Name */
-
+    CFE_ES_TaskId_t           TaskId;                    /* The actual TaskID of this entry, or undefined */
+    char                      TaskName[OS_MAX_API_NAME]; /* Task Name */
+    CFE_ES_AppId_t            AppId;                     /* The parent Application's App ID */
+    CFE_ES_TaskStartParams_t  StartParams;               /* The start parameters for the task */
+    CFE_ES_TaskEntryFuncPtr_t EntryFunc;                 /* Task entry function */
+    uint32                    ExecutionCounter;          /* The execution counter for the task */
 
 } CFE_ES_TaskRecord_t;
 
@@ -160,9 +170,11 @@ typedef struct
 */
 typedef struct
 {
-   CFE_ES_LibId_t             LibId;          /* The actual LibID of this entry, or undefined */
-   CFE_ES_ModuleLoadParams_t  BasicInfo;      /* Basic (static) information about the module */
-   CFE_ES_ModuleLoadStatus_t  ModuleInfo;     /* Runtime information about the module */
+    CFE_ES_LibId_t            LibId;                    /* The actual LibID of this entry, or undefined */
+    char                      LibName[OS_MAX_API_NAME]; /* Library Name */
+    CFE_ES_ModuleLoadParams_t LoadParams;               /* Basic (static) information about the module */
+    CFE_ES_ModuleLoadStatus_t LoadStatus;               /* Runtime information about the module */
+
 } CFE_ES_LibRecord_t;
 
 /*
@@ -198,7 +210,7 @@ int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens);
 ** This only loads the code and looks up relevent runtime information.
 ** It does not start any tasks.
 */
-int32 CFE_ES_LoadModule(CFE_ResourceId_t ResourceId, const CFE_ES_ModuleLoadParams_t* LoadParams, CFE_ES_ModuleLoadStatus_t *LoadStatus);
+int32 CFE_ES_LoadModule(CFE_ResourceId_t ParentResourceId, const char *ModuleName, const CFE_ES_ModuleLoadParams_t* LoadParams, CFE_ES_ModuleLoadStatus_t *LoadStatus);
 
 /*
 ** Internal function to determine the entry point of an app.
@@ -206,37 +218,29 @@ int32 CFE_ES_LoadModule(CFE_ResourceId_t ResourceId, const CFE_ES_ModuleLoadPara
 ** then this delays until the app is completely configured and the entry point is
 ** confirmed to be valid.
 */
-int32 CFE_ES_GetAppEntryPoint(osal_task_entry *FuncPtr);
+int32 CFE_ES_GetTaskFunction(CFE_ES_TaskEntryFuncPtr_t *FuncPtr);
 
 /*
-** Intermediate entry point of an app.  Determines the actual
+** Intermediate entry point of all tasks.  Determines the actual
 ** entry point from the global data structures.
 */
-void CFE_ES_AppEntryPoint(void);
+void CFE_ES_TaskEntryPoint(void);
 
 /*
-** Internal function to start the main task of an app.
+** Internal function to start a task associated with an app.
 */
-int32 CFE_ES_StartAppTask(const CFE_ES_AppStartParams_t* StartParams, CFE_ES_AppId_t RefAppId, CFE_ES_TaskId_t *TaskIdPtr);
+int32 CFE_ES_StartAppTask(CFE_ES_TaskId_t *TaskIdPtr, const char *TaskName, CFE_ES_TaskEntryFuncPtr_t EntryFunc, const CFE_ES_TaskStartParams_t* Params, CFE_ES_AppId_t ParentAppId);
 
 /*
 ** Internal function to create/start a new cFE app
 ** based on the parameters passed in
 */
-int32 CFE_ES_AppCreate(CFE_ES_AppId_t *ApplicationIdPtr,
-                       const char   *FileName,
-                       const char   *EntryPointName,
-                       const char   *AppName,
-                       CFE_ES_TaskPriority_Atom_t    Priority,
-                       size_t                        StackSize,
-                       CFE_ES_ExceptionAction_Enum_t ExceptionAction);
+int32 CFE_ES_AppCreate(CFE_ES_AppId_t *ApplicationIdPtr, const char *AppName, const CFE_ES_AppStartParams_t *Params);
+
 /*
 ** Internal function to load a a new cFE shared Library
 */
-int32 CFE_ES_LoadLibrary(CFE_ES_LibId_t *LibraryIdPtr,
-                       const char   *FileName,
-                       const char   *EntryPointName,
-                       const char   *LibName);
+int32 CFE_ES_LoadLibrary(CFE_ES_LibId_t *LibraryIdPtr, const char *LibName, const CFE_ES_ModuleLoadParams_t *Params);
 
 /*
 ** Scan the Application Table for actions to take

--- a/fsw/cfe-core/src/es/cfe_es_objtab.c
+++ b/fsw/cfe-core/src/es/cfe_es_objtab.c
@@ -129,7 +129,7 @@ CFE_ES_ObjectTable_t  CFE_ES_ObjectTable[CFE_PLATFORM_ES_OBJECT_TABLE_SIZE] =
    {
            .ObjectType = CFE_ES_CORE_TASK,
            .ObjectName = "CFE_EVS",
-           .FuncPtrUnion.MainAppPtr = CFE_EVS_TaskMain,
+           .FuncPtrUnion.MainTaskPtr = CFE_EVS_TaskMain,
            .ObjectPriority = CFE_PLATFORM_EVS_START_TASK_PRIORITY,
            .ObjectSize = CFE_PLATFORM_EVS_START_TASK_STACK_SIZE
    },
@@ -139,7 +139,7 @@ CFE_ES_ObjectTable_t  CFE_ES_ObjectTable[CFE_PLATFORM_ES_OBJECT_TABLE_SIZE] =
    {
            .ObjectType = CFE_ES_CORE_TASK,
            .ObjectName = "CFE_SB",
-           .FuncPtrUnion.MainAppPtr = CFE_SB_TaskMain,
+           .FuncPtrUnion.MainTaskPtr = CFE_SB_TaskMain,
            .ObjectPriority = CFE_PLATFORM_SB_START_TASK_PRIORITY,
            .ObjectSize = CFE_PLATFORM_SB_START_TASK_STACK_SIZE
    },
@@ -149,7 +149,7 @@ CFE_ES_ObjectTable_t  CFE_ES_ObjectTable[CFE_PLATFORM_ES_OBJECT_TABLE_SIZE] =
    {
            .ObjectType = CFE_ES_CORE_TASK,
            .ObjectName = "CFE_ES",
-           .FuncPtrUnion.MainAppPtr = CFE_ES_TaskMain,
+           .FuncPtrUnion.MainTaskPtr = CFE_ES_TaskMain,
            .ObjectPriority = CFE_PLATFORM_ES_START_TASK_PRIORITY,
            .ObjectSize = CFE_PLATFORM_ES_START_TASK_STACK_SIZE
    },
@@ -159,7 +159,7 @@ CFE_ES_ObjectTable_t  CFE_ES_ObjectTable[CFE_PLATFORM_ES_OBJECT_TABLE_SIZE] =
    {
            .ObjectType = CFE_ES_CORE_TASK,
            .ObjectName = "CFE_TIME",
-           .FuncPtrUnion.MainAppPtr = CFE_TIME_TaskMain,
+           .FuncPtrUnion.MainTaskPtr = CFE_TIME_TaskMain,
            .ObjectPriority = CFE_PLATFORM_TIME_START_TASK_PRIORITY,
            .ObjectSize = CFE_PLATFORM_TIME_START_TASK_STACK_SIZE
    },
@@ -169,7 +169,7 @@ CFE_ES_ObjectTable_t  CFE_ES_ObjectTable[CFE_PLATFORM_ES_OBJECT_TABLE_SIZE] =
    {
            .ObjectType = CFE_ES_CORE_TASK,
            .ObjectName = "CFE_TBL",
-           .FuncPtrUnion.MainAppPtr = CFE_TBL_TaskMain,
+           .FuncPtrUnion.MainTaskPtr = CFE_TBL_TaskMain,
            .ObjectPriority = CFE_PLATFORM_TBL_START_TASK_PRIORITY,
            .ObjectSize = CFE_PLATFORM_TBL_START_TASK_STACK_SIZE
    },

--- a/fsw/cfe-core/src/es/cfe_es_resource.h
+++ b/fsw/cfe-core/src/es/cfe_es_resource.h
@@ -173,7 +173,7 @@ static inline bool CFE_ES_AppRecordIsMatch(const CFE_ES_AppRecord_t *AppRecPtr, 
  */
 static inline const char* CFE_ES_AppRecordGetName(const CFE_ES_AppRecord_t *AppRecPtr)
 {
-    return AppRecPtr->StartParams.BasicInfo.Name;
+    return AppRecPtr->AppName;
 }
 
 
@@ -266,7 +266,7 @@ static inline bool CFE_ES_LibRecordIsMatch(const CFE_ES_LibRecord_t *LibRecPtr, 
  */
 static inline const char* CFE_ES_LibRecordGetName(const CFE_ES_LibRecord_t *LibRecPtr)
 {
-    return LibRecPtr->BasicInfo.Name;
+    return LibRecPtr->LibName;
 }
 
 

--- a/fsw/cfe-core/src/es/cfe_es_start.h
+++ b/fsw/cfe-core/src/es/cfe_es_start.h
@@ -62,12 +62,11 @@
 */
 
 typedef int32 (*CFE_ES_EarlyInitFuncPtr_t)(void); /**< \brief Req'd prototype of Early Init Functions */
-typedef void  (*CFE_ES_MainAppFuncPtr_t)(void);   /**< \brief Req'd prototype of Application Main Functions */
 
 typedef union
 {
     CFE_ES_EarlyInitFuncPtr_t     FunctionPtr;
-    CFE_ES_MainAppFuncPtr_t       MainAppPtr;
+    CFE_ES_TaskEntryFuncPtr_t     MainTaskPtr;
     void                         *VoidPtr;
 } CFE_ES_FuncPtrUnion_t;
 

--- a/fsw/cfe-core/src/es/cfe_es_task.c
+++ b/fsw/cfe-core/src/es/cfe_es_task.c
@@ -849,19 +849,18 @@ int32 CFE_ES_StartAppCmd(const CFE_ES_StartAppCmd_t *data)
     int32                 FilenameLen;
     int32                 AppEntryLen;
     int32                 AppNameLen;
-    size_t                AppStackSize;
-    char                  LocalFile[OS_MAX_PATH_LEN];
-    char                  LocalEntryPt[OS_MAX_API_NAME];
     char                  LocalAppName[OS_MAX_API_NAME];
+    CFE_ES_AppStartParams_t StartParams;
+    
 
     /* Create local copies of all input strings and ensure null termination */
-    FilenameLen = CFE_SB_MessageStringGet(LocalFile, (char *)cmd->AppFileName, NULL,
-            sizeof(LocalFile), sizeof(cmd->AppFileName));
+    FilenameLen = CFE_SB_MessageStringGet(StartParams.BasicInfo.FileName, cmd->AppFileName, NULL,
+            sizeof(StartParams.BasicInfo.FileName), sizeof(cmd->AppFileName));
 
-    AppEntryLen = CFE_SB_MessageStringGet(LocalEntryPt, (char *)cmd->AppEntryPoint, NULL,
-            sizeof(LocalEntryPt), sizeof(cmd->AppEntryPoint));
+    AppEntryLen = CFE_SB_MessageStringGet(StartParams.BasicInfo.InitSymbolName, cmd->AppEntryPoint, NULL,
+            sizeof(StartParams.BasicInfo.InitSymbolName), sizeof(cmd->AppEntryPoint));
 
-    AppNameLen = CFE_SB_MessageStringGet(LocalAppName, (char *)cmd->Application, NULL,
+    AppNameLen = CFE_SB_MessageStringGet(LocalAppName, cmd->Application, NULL,
             sizeof(LocalAppName), sizeof(cmd->Application));
 
     /*
@@ -872,19 +871,19 @@ int32 CFE_ES_StartAppCmd(const CFE_ES_StartAppCmd_t *data)
         CFE_ES_TaskData.CommandErrorCounter++;
         CFE_EVS_SendEvent(CFE_ES_START_INVALID_FILENAME_ERR_EID, CFE_EVS_EventType_ERROR,
                 "CFE_ES_StartAppCmd: invalid filename: %s",
-                LocalFile);
+                StartParams.BasicInfo.FileName);
     }
     else if (AppEntryLen <= 0)
     {
         CFE_ES_TaskData.CommandErrorCounter++;
         CFE_EVS_SendEvent(CFE_ES_START_INVALID_ENTRY_POINT_ERR_EID, CFE_EVS_EventType_ERROR,
-                "CFE_ES_StartAppCmd: App Entry Point is NULL.");
+                "CFE_ES_StartAppCmd: App Entry Point is empty.");
     }
     else if (AppNameLen <= 0)
     {
         CFE_ES_TaskData.CommandErrorCounter++;
         CFE_EVS_SendEvent(CFE_ES_START_NULL_APP_NAME_ERR_EID, CFE_EVS_EventType_ERROR,
-                "CFE_ES_StartAppCmd: App Name is NULL.");
+                "CFE_ES_StartAppCmd: App Name is empty.");
     }
     else if (cmd->Priority > OS_MAX_PRIORITY)
     {
@@ -906,22 +905,20 @@ int32 CFE_ES_StartAppCmd(const CFE_ES_StartAppCmd_t *data)
        /* If stack size was provided, use it, otherwise use default. */
        if (cmd->StackSize == 0)
        {
-           AppStackSize = CFE_PLATFORM_ES_DEFAULT_STACK_SIZE;
+           StartParams.MainTaskInfo.StackSize = CFE_PLATFORM_ES_DEFAULT_STACK_SIZE;
        }
        else
        {
-           AppStackSize = cmd->StackSize;
+           StartParams.MainTaskInfo.StackSize = cmd->StackSize;
        }
+
+       StartParams.MainTaskInfo.Priority = cmd->Priority;
+       StartParams.ExceptionAction = cmd->ExceptionAction;
 
        /*
        ** Invoke application loader/startup function.
        */
-       Result = CFE_ES_AppCreate(&AppID, LocalFile,
-                   LocalEntryPt,
-                   LocalAppName,
-                   cmd->Priority,
-                   AppStackSize,
-                   cmd->ExceptionAction);
+       Result = CFE_ES_AppCreate(&AppID, LocalAppName, &StartParams);
 
         /*
         ** Send appropriate event message
@@ -931,14 +928,14 @@ int32 CFE_ES_StartAppCmd(const CFE_ES_StartAppCmd_t *data)
             CFE_ES_TaskData.CommandCounter++;
             CFE_EVS_SendEvent(CFE_ES_START_INF_EID, CFE_EVS_EventType_INFORMATION,
                     "Started %s from %s, AppID = %lu",
-                    LocalAppName, LocalFile, CFE_RESOURCEID_TO_ULONG(AppID));
+                    LocalAppName, StartParams.BasicInfo.FileName, CFE_RESOURCEID_TO_ULONG(AppID));
         }
         else
         {
             CFE_ES_TaskData.CommandErrorCounter++;
             CFE_EVS_SendEvent(CFE_ES_START_ERR_EID, CFE_EVS_EventType_ERROR,
                     "Failed to start %s from %s, RC = 0x%08X",
-                    LocalAppName, LocalFile, (unsigned int)Result);
+                    LocalAppName, StartParams.BasicInfo.FileName, (unsigned int)Result);
         }
 
     } /* End if -- command parameter validation */

--- a/fsw/cfe-core/src/inc/cfe_es.h
+++ b/fsw/cfe-core/src/inc/cfe_es.h
@@ -140,10 +140,17 @@
 */
 
 /*
-** Child Task Main Function Prototype
+** Entry Function Prototypes
 */
-typedef void (*CFE_ES_ChildTaskMainFuncPtr_t)(void); /**< \brief Required Prototype of Child Task Main Functions */
+typedef void (*CFE_ES_TaskEntryFuncPtr_t)(void); /**< \brief Required Prototype of Task Main Functions */
 typedef int32 (*CFE_ES_LibraryEntryFuncPtr_t)(CFE_ES_LibId_t LibId); /**< \brief Required Prototype of Library Initialization Functions */
+
+/**
+ * \brief Compatible typedef for ES child task entry point.
+ * 
+ * All ES task functions (main + child) use the same entry point type.
+ */
+typedef CFE_ES_TaskEntryFuncPtr_t CFE_ES_ChildTaskMainFuncPtr_t;
 
 /**
  * @brief Type for the stack pointer of tasks.

--- a/fsw/cfe-core/unit-test/es_UT.c
+++ b/fsw/cfe-core/unit-test/es_UT.c
@@ -276,6 +276,51 @@ CFE_ResourceId_t ES_UT_MakeCDSIdForIndex(uint32 ArrayIdx)
 }
 
 /*
+ * A local stub that can serve as the user function for testing ES tasks
+ */
+void ES_UT_TaskFunction(void)
+{
+    UT_DEFAULT_IMPL(ES_UT_TaskFunction);
+}
+
+/*
+ * Helper function to assemble basic bits of info into the "CFE_ES_ModuleLoadParams_t" struct 
+ */
+void ES_UT_SetupModuleLoadParams(CFE_ES_ModuleLoadParams_t *Params, const char *FileName, const char *EntryName)
+{
+    char Empty = 0;
+
+    if (FileName == NULL)
+    {
+        FileName = &Empty;
+    }
+    
+    if (EntryName == NULL)
+    {
+        EntryName = &Empty;
+    }
+
+    strncpy(Params->FileName, FileName, sizeof(Params->FileName));
+    strncpy(Params->InitSymbolName, EntryName, sizeof(Params->InitSymbolName));
+}
+
+/*
+ * Helper function to assemble basic bits of info into the "CFE_ES_AppStartParams_t" struct 
+ */
+void ES_UT_SetupAppStartParams(CFE_ES_AppStartParams_t *Params, const char *FileName, const char *EntryName,
+                               size_t StackSize, CFE_ES_TaskPriority_Atom_t Priority,
+                               CFE_ES_ExceptionAction_Enum_t ExceptionAction)
+{
+    ES_UT_SetupModuleLoadParams(&Params->BasicInfo, FileName, EntryName);
+    Params->MainTaskInfo.StackSize = StackSize;
+    Params->MainTaskInfo.Priority = Priority;
+    Params->ExceptionAction = ExceptionAction;
+}
+
+
+
+
+/*
  * Helper function to setup a single app ID in the given state, along with
  * a main task ID.  A pointer to the App and Task record is output so the
  * record can be modified
@@ -306,11 +351,9 @@ void ES_UT_SetupSingleAppId(CFE_ES_AppType_Enum_t AppType, CFE_ES_AppState_Enum_
 
     if (AppName)
     {
-        strncpy(LocalAppPtr->StartParams.BasicInfo.Name, AppName,
-                sizeof(LocalAppPtr->StartParams.BasicInfo.Name)-1);
-        LocalAppPtr->StartParams.BasicInfo.Name[sizeof(LocalAppPtr->StartParams.BasicInfo.Name)-1] = 0;
-        strncpy(LocalTaskPtr->TaskName, AppName,
-                sizeof(LocalTaskPtr->TaskName)-1);
+        strncpy(LocalAppPtr->AppName, AppName, sizeof(LocalAppPtr->AppName)-1);
+        LocalAppPtr->AppName[sizeof(LocalAppPtr->AppName)-1] = 0;
+        strncpy(LocalTaskPtr->TaskName, AppName, sizeof(LocalTaskPtr->TaskName)-1);
         LocalTaskPtr->TaskName[sizeof(LocalTaskPtr->TaskName)-1] = 0;
     }
 
@@ -332,7 +375,7 @@ void ES_UT_SetupSingleAppId(CFE_ES_AppType_Enum_t AppType, CFE_ES_AppState_Enum_
         ++CFE_ES_Global.RegisteredExternalApps;
 
         OS_ModuleLoad(&UtOsalId, NULL, NULL, 0);
-        LocalAppPtr->ModuleInfo.ModuleId = UtOsalId;
+        LocalAppPtr->LoadStatus.ModuleId = UtOsalId;
     }
     ++CFE_ES_Global.RegisteredTasks;
 }
@@ -391,9 +434,9 @@ void ES_UT_SetupSingleLibId(const char *LibName, CFE_ES_LibRecord_t **OutLibRec)
 
     if (LibName)
     {
-        strncpy(LocalLibPtr->BasicInfo.Name, LibName,
-                sizeof(LocalLibPtr->BasicInfo.Name)-1);
-        LocalLibPtr->BasicInfo.Name[sizeof(LocalLibPtr->BasicInfo.Name)-1] = 0;
+        strncpy(LocalLibPtr->LibName, LibName,
+                sizeof(LocalLibPtr->LibName)-1);
+        LocalLibPtr->LibName[sizeof(LocalLibPtr->LibName)-1] = 0;
     }
 
     if (OutLibRec)
@@ -1168,6 +1211,7 @@ void TestApps(void)
     CFE_ES_AppRecord_t *UtAppRecPtr;
     CFE_ES_MemPoolRecord_t *UtPoolRecPtr;
     char NameBuffer[OS_MAX_API_NAME+5];
+    CFE_ES_AppStartParams_t StartParams;
 
     UtPrintf("Begin Test Apps");
 
@@ -1271,25 +1315,23 @@ void TestApps(void)
     /* Test application loading and creation with a task creation failure */
     ES_ResetUnitTest();
     UT_SetDefaultReturnValue(UT_KEY(OS_TaskCreate), OS_ERROR);
-    Return = CFE_ES_AppCreate(&AppId,
+    ES_UT_SetupAppStartParams(&StartParams, 
                               "ut/filename",
                               "EntryPoint",
-                              "AppName",
                               170,
                               4096,
                               1);
+    Return = CFE_ES_AppCreate(&AppId,
+                              "AppName",
+                              &StartParams);
     UtAssert_INT32_EQ(Return, CFE_STATUS_EXTERNAL_RESOURCE_FAIL);
     UtAssert_NONZERO(UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_APP_CREATE]));
     
-    /* Test application creation with NULL file name */
+    /* Test application creation with NULL parameters */
     ES_ResetUnitTest();
     Return = CFE_ES_AppCreate(&AppId,
-                              NULL,
-                              "EntryPoint",
                               "AppName",
-                              170,
-                              4096,
-                              1);
+                              NULL);
     UT_Report(__FILE__, __LINE__,
               Return == CFE_ES_BAD_ARGUMENT,
               "CFE_ES_AppCreate",
@@ -1298,13 +1340,15 @@ void TestApps(void)
     /* Test application creation with name too long */
     memset(NameBuffer, 'x', sizeof(NameBuffer)-1);
     NameBuffer[sizeof(NameBuffer)-1] = 0;
-    Return = CFE_ES_AppCreate(&AppId,
+    ES_UT_SetupAppStartParams(&StartParams, 
                               "ut/filename.x",
                               "EntryPoint",
-                              NameBuffer,
                               170,
                               4096,
                               1);
+    Return = CFE_ES_AppCreate(&AppId,
+                              NameBuffer,
+                              &StartParams);
     UT_Report(__FILE__, __LINE__,
               Return == CFE_ES_BAD_ARGUMENT,
               "CFE_ES_AppCreate",
@@ -1313,26 +1357,30 @@ void TestApps(void)
 
     /* Test successful application loading and creation  */
     ES_ResetUnitTest();
-    Return = CFE_ES_AppCreate(&AppId,
+    ES_UT_SetupAppStartParams(&StartParams, 
                               "ut/filename.x",
                               "EntryPoint",
-                              "AppName",
                               170,
                               8192,
                               1);
+    Return = CFE_ES_AppCreate(&AppId,
+                              "AppName",
+                              &StartParams);
     UT_Report(__FILE__, __LINE__,
               Return == CFE_SUCCESS,
               "CFE_ES_AppCreate",
               "Application load/create; successful");
 
     /* Test application loading of the same name again */
-    Return = CFE_ES_AppCreate(&AppId,
+    ES_UT_SetupAppStartParams(&StartParams, 
                               "ut/filename.x",
                               "EntryPoint",
-                              "AppName",
                               170,
                               8192,
                               1);
+    Return = CFE_ES_AppCreate(&AppId,
+                              "AppName",
+                              &StartParams);
     UT_Report(__FILE__, __LINE__,
               Return == CFE_ES_ERR_DUPLICATE_NAME,
               "CFE_ES_AppCreate",
@@ -1341,26 +1389,30 @@ void TestApps(void)
     /* Test application loading and creation where the file cannot be loaded */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(OS_ModuleLoad), 1, -1);
-    Return = CFE_ES_AppCreate(&AppId,
+    ES_UT_SetupAppStartParams(&StartParams, 
                               "ut/filename.x",
                               "EntryPoint",
-                              "AppName2",
                               170,
                               8192,
                               1);
+    Return = CFE_ES_AppCreate(&AppId,
+                              "AppName2",
+                              &StartParams);
     UtAssert_INT32_EQ(Return, CFE_STATUS_EXTERNAL_RESOURCE_FAIL);
     UtAssert_NONZERO(UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_EXTRACT_FILENAME_UT55]));
 
     /* Test application loading and creation where all app slots are taken */
     ES_ResetUnitTest();
     UT_SetDefaultReturnValue(UT_KEY(CFE_ResourceId_FindNext), OS_ERROR);
-    Return = CFE_ES_AppCreate(&AppId,
+    ES_UT_SetupAppStartParams(&StartParams, 
                               "ut/filename.x",
                               "EntryPoint",
-                              "AppName",
                               170,
                               8192,
                               1);
+    Return = CFE_ES_AppCreate(&AppId,
+                              "AppName",
+                              &StartParams);
     UT_Report(__FILE__, __LINE__,
               Return == CFE_ES_NO_RESOURCE_IDS_AVAILABLE &&
                 UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_NO_FREE_APP_SLOTS]),
@@ -1378,13 +1430,15 @@ void TestApps(void)
      */
     ES_ResetUnitTest();
     UT_SetDeferredRetcode(UT_KEY(OS_ModuleSymbolLookup), 1, -1);
-    Return = CFE_ES_AppCreate(&AppId,
+    ES_UT_SetupAppStartParams(&StartParams, 
                               "ut/filename.x",
                               "EntryPoint",
-                              "AppName",
                               170,
                               8192,
                               1);
+    Return = CFE_ES_AppCreate(&AppId,
+                              "AppName",
+                              &StartParams);
     UtAssert_INT32_EQ(Return, CFE_STATUS_EXTERNAL_RESOURCE_FAIL);
     UtAssert_NONZERO(UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_CANNOT_FIND_SYMBOL]));
 
@@ -1395,13 +1449,15 @@ void TestApps(void)
     ES_ResetUnitTest();
     UT_SetDeferredRetcode(UT_KEY(OS_ModuleSymbolLookup), 1, -1);
     UT_SetDeferredRetcode(UT_KEY(OS_ModuleUnload), 1, -1);
-    Return = CFE_ES_AppCreate(&AppId,
+    ES_UT_SetupAppStartParams(&StartParams, 
                               "ut/filename.x",
                               "EntryPoint",
-                              "AppName",
                               170,
                               8192,
                               1);
+    Return = CFE_ES_AppCreate(&AppId,
+                              "AppName",
+                              &StartParams);
     UtAssert_INT32_EQ(Return, CFE_STATUS_EXTERNAL_RESOURCE_FAIL);
     UtAssert_NONZERO(UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_CANNOT_FIND_SYMBOL]));
     UtAssert_NONZERO(UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_MODULE_UNLOAD_FAILED]));
@@ -1487,15 +1543,12 @@ void TestApps(void)
     /* Test a successful control action request to exit an application */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
-    strncpy(UtAppRecPtr->StartParams.BasicInfo.FileName, 
-            "/ram/Filename", sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1);
-    UtAppRecPtr->StartParams.BasicInfo.FileName[sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1] = '\0';
-    strncpy(UtAppRecPtr->StartParams.BasicInfo.EntryPoint,
-            "NotNULL", sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1);
-    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1] = '\0';
-    UtAppRecPtr->StartParams.Priority = 255;
-    UtAppRecPtr->StartParams.StackSize = 8192;
-    UtAppRecPtr->StartParams.ExceptionAction = 0;
+    ES_UT_SetupAppStartParams(&UtAppRecPtr->StartParams,
+            "/ram/Filename",
+            "NotNULL",
+            8192,
+            255,
+            0);
     UtAppRecPtr->ControlReq.AppControlRequest =
       CFE_ES_RunStatus_APP_EXIT;
     AppId = CFE_ES_AppRecordGetID(UtAppRecPtr);
@@ -1556,7 +1609,7 @@ void TestApps(void)
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
     UtAppRecPtr->ControlReq.AppControlRequest =
         CFE_ES_RunStatus_SYS_RESTART;
-    OS_ModuleLoad(&UtAppRecPtr->ModuleInfo.ModuleId, NULL, NULL, 0);
+    OS_ModuleLoad(&UtAppRecPtr->LoadStatus.ModuleId, NULL, NULL, 0);
     UT_SetDefaultReturnValue(UT_KEY(OS_TaskCreate), OS_ERROR);
     AppId = CFE_ES_AppRecordGetID(UtAppRecPtr);
     CFE_ES_ProcessControlRequest(AppId);
@@ -1587,7 +1640,7 @@ void TestApps(void)
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
     UtAppRecPtr->ControlReq.AppControlRequest =
         CFE_ES_RunStatus_SYS_RELOAD;
-    OS_ModuleLoad(&UtAppRecPtr->ModuleInfo.ModuleId, NULL, NULL, 0);
+    OS_ModuleLoad(&UtAppRecPtr->LoadStatus.ModuleId, NULL, NULL, 0);
     UT_SetDefaultReturnValue(UT_KEY(OS_TaskCreate), OS_ERROR);
     AppId = CFE_ES_AppRecordGetID(UtAppRecPtr);
     CFE_ES_ProcessControlRequest(AppId);
@@ -1601,15 +1654,13 @@ void TestApps(void)
      */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
-    strncpy(UtAppRecPtr->StartParams.BasicInfo.FileName,
-            "/ram/FileName", sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1);
-    UtAppRecPtr->StartParams.BasicInfo.FileName[sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1] = '\0';
-    strncpy(UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
-            sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1);
-    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1] = '\0';
-    UtAppRecPtr->StartParams.Priority = 255;
-    UtAppRecPtr->StartParams.StackSize = 8192;
-    UtAppRecPtr->StartParams.ExceptionAction = 0;
+    ES_UT_SetupAppStartParams(&UtAppRecPtr->StartParams,
+            "/ram/FileName",
+            "NULL",
+            8192,
+            255,
+            0);
+
     UtAppRecPtr->ControlReq.AppControlRequest =
       CFE_ES_RunStatus_APP_ERROR;
     AppId = CFE_ES_AppRecordGetID(UtAppRecPtr);
@@ -1637,15 +1688,12 @@ void TestApps(void)
     /* Test a successful control action request to stop an application */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
-    strncpy(UtAppRecPtr->StartParams.BasicInfo.FileName,
-            "/ram/FileName", sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1);
-    UtAppRecPtr->StartParams.BasicInfo.FileName[sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1] = '\0';
-    strncpy(UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
-            sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1);
-    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1] = '\0';
-    UtAppRecPtr->StartParams.Priority = 255;
-    UtAppRecPtr->StartParams.StackSize = 8192;
-    UtAppRecPtr->StartParams.ExceptionAction = 0;
+    ES_UT_SetupAppStartParams(&UtAppRecPtr->StartParams,
+            "/ram/FileName",
+            "NULL",
+            8192,
+            255,
+            0);
     UtAppRecPtr->ControlReq.AppControlRequest =
         CFE_ES_RunStatus_SYS_DELETE;
     AppId = CFE_ES_AppRecordGetID(UtAppRecPtr);
@@ -1658,15 +1706,12 @@ void TestApps(void)
     /* Test a successful control action request to restart an application */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
-    strncpy(UtAppRecPtr->StartParams.BasicInfo.FileName,
-            "/ram/FileName", sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1);
-    UtAppRecPtr->StartParams.BasicInfo.FileName[sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1] = '\0';
-    strncpy(UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
-            sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1);
-    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1] = '\0';
-    UtAppRecPtr->StartParams.Priority = 255;
-    UtAppRecPtr->StartParams.StackSize = 8192;
-    UtAppRecPtr->StartParams.ExceptionAction = 0;
+    ES_UT_SetupAppStartParams(&UtAppRecPtr->StartParams,
+            "/ram/FileName",
+            "NULL",
+            8192,
+            255,
+            0);
     UtAppRecPtr->ControlReq.AppControlRequest =
         CFE_ES_RunStatus_SYS_RESTART;
     AppId = CFE_ES_AppRecordGetID(UtAppRecPtr);
@@ -1679,15 +1724,12 @@ void TestApps(void)
     /* Test a successful control action request to reload an application */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
-    strncpy(UtAppRecPtr->StartParams.BasicInfo.FileName,
-            "/ram/FileName", sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) -1);
-    UtAppRecPtr->StartParams.BasicInfo.FileName[sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) -1] = '\0';
-    strncpy(UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
-            sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1);
-    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1] = '\0';
-    UtAppRecPtr->StartParams.Priority = 255;
-    UtAppRecPtr->StartParams.StackSize = 8192;
-    UtAppRecPtr->StartParams.ExceptionAction = 0;
+    ES_UT_SetupAppStartParams(&UtAppRecPtr->StartParams,
+            "/ram/FileName",
+            "NULL",
+            8192,
+            255,
+            0);
     UtAppRecPtr->ControlReq.AppControlRequest =
         CFE_ES_RunStatus_SYS_RELOAD;
     AppId = CFE_ES_AppRecordGetID(UtAppRecPtr);
@@ -1702,15 +1744,12 @@ void TestApps(void)
      */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
-    strncpy(UtAppRecPtr->StartParams.BasicInfo.FileName,
-            "/ram/FileName", sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1);
-    UtAppRecPtr->StartParams.BasicInfo.FileName[sizeof(UtAppRecPtr->StartParams.BasicInfo.FileName) - 1] = '\0';
-    strncpy(UtAppRecPtr->StartParams.BasicInfo.EntryPoint, "NULL",
-            sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1);
-    UtAppRecPtr->StartParams.BasicInfo.EntryPoint[sizeof(UtAppRecPtr->StartParams.BasicInfo.EntryPoint) - 1] = '\0';
-    UtAppRecPtr->StartParams.Priority = 255;
-    UtAppRecPtr->StartParams.StackSize = 8192;
-    UtAppRecPtr->StartParams.ExceptionAction = 0;
+    ES_UT_SetupAppStartParams(&UtAppRecPtr->StartParams,
+            "/ram/FileName",
+            "NULL",
+            8192,
+            255,
+            0);
     UtAppRecPtr->ControlReq.AppControlRequest =
         CFE_ES_RunStatus_SYS_EXCEPTION;
     AppId = CFE_ES_AppRecordGetID(UtAppRecPtr);
@@ -1781,7 +1820,7 @@ void TestApps(void)
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
     ES_UT_SetupForOSCleanup();
 
-    OS_ModuleLoad(&UtAppRecPtr->ModuleInfo.ModuleId, NULL, NULL, 0);
+    OS_ModuleLoad(&UtAppRecPtr->LoadStatus.ModuleId, NULL, NULL, 0);
     UT_SetDefaultReturnValue(UT_KEY(OS_TaskDelete), OS_ERROR);
     UT_SetDefaultReturnValue(UT_KEY(OS_close), OS_ERROR);
     AppId = CFE_ES_AppRecordGetID(UtAppRecPtr);
@@ -2156,36 +2195,29 @@ void TestResourceID(void)
 void TestLibs(void)
 {
     CFE_ES_LibRecord_t *UtLibRecPtr;
-    char LongLibraryName[sizeof(UtLibRecPtr->BasicInfo.Name)+1];
+    char LongLibraryName[sizeof(UtLibRecPtr->LibName)+1];
     CFE_ES_LibId_t Id;
     int32 Return;
+    CFE_ES_ModuleLoadParams_t LoadParams;
 
     /* Test shared library loading and initialization where the initialization
      * routine returns an error
      */
     ES_ResetUnitTest();
     UT_SetDummyFuncRtn(-444);
-    Return = CFE_ES_LoadLibrary(&Id,
-                                "filename",
-                                "EntryPoint",
-                                "LibName");
+    ES_UT_SetupModuleLoadParams(&LoadParams, "filename", "entrypt");
+    Return = CFE_ES_LoadLibrary(&Id, "LibName", &LoadParams);
     UtAssert_INT32_EQ(Return, -444);
     UtAssert_NONZERO(UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_SHARED_LIBRARY_INIT]));
 
     /* Test Load library returning an error on a null pointer argument */
-    Return = CFE_ES_LoadLibrary(&Id,
-                                NULL,
-                                "EntryPoint",
-                                "LibName");
+    Return = CFE_ES_LoadLibrary(&Id, "LibName", NULL);
     UT_Report(__FILE__, __LINE__,
               Return == CFE_ES_BAD_ARGUMENT,
               "CFE_ES_LoadLibrary",
               "Load shared library bad argument (NULL filename)");
 
-    Return = CFE_ES_LoadLibrary(&Id,
-                                "filename",
-                                "EntryPoint",
-                                NULL);
+    Return = CFE_ES_LoadLibrary(&Id, NULL, &LoadParams);
     UT_Report(__FILE__, __LINE__,
               Return == CFE_ES_BAD_ARGUMENT,
               "CFE_ES_LoadLibrary",
@@ -2194,10 +2226,7 @@ void TestLibs(void)
     /* Test Load library returning an error on a too long library name */
     memset(LongLibraryName, 'a', sizeof(LongLibraryName)-1);
     LongLibraryName[sizeof(LongLibraryName)-1] = '\0';
-    Return = CFE_ES_LoadLibrary(&Id,
-                                "filename",
-                                "EntryPoint",
-                                &LongLibraryName[0]);
+    Return = CFE_ES_LoadLibrary(&Id, LongLibraryName, &LoadParams);
     UT_Report(__FILE__, __LINE__,
               Return == CFE_ES_BAD_ARGUMENT,
               "CFE_ES_LoadLibrary",
@@ -2206,10 +2235,7 @@ void TestLibs(void)
     /* Test successful shared library loading and initialization */
     UT_InitData();
     UT_SetDummyFuncRtn(OS_SUCCESS);
-    Return = CFE_ES_LoadLibrary(&Id,
-                                "/cf/apps/tst_lib.bundle",
-                                "TST_LIB_Init",
-                                "TST_LIB");
+    Return = CFE_ES_LoadLibrary(&Id, "TST_LIB", &LoadParams);
     UT_Report(__FILE__, __LINE__,
               Return == CFE_SUCCESS,
               "CFE_ES_LoadLibrary",
@@ -2220,10 +2246,7 @@ void TestLibs(void)
     UtAssert_True(CFE_ES_LibRecordIsUsed(UtLibRecPtr), "CFE_ES_LoadLibrary() record used");
 
     /* Try loading same library again, should return the DUPLICATE code */
-    Return = CFE_ES_LoadLibrary(&Id,
-                                "/cf/apps/tst_lib.bundle",
-                                "TST_LIB_Init",
-                                "TST_LIB");
+    Return = CFE_ES_LoadLibrary(&Id, "TST_LIB", &LoadParams);
     UT_Report(__FILE__, __LINE__,
               Return == CFE_ES_ERR_DUPLICATE_NAME,
               "CFE_ES_LoadLibrary",
@@ -2236,10 +2259,7 @@ void TestLibs(void)
      */
     ES_ResetUnitTest();
     UT_SetDeferredRetcode(UT_KEY(OS_ModuleLoad), 1, -1);
-    Return = CFE_ES_LoadLibrary(&Id,
-                                "/cf/apps/tst_lib.bundle",
-                                "TST_LIB_Init",
-                                "TST_LIB");
+    Return = CFE_ES_LoadLibrary(&Id, "TST_LIB", &LoadParams);
     UtAssert_INT32_EQ(Return, CFE_STATUS_EXTERNAL_RESOURCE_FAIL);
 
     /* Test shared library loading and initialization where the library
@@ -2247,10 +2267,7 @@ void TestLibs(void)
      */
     ES_ResetUnitTest();
     UT_SetDeferredRetcode(UT_KEY(OS_ModuleSymbolLookup), 1, -1);
-    Return = CFE_ES_LoadLibrary(&Id,
-                                "/cf/apps/tst_lib.bundle",
-                                "TST_LIB_Init",
-                                "TST_LIB");
+    Return = CFE_ES_LoadLibrary(&Id, "TST_LIB", &LoadParams);
     UtAssert_INT32_EQ(Return, CFE_STATUS_EXTERNAL_RESOURCE_FAIL);
 
     /* Test shared library loading and initialization where the library
@@ -2259,10 +2276,8 @@ void TestLibs(void)
     ES_ResetUnitTest();
     UT_SetDefaultReturnValue(UT_KEY(OS_remove), OS_ERROR); /* for coverage of error path */
     UT_SetDefaultReturnValue(UT_KEY(dummy_function), -555);
-    Return = CFE_ES_LoadLibrary(&Id,
-                                "/cf/apps/tst_lib.bundle",
-                                "dummy_function",
-                            "TST_LIB");
+    ES_UT_SetupModuleLoadParams(&LoadParams, "filename", "dummy_function");
+    Return = CFE_ES_LoadLibrary(&Id, "TST_LIB", &LoadParams);
     UT_Report(__FILE__, __LINE__,
               Return == -555,
               "CFE_ES_LoadLibrary",
@@ -2273,10 +2288,7 @@ void TestLibs(void)
      */
     ES_ResetUnitTest();
     UT_SetDefaultReturnValue(UT_KEY(CFE_ResourceId_FindNext), OS_ERROR);
-    Return = CFE_ES_LoadLibrary(&Id,
-                                "filename",
-                                "EntryPoint",
-                                "LibName");
+    Return = CFE_ES_LoadLibrary(&Id, "LibName", &LoadParams);
     UT_Report(__FILE__, __LINE__,
               Return == CFE_ES_NO_RESOURCE_IDS_AVAILABLE &&
               UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_LIBRARY_SLOTS]),
@@ -4870,7 +4882,7 @@ void TestAPI(void)
                                     400,
                                     0);
     UT_Report(__FILE__, __LINE__,
-              Return == CFE_ES_ERR_CHILD_TASK_CREATE,
+              Return == CFE_STATUS_EXTERNAL_RESOURCE_FAIL,
               "CFE_ES_ChildTaskCreate",
               "OS task create failed");
 
@@ -4961,6 +4973,26 @@ void TestAPI(void)
     UT_Report(__FILE__, __LINE__,
               Return == CFE_SUCCESS, "CFE_ES_CreateChildTask",
               "Create child task successful");
+
+    /* Test common entry point */
+    ES_ResetUnitTest();
+
+    /* 
+     * Without no app/task set up the entry point will not be found.
+     * There is no return value to check here, it just will not do anything.
+     */
+    CFE_ES_TaskEntryPoint();
+
+    /* Now set up an app+task */
+    ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, &UtTaskRecPtr);
+
+    /* Test with app/task set up but no entry point defined */
+    CFE_ES_TaskEntryPoint();
+
+    /* Finally set entry point, nominal mode */
+    UtTaskRecPtr->EntryFunc = ES_UT_TaskFunction;
+    CFE_ES_TaskEntryPoint();
+    UtAssert_STUB_COUNT(ES_UT_TaskFunction, 1);
 
     /* Test deleting a child task using a main task's ID */
     ES_ResetUnitTest();


### PR DESCRIPTION
**Describe the contribution**
Encapsulate all parameters for apps and tasks into a structure object and clean up internal APIs to pass this object rather than individual parameters.  These parameters can then easily be stored with the relevant record in the internal table (tasks, apps, libs) and makes management easier - as code copies one object rather than many individual fields with (potentially) different names.

All parameters are stored in the record, which facilitates future telemetry generation/stats and/or for when an app might get restarted or reloaded in the future.

Notably this changes all task startup to go through the same basic routine (there is no longer a need for different accounting between main tasks and child tasks) and share the same common entry point.  

Fixes #978 

**Testing performed**
Build and sanity check CFE.  In particular ensure that all tasks + child tasks are starting and running normally.  Also checked that the app restart command is working as expected.  

Run all unit tests and confirm coverage.

**Expected behavior changes**
No public API change.  Internal APIs are simplified, internal data structures are more consistent, and more detail is stored with the relevant record (i.e. task record has all relevant task details, so when looking up task info one does not have to traverse to the app record which previously held some of this data).

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Using the common entry point for child tasks avoids a theoretical race condition where the child task might not have been fully accounted for in the global table at the time the user function started execution.  Previously this would directly invoke the user-supplied function immediately.  Now using the common entry point this delays until the task record is completely accounted for (linked back to app, etc) before calling the user function.  So functions such as `CFE_ES_GetAppID()` and others will work right from the beginning.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
