### PR TITLE
Fix #1020, refactor SB buffer descriptor object

### DIFF
--- a/fsw/cfe-core/src/sb/cfe_sb_init.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_init.c
@@ -118,8 +118,6 @@ int32 CFE_SB_EarlyInit (void) {
                  CFE_SB_ValueToMsgId(CFE_SB_STATS_TLM_MID),
                  sizeof(CFE_SB_Global.StatTlmMsg));
 
-    CFE_SB_Global.ZeroCopyTail = NULL;
-
     return Stat;
 
 }/* end CFE_SB_EarlyInit */
@@ -156,6 +154,12 @@ int32  CFE_SB_InitBuffers(void) {
               (unsigned long)CFE_SB_Global.Mem.Partition.Data,CFE_PLATFORM_SB_BUF_MEMORY_BYTES,(unsigned int)Stat);
         return Stat;
     }
+
+    /* 
+     * Initialize the buffer tracking lists to be empty
+     */
+    CFE_SB_TrackingListReset(&CFE_SB_Global.InTransitList);
+    CFE_SB_TrackingListReset(&CFE_SB_Global.ZeroCopyList);
     
     return CFE_SUCCESS;
     

--- a/fsw/cfe-core/src/sb/cfe_sb_priv.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_priv.c
@@ -535,20 +535,49 @@ void CFE_SB_RemoveDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *Nod
 ******************************************************************************/
 int32 CFE_SB_ZeroCopyReleaseAppId(CFE_ES_AppId_t AppId)
 {
-    CFE_SB_ZeroCopyD_t *prev = NULL;
-    CFE_SB_ZeroCopyD_t *zcd = (CFE_SB_ZeroCopyD_t *) (CFE_SB_Global.ZeroCopyTail);
+    CFE_SB_BufferLink_t *NextLink;
 
-    while(zcd != NULL){
-        prev = (CFE_SB_ZeroCopyD_t *) (zcd->Prev);
-        if( CFE_RESOURCEID_TEST_EQUAL(zcd->AppID, AppId) )
+    /* Using a union type permits promotion of CFE_SB_BufferLink_t* to CFE_SB_BufferD_t*
+     * without violating aliasing rules or alignment rules.  Note that the first element
+     * of CFE_SB_BufferD_t is a CFE_SB_BufferLink_t, which makes this possible. */
+    union LocalBufDesc
+    {
+        CFE_SB_BufferLink_t As_Link;
+        CFE_SB_BufferD_t    As_Dsc;
+    } *BufPtr;
+
+    /*
+     * First go through the "ZeroCopy" tracking list and find all nodes
+     * with a matching AppID.  This needs to be done while locked to
+     * prevent other tasks from changing the list at the same time.
+     */
+    if (CFE_RESOURCEID_TEST_DEFINED(AppId))
+    {
+        CFE_SB_LockSharedData(__func__, __LINE__);
+
+        /* Get start of list */
+        NextLink = CFE_SB_TrackingListGetNext(&CFE_SB_Global.ZeroCopyList);
+        while(!CFE_SB_TrackingListIsEnd(&CFE_SB_Global.ZeroCopyList, NextLink))
         {
-            CFE_SB_ZeroCopyReleasePtr((CFE_SB_Buffer_t *) zcd->Buffer, (CFE_SB_ZeroCopyHandle_t) zcd);
+            /* Get buffer descriptor pointer */
+            BufPtr = (union LocalBufDesc*)NextLink;
+
+            /* Read the next link now in case this node gets moved */
+            NextLink = CFE_SB_TrackingListGetNext(NextLink);
+
+            /* Check if it is a zero-copy buffer owned by this app */
+            if (CFE_RESOURCEID_TEST_EQUAL(BufPtr->As_Dsc.AppId, AppId))
+            {
+                /* If so, decrement the use count as the app has now gone away */
+                CFE_SB_DecrBufUseCnt(&BufPtr->As_Dsc);
+            }
         }
-        zcd = prev;
+
+        CFE_SB_UnlockSharedData(__func__, __LINE__);
     }
 
     return CFE_SUCCESS;
 
-}/* end CFE_SB_ZeroCopyReleasePtr */
+}/* end CFE_SB_ZeroCopyReleaseAppId */
 
 /*****************************************************************************/

--- a/fsw/cfe-core/unit-test/sb_UT.h
+++ b/fsw/cfe-core/unit-test/sb_UT.h
@@ -1938,6 +1938,21 @@ void Test_TransmitBuffer_IncrementSeqCnt(void);
 
 /*****************************************************************************/
 /**
+** \brief Test the zero-copy handle validation performed by CFE_SB_ZeroCopyHandleValidate()
+**
+** \par Description
+**        Exercises the validation checks within this function
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+******************************************************************************/
+void Test_TransmitMsg_ZeroCopyHandleValidate(void);
+
+/*****************************************************************************/
+/**
 ** \brief Test successfully sending a message in zero copy mode (telemetry
 **        source sequence count is unchanged)
 **
@@ -1987,10 +2002,10 @@ void Test_TransmitMsg_DisabledDestination(void);
 
 /*****************************************************************************/
 /**
-** \brief Test successful CFE_SB_TransmitBufferFull
+** \brief Test CFE_SB_BroadcastBufferToRoute
 **
 ** \par Description
-**        This function tests successfully sending a message with the metadata.
+**        This function tests broadcasting a message buffer with the metadata.
 **
 ** \par Assumptions, External Events, and Notes:
 **        None
@@ -1998,7 +2013,7 @@ void Test_TransmitMsg_DisabledDestination(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_TransmitBufferFull(void);
+void Test_BroadcastBufferToRoute(void);
 
 /*****************************************************************************/
 /**


### PR DESCRIPTION
**Describe the contribution**
Refactor the SB buffer descriptor object (`CFE_SB_BufferD_t`) and simplify the zero-copy buffer paradigm.

Combine the zero-copy and the normal CFE buffer descriptor into a single unified CFE_SB_BufferD_t object.  This cleans up a bunch of extra logic related to zero-copy buffers, including the extra descriptor object.  The result is a simpler zero-copy design that is much less different from the standard (non-zero-copy) message path.

All message descriptor objects are now tracked in a list by SB, not just the zero-copy descriptors (for consistency - if any buffers need to be tracked, they should all be tracked).

This notably puts the buffer content as a _member_ within the descriptor, rather than a calculated pointer, so it will be aligned properly.

Fixes #1020 

**Testing performed**
Build and run all unit tests
Sanity check CFE

**Expected behavior changes**
All changes are internal to SB.  This does not affect API or behavior of any existing APIs (but see note)

It also ensures that zero-copy buffers (and the associated CFE_SB_TransmitBuffer API) behave as similarly as possible to the normal CFE_SB_TransmitMsg API.  Notably this corrects a minor issue where the MsgSendErrorCounter would get incremented if there were no subscribers, but only in the zero copy API.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
This does not change public API in any way.  However now there is no extra descriptor for the "zero copy" buffers - they are all just buffer descriptors, regardless of whether they were allocated on the fly or pre-allocated by the application.

This means that the `CFE_SB_ZeroCopyHandle_t` value that is output from `CFE_SB_ZeroCopyGetPtr()` and others is now largely redundant.  It is equal to the buffer descriptor address, but it can be easily determined from the buffer content pointer too, so it is really not necessary to pass around two values for zero copy buffers.  This can be simplified in a future change - but that will change the public API.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
