### PR TITLE
Fix #979, add fields to task info struct

### DIFF
--- a/fsw/cfe-core/src/es/cfe_es_api.c
+++ b/fsw/cfe-core/src/es/cfe_es_api.c
@@ -1208,9 +1208,11 @@ int32 CFE_ES_GetTaskInfo(CFE_ES_TaskInfo_t *TaskInfo, CFE_ES_TaskId_t TaskId)
         TaskInfo->TaskId = CFE_ES_TaskRecordGetID(TaskRecPtr);
 
         /*
-        ** Get the Execution counter for the task
+        ** Get the other stats for the task
         */
         TaskInfo->ExecutionCounter =  TaskRecPtr->ExecutionCounter;
+        TaskInfo->StackSize = TaskRecPtr->StartParams.StackSize;
+        TaskInfo->Priority = TaskRecPtr->StartParams.Priority;
 
         /*
         ** Get the Application Details

--- a/fsw/cfe-core/src/inc/cfe_es_msg.h
+++ b/fsw/cfe-core/src/inc/cfe_es_msg.h
@@ -1497,11 +1497,14 @@ typedef struct CFE_ES_AppInfo
  */
 typedef struct CFE_ES_TaskInfo
 {
-   CFE_ES_TaskId_t     TaskId;                            /**< \brief Task Id */
-   uint32              ExecutionCounter;                  /**< \brief Task Execution Counter */
-   char                TaskName[CFE_MISSION_MAX_API_LEN]; /**< \brief Task Name */
-   CFE_ES_AppId_t      AppId;                             /**< \brief Parent Application ID */
-   char                AppName[CFE_MISSION_MAX_API_LEN];  /**< \brief Parent Application Name */
+    CFE_ES_TaskId_t            TaskId;                            /**< \brief Task Id */
+    uint32                     ExecutionCounter;                  /**< \brief Task Execution Counter */
+    char                       TaskName[CFE_MISSION_MAX_API_LEN]; /**< \brief Task Name */
+    CFE_ES_AppId_t             AppId;                             /**< \brief Parent Application ID */
+    char                       AppName[CFE_MISSION_MAX_API_LEN];  /**< \brief Parent Application Name */
+    CFE_ES_MemOffset_t         StackSize;                         /**< Size of task stack */
+    CFE_ES_TaskPriority_Atom_t Priority;                          /**< Priority of task */
+    uint8                      Spare[2];                          /**< Spare bytes for alignment */
 } CFE_ES_TaskInfo_t;
 
 /**


### PR DESCRIPTION
**Describe the contribution**

Adds stack size and priority to the task info structure written by `CFE_ES_QUERY_ALL_TASKS_CC` command.

Fixes #979 

**Testing performed**
Build and run CFE, issue QUERY_ALL_TASKS command, confirm data is in the resulting file.
Run all unit tests.

**Expected behavior changes**
Adds two new fields to the file produced by the command.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
