### PR TITLE
Fix #1166, Remove deployment guide reference

### DIFF
--- a/cmake/README.md
+++ b/cmake/README.md
@@ -4,50 +4,21 @@ HOW TO BUILD USING CMAKE SCRIPTS
 
 This README file only covers the very basics of how to build a CFS mission
 using the CMake build scripts.  For a more in-depth guide and specific
-examples, see Appendix A of the cFS Deployment Guide.
+examples, see [OpenSatKit](https://github.com/OpenSatKit/OpenSatKit)
+and [CFS-101](https://github.com/nasa/CFS-101)
 
-Special Notes for the CFE 6.5.0 Open Source Release
+Quick Start+
 ---------------------------------------------------
 
-Quick instructions for doing a CMake based build:
+The cFS Bundle documents quick set-up, build, and run:
 
-* Get into the directory containing psp, cfe, tools, and apps.
+* [Setup](https://github.com/nasa/cFS#setup)
 
-* Get a proper copy of OSAL per instructions in osal/readme.txt
+* [Build and Run](https://github.com/nasa/cFS#build-and-run)
 
-* Delete any existing "build" tree (or rename it away).
+* [Send commands and Receive Telemetry](https://github.com/nasa/cFS#send-commands-receive-telemetry)
 
-* Copy the sample CMake configuration into the top:
-
-	cp cfe/cmake/Makefile.sample Makefile
-	cp -r cfe/cmake/sample\_defs sample\_defs
-
-The files in "sample\_defs" will need to be adjusted to meet the
-needs of your mission, but the sample values provided are sufficient
-for an initial build.
-
-* optional step: ask CMake to generate Makefiles, then stop:
-
-	make prep
-
-   This step is optional as it will automatically be done by
-   subsequent steps. It may be usful
-
-* optional step: compile programs for the target, then stop:
-
-	make
-
-   This prepares all objects for the target, but but will not copy
-   them into place in the final installation location. This step is
-   optional as it will automatically be done by the next step.
-
-* normal "all in one" command: build and prepare for deployment:
-
-	make install
-
-   Running this command at the top level of the tree will do all the
-   necessary steps to constuct the installation images as
-   subtrees found in:
+* After install, the following directories will be populated:
 
    * ``build/exe/host`` contains programs to be deployed to the ground
      station (or ground-station like machine).
@@ -66,7 +37,6 @@ compile source code using these libraries.
 
 * gcc, make, libc-dev, etc. - Standard prerequisites for any build environment.
 * cmake - The build system uses this.  Any recent version should work.
-* libexpat (XML parser) - Any recent version should work.
 * git - Required if you want to access the official CFS distribution directly
 from the CFS community source repositories.
 

--- a/cmake/sample_defs/cpu1_platform_cfg.h
+++ b/cmake/sample_defs/cpu1_platform_cfg.h
@@ -1390,8 +1390,7 @@
 **       CFE_PLATFORM_ES_MAX_BLOCK_SIZE must be larger than CFE_MISSION_SB_MAX_SB_MSG_SIZE and both
 **       CFE_PLATFORM_TBL_MAX_SNGL_TABLE_SIZE and CFE_PLATFORM_TBL_MAX_DBL_TABLE_SIZE.  Note that if Table
 **       Services have been removed from the CFE, the table size limits are still
-**       enforced although the table size definitions may be reduced.  Refer to the CFS
-**       Deployment Guide for information about removing CFE Table Services from the CFE.
+**       enforced although the table size definitions may be reduced.
 */
 #define CFE_PLATFORM_ES_MEM_BLOCK_SIZE_01              8
 #define CFE_PLATFORM_ES_MEM_BLOCK_SIZE_02             16

--- a/docs/cFE Application Developers Guide.md
+++ b/docs/cFE Application Developers Guide.md
@@ -582,10 +582,7 @@ Reference cFE API documentation for more detail on reset types.
 #### 5.5 Shared Libraries
 
 The cFE contains support for shared libraries. For the current version
-of the cFE, the shared libraries must be loaded on cFE startup (see the
-cFE Deployment Guide on how to modify the cfe_es_startup.scr in order
-to load a shared library at startup). The capability to add and remove
-shared libraries during runtime will be available in a later build.
+of the cFE, the shared libraries must be loaded on cFE startup.
 
 Reference sample_lib on Github for a “live” example.
 

--- a/docs/src/cfe_es.dox
+++ b/docs/src/cfe_es.dox
@@ -178,8 +178,7 @@
   \ref cfeesugsyslogsrv. The \ref cfeesugsyslogsrv 
   may also contain positive acknowledge messages regarding the startup script processing.
 
-  Refer to the CFS Deployment Guide for more 
-  information regarding the startup script. The startup script delivered with the 
+  The startup script delivered with the 
   cFE (<tt>cfe_es_startup.scr</tt>) also has some detailed information about the fields 
   and the settings.
     
@@ -299,9 +298,7 @@
   startup script contains a list of applications and library 
   routines to load and start immediately after the cFE finishes 
   its startup sequence. The parameters in the command, match the 
-  elements of an entry in the startup script. See the cFE Deployment 
-  Guide for more information about starting applications by way of 
-  the startup script. 
+  elements of an entry in the startup script.
 
   The format of the Start Application command, is defined in the 
   structure #CFE_ES_StartAppCmd_t. The members of the structure


### PR DESCRIPTION
**Describe the contribution**
Fix #1166 - Removes deployment guide reference from cmake/README.md

Partially addresses #1033 (removal of deployment guide reference)

**Testing performed**
N/A - readme update only

**Expected behavior changes**
None

**System(s) tested on**
N/A

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC