### PR TITLE
Fix #1165, remove configs about shells

### DIFF
--- a/cmake/sample_defs/cpu1_platform_cfg.h
+++ b/cmake/sample_defs/cpu1_platform_cfg.h
@@ -831,69 +831,6 @@
 #define CFE_PLATFORM_ES_VOLATILE_STARTUP_FILE  "/ram/cfe_es_startup.scr"
 
 /**
-**  \cfeescfg Default Shell Filename
-**
-**  \par Description:
-**       The value of this constant defines the filename used to store the shell
-**       output after a shell command is received by ES. This file contains the
-**       entire shell output. The fsw also sends the shell output in series of fixed
-**       size telemetry packets. This filename is used only when no filename
-**       is specified in the shell command.
-**
-**  \par Limits
-**       The length of each string, including the NULL terminator cannot exceed the
-**       #OS_MAX_PATH_LEN value.
-*/
-#define CFE_PLATFORM_ES_DEFAULT_SHELL_FILENAME  "/ram/ShellCmd.out"
-
-
-/**
-**  \cfeescfg Define Max Shell Command Size
-**
-**  \par Description:
-**       Defines the maximum size in characters of the shell command.
-**
-**  \par Limits
-**       There is a lower limit of 64 and an upper limit of #OS_MAX_CMD_LEN. Units are
-**       characters.
-*/
-#define CFE_PLATFORM_ES_MAX_SHELL_CMD  64
-
-
-/**
-**  \cfeescfg Define Shell Command Telemetry Pkt Segment Size
-**
-**  \par Description:
-**       Defines the size of the shell command tlm packet segments.The shell command
-**       output size is dependant on the shell command itself. If the shell output
-**       size is greater than the size of the packet defined here, the fsw will
-**       generate a series of tlm packets (of the size defined here) that can be
-**       reconstructed by the ground system.
-**
-**  \par Limits
-**       There is a lower limit of 32 and an upper limit of #CFE_MISSION_SB_MAX_SB_MSG_SIZE.
-*/
-#define CFE_PLATFORM_ES_MAX_SHELL_PKT    64
-
-/**
-**  \cfeescfg Define OS Task Delay Value for ES Shell Command
-**
-**  \par Description:
-**       This parameter defines the length of time (in milliseconds) ES will 
-**       delay when sending shell command packets over the software bus to not 
-**       flood the pipe on large messages.
-** 
-**       Note: The milliseconds passed into OS_TaskDelay are converted into the 
-**       units the underlying OS uses to measure time passing.  Many platforms 
-**       limit the precision of this value however, a delay may not be
-**       needed at all in which the value may be set to zero.
-**
-**  \par Limits
-**       Not Applicable
-*/
-#define CFE_PLATFORM_ES_SHELL_OS_DELAY_MILLISEC   200
-
-/**
 **  \cfeescfg Default Application Information Filename
 **
 **  \par Description:

--- a/cmake/sample_defs/sample_mission_cfg.h
+++ b/cmake/sample_defs/sample_mission_cfg.h
@@ -378,7 +378,6 @@
 #define CFE_MISSION_TBL_REG_TLM_MSG           12
 #define CFE_MISSION_SB_ALLSUBS_TLM_MSG        13
 #define CFE_MISSION_SB_ONESUB_TLM_MSG         14
-#define CFE_MISSION_ES_SHELL_TLM_MSG          15
 #define CFE_MISSION_ES_MEMSTATS_TLM_MSG       16
 
 /**
@@ -396,51 +395,6 @@
 **       to exceed the max length.
 */
 #define CFE_MISSION_ES_MAX_APPLICATIONS    16
-
-
-/**
-**  \cfeescfg Define Max Shell Command Size for messages
-**
-**  \par Description:
-**       Defines the maximum size in characters of the shell command.
-**
-**      This affects the layout of command/telemetry messages but does not affect run
-**      time behavior or internal allocation.
-**
-**  \par Limits
-**       All CPUs within the same SB domain (mission) must share the same definition
-**       Note this affects the size of messages, so it must not cause any message
-**       to exceed the max length.
-**
-**       This value should be kept as a multiple of 4, to maintain alignment of
-**       any possible neighboring fields without implicit padding.
-*/
-#define CFE_MISSION_ES_MAX_SHELL_CMD  64
-
-
-/**
-**  \cfeescfg Define Shell Command Telemetry Pkt Segment Size for messages
-**
-**  \par Description:
-**       Defines the size of the shell command tlm packet segments.The shell command
-**       output size is dependant on the shell command itself. If the shell output
-**       size is greater than the size of the packet defined here, the fsw will
-**       generate a series of tlm packets (of the size defined here) that can be
-**       reconstructed by the ground system.
-**
-**      This affects the layout of command/telemetry messages but does not affect run
-**      time behavior or internal allocation.
-**
-**  \par Limits
-**       All CPUs within the same SB domain (mission) must share the same definition
-**       Note this affects the size of messages, so it must not cause any message
-**       to exceed the max length.
-**
-**       This value should be kept as a multiple of 4, to maintain alignment of
-**       any possible neighboring fields without implicit padding.
-**
-*/
-#define CFE_MISSION_ES_MAX_SHELL_PKT    64
 
 /**
 **  \cfeescfg Define Max Number of Performance IDs for messages

--- a/fsw/cfe-core/src/es/cfe_es_verify.h
+++ b/fsw/cfe-core/src/es/cfe_es_verify.h
@@ -121,30 +121,6 @@
 #endif
 
 /* 
-** The size of a command to the OS that lies under the cFE 
-*/
-#if CFE_PLATFORM_ES_MAX_SHELL_CMD  <  64
-    #error CFE_PLATFORM_ES_MAX_SHELL_CMD cannot be less than 64!
-#endif
-
-/* 
-** The size of a command to the OS that lies under the cFE must avoid overflow 
-*/
-#if CFE_PLATFORM_ES_MAX_SHELL_CMD  >  OS_MAX_CMD_LEN
-    #error CFE_PLATFORM_ES_MAX_SHELL_CMD cannot be greater than OS_MAX_CMD_LEN!
-#endif
-
-/* 
-** The size of the chunks to break the output of the shell command into 
- * to send down in telemetry 
-*/
-#if CFE_PLATFORM_ES_MAX_SHELL_PKT  <  32
-    #error CFE_PLATFORM_ES_MAX_SHELL_PKT cannot be less than 32!
-#elif CFE_PLATFORM_ES_MAX_SHELL_PKT  >  CFE_MISSION_SB_MAX_SB_MSG_SIZE
-    #error CFE_PLATFORM_ES_MAX_SHELL_PKT cannot be greater than CFE_MISSION_SB_MAX_SB_MSG_SIZE!
-#endif
-
-/* 
 ** SysLog mode
 */
 #if CFE_PLATFORM_ES_DEFAULT_SYSLOG_MODE  <  0
@@ -352,12 +328,6 @@
 #endif
 #if ((CFE_MISSION_MAX_FILE_LEN % 4) != 0)
     #error CFE_MISSION_MAX_FILE_LEN must be a multiple of 4
-#endif
-#if ((CFE_MISSION_ES_MAX_SHELL_CMD % 4) != 0)
-    #error CFE_MISSION_ES_MAX_SHELL_CMD must be a multiple of 4
-#endif
-#if ((CFE_MISSION_ES_MAX_SHELL_PKT % 4) != 0)
-    #error CFE_MISSION_ES_MAX_SHELL_PKT must be a multiple of 4
 #endif
 #if ((CFE_MISSION_ES_CDS_MAX_NAME_LENGTH % 4) != 0)
     #error CFE_MISSION_ES_CDS_MAX_NAME_LENGTH must be a multiple of 4


### PR DESCRIPTION
**Describe the contribution**
Fixes #1165
removes unused configs relating to shell commands

**Testing performed**
Build and run unit test

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC