### PR TITLE
Fix #1172, Update to use Ut_Stub_CheckDefaultReturnValue API

### DIFF
--- a/fsw/cfe-core/ut-stubs/ut_tbl_stubs.c
+++ b/fsw/cfe-core/ut-stubs/ut_tbl_stubs.c
@@ -132,7 +132,7 @@ int32 CFE_TBL_GetAddress (void **TblPtr, CFE_TBL_Handle_t TblHandle)
     int32 ForceValue;
     
     status = UT_DEFAULT_IMPL(CFE_TBL_GetAddress);
-    if (status >= 0 && !UT_Stub_CheckForceFail(UT_KEY(CFE_TBL_GetAddress), &ForceValue))
+    if (status >= 0 && !UT_Stub_CheckDefaultReturnValue(UT_KEY(CFE_TBL_GetAddress), &ForceValue))
     {
         UT_Stub_CopyToLocal(UT_KEY(CFE_TBL_GetAddress), (uint8 *)TblPtr, sizeof(void*));
     }


### PR DESCRIPTION
**Describe the contribution**
Fix #1172 - updates API name for nasa/osal#737 fix

**Testing performed**
Build and execute unit tests

**Expected behavior changes**
None, name change (as long as corresponding nasa/osal#823 in)

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + nasa/osal#823 + this commit

**Additional context**
Depends on osal PR

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC