### PR TITLE
Fix #1160, Shorten task info default filename

### DIFF
--- a/cmake/sample_defs/cpu1_platform_cfg.h
+++ b/cmake/sample_defs/cpu1_platform_cfg.h
@@ -901,7 +901,7 @@
 **       The length of each string, including the NULL terminator cannot exceed the
 **       #OS_MAX_PATH_LEN value.
 */
-#define CFE_PLATFORM_ES_DEFAULT_TASK_LOG_FILE   "/ram/cfe_es_task_info.log"
+#define CFE_PLATFORM_ES_DEFAULT_TASK_LOG_FILE   "/ram/cfe_es_taskinfo.log"
 
 /**
 **  \cfeescfg Default System Log Filename


### PR DESCRIPTION
**Describe the contribution**
Fix #1160 - shortened `CFE_PLATFORM_ES_DEFAULT_TASK_LOG_FILE` name so it is within the `OSAL_MAX_FILE_NAME` size limit

**Testing performed**
Built and ran unit tests, passed.  Ran cFS and sent `CFE_ES_QUERY_ALL_TASKS_CC` command, confirmed file was generated.

**Expected behavior changes**
Will now output task info to default filename if no filename is provided in command.

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC