### PR TITLE
Fix #1153, Remove logic based on LogEnabled status

### DIFF
--- a/fsw/cfe-core/src/inc/cfe_error.h
+++ b/fsw/cfe-core/src/inc/cfe_error.h
@@ -264,15 +264,6 @@ typedef int32 CFE_Status_t;
 #define CFE_EVS_INVALID_PARAMETER ((CFE_Status_t)0xc2000008)
 
 /**
- * @brief Function Disabled
- *
- *  EVS command sent that requires a feature currently turned off
- *  This is to differentiate between "NOT_IMPLEMENTED" where the
- *  feature IS implemented but it is disabled at runtime.
- */
-#define CFE_EVS_FUNCTION_DISABLED ((CFE_Status_t)0xc2000009)
-
-/**
  * @brief Not Implemented
  *
  *  Current version of cFE does not have the function or the feature

--- a/fsw/cfe-core/src/inc/cfe_evs_events.h
+++ b/fsw/cfe-core/src/inc/cfe_evs_events.h
@@ -533,51 +533,6 @@
 **/
 #define CFE_EVS_WRLOG_EID                 33
 
-/** \brief <tt> 'Set Log Mode Command: Event Log is Disabled' </tt>
-**  \event <tt> 'Set Log Mode Command: Event Log is Disabled' </tt> 
-**
-**  \par Type: ERROR
-**
-**  \par Cause:
-**
-**  This event message is generated upon receipt of a "Set Log Mode"
-**  command when the use of the Event Log has been disabled. The EVS task
-**  must succeed during task initialization in acquiring a pointer to
-**  the cFE reset area and in the creation of a serializing semaphore to
-**  control access to the Event Log.
-**/
-#define CFE_EVS_NO_LOGSET_EID             34
-
-/** \brief <tt> 'Clear Log Command: Event Log is Disabled' </tt>
-**  \event <tt> 'Clear Log Command: Event Log is Disabled' </tt> 
-**
-**  \par Type: ERROR
-**
-**  \par Cause:
-**
-**  This event message is generated upon receipt of a "Clear Log"
-**  command when the use of the Event Log has been disabled. The EVS task
-**  must succeed during task initialization in acquiring a pointer to
-**  the cFE reset area and in the creation of a serializing semaphore to
-**  control access to the Event Log.
-**/
-#define CFE_EVS_NO_LOGCLR_EID             35
-
-/** \brief <tt> 'Write Log Command: Event Log is Disabled' </tt>
-**  \event <tt> 'Write Log Command: Event Log is Disabled' </tt> 
-**
-**  \par Type: ERROR
-**
-**  \par Cause:
-**
-**  This event message is generated upon receipt of a "Write Log"
-**  command when the use of the Event Log has been disabled. The EVS task
-**  must succeed during task initialization in acquiring a pointer to
-**  the cFE reset area and in the creation of a serializing semaphore to
-**  control access to the Event Log.
-**/
-#define CFE_EVS_NO_LOGWR_EID              36
-
 /** \brief <tt> 'Add Filter Command:AppName = \%s, EventID = 0x\%08x is already registered for filtering' </tt>
 **  \event <tt> 'Add Filter Command:AppName = \%s, EventID = 0x\%08x is already registered for filtering' </tt> 
 **


### PR DESCRIPTION
**Describe the contribution**
Fix #1153 - no longer utilizing the LogEnabled element in HK telemetry for EVS logic, log is always enabled in this implementation

**Testing performed**
Built and executed unit tests, passed

**Expected behavior changes**
No real change, but on failures (reset area or semaphore) will panic.

**System(s) tested on**
 - Hardware: [e.g. PC, SP0, MCP750]
 - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Confirmed still getting 100% line coverage

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC