### PR TITLE
Fix #1189, correct compiler warnings

### DIFF
--- a/fsw/cfe-core/src/inc/private/cfe_sbr.h
+++ b/fsw/cfe-core/src/inc/private/cfe_sbr.h
@@ -38,6 +38,13 @@
 #include "cfe_msg_typedefs.h"
 #include "cfe_platform_cfg.h"
 
+/*
+ * Macro Definitions
+ */
+
+/** \brief Invalid route id */
+#define CFE_SBR_INVALID_ROUTE_ID ((CFE_SBR_RouteId_t) {.RouteId = 0})
+
 /******************************************************************************
  * Type Definitions
  */

--- a/fsw/cfe-core/src/sb/cfe_sb_api.c
+++ b/fsw/cfe-core/src/sb/cfe_sb_api.c
@@ -1397,6 +1397,7 @@ int32  CFE_SB_TransmitMsg(CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount
 
     PendingEventID = 0;
     BufDscPtr = NULL;
+    RouteId = CFE_SBR_INVALID_ROUTE_ID;
 
     Status = CFE_SB_TransmitMsgValidate(MsgPtr, &MsgId, &Size, &RouteId);
 
@@ -1886,6 +1887,7 @@ int32  CFE_SB_ReceiveBuffer(CFE_SB_Buffer_t **BufPtr,
     BufDscPtr = NULL;
     DestPtr = NULL;
     BufDscSize = 0;
+    RcvStatus = OS_SUCCESS;
     
     /*
      * Check input args and see if any are bad, which require

--- a/modules/sbr/private_inc/cfe_sbr_priv.h
+++ b/modules/sbr/private_inc/cfe_sbr_priv.h
@@ -31,12 +31,6 @@
  */
 #include "private/cfe_sbr.h"
 
-/*
- * Macro Definitions
- */
-
-/** \brief Invalid route id */
-#define CFE_SBR_INVALID_ROUTE_ID ((CFE_SBR_RouteId_t) {.RouteId = 0})
 
 /******************************************************************************
  * Function prototypes


### PR DESCRIPTION
**Describe the contribution**
Corrects some (false) warnings about use before init.
Also corrects an alignment warning and removes unneeded union type (union type is not the best way to deal with this situation).

Fixes #1189 

**Testing performed**
Build and sanity check CFE for Raspberry Pi (older GCC w/strict alignment) and native (64-bit)
Run all unit tests

**Expected behavior changes**
None, just compiler warning fixes

**System(s) tested on**
Ubuntu 20.04 (native)
Raspbian (cross compiled; gcc 4.9.3)

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
