### PR TITLE
Fix #1217, bit order macros

### DIFF
--- a/modules/core_api/fsw/inc/cfe_endian.h
+++ b/modules/core_api/fsw/inc/cfe_endian.h
@@ -34,6 +34,30 @@
 */
 #include "common_types.h"
 
+/*
+ * SOFTWARE_BIG/LITTLE_BIT_ORDER COMPATIBILITY MACRO -
+ *
+ * This is provided only for backward compatibilty.  Do not write any new code that
+ * uses this macro.
+ */
+#if !defined(SOFTWARE_BIG_BIT_ORDER) && !defined(SOFTWARE_LITTLE_BIT_ORDER)
+
+#if defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN || defined(__BIG_ENDIAN__) || defined(__ARMEB__) || \
+    defined(__THUMBEB__) || defined(__AARCH64EB__) || defined(_MIBSEB) || defined(__MIBSEB) || defined(__MIBSEB__)
+/* It is a big-endian target architecture */
+#define SOFTWARE_BIG_BIT_ORDER
+#elif defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN || defined(__LITTLE_ENDIAN__) || defined(__ARMEL__) || \
+    defined(__THUMBEL__) || defined(__AARCH64EL__) || defined(_MIPSEL) || defined(__MIPSEL) || defined(__MIPSEL__) || \
+    defined(__i386) || defined(__i386__) || defined(__i686) || defined(__i686__) || defined(__x86_64) ||              \
+    defined(__x86_64__)
+/* It is a little-endian target architecture */
+#define SOFTWARE_LITTLE_BIT_ORDER
+#else
+#error Unknown byte order on this platform
+#endif
+
+#endif /* !defined(SOFTWARE_BIG_BIT_ORDER) && !defined(SOFTWARE_LITTLE_BIT_ORDER) */
+
 /* Macro to convert 16/32 bit types from platform "endianness" to Big Endian */
 #ifdef SOFTWARE_BIG_BIT_ORDER
 #define CFE_MAKE_BIG16(n) (n)


### PR DESCRIPTION
**Describe the contribution**
Provide a local definition of SOFTWARE_BIG/LITTLE_BIT_ORDER directly inside `cfe_endian.h` to provide a compatible symbol for 
apps that still require this.  This allows CFE to build and run successfully when OSAL stops providing this in common_types.h.

Fixes #1217 

**Testing performed**
Build and sanity check CFE, run all unit tests

**Expected behavior changes**
Maintains backward compatibility after nasa/osal#843

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Prerequisite of nasa/osal#843.  This PR is needed in same merge cycle or before.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
