### PR TITLE
Fix #1224, reinstate recipes for coverage test

### DIFF
--- a/modules/core_private/fsw/inc/cfe_time_resetvars_typedef.h
+++ b/modules/core_private/fsw/inc/cfe_time_resetvars_typedef.h
@@ -41,6 +41,8 @@
 #include "common_types.h"
 #include "cfe_time_extern_typedefs.h"
 
+#define CFE_TIME_RESET_SIGNATURE 0xA5A55A5A
+
 /**
 **  \brief Time related variables that are maintained through a Processor Reset
 **

--- a/modules/core_private/ut-stubs/src/ut_support.c
+++ b/modules/core_private/ut-stubs/src/ut_support.c
@@ -33,6 +33,7 @@
 ** Includes
 */
 #include "ut_support.h"
+#include "cfe_core_resourceid_basevalues.h"
 
 #include <string.h>
 
@@ -163,6 +164,11 @@ void UT_InitData(void)
      * This should return the UT_appname
      */
     UT_SetDataBuffer(UT_KEY(CFE_ES_GetAppName), (uint8 *)UT_appname, sizeof(UT_appname), false);
+
+    /*
+     * Set up CFE_ES_GetAppID() to return the equivalent of AppID 1 by default
+     */
+    UT_SetAppID(CFE_ES_APPID_C(CFE_ResourceId_FromInteger(CFE_ES_APPID_BASE + 1)));
 
     /*
      * Reset the OSAL stubs to the default state

--- a/modules/es/ut-coverage/CMakeLists.txt
+++ b/modules/es/ut-coverage/CMakeLists.txt
@@ -4,4 +4,19 @@
 #
 ##################################################################
 
-# Nothing yet - placeholder for future use
+foreach(SRC ${es_SOURCES})
+    list(APPEND UT_SOURCES "${CFE_ES_SOURCE_DIR}/${SRC}")
+endforeach()
+
+add_cfe_coverage_test(es ALL
+    "es_UT.c"
+    "${UT_SOURCES}"
+)
+
+# This permits UT test cases to directly access private headers in the fsw/src dir
+target_include_directories(coverage-es-ALL-testrunner PRIVATE
+    ${CFE_ES_SOURCE_DIR}/fsw/src
+)
+
+target_link_libraries(coverage-es-ALL-testrunner ut_core_private_stubs)
+

--- a/modules/es/ut-coverage/es_UT.h
+++ b/modules/es/ut-coverage/es_UT.h
@@ -47,21 +47,12 @@
 ** Includes
 */
 #include <string.h>
-#include "cfe.h"
-#include "common_types.h"
-#include "osapi.h"
+#include "cfe_es_module_all.h"
+#include "cfe_time_core_internal.h"
+#include "cfe_tbl_core_internal.h"
+#include "cfe_evs_core_internal.h"
+#include "cfe_sb_core_internal.h"
 #include "cfe_version.h"
-#include "cfe_es.h"
-#include "cfe_es_cds.h"
-#include "cfe_es_cds_mempool.h"
-#include "cfe_es_generic_pool.h"
-#include "cfe_es_global.h"
-#include "cfe_es_resource.h"
-#include "cfe_es_log.h"
-#include "cfe_es_perf.h"
-#include "cfe_es_task.h"
-#include "cfe_es_verify.h"
-#include "cfe_es_start.h"
 #include "ut_support.h"
 #include "ut_osprintf_stubs.h"
 

--- a/modules/evs/ut-coverage/CMakeLists.txt
+++ b/modules/evs/ut-coverage/CMakeLists.txt
@@ -4,4 +4,20 @@
 #
 ##################################################################
 
-# Nothing yet - placeholder for future use
+
+foreach(SRC ${evs_SOURCES})
+    list(APPEND UT_SOURCES "${CFE_EVS_SOURCE_DIR}/${SRC}")
+endforeach()
+
+add_cfe_coverage_test(evs ALL
+    "evs_UT.c"
+    "${UT_SOURCES}"
+)
+
+# This permits UT test cases to directly access private headers in the fsw/src dir
+target_include_directories(coverage-evs-ALL-testrunner PRIVATE
+    ${CFE_EVS_SOURCE_DIR}/fsw/src
+)
+
+target_link_libraries(coverage-evs-ALL-testrunner ut_core_private_stubs)
+

--- a/modules/evs/ut-coverage/evs_UT.h
+++ b/modules/evs/ut-coverage/evs_UT.h
@@ -41,16 +41,7 @@
 ** Includes
 */
 #include <string.h>
-#include "cfe.h"
-#include "common_types.h"
-#include "osapi.h"
-#include "cfe_evs.h"
-#include "cfe_evs_log.h"
-#include "cfe_evs_task.h"
-#include "cfe_evs_utils.h"
-#include "cfe_sb.h"
-#include "cfe_es.h"
-#include "cfe_time.h"
+#include "cfe_evs_module_all.h"
 #include "ut_support.h"
 
 /* EVS unit test functions */

--- a/modules/fs/ut-coverage/CMakeLists.txt
+++ b/modules/fs/ut-coverage/CMakeLists.txt
@@ -4,4 +4,20 @@
 #
 ##################################################################
 
-# Nothing yet - placeholder for future use
+
+foreach(SRC ${fs_SOURCES})
+    list(APPEND UT_SOURCES "${CFE_FS_SOURCE_DIR}/${SRC}")
+endforeach()
+
+add_cfe_coverage_test(fs ALL
+    "fs_UT.c"
+    "${UT_SOURCES}"
+)
+
+# This permits UT test cases to directly access private headers in the fsw/src dir
+target_include_directories(coverage-fs-ALL-testrunner PRIVATE
+    ${CFE_FS_SOURCE_DIR}/fsw/src
+)
+
+target_link_libraries(coverage-fs-ALL-testrunner ut_core_private_stubs)
+

--- a/modules/fs/ut-coverage/fs_UT.h
+++ b/modules/fs/ut-coverage/fs_UT.h
@@ -44,10 +44,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
-#include "cfe.h"
-#include "cfe_fs.h"
-#include "cfe_fs_priv.h"
-#include "common_types.h"
+#include "cfe_fs_module_all.h"
 #include "ut_support.h"
 
 /* FS unit test functions */

--- a/modules/sb/ut-coverage/CMakeLists.txt
+++ b/modules/sb/ut-coverage/CMakeLists.txt
@@ -4,4 +4,20 @@
 #
 ##################################################################
 
-# Nothing yet - placeholder for future use
+foreach(SRC ${sb_SOURCES})
+    list(APPEND UT_SOURCES "${CFE_SB_SOURCE_DIR}/${SRC}")
+endforeach()
+
+add_cfe_coverage_test(sb ALL
+    "sb_UT.c"
+    "${UT_SOURCES}"
+)
+
+# This permits UT test cases to directly access private headers in the fsw/src dir
+target_include_directories(coverage-sb-ALL-testrunner PRIVATE
+    ${CFE_SB_SOURCE_DIR}/fsw/src
+)
+
+# The SB tests currently link with the _real_ SBR implementation (not a stub)
+target_link_libraries(coverage-sb-ALL-testrunner ut_core_private_stubs sbr)
+

--- a/modules/sb/ut-coverage/sb_UT.h
+++ b/modules/sb/ut-coverage/sb_UT.h
@@ -41,11 +41,7 @@
 ** Includes
 */
 #include <string.h>
-#include "cfe.h"
-#include "cfe_sb_events.h"
-#include "cfe_sb_priv.h"
-#include "osapi.h"
-#include "common_types.h"
+#include "cfe_sb_module_all.h"
 #include "ut_support.h"
 
 /*

--- a/modules/tbl/ut-coverage/CMakeLists.txt
+++ b/modules/tbl/ut-coverage/CMakeLists.txt
@@ -4,4 +4,21 @@
 #
 ##################################################################
 
-# Nothing yet - placeholder for future use
+
+foreach(SRC ${tbl_SOURCES})
+    list(APPEND UT_SOURCES "${CFE_TBL_SOURCE_DIR}/${SRC}")
+endforeach()
+
+add_cfe_coverage_test(tbl ALL
+    "tbl_UT.c"
+    "${UT_SOURCES}"
+)
+
+# This permits UT test cases to directly access private headers in the fsw/src dir
+target_include_directories(coverage-tbl-ALL-testrunner PRIVATE
+    ${CFE_TBL_SOURCE_DIR}/fsw/src
+)
+
+target_link_libraries(coverage-tbl-ALL-testrunner ut_core_private_stubs)
+
+

--- a/modules/tbl/ut-coverage/tbl_UT.h
+++ b/modules/tbl/ut-coverage/tbl_UT.h
@@ -41,14 +41,8 @@
 ** Includes
 */
 #include <string.h>
-#include "cfe.h"
-#include "cfe_tbl.h"
-#include "common_types.h"
-#include "ut_support.h"
-#include "cfe_tbl_msg.h"
 #include "cfe_tbl_module_all.h"
-#include "cfe_tbl_task.h"
-#include "cfe_tbl_task_cmds.h"
+#include "ut_support.h"
 
 typedef struct
 {

--- a/modules/time/fsw/src/cfe_time_utils.h
+++ b/modules/time/fsw/src/cfe_time_utils.h
@@ -49,8 +49,7 @@
 /*
 ** Main task definitions...
 */
-#define CFE_TIME_TASK_NAME       "CFE_TIME"
-#define CFE_TIME_RESET_SIGNATURE 0xA5A55A5A
+#define CFE_TIME_TASK_NAME "CFE_TIME"
 
 /*
 ** Interrupt task definitions...

--- a/modules/time/ut-coverage/CMakeLists.txt
+++ b/modules/time/ut-coverage/CMakeLists.txt
@@ -4,4 +4,21 @@
 #
 ##################################################################
 
-# Nothing yet - placeholder for future use
+
+foreach(SRC ${time_SOURCES})
+    list(APPEND UT_SOURCES "${CFE_TIME_SOURCE_DIR}/${SRC}")
+endforeach()
+
+add_cfe_coverage_test(time ALL
+    "time_UT.c"
+    "${UT_SOURCES}"
+)
+
+# This permits UT test cases to directly access private headers in the fsw/src dir
+target_include_directories(coverage-time-ALL-testrunner PRIVATE
+    ${CFE_TIME_SOURCE_DIR}/fsw/src
+)
+
+target_link_libraries(coverage-time-ALL-testrunner ut_core_private_stubs)
+
+

--- a/modules/time/ut-coverage/time_UT.h
+++ b/modules/time/ut-coverage/time_UT.h
@@ -41,12 +41,7 @@
 ** Includes
 */
 #include <string.h>
-#include "cfe_platform_cfg.h"
-#include "cfe_sb.h"
-#include "cfe_time.h"
-#include "cfe_time_msg.h"
-#include "cfe_time_utils.h"
-#include "common_types.h"
+#include "cfe_time_module_all.h"
 #include "ut_support.h"
 
 /*


### PR DESCRIPTION
**Describe the contribution**
Builds the CFE coverage tests using new CMake functions.  Also requires fixing up some include directives in UT headers to make this all work correctly.

Fixes #1224

**Testing performed**
Build and run unit tests, confirm that cFE core module coverage tests are now part of the group as they should be.

**Expected behavior changes**
cFE core coverage tests are built.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.