### PR TITLE
Fix #1164, use FS file name parser for commands

### DIFF
--- a/modules/evs/fsw/src/cfe_evs_task.c
+++ b/modules/evs/fsw/src/cfe_evs_task.c
@@ -1693,20 +1693,33 @@ int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFileCmd_t *data)
     const CFE_EVS_AppDataCmd_Payload_t *CmdPtr = &data->Payload;
     char                                LocalName[OS_MAX_PATH_LEN];
 
-    /* Copy the commanded filename into local buffer to ensure size limitation and to allow for modification */
-    CFE_SB_MessageStringGet(LocalName, CmdPtr->AppDataFilename, CFE_PLATFORM_EVS_DEFAULT_APP_DATA_FILE,
-                            sizeof(LocalName), sizeof(CmdPtr->AppDataFilename));
+    /*
+    ** Copy the filename into local buffer with default name/path/extension if not specified
+    */
+    Result = CFE_FS_ParseInputFileNameEx(LocalName, CmdPtr->AppDataFilename, sizeof(LocalName),
+                                         sizeof(CmdPtr->AppDataFilename), CFE_PLATFORM_EVS_DEFAULT_APP_DATA_FILE,
+                                         CFE_FS_GetDefaultMountPoint(CFE_FS_FileCategory_BINARY_DATA_DUMP),
+                                         CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_BINARY_DATA_DUMP));
 
-    /* Create Application Data File */
-    Result = OS_OpenCreate(&FileHandle, LocalName, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
-
-    if (Result < OS_SUCCESS)
+    if (Result != CFE_SUCCESS)
     {
         EVS_SendEvent(CFE_EVS_ERR_CRDATFILE_EID, CFE_EVS_EventType_ERROR,
-                      "Write App Data Command Error: OS_OpenCreate = 0x%08X, filename = %s", (unsigned int)Result,
-                      LocalName);
+                      "Write App Data Command Error: CFE_FS_ParseInputFileNameEx() = 0x%08X", (unsigned int)Result);
     }
     else
+    {
+        /* Create Application Data File */
+        Result = OS_OpenCreate(&FileHandle, LocalName, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
+
+        if (Result != OS_SUCCESS)
+        {
+            EVS_SendEvent(CFE_EVS_ERR_CRDATFILE_EID, CFE_EVS_EventType_ERROR,
+                          "Write App Data Command Error: OS_OpenCreate = 0x%08X, filename = %s", (unsigned int)Result,
+                          LocalName);
+        }
+    }
+
+    if (Result == OS_SUCCESS)
     {
         /* Result will be overridden if everything works */
         Result = CFE_EVS_FILE_WRITE_ERROR;

--- a/modules/evs/ut-coverage/evs_UT.c
+++ b/modules/evs/ut-coverage/evs_UT.c
@@ -1023,6 +1023,12 @@ void Test_Logging(void)
     UT_Report(__FILE__, __LINE__, CFE_EVS_WriteLogDataFileCmd(&CmdBuf.logfilecmd) == CFE_SUCCESS,
               "CFE_EVS_WriteLogDataFileCmd", "Write single event log entry - successful (default log name)");
 
+    /* Test writing a log entry with a file name failure */
+    UT_InitData();
+    UT_SetDeferredRetcode(UT_KEY(CFE_FS_ParseInputFileNameEx), 1, CFE_FS_INVALID_PATH);
+    UT_Report(__FILE__, __LINE__, CFE_EVS_WriteLogDataFileCmd(&CmdBuf.logfilecmd) != CFE_SUCCESS,
+              "CFE_EVS_WriteLogDataFileCmd", "FS parse filename failure");
+
     /* Test writing a log entry with a create failure */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(OS_MutSemCreate), 1, OS_SUCCESS);
@@ -1112,6 +1118,14 @@ void Test_WriteApp(void)
                                  UT_TPID_CFE_EVS_CMD_WRITE_APP_DATA_FILE_CC, &UT_EVS_EventBuf);
     UT_Report(__FILE__, __LINE__, UT_EVS_EventBuf.EventID == CFE_EVS_ERR_CRDATFILE_EID, "CFE_EVS_WriteAppDataFileCmd",
               "OS create fail (default file name)");
+
+    /* Test writing application data with bad file name */
+    UT_InitData();
+    UT_SetDeferredRetcode(UT_KEY(CFE_FS_ParseInputFileNameEx), 1, CFE_FS_INVALID_PATH);
+    UT_EVS_DoDispatchCheckEvents(&CmdBuf.AppDataCmd, sizeof(CmdBuf.AppDataCmd),
+                                 UT_TPID_CFE_EVS_CMD_WRITE_APP_DATA_FILE_CC, &UT_EVS_EventBuf);
+    UT_Report(__FILE__, __LINE__, UT_EVS_EventBuf.EventID == CFE_EVS_ERR_CRDATFILE_EID, "CFE_EVS_WriteAppDataFileCmd",
+              "parse filename failure");
 
     /* Test writing application data with a write/close failure */
     UT_InitData();

--- a/modules/sb/fsw/src/cfe_sb_task.c
+++ b/modules/sb/fsw/src/cfe_sb_task.c
@@ -1022,11 +1022,6 @@ int32 CFE_SB_WriteRoutingInfoCmd(const CFE_SB_WriteRoutingInfoCmd_t *data)
         /* Reset the entire state object (just for good measure, ensure no stale data) */
         memset(StatePtr, 0, sizeof(*StatePtr));
 
-        /* Copy the commanded filename into local buffer to ensure size limitation and to allow for modification */
-        CFE_SB_MessageStringGet(StatePtr->FileWrite.FileName, CmdPtr->Filename,
-                                CFE_PLATFORM_SB_DEFAULT_ROUTING_FILENAME, sizeof(StatePtr->FileWrite.FileName),
-                                sizeof(CmdPtr->Filename));
-
         /*
          * Fill out the remainder of meta data.
          * This data is currently the same for every request
@@ -1037,7 +1032,19 @@ int32 CFE_SB_WriteRoutingInfoCmd(const CFE_SB_WriteRoutingInfoCmd_t *data)
         StatePtr->FileWrite.GetData = CFE_SB_WriteRouteInfoDataGetter;
         StatePtr->FileWrite.OnEvent = CFE_SB_BackgroundFileEventHandler;
 
-        Status = CFE_FS_BackgroundFileDumpRequest(&StatePtr->FileWrite);
+        /*
+        ** Copy the filename into local buffer with default name/path/extension if not specified
+        */
+        Status = CFE_FS_ParseInputFileNameEx(StatePtr->FileWrite.FileName, CmdPtr->Filename,
+                                             sizeof(StatePtr->FileWrite.FileName), sizeof(CmdPtr->Filename),
+                                             CFE_PLATFORM_SB_DEFAULT_ROUTING_FILENAME,
+                                             CFE_FS_GetDefaultMountPoint(CFE_FS_FileCategory_BINARY_DATA_DUMP),
+                                             CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_BINARY_DATA_DUMP));
+
+        if (Status == CFE_SUCCESS)
+        {
+            Status = CFE_FS_BackgroundFileDumpRequest(&StatePtr->FileWrite);
+        }
     }
     else
     {
@@ -1153,10 +1160,6 @@ int32 CFE_SB_WritePipeInfoCmd(const CFE_SB_WritePipeInfoCmd_t *data)
         /* Reset the entire state object (just for good measure, ensure no stale data) */
         memset(StatePtr, 0, sizeof(*StatePtr));
 
-        /* Copy the commanded filename into local buffer to ensure size limitation and to allow for modification */
-        CFE_SB_MessageStringGet(StatePtr->FileWrite.FileName, CmdPtr->Filename, CFE_PLATFORM_SB_DEFAULT_PIPE_FILENAME,
-                                sizeof(StatePtr->FileWrite.FileName), sizeof(CmdPtr->Filename));
-
         /*
          * Fill out the remainder of meta data.
          * This data is currently the same for every request
@@ -1167,7 +1170,19 @@ int32 CFE_SB_WritePipeInfoCmd(const CFE_SB_WritePipeInfoCmd_t *data)
         StatePtr->FileWrite.GetData = CFE_SB_WritePipeInfoDataGetter;
         StatePtr->FileWrite.OnEvent = CFE_SB_BackgroundFileEventHandler;
 
-        Status = CFE_FS_BackgroundFileDumpRequest(&StatePtr->FileWrite);
+        /*
+        ** Copy the filename into local buffer with default name/path/extension if not specified
+        */
+        Status = CFE_FS_ParseInputFileNameEx(StatePtr->FileWrite.FileName, CmdPtr->Filename,
+                                             sizeof(StatePtr->FileWrite.FileName), sizeof(CmdPtr->Filename),
+                                             CFE_PLATFORM_SB_DEFAULT_PIPE_FILENAME,
+                                             CFE_FS_GetDefaultMountPoint(CFE_FS_FileCategory_BINARY_DATA_DUMP),
+                                             CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_BINARY_DATA_DUMP));
+
+        if (Status == CFE_SUCCESS)
+        {
+            Status = CFE_FS_BackgroundFileDumpRequest(&StatePtr->FileWrite);
+        }
     }
     else
     {
@@ -1261,10 +1276,6 @@ int32 CFE_SB_WriteMapInfoCmd(const CFE_SB_WriteMapInfoCmd_t *data)
         /* Reset the entire state object (just for good measure, ensure no stale data) */
         memset(StatePtr, 0, sizeof(*StatePtr));
 
-        /* Copy the commanded filename into local buffer to ensure size limitation and to allow for modification */
-        CFE_SB_MessageStringGet(StatePtr->FileWrite.FileName, CmdPtr->Filename, CFE_PLATFORM_SB_DEFAULT_MAP_FILENAME,
-                                sizeof(StatePtr->FileWrite.FileName), sizeof(CmdPtr->Filename));
-
         /*
          * Fill out the remainder of meta data.
          * This data is currently the same for every request
@@ -1275,7 +1286,19 @@ int32 CFE_SB_WriteMapInfoCmd(const CFE_SB_WriteMapInfoCmd_t *data)
         StatePtr->FileWrite.GetData = CFE_SB_WriteMsgMapInfoDataGetter;
         StatePtr->FileWrite.OnEvent = CFE_SB_BackgroundFileEventHandler;
 
-        Status = CFE_FS_BackgroundFileDumpRequest(&StatePtr->FileWrite);
+        /*
+        ** Copy the filename into local buffer with default name/path/extension if not specified
+        */
+        Status = CFE_FS_ParseInputFileNameEx(StatePtr->FileWrite.FileName, CmdPtr->Filename,
+                                             sizeof(StatePtr->FileWrite.FileName), sizeof(CmdPtr->Filename),
+                                             CFE_PLATFORM_SB_DEFAULT_MAP_FILENAME,
+                                             CFE_FS_GetDefaultMountPoint(CFE_FS_FileCategory_BINARY_DATA_DUMP),
+                                             CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_BINARY_DATA_DUMP));
+
+        if (Status == CFE_SUCCESS)
+        {
+            Status = CFE_FS_BackgroundFileDumpRequest(&StatePtr->FileWrite);
+        }
     }
     else
     {

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -529,6 +529,15 @@ void Test_SB_Cmds_RoutingInfoDef(void)
 
     EVTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
+    /* Also test with a bad file name - should generate CFE_SB_SND_RTG_ERR1_EID */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+    UT_SetDeferredRetcode(UT_KEY(CFE_FS_ParseInputFileNameEx), 1, CFE_FS_INVALID_PATH);
+    CFE_SB_ProcessCmdPipePkt(&WriteRoutingInfo.SBBuf);
+
+    EVTSENT(CFE_SB_SND_RTG_ERR1_EID);
+
     TEARDOWN(CFE_SB_DeletePipe(CFE_SB_Global.CmdPipe));
 
 } /* end Test_SB_Cmds_RoutingInfoDef */
@@ -643,6 +652,14 @@ void Test_SB_Cmds_PipeInfoDef(void)
     EVTCNT(3);
 
     EVTSENT(CFE_SB_PIPE_ADDED_EID);
+
+    /* Also test with a bad file name - should generate CFE_SB_SND_RTG_ERR1_EID */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+    UT_SetDeferredRetcode(UT_KEY(CFE_FS_ParseInputFileNameEx), 1, CFE_FS_INVALID_PATH);
+    CFE_SB_ProcessCmdPipePkt(&WritePipeInfo.SBBuf);
+    EVTSENT(CFE_SB_SND_RTG_ERR1_EID);
 
     TEARDOWN(CFE_SB_DeletePipe(PipeId1));
     TEARDOWN(CFE_SB_DeletePipe(PipeId2));
@@ -846,6 +863,14 @@ void Test_SB_Cmds_MapInfoDef(void)
     EVTSENT(CFE_SB_PIPE_ADDED_EID);
 
     EVTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+
+    /* Also test with a bad file name - should generate CFE_SB_SND_RTG_ERR1_EID */
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+    UT_SetDeferredRetcode(UT_KEY(CFE_FS_ParseInputFileNameEx), 1, CFE_FS_INVALID_PATH);
+    CFE_SB_ProcessCmdPipePkt(&WriteMapInfo.SBBuf);
+    EVTSENT(CFE_SB_SND_RTG_ERR1_EID);
 
     TEARDOWN(CFE_SB_DeletePipe(PipeId1));
     TEARDOWN(CFE_SB_DeletePipe(PipeId2));

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
@@ -1230,11 +1230,6 @@ int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data)
     /* If a reg dump was already pending, do not overwrite the current request */
     if (!CFE_FS_BackgroundFileDumpIsPending(&StatePtr->FileWrite))
     {
-        /* Copy the commanded filename into local buffer to ensure size limitation and to allow for modification */
-        CFE_SB_MessageStringGet(StatePtr->FileWrite.FileName, CmdPtr->DumpFilename,
-                                CFE_PLATFORM_TBL_DEFAULT_REG_DUMP_FILE, sizeof(StatePtr->FileWrite.FileName),
-                                sizeof(CmdPtr->DumpFilename));
-
         /*
          * Fill out the remainder of meta data.
          * This data is currently the same for every request
@@ -1246,19 +1241,30 @@ int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data)
         StatePtr->FileWrite.OnEvent = CFE_TBL_DumpRegistryEventHandler;
 
         /*
-         * Before submitting the background request, use OS_stat() to check if the file exists already.
-         *
-         * This is because TBL services issued a different event ID in some cases if
-         * it is overwriting a file vs. creating a new file.
-         */
-        StatePtr->FileExisted = (OS_stat(StatePtr->FileWrite.FileName, &FileStat) == OS_SUCCESS);
-
-        Status = CFE_FS_BackgroundFileDumpRequest(&StatePtr->FileWrite);
+        ** Copy the filename into local buffer with default name/path/extension if not specified
+        */
+        Status = CFE_FS_ParseInputFileNameEx(StatePtr->FileWrite.FileName, CmdPtr->DumpFilename,
+                                             sizeof(StatePtr->FileWrite.FileName), sizeof(CmdPtr->DumpFilename),
+                                             CFE_PLATFORM_TBL_DEFAULT_REG_DUMP_FILE,
+                                             CFE_FS_GetDefaultMountPoint(CFE_FS_FileCategory_BINARY_DATA_DUMP),
+                                             CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_BINARY_DATA_DUMP));
 
         if (Status == CFE_SUCCESS)
         {
-            /* Increment the TBL generic command counter (successfully queued for background job) */
-            ReturnCode = CFE_TBL_INC_CMD_CTR;
+            /*
+             * Before submitting the background request, use OS_stat() to check if the file exists already.
+             *
+             * This is because TBL services issued a different event ID in some cases if
+             * it is overwriting a file vs. creating a new file.
+             */
+            StatePtr->FileExisted = (OS_stat(StatePtr->FileWrite.FileName, &FileStat) == OS_SUCCESS);
+
+            Status = CFE_FS_BackgroundFileDumpRequest(&StatePtr->FileWrite);
+            if (Status == CFE_SUCCESS)
+            {
+                /* Increment the TBL generic command counter (successfully queued for background job) */
+                ReturnCode = CFE_TBL_INC_CMD_CTR;
+            }
         }
     }
 

--- a/modules/tbl/ut-coverage/tbl_UT.c
+++ b/modules/tbl/ut-coverage/tbl_UT.c
@@ -963,6 +963,12 @@ void Test_CFE_TBL_DumpRegCmd(void)
     UT_Report(__FILE__, __LINE__, CFE_TBL_DumpRegistryCmd(&DumpRegCmd) == CFE_TBL_INC_CMD_CTR,
               "CFE_TBL_DumpRegistryCmd", "Default dump file name");
 
+    /* Test command with a bad file name */
+    UT_SetDeferredRetcode(UT_KEY(CFE_FS_ParseInputFileNameEx), 1, CFE_FS_INVALID_PATH);
+    UT_Report(__FILE__, __LINE__, CFE_TBL_DumpRegistryCmd(&DumpRegCmd) == CFE_TBL_INC_ERR_CTR,
+              "CFE_TBL_DumpRegistryCmd", "Dump file name invalid");
+    UT_ResetState(UT_KEY(CFE_FS_ParseInputFileNameEx));
+
     /* Test command with the dump file already pending (max requests pending) */
     UT_SetDefaultReturnValue(UT_KEY(CFE_FS_BackgroundFileDumpIsPending), true);
     UT_SetDefaultReturnValue(UT_KEY(CFE_FS_BackgroundFileDumpRequest), CFE_STATUS_REQUEST_ALREADY_PENDING);


### PR DESCRIPTION
**Describe the contribution**
For commands containing file names, replace the call to CFE_SB_MessageStringGet() - which is just a basic copy - to
the new filename-aware function CFE_FS_ParseInputFileName().

This means that the default pathname/extension logic is applied here too and only a "basename" is strictly necessary, although
if a full/absolute path is given, it will be used as is.

Fixes #1164

**Testing performed**
Build and sanity check CFE
Issue commands which accept file names (e.g. RESTART app) and confirm they accept the same file names as the startup script accepts.

**Expected behavior changes**
Commands accept "bare" file names using same logic as startup script, assuming a default path and extension if omitted.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
