### PR TITLE
Fix #1208, Cast isspace input to unsigned char

### DIFF
--- a/modules/es/fsw/src/cfe_es_syslog.c
+++ b/modules/es/fsw/src/cfe_es_syslog.c
@@ -417,7 +417,7 @@ void CFE_ES_SysLog_vsnprintf(char *Buffer, size_t BufferSize, const char *SpecSt
          *
          * Strip off all trailing whitespace, and add back a single newline
          */
-        while (StringLen > 0 && isspace((int)Buffer[StringLen - 1]))
+        while (StringLen > 0 && isspace((unsigned char)Buffer[StringLen - 1]))
         {
             --StringLen;
         }


### PR DESCRIPTION
**Describe the contribution**
Fix #1208 - cast isspace input to unsigned char to avoid undefined behavior

**Testing performed**
Build/run unit tests (note issue #1224)

**Expected behavior changes**
Squash static analysis warning

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC