### PR TITLE
Fix #1204, Use mask instead of cast to alter value

### DIFF
--- a/modules/msg/fsw/src/cfe_msg_msgid_v1.c
+++ b/modules/msg/fsw/src/cfe_msg_msgid_v1.c
@@ -65,8 +65,9 @@ int32 CFE_MSG_SetMsgId(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId)
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    MsgPtr->CCSDS.Pri.StreamId[0] = (uint8)(msgidval >> 8);
-    MsgPtr->CCSDS.Pri.StreamId[1] = (uint8)(msgidval);
+    /* Shift and mask bytes to be endian agnostic */
+    MsgPtr->CCSDS.Pri.StreamId[0] = (msgidval >> 8) & 0xFF;
+    MsgPtr->CCSDS.Pri.StreamId[1] = msgidval & 0xFF;
 
     return CFE_SUCCESS;
 }


### PR DESCRIPTION
**Describe the contribution**
Fix #1204 - updated message module, msgid v1 to use mask instead of cast to alter value (and added comment)

**Testing performed**
Build/run unit tests (note see #1224)

**Expected behavior changes**
Squash static analysis warnings

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC