### PR TITLE
Fix #1200, Resolve type issues with CFE_ES_FileWriteByteCntErr and CFE_TBL_FindTableInRegistry

### DIFF
--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -1990,12 +1990,12 @@ int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistryCmd_t *data)
 /*                                a byte count discrepancy has been*/
 /*                                detected during the file write   */
 /* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-void CFE_ES_FileWriteByteCntErr(const char *Filename, size_t Requested, size_t Actual)
+void CFE_ES_FileWriteByteCntErr(const char *Filename, size_t Requested, int32 Status)
 {
 
     CFE_EVS_SendEvent(CFE_ES_FILEWRITE_ERR_EID, CFE_EVS_EventType_ERROR,
-                      "File write,byte cnt err,file %s,request=%u,actual=%u", Filename, (unsigned int)Requested,
-                      (unsigned int)Actual);
+                      "File write,byte cnt err,file %s,request=%u,status=0x%08x", Filename, (unsigned int)Requested,
+                      (unsigned int)Status);
 
 } /* End of CFE_ES_FileWriteByteCntErr() */
 

--- a/modules/es/fsw/src/cfe_es_task.h
+++ b/modules/es/fsw/src/cfe_es_task.h
@@ -197,7 +197,7 @@ int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistryCmd_t *data);
 */
 bool CFE_ES_ValidateHandle(CFE_ES_MemHandle_t Handle);
 bool CFE_ES_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength);
-void CFE_ES_FileWriteByteCntErr(const char *Filename, size_t Requested, size_t Actual);
+void CFE_ES_FileWriteByteCntErr(const char *Filename, size_t Requested, int32 Status);
 
 /*************************************************************************/
 

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
@@ -360,6 +360,7 @@ int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
     CFE_TBL_File_Hdr_t               TblFileHeader;
     osal_id_t                        FileDescriptor;
     int32                            Status;
+    int16                            RegIndex;
     CFE_TBL_RegistryRec_t *          RegRecPtr;
     CFE_TBL_LoadBuff_t *             WorkingBufferPtr;
     char                             LoadFilename[OS_MAX_PATH_LEN];
@@ -379,9 +380,9 @@ int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
         if (Status == CFE_SUCCESS)
         {
             /* Locate specified table in registry */
-            Status = CFE_TBL_FindTableInRegistry(TblFileHeader.TableName);
+            RegIndex = CFE_TBL_FindTableInRegistry(TblFileHeader.TableName);
 
-            if (Status == CFE_TBL_NOT_FOUND)
+            if (RegIndex == CFE_TBL_NOT_FOUND)
             {
                 CFE_EVS_SendEvent(CFE_TBL_NO_SUCH_TABLE_ERR_EID, CFE_EVS_EventType_ERROR,
                                   "Unable to locate '%s' in Table Registry", TblFileHeader.TableName);
@@ -389,7 +390,7 @@ int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
             else
             {
                 /* Translate the registry index into a record pointer */
-                RegRecPtr = &CFE_TBL_Global.Registry[Status];
+                RegRecPtr = &CFE_TBL_Global.Registry[RegIndex];
 
                 if (RegRecPtr->DumpOnly)
                 {
@@ -1321,7 +1322,7 @@ int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data)
     char                               TableName[CFE_TBL_MAX_FULL_NAME_LEN];
     CFE_TBL_CritRegRec_t *             CritRegRecPtr = NULL;
     uint32                             i;
-    uint32                             RegIndex;
+    int16                              RegIndex;
     int32                              Status;
 
     /* Make sure all strings are null terminated before attempting to process them */

--- a/modules/tbl/ut-coverage/tbl_UT.c
+++ b/modules/tbl/ut-coverage/tbl_UT.c
@@ -2589,7 +2589,7 @@ void Test_CFE_TBL_Manage(void)
 {
     int32                       RtnCode;
     bool                        EventsCorrect;
-    int32                       RegIndex;
+    int16                       RegIndex;
     CFE_TBL_RegistryRec_t *     RegRecPtr;
     CFE_TBL_LoadBuff_t *        WorkingBufferPtr;
     UT_Table1_t                 TestTable1;


### PR DESCRIPTION
**Describe the contribution**
Fix #1200 
 - Use int16 for local type from CFE_TBL_FindTableInRegistry (it's an index, not a status)
 - Update CFE_ES_FileWriteByteCntErr to report status, not a size_t actual (OS_write returns int32)

**Testing performed**
Build/run unit tests, passed

**Expected behavior changes**
Squash static analysis warnings

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle Main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC