### PR TITLE
Fix #1192, Initialize TotalMsgSize in CFE_SB_GetUserDataLength

### DIFF
--- a/modules/sb/fsw/src/cfe_sb_util.c
+++ b/modules/sb/fsw/src/cfe_sb_util.c
@@ -119,7 +119,7 @@ void *CFE_SB_GetUserData(CFE_MSG_Message_t *MsgPtr)
  */
 size_t CFE_SB_GetUserDataLength(const CFE_MSG_Message_t *MsgPtr)
 {
-    CFE_MSG_Size_t TotalMsgSize;
+    CFE_MSG_Size_t TotalMsgSize = 0;
     size_t         HdrSize;
 
     if (MsgPtr == NULL)


### PR DESCRIPTION
**Describe the contribution**
Fix #1192 - Initialize TotalMsgSize to 0 to avoid false use before initialized static analysis warning

**Testing performed**
Build/run unit tests

**Expected behavior changes**
None, just squashes warning

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC