### PR TITLE
Fix #1195, Avoid implicit conversion from vsnprintf errors

### DIFF
--- a/modules/evs/fsw/src/cfe_evs_utils.c
+++ b/modules/evs/fsw/src/cfe_evs_utils.c
@@ -393,8 +393,11 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint1
     ExpandedLength =
         vsnprintf((char *)LongEventTlm.Payload.Message, sizeof(LongEventTlm.Payload.Message), MsgSpec, ArgPtr);
 
-    /* Were any characters truncated in the buffer? */
-    if (ExpandedLength >= sizeof(LongEventTlm.Payload.Message))
+    /*
+     * If vsnprintf is bigger than message size, mark with truncation character
+     * Note negative returns (error from vsnprintf) will just leave the message as-is
+     */
+    if (ExpandedLength >= (int)sizeof(LongEventTlm.Payload.Message))
     {
         /* Mark character before zero terminator to indicate truncation */
         LongEventTlm.Payload.Message[sizeof(LongEventTlm.Payload.Message) - 2] = CFE_EVS_MSG_TRUNCATED;


### PR DESCRIPTION
**Describe the contribution**
Fix #1195 - adds cast to avoid implicit conversion on a vsnprintf error, and comments to explain

**Testing performed**
Build/run unit tests (note #1224)

**Expected behavior changes**
No real change, vsnprintf should never error but does avoid static analysis warnings.

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC