### PR TITLE
Fix #1180, Remove impossible conditions

### DIFF
--- a/modules/es/fsw/src/cfe_es_apps.c
+++ b/modules/es/fsw/src/cfe_es_apps.c
@@ -1287,42 +1287,37 @@ void CFE_ES_ProcessControlRequest(CFE_ES_AppId_t AppId)
             break;
     }
 
-    if (EventID != 0 && ReqName != NULL)
+    if (MessageDetail[0] != 0)
     {
-        if (MessageDetail[0] != 0)
-        {
-            /* Detail message already set, assume it is an error event */
-            EventType = CFE_EVS_EventType_ERROR;
-        }
-        else if (StartupStatus != CFE_SUCCESS)
-        {
-            /* Make detail message for event containing startup error code */
-            EventType = CFE_EVS_EventType_ERROR;
-            snprintf(MessageDetail, sizeof(MessageDetail), "Failed: AppCreate Error 0x%08X.",
-                     (unsigned int)StartupStatus);
-        }
-        else if (CleanupStatus != CFE_SUCCESS)
-        {
-            /* Make detail message for event containing cleanup error code */
-            EventType = CFE_EVS_EventType_ERROR;
-            snprintf(MessageDetail, sizeof(MessageDetail), "Failed: CleanUpApp Error 0x%08X.",
-                     (unsigned int)CleanupStatus);
-        }
-        else if (CFE_RESOURCEID_TEST_DEFINED(NewAppId))
-        {
-            /* Record success message for event where app is restarted */
-            EventType = CFE_EVS_EventType_INFORMATION;
-            snprintf(MessageDetail, sizeof(MessageDetail), "Completed, AppID=%lu", CFE_RESOURCEID_TO_ULONG(NewAppId));
-        }
-        else
-        {
-            /* Record success message for event */
-            EventType = CFE_EVS_EventType_INFORMATION;
-            snprintf(MessageDetail, sizeof(MessageDetail), "Completed.");
-        }
-
-        CFE_EVS_SendEvent(EventID, EventType, "%s Application %s %s", ReqName, OrigAppName, MessageDetail);
+        /* Detail message already set, assume it is an error event */
+        EventType = CFE_EVS_EventType_ERROR;
     }
+    else if (StartupStatus != CFE_SUCCESS)
+    {
+        /* Make detail message for event containing startup error code */
+        EventType = CFE_EVS_EventType_ERROR;
+        snprintf(MessageDetail, sizeof(MessageDetail), "Failed: AppCreate Error 0x%08X.", (unsigned int)StartupStatus);
+    }
+    else if (CleanupStatus != CFE_SUCCESS)
+    {
+        /* Make detail message for event containing cleanup error code */
+        EventType = CFE_EVS_EventType_ERROR;
+        snprintf(MessageDetail, sizeof(MessageDetail), "Failed: CleanUpApp Error 0x%08X.", (unsigned int)CleanupStatus);
+    }
+    else if (CFE_RESOURCEID_TEST_DEFINED(NewAppId))
+    {
+        /* Record success message for event where app is restarted */
+        EventType = CFE_EVS_EventType_INFORMATION;
+        snprintf(MessageDetail, sizeof(MessageDetail), "Completed, AppID=%lu", CFE_RESOURCEID_TO_ULONG(NewAppId));
+    }
+    else
+    {
+        /* Record success message for event */
+        EventType = CFE_EVS_EventType_INFORMATION;
+        snprintf(MessageDetail, sizeof(MessageDetail), "Completed.");
+    }
+
+    CFE_EVS_SendEvent(EventID, EventType, "%s Application %s %s", ReqName, OrigAppName, MessageDetail);
 
 } /* End Function */
 

--- a/modules/tbl/fsw/src/cfe_tbl_internal.c
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.c
@@ -145,7 +145,7 @@ int32 CFE_TBL_EarlyInit(void)
             }
 
             j++;
-        } while ((j < CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS) && (Status >= CFE_PLATFORM_TBL_MAX_SNGL_TABLE_SIZE));
+        } while (j < CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS);
     }
 
     /* Try to obtain a previous image of the Critical Table Registry from the Critical Data Store */


### PR DESCRIPTION
**Describe the contribution**
Fix #1180 - removes impossible conditions (typically a test that could never hit the alternate condition since the condition was already checked)

**Testing performed**
Build/run unit tests

**Expected behavior changes**
None, squash static analysis warning

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC