### PR TITLE
Fix #1185, Squash possible uninitialized variable false alarms

### DIFF
--- a/modules/es/fsw/src/cfe_es_apps.c
+++ b/modules/es/fsw/src/cfe_es_apps.c
@@ -660,7 +660,7 @@ int32 CFE_ES_AppCreate(CFE_ES_AppId_t *ApplicationIdPtr, const char *AppName, co
 {
     CFE_Status_t        Status;
     CFE_ES_AppRecord_t *AppRecPtr;
-    CFE_ResourceId_t    PendingResourceId;
+    CFE_ResourceId_t    PendingResourceId = CFE_RESOURCEID_UNDEFINED;
 
     /*
      * The AppName must not be NULL

--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -95,7 +95,7 @@ int32 CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16 Depth, const char *Pi
     osal_id_t        SysQueueId;
     int32            Status;
     CFE_SB_PipeD_t * PipeDscPtr;
-    CFE_ResourceId_t PendingPipeId;
+    CFE_ResourceId_t PendingPipeId = CFE_RESOURCEID_UNDEFINED;
     uint16           PendingEventId;
     char             FullName[(OS_MAX_API_NAME * 2)];
 

--- a/modules/time/fsw/src/cfe_time_api.c
+++ b/modules/time/fsw/src/cfe_time_api.c
@@ -736,21 +736,20 @@ int32 CFE_TIME_UnregisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncP
     if (Status == CFE_SUCCESS)
     {
         Status = CFE_ES_AppID_ToIndex(AppId, &AppIndex);
-    }
-    if (Status != CFE_SUCCESS)
-    {
-        /* Called from an invalid context */
-        return Status;
-    }
 
-    if (AppIndex >= (sizeof(CFE_TIME_Global.SynchCallback) / sizeof(CFE_TIME_Global.SynchCallback[0])) ||
-        CFE_TIME_Global.SynchCallback[AppIndex].Ptr != CallbackFuncPtr)
-    {
-        Status = CFE_TIME_CALLBACK_NOT_REGISTERED;
-    }
-    else
-    {
-        CFE_TIME_Global.SynchCallback[AppIndex].Ptr = NULL;
+        if (Status == CFE_SUCCESS)
+        {
+
+            if (AppIndex >= (sizeof(CFE_TIME_Global.SynchCallback) / sizeof(CFE_TIME_Global.SynchCallback[0])) ||
+                CFE_TIME_Global.SynchCallback[AppIndex].Ptr != CallbackFuncPtr)
+            {
+                Status = CFE_TIME_CALLBACK_NOT_REGISTERED;
+            }
+            else
+            {
+                CFE_TIME_Global.SynchCallback[AppIndex].Ptr = NULL;
+            }
+        }
     }
 
     return Status;


### PR DESCRIPTION
**Describe the contribution**
Fix #1185 - Swash uninitialized variable false alarms with a minor refactor and initializations where required.

2 elements listed in #1185 were OBE, will rerun analysis and write a new issue if additional fixes required.

**Testing performed**
Build/run unit tests

**Expected behavior changes**
None, squashes static analysis warnings

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + cfe main (for unit test fix) + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC