### PR TITLE
Fix #1223, #1264 shorten TestRunner function name and update cfe_es_startup.scr docs

### DIFF
--- a/docs/README_functionaltest.md
+++ b/docs/README_functionaltest.md
@@ -30,7 +30,7 @@ To execute tests at startup, the following lines can be added to `cfe_es_startup
 designated test target:
 
     CFE_LIB, /cf/cfe_assert.so,     CFE_Assert_LibInit,     ASSERT_LIB,  0,     0,      0x0, 0;
-    CFE_APP, /cf/cfe_testrunner.so, CFE_TestRunner_AppMain, TESTRUN_APP, 100,   16384,  0x0, 0;
+    CFE_APP, /cf/cfe_testrunner.so, CFE_TR_AppMain, TESTRUN_APP, 100,   16384,  0x0, 0;
     CFE_LIB, /cf/cfe_testcase.so,   CFE_Test_Init,          CFETEST_LIB, 0,     0,      0x0, 0;
     CFE_LIB, /cf/psp_test.so,       PSP_Test_Init,          PSPTEST_LIB, 0,     0,      0x0, 0;
 

--- a/docs/README_functionaltest.md
+++ b/docs/README_functionaltest.md
@@ -29,10 +29,10 @@ cases.  It also must be loaded after `cfe_assert`.
 To execute tests at startup, the following lines can be added to `cfe_es_startup.scr` on the
 designated test target:
 
-    CFE_LIB, /cf/cfe_assert.so,     CFE_Assert_LibInit,     ASSERT_LIB,  0,     0,      0x0, 0;
-    CFE_APP, /cf/cfe_testrunner.so, CFE_TR_AppMain, TESTRUN_APP, 100,   16384,  0x0, 0;
-    CFE_LIB, /cf/cfe_testcase.so,   CFE_Test_Init,          CFETEST_LIB, 0,     0,      0x0, 0;
-    CFE_LIB, /cf/psp_test.so,       PSP_Test_Init,          PSPTEST_LIB, 0,     0,      0x0, 0;
+    CFE_LIB, cfe_assert,     CFE_Assert_LibInit, ASSERT_LIB,  0,     0,      0x0, 0;
+    CFE_APP, cfe_testrunner, CFE_TR_AppMain,     TESTRUN_APP, 100,   16384,  0x0, 0;
+    CFE_LIB, cfe_testcase,   CFE_Test_Init,      CFETEST_LIB, 0,     0,      0x0, 0;
+    CFE_LIB, psp_test,       PSP_Test_Init,      PSPTEST_LIB, 0,     0,      0x0, 0;
 
 It is important that `cfe_assert` is loaded first, as all other test libraries depend on
 symbols provided in this library.  The order of loading other test cases should not

--- a/modules/cfe_testrunner/inc/cfe_testrunner.h
+++ b/modules/cfe_testrunner/inc/cfe_testrunner.h
@@ -54,7 +54,7 @@
 **
 **
 *************************************************************************/
-void CFE_TestRunner_AppMain(void);
+void CFE_TR_AppMain(void);
 
 #endif /* cfe_testrunner_h_ */
 

--- a/modules/cfe_testrunner/src/cfe_testrunner_main.c
+++ b/modules/cfe_testrunner/src/cfe_testrunner_main.c
@@ -59,7 +59,7 @@
 /*
  * Entry point for this application
  */
-void CFE_TestRunner_AppMain(void)
+void CFE_TR_AppMain(void)
 {
     int32  rc;
     uint32 RunStatus;


### PR DESCRIPTION
**Describe the contribution**
Fixes #1223
Change the name of the testrunner main function to be less than 20 characters. 

Fixes #1264
Use simple filenames. 

**Testing performed**
Build and run unit test

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC