### PR TITLE
Fix #1187, Increment CreatePipeErrorCounter for all create pipe errors

### DIFF
--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -211,19 +211,8 @@ int32 CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16 Depth, const char *Pi
         }
         PendingPipeId = CFE_RESOURCEID_UNDEFINED;
 
-        /*
-         * If there is a relevant error counter, increment it now
-         * while the global data is locked.
-         */
-        switch (PendingEventId)
-        {
-            case CFE_SB_CR_PIPE_BAD_ARG_EID:
-                ++CFE_SB_Global.HKTlmMsg.Payload.CreatePipeErrorCounter;
-                break;
-            default:
-                /* no counter */
-                break;
-        }
+        /* Increment error counter for all errors */
+        CFE_SB_Global.HKTlmMsg.Payload.CreatePipeErrorCounter++;
     }
 
     CFE_SB_UnlockSharedData(__func__, __LINE__);


### PR DESCRIPTION
**Describe the contribution**
Fix #1187 - increments the CreatePipeErrorCounter for all create pipe errors which eliminates a static analysis warning for trivial case

**Testing performed**
Build/run unit tests, passed

**Expected behavior changes**
Increments the error counter for all pipe creation errors

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC