### PR TITLE
Fix #1246, Typo in CFE_TBL_Validate AppName

### DIFF
--- a/modules/tbl/fsw/src/cfe_tbl_api.c
+++ b/modules/tbl/fsw/src/cfe_tbl_api.c
@@ -1114,7 +1114,7 @@ int32 CFE_TBL_Validate(CFE_TBL_Handle_t TblHandle)
     CFE_ES_AppId_t              ThisAppId;
     CFE_TBL_RegistryRec_t *     RegRecPtr;
     CFE_TBL_AccessDescriptor_t *AccessDescPtr;
-    char                        AppName[OS_MAX_API_NAME] = {"UNKNWON"};
+    char                        AppName[OS_MAX_API_NAME] = {"UNKNOWN"};
 
     /* Verify that this application has the right to perform operation */
     Status = CFE_TBL_ValidateAccess(TblHandle, &ThisAppId);


### PR DESCRIPTION
**Describe the contribution**
Fix #1246 - AppName initialization from "UNKNWON" to "UNKNOWN"

**Testing performed**
CI

**Expected behavior changes**
None, just fixes the typo in initialization (typically replaced by the real AppName).

**System(s) tested on**
CI

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC