### PR TITLE
Fix #1252, Squash potentially uninitialized variable warnings

### DIFF
--- a/modules/es/fsw/src/cfe_es_apps.c
+++ b/modules/es/fsw/src/cfe_es_apps.c
@@ -79,7 +79,7 @@ void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath)
     const char *TokenList[CFE_ES_STARTSCRIPT_MAX_TOKENS_PER_LINE];
     uint32      NumTokens;
     uint32      BuffLen; /* Length of the current buffer */
-    osal_id_t   AppFile;
+    osal_id_t   AppFile = OS_OBJECT_ID_UNDEFINED;
     int32       Status;
     char        c;
     bool        LineTooLong = false;

--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -1218,7 +1218,7 @@ int32 CFE_ES_QueryOneCmd(const CFE_ES_QueryOneCmd_t *data)
 int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAllCmd_t *data)
 {
     CFE_FS_Header_t                     FileHeader;
-    osal_id_t                           FileDescriptor;
+    osal_id_t                           FileDescriptor = OS_OBJECT_ID_UNDEFINED;
     uint32                              i;
     uint32                              EntryCount = 0;
     uint32                              FileSize   = 0;
@@ -1373,7 +1373,7 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAllCmd_t *data)
 int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasksCmd_t *data)
 {
     CFE_FS_Header_t                     FileHeader;
-    osal_id_t                           FileDescriptor;
+    osal_id_t                           FileDescriptor = OS_OBJECT_ID_UNDEFINED;
     uint32                              i;
     uint32                              EntryCount = 0;
     uint32                              FileSize   = 0;
@@ -1884,7 +1884,7 @@ int32 CFE_ES_SendMemPoolStatsCmd(const CFE_ES_SendMemPoolStatsCmd_t *data)
 int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistryCmd_t *data)
 {
     CFE_FS_Header_t                            StdFileHeader;
-    osal_id_t                                  FileDescriptor;
+    osal_id_t                                  FileDescriptor = OS_OBJECT_ID_UNDEFINED;
     int32                                      Status;
     int16                                      RegIndex = 0;
     const CFE_ES_DumpCDSRegistryCmd_Payload_t *CmdPtr   = &data->Payload;

--- a/modules/evs/fsw/src/cfe_evs_log.c
+++ b/modules/evs/fsw/src/cfe_evs_log.c
@@ -139,7 +139,7 @@ int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFileCmd_t *data)
     int32                               Result;
     int32                               LogIndex;
     int32                               BytesWritten;
-    osal_id_t                           LogFileHandle;
+    osal_id_t                           LogFileHandle = OS_OBJECT_ID_UNDEFINED;
     uint32                              i;
     CFE_FS_Header_t                     LogFileHdr;
     char                                LogFilename[OS_MAX_PATH_LEN];

--- a/modules/evs/fsw/src/cfe_evs_task.c
+++ b/modules/evs/fsw/src/cfe_evs_task.c
@@ -1683,7 +1683,7 @@ int32 CFE_EVS_DeleteEventFilterCmd(const CFE_EVS_DeleteEventFilterCmd_t *data)
 int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFileCmd_t *data)
 {
     int32                               Result;
-    osal_id_t                           FileHandle;
+    osal_id_t                           FileHandle = OS_OBJECT_ID_UNDEFINED;
     int32                               BytesWritten;
     uint32                              EntryCount = 0;
     uint32                              i;

--- a/modules/msg/fsw/src/cfe_msg_msgid_shared.c
+++ b/modules/msg/fsw/src/cfe_msg_msgid_shared.c
@@ -34,6 +34,9 @@ int32 CFE_MSG_GetTypeFromMsgId(CFE_SB_MsgId_t MsgId, CFE_MSG_Type_t *Type)
 
     CFE_MSG_Message_t msg;
 
+    /* Memset to initialize avoids possible GCC bug 53119 */
+    memset(&msg, 0, sizeof(msg));
+
     if (Type == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;

--- a/modules/sb/fsw/src/cfe_sb_task.c
+++ b/modules/sb/fsw/src/cfe_sb_task.c
@@ -1060,7 +1060,7 @@ bool CFE_SB_WritePipeInfoDataGetter(void *Meta, uint32 RecordNum, void **Buffer,
     CFE_SB_BackgroundFileStateInfo_t *BgFilePtr;
     CFE_SB_PipeInfoEntry_t *          PipeBufferPtr;
     CFE_SB_PipeD_t *                  PipeDscPtr;
-    osal_id_t                         SysQueueId;
+    osal_id_t                         SysQueueId = OS_OBJECT_ID_UNDEFINED;
     bool                              PipeIsValid;
 
     BgFilePtr   = (CFE_SB_BackgroundFileStateInfo_t *)Meta;
@@ -1098,10 +1098,6 @@ bool CFE_SB_WritePipeInfoDataGetter(void *Meta, uint32 RecordNum, void **Buffer,
             PipeBufferPtr->PeakQueueDepth    = PipeDscPtr->PeakQueueDepth;
 
             SysQueueId = PipeDscPtr->SysQueueId;
-        }
-        else
-        {
-            SysQueueId = OS_OBJECT_ID_UNDEFINED;
         }
 
         CFE_SB_UnlockSharedData(__FILE__, __LINE__);


### PR DESCRIPTION
**Describe the contribution**
Fix #1252 - Initialized all the potentially uninitialized variables (all false alarms)

**Testing performed**
Build/run unit tests, passed

**Expected behavior changes**
None, just squashes CodeQL warnings

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
Static analysis warning squash

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
jacob Hageman - NASA/GSFC