### PR TITLE
Fix #1194, check for NULL in SlotUsed helpers

### DIFF
--- a/modules/es/fsw/src/cfe_es_cds.c
+++ b/modules/es/fsw/src/cfe_es_cds.c
@@ -170,7 +170,14 @@ int32 CFE_ES_CDSHandle_ToIndex(CFE_ES_CDSHandle_t BlockID, uint32 *Idx)
  */
 bool CFE_ES_CheckCDSHandleSlotUsed(CFE_ResourceId_t CheckId)
 {
-    return CFE_ES_CDSBlockRecordIsUsed(CFE_ES_LocateCDSBlockRecordByID(CFE_ES_CDSHANDLE_C(CheckId)));
+    CFE_ES_CDS_RegRec_t *CDSRegRecPtr;
+    /*
+     * Note - The pointer here should never be NULL because the ID should always be
+     * within the expected range, but if it ever is NULL, this should return true
+     * such that the caller will _not_ attempt to use the record.
+     */
+    CDSRegRecPtr = CFE_ES_LocateCDSBlockRecordByID(CFE_ES_CDSHANDLE_C(CheckId));
+    return (CDSRegRecPtr == NULL || CFE_ES_CDSBlockRecordIsUsed(CDSRegRecPtr));
 }
 
 /*******************************************************************/

--- a/modules/es/fsw/src/cfe_es_mempool.c
+++ b/modules/es/fsw/src/cfe_es_mempool.c
@@ -104,7 +104,14 @@ int32 CFE_ES_MemPoolID_ToIndex(CFE_ES_MemHandle_t PoolID, uint32 *Idx)
  */
 bool CFE_ES_CheckMemPoolSlotUsed(CFE_ResourceId_t CheckId)
 {
-    return CFE_ES_MemPoolRecordIsUsed(CFE_ES_LocateMemPoolRecordByID(CFE_ES_MEMHANDLE_C(CheckId)));
+    CFE_ES_MemPoolRecord_t *MemPoolRecPtr;
+    /*
+     * Note - The pointer here should never be NULL because the ID should always be
+     * within the expected range, but if it ever is NULL, this should return true
+     * such that the caller will _not_ attempt to use the record.
+     */
+    MemPoolRecPtr = CFE_ES_LocateMemPoolRecordByID(CFE_ES_MEMHANDLE_C(CheckId));
+    return (MemPoolRecPtr == NULL || CFE_ES_MemPoolRecordIsUsed(MemPoolRecPtr));
 }
 
 CFE_ES_MemPoolRecord_t *CFE_ES_LocateMemPoolRecordByID(CFE_ES_MemHandle_t PoolID)

--- a/modules/es/fsw/src/cfe_es_resource.c
+++ b/modules/es/fsw/src/cfe_es_resource.c
@@ -357,7 +357,14 @@ CFE_ES_AppRecord_t *CFE_ES_GetAppRecordByContext(void)
  */
 bool CFE_ES_CheckCounterIdSlotUsed(CFE_ResourceId_t CheckId)
 {
-    return CFE_ES_CounterRecordIsUsed(CFE_ES_LocateCounterRecordByID(CFE_ES_COUNTERID_C(CheckId)));
+    CFE_ES_GenCounterRecord_t *GenCounterRecPtr;
+    /*
+     * Note - The pointer here should never be NULL because the ID should always be
+     * within the expected range, but if it ever is NULL, this should return true
+     * such that the caller will _not_ attempt to use the record.
+     */
+    GenCounterRecPtr = CFE_ES_LocateCounterRecordByID(CFE_ES_COUNTERID_C(CheckId));
+    return (GenCounterRecPtr == NULL || CFE_ES_CounterRecordIsUsed(GenCounterRecPtr));
 }
 
 /*
@@ -370,7 +377,14 @@ bool CFE_ES_CheckCounterIdSlotUsed(CFE_ResourceId_t CheckId)
  */
 bool CFE_ES_CheckAppIdSlotUsed(CFE_ResourceId_t CheckId)
 {
-    return CFE_ES_AppRecordIsUsed(CFE_ES_LocateAppRecordByID(CFE_ES_APPID_C(CheckId)));
+    CFE_ES_AppRecord_t *AppRecPtr;
+    /*
+     * Note - The pointer here should never be NULL because the ID should always be
+     * within the expected range, but if it ever is NULL, this should return true
+     * such that the caller will _not_ attempt to use the record.
+     */
+    AppRecPtr = CFE_ES_LocateAppRecordByID(CFE_ES_APPID_C(CheckId));
+    return (AppRecPtr == NULL || CFE_ES_AppRecordIsUsed(AppRecPtr));
 }
 
 /*
@@ -383,5 +397,12 @@ bool CFE_ES_CheckAppIdSlotUsed(CFE_ResourceId_t CheckId)
  */
 bool CFE_ES_CheckLibIdSlotUsed(CFE_ResourceId_t CheckId)
 {
-    return CFE_ES_LibRecordIsUsed(CFE_ES_LocateLibRecordByID(CFE_ES_LIBID_C(CheckId)));
+    CFE_ES_LibRecord_t *LibRecPtr;
+    /*
+     * Note - The pointer here should never be NULL because the ID should always be
+     * within the expected range, but if it ever is NULL, this should return true
+     * such that the caller will _not_ attempt to use the record.
+     */
+    LibRecPtr = CFE_ES_LocateLibRecordByID(CFE_ES_LIBID_C(CheckId));
+    return (LibRecPtr == NULL || CFE_ES_LibRecordIsUsed(LibRecPtr));
 }

--- a/modules/sb/fsw/src/cfe_sb_priv.c
+++ b/modules/sb/fsw/src/cfe_sb_priv.c
@@ -298,7 +298,14 @@ CFE_SB_PipeD_t *CFE_SB_LocatePipeDescByID(CFE_SB_PipeId_t PipeId)
  */
 bool CFE_SB_CheckPipeDescSlotUsed(CFE_ResourceId_t CheckId)
 {
-    return CFE_SB_PipeDescIsUsed(CFE_SB_LocatePipeDescByID(CFE_SB_PIPEID_C(CheckId)));
+    CFE_SB_PipeD_t *PipeDscPtr;
+    /*
+     * Note - The pointer here should never be NULL because the ID should always be
+     * within the expected range, but if it ever is NULL, this should return true
+     * such that the caller will _not_ attempt to use the record.
+     */
+    PipeDscPtr = CFE_SB_LocatePipeDescByID(CFE_SB_PIPEID_C(CheckId));
+    return (PipeDscPtr == NULL || CFE_SB_PipeDescIsUsed(PipeDscPtr));
 }
 
 /******************************************************************************


### PR DESCRIPTION
**Describe the contribution**
These are internal helper functions that determine if a table slot corresponding to a given ID is in use or free/available.

This updates the function to handle NULL pointers even though in context they are used the lookup should always work.

Fixes #1194

**Testing performed**
Build and sanity check CFE, run all unit tests

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Should resolve a static analysis warning

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
