### PR TITLE
Fix #1259, Add branch coverage option to genhtml

### DIFF
--- a/cmake/Makefile.sample
+++ b/cmake/Makefile.sample
@@ -141,7 +141,7 @@ test:
 lcov:
 	lcov --capture --rc lcov_branch_coverage=1 --directory $(O)/$(ARCH) --output-file $(O)/$(ARCH)/coverage_test.info
 	lcov --rc lcov_branch_coverage=1 --add-tracefile $(O)/$(ARCH)/coverage_base.info --add-tracefile $(O)/$(ARCH)/coverage_test.info --output-file $(O)/$(ARCH)/coverage_total.info
-	genhtml $(O)/$(ARCH)/coverage_total.info --output-directory $(O)/$(ARCH)/lcov
+	genhtml $(O)/$(ARCH)/coverage_total.info --branch-coverage --output-directory $(O)/$(ARCH)/lcov
 	@/bin/echo -e "\n\nCoverage Report Link: file:$(CURDIR)/$(O)/$(ARCH)/lcov/index.html\n"
 
 doc:


### PR DESCRIPTION
**Describe the contribution**
Fix #1259, adds --branch-coverage option to genhtml line in lcov Makefile rule

**Testing performed**
`make lcov` - observe branch coverage summary reported, also checked and html includes branch coverage

**Expected behavior changes**
No code behavior changes

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC