### PR TITLE
Fix #1239, scrub include header guards

### DIFF
--- a/cmake/sample_defs/cpu1_msgids.h
+++ b/cmake/sample_defs/cpu1_msgids.h
@@ -18,22 +18,24 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
-** File: cfe_msgids.h
-**
-** Purpose:
-**   This header file contains the Message Id's for messages used by the
-**   cFE core.
-**
-** Author:   R.McGraw/SSI
-**
-** Notes:
-**   This file should not contain messages defined by cFE external
-**   applications.
-**
-******************************************************************************/
-#ifndef _cfe_msgids_
-#define _cfe_msgids_
+/**
+ * @file
+ *
+ *
+ * Purpose:
+ *   This header file contains the Message Id's for messages used by the
+ *   cFE core.
+ *
+ * Author:   R.McGraw/SSI
+ *
+ * Notes:
+ *   This file should not contain messages defined by cFE external
+ *   applications.
+ *
+ */
+
+#ifndef CPU1_MSGIDS_H
+#define CPU1_MSGIDS_H
 
 /*
 ** Includes
@@ -129,4 +131,4 @@
 #define CFE_SB_ONESUB_TLM_MID       CFE_PLATFORM_TLM_MID_BASE + CFE_MISSION_SB_ONESUB_TLM_MSG       /* 0x080E */
 #define CFE_ES_MEMSTATS_TLM_MID     CFE_PLATFORM_TLM_MID_BASE + CFE_MISSION_ES_MEMSTATS_TLM_MSG     /* 0x0810 */
 
-#endif
+#endif /* CPU1_MSGIDS_H */

--- a/cmake/sample_defs/cpu1_msgids.h
+++ b/cmake/sample_defs/cpu1_msgids.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:
  *   This header file contains the Message Id's for messages used by the
  *   cFE core.

--- a/cmake/sample_defs/cpu1_platform_cfg.h
+++ b/cmake/sample_defs/cpu1_platform_cfg.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:
  *   This header file contains the platform configuration parameters.
  *

--- a/cmake/sample_defs/cpu1_platform_cfg.h
+++ b/cmake/sample_defs/cpu1_platform_cfg.h
@@ -18,23 +18,24 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
-** File: cfe_platform_cfg.h
-**
-** Purpose:
-**   This header file contains the platform configuration parameters.
-**
-** Notes:
-**   The impact of changing these configurations from their default value is
-**   not yet documented.  Changing these values may impact the performance
-**   and functionality of the system.
-**
-** Author:   R.McGraw/SSI
-**
-******************************************************************************/
+/**
+ * @file
+ *
+ *
+ * Purpose:
+ *   This header file contains the platform configuration parameters.
+ *
+ * Notes:
+ *   The impact of changing these configurations from their default value is
+ *   not yet documented.  Changing these values may impact the performance
+ *   and functionality of the system.
+ *
+ * Author:   R.McGraw/SSI
+ *
+ */
 
-#ifndef _cfe_platform_cfg_
-#define _cfe_platform_cfg_
+#ifndef CPU1_PLATFORM_CFG_H
+#define CPU1_PLATFORM_CFG_H
 
 /**
 **  \cfeescfg Default virtual path for persistent storage
@@ -1708,4 +1709,4 @@
 */
 #define CFE_PLATFORM_ES_STARTUP_SCRIPT_TIMEOUT_MSEC 1000
 
-#endif /* _cfe_platform_cfg_ */
+#endif /* CPU1_PLATFORM_CFG_H */

--- a/cmake/sample_defs/sample_mission_cfg.h
+++ b/cmake/sample_defs/sample_mission_cfg.h
@@ -18,24 +18,25 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
-** File: cfe_mission_cfg.h
-**
-** Purpose:
-**   This header file contains the mission configuration parameters and
-**   typedefs with mission scope.
-**
-** Notes:
-**   The impact of changing these configurations from their default value is
-**   not yet documented.  Changing these values may impact the performance
-**   and functionality of the system.
-**
-** Author:   R.McGraw/SSI
-**
-******************************************************************************/
+/**
+ * @file
+ *
+ *
+ * Purpose:
+ *   This header file contains the mission configuration parameters and
+ *   typedefs with mission scope.
+ *
+ * Notes:
+ *   The impact of changing these configurations from their default value is
+ *   not yet documented.  Changing these values may impact the performance
+ *   and functionality of the system.
+ *
+ * Author:   R.McGraw/SSI
+ *
+ */
 
-#ifndef _cfe_mission_cfg_
-#define _cfe_mission_cfg_
+#ifndef SAMPLE_MISSION_CFG_H
+#define SAMPLE_MISSION_CFG_H
 
 /**
 **  \cfesbcfg Maximum SB Message Size
@@ -562,4 +563,4 @@
 */
 #define CFE_MISSION_ES_CDS_MAX_FULL_NAME_LEN (CFE_MISSION_ES_CDS_MAX_NAME_LENGTH + CFE_MISSION_MAX_API_LEN + 4)
 
-#endif /* _cfe_mission_cfg_ */
+#endif /* SAMPLE_MISSION_CFG_H */

--- a/cmake/sample_defs/sample_mission_cfg.h
+++ b/cmake/sample_defs/sample_mission_cfg.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:
  *   This header file contains the mission configuration parameters and
  *   typedefs with mission scope.
@@ -66,7 +65,6 @@
 **      format.  This avoids having to modify each individual caller
 **      when the default choice is changed.
 **
-**
 **  \par Limits
 **      if CFE_MISSION_TIME_CFG_DEFAULT_TAI is defined as true then CFE_MISSION_TIME_CFG_DEFAULT_UTC must be
 **      defined as false.
@@ -82,7 +80,6 @@
 **  \par Description:
 **      The following definition enables the use of a simulated time at
 **      the tone signal using a software bus message.
-**
 **
 **  \par Limits
 **      Not Applicable
@@ -131,7 +128,6 @@
 **      before the tone.
 **
 **      Note: units are in micro-seconds
-**
 **
 **  \par Limits
 **       0 to 999,999 decimal
@@ -421,7 +417,6 @@
 **       Must be at least one.  No specific upper limit, but the number is
 **       anticipated to be reasonably small (i.e. tens, not hundreds).  Large
 **       values have not been tested.
-**
 **
 */
 #define CFE_MISSION_ES_POOL_MAX_BUCKETS 17

--- a/cmake/sample_defs/sample_perfids.h
+++ b/cmake/sample_defs/sample_perfids.h
@@ -18,24 +18,25 @@
 **  limitations under the License.
 */
 
-/*
-** File: cfe_perfids.h
-**
-** Purpose: This file contains the cFE performance IDs
-**
-** Design Notes:
-**   Each performance id is used to identify something that needs to be
-**   measured.  Performance ids are limited to the range of 0 to
-**   CFE_MISSION_ES_PERF_MAX_IDS - 1.  Any performance ids outside of this range
-**   will be ignored and will be flagged as an error.  Note that
-**   performance ids 0-31 are reserved for the cFE Core.
-**
-** References:
-**
-*/
+/**
+ * @file
+ *
+ *
+ * Purpose: This file contains the cFE performance IDs
+ *
+ * Design Notes:
+ *   Each performance id is used to identify something that needs to be
+ *   measured.  Performance ids are limited to the range of 0 to
+ *   CFE_MISSION_ES_PERF_MAX_IDS - 1.  Any performance ids outside of this range
+ *   will be ignored and will be flagged as an error.  Note that
+ *   performance ids 0-31 are reserved for the cFE Core.
+ *
+ * References:
+ *
+ */
 
-#ifndef _cfe_perfids_
-#define _cfe_perfids_
+#ifndef SAMPLE_PERFIDS_H
+#define SAMPLE_PERFIDS_H
 
 #define CFE_MISSION_ES_PERF_EXIT_BIT 31 /**< \brief bit (31) is reserved by the perf utilities */
 
@@ -58,4 +59,4 @@
 
 /** \} */
 
-#endif /* _cfe_perfids_ */
+#endif /* SAMPLE_PERFIDS_H */

--- a/cmake/sample_defs/sample_perfids.h
+++ b/cmake/sample_defs/sample_perfids.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose: This file contains the cFE performance IDs
  *
  * Design Notes:

--- a/cmake/target/inc/target_config.h
+++ b/cmake/target/inc/target_config.h
@@ -19,10 +19,7 @@
 */
 
 /**
- * \file target_config.h
- *
- *  Created on: Dec 12, 2014
- *  Created by: joseph.p.hickey@nasa.gov
+ * @file
  *
  * Defines structures for the global system-wide configuration data.
  * These structures can be accessed at runtime and are an alternative to
@@ -31,8 +28,8 @@
  * code becomes more portable.
  */
 
-#ifndef TARGET_CONFIG_H_
-#define TARGET_CONFIG_H_
+#ifndef TARGET_CONFIG_H
+#define TARGET_CONFIG_H
 
 #include "common_types.h"
 #include "cfe_psp_configdata.h"
@@ -213,4 +210,4 @@ typedef const struct
  */
 extern Target_ConfigData GLOBAL_CONFIGDATA;
 
-#endif /* TARGET_CONFIG_H_ */
+#endif /* TARGET_CONFIG_H */

--- a/modules/cfe_assert/inc/cfe_assert.h
+++ b/modules/cfe_assert/inc/cfe_assert.h
@@ -24,8 +24,15 @@
 **   Specification for the CFE assert (UT assert wrapper) functions.
 **
 *************************************************************************/
-#ifndef cfe_assert_h_
-#define cfe_assert_h_
+
+/**
+ * @file
+ *
+ * Declarations and prototypes for cfe_assert module
+ */
+
+#ifndef CFE_ASSERT_H
+#define CFE_ASSERT_H
 
 /************************************************************************
 ** Includes
@@ -56,8 +63,4 @@
 *************************************************************************/
 void CFE_Assert_AppMain(void);
 
-#endif /* cfe_assert_h_ */
-
-/************************/
-/*  End of File Comment */
-/************************/
+#endif /* CFE_ASSERT_H */

--- a/modules/cfe_assert/inc/cfe_assert.h
+++ b/modules/cfe_assert/inc/cfe_assert.h
@@ -59,7 +59,6 @@
 **
 **  \return Execution status, see \ref CFEReturnCodes
 **
-**
 *************************************************************************/
 void CFE_Assert_AppMain(void);
 

--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -26,13 +26,18 @@
 **
 *************************************************************************/
 
+/**
+ * @file
+ *
+ * Declarations and prototypes for cfe_test module
+ */
+
 #ifndef CFE_TEST_H
 #define CFE_TEST_H
 
 /*
  * Includes
  */
-
 #include "cfe.h"
 
 #include "uttest.h"

--- a/modules/cfe_testrunner/inc/cfe_testrunner.h
+++ b/modules/cfe_testrunner/inc/cfe_testrunner.h
@@ -59,7 +59,6 @@
 **
 **  \return Execution status, see \ref CFEReturnCodes
 **
-**
 *************************************************************************/
 void CFE_TestRunner_AppMain(void);
 

--- a/modules/cfe_testrunner/inc/cfe_testrunner.h
+++ b/modules/cfe_testrunner/inc/cfe_testrunner.h
@@ -24,8 +24,15 @@
 **   Specification for the CFE testrunner (UT testrunner wrapper) functions.
 **
 *************************************************************************/
-#ifndef cfe_testrunner_h_
-#define cfe_testrunner_h_
+
+/**
+ * @file
+ *
+ * Declarations and prototypes for cfe_testrunner module
+ */
+
+#ifndef CFE_TESTRUNNER_H
+#define CFE_TESTRUNNER_H
 
 /************************************************************************
 ** Includes
@@ -56,8 +63,4 @@
 *************************************************************************/
 void CFE_TestRunner_AppMain(void);
 
-#endif /* cfe_testrunner_h_ */
-
-/************************/
-/*  End of File Comment */
-/************************/
+#endif /* CFE_TESTRUNNER_H */

--- a/modules/core_api/fsw/inc/cfe.h
+++ b/modules/core_api/fsw/inc/cfe.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:  cFE header file
  *
  * Author:   David Kobe, the Hammers Company, Inc.

--- a/modules/core_api/fsw/inc/cfe.h
+++ b/modules/core_api/fsw/inc/cfe.h
@@ -18,24 +18,20 @@
 **  limitations under the License.
 */
 
-/*
-** File: cfe.h
-**
-** Purpose:  cFE header file
-**
-** Author:   David Kobe, the Hammers Company, Inc.
-**
-** Notes:    This header file centralizes the includes for all cFE
-**           Applications.  It includes all header files necessary
-**           to completely define the cFE interface.
-**
-*/
+/**
+ * @file
+ *
+ *
+ * Purpose:  cFE header file
+ *
+ * Author:   David Kobe, the Hammers Company, Inc.
+ *
+ * Notes:    This header file centralizes the includes for all cFE
+ *           Applications.  It includes all header files necessary
+ *           to completely define the cFE interface.
+ *
+ */
 
-/*************************************************************************/
-
-/*
-** Ensure that header is included only once...
-*/
 #ifndef CFE_H
 #define CFE_H
 

--- a/modules/core_api/fsw/inc/cfe_endian.h
+++ b/modules/core_api/fsw/inc/cfe_endian.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:
  *      Define macros to enforce big-endian/network byte order for 16 and 32 bit integers
  *

--- a/modules/core_api/fsw/inc/cfe_endian.h
+++ b/modules/core_api/fsw/inc/cfe_endian.h
@@ -18,13 +18,14 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
-** File:  cfe_endian.h
-**
-** Purpose:
-**      Define macros to enforce big-endian/network byte order for 16 and 32 bit integers
-**
-******************************************************************************/
+/**
+ * @file
+ *
+ *
+ * Purpose:
+ *      Define macros to enforce big-endian/network byte order for 16 and 32 bit integers
+ *
+ */
 
 #ifndef CFE_ENDIAN_H
 #define CFE_ENDIAN_H

--- a/modules/core_api/fsw/inc/cfe_error.h
+++ b/modules/core_api/fsw/inc/cfe_error.h
@@ -18,26 +18,24 @@
 **  limitations under the License.
 */
 
-/*
-**  Filename: cfe_error.h
-**
-**  Title:    cFE Status Code Definition Header File
-**
-**  Purpose:
-**            Common source of cFE API return status codes.
-**
-**  Design Notes:
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**
-**/
+/**
+ * @file
+ *
+ *
+ *  Title:    cFE Status Code Definition Header File
+ *
+ *  Purpose:
+ *            Common source of cFE API return status codes.
+ *
+ *  Design Notes:
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *
+ */
 
-/*
-** Ensure that header is included only once...
-*/
-#ifndef _cfe_error_
-#define _cfe_error_
+#ifndef CFE_ERROR_H
+#define CFE_ERROR_H
 
 /* Include Files */
 #include "osapi.h"
@@ -45,7 +43,6 @@
 /*
  * Define a type for readability.
  */
-
 typedef int32 CFE_Status_t;
 
 /*
@@ -1381,4 +1378,4 @@ typedef int32 CFE_Status_t;
 #define CFE_ES_CDS_REGISTRY_FULL CFE_ES_NO_RESOURCE_IDS_AVAILABLE
 #endif
 
-#endif /* _cfe_error_ */
+#endif /* CFE_ERROR_H */

--- a/modules/core_api/fsw/inc/cfe_error.h
+++ b/modules/core_api/fsw/inc/cfe_error.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Title:    cFE Status Code Definition Header File
  *
  *  Purpose:
@@ -74,7 +73,6 @@ typedef int32 CFE_Status_t;
 **          101 - Software Bus Services
 **          110 - Tables Services
 **          111 - Time Services
-**
 **
 **      Mission Defined - These bits are available for Mission
 **                        specific coding standards.  They can

--- a/modules/core_api/fsw/inc/cfe_es.h
+++ b/modules/core_api/fsw/inc/cfe_es.h
@@ -18,22 +18,23 @@
 **  limitations under the License.
 */
 
-/*
-**  File: cfe_es.h
-**
-**  Purpose:
-**	Unit specification for Executive Services library functions and macros.
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**     cFE Flight Software Application Developers Guide
-**
-**	Notes:
-**
-*/
+/**
+ * @file
+ *
+ *
+ *  Purpose:
+ *	Unit specification for Executive Services library functions and macros.
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *     cFE Flight Software Application Developers Guide
+ *
+ *	Notes:
+ *
+ */
 
-#ifndef CFE_ES_API_H
-#define CFE_ES_API_H
+#ifndef CFE_ES_H
+#define CFE_ES_H
 
 /*
 ** Includes
@@ -1676,4 +1677,4 @@ CFE_Status_t CFE_ES_GetGenCounterName(char *CounterName, CFE_ES_CounterId_t Coun
 
 /**@}*/
 
-#endif /* CFE_ES_API_H */
+#endif /* CFE_ES_H */

--- a/modules/core_api/fsw/inc/cfe_es.h
+++ b/modules/core_api/fsw/inc/cfe_es.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Purpose:
  *	Unit specification for Executive Services library functions and macros.
  *
@@ -341,7 +340,6 @@ CFE_Status_t CFE_ES_DeleteApp(CFE_ES_AppId_t AppID);
 ** \arg #CFE_ES_RunStatus_CORE_APP_INIT_ERROR - \copybrief CFE_ES_RunStatus_CORE_APP_INIT_ERROR
 ** \arg #CFE_ES_RunStatus_CORE_APP_RUNTIME_ERROR - \copybrief CFE_ES_RunStatus_CORE_APP_RUNTIME_ERROR
 **
-**
 ** \sa #CFE_ES_RunLoop, #CFE_ES_RegisterApp
 **
 ******************************************************************************/
@@ -431,7 +429,6 @@ CFE_Status_t CFE_ES_WaitForSystemState(uint32 MinSystemState, uint32 TimeOutMill
 **                                   wait indefinitely to avoid hanging a critical
 **                                   application because a non-critical app did not start.
 **
-**
 ** \sa #CFE_ES_RunLoop
 **
 ******************************************************************************/
@@ -498,7 +495,6 @@ void CFE_ES_IncrementTaskCounter(void);
 **                                      stored at the given address. For a list of possible Sub-Type values, see \link
 **                                      #CFE_PSP_RST_SUBTYPE_POWER_CYCLE "Reset Sub-Types" \endlink.
 **
-**
 ** \return Processor reset type
 ** \retval #CFE_PSP_RST_TYPE_POWERON   \copybrief CFE_PSP_RST_TYPE_POWERON
 ** \retval #CFE_PSP_RST_TYPE_PROCESSOR \copybrief CFE_PSP_RST_TYPE_PROCESSOR
@@ -520,7 +516,6 @@ int32 CFE_ES_GetResetType(uint32 *ResetSubtypePtr);
 **
 ** \param[out]   AppIdPtr       Pointer to variable that is to receive the Application's ID.
 **                              *AppIdPtr will be set to the application ID of the calling Application.
-**
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                      \copybrief CFE_SUCCESS
@@ -569,7 +564,6 @@ CFE_Status_t CFE_ES_GetTaskID(CFE_ES_TaskId_t *TaskIdPtr);
 ** \param[out]  AppIdPtr       Pointer to variable that is to receive the Application's ID.
 ** \param[in]   AppName        Pointer to null terminated character string containing an Application name.
 **
-**
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                 \copybrief CFE_SUCCESS
 ** \retval #CFE_ES_ERR_NAME_NOT_FOUND   \copybrief CFE_ES_ERR_NAME_NOT_FOUND
@@ -593,7 +587,6 @@ CFE_Status_t CFE_ES_GetAppIDByName(CFE_ES_AppId_t *AppIdPtr, const char *AppName
 **
 ** \param[out]  LibIdPtr       Pointer to variable that is to receive the Library's ID.
 ** \param[in]   LibName        Pointer to null terminated character string containing a Library name.
-**
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                 \copybrief CFE_SUCCESS
@@ -625,7 +618,6 @@ CFE_Status_t CFE_ES_GetLibIDByName(CFE_ES_LibId_t *LibIdPtr, const char *LibName
 **                            into the \c AppName buffer.  This routine will truncate the name to this length,
 **                            if necessary.
 **
-**
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                      \copybrief CFE_SUCCESS
 ** \retval #CFE_ES_ERR_RESOURCEID_NOT_VALID  \copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID
@@ -655,7 +647,6 @@ CFE_Status_t CFE_ES_GetAppName(char *AppName, CFE_ES_AppId_t AppId, size_t Buffe
 **                            into the \c LibName buffer.  This routine will truncate the name to this length,
 **                            if necessary.
 **
-**
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                      \copybrief CFE_SUCCESS
 ** \retval #CFE_ES_ERR_RESOURCEID_NOT_VALID  \copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID
@@ -680,7 +671,6 @@ CFE_Status_t CFE_ES_GetLibName(char *LibName, CFE_ES_LibId_t LibId, size_t Buffe
 ** \param[out]  AppInfo      Pointer to a structure that will be filled with
 **                           resource name and memory addresses information.
 ** \param[in]   AppId        ID of application to obtain information about
-**
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                      \copybrief CFE_SUCCESS
@@ -709,7 +699,6 @@ CFE_Status_t CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, CFE_ES_AppId_t AppId);
 **                            the Task Name, Parent App Name, Parent App ID among other fields.
 **
 ** \param[in]   TaskId        Application ID of Application whose name is being requested.
-**
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                      \copybrief CFE_SUCCESS
@@ -743,7 +732,6 @@ CFE_Status_t CFE_ES_GetTaskInfo(CFE_ES_TaskInfo_t *TaskInfo, CFE_ES_TaskId_t Tas
 **                           resource name and memory addresses information.
 ** \param[in]   LibId        ID of application to obtain information about
 **
-**
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                      \copybrief CFE_SUCCESS
 ** \retval #CFE_ES_ERR_RESOURCEID_NOT_VALID  \copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID
@@ -769,14 +757,12 @@ int32 CFE_ES_GetLibInfo(CFE_ES_AppInfo_t *LibInfo, CFE_ES_LibId_t LibId);
 **        easily ported to operate on either Libraries or Applications, where
 **        relevant.
 **
-**
 ** \par Assumptions, External Events, and Notes:
 **        None
 **
 ** \param[out]  ModuleInfo   Pointer to a structure that will be filled with
 **                           resource name and memory addresses information.
 ** \param[in]   ResourceId   ID of application or library to obtain information about
-**
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                      \copybrief CFE_SUCCESS
@@ -872,7 +858,6 @@ CFE_Status_t CFE_ES_CreateChildTask(CFE_ES_TaskId_t *TaskIdPtr, const char *Task
 ** \param[out]  TaskIdPtr       Pointer to variable that is to receive the Task's ID.
 ** \param[in]   TaskName        Pointer to null terminated character string containing an Task name.
 **
-**
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                 \copybrief CFE_SUCCESS
 ** \retval #CFE_ES_ERR_NAME_NOT_FOUND   \copybrief CFE_ES_ERR_NAME_NOT_FOUND
@@ -902,7 +887,6 @@ CFE_Status_t CFE_ES_GetTaskIDByName(CFE_ES_TaskId_t *TaskIdPtr, const char *Task
 ** \param[in]   BufferLength  The maximum number of characters, including the null terminator, that can be put
 **                            into the \c TaskName buffer.  This routine will truncate the name to this length,
 **                            if necessary.
-**
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                      \copybrief CFE_SUCCESS
@@ -975,7 +959,6 @@ void CFE_ES_ExitChildTask(void);
 **        based on the amount of time elapsed since the last wakeup.  Waking the task
 **        early will not cause the background task to do more work than it otherwise
 **        would - it just reduces the delay before work starts initially.
-**
 **
 ******************************************************************************/
 void CFE_ES_BackgroundWakeup(void);
@@ -1051,7 +1034,6 @@ uint32 CFE_ES_CalculateCRC(const void *DataPtr, size_t DataLength, uint32 InputC
 **        context which may use OSAL primitives.  In general this means that
 **        it shouldn't be _directly_ invoked from an ISR/signal context.
 **
-**
 ******************************************************************************/
 void CFE_ES_ProcessAsyncEvent(void);
 
@@ -1081,7 +1063,6 @@ void CFE_ES_ProcessAsyncEvent(void);
 ** \param[in]   Name        A pointer to a character string containing an application
 **                          unique name of #CFE_MISSION_ES_CDS_MAX_NAME_LENGTH characters or less.
 **
-**
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS               The memory block was successfully created in the CDS.
 ** \retval #CFE_ES_NOT_IMPLEMENTED    The processor does not support a Critical Data Store.
@@ -1108,7 +1089,6 @@ CFE_Status_t CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *HandlePtr, size_t BlockSize,
 **
 ** \param[out]  BlockIdPtr       Pointer to variable that is to receive the CDS Block ID.
 ** \param[in]   BlockName        Pointer to null terminated character string containing a CDS Block name.
-**
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                 \copybrief CFE_SUCCESS
@@ -1139,7 +1119,6 @@ CFE_Status_t CFE_ES_GetCDSBlockIDByName(CFE_ES_CDSHandle_t *BlockIdPtr, const ch
 ** \param[in]   BufferLength  The maximum number of characters, including the null terminator, that can be put
 **                            into the \c BlockName buffer.  This routine will truncate the name to this length,
 **                            if necessary.
-**
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                      \copybrief CFE_SUCCESS
@@ -1428,7 +1407,6 @@ int32 CFE_ES_PutPoolBuf(CFE_ES_MemHandle_t PoolID, CFE_ES_MemPoolBuf_t BufPtr);
 **
 ** \param[in]   Handle      The handle to the memory pool whose statistics are desired.
 **
-**
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                      \copybrief CFE_SUCCESS
 ** \retval #CFE_ES_ERR_RESOURCEID_NOT_VALID  \copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID
@@ -1664,7 +1642,6 @@ CFE_Status_t CFE_ES_GetGenCounterIDByName(CFE_ES_CounterId_t *CounterIdPtr, cons
 ** \param[in]   BufferLength  The maximum number of characters, including the null terminator, that can be put
 **                            into the \c CounterName buffer.  This routine will truncate the name to this length,
 **                            if necessary.
-**
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                      \copybrief CFE_SUCCESS

--- a/modules/core_api/fsw/inc/cfe_es_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_es_api_typedefs.h
@@ -18,22 +18,23 @@
 **  limitations under the License.
 */
 
-/*
-**  File: cfe_es_api_typedefs.h
-**
-**  Purpose:
-**	Unit specification for Executive Services library functions and macros.
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**     cFE Flight Software Application Developers Guide
-**
-**	Notes:
-**
-*/
+/**
+ * @file
+ *
+ *
+ *  Purpose:
+ *	Unit specification for Executive Services library functions and macros.
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *     cFE Flight Software Application Developers Guide
+ *
+ *	Notes:
+ *
+ */
 
-#ifndef CFE_ES_ABSTRACT_TYPES_H
-#define CFE_ES_ABSTRACT_TYPES_H
+#ifndef CFE_ES_API_TYPEDEFS_H
+#define CFE_ES_API_TYPEDEFS_H
 
 /*
 ** Includes
@@ -190,4 +191,4 @@ typedef void *CFE_ES_MemPoolBuf_t;
 #define CFE_ES_NO_MUTEX  false /**< \brief Indicates that the memory pool selection will not use a semaphore */
 #define CFE_ES_USE_MUTEX true  /**< \brief Indicates that the memory pool selection will use a semaphore */
 
-#endif /* CFE_ES_ABSTRACT_TYPES_H */
+#endif /* CFE_ES_API_TYPEDEFS_H */

--- a/modules/core_api/fsw/inc/cfe_es_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_es_api_typedefs.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Purpose:
  *	Unit specification for Executive Services library functions and macros.
  *

--- a/modules/core_api/fsw/inc/cfe_es_core_internal.h
+++ b/modules/core_api/fsw/inc/cfe_es_core_internal.h
@@ -18,19 +18,20 @@
 **  limitations under the License.
 */
 
-/*
-**  File: cfe_es.h
-**
-**  Purpose:
-**	Unit specification for Executive Services library functions and macros.
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**     cFE Flight Software Application Developers Guide
-**
-**	Notes:
-**
-*/
+/**
+ * @file
+ *
+ *
+ *  Purpose:
+ *	Unit specification for Executive Services library functions and macros.
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *     cFE Flight Software Application Developers Guide
+ *
+ *	Notes:
+ *
+ */
 
 #ifndef CFE_ES_CORE_INTERNAL_H
 #define CFE_ES_CORE_INTERNAL_H

--- a/modules/core_api/fsw/inc/cfe_es_core_internal.h
+++ b/modules/core_api/fsw/inc/cfe_es_core_internal.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Purpose:
  *	Unit specification for Executive Services library functions and macros.
  *
@@ -58,7 +57,6 @@
 **
 ** \par Assumptions, External Events, and Notes:
 **          None
-**
 **
 ******************************************************************************/
 extern void CFE_ES_TaskMain(void);
@@ -100,7 +98,6 @@ extern int32 CFE_ES_CDS_EarlyInit(void);
 **                          the CDS.
 **
 ** \param[in]   CriticalTbl   Indicates whether the CDS is to be used as a Critical Table or not
-**
 **
 ** \return See return codes for #CFE_ES_RegisterCDS
 **

--- a/modules/core_api/fsw/inc/cfe_es_extern_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_es_extern_typedefs.h
@@ -61,7 +61,6 @@ enum CFE_ES_LogMode
 /**
  * @brief Identifies handling of log messages after storage is filled
  *
- *
  * @sa enum CFE_ES_LogMode
  */
 typedef uint8 CFE_ES_LogMode_Enum_t;
@@ -85,7 +84,6 @@ enum CFE_ES_ExceptionAction
 
 /**
  * @brief Identifies action to take if exception occurs
- *
  *
  * @sa enum CFE_ES_ExceptionAction
  */
@@ -115,7 +113,6 @@ enum CFE_ES_AppType
 
 /**
  * @brief Identifies type of CFE application
- *
  *
  * @sa enum CFE_ES_AppType
  */
@@ -186,7 +183,6 @@ enum CFE_ES_RunStatus
 /**
  * @brief Run Status and Exit Status identifiers
  *
- *
  * @sa enum CFE_ES_RunStatus
  */
 typedef uint32 CFE_ES_RunStatus_Enum_t;
@@ -241,7 +237,6 @@ enum CFE_ES_SystemState
 /**
  * @brief The overall cFE System State
  *
- *
  * These values are used with the #CFE_ES_WaitForSystemState API call to synchronize application startup.
  *
  * @note These are defined in order so that relational comparisons e.g. if (STATEA < STATEB) are possible
@@ -269,7 +264,6 @@ enum CFE_ES_LogEntryType
 
 /**
  * @brief Type of entry in the Error and Reset (ER) Log
- *
  *
  * @sa enum CFE_ES_LogEntryType
  */
@@ -319,7 +313,6 @@ enum CFE_ES_AppState
 
 /**
  * @brief Application Run State
- *
  *
  * The normal progression of APP states:
  * UNDEFINED -> EARLY_INIT -> LATE_INIT -> RUNNING -> WAITING -> STOPPED

--- a/modules/core_api/fsw/inc/cfe_es_extern_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_es_extern_typedefs.h
@@ -18,8 +18,14 @@
 **  limitations under the License.
 */
 
-#ifndef _CFE_ES_EXTERN_TYPEDEFS_H_
-#define _CFE_ES_EXTERN_TYPEDEFS_H_
+/**
+ * @file
+ *
+ * Declarations and prototypes for cfe_es_extern_typedefs module
+ */
+
+#ifndef CFE_ES_EXTERN_TYPEDEFS_H
+#define CFE_ES_EXTERN_TYPEDEFS_H
 
 /* This header may be generated from an EDS file,
  * tools are available and the feature is enabled */
@@ -571,4 +577,4 @@ typedef struct CFE_ES_MemPoolStats
 
 #endif /* CFE_EDS_ENABLED_BUILD */
 
-#endif /* _CFE_ES_EXTERN_TYPEDEFS_H_ */
+#endif /* CFE_ES_EXTERN_TYPEDEFS_H */

--- a/modules/core_api/fsw/inc/cfe_evs.h
+++ b/modules/core_api/fsw/inc/cfe_evs.h
@@ -18,22 +18,23 @@
 **  limitations under the License.
 */
 
-/*
-**  Filename: cfe_evs.h
-**
-**  Title:    Event Services API Application Library Header File
-**
-**  Purpose:
-**	           Unit specification for Event services library functions and macros.
-**
-**  Design Notes:
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**/
+/**
+ * @file
+ *
+ *
+ *  Title:    Event Services API Application Library Header File
+ *
+ *  Purpose:
+ *	           Unit specification for Event services library functions and macros.
+ *
+ *  Design Notes:
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ */
 
-#ifndef CFE_EVS_API_H
-#define CFE_EVS_API_H
+#ifndef CFE_EVS_H
+#define CFE_EVS_H
 
 /********************************** Include Files  ************************************/
 #include "common_types.h" /* Basic data types */
@@ -328,4 +329,4 @@ CFE_Status_t CFE_EVS_ResetFilter(int16 EventID);
 CFE_Status_t CFE_EVS_ResetAllFilters(void);
 /**@}*/
 
-#endif /* CFE_EVS_API_H */
+#endif /* CFE_EVS_H */

--- a/modules/core_api/fsw/inc/cfe_evs.h
+++ b/modules/core_api/fsw/inc/cfe_evs.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Title:    Event Services API Application Library Header File
  *
  *  Purpose:

--- a/modules/core_api/fsw/inc/cfe_evs_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_evs_api_typedefs.h
@@ -18,22 +18,23 @@
 **  limitations under the License.
 */
 
-/*
-**  Filename: cfe_evs.h
-**
-**  Title:    Event Services API Application Library Header File
-**
-**  Purpose:
-**	           Unit specification for Event services library functions and macros.
-**
-**  Design Notes:
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**/
+/**
+ * @file
+ *
+ *
+ *  Title:    Event Services API Application Library Header File
+ *
+ *  Purpose:
+ *	           Unit specification for Event services library functions and macros.
+ *
+ *  Design Notes:
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ */
 
-#ifndef CFE_EVS_ABSTRACT_TYPES_H
-#define CFE_EVS_ABSTRACT_TYPES_H
+#ifndef CFE_EVS_API_TYPEDEFS_H
+#define CFE_EVS_API_TYPEDEFS_H
 
 /********************************** Include Files  ************************************/
 #include "common_types.h" /* Basic data types */
@@ -64,4 +65,4 @@ typedef struct CFE_EVS_BinFilter
 
 } CFE_EVS_BinFilter_t;
 
-#endif /* CFE_EVS_ABSTRACT_TYPES_H */
+#endif /* CFE_EVS_API_TYPEDEFS_H */

--- a/modules/core_api/fsw/inc/cfe_evs_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_evs_api_typedefs.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Title:    Event Services API Application Library Header File
  *
  *  Purpose:

--- a/modules/core_api/fsw/inc/cfe_evs_core_internal.h
+++ b/modules/core_api/fsw/inc/cfe_evs_core_internal.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Title:    Event Services API Application Library Header File
  *
  *  Purpose:
@@ -58,7 +57,6 @@
 **
 ** \par Assumptions, External Events, and Notes:
 **          None
-**
 **
 ******************************************************************************/
 extern void CFE_EVS_TaskMain(void);

--- a/modules/core_api/fsw/inc/cfe_evs_core_internal.h
+++ b/modules/core_api/fsw/inc/cfe_evs_core_internal.h
@@ -18,19 +18,20 @@
 **  limitations under the License.
 */
 
-/*
-**  Filename: cfe_evs.h
-**
-**  Title:    Event Services API Application Library Header File
-**
-**  Purpose:
-**	           Unit specification for Event services library functions and macros.
-**
-**  Design Notes:
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**/
+/**
+ * @file
+ *
+ *
+ *  Title:    Event Services API Application Library Header File
+ *
+ *  Purpose:
+ *	           Unit specification for Event services library functions and macros.
+ *
+ *  Design Notes:
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ */
 
 #ifndef CFE_EVS_CORE_INTERNAL_H
 #define CFE_EVS_CORE_INTERNAL_H

--- a/modules/core_api/fsw/inc/cfe_evs_extern_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_evs_extern_typedefs.h
@@ -59,7 +59,6 @@ enum CFE_EVS_MsgFormat
 /**
  * @brief Identifies format of log messages
  *
- *
  * @sa enum CFE_EVS_MsgFormat
  */
 typedef uint8 CFE_EVS_MsgFormat_Enum_t;
@@ -83,7 +82,6 @@ enum CFE_EVS_LogMode
 
 /**
  * @brief Identifies handling of log messages after storage is filled
- *
  *
  * @sa enum CFE_EVS_LogMode
  */
@@ -119,7 +117,6 @@ enum CFE_EVS_EventType
 /**
  * @brief Identifies type of event message
  *
- *
  * @sa enum CFE_EVS_EventType
  */
 typedef uint16 CFE_EVS_EventType_Enum_t;
@@ -138,7 +135,6 @@ enum CFE_EVS_EventFilter
 
 /**
  * @brief Identifies event filter schemes
- *
  *
  * @sa enum CFE_EVS_EventFilter
  */
@@ -173,7 +169,6 @@ enum CFE_EVS_EventOutput
 
 /**
  * @brief Identifies event output port
- *
  *
  * @sa enum CFE_EVS_EventOutput
  */

--- a/modules/core_api/fsw/inc/cfe_evs_extern_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_evs_extern_typedefs.h
@@ -18,8 +18,14 @@
 **  limitations under the License.
 */
 
-#ifndef _CFE_EVS_EXTERN_TYPEDEFS_H_
-#define _CFE_EVS_EXTERN_TYPEDEFS_H_
+/**
+ * @file
+ *
+ * Declarations and prototypes for cfe_evs_extern_typedefs module
+ */
+
+#ifndef CFE_EVS_EXTERN_TYPEDEFS_H
+#define CFE_EVS_EXTERN_TYPEDEFS_H
 
 /* This header may be generated from an EDS file,
  * tools are available and the feature is enabled */
@@ -175,4 +181,4 @@ typedef uint8 CFE_EVS_EventOutput_Enum_t;
 
 #endif /* CFE_EDS_ENABLED_BUILD */
 
-#endif /* _CFE_EVS_EXTERN_TYPEDEFS_H_ */
+#endif /* CFE_EVS_EXTERN_TYPEDEFS_H */

--- a/modules/core_api/fsw/inc/cfe_fs.h
+++ b/modules/core_api/fsw/inc/cfe_fs.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:  cFE File Services (FS) library API header file
  *
  * Author:   S.Walling/Microtel
@@ -111,7 +110,6 @@ void CFE_FS_InitHeader(CFE_FS_Header_t *Hdr, const char *Description, uint32 Sub
 **                                                                       by #CFE_TIME_GetTime
 **      -# \link #CFE_FS_Header_t::TimeSubSeconds \c TimeSubSeconds \endlink - Filled with the Time, subseconds, as
 **                                                                             obtained by #CFE_TIME_GetTime
-**
 **
 ** \par Assumptions, External Events, and Notes:
 **        -# The File has already been successfully opened using #OS_OpenCreate and

--- a/modules/core_api/fsw/inc/cfe_fs.h
+++ b/modules/core_api/fsw/inc/cfe_fs.h
@@ -18,20 +18,18 @@
 **  limitations under the License.
 */
 
-/*
-** File: cfe_fs.h
-**
-** Purpose:  cFE File Services (FS) library API header file
-**
-** Author:   S.Walling/Microtel
-**
-*/
+/**
+ * @file
+ *
+ *
+ * Purpose:  cFE File Services (FS) library API header file
+ *
+ * Author:   S.Walling/Microtel
+ *
+ */
 
-/*
-** Ensure that header is included only once...
-*/
-#ifndef _cfe_fs_
-#define _cfe_fs_
+#ifndef CFE_FS_H
+#define CFE_FS_H
 
 /*
 ** Required header files...
@@ -345,8 +343,4 @@ bool CFE_FS_RunBackgroundFileDump(uint32 ElapsedTime, void *Arg);
 
 /**@}*/
 
-#endif /* _cfe_fs_ */
-
-/************************/
-/*  End of File Comment */
-/************************/
+#endif /* CFE_FS_H */

--- a/modules/core_api/fsw/inc/cfe_fs_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_fs_api_typedefs.h
@@ -18,20 +18,18 @@
 **  limitations under the License.
 */
 
-/*
-** File: cfe_fs_api_typedefs.h
-**
-** Purpose:  cFE File Services (FS) library API header file
-**
-** Author:   S.Walling/Microtel
-**
-*/
+/**
+ * @file
+ *
+ *
+ * Purpose:  cFE File Services (FS) library API header file
+ *
+ * Author:   S.Walling/Microtel
+ *
+ */
 
-/*
-** Ensure that header is included only once...
-*/
-#ifndef CFE_FS_ABSTRACT_TYPES_H
-#define CFE_FS_ABSTRACT_TYPES_H
+#ifndef CFE_FS_API_TYPEDEFS_H
+#define CFE_FS_API_TYPEDEFS_H
 
 /*
 ** Required header files...
@@ -121,8 +119,4 @@ typedef struct CFE_FS_FileWriteMetaData
 
 } CFE_FS_FileWriteMetaData_t;
 
-#endif /* CFE_FS_ABSTRACT_TYPES_H */
-
-/************************/
-/*  End of File Comment */
-/************************/
+#endif /* CFE_FS_API_TYPEDEFS_H */

--- a/modules/core_api/fsw/inc/cfe_fs_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_fs_api_typedefs.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:  cFE File Services (FS) library API header file
  *
  * Author:   S.Walling/Microtel

--- a/modules/core_api/fsw/inc/cfe_fs_core_internal.h
+++ b/modules/core_api/fsw/inc/cfe_fs_core_internal.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:  cFE File Services (FS) library API header file
  *
  * Author:   S.Walling/Microtel

--- a/modules/core_api/fsw/inc/cfe_fs_core_internal.h
+++ b/modules/core_api/fsw/inc/cfe_fs_core_internal.h
@@ -18,18 +18,16 @@
 **  limitations under the License.
 */
 
-/*
-** File: cfe_fs.h
-**
-** Purpose:  cFE File Services (FS) library API header file
-**
-** Author:   S.Walling/Microtel
-**
-*/
+/**
+ * @file
+ *
+ *
+ * Purpose:  cFE File Services (FS) library API header file
+ *
+ * Author:   S.Walling/Microtel
+ *
+ */
 
-/*
-** Ensure that header is included only once...
-*/
 #ifndef CFE_FS_CORE_INTERNAL_H
 #define CFE_FS_CORE_INTERNAL_H
 
@@ -61,7 +59,3 @@ extern int32 CFE_FS_EarlyInit(void);
 /**@}*/
 
 #endif /* CFE_FS_CORE_INTERNAL_H */
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/modules/core_api/fsw/inc/cfe_fs_extern_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_fs_extern_typedefs.h
@@ -61,7 +61,6 @@ enum CFE_FS_SubType
     /**
      * @brief Executive Services Exception/Reset Log Type
      *
-     *
      * Executive Services Exception/Reset Log File which is generated in response to a
      * \link #CFE_ES_WRITE_ER_LOG_CC \ES_WRITEERLOG2FILE \endlink
      * command.
@@ -71,7 +70,6 @@ enum CFE_FS_SubType
 
     /**
      * @brief Executive Services System Log Type
-     *
      *
      * Executive Services System Log File which is generated in response to a
      * \link #CFE_ES_WRITE_SYSLOG_CC \ES_WRITESYSLOG2FILE \endlink
@@ -83,7 +81,6 @@ enum CFE_FS_SubType
     /**
      * @brief Executive Services Information on All Applications File
      *
-     *
      * Executive Services Information on All Applications File which is generated in response to a
      * \link #CFE_ES_QUERY_ALL_CC \ES_WRITEAPPINFO2FILE \endlink
      * command.
@@ -93,7 +90,6 @@ enum CFE_FS_SubType
 
     /**
      * @brief Executive Services Performance Data File
-     *
      *
      * Executive Services Performance Analyzer Data File which is generated in response to a
      * \link #CFE_ES_STOP_PERF_DATA_CC \ES_STOPLADATA \endlink
@@ -105,7 +101,6 @@ enum CFE_FS_SubType
     /**
      * @brief Executive Services Shell Response File
      *
-     *
      * Executive Services Shell Response Data File which is generated in response to a
      * shell command.
      *
@@ -114,7 +109,6 @@ enum CFE_FS_SubType
 
     /**
      * @brief Executive Services Critical Data Store Registry Dump File
-     *
      *
      * Executive Services Critical Data Store Registry Dump File which is generated in response to a
      * \link #CFE_ES_DUMP_CDS_REGISTRY_CC \ES_DUMPCDSREG \endlink
@@ -126,7 +120,6 @@ enum CFE_FS_SubType
     /**
      * @brief Table Services Registry Dump File
      *
-     *
      * Table Services Registry Dump File which is generated in response to a
      * \link #CFE_TBL_DUMP_REGISTRY_CC \TBL_WRITEREG2FILE \endlink
      * command.
@@ -137,7 +130,6 @@ enum CFE_FS_SubType
     /**
      * @brief Table Services Table Image File
      *
-     *
      * Table Services Table Image File which is generated either on the ground or in response to a
      * \link #CFE_TBL_DUMP_CC \TBL_DUMP \endlink command.
      *
@@ -146,7 +138,6 @@ enum CFE_FS_SubType
 
     /**
      * @brief Event Services Application Data Dump File
-     *
      *
      * Event Services Application Data Dump File which is generated in response to a
      * \link #CFE_EVS_WRITE_APP_DATA_FILE_CC \EVS_WRITEAPPDATA2FILE \endlink
@@ -158,7 +149,6 @@ enum CFE_FS_SubType
     /**
      * @brief Event Services Local Event Log Dump File
      *
-     *
      * Event Services Local Event Log Dump File which is generated in response to a
      * \link  #CFE_EVS_WRITE_LOG_DATA_FILE_CC \EVS_WRITELOG2FILE \endlink
      * command.
@@ -168,7 +158,6 @@ enum CFE_FS_SubType
 
     /**
      * @brief Software Bus Pipe Data Dump File
-     *
      *
      * Software Bus Pipe Data Dump File which is generated in response to a
      * \link #CFE_SB_WRITE_PIPE_INFO_CC \SB_WRITEPIPE2FILE \endlink
@@ -180,7 +169,6 @@ enum CFE_FS_SubType
     /**
      * @brief Software Bus Message Routing Data Dump File
      *
-     *
      * Software Bus Message Routing Data Dump File which is generated in response to a
      * \link #CFE_SB_WRITE_ROUTING_INFO_CC \SB_WRITEROUTING2FILE \endlink
      * command.
@@ -190,7 +178,6 @@ enum CFE_FS_SubType
 
     /**
      * @brief Software Bus Message Mapping Data Dump File
-     *
      *
      * Software Bus Message Mapping Data Dump File which is generated in response to a
      * \link #CFE_SB_WRITE_MAP_INFO_CC \SB_WRITEMAP2FILE \endlink
@@ -202,7 +189,6 @@ enum CFE_FS_SubType
     /**
      * @brief Executive Services Query All Tasks Data File
      *
-     *
      * Executive Services Query All Tasks Data File which is generated in response to a
      * \link #CFE_ES_QUERY_ALL_TASKS_CC \ES_WRITETASKINFO2FILE \endlink
      * command.
@@ -213,7 +199,6 @@ enum CFE_FS_SubType
 
 /**
  * @brief Content descriptor for File Headers
- *
  *
  * @sa enum CFE_FS_SubType
  */

--- a/modules/core_api/fsw/inc/cfe_fs_extern_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_fs_extern_typedefs.h
@@ -18,8 +18,14 @@
 **  limitations under the License.
 */
 
-#ifndef _CFE_FS_EXTERN_TYPEDEFS_H_
-#define _CFE_FS_EXTERN_TYPEDEFS_H_
+/**
+ * @file
+ *
+ * Declarations and prototypes for cfe_fs_extern_typedefs module
+ */
+
+#ifndef CFE_FS_EXTERN_TYPEDEFS_H
+#define CFE_FS_EXTERN_TYPEDEFS_H
 
 /* This header may be generated from an EDS file,
  * tools are available and the feature is enabled */
@@ -236,4 +242,4 @@ typedef struct CFE_FS_Header
 
 #endif /* CFE_EDS_ENABLED_BUILD */
 
-#endif /* _CFE_FS_EXTERN_TYPEDEFS_H_ */
+#endif /* CFE_FS_EXTERN_TYPEDEFS_H */

--- a/modules/core_api/fsw/inc/cfe_msg.h
+++ b/modules/core_api/fsw/inc/cfe_msg.h
@@ -18,12 +18,14 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
+/**
+ * @file
+ *
  * Message access APIs
  */
 
-#ifndef _cfe_msg_api_
-#define _cfe_msg_api_
+#ifndef CFE_MSG_H
+#define CFE_MSG_H
 
 /*
  * Includes
@@ -664,4 +666,4 @@ CFE_Status_t CFE_MSG_GetTypeFromMsgId(CFE_SB_MsgId_t MsgId, CFE_MSG_Type_t *Type
 
 /**\}*/
 
-#endif /* _cfe_msg_api_ */
+#endif /* CFE_MSG_H */

--- a/modules/core_api/fsw/inc/cfe_msg_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_msg_api_typedefs.h
@@ -18,13 +18,15 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
- * Message type defines
+/**
+ * @file
+ *
+ * Typedefs for Message API
  *  - Separate from API so these can be adjusted for custom implementations
  */
 
-#ifndef _cfe_msg_typedefs_
-#define _cfe_msg_typedefs_
+#ifndef CFE_MSG_API_TYPEDEFS_H
+#define CFE_MSG_API_TYPEDEFS_H
 
 /*
  * Includes
@@ -111,4 +113,4 @@ typedef struct CFE_MSG_CommandHeader CFE_MSG_CommandHeader_t;
  */
 typedef struct CFE_MSG_TelemetryHeader CFE_MSG_TelemetryHeader_t;
 
-#endif /* _cfe_msg_typedefs_ */
+#endif /* CFE_MSG_API_TYPEDEFS_H */

--- a/modules/core_api/fsw/inc/cfe_resourceid.h
+++ b/modules/core_api/fsw/inc/cfe_resourceid.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Contains global prototypes and definitions related to resource
  * management and related CFE resource IDs.
  *

--- a/modules/core_api/fsw/inc/cfe_resourceid.h
+++ b/modules/core_api/fsw/inc/cfe_resourceid.h
@@ -19,7 +19,8 @@
 */
 
 /**
- * \file cfe_resourceid.h
+ * @file
+ *
  *
  * Contains global prototypes and definitions related to resource
  * management and related CFE resource IDs.
@@ -36,8 +37,8 @@
  *  - Convert simple integer to ID (inverse of above)
  */
 
-#ifndef CFE_RESOURCEID_API_H
-#define CFE_RESOURCEID_API_H
+#ifndef CFE_RESOURCEID_H
+#define CFE_RESOURCEID_H
 
 /*
  * The basic resource ID API definitions

--- a/modules/core_api/fsw/inc/cfe_resourceid_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_resourceid_api_typedefs.h
@@ -19,7 +19,7 @@
 */
 
 /**
- * \file cfe_resourceid_api_typedefs.h
+ * @file
  *
  * Contains global prototypes and definitions related to resource
  * management and related CFE resource IDs.

--- a/modules/core_api/fsw/inc/cfe_sb.h
+++ b/modules/core_api/fsw/inc/cfe_sb.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:
  *      This header file contains all definitions for the cFE Software Bus
  *      Application Programmer's Interface.

--- a/modules/core_api/fsw/inc/cfe_sb.h
+++ b/modules/core_api/fsw/inc/cfe_sb.h
@@ -18,19 +18,20 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
-** File: cfe_sb.h
-**
-** Purpose:
-**      This header file contains all definitions for the cFE Software Bus
-**      Application Programmer's Interface.
-**
-** Author:   R.McGraw/SSI
-**
-******************************************************************************/
+/**
+ * @file
+ *
+ *
+ * Purpose:
+ *      This header file contains all definitions for the cFE Software Bus
+ *      Application Programmer's Interface.
+ *
+ * Author:   R.McGraw/SSI
+ *
+ */
 
-#ifndef CFE_SB_API_H
-#define CFE_SB_API_H
+#ifndef CFE_SB_H
+#define CFE_SB_H
 
 /*
 ** Includes
@@ -1309,5 +1310,4 @@ uint32 CFE_SB_GetPktType(CFE_SB_MsgId_t MsgId);
 
 /**@}*/
 
-#endif /* CFE_SB_API_H */
-/*****************************************************************************/
+#endif /* CFE_SB_H */

--- a/modules/core_api/fsw/inc/cfe_sb_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_sb_api_typedefs.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:
  *      This header file contains all definitions for the cFE Software Bus
  *      Application Programmer's Interface.

--- a/modules/core_api/fsw/inc/cfe_sb_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_sb_api_typedefs.h
@@ -18,16 +18,17 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
-** File: cfe_sb.h
-**
-** Purpose:
-**      This header file contains all definitions for the cFE Software Bus
-**      Application Programmer's Interface.
-**
-** Author:   R.McGraw/SSI
-**
-******************************************************************************/
+/**
+ * @file
+ *
+ *
+ * Purpose:
+ *      This header file contains all definitions for the cFE Software Bus
+ *      Application Programmer's Interface.
+ *
+ * Author:   R.McGraw/SSI
+ *
+ */
 
 #ifndef CFE_SB_API_TYPEDEFS_H
 #define CFE_SB_API_TYPEDEFS_H
@@ -183,4 +184,3 @@ typedef struct
 #endif /* CFE_OMIT_DEPRECATED_6_8 */
 
 #endif /* CFE_SB_API_TYPEDEFS_H */
-/*****************************************************************************/

--- a/modules/core_api/fsw/inc/cfe_sb_core_internal.h
+++ b/modules/core_api/fsw/inc/cfe_sb_core_internal.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:
  *      This header file contains all definitions for the cFE Software Bus
  *      Application Programmer's Interface.
@@ -55,7 +54,6 @@
 **
 ** \par Assumptions, External Events, and Notes:
 **          None
-**
 **
 ******************************************************************************/
 extern void CFE_SB_TaskMain(void);

--- a/modules/core_api/fsw/inc/cfe_sb_core_internal.h
+++ b/modules/core_api/fsw/inc/cfe_sb_core_internal.h
@@ -18,16 +18,17 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
-** File: cfe_sb.h
-**
-** Purpose:
-**      This header file contains all definitions for the cFE Software Bus
-**      Application Programmer's Interface.
-**
-** Author:   R.McGraw/SSI
-**
-******************************************************************************/
+/**
+ * @file
+ *
+ *
+ * Purpose:
+ *      This header file contains all definitions for the cFE Software Bus
+ *      Application Programmer's Interface.
+ *
+ * Author:   R.McGraw/SSI
+ *
+ */
 
 #ifndef CFE_SB_CORE_INTERNAL_H
 #define CFE_SB_CORE_INTERNAL_H
@@ -87,4 +88,3 @@ extern int32 CFE_SB_CleanUpApp(CFE_ES_AppId_t AppId);
 /**@}*/
 
 #endif /* CFE_SB_CORE_INTERNAL_H */
-/*****************************************************************************/

--- a/modules/core_api/fsw/inc/cfe_sb_extern_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_sb_extern_typedefs.h
@@ -18,8 +18,14 @@
 **  limitations under the License.
 */
 
-#ifndef _CFE_SB_EXTERN_TYPEDEFS_H_
-#define _CFE_SB_EXTERN_TYPEDEFS_H_
+/**
+ * @file
+ *
+ * Declarations and prototypes for cfe_sb_extern_typedefs module
+ */
+
+#ifndef CFE_SB_EXTERN_TYPEDEFS_H
+#define CFE_SB_EXTERN_TYPEDEFS_H
 
 /* This header may be generated from an EDS file,
  * tools are available and the feature is enabled */
@@ -134,4 +140,4 @@ typedef struct
 
 #endif /* CFE_EDS_ENABLED_BUILD */
 
-#endif /* _CFE_SB_EXTERN_TYPEDEFS_H_ */
+#endif /* CFE_SB_EXTERN_TYPEDEFS_H */

--- a/modules/core_api/fsw/inc/cfe_sb_extern_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_sb_extern_typedefs.h
@@ -63,7 +63,6 @@ enum CFE_SB_QosPriority
 /**
  * @brief Selects the priorty level for message routing
  *
- *
  * @sa enum CFE_SB_QosPriority
  */
 typedef uint8 CFE_SB_QosPriority_Enum_t;
@@ -87,7 +86,6 @@ enum CFE_SB_QosReliability
 
 /**
  * @brief Selects the reliability level for message routing
- *
  *
  * @sa enum CFE_SB_QosReliability
  */

--- a/modules/core_api/fsw/inc/cfe_tbl.h
+++ b/modules/core_api/fsw/inc/cfe_tbl.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Title:   Table Services API Application Library Header File
  *
  *  Purpose:

--- a/modules/core_api/fsw/inc/cfe_tbl.h
+++ b/modules/core_api/fsw/inc/cfe_tbl.h
@@ -18,25 +18,26 @@
 **  limitations under the License.
 */
 
-/*
-**  File: cfe_tbl.h
-**
-**  Title:   Table Services API Application Library Header File
-**
-**  Purpose:
-**     Unit specification for Table services library functions and macros.
-**
-**  Design Notes:
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**
-**  Notes:
-**
-**/
+/**
+ * @file
+ *
+ *
+ *  Title:   Table Services API Application Library Header File
+ *
+ *  Purpose:
+ *     Unit specification for Table services library functions and macros.
+ *
+ *  Design Notes:
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *
+ *  Notes:
+ *
+ */
 
-#ifndef CFE_TBL_API_H
-#define CFE_TBL_API_H
+#ifndef CFE_TBL_H
+#define CFE_TBL_H
 
 /********************* Include Files  ************************/
 #include "common_types.h" /* Basic Data Types */
@@ -739,4 +740,4 @@ CFE_Status_t CFE_TBL_NotifyByMessage(CFE_TBL_Handle_t TblHandle, CFE_SB_MsgId_t 
                                      uint32 Parameter);
 /**@}*/
 
-#endif /* CFE_TBL_API_H */
+#endif /* CFE_TBL_H */

--- a/modules/core_api/fsw/inc/cfe_tbl_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_tbl_api_typedefs.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Title:   Table Services API Application Library Header File
  *
  *  Purpose:

--- a/modules/core_api/fsw/inc/cfe_tbl_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_tbl_api_typedefs.h
@@ -18,25 +18,26 @@
 **  limitations under the License.
 */
 
-/*
-**  File: cfe_tbl.h
-**
-**  Title:   Table Services API Application Library Header File
-**
-**  Purpose:
-**     Unit specification for Table services library functions and macros.
-**
-**  Design Notes:
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**
-**  Notes:
-**
-**/
+/**
+ * @file
+ *
+ *
+ *  Title:   Table Services API Application Library Header File
+ *
+ *  Purpose:
+ *     Unit specification for Table services library functions and macros.
+ *
+ *  Design Notes:
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *
+ *  Notes:
+ *
+ */
 
-#ifndef CFE_TBL_ABSTRACT_TYPES_H
-#define CFE_TBL_ABSTRACT_TYPES_H
+#ifndef CFE_TBL_API_TYPEDEFS_H
+#define CFE_TBL_API_TYPEDEFS_H
 
 /********************* Include Files  ************************/
 #include "common_types.h" /* Basic Data Types */
@@ -123,4 +124,4 @@ typedef struct CFE_TBL_Info
     char               LastFileLoaded[CFE_MISSION_MAX_PATH_LEN]; /**< \brief Filename of last file loaded into table */
 } CFE_TBL_Info_t;
 
-#endif /* CFE_TBL_ABSTRACT_TYPES_H */
+#endif /* CFE_TBL_API_TYPEDEFS_H */

--- a/modules/core_api/fsw/inc/cfe_tbl_core_internal.h
+++ b/modules/core_api/fsw/inc/cfe_tbl_core_internal.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Title:   Table Services API Application Library Header File
  *
  *  Purpose:
@@ -63,7 +62,6 @@
 **
 ** \par Assumptions, External Events, and Notes:
 **          None
-**
 **
 ******************************************************************************/
 extern void CFE_TBL_TaskMain(void);

--- a/modules/core_api/fsw/inc/cfe_tbl_core_internal.h
+++ b/modules/core_api/fsw/inc/cfe_tbl_core_internal.h
@@ -18,22 +18,23 @@
 **  limitations under the License.
 */
 
-/*
-**  File: cfe_tbl.h
-**
-**  Title:   Table Services API Application Library Header File
-**
-**  Purpose:
-**     Unit specification for Table services library functions and macros.
-**
-**  Design Notes:
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**
-**  Notes:
-**
-**/
+/**
+ * @file
+ *
+ *
+ *  Title:   Table Services API Application Library Header File
+ *
+ *  Purpose:
+ *     Unit specification for Table services library functions and macros.
+ *
+ *  Design Notes:
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *
+ *  Notes:
+ *
+ */
 
 #ifndef CFE_TBL_CORE_INTERNAL_H
 #define CFE_TBL_CORE_INTERNAL_H

--- a/modules/core_api/fsw/inc/cfe_tbl_extern_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_tbl_extern_typedefs.h
@@ -18,8 +18,14 @@
 **  limitations under the License.
 */
 
-#ifndef _CFE_TBL_EXTERN_TYPEDEFS_H_
-#define _CFE_TBL_EXTERN_TYPEDEFS_H_
+/**
+ * @file
+ *
+ * Declarations and prototypes for cfe_tbl_extern_typedefs module
+ */
+
+#ifndef CFE_TBL_EXTERN_TYPEDEFS_H
+#define CFE_TBL_EXTERN_TYPEDEFS_H
 
 /* This header may be generated from an EDS file,
  * tools are available and the feature is enabled */
@@ -75,4 +81,4 @@ typedef struct CFE_TBL_File_Hdr
 
 #endif /* CFE_EDS_ENABLED_BUILD */
 
-#endif /* _CFE_TBL_EXTERN_TYPEDEFS_H_ */
+#endif /* CFE_TBL_EXTERN_TYPEDEFS_H */

--- a/modules/core_api/fsw/inc/cfe_tbl_extern_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_tbl_extern_typedefs.h
@@ -61,7 +61,6 @@ enum CFE_TBL_BufferSelect
 /**
  * @brief Selects the buffer to operate on for validate or dump commands
  *
- *
  * @sa enum CFE_TBL_BufferSelect
  */
 typedef uint16 CFE_TBL_BufferSelect_Enum_t;

--- a/modules/core_api/fsw/inc/cfe_tbl_filedef.h
+++ b/modules/core_api/fsw/inc/cfe_tbl_filedef.h
@@ -18,36 +18,34 @@
 **  limitations under the License.
 */
 
-/*
-**  File: cfe_tbl_filedef.h
-**
-**  Title:   ELF2CFETBL Utility Header File for Table Images
-**
-**  Purpose:
-**     This header file provides a data structure definition and macro definition
-**     required in source code that is intended to be compiled into a cFE compatible
-**     Table Image file.
-**
-**  Design Notes:
-**
-**     Typically, a user would include this file in a ".c" file that contains nothing
-**     but a desired instantiation of values for a table image along with the macro
-**     defined below.  After compilation, the resultant elf file can be processed using
-**     the 'elf2cfetbl' utility to generate a file that can be loaded onto a cFE flight
-**     system and successfully loaded into a table using the cFE Table Services.
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**
-**  Notes:
-**
-*/
+/**
+ * @file
+ *
+ *
+ *  Title:   ELF2CFETBL Utility Header File for Table Images
+ *
+ *  Purpose:
+ *     This header file provides a data structure definition and macro definition
+ *     required in source code that is intended to be compiled into a cFE compatible
+ *     Table Image file.
+ *
+ *  Design Notes:
+ *
+ *     Typically, a user would include this file in a ".c" file that contains nothing
+ *     but a desired instantiation of values for a table image along with the macro
+ *     defined below.  After compilation, the resultant elf file can be processed using
+ *     the 'elf2cfetbl' utility to generate a file that can be loaded onto a cFE flight
+ *     system and successfully loaded into a table using the cFE Table Services.
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *
+ *  Notes:
+ *
+ */
 
-/*
-** Ensure that header is included only once...
-*/
-#ifndef _cfe_tbl_filedef_
-#define _cfe_tbl_filedef_
+#ifndef CFE_TBL_FILEDEF_H
+#define CFE_TBL_FILEDEF_H
 
 #include "cfe_mission_cfg.h"
 #include "common_types.h"
@@ -103,8 +101,4 @@ utility.
 
 /*************************************************************************/
 
-#endif /* _cfe_tbl_filedef_ */
-
-/************************/
-/*  End of File Comment */
-/************************/
+#endif /* CFE_TBL_FILEDEF_H */

--- a/modules/core_api/fsw/inc/cfe_tbl_filedef.h
+++ b/modules/core_api/fsw/inc/cfe_tbl_filedef.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Title:   ELF2CFETBL Utility Header File for Table Images
  *
  *  Purpose:

--- a/modules/core_api/fsw/inc/cfe_time.h
+++ b/modules/core_api/fsw/inc/cfe_time.h
@@ -18,22 +18,20 @@
 **  limitations under the License.
 */
 
-/*
-** File: cfe_time.h
-**
-** Purpose:  cFE Time Services (TIME) library API header file
-**
-** Author:   S.Walling/Microtel
-**
-** Notes:
-**
-*/
+/**
+ * @file
+ *
+ *
+ * Purpose:  cFE Time Services (TIME) library API header file
+ *
+ * Author:   S.Walling/Microtel
+ *
+ * Notes:
+ *
+ */
 
-/*
-** Ensure that header is included only once...
-*/
-#ifndef _cfe_time_
-#define _cfe_time_
+#ifndef CFE_TIME_H
+#define CFE_TIME_H
 
 /*
 ** Includes
@@ -723,8 +721,4 @@ void CFE_TIME_Print(char *PrintBuffer, CFE_TIME_SysTime_t TimeToPrint);
 void CFE_TIME_Local1HzISR(void);
 /**@}*/
 
-#endif /* _cfe_time_ */
-
-/************************/
-/*  End of File Comment */
-/************************/
+#endif /* CFE_TIME_H */

--- a/modules/core_api/fsw/inc/cfe_time.h
+++ b/modules/core_api/fsw/inc/cfe_time.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:  cFE Time Services (TIME) library API header file
  *
  * Author:   S.Walling/Microtel
@@ -715,7 +714,6 @@ void CFE_TIME_Print(char *PrintBuffer, CFE_TIME_SysTime_t TimeToPrint);
 ** \par Assumptions, External Events, and Notes:
 **        This will update the global data structures accordingly, incrementing each
 **        by the 1Hz amount.
-**
 **
 ******************************************************************************/
 void CFE_TIME_Local1HzISR(void);

--- a/modules/core_api/fsw/inc/cfe_time_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_time_api_typedefs.h
@@ -18,22 +18,20 @@
 **  limitations under the License.
 */
 
-/*
-** File: cfe_time.h
-**
-** Purpose:  cFE Time Services (TIME) library API header file
-**
-** Author:   S.Walling/Microtel
-**
-** Notes:
-**
-*/
+/**
+ * @file
+ *
+ *
+ * Purpose:  cFE Time Services (TIME) library API header file
+ *
+ * Author:   S.Walling/Microtel
+ *
+ * Notes:
+ *
+ */
 
-/*
-** Ensure that header is included only once...
-*/
-#ifndef CFE_TIME_API_TYPES_H
-#define CFE_TIME_API_TYPES_H
+#ifndef CFE_TIME_API_TYPEDEFS_H
+#define CFE_TIME_API_TYPEDEFS_H
 
 /*
 ** Includes
@@ -79,8 +77,4 @@ typedef enum CFE_TIME_Compare
 */
 typedef int32 (*CFE_TIME_SynchCallbackPtr_t)(void);
 
-#endif /* CFE_TIME_API_TYPES_H */
-
-/************************/
-/*  End of File Comment */
-/************************/
+#endif /* CFE_TIME_API_TYPEDEFS_H */

--- a/modules/core_api/fsw/inc/cfe_time_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_time_api_typedefs.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:  cFE Time Services (TIME) library API header file
  *
  * Author:   S.Walling/Microtel

--- a/modules/core_api/fsw/inc/cfe_time_core_internal.h
+++ b/modules/core_api/fsw/inc/cfe_time_core_internal.h
@@ -18,20 +18,18 @@
 **  limitations under the License.
 */
 
-/*
-** File: cfe_time_core_internal.h
-**
-** Purpose:  cFE Time Services (TIME) library API header file
-**
-** Author:   S.Walling/Microtel
-**
-** Notes:
-**
-*/
+/**
+ * @file
+ *
+ *
+ * Purpose:  cFE Time Services (TIME) library API header file
+ *
+ * Author:   S.Walling/Microtel
+ *
+ * Notes:
+ *
+ */
 
-/*
-** Ensure that header is included only once...
-*/
 #ifndef CFE_TIME_CORE_INTERNAL_H
 #define CFE_TIME_CORE_INTERNAL_H
 
@@ -90,7 +88,3 @@ extern int32 CFE_TIME_CleanUpApp(CFE_ES_AppId_t AppId);
 /**@}*/
 
 #endif /* CFE_TIME_CORE_INTERNAL_H */
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/modules/core_api/fsw/inc/cfe_time_core_internal.h
+++ b/modules/core_api/fsw/inc/cfe_time_core_internal.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:  cFE Time Services (TIME) library API header file
  *
  * Author:   S.Walling/Microtel
@@ -55,7 +54,6 @@
 **
 ** \par Assumptions, External Events, and Notes:
 **          None
-**
 **
 ******************************************************************************/
 extern void CFE_TIME_TaskMain(void);

--- a/modules/core_api/fsw/inc/cfe_time_extern_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_time_extern_typedefs.h
@@ -121,7 +121,6 @@ enum CFE_TIME_FlagBit
 /**
  * @brief Bit positions of the various clock state flags
  *
- *
  * @sa enum CFE_TIME_FlagBit
  */
 typedef uint8 CFE_TIME_FlagBit_Enum_t;
@@ -164,7 +163,6 @@ enum CFE_TIME_ClockState
 /**
  * @brief Enumerated types identifying the quality of the current time
  *
- *
  * \par Description
  * The #CFE_TIME_ClockState_Enum_t enumerations identify the three recognized states of the current time.
  * If the clock has never been successfully synchronized with the primary onboard clock source, the
@@ -200,7 +198,6 @@ enum CFE_TIME_SourceSelect
 /**
  * @brief Clock Source Selection Parameters
  *
- *
  * @sa enum CFE_TIME_SourceSelect
  */
 typedef uint8 CFE_TIME_SourceSelect_Enum_t;
@@ -224,7 +221,6 @@ enum CFE_TIME_ToneSignalSelect
 
 /**
  * @brief Tone Signal Selection Parameters
- *
  *
  * @sa enum CFE_TIME_ToneSignalSelect
  */
@@ -250,7 +246,6 @@ enum CFE_TIME_AdjustDirection
 /**
  * @brief STCF adjustment direction (for both one-time and 1Hz adjustments)
  *
- *
  * @sa enum CFE_TIME_AdjustDirection
  */
 typedef uint8 CFE_TIME_AdjustDirection_Enum_t;
@@ -275,7 +270,6 @@ enum CFE_TIME_FlywheelState
 /**
  * @brief Fly-wheel status values
  *
- *
  * @sa enum CFE_TIME_FlywheelState
  */
 typedef uint8 CFE_TIME_FlywheelState_Enum_t;
@@ -299,7 +293,6 @@ enum CFE_TIME_SetState
 
 /**
  * @brief Clock status values (has the clock been set to correct time)
- *
  *
  * @sa enum CFE_TIME_SetState
  */

--- a/modules/core_api/fsw/inc/cfe_time_extern_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_time_extern_typedefs.h
@@ -18,8 +18,14 @@
 **  limitations under the License.
 */
 
-#ifndef _CFE_TIME_EXTERN_TYPEDEFS_H_
-#define _CFE_TIME_EXTERN_TYPEDEFS_H_
+/**
+ * @file
+ *
+ * Declarations and prototypes for cfe_time_extern_typedefs module
+ */
+
+#ifndef CFE_TIME_EXTERN_TYPEDEFS_H
+#define CFE_TIME_EXTERN_TYPEDEFS_H
 
 /* This header may be generated from an EDS file,
  * tools are available and the feature is enabled */
@@ -301,4 +307,4 @@ typedef uint8 CFE_TIME_SetState_Enum_t;
 
 #endif /* CFE_EDS_ENABLED_BUILD */
 
-#endif /* _CFE_TIME_EXTERN_TYPEDEFS_H_ */
+#endif /* CFE_TIME_EXTERN_TYPEDEFS_H */

--- a/modules/core_api/fsw/inc/cfe_version.h
+++ b/modules/core_api/fsw/inc/cfe_version.h
@@ -18,18 +18,14 @@
 **  limitations under the License.
 */
 
-#ifndef _cfe_version_
-#define _cfe_version_
-
-/*! @file cfe_version.h
- * @brief Purpose:
- *     Provide version identifiers for the cFE core.
+/**
+ * @file
  *
- * target_config.h contains extended version information within it.
- * This information is generated automatically by the build using
- * git to determine the most recent tag and commit id.
- *
+ * Provide version identifiers for the cFE core.
  */
+
+#ifndef CFE_VERSION_H
+#define CFE_VERSION_H
 
 /* Development Build Macro Definitions */
 #define CFE_BUILD_NUMBER 436 /*!< Development Build: Number of commits since baseline */
@@ -62,4 +58,4 @@
     " cFE DEVELOPMENT BUILD " CFE_SRC_VERSION " (Codename: Bootes)" /* Codename for current development */ \
     ", Last Official Release: cfe v6.7.0"                           /* For full support please use this version */
 
-#endif /* _cfe_version_ */
+#endif /* CFE_VERSION_H */

--- a/modules/core_private/fsw/inc/cfe_core_resourceid_basevalues.h
+++ b/modules/core_private/fsw/inc/cfe_core_resourceid_basevalues.h
@@ -19,7 +19,7 @@
 */
 
 /**
- * \file cfe_core_resourceid_basevalues.h
+ * @file
  *
  * Contains CFE internal prototypes and definitions related to resource
  * management and related CFE resource IDs.

--- a/modules/core_private/fsw/inc/cfe_es_erlog_typedef.h
+++ b/modules/core_private/fsw/inc/cfe_es_erlog_typedef.h
@@ -19,17 +19,14 @@
 */
 
 /**
- * \file cfe_es_erlog_typedef.h
- *
- *  Created on: Jan 22, 2015
- *      Author: joseph.p.hickey@nasa.gov
+ * @file
  *
  * Definition of the CFE_ES_ERLog structure type.
  * This was moved into its own header file since it is referenced by multiple CFE core apps.
  */
 
-#ifndef CFE_ES_ERLOG_TYPEDEF_H_
-#define CFE_ES_ERLOG_TYPEDEF_H_
+#ifndef CFE_ES_ERLOG_TYPEDEF_H
+#define CFE_ES_ERLOG_TYPEDEF_H
 
 #include "common_types.h"
 #include "cfe_platform_cfg.h"
@@ -98,4 +95,4 @@ typedef struct
     uint32                  PspContextId; /**< Reference to context information stored in PSP */
 } CFE_ES_ERLog_MetaData_t;
 
-#endif /* CFE_ES_ERLOG_TYPEDEF_H_ */
+#endif /* CFE_ES_ERLOG_TYPEDEF_H */

--- a/modules/core_private/fsw/inc/cfe_es_perfdata_typedef.h
+++ b/modules/core_private/fsw/inc/cfe_es_perfdata_typedef.h
@@ -19,16 +19,13 @@
 */
 
 /**
- * \file cfe_es_perfdata_typedef.h
+ * @file
  *
- *  Created on: Jan 22, 2015
- *      Author: joseph.p.hickey@nasa.gov
- *
- * Placeholder for file content description
+ * Definition of CFE_ES_PerfData_t structure type
  */
 
-#ifndef CFE_ES_PERFDATA_TYPEDEF_H_
-#define CFE_ES_PERFDATA_TYPEDEF_H_
+#ifndef CFE_ES_PERFDATA_TYPEDEF_H
+#define CFE_ES_PERFDATA_TYPEDEF_H
 
 #include "common_types.h"
 #include "cfe_mission_cfg.h"  /* Required for CFE_MISSION_ES_PERF_MAX_IDS */
@@ -75,4 +72,4 @@ typedef struct
     CFE_ES_PerfDataEntry_t DataBuffer[CFE_PLATFORM_ES_PERF_DATA_BUFFER_SIZE];
 } CFE_ES_PerfData_t;
 
-#endif /* CFE_ES_PERFDATA_TYPEDEF_H_ */
+#endif /* CFE_ES_PERFDATA_TYPEDEF_H */

--- a/modules/core_private/fsw/inc/cfe_es_resetdata_typedef.h
+++ b/modules/core_private/fsw/inc/cfe_es_resetdata_typedef.h
@@ -19,17 +19,14 @@
 */
 
 /**
- * \file cfe_es_resetdata_typedef.h
- *
- *  Created on: Jan 22, 2015
- *      Author: joseph.p.hickey@nasa.gov
+ * @file
  *
  * Definition of the CFE_ES_ResetData structure type.
  * This was moved into its own header file since it is referenced by multiple CFE core apps.
  */
 
-#ifndef CFE_ES_RESETDATA_TYPEDEF_H_
-#define CFE_ES_RESETDATA_TYPEDEF_H_
+#ifndef CFE_ES_RESETDATA_TYPEDEF_H
+#define CFE_ES_RESETDATA_TYPEDEF_H
 
 #include "common_types.h"
 
@@ -99,4 +96,4 @@ typedef struct
 
 } CFE_ES_ResetData_t;
 
-#endif /* CFE_ES_RESETDATA_TYPEDEF_H_ */
+#endif /* CFE_ES_RESETDATA_TYPEDEF_H */

--- a/modules/core_private/fsw/inc/cfe_evs_log_typedef.h
+++ b/modules/core_private/fsw/inc/cfe_evs_log_typedef.h
@@ -19,17 +19,14 @@
 */
 
 /**
- * \file cfe_evs_log_typedef.h
- *
- *  Created on: Jan 22, 2015
- *      Author: joseph.p.hickey@nasa.gov
+ * @file
  *
  * Definition of the CFE_EVS_Log structure type.
  * This was moved into its own header file since it is referenced by multiple CFE core apps.
  */
 
-#ifndef CFE_EVS_LOG_TYPEDEF_H_
-#define CFE_EVS_LOG_TYPEDEF_H_
+#ifndef CFE_EVS_LOG_TYPEDEF_H
+#define CFE_EVS_LOG_TYPEDEF_H
 
 #include "common_types.h"
 #include "cfe_platform_cfg.h"
@@ -51,4 +48,4 @@ typedef struct
 
 } CFE_EVS_Log_t;
 
-#endif /* CFE_EVS_LOG_TYPEDEF_H_ */
+#endif /* CFE_EVS_LOG_TYPEDEF_H */

--- a/modules/core_private/fsw/inc/cfe_sb_destination_typedef.h
+++ b/modules/core_private/fsw/inc/cfe_sb_destination_typedef.h
@@ -19,12 +19,14 @@
 */
 
 /**
- * Definition of the CFE_SB_DestinationD_t type.
+ * @file
+ *
+ * Definition of the CFE_SB_DestinationD_t structure type
  * This was moved into its own header file since it is referenced by multiple CFE modules.
  */
 
-#ifndef CFE_SB_DESTINATION_TYPEDEF_H_
-#define CFE_SB_DESTINATION_TYPEDEF_H_
+#ifndef CFE_SB_DESTINATION_TYPEDEF_H
+#define CFE_SB_DESTINATION_TYPEDEF_H
 
 #include "common_types.h"
 #include "cfe_sb_extern_typedefs.h" /* Required for CFE_SB_PipeId_t definition */
@@ -49,4 +51,4 @@ typedef struct
     void *          Next;
 } CFE_SB_DestinationD_t;
 
-#endif /* CFE_SB_DESTINATION_TYPEDEF_H_ */
+#endif /* CFE_SB_DESTINATION_TYPEDEF_H */

--- a/modules/core_private/fsw/inc/cfe_sbr.h
+++ b/modules/core_private/fsw/inc/cfe_sbr.h
@@ -18,13 +18,13 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
- * File: cfe_sbr.h
+/**
+ * @file
  *
  * Purpose:
  *      Prototypes for private functions and type definitions for SB
  *      routing internal use.
- *****************************************************************************/
+ */
 
 #ifndef CFE_SBR_H
 #define CFE_SBR_H

--- a/modules/core_private/fsw/inc/cfe_sbr_api_typedefs.h
+++ b/modules/core_private/fsw/inc/cfe_sbr_api_typedefs.h
@@ -18,13 +18,13 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
- * File: cfe_sbr.h
+/**
+ * @file
  *
  * Purpose:
  *      Prototypes for private functions and type definitions for SB
  *      routing internal use.
- *****************************************************************************/
+ */
 
 #ifndef CFE_SBR_API_TYPEDEFS_H
 #define CFE_SBR_API_TYPEDEFS_H

--- a/modules/core_private/fsw/inc/cfe_time_resetvars_typedef.h
+++ b/modules/core_private/fsw/inc/cfe_time_resetvars_typedef.h
@@ -18,20 +18,12 @@
 **  limitations under the License.
 */
 
-/*
-** File: cfe_time.h
-**
-** Purpose:  cFE Time Services (TIME) library API header file
-**
-** Author:   S.Walling/Microtel
-**
-** Notes:
-**
-*/
+/**
+ * @file
+ *
+ * Definition of the CFE_TIME_ResetVars_t structure type
+ */
 
-/*
-** Ensure that header is included only once...
-*/
 #ifndef CFE_TIME_RESETVARS_TYPEDEF_H
 #define CFE_TIME_RESETVARS_TYPEDEF_H
 
@@ -63,7 +55,3 @@ typedef struct CFE_TIME_ResetVars
 } CFE_TIME_ResetVars_t;
 
 #endif /* CFE_TIME_RESETVARS_TYPEDEF_H */
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/modules/core_private/ut-stubs/inc/ut_osprintf_stubs.h
+++ b/modules/core_private/ut-stubs/inc/ut_osprintf_stubs.h
@@ -18,24 +18,25 @@
 **  limitations under the License.
 */
 
-/*
-** File:
-**    ut_osprintf_stubs.h
-**
-** Purpose:
-**    OS API unit test header
-**
-** References:
-**    1. cFE Application Developers Guide
-**    2. unit test standard 092503
-**    3. C Coding Standard 102904
-**
-** Notes:
-**    1. This is unit test code only, not for use in flight
-**
-*/
-#ifndef _UT_OSPRINTF_STUBS_H_
-#define _UT_OSPRINTF_STUBS_H_
+/**
+ * @file
+ *
+ *
+ * Purpose:
+ *    OS API unit test header
+ *
+ * References:
+ *    1. cFE Application Developers Guide
+ *    2. unit test standard 092503
+ *    3. C Coding Standard 102904
+ *
+ * Notes:
+ *    1. This is unit test code only, not for use in flight
+ *
+ */
+
+#ifndef UT_OSPRINTF_STUBS_H
+#define UT_OSPRINTF_STUBS_H
 
 #define UT_OSP_CORE_INIT                  11
 #define UT_OSP_POR_MAX_PROC_RESETS        12
@@ -99,4 +100,4 @@
 #define UT_OSP_BACKGROUND_REGISTER        70
 #define UT_OSP_BACKGROUND_TAKE            71
 
-#endif
+#endif /* UT_OSPRINTF_STUBS_H */

--- a/modules/core_private/ut-stubs/inc/ut_osprintf_stubs.h
+++ b/modules/core_private/ut-stubs/inc/ut_osprintf_stubs.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:
  *    OS API unit test header
  *

--- a/modules/core_private/ut-stubs/inc/ut_support.h
+++ b/modules/core_private/ut-stubs/inc/ut_support.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:
  * Unit specification for Unit Test Stubs
  *

--- a/modules/core_private/ut-stubs/inc/ut_support.h
+++ b/modules/core_private/ut-stubs/inc/ut_support.h
@@ -18,19 +18,21 @@
 **  limitations under the License.
 */
 
-/*
-** File: ut_support.h
-**
-** Purpose:
-** Unit specification for Unit Test Stubs
-**
-** Notes:
-** These routines contain a minimum amount of functionality required for
-** unit testing full path coverage
-**
-*/
-#ifndef _UT_CFE_SUPPORT_H_
-#define _UT_CFE_SUPPORT_H_
+/**
+ * @file
+ *
+ *
+ * Purpose:
+ * Unit specification for Unit Test Stubs
+ *
+ * Notes:
+ * These routines contain a minimum amount of functionality required for
+ * unit testing full path coverage
+ *
+ */
+
+#ifndef UT_SUPPORT_H
+#define UT_SUPPORT_H
 
 /*
 ** Includes
@@ -736,4 +738,4 @@ void UT_TEARDOWN_impl(const char *FileName, int LineNum, const char *TestName, c
 ******************************************************************************/
 #define TEARDOWN(FN) (UT_TEARDOWN_impl(__FILE__, __LINE__, __func__, (#FN), (FN)))
 
-#endif /* __UT_STUBS_H_ */
+#endif /* UT_SUPPORT_H */

--- a/modules/es/fsw/inc/cfe_es_events.h
+++ b/modules/es/fsw/inc/cfe_es_events.h
@@ -18,22 +18,23 @@
 **  limitations under the License.
 */
 
-/*
-**  File: cfe_es_events.h
-**
-**  Purpose:
-**  cFE Executive Services (ES) Event IDs
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**     cFE Flight Software Application Developers Guide
-**
-**  Notes:
-**
-*/
-/*************************************************************************/
-#ifndef _cfe_es_events_
-#define _cfe_es_events_
+/**
+ * @file
+ *
+ *
+ *  Purpose:
+ *  cFE Executive Services (ES) Event IDs
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *     cFE Flight Software Application Developers Guide
+ *
+ *  Notes:
+ *
+ */
+
+#ifndef CFE_ES_EVENTS_H
+#define CFE_ES_EVENTS_H
 
 /* **************************
 ** ****** Maximum EID. ******
@@ -1449,8 +1450,4 @@
 **/
 #define CFE_ES_ERLOG_PENDING_ERR_EID 93
 
-#endif /* _cfe_es_events_ */
-
-/************************/
-/*  End of File Comment */
-/************************/
+#endif /* CFE_ES_EVENTS_H */

--- a/modules/es/fsw/inc/cfe_es_events.h
+++ b/modules/es/fsw/inc/cfe_es_events.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Purpose:
  *  cFE Executive Services (ES) Event IDs
  *
@@ -196,7 +195,6 @@
 **  Note that when this event is displayed, the Application is not reloaded. ES has
 **  accepted the request to reload the application, and it will be reloaded after the app exits
 **  it's main loop, or times out.
-**
 **
 **  The \c 's' field identifies the name of the Application that will be reloaded.
 **/

--- a/modules/es/fsw/inc/cfe_es_msg.h
+++ b/modules/es/fsw/inc/cfe_es_msg.h
@@ -18,22 +18,23 @@
 **  limitations under the License.
 */
 
-/*
-**  File: cfe_es_msg.h
-**
-**  Purpose:
-**  cFE Executive Services (ES) Command and Telemetry packet definition file.
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**     cFE Flight Software Application Developers Guide
-**
-**  Notes:
-**
-*/
-/*************************************************************************/
-#ifndef _cfe_es_msg_
-#define _cfe_es_msg_
+/**
+ * @file
+ *
+ *
+ *  Purpose:
+ *  cFE Executive Services (ES) Command and Telemetry packet definition file.
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *     cFE Flight Software Application Developers Guide
+ *
+ *  Notes:
+ *
+ */
+
+#ifndef CFE_ES_MSG_H
+#define CFE_ES_MSG_H
 
 /*
 ** Includes
@@ -1558,8 +1559,4 @@ typedef struct CFE_ES_HousekeepingTlm
 
 } CFE_ES_HousekeepingTlm_t;
 
-#endif /* _cfe_es_msg_ */
-
-/************************/
-/*  End of File Comment */
-/************************/
+#endif /* CFE_ES_MSG_H */

--- a/modules/es/fsw/inc/cfe_es_msg.h
+++ b/modules/es/fsw/inc/cfe_es_msg.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Purpose:
  *  cFE Executive Services (ES) Command and Telemetry packet definition file.
  *

--- a/modules/es/fsw/src/cfe_es_apps.h
+++ b/modules/es/fsw/src/cfe_es_apps.h
@@ -18,22 +18,21 @@
 **  limitations under the License.
 */
 
-/*
-**  File:
-**  cfe_es_apps.h
-**
-**  Purpose:
-**  This file contains the Internal interface for the cFE Application control functions of ES.
-**  These functions and data structures manage the Applications and Child tasks in the cFE.
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**     cFE Flight Software Application Developers Guide
-**
-*/
+/**
+ * @file
+ *
+ *  Purpose:
+ *  This file contains the Internal interface for the cFE Application control functions of ES.
+ *  These functions and data structures manage the Applications and Child tasks in the cFE.
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *     cFE Flight Software Application Developers Guide
+ *
+ */
 
-#ifndef _cfe_es_apps_
-#define _cfe_es_apps_
+#ifndef CFE_ES_APPS_H
+#define CFE_ES_APPS_H
 
 /*
 ** Include Files
@@ -301,4 +300,4 @@ void CFE_ES_CopyModuleStatusInfo(const CFE_ES_ModuleLoadStatus_t *StatusPtr, CFE
 */
 void CFE_ES_CopyModuleAddressInfo(osal_id_t ModuleId, CFE_ES_AppInfo_t *AppInfoPtr);
 
-#endif /* _cfe_es_apps_ */
+#endif /* CFE_ES_APPS_H */

--- a/modules/es/fsw/src/cfe_es_cds.h
+++ b/modules/es/fsw/src/cfe_es_cds.h
@@ -18,24 +18,24 @@
 **  limitations under the License.
 */
 
-/*
-**  File:
-**  cfe_es_cds.h
-**
-**  Purpose:
-**  This file contains the Internal interface for the cFE Critical Data Store functions.
-**  These functions and data structures manage the Critical Data Store in the cFE.
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**     cFE Flight Software Application Developers Guide
-**
-**  Notes:
-**
-*/
+/**
+ * @file
+ *
+ *
+ *  Purpose:
+ *  This file contains the Internal interface for the cFE Critical Data Store functions.
+ *  These functions and data structures manage the Critical Data Store in the cFE.
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *     cFE Flight Software Application Developers Guide
+ *
+ *  Notes:
+ *
+ */
 
-#ifndef _cfe_es_cds_
-#define _cfe_es_cds_
+#ifndef CFE_ES_CDS_H
+#define CFE_ES_CDS_H
 
 /*
 ** Include Files
@@ -642,4 +642,4 @@ int32 CFE_ES_ClearCDS(void);
 ******************************************************************************/
 int32 CFE_ES_InitCDSSignatures(void);
 
-#endif /* _cfe_es_cds_ */
+#endif /* CFE_ES_CDS_H */

--- a/modules/es/fsw/src/cfe_es_cds.h
+++ b/modules/es/fsw/src/cfe_es_cds.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Purpose:
  *  This file contains the Internal interface for the cFE Critical Data Store functions.
  *  These functions and data structures manage the Critical Data Store in the cFE.
@@ -244,7 +243,6 @@ int32 CFE_ES_CDS_CacheFlush(CFE_ES_CDS_AccessCache_t *Cache);
  * Only one thread can use CDS cache at a given time, so the CDS access
  * control mutex must be obtained before calling this function.
  *
- *
  * @param[inout] Cache  the global CDS cache buffer
  * @param[in]    Source the local object to load into cache
  * @param[in]    Offset the CDS offset to fetch
@@ -403,7 +401,6 @@ bool CFE_ES_CheckCDSHandleSlotUsed(CFE_ResourceId_t CheckId);
 **
 ** \par SysLog Messages
 **
-**
 ** \return None
 **
 ******************************************************************************/
@@ -497,7 +494,6 @@ int32 CFE_ES_UpdateCDSRegistry(void);
 **                     the CDS.
 **
 ** \param[in]  ThisAppId the Application ID of the Application making the call.
-**
 **
 ******************************************************************************/
 void CFE_ES_FormCDSName(char *FullCDSName, const char *CDSName, CFE_ES_AppId_t ThisAppId);

--- a/modules/es/fsw/src/cfe_es_cds_mempool.h
+++ b/modules/es/fsw/src/cfe_es_cds_mempool.h
@@ -18,24 +18,24 @@
 **  limitations under the License.
 */
 
-/*
-**  File:
-**  cfe_es_cds_mempool.h
-**
-**  Purpose:
-**  This file contains the Internal interface for the cFE Critical Data Store
-**  memory pool functions.
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**     cFE Flight Software Application Developers Guide
-**
-**  Notes:
-**
-*/
+/**
+ * @file
+ *
+ *
+ *  Purpose:
+ *  This file contains the Internal interface for the cFE Critical Data Store
+ *  memory pool functions.
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *     cFE Flight Software Application Developers Guide
+ *
+ *  Notes:
+ *
+ */
 
-#ifndef _cfe_es_cds_mempool_
-#define _cfe_es_cds_mempool_
+#ifndef CFE_ES_CDS_MEMPOOL_H
+#define CFE_ES_CDS_MEMPOOL_H
 
 /*
 ** Include Files
@@ -76,4 +76,4 @@ int32 CFE_ES_CDSBlockRead(void *DataRead, CFE_ES_CDSHandle_t Handle);
 
 size_t CFE_ES_CDSReqdMinSize(uint32 MaxNumBlocksToSupport);
 
-#endif /* _cfe_es_cds_mempool_ */
+#endif /* CFE_ES_CDS_MEMPOOL_H */

--- a/modules/es/fsw/src/cfe_es_cds_mempool.h
+++ b/modules/es/fsw/src/cfe_es_cds_mempool.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Purpose:
  *  This file contains the Internal interface for the cFE Critical Data Store
  *  memory pool functions.

--- a/modules/es/fsw/src/cfe_es_generic_pool.h
+++ b/modules/es/fsw/src/cfe_es_generic_pool.h
@@ -18,24 +18,24 @@
 **  limitations under the License.
 */
 
-/*
-**  File:
-**  cfe_es_generic_pool.h
-**
-**  Purpose:
-**  This file contains the Internal interface for the cFE Critical Data Store
-**  memory pool functions.
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**     cFE Flight Software Application Developers Guide
-**
-**  Notes:
-**
-*/
+/**
+ * @file
+ *
+ *
+ *  Purpose:
+ *  This file contains the Internal interface for the cFE Critical Data Store
+ *  memory pool functions.
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *     cFE Flight Software Application Developers Guide
+ *
+ *  Notes:
+ *
+ */
 
-#ifndef cfe_es_generic_pool_h
-#define cfe_es_generic_pool_h
+#ifndef CFE_ES_GENERIC_POOL_H
+#define CFE_ES_GENERIC_POOL_H
 
 /*
 ** Include Files
@@ -281,4 +281,4 @@ void CFE_ES_GenPoolGetBucketUsage(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 Buc
  */
 size_t CFE_ES_GenPoolCalcMinSize(uint16 NumBlockSizes, const size_t *BlockSizeList, uint32 NumBlocks);
 
-#endif /* _cfe_es_generic_pool_ */
+#endif /* CFE_ES_GENERIC_POOL_H */

--- a/modules/es/fsw/src/cfe_es_generic_pool.h
+++ b/modules/es/fsw/src/cfe_es_generic_pool.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Purpose:
  *  This file contains the Internal interface for the cFE Critical Data Store
  *  memory pool functions.

--- a/modules/es/fsw/src/cfe_es_global.h
+++ b/modules/es/fsw/src/cfe_es_global.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Purpose:
  *  This file contains the ES global data definitions.
  *

--- a/modules/es/fsw/src/cfe_es_global.h
+++ b/modules/es/fsw/src/cfe_es_global.h
@@ -18,21 +18,21 @@
 **  limitations under the License.
 */
 
-/*
-**  File:
-**  cfe_es_global.h
-**
-**  Purpose:
-**  This file contains the ES global data definitions.
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**     cFE Flight Software Application Developers Guide
-**
-*/
+/**
+ * @file
+ *
+ *
+ *  Purpose:
+ *  This file contains the ES global data definitions.
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *     cFE Flight Software Application Developers Guide
+ *
+ */
 
-#ifndef _cfe_es_global_
-#define _cfe_es_global_
+#ifndef CFE_ES_GLOBAL_H
+#define CFE_ES_GLOBAL_H
 
 /*
 ** Includes
@@ -161,4 +161,4 @@ extern CFE_ES_ResetData_t *CFE_ES_ResetDataPtr;
 extern void CFE_ES_LockSharedData(const char *FunctionName, int32 LineNumber);
 extern void CFE_ES_UnlockSharedData(const char *FunctionName, int32 LineNumber);
 
-#endif
+#endif /* CFE_ES_GLOBAL_H */

--- a/modules/es/fsw/src/cfe_es_log.h
+++ b/modules/es/fsw/src/cfe_es_log.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Purpose:
  *    This file contains definitions needed for the cFE ES Logs. The
  *    logs include the Mode Transition log, the System Log, and the

--- a/modules/es/fsw/src/cfe_es_log.h
+++ b/modules/es/fsw/src/cfe_es_log.h
@@ -18,25 +18,25 @@
 **  limitations under the License.
 */
 
-/*
-**  File:
-**    cfe_es_log.h
-**
-**  Purpose:
-**    This file contains definitions needed for the cFE ES Logs. The
-**    logs include the Mode Transition log, the System Log, and the
-**    Performance log.
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**     cFE Flight Software Application Developers Guide
-**
-**  Notes:
-**
-*/
+/**
+ * @file
+ *
+ *
+ *  Purpose:
+ *    This file contains definitions needed for the cFE ES Logs. The
+ *    logs include the Mode Transition log, the System Log, and the
+ *    Performance log.
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *     cFE Flight Software Application Developers Guide
+ *
+ *  Notes:
+ *
+ */
 
-#ifndef _cfe_es_log_
-#define _cfe_es_log_
+#ifndef CFE_ES_LOG_H
+#define CFE_ES_LOG_H
 
 /*
 ** Include Files
@@ -359,4 +359,4 @@ int32 CFE_ES_WriteToERLog(CFE_ES_LogEntryType_Enum_t EntryType, uint32 ResetType
 int32 CFE_ES_WriteToERLogWithContext(CFE_ES_LogEntryType_Enum_t EntryType, uint32 ResetType, uint32 ResetSubtype,
                                      const char *Description, CFE_ES_AppId_t AppId, uint32 PspContextId);
 
-#endif /* _cfe_es_log_ */
+#endif /* CFE_ES_LOG_H */

--- a/modules/es/fsw/src/cfe_es_mempool.h
+++ b/modules/es/fsw/src/cfe_es_mempool.h
@@ -19,7 +19,8 @@
 */
 
 /**
- * \file cfe_es_mempool.h
+ * @file
+ *
  *
  * Contains data structure definitions used by the ES mempool implementation.
  *
@@ -27,8 +28,8 @@
  * with a layer on top to translate into memory mapped buffer addresses.
  */
 
-#ifndef _CFE_ES_MEMPOOL_H_
-#define _CFE_ES_MEMPOOL_H_
+#ifndef CFE_ES_MEMPOOL_H
+#define CFE_ES_MEMPOOL_H
 
 /*
 ** Include Files
@@ -197,4 +198,4 @@ static inline bool CFE_ES_MemPoolRecordIsMatch(const CFE_ES_MemPoolRecord_t *Poo
  */
 bool CFE_ES_CheckMemPoolSlotUsed(CFE_ResourceId_t CheckId);
 
-#endif /* _CFE_ES_MEMPOOL_H_ */
+#endif /* CFE_ES_MEMPOOL_H */

--- a/modules/es/fsw/src/cfe_es_mempool.h
+++ b/modules/es/fsw/src/cfe_es_mempool.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Contains data structure definitions used by the ES mempool implementation.
  *
  * The ES memory pools are now built on top of the generic memory pool implementation,

--- a/modules/es/fsw/src/cfe_es_module_all.h
+++ b/modules/es/fsw/src/cfe_es_module_all.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Encapsulates all ES module internal header files, as well
  * as the public API from all other CFE core modules, OSAL, and PSP.
  *

--- a/modules/es/fsw/src/cfe_es_module_all.h
+++ b/modules/es/fsw/src/cfe_es_module_all.h
@@ -19,7 +19,8 @@
 */
 
 /**
- * @file cfe_es_module_all.h
+ * @file
+ *
  *
  * Encapsulates all ES module internal header files, as well
  * as the public API from all other CFE core modules, OSAL, and PSP.
@@ -54,4 +55,4 @@
 #include "cfe_es_resource.h"
 #include "cfe_es_log.h"
 
-#endif
+#endif /* CFE_ES_MODULE_ALL_H */

--- a/modules/es/fsw/src/cfe_es_perf.h
+++ b/modules/es/fsw/src/cfe_es_perf.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose: Performance Analyzer data structures
  *
  * Design Notes:

--- a/modules/es/fsw/src/cfe_es_perf.h
+++ b/modules/es/fsw/src/cfe_es_perf.h
@@ -18,19 +18,20 @@
 **  limitations under the License.
 */
 
-/*
-** File:  cfe_es_perf.h
-**
-** Purpose: Performance Analyzer data structures
-**
-** Design Notes:
-**
-** References:
-**
-*/
+/**
+ * @file
+ *
+ *
+ * Purpose: Performance Analyzer data structures
+ *
+ * Design Notes:
+ *
+ * References:
+ *
+ */
 
-#ifndef _cfe_es_perf_
-#define _cfe_es_perf_
+#ifndef CFE_ES_PERF_H
+#define CFE_ES_PERF_H
 
 /*
 ** Include Files
@@ -132,4 +133,4 @@ uint32 CFE_ES_GetPerfLogDumpRemaining(void);
  */
 bool CFE_ES_RunPerfLogDump(uint32 ElapsedTime, void *Arg);
 
-#endif /* _cfe_es_perf_ */
+#endif /* CFE_ES_PERF_H */

--- a/modules/es/fsw/src/cfe_es_resource.h
+++ b/modules/es/fsw/src/cfe_es_resource.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Contains basic prototypes and definitions related to CFE ES resource
  * management and related resource IDs.
  *

--- a/modules/es/fsw/src/cfe_es_resource.h
+++ b/modules/es/fsw/src/cfe_es_resource.h
@@ -19,7 +19,8 @@
 */
 
 /**
- * \file cfe_es_resource.h
+ * @file
+ *
  *
  * Contains basic prototypes and definitions related to CFE ES resource
  * management and related resource IDs.

--- a/modules/es/fsw/src/cfe_es_start.h
+++ b/modules/es/fsw/src/cfe_es_start.h
@@ -18,29 +18,26 @@
 **  limitations under the License.
 */
 
-/*
-**
-**  File:
-**  cfe_es_start.h
-**
-**  Purpose:
-**  cFE core startup module defines, data types and prototypes.
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**     cFE Flight Software Application Developers Guide
-**
-**  Notes:
-**
-*/
+/**
+ * @file
+ *
+ *  Purpose:
+ *  cFE core startup module defines, data types and prototypes.
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *     cFE Flight Software Application Developers Guide
+ *
+ *  Notes:
+ *
+ */
 
-#ifndef _cfe_es_start_
-#define _cfe_es_start_
+#ifndef CFE_ES_START_H
+#define CFE_ES_START_H
 
 /*
 ** Include Files
 */
-
 #include "cfe_es_api_typedefs.h"
 
 /*
@@ -94,4 +91,4 @@ extern void CFE_ES_SetupResetVariables(uint32 StartType, uint32 StartSubtype, ui
 extern void CFE_ES_InitializeFileSystems(uint32 StartType);
 extern void CFE_ES_SetupPerfVariables(uint32 ResetType);
 
-#endif /* _cfe_es_start_ */
+#endif /* CFE_ES_START_H */

--- a/modules/es/fsw/src/cfe_es_task.h
+++ b/modules/es/fsw/src/cfe_es_task.h
@@ -18,22 +18,23 @@
 **  limitations under the License.
 */
 
-/*
-**  File: cfe_es_task.h
-**
-**  Purpose:
-**  cFE Executive Services (ES) task header file
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**     cFE Flight Software Application Developers Guide
-**
-**  Notes:
-**
-*/
-/*************************************************************************/
-#ifndef _cfe_es_task_
-#define _cfe_es_task_
+/**
+ * @file
+ *
+ *
+ *  Purpose:
+ *  cFE Executive Services (ES) task header file
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *     cFE Flight Software Application Developers Guide
+ *
+ *  Notes:
+ *
+ */
+
+#ifndef CFE_ES_TASK_H
+#define CFE_ES_TASK_H
 
 /*
 ** Includes
@@ -201,8 +202,4 @@ void CFE_ES_FileWriteByteCntErr(const char *Filename, size_t Requested, int32 St
 
 /*************************************************************************/
 
-#endif /* _cfe_es_task_ */
-
-/************************/
-/*  End of File Comment */
-/************************/
+#endif /* CFE_ES_TASK_H */

--- a/modules/es/fsw/src/cfe_es_task.h
+++ b/modules/es/fsw/src/cfe_es_task.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Purpose:
  *  cFE Executive Services (ES) task header file
  *

--- a/modules/es/fsw/src/cfe_es_verify.h
+++ b/modules/es/fsw/src/cfe_es_verify.h
@@ -21,11 +21,9 @@
 /**
  * @file
  *
- *
  * Purpose:
  *   This header file performs compile time checking for ES configuration
  *   parameters.
- *
  *
  *  References:
  *     Flight Software Branch C Coding Standard Version 1.0a

--- a/modules/es/fsw/src/cfe_es_verify.h
+++ b/modules/es/fsw/src/cfe_es_verify.h
@@ -18,25 +18,26 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
-** File: cfe_es_verify.h
-**
-** Purpose:
-**   This header file performs compile time checking for ES configuration
-**   parameters.
-**
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**     cFE Flight Software Application Developers Guide
-**
-**  Notes:
-**     The upper limits are somewhat arbitrary right now.
-**
-******************************************************************************/
+/**
+ * @file
+ *
+ *
+ * Purpose:
+ *   This header file performs compile time checking for ES configuration
+ *   parameters.
+ *
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *     cFE Flight Software Application Developers Guide
+ *
+ *  Notes:
+ *     The upper limits are somewhat arbitrary right now.
+ *
+ */
 
-#ifndef _cfe_es_verify_
-#define _cfe_es_verify_
+#ifndef CFE_ES_VERIFY_H
+#define CFE_ES_VERIFY_H
 
 #include <stdint.h>
 
@@ -335,5 +336,4 @@
 #error CFE_MISSION_ES_CDS_MAX_FULL_NAME_LEN must be a multiple of 4
 #endif
 
-#endif /* _cfe_es_verify_ */
-/*****************************************************************************/
+#endif /* CFE_ES_VERIFY_H */

--- a/modules/es/ut-coverage/es_UT.h
+++ b/modules/es/ut-coverage/es_UT.h
@@ -18,24 +18,24 @@
 **  limitations under the License.
 */
 
-/*
-** File:
-**    es_UT.h
-**
-** Purpose:
-**    ES unit test header
-**
-** References:
-**    1. cFE Application Developers Guide
-**    2. unit test standard 092503
-**    3. C Coding Standard 102904
-**
-** Notes:
-**    1. This is unit test code only, not for use in flight
-**
-*/
-#ifndef _es_UT_h_
-#define _es_UT_h_
+/**
+ * @file
+ *
+ * Purpose:
+ *    ES unit test header
+ *
+ * References:
+ *    1. cFE Application Developers Guide
+ *    2. unit test standard 092503
+ *    3. C Coding Standard 102904
+ *
+ * Notes:
+ *    1. This is unit test code only, not for use in flight
+ *
+ */
+
+#ifndef ES_UT_H
+#define ES_UT_H
 
 /*
 ** Macro definitions
@@ -251,4 +251,4 @@ void TestGenericCounterAPI(void);
 void TestGenericPool(void);
 void TestLibs(void);
 
-#endif /* _es_ut_h_ */
+#endif /* ES_UT_H */

--- a/modules/evs/fsw/inc/cfe_evs_events.h
+++ b/modules/evs/fsw/inc/cfe_evs_events.h
@@ -18,21 +18,22 @@
 **  limitations under the License.
 */
 
-/*
-**  Filename: cfe_evs_events.h
-**
-**  Purpose:
-**	           cFE Event Services (EVS) Event IDs
-**
-**  Design Notes:
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**
-*/
+/**
+ * @file
+ *
+ *
+ *  Purpose:
+ *	           cFE Event Services (EVS) Event IDs
+ *
+ *  Design Notes:
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *
+ */
 
-#ifndef _cfe_evs_events_
-#define _cfe_evs_events_
+#ifndef CFE_EVS_EVENTS_H
+#define CFE_EVS_EVENTS_H
 
 /* **************************
 ** ****** Maximum EID. ******
@@ -639,4 +640,4 @@
 **/
 #define CFE_EVS_LEN_ERR_EID 43
 
-#endif /* _cfe_evs_events_ */
+#endif /* CFE_EVS_EVENTS_H */

--- a/modules/evs/fsw/inc/cfe_evs_events.h
+++ b/modules/evs/fsw/inc/cfe_evs_events.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Purpose:
  *	           cFE Event Services (EVS) Event IDs
  *

--- a/modules/evs/fsw/inc/cfe_evs_msg.h
+++ b/modules/evs/fsw/inc/cfe_evs_msg.h
@@ -18,22 +18,24 @@
 **  limitations under the License.
 */
 
-/*
-**  Filename: cfe_evs_msg.h
-**
-**  Title:    Event Services Message definition header file Header File
-**
-**  Purpose:
-**	           Unit specification for Event services command codes and data structures.
-**
-**  Design Notes:
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**
-*/
-#ifndef _cfe_evs_msg_
-#define _cfe_evs_msg_
+/**
+ * @file
+ *
+ *
+ *  Title:    Event Services Message definition header file Header File
+ *
+ *  Purpose:
+ *	           Unit specification for Event services command codes and data structures.
+ *
+ *  Design Notes:
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *
+ */
+
+#ifndef CFE_EVS_MSG_H
+#define CFE_EVS_MSG_H
 
 /********************************** Include Files  ************************************/
 #include "common_types.h"            /* Basic data types */
@@ -1286,4 +1288,4 @@ typedef struct CFE_EVS_ShortEventTlm
 
 } CFE_EVS_ShortEventTlm_t;
 
-#endif
+#endif /* CFE_EVS_MSG_H */

--- a/modules/evs/fsw/inc/cfe_evs_msg.h
+++ b/modules/evs/fsw/inc/cfe_evs_msg.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Title:    Event Services Message definition header file Header File
  *
  *  Purpose:
@@ -254,7 +253,6 @@
 **       - \b \c \EVS_CMDEC - command error counter will increment
 **       - An Error specific event message
 **
-**
 **  \par Criticality
 **      Setting the event format mode is not particularly hazardous, as the
 **      result may be saving necessary bandwidth.  However, inappropriately
@@ -296,7 +294,6 @@
 **       increment
 **       - The generation of #CFE_EVS_ENAAPPEVTTYPE_EID debug event message
 **
-**
 **  \par Error Conditions
 **      This command may fail for the following reason(s):
 **      - Invalid Event Type Selection
@@ -304,7 +301,6 @@
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \EVS_CMDEC - command error counter will increment
 **       - An Error specific event message
-**
 **
 **  \par Criticality
 **      Enabling an application event type is not particularly hazardous, as

--- a/modules/evs/fsw/src/cfe_evs_log.h
+++ b/modules/evs/fsw/src/cfe_evs_log.h
@@ -18,30 +18,29 @@
 **  limitations under the License.
 */
 
-/*
-**  Filename: cfe_evs_log.h
-**
-**  Title:    Event Services API Log Control Interfaces.
-**
-**  Purpose:
-**            Unit specification for the event services log control interfaces.
-**
-**  Contents:
-**       I.  macro and constant type definitions
-**      II.  EVM internal structures
-**     III.  function prototypes
-**
-**  Design Notes:
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**
-**  Notes:
-**
-**/
+/**
+ * @file
+ *
+ *  Title:    Event Services API Log Control Interfaces.
+ *
+ *  Purpose:
+ *            Unit specification for the event services log control interfaces.
+ *
+ *  Contents:
+ *       I.  macro and constant type definitions
+ *      II.  EVM internal structures
+ *     III.  function prototypes
+ *
+ *  Design Notes:
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *
+ *  Notes:
+ */
 
-#ifndef _cfe_evs_log_
-#define _cfe_evs_log_
+#ifndef CFE_EVS_LOG_H
+#define CFE_EVS_LOG_H
 
 /********************* Include Files  ************************/
 
@@ -58,4 +57,4 @@ void  EVS_ClearLog(void);
 int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFileCmd_t *data);
 int32 CFE_EVS_SetLogModeCmd(const CFE_EVS_SetLogModeCmd_t *data);
 
-#endif /* _cfe_evs_log_ */
+#endif /* CFE_EVS_LOG_H */

--- a/modules/evs/fsw/src/cfe_evs_module_all.h
+++ b/modules/evs/fsw/src/cfe_evs_module_all.h
@@ -19,7 +19,7 @@
 */
 
 /**
- * @file cfe_evs_module_all.h
+ * @file
  *
  * Encapsulates all EVS module internal header files, as well
  * as the public API from all other CFE core modules, OSAL, and PSP.

--- a/modules/evs/fsw/src/cfe_evs_task.h
+++ b/modules/evs/fsw/src/cfe_evs_task.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Title:    Event Services API - Management Control Interfaces.
  *
  *  Purpose:

--- a/modules/evs/fsw/src/cfe_evs_task.h
+++ b/modules/evs/fsw/src/cfe_evs_task.h
@@ -18,28 +18,29 @@
 **  limitations under the License.
 */
 
-/*
-**  Filename: cfe_evs_task.h
-**
-**  Title:    Event Services API - Management Control Interfaces.
-**
-**  Purpose:
-**            Unit specification for the event services management control interfaces.
-**
-**  Contents:
-**       I.  macro and constant type definitions
-**      II.  EVS internal structures
-**     III.  function prototypes
-**
-**  Design Notes:
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**
-**/
+/**
+ * @file
+ *
+ *
+ *  Title:    Event Services API - Management Control Interfaces.
+ *
+ *  Purpose:
+ *            Unit specification for the event services management control interfaces.
+ *
+ *  Contents:
+ *       I.  macro and constant type definitions
+ *      II.  EVS internal structures
+ *     III.  function prototypes
+ *
+ *  Design Notes:
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *
+ */
 
-#ifndef _cfe_evs_task_
-#define _cfe_evs_task_
+#ifndef CFE_EVS_TASK_H
+#define CFE_EVS_TASK_H
 
 /********************************** Include Files  ************************************/
 #include "common_types.h"
@@ -159,4 +160,4 @@ int32 CFE_EVS_DeleteEventFilterCmd(const CFE_EVS_DeleteEventFilterCmd_t *data);
 int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFileCmd_t *data);
 int32 CFE_EVS_ResetAllFiltersCmd(const CFE_EVS_ResetAllFiltersCmd_t *data);
 
-#endif /* _cfe_evs_task_ */
+#endif /* CFE_EVS_TASK_H */

--- a/modules/evs/fsw/src/cfe_evs_utils.h
+++ b/modules/evs/fsw/src/cfe_evs_utils.h
@@ -18,28 +18,29 @@
 **  limitations under the License.
 */
 
-/*
-**  Filename: cfe_evs_utils.h
-**
-**  Title:    Event Services Task and API - Utility functions.
-**
-**  Purpose:
-**            Unit specification for the event services utility functions.
-**
-**  Contents:
-**       I.  macro and constant type definitions
-**      II.  EVS utility internal structures
-**     III.  function prototypes
-**
-**  Design Notes:
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**
-*/
+/**
+ * @file
+ *
+ *
+ *  Title:    Event Services Task and API - Utility functions.
+ *
+ *  Purpose:
+ *            Unit specification for the event services utility functions.
+ *
+ *  Contents:
+ *       I.  macro and constant type definitions
+ *      II.  EVS utility internal structures
+ *     III.  function prototypes
+ *
+ *  Design Notes:
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *
+ */
 
-#ifndef _cfe_evs_utils_
-#define _cfe_evs_utils_
+#ifndef CFE_EVS_UTILS_H
+#define CFE_EVS_UTILS_H
 
 /********************* Include Files  ************************/
 
@@ -173,4 +174,4 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint1
 
 int32 EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spec, ...);
 
-#endif /* _cfe_evs_utils_ */
+#endif /* CFE_EVS_UTILS_H */

--- a/modules/evs/fsw/src/cfe_evs_utils.h
+++ b/modules/evs/fsw/src/cfe_evs_utils.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Title:    Event Services Task and API - Utility functions.
  *
  *  Purpose:

--- a/modules/evs/fsw/src/cfe_evs_verify.h
+++ b/modules/evs/fsw/src/cfe_evs_verify.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:
  *   This header file performs compile time checking for EVS configuration
  *   parameters.
@@ -29,7 +28,6 @@
  * Author:   K.Audra(Microtel)
  *
  * Notes:
- *
  *
  */
 

--- a/modules/evs/fsw/src/cfe_evs_verify.h
+++ b/modules/evs/fsw/src/cfe_evs_verify.h
@@ -18,22 +18,23 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
-** File: cfe_evs_verify.h
-**
-** Purpose:
-**   This header file performs compile time checking for EVS configuration
-**   parameters.
-**
-** Author:   K.Audra(Microtel)
-**
-** Notes:
-**
-**
-******************************************************************************/
+/**
+ * @file
+ *
+ *
+ * Purpose:
+ *   This header file performs compile time checking for EVS configuration
+ *   parameters.
+ *
+ * Author:   K.Audra(Microtel)
+ *
+ * Notes:
+ *
+ *
+ */
 
-#ifndef _cfe_evs_verify_
-#define _cfe_evs_verify_
+#ifndef CFE_EVS_VERIFY_H
+#define CFE_EVS_VERIFY_H
 
 /* NOTE: Besides the checks in this file, there is one more in cfe_evs_task.h.
  * The check is not here because it is checking a local #define based on a
@@ -64,5 +65,4 @@
 #error CFE_PLATFORM_EVS_START_TASK_STACK_SIZE must be greater than or equal to 2048
 #endif
 
-#endif /* _cfe_evs_verify_ */
-/*****************************************************************************/
+#endif /* CFE_EVS_VERIFY_H */

--- a/modules/evs/ut-coverage/evs_UT.h
+++ b/modules/evs/ut-coverage/evs_UT.h
@@ -18,24 +18,25 @@
 **  limitations under the License.
 */
 
-/*
-** File:
-**    evs_UT.h
-**
-** Purpose:
-**    EVS unit test header
-**
-** References:
-**    1. cFE Application Developers Guide
-**    2. unit test standard 092503
-**    3. C Coding Standard 102904
-**
-** Notes:
-**    1. This is unit test code only, not for use in flight
-**
-*/
-#ifndef _evs_UT_h_
-#define _evs_UT_h_
+/**
+ * @file
+ *
+ *
+ * Purpose:
+ *    EVS unit test header
+ *
+ * References:
+ *    1. cFE Application Developers Guide
+ *    2. unit test standard 092503
+ *    3. C Coding Standard 102904
+ *
+ * Notes:
+ *    1. This is unit test code only, not for use in flight
+ *
+ */
+
+#ifndef EVS_UT_H
+#define EVS_UT_H
 
 /*
 ** Includes
@@ -265,4 +266,4 @@ void Test_InvalidCmd(void);
 ******************************************************************************/
 void Test_Misc(void);
 
-#endif /* _evs_UT_h_ */
+#endif /* EVS_UT_H */

--- a/modules/evs/ut-coverage/evs_UT.h
+++ b/modules/evs/ut-coverage/evs_UT.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:
  *    EVS unit test header
  *

--- a/modules/fs/fsw/src/cfe_fs_module_all.h
+++ b/modules/fs/fsw/src/cfe_fs_module_all.h
@@ -19,7 +19,7 @@
 */
 
 /**
- * @file cfe_fs_module_all.h
+ * @file
  *
  * Encapsulates all FS module internal header files, as well
  * as the public API from all other CFE core modules, OSAL, and PSP.
@@ -39,4 +39,3 @@
 #include "cfe_fs_core_internal.h"
 
 #endif /* CFE_FS_MODULE_ALL_H */
-/*****************************************************************************/

--- a/modules/fs/fsw/src/cfe_fs_priv.h
+++ b/modules/fs/fsw/src/cfe_fs_priv.h
@@ -21,13 +21,11 @@
 /**
  * @file
  *
- *
  * Purpose:
  *      This header file contains prototypes for private functions and type
  *      definitions for FS internal use.
  *
  * Author:  A. Cudmore/NASA GSFC
- *
  *
  */
 

--- a/modules/fs/fsw/src/cfe_fs_priv.h
+++ b/modules/fs/fsw/src/cfe_fs_priv.h
@@ -18,20 +18,21 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
-** File: cfe_fs_priv.h
-**
-** Purpose:
-**      This header file contains prototypes for private functions and type
-**      definitions for FS internal use.
-**
-** Author:  A. Cudmore/NASA GSFC
-**
-**
-******************************************************************************/
+/**
+ * @file
+ *
+ *
+ * Purpose:
+ *      This header file contains prototypes for private functions and type
+ *      definitions for FS internal use.
+ *
+ * Author:  A. Cudmore/NASA GSFC
+ *
+ *
+ */
 
-#ifndef _cfe_fs_priv_
-#define _cfe_fs_priv_
+#ifndef CFE_FS_PRIV_H
+#define CFE_FS_PRIV_H
 
 /*
 ** Includes
@@ -153,5 +154,4 @@ extern void CFE_FS_UnlockSharedData(const char *FunctionName);
 extern void CFE_FS_ByteSwapCFEHeader(CFE_FS_Header_t *Hdr);
 extern void CFE_FS_ByteSwapUint32(uint32 *Uint32ToSwapPtr);
 
-#endif /* _cfe_fs_priv_ */
-/*****************************************************************************/
+#endif /* CFE_FS_PRIV_H */

--- a/modules/fs/ut-coverage/fs_UT.h
+++ b/modules/fs/ut-coverage/fs_UT.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:
  *    FS unit test header
  *

--- a/modules/fs/ut-coverage/fs_UT.h
+++ b/modules/fs/ut-coverage/fs_UT.h
@@ -18,24 +18,25 @@
 **  limitations under the License.
 */
 
-/*
-** File:
-**    fs_UT.h
-**
-** Purpose:
-**    FS unit test header
-**
-** References:
-**    1. cFE Application Developers Guide
-**    2. unit test standard 092503
-**    3. C Coding Standard 102904
-**
-** Notes:
-**    1. This is unit test code only, not for use in flight
-**
-*/
-#ifndef _fs_UT_h_
-#define _fs_UT_h_
+/**
+ * @file
+ *
+ *
+ * Purpose:
+ *    FS unit test header
+ *
+ * References:
+ *    1. cFE Application Developers Guide
+ *    2. unit test standard 092503
+ *    3. C Coding Standard 102904
+ *
+ * Notes:
+ *    1. This is unit test code only, not for use in flight
+ *
+ */
+
+#ifndef FS_UT_H
+#define FS_UT_H
 
 /*
 ** Includes
@@ -314,4 +315,4 @@ void Test_CFE_FS_GetUncompressedFile(void);
 ******************************************************************************/
 void Test_CFE_FS_BackgroundFileDump(void);
 
-#endif /* _es_ut_h_ */
+#endif /* FS_UT_H */

--- a/modules/msg/fsw/inc/ccsds_hdr.h
+++ b/modules/msg/fsw/inc/ccsds_hdr.h
@@ -18,14 +18,16 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
+/**
+ * @file
+ *
  * Define CCSDS packet header types
  *  - Avoid direct access for portability, use APIs
  *  - Used to construct message structures
  */
 
-#ifndef _ccsds_hdr_
-#define _ccsds_hdr_
+#ifndef CCSDS_HDR_H
+#define CCSDS_HDR_H
 
 /*
  * Include Files
@@ -87,4 +89,4 @@ typedef struct CCSDS_ExtendedHeader
 
 } CCSDS_ExtendedHeader_t;
 
-#endif /* _ccsds_hdr_ */
+#endif /* CCSDS_HDR_H */

--- a/modules/msg/fsw/src/cfe_msg_defaults.h
+++ b/modules/msg/fsw/src/cfe_msg_defaults.h
@@ -18,13 +18,15 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
+/**
+ * @file
+ *
  * Message header defaults, used to initialize messages
  *  - Avoid including outside this module
  */
 
-#ifndef _cfe_msg_defaults_
-#define _cfe_msg_defaults_
+#ifndef CFE_MSG_DEFAULTS_H
+#define CFE_MSG_DEFAULTS_H
 
 /*
  * Includes
@@ -78,4 +80,4 @@ void CFE_MSG_SetDefaultCCSDSPri(CFE_MSG_Message_t *MsgPtr);
  */
 void CFE_MSG_SetDefaultCCSDSExt(CFE_MSG_Message_t *MsgPtr);
 
-#endif /* _cfe_msg_default_ */
+#endif /* CFE_MSG_DEFAULTS_H */

--- a/modules/msg/fsw/src/cfe_msg_priv.h
+++ b/modules/msg/fsw/src/cfe_msg_priv.h
@@ -18,13 +18,15 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
+/**
+ * @file
+ *
  * Message private header
  *  - Avoid including outside this module
  */
 
-#ifndef _cfe_msg_priv_
-#define _cfe_msg_priv_
+#ifndef CFE_MSG_PRIV_H
+#define CFE_MSG_PRIV_H
 
 /*
  * Includes
@@ -79,4 +81,4 @@ static inline void CFE_MSG_SetHeaderField(uint8 *Word, uint16 Val, uint16 Mask)
  */
 void CFE_MSG_InitDefaultHdr(CFE_MSG_Message_t *MsgPtr);
 
-#endif /* _cfe_msg_priv_ */
+#endif /* CFE_MSG_PRIV_H */

--- a/modules/msg/option_inc/default_cfe_msg_hdr_pri.h
+++ b/modules/msg/option_inc/default_cfe_msg_hdr_pri.h
@@ -18,14 +18,16 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
+/**
+ * @file
+ *
  * Define cFS standard full header
  *  - Avoid direct access for portability, use APIs
  *  - Used to construct message structures
  */
 
-#ifndef _cfe_msg_hdr_
-#define _cfe_msg_hdr_
+#ifndef DEFAULT_CFE_MSG_HDR_PRI_H
+#define DEFAULT_CFE_MSG_HDR_PRI_H
 
 /*
  * Include Files
@@ -89,4 +91,4 @@ struct CFE_MSG_TelemetryHeader
     uint8                              Spare[4]; /**< \brief Padding to end on 64 bit boundary */
 };
 
-#endif /* _cfe_msg_hdr_ */
+#endif /* DEFAULT_CFE_MSG_HDR_PRI_H */

--- a/modules/msg/option_inc/default_cfe_msg_hdr_priext.h
+++ b/modules/msg/option_inc/default_cfe_msg_hdr_priext.h
@@ -18,14 +18,16 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
+/**
+ * @file
+ *
  * Define cFS standard full header
  *  - Avoid direct access for portability, use APIs
  *  - Used to construct message structures
  */
 
-#ifndef _cfe_msg_hdr_
-#define _cfe_msg_hdr_
+#ifndef DEFAULT_CFE_MSG_HDR_PRIEXT_H
+#define DEFAULT_CFE_MSG_HDR_PRIEXT_H
 
 /*
  * Include Files
@@ -87,4 +89,4 @@ typedef struct
 
 } CFE_MSG_TelemetryHeader_t;
 
-#endif /* _cfe_msg_hdr_ */
+#endif /* DEFAULT_CFE_MSG_HDR_PRIEXT_H */

--- a/modules/msg/option_inc/default_cfe_msg_sechdr.h
+++ b/modules/msg/option_inc/default_cfe_msg_sechdr.h
@@ -18,14 +18,16 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
+/**
+ * @file
+ *
  * Define cFS standard secondary header
  *  - Avoid direct access for portability, use APIs
  *  - Used to construct message structures
  */
 
-#ifndef _cfe_msg_sechdr_
-#define _cfe_msg_sechdr_
+#ifndef DEFAULT_CFE_MSG_SECHDR_H
+#define DEFAULT_CFE_MSG_SECHDR_H
 
 /*
  * Include Files
@@ -74,4 +76,4 @@ typedef struct
 
 } CFE_MSG_TelemetrySecondaryHeader_t;
 
-#endif /* _cfe_msg_sechdr_ */
+#endif /* DEFAULT_CFE_MSG_SECHDR_H */

--- a/modules/msg/ut-coverage/test_cfe_msg_ccsdsext.h
+++ b/modules/msg/ut-coverage/test_cfe_msg_ccsdsext.h
@@ -18,11 +18,13 @@
 **  limitations under the License.
 */
 
-/*
+/**
+ * @file
+ *
  * cfe_msg_ccsdsext test header
  */
-#ifndef test_cfe_msg_ccsdsext_
-#define test_cfe_msg_ccsdsext_
+#ifndef TEST_CFE_MSG_CCSDSEXT_H
+#define TEST_CFE_MSG_CCSDSEXT_H
 
 /*
  * Defines
@@ -34,4 +36,4 @@
 /* Test CCSDS Extended header accessor functions */
 void Test_MSG_CCSDSExt(void);
 
-#endif /* test_cfe_msg_ccsdsext_ */
+#endif /* TEST_CFE_MSG_CCSDSEXT_H */

--- a/modules/msg/ut-coverage/test_cfe_msg_ccsdspri.h
+++ b/modules/msg/ut-coverage/test_cfe_msg_ccsdspri.h
@@ -18,11 +18,14 @@
 **  limitations under the License.
 */
 
-/*
+/**
+ * @file
+ *
  * cfe_msg_ccsdspri test header
  */
-#ifndef test_cfe_msg_ccsdspri_
-#define test_cfe_msg_ccsdspri_
+
+#ifndef TEST_CFE_MSG_CCSDSPRI_H
+#define TEST_CFE_MSG_CCSDSPRI_H
 
 /*
  * Defines
@@ -36,4 +39,4 @@
 /* Test CCSDS Primary header accessor functions */
 void Test_MSG_CCSDSPri(void);
 
-#endif /* test_cfe_msg_ccsdspri_ */
+#endif /* TEST_CFE_MSG_CCSDSPRI_H */

--- a/modules/msg/ut-coverage/test_cfe_msg_checksum.h
+++ b/modules/msg/ut-coverage/test_cfe_msg_checksum.h
@@ -18,11 +18,13 @@
 **  limitations under the License.
 */
 
-/*
+/**
+ * @file
+ *
  * cfe_msg_checksum test header
  */
-#ifndef test_cfe_msg_checksum_
-#define test_cfe_msg_checksum_
+#ifndef TEST_CFE_MSG_CHECKSUM_H
+#define TEST_CFE_MSG_CHECKSUM_H
 
 /*
  * Functions
@@ -30,4 +32,4 @@
 /* Test checksum accessor functions */
 void Test_MSG_Checksum(void);
 
-#endif /* test_cfe_msg_checksum_ */
+#endif /* TEST_CFE_MSG_CHECKSUM_H */

--- a/modules/msg/ut-coverage/test_cfe_msg_fc.h
+++ b/modules/msg/ut-coverage/test_cfe_msg_fc.h
@@ -18,11 +18,13 @@
 **  limitations under the License.
 */
 
-/*
+/**
+ * @file
+ *
  * cfe_msg_fc test header
  */
-#ifndef test_cfe_msg_fc_
-#define test_cfe_msg_fc_
+#ifndef TEST_CFE_MSG_FC_H
+#define TEST_CFE_MSG_FC_H
 
 /*
  * Functions
@@ -30,4 +32,4 @@
 /* Test function code accessor functions */
 void Test_MSG_FcnCode(void);
 
-#endif /* test_cfe_msg_fc_ */
+#endif /* TEST_CFE_MSG_FC_H */

--- a/modules/msg/ut-coverage/test_cfe_msg_init.h
+++ b/modules/msg/ut-coverage/test_cfe_msg_init.h
@@ -18,11 +18,13 @@
 **  limitations under the License.
 */
 
-/*
+/**
+ * @file
+ *
  * cfe_msg_init test header
  */
-#ifndef test_cfe_msg_init_
-#define test_cfe_msg_init_
+#ifndef TEST_CFE_MSG_INIT_H
+#define TEST_CFE_MSG_INIT_H
 
 /*
  * Includes
@@ -34,4 +36,4 @@
 /* Test extended header mission functionality */
 void Test_MSG_Init(void);
 
-#endif /* test_cfe_msg_init_ */
+#endif /* TEST_CFE_MSG_INIT_H */

--- a/modules/msg/ut-coverage/test_cfe_msg_msgid.h
+++ b/modules/msg/ut-coverage/test_cfe_msg_msgid.h
@@ -18,11 +18,13 @@
 **  limitations under the License.
 */
 
-/*
+/**
+ * @file
+ *
  * Message ID V2 accessor function test header
  */
-#ifndef test_cfe_msg_msgid_
-#define test_cfe_msg_msgid_
+#ifndef TEST_CFE_MSG_MSGID_H
+#define TEST_CFE_MSG_MSGID_H
 
 /*
  * Functions
@@ -30,4 +32,4 @@
 /* Test msgid accessor functions */
 void Test_MSG_MsgId(void);
 
-#endif /* test_cfe_msg_msgid_ */
+#endif /* TEST_CFE_MSG_MSGID_H */

--- a/modules/msg/ut-coverage/test_cfe_msg_msgid_shared.h
+++ b/modules/msg/ut-coverage/test_cfe_msg_msgid_shared.h
@@ -18,11 +18,13 @@
 **  limitations under the License.
 */
 
-/*
+/**
+ * @file
+ *
  * cfe_msg_msgid_shared test header
  */
-#ifndef test_cfe_msg_msgid_shared_
-#define test_cfe_msg_msgid_shared_
+#ifndef TEST_CFE_MSG_MSGID_SHARED_H
+#define TEST_CFE_MSG_MSGID_SHARED_H
 
 /*
  * Functions
@@ -30,4 +32,4 @@
 /* Test msgid shared accessor functions */
 void Test_MSG_MsgId_Shared(void);
 
-#endif /* test_cfe_msg_msgid_shared_ */
+#endif /* TEST_CFE_MSG_MSGID_SHARED_H */

--- a/modules/msg/ut-coverage/test_cfe_msg_time.h
+++ b/modules/msg/ut-coverage/test_cfe_msg_time.h
@@ -18,11 +18,13 @@
 **  limitations under the License.
 */
 
-/*
+/**
+ * @file
+ *
  * cfe_msg_time test header
  */
-#ifndef test_cfe_msg_time_
-#define test_cfe_msg_time_
+#ifndef TEST_CFE_MSG_TIME_H
+#define TEST_CFE_MSG_TIME_H
 
 /*
  * Functions
@@ -30,4 +32,4 @@
 /* Test time accessor functions */
 void Test_MSG_Time(void);
 
-#endif /* test_cfe_msg_time_ */
+#endif /* TEST_CFE_MSG_TIME_H */

--- a/modules/msg/ut-coverage/test_msg_not.h
+++ b/modules/msg/ut-coverage/test_msg_not.h
@@ -18,11 +18,14 @@
 **  limitations under the License.
 */
 
-/*
+/**
+ * @file
+ *
  * Message header fields not (Zero or F's)
  */
-#ifndef test_msg_not_
-#define test_msg_not_
+
+#ifndef TEST_MSG_NOT_H
+#define TEST_MSG_NOT_H
 
 /*
  * Defines
@@ -64,4 +67,4 @@ unsigned int Test_MSG_NotF(const CFE_MSG_Message_t *MsgPtr);
 unsigned int Test_MSG_Pri_NotF(const CFE_MSG_Message_t *MsgPtr);
 unsigned int Test_MSG_Ext_NotF(const CFE_MSG_Message_t *MsgPtr);
 
-#endif /* test_msg_not_ */
+#endif /* TEST_MSG_NOT_H */

--- a/modules/msg/ut-coverage/test_msg_utils.h
+++ b/modules/msg/ut-coverage/test_msg_utils.h
@@ -18,11 +18,14 @@
 **  limitations under the License.
 */
 
-/*
+/**
+ * @file
+ *
  * Message header test utilities
  */
-#ifndef test_msg_utils_
-#define test_msg_utils_
+
+#ifndef TEST_MSG_UTILS_H
+#define TEST_MSG_UTILS_H
 
 /*
  * Includes
@@ -36,4 +39,4 @@
 /* Subtest macro */
 #define MSG_UT_ADD_SUBTEST(Func) UT_AddSubTest(Func, NULL, NULL, __func__, #Func)
 
-#endif /* test_msg_utils_ */
+#endif /* TEST_MSG_UTILS_H */

--- a/modules/resourceid/option_inc/cfe_resourceid_osal_compatible.h
+++ b/modules/resourceid/option_inc/cfe_resourceid_osal_compatible.h
@@ -19,7 +19,7 @@
 */
 
 /**
- * \file cfe_resourceid_osal_compatible.h
+ * @file
  *
  * An implementation of CFE resource ID base values/limits that will be
  * compatible with OSAL IDs.  This is intended as a transitional tool to

--- a/modules/resourceid/option_inc/cfe_resourceid_simple.h
+++ b/modules/resourceid/option_inc/cfe_resourceid_simple.h
@@ -18,6 +18,12 @@
 **  limitations under the License.
 */
 
+/**
+ * @file
+ *
+ * Declarations and prototypes for simple (uint32 compatible) resource ID implementation
+ */
+
 #ifndef CFE_RESOURCEID_SIMPLE_H
 #define CFE_RESOURCEID_SIMPLE_H
 

--- a/modules/resourceid/option_inc/cfe_resourceid_strict.h
+++ b/modules/resourceid/option_inc/cfe_resourceid_strict.h
@@ -18,6 +18,12 @@
 **  limitations under the License.
 */
 
+/**
+ * @file
+ *
+ * Declarations and prototypes for strict (type-safe) resource ID implementation
+ */
+
 #ifndef CFE_RESOURCEID_STRICT_H
 #define CFE_RESOURCEID_STRICT_H
 

--- a/modules/sb/fsw/inc/cfe_sb_events.h
+++ b/modules/sb/fsw/inc/cfe_sb_events.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Purpose:
  *      cFE Software Bus (SB) Event IDs
  *

--- a/modules/sb/fsw/inc/cfe_sb_events.h
+++ b/modules/sb/fsw/inc/cfe_sb_events.h
@@ -18,19 +18,21 @@
 **  limitations under the License.
 */
 
-/*
-**  File: cfe_sb_events.h
-**
-**  Purpose:
-**      cFE Software Bus (SB) Event IDs
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**     cFE Flight Software Application Developers Guide
-**
-**************************************************************************/
-#ifndef _cfe_sb_events_
-#define _cfe_sb_events_
+/**
+ * @file
+ *
+ *
+ *  Purpose:
+ *      cFE Software Bus (SB) Event IDs
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *     cFE Flight Software Application Developers Guide
+ *
+ */
+
+#ifndef CFE_SB_EVENTS_H
+#define CFE_SB_EVENTS_H
 
 /* **************************
 ** ****** Maximum EID. ******
@@ -902,8 +904,4 @@
 **/
 #define CFE_SB_CR_PIPE_NO_FREE_EID 63
 
-#endif /* _cfe_sb_events_ */
-
-/************************/
-/*  End of File Comment */
-/************************/
+#endif /* CFE_SB_EVENTS_H */

--- a/modules/sb/fsw/inc/cfe_sb_msg.h
+++ b/modules/sb/fsw/inc/cfe_sb_msg.h
@@ -18,19 +18,20 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
-** File: cfe_sb_msg.h
-**
-** Purpose:
-**      This header file contains structure definitions for all SB command and
-**      telemetry packets
-**
-** Author:   R.McGraw/SSI
-**
-******************************************************************************/
+/**
+ * @file
+ *
+ *
+ * Purpose:
+ *      This header file contains structure definitions for all SB command and
+ *      telemetry packets
+ *
+ * Author:   R.McGraw/SSI
+ *
+ */
 
-#ifndef _cfe_sb_msg_
-#define _cfe_sb_msg_
+#ifndef CFE_SB_MSG_H
+#define CFE_SB_MSG_H
 
 /*
 ** Includes
@@ -784,5 +785,4 @@ typedef struct CFE_SB_AllSubscriptionsTlm
     CFE_SB_AllSubscriptionsTlm_Payload_t Payload; /**< \brief Telemetry payload */
 } CFE_SB_AllSubscriptionsTlm_t;
 
-#endif /* _cfe_sb_msg_ */
-/*****************************************************************************/
+#endif /* CFE_SB_MSG_H */

--- a/modules/sb/fsw/inc/cfe_sb_msg.h
+++ b/modules/sb/fsw/inc/cfe_sb_msg.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:
  *      This header file contains structure definitions for all SB command and
  *      telemetry packets

--- a/modules/sb/fsw/src/cfe_sb_module_all.h
+++ b/modules/sb/fsw/src/cfe_sb_module_all.h
@@ -19,7 +19,7 @@
 */
 
 /**
- * @file cfe_sb_module_all.h
+ * @file
  *
  * Encapsulates all SB module internal header files, as well
  * as the public API from all other CFE core modules, OSAL, and PSP.

--- a/modules/sb/fsw/src/cfe_sb_priv.h
+++ b/modules/sb/fsw/src/cfe_sb_priv.h
@@ -18,19 +18,20 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
-** File: cfe_sb_priv.h
-**
-** Purpose:
-**      This header file contains prototypes for private functions and type
-**      definitions for SB internal use.
-**
-** Author:   R.McGraw/SSI
-**
-******************************************************************************/
+/**
+ * @file
+ *
+ *
+ * Purpose:
+ *      This header file contains prototypes for private functions and type
+ *      definitions for SB internal use.
+ *
+ * Author:   R.McGraw/SSI
+ *
+ */
 
-#ifndef _cfe_sb_priv_
-#define _cfe_sb_priv_
+#ifndef CFE_SB_PRIV_H
+#define CFE_SB_PRIV_H
 
 /*
 ** Includes
@@ -632,5 +633,4 @@ void CFE_SB_BackgroundFileEventHandler(void *Meta, CFE_FS_FileWriteEvent_t Event
 
 extern CFE_SB_Global_t CFE_SB_Global;
 
-#endif /* _cfe_sb_priv_ */
-/*****************************************************************************/
+#endif /* CFE_SB_PRIV_H */

--- a/modules/sb/fsw/src/cfe_sb_priv.h
+++ b/modules/sb/fsw/src/cfe_sb_priv.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:
  *      This header file contains prototypes for private functions and type
  *      definitions for SB internal use.

--- a/modules/sb/fsw/src/cfe_sb_verify.h
+++ b/modules/sb/fsw/src/cfe_sb_verify.h
@@ -18,19 +18,20 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
-** File: cfe_sb_verify.h
-**
-** Purpose:
-**      This header file performs compile time checking for SB configuration
-**      parameters.
-**
-** Author:   R.McGraw/SSI
-**
-******************************************************************************/
+/**
+ * @file
+ *
+ *
+ * Purpose:
+ *      This header file performs compile time checking for SB configuration
+ *      parameters.
+ *
+ * Author:   R.McGraw/SSI
+ *
+ */
 
-#ifndef _cfe_sb_verify_
-#define _cfe_sb_verify_
+#ifndef CFE_SB_VERIFY_H
+#define CFE_SB_VERIFY_H
 
 #include <stdint.h>
 
@@ -164,5 +165,4 @@
 #error CFE_PLATFORM_SB_START_TASK_STACK_SIZE must be greater than or equal to 2048
 #endif
 
-#endif /* _cfe_sb_verify_ */
-/*****************************************************************************/
+#endif /* CFE_SB_VERIFY_H */

--- a/modules/sb/fsw/src/cfe_sb_verify.h
+++ b/modules/sb/fsw/src/cfe_sb_verify.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:
  *      This header file performs compile time checking for SB configuration
  *      parameters.

--- a/modules/sb/ut-coverage/sb_UT.h
+++ b/modules/sb/ut-coverage/sb_UT.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:
  *    SB unit test header
  *

--- a/modules/sb/ut-coverage/sb_UT.h
+++ b/modules/sb/ut-coverage/sb_UT.h
@@ -18,24 +18,25 @@
 **  limitations under the License.
 */
 
-/*
-** File:
-**    sb_UT.h
-**
-** Purpose:
-**    SB unit test header
-**
-** References:
-**    1. cFE Application Developers Guide
-**    2. unit test standard 092503
-**    3. C Coding Standard 102904
-**
-** Notes:
-**    1. This is unit test code only, not for use in flight
-**
-*/
-#ifndef _sb_UT_h_
-#define _sb_UT_h_
+/**
+ * @file
+ *
+ *
+ * Purpose:
+ *    SB unit test header
+ *
+ * References:
+ *    1. cFE Application Developers Guide
+ *    2. unit test standard 092503
+ *    3. C Coding Standard 102904
+ *
+ * Notes:
+ *    1. This is unit test code only, not for use in flight
+ *
+ */
+
+#ifndef SB_UT_H
+#define SB_UT_H
 
 /*
 ** Includes
@@ -2421,4 +2422,4 @@ void Test_SB_CCSDSPriHdr_Macros(void);
 void Test_SB_CCSDSSecHdr_Macros(void);
 void Test_SB_IdxPushPop(void);
 
-#endif /* _sb_ut_h_ */
+#endif /* SB_UT_H */

--- a/modules/sbr/fsw/src/cfe_sbr_priv.h
+++ b/modules/sbr/fsw/src/cfe_sbr_priv.h
@@ -18,13 +18,15 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
+/**
+ * @file
+ *
  * Prototypes for private functions and type definitions for SB
  * routing internal use.
- *****************************************************************************/
+ */
 
-#ifndef CFE_SBR_PRIV_H_
-#define CFE_SBR_PRIV_H_
+#ifndef CFE_SBR_PRIV_H
+#define CFE_SBR_PRIV_H
 
 /*
  * Includes
@@ -56,4 +58,4 @@ void CFE_SBR_Init_Map(void);
  */
 uint32 CFE_SBR_SetRouteId(CFE_SB_MsgId_t MsgId, CFE_SBR_RouteId_t RouteId);
 
-#endif /* CFE_SBR_PRIV_H_ */
+#endif /* CFE_SBR_PRIV_H */

--- a/modules/tbl/fsw/inc/cfe_tbl_events.h
+++ b/modules/tbl/fsw/inc/cfe_tbl_events.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Title:   Table Services API Event ID Header File
  *
  *  Purpose:

--- a/modules/tbl/fsw/inc/cfe_tbl_events.h
+++ b/modules/tbl/fsw/inc/cfe_tbl_events.h
@@ -18,25 +18,26 @@
 **  limitations under the License.
 */
 
-/*
-**  File: cfe_tbl_events.h
-**
-**  Title:   Table Services API Event ID Header File
-**
-**  Purpose:
-**     Identifies event codes for event messages issued by Table Services.
-**
-**  Design Notes:
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**
-**  Notes:
-**
-**/
+/**
+ * @file
+ *
+ *
+ *  Title:   Table Services API Event ID Header File
+ *
+ *  Purpose:
+ *     Identifies event codes for event messages issued by Table Services.
+ *
+ *  Design Notes:
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *
+ *  Notes:
+ *
+ */
 
-#ifndef _cfe_tbl_events_
-#define _cfe_tbl_events_
+#ifndef CFE_TBL_EVENTS_H
+#define CFE_TBL_EVENTS_H
 
 /* **************************
 ** ****** Maximum EID. ******
@@ -1097,8 +1098,4 @@
 
 /** \} */
 
-#endif /* _cfe_tbl_events_ */
-
-/************************/
-/*  End of File Comment */
-/************************/
+#endif /* CFE_TBL_EVENTS_H */

--- a/modules/tbl/fsw/inc/cfe_tbl_msg.h
+++ b/modules/tbl/fsw/inc/cfe_tbl_msg.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:  cFE Table Services (TBL) SB message definitions header file
  *
  * Author:   D.Kobe/Hammers

--- a/modules/tbl/fsw/inc/cfe_tbl_msg.h
+++ b/modules/tbl/fsw/inc/cfe_tbl_msg.h
@@ -18,22 +18,20 @@
 **  limitations under the License.
 */
 
-/*
-** File: cfe_tbl_msg.h
-**
-** Purpose:  cFE Table Services (TBL) SB message definitions header file
-**
-** Author:   D.Kobe/Hammers
-**
-** Notes:
-**
-*/
+/**
+ * @file
+ *
+ *
+ * Purpose:  cFE Table Services (TBL) SB message definitions header file
+ *
+ * Author:   D.Kobe/Hammers
+ *
+ * Notes:
+ *
+ */
 
-/*
-** Ensure that header is included only once...
-*/
-#ifndef _cfe_tbl_msg_
-#define _cfe_tbl_msg_
+#ifndef CFE_TBL_MSG_H
+#define CFE_TBL_MSG_H
 
 /*
 ** Required header files...
@@ -839,8 +837,4 @@ typedef struct CFE_TBL_TableRegistryTlm
     CFE_TBL_TblRegPacket_Payload_t Payload;   /**< \brief Telemetry payload */
 } CFE_TBL_TableRegistryTlm_t;
 
-#endif /* _cfe_tbl_msg_ */
-
-/************************/
-/*  End of File Comment */
-/************************/
+#endif /* CFE_TBL_MSG_H */

--- a/modules/tbl/fsw/src/cfe_tbl_internal.h
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:  cFE Table Services (TBL) utility function interface file
  *
  * Author:   D. Kobe/the Hammers Company, Inc.
@@ -92,7 +91,6 @@ int32 CFE_TBL_ValidateHandle(CFE_TBL_Handle_t TblHandle);
 **
 ** \param[in, out]  AppIdPtr  Pointer to value that will hold AppID on return. *AppIdPtr is the AppID as obtained from
 *#CFE_ES_GetAppID
-**
 **
 ** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
 ** \retval #CFE_TBL_ERR_BAD_APP_ID          \copydoc CFE_TBL_ERR_BAD_APP_ID
@@ -165,7 +163,6 @@ int32 CFE_TBL_RemoveAccessLink(CFE_TBL_Handle_t TblHandle);
 **                            the Table Data.
 ** \param[in]  TblHandle Handle of Table whose address is needed.
 ** \param[in]  ThisAppId AppID of application making the address request.
-**
 **
 ** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
 ** \retval #CFE_TBL_ERR_INVALID_HANDLE      \copydoc CFE_TBL_ERR_INVALID_HANDLE
@@ -263,8 +260,6 @@ CFE_TBL_Handle_t CFE_TBL_FindFreeHandle(void);
 **
 ** \param[in]  ThisAppId the Application ID of the Application making the call.
 **
-**
-**
 ******************************************************************************/
 void CFE_TBL_FormTableName(char *FullTblName, const char *TblName, CFE_ES_AppId_t ThisAppId);
 
@@ -325,7 +320,6 @@ int32 CFE_TBL_UnlockRegistry(void);
 ** \param[in]  CalledByApp       Boolean that identifies whether this internal API
 **                               function is being called by a user Application (true)
 **                               or by the Table Services Application (false)
-**
 **
 ** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
 ** \retval #CFE_TBL_ERR_NO_BUFFER_AVAIL     \copydoc CFE_TBL_ERR_NO_BUFFER_AVAIL
@@ -443,8 +437,6 @@ void CFE_TBL_NotifyTblUsersOfUpdate(CFE_TBL_RegistryRec_t *RegRecPtr);
 ** \param[in]  LoadFilename      Pointer to character string containing full path
 **                               and filename of table image to be loaded
 **
-**
-**
 ** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
 ** \retval #CFE_TBL_ERR_NO_STD_HEADER       \copydoc CFE_TBL_ERR_NO_STD_HEADER
 ** \retval #CFE_TBL_ERR_NO_TBL_HEADER       \copydoc CFE_TBL_ERR_NO_TBL_HEADER
@@ -483,7 +475,6 @@ void CFE_TBL_InitRegistryRecord(CFE_TBL_RegistryRec_t *RegRecPtr);
 **
 ** \param[in, out]  HdrPtr   Pointer to table header that needs to be swapped. *HdrPtr provides the swapped header
 **
-**
 ******************************************************************************/
 void CFE_TBL_ByteSwapTblHeader(CFE_TBL_File_Hdr_t *HdrPtr);
 
@@ -509,7 +500,6 @@ void CFE_TBL_ByteSwapTblHeader(CFE_TBL_File_Hdr_t *HdrPtr);
 **
 ** \param[in]  CDSHandleToFind   CDS Handle to be located in Critical Table Registry.
 **
-**
 ******************************************************************************/
 void CFE_TBL_FindCriticalTblInfo(CFE_TBL_CritRegRec_t **CritRegRecPtr, CFE_ES_CDSHandle_t CDSHandleToFind);
 
@@ -529,7 +519,6 @@ void CFE_TBL_FindCriticalTblInfo(CFE_TBL_CritRegRec_t **CritRegRecPtr, CFE_ES_CD
 ** \param[in]  RegRecPtr Pointer to Registry Record of Critical Table whose CDS
 **                       needs to be updated.
 **
-**
 ******************************************************************************/
 void CFE_TBL_UpdateCriticalTblCDS(CFE_TBL_RegistryRec_t *RegRecPtr);
 
@@ -548,7 +537,6 @@ void CFE_TBL_UpdateCriticalTblCDS(CFE_TBL_RegistryRec_t *RegRecPtr);
 **
 ** \param[in]  RegRecPtr Pointer to Registry Record of Table whose owner needs notifying.
 **
-**
 ******************************************************************************/
 int32 CFE_TBL_SendNotificationMsg(CFE_TBL_RegistryRec_t *RegRecPtr);
 
@@ -564,7 +552,6 @@ int32 CFE_TBL_SendNotificationMsg(CFE_TBL_RegistryRec_t *RegRecPtr);
 **          None
 **
 ** \param[in, out]  Uint32ToSwapPtr Pointer to uint32 value to be swapped. *Uint32ToSwapPtr is the swapped uint32 value
-**
 **
 ******************************************************************************/
 extern void CFE_TBL_ByteSwapUint32(uint32 *Uint32ToSwapPtr);

--- a/modules/tbl/fsw/src/cfe_tbl_internal.h
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.h
@@ -18,16 +18,17 @@
 **  limitations under the License.
 */
 
-/*
-** File: cfe_tbl_internal.h
-**
-** Purpose:  cFE Table Services (TBL) utility function interface file
-**
-** Author:   D. Kobe/the Hammers Company, Inc.
-**
-** Notes:
-**
-*/
+/**
+ * @file
+ *
+ *
+ * Purpose:  cFE Table Services (TBL) utility function interface file
+ *
+ * Author:   D. Kobe/the Hammers Company, Inc.
+ *
+ * Notes:
+ *
+ */
 
 #ifndef CFE_TBL_INTERNAL_H
 #define CFE_TBL_INTERNAL_H

--- a/modules/tbl/fsw/src/cfe_tbl_module_all.h
+++ b/modules/tbl/fsw/src/cfe_tbl_module_all.h
@@ -19,7 +19,7 @@
 */
 
 /**
- * @file cfe_tbl_module_all.h
+ * @file
  *
  * Encapsulates all TBL module internal header files, as well
  * as the public API from all other CFE core modules, OSAL, and PSP.

--- a/modules/tbl/fsw/src/cfe_tbl_task.h
+++ b/modules/tbl/fsw/src/cfe_tbl_task.h
@@ -18,22 +18,20 @@
 **  limitations under the License.
 */
 
-/*
-** File: cfe_tbl_task.h
-**
-** Purpose:  cFE Table Services (TBL) task header file
-**
-** Author:   David Kobe (the Hammers Company, Inc.)
-**
-** Notes:
-**
-*/
+/**
+ * @file
+ *
+ *
+ * Purpose:  cFE Table Services (TBL) task header file
+ *
+ * Author:   David Kobe (the Hammers Company, Inc.)
+ *
+ * Notes:
+ *
+ */
 
-/*
-** Ensure that header is included only once...
-*/
-#ifndef _cfe_tbl_task_
-#define _cfe_tbl_task_
+#ifndef CFE_TBL_TASK_H
+#define CFE_TBL_TASK_H
 
 /*
 ** Required header files
@@ -425,8 +423,4 @@ void CFE_TBL_TaskPipe(CFE_SB_Buffer_t *SBBufPtr);
 ******************************************************************************/
 void CFE_TBL_InitData(void);
 
-#endif /* _cfe_tbl_task_ */
-
-/************************/
-/*  End of File Comment */
-/************************/
+#endif /* CFE_TBL_TASK_H */

--- a/modules/tbl/fsw/src/cfe_tbl_task.h
+++ b/modules/tbl/fsw/src/cfe_tbl_task.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:  cFE Table Services (TBL) task header file
  *
  * Author:   David Kobe (the Hammers Company, Inc.)
@@ -405,7 +404,6 @@ int32 CFE_TBL_TaskInit(void);
 **
 ** \param[in] MessagePtr a pointer to the message received from the command pipe
 **
-**
 ******************************************************************************/
 void CFE_TBL_TaskPipe(CFE_SB_Buffer_t *SBBufPtr);
 
@@ -418,7 +416,6 @@ void CFE_TBL_TaskPipe(CFE_SB_Buffer_t *SBBufPtr);
 **
 ** \par Assumptions, External Events, and Notes:
 **          None
-**
 **
 ******************************************************************************/
 void CFE_TBL_InitData(void);

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.h
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Subsystem: cFE TBL Task Command Handler Interface Definition File
  *
  * Author: David Kobe (the Hammers Company, Inc.)
@@ -99,7 +98,6 @@ typedef struct
 ** \par Assumptions, External Events, and Notes:
 **          None
 **
-**
 ******************************************************************************/
 extern void CFE_TBL_GetHkData(void);
 
@@ -115,7 +113,6 @@ extern void CFE_TBL_GetHkData(void);
 ** \par Assumptions, External Events, and Notes:
 **        #CFE_TBL_Global_t::HkTlmTblRegIndex is assumed to be a valid index into
 **           the Table Registry.
-**
 **
 ******************************************************************************/
 extern void CFE_TBL_GetTblRegData(void);

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.h
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.h
@@ -18,19 +18,20 @@
 **  limitations under the License.
 */
 
-/*
-** File: cfe_tbl_task_cmds.h
-**
-** Subsystem: cFE TBL Task Command Handler Interface Definition File
-**
-** Author: David Kobe (the Hammers Company, Inc.)
-**
-** Notes:
-**
-*/
+/**
+ * @file
+ *
+ *
+ * Subsystem: cFE TBL Task Command Handler Interface Definition File
+ *
+ * Author: David Kobe (the Hammers Company, Inc.)
+ *
+ * Notes:
+ *
+ */
 
-#ifndef _cfe_tbl_task_cmds_
-#define _cfe_tbl_task_cmds_
+#ifndef CFE_TBL_TASK_CMDS_H
+#define CFE_TBL_TASK_CMDS_H
 
 /*
 ** Required header files
@@ -354,4 +355,4 @@ extern CFE_TBL_CmdProcRet_t CFE_TBL_DumpToFile(const char *DumpFilename, const c
 ******************************************************************************/
 void CFE_TBL_AbortLoad(CFE_TBL_RegistryRec_t *RegRecPtr);
 
-#endif /* _cfe_tbl_task_cmds_ */
+#endif /* CFE_TBL_TASK_CMDS_H */

--- a/modules/tbl/fsw/src/cfe_tbl_verify.h
+++ b/modules/tbl/fsw/src/cfe_tbl_verify.h
@@ -18,19 +18,20 @@
 **  limitations under the License.
 */
 
-/******************************************************************************
-**  File: cfe_tbl_verify.h
-**
-**  File: cfe_tbl_verify.h
-**
-**  Purpose:
-**    This header file performs compile time checking for TBL configuration
-**    parameters.
-**
-******************************************************************************/
+/**
+ * @file
+ *
+ *
+ *
+ *  Purpose:
+ *    This header file performs compile time checking for TBL configuration
+ *    parameters.
+ *
+ */
 
-#ifndef _cfe_tbl_verify_
-#define _cfe_tbl_verify_
+#ifndef CFE_TBL_VERIFY_H
+#define CFE_TBL_VERIFY_H
+
 #include "cfe_platform_cfg.h"
 
 #if (2 * CFE_PLATFORM_TBL_MAX_DBL_TABLE_SIZE) > CFE_PLATFORM_TBL_BUF_MEMORY_BYTES
@@ -92,5 +93,4 @@ OS_MAX_PATH_LEN #endif
 #error CFE_MISSION_TBL_MAX_FULL_NAME_LEN must be a multiple of 4
 #endif
 
-#endif /* _cfe_tbl_verify_ */
-/*****************************************************************************/
+#endif /* CFE_TBL_VERIFY_H */

--- a/modules/tbl/fsw/src/cfe_tbl_verify.h
+++ b/modules/tbl/fsw/src/cfe_tbl_verify.h
@@ -21,8 +21,6 @@
 /**
  * @file
  *
- *
- *
  *  Purpose:
  *    This header file performs compile time checking for TBL configuration
  *    parameters.

--- a/modules/tbl/ut-coverage/tbl_UT.h
+++ b/modules/tbl/ut-coverage/tbl_UT.h
@@ -18,24 +18,25 @@
 **  limitations under the License.
 */
 
-/*
-** File:
-**    tbl_UT.h
-**
-** Purpose:
-**    TBL unit test header
-**
-** References:
-**    1. cFE Application Developers Guide
-**    2. unit test standard 092503
-**    3. C Coding Standard 102904
-**
-** Notes:
-**    1. This is unit test code only, not for use in flight
-**
-*/
-#ifndef _tbl_UT_h_
-#define _tbl_UT_h_
+/**
+ * @file
+ *
+ *
+ * Purpose:
+ *    TBL unit test header
+ *
+ * References:
+ *    1. cFE Application Developers Guide
+ *    2. unit test standard 092503
+ *    3. C Coding Standard 102904
+ *
+ * Notes:
+ *    1. This is unit test code only, not for use in flight
+ *
+ */
+
+#ifndef TBL_UT_H
+#define TBL_UT_H
 
 /*
 ** Includes
@@ -667,4 +668,4 @@ void Test_CFE_TBL_Internal(void);
 ******************************************************************************/
 int32 Test_CFE_TBL_ValidationFunc(void *TblPtr);
 
-#endif /* _tbl_ut_h_ */
+#endif /* TBL_UT_H */

--- a/modules/tbl/ut-coverage/tbl_UT.h
+++ b/modules/tbl/ut-coverage/tbl_UT.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:
  *    TBL unit test header
  *

--- a/modules/time/fsw/inc/cfe_time_events.h
+++ b/modules/time/fsw/inc/cfe_time_events.h
@@ -18,21 +18,22 @@
 **  limitations under the License.
 */
 
-/*
-**  Filename: cfe_time_events.h
-**
-**  Purpose:
-**	           cFE Time Services (Time) Event IDs
-**
-**  Design Notes:
-**
-**  References:
-**     Flight Software Branch C Coding Standard Version 1.0a
-**
-*/
+/**
+ * @file
+ *
+ *
+ *  Purpose:
+ *	           cFE Time Services (Time) Event IDs
+ *
+ *  Design Notes:
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *
+ */
 
-#ifndef _cfe_time_events_
-#define _cfe_time_events_
+#ifndef CFE_TIME_EVENTS_H
+#define CFE_TIME_EVENTS_H
 
 /* **************************
 ** ****** Maximum EID. ******
@@ -619,4 +620,4 @@
 **/
 #define CFE_TIME_LEN_ERR_EID 49
 
-#endif /* _cfe_time_events_ */
+#endif /* CFE_TIME_EVENTS_H */

--- a/modules/time/fsw/inc/cfe_time_events.h
+++ b/modules/time/fsw/inc/cfe_time_events.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  *  Purpose:
  *	           cFE Time Services (Time) Event IDs
  *

--- a/modules/time/fsw/inc/cfe_time_msg.h
+++ b/modules/time/fsw/inc/cfe_time_msg.h
@@ -18,22 +18,20 @@
 **  limitations under the License.
 */
 
-/*
-** File: cfe_time_msg.h
-**
-** Purpose:  cFE Time Services (TIME) SB message definitions header file
-**
-** Author:   S.Walling/Microtel
-**
-** Notes:
-**
-*/
+/**
+ * @file
+ *
+ *
+ * Purpose:  cFE Time Services (TIME) SB message definitions header file
+ *
+ * Author:   S.Walling/Microtel
+ *
+ * Notes:
+ *
+ */
 
-/*
-** Ensure that header is included only once...
-*/
-#ifndef _cfe_time_msg_
-#define _cfe_time_msg_
+#ifndef CFE_TIME_MSG_H
+#define CFE_TIME_MSG_H
 
 /*
 ** Required header files...
@@ -1126,8 +1124,4 @@ typedef struct CFE_TIME_DiagnosticTlm
     CFE_TIME_DiagnosticTlm_Payload_t Payload;   /**< \brief Telemetry payload */
 } CFE_TIME_DiagnosticTlm_t;
 
-#endif /* _cfe_time_msg_ */
-
-/************************/
-/*  End of File Comment */
-/************************/
+#endif /* CFE_TIME_MSG_H */

--- a/modules/time/fsw/inc/cfe_time_msg.h
+++ b/modules/time/fsw/inc/cfe_time_msg.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:  cFE Time Services (TIME) SB message definitions header file
  *
  * Author:   S.Walling/Microtel

--- a/modules/time/fsw/src/cfe_time_module_all.h
+++ b/modules/time/fsw/src/cfe_time_module_all.h
@@ -19,7 +19,7 @@
 */
 
 /**
- * @file cfe_time_module_all.h
+ * @file
  *
  * Encapsulates all TIME module internal header files, as well
  * as the public API from all other CFE core modules, OSAL, and PSP.

--- a/modules/time/fsw/src/cfe_time_utils.h
+++ b/modules/time/fsw/src/cfe_time_utils.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:  cFE Time Services (TIME) library utilities header file
  *
  * Author:   S.Walling/Microtel

--- a/modules/time/fsw/src/cfe_time_utils.h
+++ b/modules/time/fsw/src/cfe_time_utils.h
@@ -18,22 +18,20 @@
 **  limitations under the License.
 */
 
-/*
-** File: cfe_time_utils.h
-**
-** Purpose:  cFE Time Services (TIME) library utilities header file
-**
-** Author:   S.Walling/Microtel
-**
-** Notes:
-**
-*/
+/**
+ * @file
+ *
+ *
+ * Purpose:  cFE Time Services (TIME) library utilities header file
+ *
+ * Author:   S.Walling/Microtel
+ *
+ * Notes:
+ *
+ */
 
-/*
-** Ensure that header is included only once...
-*/
-#ifndef _cfe_time_utils_
-#define _cfe_time_utils_
+#ifndef CFE_TIME_UTILS_H
+#define CFE_TIME_UTILS_H
 
 /*
 ** Required header files...
@@ -451,8 +449,4 @@ void CFE_TIME_Local1HzTask(void);
 void CFE_TIME_Local1HzStateMachine(void);
 void CFE_TIME_Local1HzTimerCallback(osal_id_t TimerId, void *Arg);
 
-#endif /* _cfe_time_utils_ */
-
-/************************/
-/*  End of File Comment */
-/************************/
+#endif /* CFE_TIME_UTILS_H */

--- a/modules/time/fsw/src/cfe_time_verify.h
+++ b/modules/time/fsw/src/cfe_time_verify.h
@@ -18,23 +18,21 @@
 **  limitations under the License.
 */
 
-/*
-** File: cfe_time_verify.h
-**
-** Purpose:  cFE Time Services (TIME) configuration verification
-**
-** Author:   S.Walling/Microtel
-**
-** Notes:
-**
-**
-*/
+/**
+ * @file
+ *
+ *
+ * Purpose:  cFE Time Services (TIME) configuration verification
+ *
+ * Author:   S.Walling/Microtel
+ *
+ * Notes:
+ *
+ *
+ */
 
-/*
-** Ensure that header is included only once...
-*/
-#ifndef _cfe_time_verify_
-#define _cfe_time_verify_
+#ifndef CFE_TIME_VERIFY_H
+#define CFE_TIME_VERIFY_H
 
 #include "cfe_mission_cfg.h"
 #include "cfe_platform_cfg.h"
@@ -188,8 +186,4 @@
 
 /*************************************************************************/
 
-#endif /* _cfe_time_verify_ */
-
-/************************/
-/*  End of File Comment */
-/************************/
+#endif /* CFE_TIME_VERIFY_H */

--- a/modules/time/fsw/src/cfe_time_verify.h
+++ b/modules/time/fsw/src/cfe_time_verify.h
@@ -21,13 +21,11 @@
 /**
  * @file
  *
- *
  * Purpose:  cFE Time Services (TIME) configuration verification
  *
  * Author:   S.Walling/Microtel
  *
  * Notes:
- *
  *
  */
 

--- a/modules/time/ut-coverage/time_UT.h
+++ b/modules/time/ut-coverage/time_UT.h
@@ -21,7 +21,6 @@
 /**
  * @file
  *
- *
  * Purpose:
  *    TIME unit test header
  *

--- a/modules/time/ut-coverage/time_UT.h
+++ b/modules/time/ut-coverage/time_UT.h
@@ -18,24 +18,25 @@
 **  limitations under the License.
 */
 
-/*
-** File:
-**    time_UT.h
-**
-** Purpose:
-**    TIME unit test header
-**
-** References:
-**    1. cFE Application Developers Guide
-**    2. unit test standard 092503
-**    3. C Coding Standard 102904
-**
-** Notes:
-**    1. This is unit test code only, not for use in flight
-**
-*/
-#ifndef _time_UT_h_
-#define _time_UT_h_
+/**
+ * @file
+ *
+ *
+ * Purpose:
+ *    TIME unit test header
+ *
+ * References:
+ *    1. cFE Application Developers Guide
+ *    2. unit test standard 092503
+ *    3. C Coding Standard 102904
+ *
+ * Notes:
+ *    1. This is unit test code only, not for use in flight
+ *
+ */
+
+#ifndef TIME_UT_H
+#define TIME_UT_H
 
 /*
 ** Includes
@@ -351,4 +352,4 @@ void Test_UnregisterSynchCallback(void);
 ******************************************************************************/
 void Test_CleanUpApp(void);
 
-#endif /* _time_ut_h_ */
+#endif /* TIME_UT_H */


### PR DESCRIPTION
**Describe the contribution**
All C header files should have a header guard matching the file name of the header, in ALL_CAPS, with no extra leading/trailing
underscores.

This also takes a first pass at converting the file-scope block comments to a doxygen format to include a summary of the file.

Fixes #1239

**Testing performed**
Build and sanity check CFE, build and run all unit tests
Build documentation and confirm the content of "Detailed Description" on the files contains the info from `@file` doxygen blocks.

**Expected behavior changes**
No impact to behavior.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.