### PR TITLE
Fix #1261, Remove redundant checks in CFE_EVS_EarlyInit

### DIFF
--- a/modules/evs/fsw/src/cfe_evs_task.c
+++ b/modules/evs/fsw/src/cfe_evs_task.c
@@ -111,11 +111,6 @@ int32 CFE_EVS_EarlyInit(void)
     }
     else
     {
-        Status = CFE_SUCCESS;
-    }
-
-    if (Status == CFE_SUCCESS)
-    {
         CFE_EVS_ResetDataPtr = (CFE_ES_ResetData_t *)resetAreaAddr;
         /* Save pointer to the EVS portion of the CFE reset area */
         CFE_EVS_Global.EVS_LogPtr = &CFE_EVS_ResetDataPtr->EVS_Log;
@@ -134,12 +129,9 @@ int32 CFE_EVS_EarlyInit(void)
         }
         else
         {
+            /* Convert to CFE success type */
             Status = CFE_SUCCESS;
         }
-    }
-
-    if (Status == CFE_SUCCESS)
-    {
 
         /* Report log as enabled */
         CFE_EVS_Global.EVS_TlmPkt.Payload.LogEnabled = true;


### PR DESCRIPTION
**Describe the contribution**
Fix #1261 - removed redundant checks for CFE_SUCCESS

**Testing performed**
Build/run unit tests, passed

**Expected behavior changes**
None, squashes static analysis warning

**System(s) tested on**
 - Hardware: cFS Dev Server
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC