### PR TITLE
Fix #1270, limit check in pool validation

### DIFF
--- a/modules/es/fsw/src/cfe_es_generic_pool.c
+++ b/modules/es/fsw/src/cfe_es_generic_pool.c
@@ -601,7 +601,7 @@ int32 CFE_ES_GenPoolRebuild(CFE_ES_GenPoolRecord_t *PoolRecPtr)
 bool CFE_ES_GenPoolValidateState(const CFE_ES_GenPoolRecord_t *PoolRecPtr)
 {
     return (PoolRecPtr->PoolTotalSize > 0 && PoolRecPtr->TailPosition <= PoolRecPtr->PoolMaxOffset &&
-            PoolRecPtr->NumBuckets > 0 && PoolRecPtr->NumBuckets < CFE_PLATFORM_ES_POOL_MAX_BUCKETS);
+            PoolRecPtr->NumBuckets > 0 && PoolRecPtr->NumBuckets <= CFE_PLATFORM_ES_POOL_MAX_BUCKETS);
 }
 
 /*


### PR DESCRIPTION
**Describe the contribution**
It is OK/valid if NumBuckets is the maximum value.

Fixes #1270

**Testing performed**
Build and run all unit tests

**Expected behavior changes**
Pool structure using max value will correctly validate

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
