### PR TITLE
Fix #1273, remove PspConfig global object

### DIFF
--- a/cmake/target/inc/target_config.h
+++ b/cmake/target/inc/target_config.h
@@ -32,7 +32,6 @@
 #define TARGET_CONFIG_H
 
 #include "common_types.h"
-#include "cfe_psp_configdata.h"
 
 /**
  * Prototype for the main system entry function implemented in CFE ES
@@ -191,7 +190,6 @@ typedef const struct
     const char *Default_CoreFilename;    /**< Default file name for CFE core executable/library */
 
     Target_CfeConfigData *CfeConfig; /**< CFE configuration sub-structure */
-    Target_PspConfigData *PspConfig; /**< PSP configuration sub-structure */
     CFE_StaticModuleLoadEntry_t
         *PspModuleList; /**< List of PSP modules (API structures) statically linked into the core EXE */
 

--- a/cmake/target/src/target_config.c
+++ b/cmake/target/src/target_config.c
@@ -174,7 +174,6 @@ Target_ConfigData GLOBAL_CONFIGDATA = {
     .Default_ModuleExtension = CFE_DEFAULT_MODULE_EXTENSION,
     .Default_CoreFilename    = CFE_DEFAULT_CORE_FILENAME,
     .CfeConfig               = &GLOBAL_CFE_CONFIGDATA,
-    .PspConfig               = &GLOBAL_PSP_CONFIGDATA,
     .PspModuleList           = CFE_PSP_MODULE_LIST,
     .BuildEnvironment        = CFE_BUILD_ENV_TABLE,
     .ModuleVersionList       = CFE_MODULE_VERSION_TABLE,

--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -465,10 +465,10 @@ int32 CFE_ES_TaskInit(void)
         return (Status);
     }
 
-    Status = CFE_EVS_SendEvent(CFE_ES_INITSTATS_INF_EID, CFE_EVS_EventType_INFORMATION,
-                               "cFS Versions: cfe %s, osal %s, psp %s. cFE chksm %d", GLOBAL_CONFIGDATA.CfeVersion,
-                               GLOBAL_CONFIGDATA.OsalVersion, CFE_PSP_VERSION,
-                               (int)CFE_ES_Global.TaskData.HkPacket.Payload.CFECoreChecksum);
+    Status =
+        CFE_EVS_SendEvent(CFE_ES_INITSTATS_INF_EID, CFE_EVS_EventType_INFORMATION,
+                          "cFS Versions: cfe %s, osal %s, psp %s. cFE chksm %d", CFE_SRC_VERSION, OS_GetVersionString(),
+                          CFE_PSP_GetVersionString(), (int)CFE_ES_Global.TaskData.HkPacket.Payload.CFECoreChecksum);
 
     if (Status != CFE_SUCCESS)
     {
@@ -847,8 +847,8 @@ int32 CFE_ES_NoopCmd(const CFE_ES_NoopCmd_t *Cmd)
     CFE_ES_Global.TaskData.CommandCounter++;
 
     CFE_EVS_SendEvent(CFE_ES_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION,
-                      "No-op command:\n cFS Versions: cfe %s, osal %s, psp %s", GLOBAL_CONFIGDATA.CfeVersion,
-                      GLOBAL_CONFIGDATA.OsalVersion, CFE_PSP_VERSION);
+                      "No-op command:\n cFS Versions: cfe %s, osal %s, psp %s", CFE_SRC_VERSION, OS_GetVersionString(),
+                      CFE_PSP_GetVersionString());
 
     return CFE_SUCCESS;
 } /* End of CFE_ES_NoopCmd() */


### PR DESCRIPTION
**Describe the contribution**
The `PspConfig` member is removed from the `GLOBAL_CONFIGDATA` object.

Updates the only remaining ref to this object inside the CFE_PSP_VERSION macro to use the API function instead.

This also updates the OSAL and CFE version print to _not_ depend on the global object too - OSAL becomes an API call and CFE can just use the macro directly because its the same library (itself) so no linking concern/issue.

Fixes #1273

**Testing performed**
Build and sanity check CFE, run all unit tests

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Co-Dependent with nasa/psp#280

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.