### PR TITLE
Fix #1157, increment sequence if indicated

### DIFF
--- a/modules/core_api/fsw/inc/cfe_sb.h
+++ b/modules/core_api/fsw/inc/cfe_sb.h
@@ -412,8 +412,7 @@ CFE_Status_t CFE_SB_UnsubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeI
 ** \param[in]  MsgPtr       A pointer to the message to be sent.  This must point
 **                          to the first byte of the message header.
 ** \param[in] IncrementSequenceCount Boolean to increment the internally tracked
-**                                   sequence count and update the message if the
-**                                   buffer contains a telemetry message
+**                                   sequence count and update the message
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS         \copybrief CFE_SUCCESS
@@ -554,8 +553,7 @@ CFE_Status_t CFE_SB_ReleaseMessageBuffer(CFE_SB_Buffer_t *BufPtr);
 **
 ** \param[in] BufPtr                 A pointer to the buffer to be sent.
 ** \param[in] IncrementSequenceCount Boolean to increment the internally tracked
-**                                   sequence count and update the message if the
-**                                   buffer contains a telemetry message
+**                                   sequence count and update the message
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS         \copybrief CFE_SUCCESS

--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -1583,8 +1583,7 @@ void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_
     if (CFE_SBR_IsValidRouteId(RouteId))
     {
         /* Set the seq count if requested (while locked) before actually sending */
-        /* For some reason this is only done for TLM types (historical, TBD) */
-        if (BufDscPtr->AutoSequence && BufDscPtr->ContentType == CFE_MSG_Type_Tlm)
+        if (BufDscPtr->AutoSequence)
         {
             CFE_SBR_IncrementSequenceCounter(RouteId);
 


### PR DESCRIPTION
**Describe the contribution**
Do not restrict sequence increment to TLM only, since CMD packets can be locally generated too (e.g. SCH, TIME).

Fixes #1157

**Testing performed**
Build and sanity check CFE, run all unit tests.

**Expected behavior changes**
All transmitted messages will get their sequence count incremented if transmitted with parameter `IncrementSequenceCount` set to true.  Previously, for some reason, this flag was only honored on TLM packets.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Thus far I've not found a real reason/explanation as to why this flag would be ignored for CMD packets.  If there is a good reason, it should be documented.  Otherwise for the sake of consistency it should be done for all messages.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.