### PR TITLE
Fix #1287, split interface and implementation modules

### DIFF
--- a/cmake/arch_build.cmake
+++ b/cmake/arch_build.cmake
@@ -258,7 +258,7 @@ endfunction(add_cfe_coverage_dependency)
 # FUNCTION: add_cfe_coverage_test
 #
 # Add executable target for coverage testing.  This builds the target
-# units with extra compiler flags for coverage instrumentation, along with 
+# units with extra compiler flags for coverage instrumentation, along with
 # a "testrunner" executable to run the tests.  It also registers
 # that testrunner with ctest via the add_test() function.
 #
@@ -620,6 +620,7 @@ function(process_arch SYSVAR)
   # this may result in "add_subdirectory" of itself which causes a loop.  This can happen
   # if the variables/lists were modified unexpectedly.
   foreach(DEP
+        ${MISSION_CORE_INTERFACES}
         ${MISSION_CORE_MODULES}
         ${TGTSYS_${SYSVAR}_PSPMODULES}
         ${TGTSYS_${SYSVAR}_STATICAPPS}
@@ -632,7 +633,7 @@ function(process_arch SYSVAR)
 
   # Add all core modules
   # The osal is handled explicitly (above) since this has special extra config
-  foreach(DEP ${MISSION_CORE_MODULES})
+  foreach(DEP ${MISSION_CORE_INTERFACES} ${MISSION_CORE_MODULES})
     if(NOT DEP STREQUAL "osal")
       message(STATUS "Building Core Module: ${DEP}")
       add_subdirectory("${${DEP}_MISSION_DIR}" ${DEP})

--- a/cmake/mission_build.cmake
+++ b/cmake/mission_build.cmake
@@ -194,7 +194,7 @@ function(prepare)
   # This reflects all modules for all CPUs.  It is set as a usage convenience
   # for iterating through the full set of dependencies regardless of which level
   # or context each dependency relates to (CFE, PSP, apps, etc).
-  set(MISSION_DEPS ${MISSION_APPS} ${MISSION_CORE_MODULES} ${MISSION_PSPMODULES})
+  set(MISSION_DEPS ${MISSION_CORE_INTERFACES} ${MISSION_APPS} ${MISSION_CORE_MODULES} ${MISSION_PSPMODULES})
   set(APP_MISSING_COUNT 0)
 
   message(STATUS "Search path for modules: ${MISSION_MODULE_SEARCH_PATH}")
@@ -288,7 +288,7 @@ function(prepare)
     "${osal_MISSION_DIR}/src/os/inc/*.h"
     "${psp_MISSION_DIR}/psp/fsw/inc/*.h"
   )
-  foreach(MODULE core_api es evs fs msg sb tbl time)
+  foreach(MODULE core_api ${MISSION_CORE_MODULES})
     list(APPEND SUBMODULE_HEADER_PATHS "${${MODULE}_MISSION_DIR}/fsw/inc/*.h")
   endforeach()
   file(GLOB MISSION_USERGUIDE_HEADERFILES
@@ -371,12 +371,6 @@ function(prepare)
   # Add all public include dirs for core components to include path for tools
   include_directories(
     ${core_api_MISSION_DIR}/fsw/inc
-    #${es_MISSION_DIR}/fsw/inc
-    #${evs_MISSION_DIR}/fsw/inc
-    #${fs_MISSION_DIR}/fsw/inc
-    #${sb_MISSION_DIR}/fsw/inc
-    #${tbl_MISSION_DIR}/fsw/inc
-    #${time_MISSION_DIR}/fsw/inc
     ${osal_MISSION_DIR}/src/os/inc
     ${psp_MISSION_DIR}/psp/fsw/inc
   )

--- a/cmake/mission_defaults.cmake
+++ b/cmake/mission_defaults.cmake
@@ -7,13 +7,23 @@
 #
 ##################################################################
 
+# The "MISSION_CORE_INTERFACES" defines the set of interface libraries
+# that comprise CFE core.  These are CMake interface libraries that define
+# a set of include directories and compile options for all modules,
+# including the ubiquitous "cfe.h" header file and all it depends on).
+# NOTE: these interfaces are really what defines "CFE core" - changing
+# this list is not recommend, as these interface names are important.
+set(MISSION_CORE_INTERFACES
+    core_api        # this is the "public" core API that apps use, includes cfe.h and all core headers
+    core_private    # this is the "private" interface that core apps use, but not used by apps
+)
+
 # The "MISSION_CORE_MODULES" will be built and statically linked as part
 # of the CFE core executable on every target.  These can be used to amend
 # or override parts of the CFE core on a mission-specific basis.
-# The "intf" modules are headers only, and define the interface(s) between components
+# NOTE: Everthing in this list becomes part of the "core_api" interface above.
+# Missions may add/remove/replace components in this list as needed.
 set(MISSION_CORE_MODULES
-    "core_api"
-    "core_private"
     "es"
     "evs"
     "fs"

--- a/cmake/target/CMakeLists.txt
+++ b/cmake/target/CMakeLists.txt
@@ -50,7 +50,7 @@ configure_file(${CFE_SOURCE_DIR}/cmake/cfe_generated_file.h.in ${CMAKE_CURRENT_B
 
 # Generate lists of modules that will be statically linked into this CFE core target
 set(GENERATED_ENTRIES_CORE_MODULES)
-foreach(DEP ${MISSION_CORE_MODULES})
+foreach(DEP core_api ${MISSION_CORE_MODULES})
     list(APPEND GENERATED_ENTRIES_CORE_MODULES "{ \"${DEP}\" },\n")
 endforeach()
 
@@ -257,6 +257,8 @@ if (DEFINED ${TGTNAME}_EMBED_FILELIST)
 endif (DEFINED ${TGTNAME}_EMBED_FILELIST)
 
 target_link_libraries(core-${TGTNAME}
+    ${MISSION_CORE_INTERFACES}
+
     # The following libs should be included whole, even if they
     # do not necessarily resolve any symbols, because they may be needed by apps
     ${START_WHOLE_ARCHIVE}

--- a/modules/core_api/CMakeLists.txt
+++ b/modules/core_api/CMakeLists.txt
@@ -12,21 +12,16 @@ add_library(core_api INTERFACE)
 # The fsw/inc here defines global/shared structures and interfaces
 target_include_directories(core_api INTERFACE fsw/inc)
 
-# The list of modules that comprise the "CFE app interface"
-# This is the set of APIs that applications and libraries may call directly
-# The include path to all of them is
-set(core_api_MODULES es evs fs msg resourceid sb tbl time osal psp)
-
 # Propagate any INTERFACE-level include dirs and compile defintions from
 # the modules into this abstract interface target
-foreach(MOD ${core_api_MODULES})
+foreach(MOD ${MISSION_CORE_MODULES})
     target_include_directories(core_api INTERFACE
         $<TARGET_PROPERTY:${MOD},INTERFACE_INCLUDE_DIRECTORIES>
     )
     target_compile_definitions(core_api INTERFACE
         $<TARGET_PROPERTY:${MOD},INTERFACE_COMPILE_DEFINITIONS>
     )
-endforeach(MOD ${core_api_MODULES})
+endforeach(MOD ${MISSION_CORE_MODULES})
 
 # Add unit test coverage subdirectory
 # This provides stubs for functions declared in fsw/inc
@@ -34,7 +29,7 @@ if (ENABLE_UNIT_TESTS)
   add_subdirectory(ut-stubs)
 endif (ENABLE_UNIT_TESTS)
 
-cfs_app_check_intf(${DEP}
+cfs_app_check_intf(core_api
     cfe_resourceid.h
     cfe_endian.h
     cfe_msg.h

--- a/modules/core_api/ut-stubs/CMakeLists.txt
+++ b/modules/core_api/ut-stubs/CMakeLists.txt
@@ -15,7 +15,7 @@ include_directories(${osal_MISSION_DIR}/ut_assert/inc)
 #
 # Create the generic stubs library
 #
-add_library(ut_${DEP}_stubs STATIC
+add_library(ut_core_api_stubs STATIC
     src/ut_es_stubs.c
     src/ut_evs_stubs.c
     src/ut_msg_stubs.c
@@ -27,13 +27,13 @@ add_library(ut_${DEP}_stubs STATIC
 )
 
 # Define _CFE_CORE_ within stubs to also reveal internal APIs in header
-target_compile_definitions(ut_${DEP}_stubs PRIVATE _CFE_CORE_)
+target_compile_definitions(ut_core_api_stubs PRIVATE _CFE_CORE_)
 
 # linking with the CFE stubs implies also linking
 # with the OSAL and PSP stubs.  This is in line with
 # how the real application is linked, in that cfe-core
 # executable also provides OSAL and PSP functions.
-target_link_libraries(ut_${DEP}_stubs
+target_link_libraries(ut_core_api_stubs
     core_api
     ut_psp-${CFE_SYSTEM_PSPNAME}_stubs
     ut_osapi_stubs

--- a/modules/core_private/CMakeLists.txt
+++ b/modules/core_private/CMakeLists.txt
@@ -23,7 +23,7 @@ if (ENABLE_UNIT_TESTS)
     add_subdirectory(ut-stubs)
 endif (ENABLE_UNIT_TESTS)
 
-cfs_app_check_intf(${DEP}
+cfs_app_check_intf(core_private
     cfe_es_erlog_typedef.h
     cfe_evs_log_typedef.h
     cfe_es_resetdata_typedef.h

--- a/modules/core_private/ut-stubs/CMakeLists.txt
+++ b/modules/core_private/ut-stubs/CMakeLists.txt
@@ -12,19 +12,19 @@
 #
 # Create the generic stubs library
 #
-add_library(ut_${DEP}_stubs STATIC
+add_library(ut_core_private_stubs STATIC
     src/ut_osprintf_stubs.c
     src/ut_support.c
 )
 
-target_include_directories(ut_${DEP}_stubs PUBLIC inc)
+target_include_directories(ut_core_private_stubs PUBLIC inc)
 
 
 # linking with the CFE stubs implies also linking
 # with the OSAL and PSP stubs.  This is in line with
 # how the real application is linked, in that cfe-core
 # executable also provides OSAL and PSP functions.
-target_link_libraries(ut_${DEP}_stubs
+target_link_libraries(ut_core_private_stubs
     core_private
     ut_core_api_stubs
     ut_psp-${CFE_SYSTEM_PSPNAME}_stubs


### PR DESCRIPTION
**Describe the contribution**
Separate the list of CFE core interface modules (e.g. core_api) from the list of CFE core implementation modules (e.g. msg).  This allows the content of core_api to be expanded to include any additional modules the user has added to cFE core locally.

Fixes #1287 

**Testing performed**
Build and sanity check CFE
Run all unit tests

**Expected behavior changes**
No FSW change, only build system.
The "core_api" interface module will now be expanded to include anything that is in the `MISSION_CORE_MODULES` list, so if the mission has locally expanded this list, the additional/expanded content will become part of `core_api` automatically.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
