### PR TITLE
cFE Integration Candidate: 2021-04-13

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ The detailed cFE user's guide can be viewed at <https://github.com/nasa/cFS/blob
 
 ## Version History
 
+### Development Build: v6.8.0-rc1+dev498
+
+- Reports test failures as CFE events. Test status messages are now sent as Events rather than Syslog. This allows for more processing capability, and allows failures to be received externally (e.g. ground system).
+- See <https://github.com/nasa/cFE/pull/1295> and <https://github.com/nasa/cFS/pull/242>
+
 ### Development Build: v6.8.0-rc1+dev494
 
 - Adds new tests for the ES Info APIs

--- a/modules/cfe_assert/CMakeLists.txt
+++ b/modules/cfe_assert/CMakeLists.txt
@@ -1,8 +1,5 @@
 project(CFE_ASSERT C)
 
-include_directories("${CFE_ASSERT_SOURCE_DIR}/inc")
-include_directories("${UT_ASSERT_SOURCE_DIR}/inc")
-
 # Create the app module
 add_cfe_app(cfe_assert
     src/cfe_assert_io.c
@@ -10,3 +7,8 @@ add_cfe_app(cfe_assert
     $<TARGET_OBJECTS:ut_assert_pic>
 )
 
+# publicize the interface to cfe_assert (and ut_assert)
+target_include_directories(cfe_assert PUBLIC
+    ${CFE_ASSERT_SOURCE_DIR}/inc
+    $<TARGET_PROPERTY:ut_assert,INTERFACE_INCLUDE_DIRECTORIES>
+)

--- a/modules/cfe_assert/inc/cfe_assert.h
+++ b/modules/cfe_assert/inc/cfe_assert.h
@@ -43,6 +43,8 @@
 ** Type Definitions
 *************************************************************************/
 
+typedef void (*CFE_Assert_StatusCallback_t)(uint8 MessageType, const char *Prefix, const char *OutputMessage);
+
 /*************************************************************************
 ** Exported Functions
 *************************************************************************/
@@ -57,9 +59,27 @@
 **  \par Assumptions, External Events, and Notes:
 **        None
 **
-**  \return Execution status, see \ref CFEReturnCodes
+**  \return None
 **
 *************************************************************************/
 void CFE_Assert_AppMain(void);
+
+/************************************************************************/
+/** \brief Register a test status callback
+ *
+ *  \par Description
+ *        This user-supplied function will be invoked with the status
+ *        of each test and the associated message.  It may be used to
+ *        write the test messages to a location other than CFE ES Syslog.
+ *
+ *  \par Assumptions, External Events, and Notes:
+ *        None
+ *
+ * \param[in] Callback  Callback function to invoke after every test
+ *
+ * \return None
+ *
+ */
+void CFE_Assert_RegisterCallback(CFE_Assert_StatusCallback_t Callback);
 
 #endif /* CFE_ASSERT_H */

--- a/modules/cfe_assert/src/cfe_assert_priv.h
+++ b/modules/cfe_assert/src/cfe_assert_priv.h
@@ -18,47 +18,42 @@
 **      See the License for the specific language governing permissions and
 **      limitations under the License.
 **
-** File: cfe_assert_main.c
+** File: cfe_assert.h
 **
 ** Purpose:
-**   Implementation of the CFE assert (UT assert wrapper) functions.
+**   Specification for the CFE assert (UT assert wrapper) functions.
 **
 *************************************************************************/
 
-/*
- * Includes
+/**
+ * @file
+ *
+ * Internal Declarations and prototypes for cfe_assert module
  */
 
-#include "cfe.h"
+#ifndef CFE_ASSERT_PRIV_H
+#define CFE_ASSERT_PRIV_H
 
-#include "cfe_assert_priv.h"
+/************************************************************************
+** Includes
+*************************************************************************/
+#include "common_types.h"
+#include "cfe_assert.h"
 
-#include "uttest.h"
-#include "utbsp.h"
+/************************************************************************
+** Type Definitions
+*************************************************************************/
 
-/*
- * Allows the test reports to be redirected to another destination
- */
-void CFE_Assert_RegisterCallback(CFE_Assert_StatusCallback_t Callback)
+typedef struct
 {
-    CFE_Assert_Global.StatusCallback = Callback;
-}
+    uint32 CurrVerbosity;
 
-/*
- * Initialization Function for this library
- */
-int32 CFE_Assert_LibInit(uint32 LibId)
-{
-    UtTest_EarlyInit();
-    UT_BSP_Setup();
-
-    /*
-     * Start a test case for all startup logic.
-     *
-     * Test libs may use assert statements within their init function and these
-     * will be reported as a "startup" test case.
+    /**
+     * Function to invoke to report test status
      */
-    UtAssert_BeginTest("CFE-STARTUP");
+    CFE_Assert_StatusCallback_t StatusCallback;
+} CFE_Assert_Global_t;
 
-    return CFE_SUCCESS;
-}
+extern CFE_Assert_Global_t CFE_Assert_Global;
+
+#endif /* CFE_ASSERT_PRIV_H */

--- a/modules/cfe_testrunner/CMakeLists.txt
+++ b/modules/cfe_testrunner/CMakeLists.txt
@@ -1,10 +1,13 @@
 project(CFE_TESTRUNNER C)
 
-include_directories("inc")
-include_directories("${UT_ASSERT_SOURCE_DIR}/inc")
-
 # Create the app module
 add_cfe_app(cfe_testrunner
     src/cfe_testrunner_main.c
 )
 
+target_include_directories(cfe_testrunner PUBLIC
+    ${CFE_TESTRUNNER_SOURCE_DIR}/inc
+)
+
+# register the dependency on cfe_assert
+add_cfe_app_dependency(cfe_testrunner cfe_assert)

--- a/modules/core_api/fsw/inc/cfe_version.h
+++ b/modules/core_api/fsw/inc/cfe_version.h
@@ -28,7 +28,7 @@
 #define CFE_VERSION_H
 
 /* Development Build Macro Definitions */
-#define CFE_BUILD_NUMBER 494 /*!< Development Build: Number of commits since baseline */
+#define CFE_BUILD_NUMBER 498 /*!< Development Build: Number of commits since baseline */
 #define CFE_BUILD_BASELINE                                                                    \
     "v6.8.0-rc1" /*!< Development Build: git tag that is the base for the current development \
                   */


### PR DESCRIPTION
## Description


### PR #1276 

Fix #1266, use events for CFE test asserts 

Reports test failures as CFE events. Test status messages are now sent as Events rather than Syslog. This allows for more processing capability, and allows failures to be received externally (e.g. ground system). 

## Context

Part of <https://github.com/nasa/cFS/pull/242>

## Tests

cFE checks <https://github.com/nasa/cFE/pull/1295/checks>
cFS bundle checks <https://github.com/nasa/cFS/pull/242/checks>

## Author

@jphickey 