### PR TITLE
Fix #1349, remove unneeded CFE_ES_SYSLOG_APPEND macro

### DIFF
--- a/modules/es/fsw/src/cfe_es_cds.c
+++ b/modules/es/fsw/src/cfe_es_cds.c
@@ -885,10 +885,9 @@ int32 CFE_ES_DeleteCDS(const char *CDSName, bool CalledByTblServices)
                 /* Report any errors incurred while freeing the CDS Memory Block */
                 if (Status != CFE_SUCCESS)
                 {
-                    CFE_ES_SysLog_snprintf(
-                        LogMessage, sizeof(LogMessage),
-                        "CFE_ES:DeleteCDS-Failed to free CDS Mem Block (Handle=0x%08lX)(Stat=0x%08X)\n",
-                        (unsigned long)RegRecPtr->BlockOffset, (unsigned int)Status);
+                    snprintf(LogMessage, sizeof(LogMessage),
+                             "Failed to free CDS Mem Block (Handle=0x%08lX)(Stat=0x%08X)\n",
+                             (unsigned long)RegRecPtr->BlockOffset, (unsigned int)Status);
                 }
                 else
                 {
@@ -899,9 +898,8 @@ int32 CFE_ES_DeleteCDS(const char *CDSName, bool CalledByTblServices)
 
                     if (Status != CFE_SUCCESS)
                     {
-                        CFE_ES_SysLog_snprintf(LogMessage, sizeof(LogMessage),
-                                               "CFE_ES:DeleteCDS-Failed to update CDS Registry (Stat=0x%08X)\n",
-                                               (unsigned int)Status);
+                        snprintf(LogMessage, sizeof(LogMessage), "Failed to update CDS Registry (Stat=0x%08X)\n",
+                                 (unsigned int)Status);
                     }
                 }
             }
@@ -922,7 +920,7 @@ int32 CFE_ES_DeleteCDS(const char *CDSName, bool CalledByTblServices)
     /* Output the message to syslog once the CDS registry resource is unlocked */
     if (LogMessage[0] != 0)
     {
-        CFE_ES_SYSLOG_APPEND(LogMessage);
+        CFE_ES_WriteToSysLog("%s(): %s", __func__, LogMessage);
     }
 
     return Status;

--- a/modules/es/fsw/src/cfe_es_cds_mempool.c
+++ b/modules/es/fsw/src/cfe_es_cds_mempool.c
@@ -201,14 +201,12 @@ int32 CFE_ES_CDSBlockWrite(CFE_ES_CDSHandle_t Handle, const void *DataToWrite)
         Status = CFE_ES_GenPoolGetBlockSize(&CDS->Pool, &BlockSize, CDSRegRecPtr->BlockOffset);
         if (Status != CFE_SUCCESS)
         {
-            CFE_ES_SysLog_snprintf(LogMessage, sizeof(LogMessage),
-                                   "CFE_ES:CDSBlkWrite-Invalid Handle or Block Descriptor.\n");
+            snprintf(LogMessage, sizeof(LogMessage), "Invalid Handle or Block Descriptor.\n");
         }
         else if (BlockSize <= sizeof(CFE_ES_CDS_BlockHeader_t) || BlockSize != CDSRegRecPtr->BlockSize)
         {
-            CFE_ES_SysLog_snprintf(LogMessage, sizeof(LogMessage),
-                                   "CFE_ES:CDSBlkWrite-Block size %lu invalid, expected %lu\n",
-                                   (unsigned long)BlockSize, (unsigned long)CDSRegRecPtr->BlockSize);
+            snprintf(LogMessage, sizeof(LogMessage), "Block size %lu invalid, expected %lu\n", (unsigned long)BlockSize,
+                     (unsigned long)CDSRegRecPtr->BlockSize);
             Status = CFE_ES_CDS_INVALID_SIZE;
         }
         else
@@ -227,20 +225,18 @@ int32 CFE_ES_CDSBlockWrite(CFE_ES_CDSHandle_t Handle, const void *DataToWrite)
             Status = CFE_ES_CDS_CacheFlush(&CDS->Cache);
             if (Status != CFE_SUCCESS)
             {
-                CFE_ES_SysLog_snprintf(
-                    LogMessage, sizeof(LogMessage),
-                    "CFE_ES:CDSBlkWrite-Err writing header data to CDS (Stat=0x%08x) @Offset=0x%08lx\n",
-                    (unsigned int)CDS->Cache.AccessStatus, (unsigned long)CDSRegRecPtr->BlockOffset);
+                snprintf(LogMessage, sizeof(LogMessage),
+                         "Err writing header data to CDS (Stat=0x%08x) @Offset=0x%08lx\n",
+                         (unsigned int)CDS->Cache.AccessStatus, (unsigned long)CDSRegRecPtr->BlockOffset);
             }
             else
             {
                 Status = CFE_PSP_WriteToCDS(DataToWrite, UserDataOffset, UserDataSize);
                 if (Status != CFE_PSP_SUCCESS)
                 {
-                    CFE_ES_SysLog_snprintf(
-                        LogMessage, sizeof(LogMessage),
-                        "CFE_ES:CDSBlkWrite-Err writing user data to CDS (Stat=0x%08x) @Offset=0x%08lx\n",
-                        (unsigned int)Status, (unsigned long)UserDataOffset);
+                    snprintf(LogMessage, sizeof(LogMessage),
+                             "Err writing user data to CDS (Stat=0x%08x) @Offset=0x%08lx\n", (unsigned int)Status,
+                             (unsigned long)UserDataOffset);
                 }
             }
         }
@@ -255,7 +251,7 @@ int32 CFE_ES_CDSBlockWrite(CFE_ES_CDSHandle_t Handle, const void *DataToWrite)
     /* Do the actual syslog if something went wrong */
     if (LogMessage[0] != 0)
     {
-        CFE_ES_SYSLOG_APPEND(LogMessage);
+        CFE_ES_WriteToSysLog("%s(): %s", __func__, LogMessage);
     }
 
     return Status;
@@ -271,16 +267,12 @@ int32 CFE_ES_CDSBlockWrite(CFE_ES_CDSHandle_t Handle, const void *DataToWrite)
 int32 CFE_ES_CDSBlockRead(void *DataRead, CFE_ES_CDSHandle_t Handle)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
-    char                   LogMessage[CFE_ES_MAX_SYSLOG_MSG_SIZE];
     int32                  Status;
     uint32                 CrcOfCDSData;
     size_t                 BlockSize;
     size_t                 UserDataSize;
     size_t                 UserDataOffset;
     CFE_ES_CDS_RegRec_t *  CDSRegRecPtr;
-
-    /* Validate the handle before doing anything */
-    LogMessage[0] = 0;
 
     CDSRegRecPtr = CFE_ES_LocateCDSBlockRecordByID(Handle);
 
@@ -344,12 +336,6 @@ int32 CFE_ES_CDSBlockRead(void *DataRead, CFE_ES_CDSHandle_t Handle)
     }
 
     CFE_ES_UnlockCDS();
-
-    /* Do the actual syslog if something went wrong */
-    if (LogMessage[0] != 0)
-    {
-        CFE_ES_SYSLOG_APPEND(LogMessage);
-    }
 
     return Status;
 }

--- a/modules/es/fsw/src/cfe_es_log.h
+++ b/modules/es/fsw/src/cfe_es_log.h
@@ -86,26 +86,6 @@
 #define CFE_ES_SYSLOG_READ_BUFFER_SIZE (3 * CFE_ES_MAX_SYSLOG_MSG_SIZE)
 
 /**
- * \brief Self-synchronized macro to call CFE_ES_SysLogAppend_Unsync
- *
- * Calls CFE_ES_SysLogAppend_Unsync() with appropriate synchronization.
- * It will acquire the shared data lock and release it after appending the log.
- *
- * This is implemented as a macro such that the "__func__" and "__LINE__" directives
- * will reflect the actual place that the append was done, rather than where this
- * wrapper was defined.
- *
- * \sa CFE_ES_SysLogAppend_Unsync()
- */
-#define CFE_ES_SYSLOG_APPEND(LogString)              \
-    {                                                \
-        CFE_ES_LockSharedData(__func__, __LINE__);   \
-        CFE_ES_SysLogAppend_Unsync(LogString);       \
-        CFE_ES_UnlockSharedData(__func__, __LINE__); \
-        OS_printf("%s", LogString);                  \
-    }
-
-/**
  * \brief Indicates no context information Error Logs
  *
  * For use with the CFE_ES_WriteToERLog() function when no context


### PR DESCRIPTION
**Describe the contribution**

Replace uses of this internal macro with the `CFE_ES_WriteToSysLog()` API.

Fixes #1349

**Testing performed**
Build and sanity check, run all unit tests

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Coding standards discourage use of multi-line macros, and for the 3 remaining uses there is no compelling reason not to just use the standard public API. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.