### PR TITLE
Fix #1342, rename "Zero" union member field

### DIFF
--- a/modules/es/fsw/src/cfe_es_cds.c
+++ b/modules/es/fsw/src/cfe_es_cds.c
@@ -531,13 +531,13 @@ int32 CFE_ES_ClearCDS(void)
 
     /* Clear the CDS to ensure everything is gone */
     /* Create a block of zeros to write to the CDS */
-    Status = CFE_ES_CDS_CachePreload(&CDS->Cache, NULL, 0, sizeof(CDS->Cache.Data.Zero));
+    Status = CFE_ES_CDS_CachePreload(&CDS->Cache, NULL, 0, sizeof(CDS->Cache.Data.GenericDataBlock));
 
     /* While there is space to write another block of zeros, then do so */
     while (CDS->Cache.Offset < CDS->TotalSize)
     {
         RemainSize = CDS->TotalSize - CDS->Cache.Offset;
-        if (RemainSize < sizeof(CDS->Cache.Data.Zero))
+        if (RemainSize < sizeof(CDS->Cache.Data.GenericDataBlock))
         {
             /* partial size */
             CDS->Cache.Size = RemainSize;

--- a/modules/es/fsw/src/cfe_es_cds.h
+++ b/modules/es/fsw/src/cfe_es_cds.h
@@ -125,10 +125,10 @@ typedef union CFE_ES_CDS_AccessCacheData
 {
     char                     Sig[CFE_ES_CDS_SIGNATURE_LEN]; /**< A signature field (beginning or end) */
     uint32                   RegistrySize;                  /**< Registry Size Field */
-    uint32                   Zero[4];                       /**< Used when clearing CDS content */
     CFE_ES_GenPoolBD_t       Desc;                          /**< A generic block descriptor */
     CFE_ES_CDS_BlockHeader_t BlockHeader;                   /**< A user block header */
     CFE_ES_CDS_RegRec_t      RegEntry;                      /**< A registry entry */
+    uint32                   GenericDataBlock[4];           /**< A small generic storage buffer for any other data */
 } CFE_ES_CDS_AccessCacheData_t;
 
 typedef struct CFE_ES_CDS_AccessCache


### PR DESCRIPTION
**Describe the contribution**
This field is just some generic bits. It is used when the CDS is cleared by zero-filling this data block and writing it to CDS repeatedly in a loop.

Renaming it to "GenericDataBlock" should be clearer as to its intent.

Fixes #1342 

**Testing performed**
Build and sanity check CFE
Confirm all unit tests pass

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Just renames internal field to avoid confusion about the name `Zero`.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
