### PR TITLE
Fix #1330, better warning about malformed startup line

### DIFF
--- a/modules/core_private/ut-stubs/src/ut_osprintf_stubs.c
+++ b/modules/core_private/ut-stubs/src/ut_osprintf_stubs.c
@@ -69,7 +69,7 @@ const char *UT_OSP_MESSAGES[] = {
     /* Warning: System Log full, log entry discarded. */
     [UT_OSP_SYSTEM_LOG_FULL] = "Warning: System Log full, log entry discarded.\n",
     /* ES Startup: ES Startup File Line is too long: 137 bytes. */
-    [UT_OSP_FILE_LINE_TOO_LONG] = "ES Startup: ES Startup File Line is too long: %u bytes.\n",
+    [UT_OSP_FILE_LINE_TOO_LONG] = "ES Startup: **WARNING** File Line %u is malformed: %u bytes, %u tokens.\n",
     /* ES Startup: Load Shared Library Init Error. */
     [UT_OSP_SHARED_LIBRARY_INIT] = "ES Startup: Load Shared Library Init Error = 0x%08x\n",
     /* ES Startup: Error Removing Volatile(RAM) Volume. EC = 0x~ */

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -1065,6 +1065,16 @@ void TestApps(void)
     UtAssert_NONZERO(UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_FILE_LINE_TOO_LONG]));
     UtAssert_NONZERO(UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_ES_APP_STARTUP_OPEN]));
 
+    /* Test starting an application where the startup script has extra tokens */
+    ES_ResetUnitTest();
+    strncpy(StartupScript, "A,B,C,D,E,F,G,H,I,J,K; !", sizeof(StartupScript) - 1);
+    StartupScript[sizeof(StartupScript) - 1] = '\0';
+    NumBytes                                 = strlen(StartupScript);
+    UT_SetReadBuffer(StartupScript, NumBytes);
+    CFE_ES_StartApplications(CFE_PSP_RST_TYPE_PROCESSOR, "ut_startup");
+    UtAssert_NONZERO(UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_FILE_LINE_TOO_LONG]));
+    UtAssert_NONZERO(UT_PrintfIsInHistory(UT_OSP_MESSAGES[UT_OSP_ES_APP_STARTUP_OPEN]));
+
     /* Create a valid startup script for subsequent tests */
     strncpy(StartupScript,
             "CFE_LIB, /cf/apps/tst_lib.bundle, TST_LIB_Init, TST_LIB, 0, 0, 0x0, 1; "


### PR DESCRIPTION
**Describe the contribution**
This improves the log message when a line in the startup script is not formed correctly, such as being too long or having too many
tokens.

Fixes #1330 

**Testing performed**
Hack CFE startup file to have a bad line with too many tokens.  Confirm that all _other_ apps started OK. 

**Expected behavior changes**
None if startup script is correctly formed.  But Startup file line with too many tokens now generates a more concise warning as opposed to being silent.  This also adds an indicator of which is the actual bad line.  Example.

    1980-012-14:07:27.50245 ES Startup: ES Startup File Line 5 is malformed: 60 bytes, 8 tokens.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
