### PR TITLE
Fix #1365, assert CFE_RESOURCEID_MAX is a bitmask

### DIFF
--- a/modules/resourceid/fsw/src/cfe_resourceid_api.c
+++ b/modules/resourceid/fsw/src/cfe_resourceid_api.c
@@ -41,6 +41,15 @@
 #include "cfe_resourceid.h"
 #include "cfe_resourceid_basevalue.h"
 
+/*
+ * The "CFE_RESOURCEID_MAX" limit is used as both a numeric maximum as well
+ * as a mask to separate the serial number bits from the base value bits.
+ *
+ * This sanity checks that the value is one less than a power of two so it
+ * works as a mask and the logic in this file works as expected.
+ */
+CompileTimeAssert(((CFE_RESOURCEID_MAX + 1) & CFE_RESOURCEID_MAX) == 0, CFE_RESOURCEID_MAX_BITMASK);
+
 /*********************************************************************/
 /*
  * CFE_ResourceId_GetBase


### PR DESCRIPTION
**Describe the contribution**
Add a compile time assert to ensure that this value is actually a power of two-1 (i.e. an LSB-justified bit mask).  

Notes in the comments that it serves as both a numeric limit and a mask.

Fixes #1365 

**Testing performed**
Build CFE normally, sanity check.
Also Intentionally set `CFE_RESOURCEID_MAX` to an invalid value and confirm that the compile time assert caught it.

**Expected behavior changes**
Will catch the case if the `CFE_RESOURCEID_MAX` value changes in such a way that makes it not usable as a bit mask as intended.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
