### PR TITLE
Fix #1346, error if alignment size not a power of two

### DIFF
--- a/modules/es/fsw/src/cfe_es_generic_pool.c
+++ b/modules/es/fsw/src/cfe_es_generic_pool.c
@@ -252,7 +252,6 @@ int32 CFE_ES_GenPoolInitialize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t StartO
 
     /*
      * Convert alignment to a bit mask.
-     * This sets all LSBs if the passed in value was not actually a power of 2.
      */
     if (AlignSize <= 1)
     {
@@ -261,11 +260,16 @@ int32 CFE_ES_GenPoolInitialize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t StartO
     else
     {
         AlignMask = AlignSize - 1;
-        AlignMask |= AlignMask >> 1;
-        AlignMask |= AlignMask >> 2;
-        AlignMask |= AlignMask >> 4;
-        AlignMask |= AlignMask >> 8;
-        AlignMask |= AlignMask >> 16;
+    }
+
+    /*
+     * This confirms that the passed in value is a power of 2.
+     * The result of this check should always be 0 if so.
+     */
+    if ((AlignMask & AlignSize) != 0)
+    {
+        CFE_ES_WriteToSysLog("%s(): invalid alignment for pool: %lu\n", __func__, (unsigned long)AlignSize);
+        return CFE_ES_BAD_ARGUMENT;
     }
 
     /* complete initialization of pool record entry */

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -1987,6 +1987,13 @@ void TestGenericPool(void)
 
     ES_ResetUnitTest();
 
+    /* Test Attempt to create pool with bad alignment / non power of 2 - should reject. */
+    memset(&UT_MemPoolDirectBuffer, 0xee, sizeof(UT_MemPoolDirectBuffer));
+    OffsetEnd = sizeof(UT_MemPoolDirectBuffer.Data);
+    UtAssert_INT32_EQ(CFE_ES_GenPoolInitialize(&Pool1, 0, OffsetEnd, 42, CFE_PLATFORM_ES_POOL_MAX_BUCKETS,
+                                               UT_POOL_BLOCK_SIZES, ES_UT_PoolDirectRetrieve, ES_UT_PoolDirectCommit),
+                      CFE_ES_BAD_ARGUMENT);
+
     /* Test successfully creating direct access pool, with alignment, no mutex */
     memset(&UT_MemPoolDirectBuffer, 0xee, sizeof(UT_MemPoolDirectBuffer));
     OffsetEnd = sizeof(UT_MemPoolDirectBuffer.Data);


### PR DESCRIPTION
**Describe the contribution**
Instead of "fixing" the alignment mask, return an error if the passed-in value is not actually a power of two.

Fixes #1346 

**Testing performed**
Build and sanity test CFE, run all unit tests

**Expected behavior changes**
Function will return  `CFE_ES_BAD_ARGUMENT` if the passed in parameter is not a power of two.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
This is an internal functions, and in ES this only gets passed from two possible sources: one is CDS, hardcoded as 4, and the other is sourced from the ALIGN_OF macro for generic memory pools.

The latter is platform-dependent but I've never seen a platform that aligns data on something other than a power of two boundary.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
