### PR TITLE
Fix #1338, check status of call to CFE_ES_CDS_CachePreload

### DIFF
--- a/modules/es/fsw/src/cfe_es_cds.c
+++ b/modules/es/fsw/src/cfe_es_cds.c
@@ -529,9 +529,11 @@ int32 CFE_ES_ClearCDS(void)
     size_t                 RemainSize;
     int32                  Status;
 
+    Status = CFE_SUCCESS;
+
     /* Clear the CDS to ensure everything is gone */
     /* Create a block of zeros to write to the CDS */
-    Status = CFE_ES_CDS_CachePreload(&CDS->Cache, NULL, 0, sizeof(CDS->Cache.Data.Zero));
+    CFE_ES_CDS_CachePreload(&CDS->Cache, NULL, 0, sizeof(CDS->Cache.Data.Zero));
 
     /* While there is space to write another block of zeros, then do so */
     while (CDS->Cache.Offset < CDS->TotalSize)


### PR DESCRIPTION
**Describe the contribution**
Confirm that the call returned CFE_SUCCESS before continuing.

Fixes #1338 

**Testing performed**
Build and sanity check CFE, run all unit tests

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Note that the error/failure condition here is effectively dead code from the beginning.  Not even coverage test can exercise it, because its a void function, and the args are largely fixed/constant values.  So this now shows up as untested lines in the coverage report.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
