### PR TITLE
Fix #1311, CFE_SUCCESS constant type

### DIFF
--- a/modules/core_api/fsw/inc/cfe_error.h
+++ b/modules/core_api/fsw/inc/cfe_error.h
@@ -117,7 +117,7 @@ typedef int32 CFE_Status_t;
  *
  *  Operation was performed successfully
  */
-#define CFE_SUCCESS (0)
+#define CFE_SUCCESS ((CFE_Status_t)0)
 
 /**
  * @brief No Counter Increment


### PR DESCRIPTION
**Describe the contribution**
Ensures that the CFE_SUCCESS constant is the CFE_Status_t type.

Fixes #1311 

**Testing performed**
Build and sanity check CFE, run all unit tests, confirm nothing went wrong.

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu 20.04

**Additional context**
The explicit cast is required on all error codes that are expected to be _negative_ values.  The problem that occurs if these are not forced to `int32` type is that the compiler up-converts them to `long`, which on a 64-bit platform can can represent the value as a positive integer.  Therefore a test for equality starts to fail.

On codes that are positive values, it doesn't matter as much, the compiler will not need to convert these literals to anything other than int, but it shouldn't hurt to add it for consistency, just in case.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
