### PR TITLE
Fix #1317, memory pool pointer type

### DIFF
--- a/modules/core_api/fsw/inc/cfe_es.h
+++ b/modules/core_api/fsw/inc/cfe_es.h
@@ -1178,10 +1178,12 @@ CFE_Status_t CFE_ES_RestoreFromCDS(void *RestoreToMemory, CFE_ES_CDSHandle_t Han
 ** \param[in, out]   PoolID   A pointer to the variable the caller wishes to have the memory pool handle kept in.
 **                            PoolID is the memory pool handle.
 **
-** \param[in]   MemPtr      A Pointer to the pool of memory created by the calling application. This address must
-**                          be on a 32-bit boundary.
+** \param[in]   MemPtr        A Pointer to the pool of memory created by the calling application. This address must
+**                            be aligned suitably for the processor architecture.  The #CFE_ES_STATIC_POOL_TYPE
+**                            macro may be used to assist in creating properly aligned memory pools.
 **
-** \param[in]   Size        The size of the pool of memory.  Note that this must be an integral number of 32 bit words.
+** \param[in]   Size          The size of the pool of memory.  Note that this must be an integral multiple of the
+**                            memory alignment of the processor architecture.
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS           \copybrief CFE_SUCCESS
@@ -1190,7 +1192,7 @@ CFE_Status_t CFE_ES_RestoreFromCDS(void *RestoreToMemory, CFE_ES_CDSHandle_t Han
 ** \sa #CFE_ES_PoolCreate, #CFE_ES_PoolCreateEx, #CFE_ES_GetPoolBuf, #CFE_ES_PutPoolBuf, #CFE_ES_GetMemPoolStats
 **
 ******************************************************************************/
-CFE_Status_t CFE_ES_PoolCreateNoSem(CFE_ES_MemHandle_t *PoolID, uint8 *MemPtr, size_t Size);
+CFE_Status_t CFE_ES_PoolCreateNoSem(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t Size);
 
 /*****************************************************************************/
 /**
@@ -1208,10 +1210,12 @@ CFE_Status_t CFE_ES_PoolCreateNoSem(CFE_ES_MemHandle_t *PoolID, uint8 *MemPtr, s
 ** \param[in, out]   PoolID   A pointer to the variable the caller wishes to have the memory pool handle kept in.
 **                            PoolID is the memory pool handle.
 **
-** \param[in]   MemPtr      A Pointer to the pool of memory created by the calling application. This address must
-**                          be on a 32-bit boundary.
+** \param[in]   MemPtr        A Pointer to the pool of memory created by the calling application. This address must
+**                            be aligned suitably for the processor architecture.  The #CFE_ES_STATIC_POOL_TYPE
+**                            macro may be used to assist in creating properly aligned memory pools.
 **
-** \param[in]   Size        The size of the pool of memory.  Note that this must be an integral number of 32 bit words.
+** \param[in]   Size          The size of the pool of memory.  Note that this must be an integral multiple of the
+**                            memory alignment of the processor architecture.
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS           \copybrief CFE_SUCCESS
@@ -1220,7 +1224,7 @@ CFE_Status_t CFE_ES_PoolCreateNoSem(CFE_ES_MemHandle_t *PoolID, uint8 *MemPtr, s
 ** \sa #CFE_ES_PoolCreateNoSem, #CFE_ES_PoolCreateEx, #CFE_ES_GetPoolBuf, #CFE_ES_PutPoolBuf, #CFE_ES_GetMemPoolStats
 **
 ******************************************************************************/
-CFE_Status_t CFE_ES_PoolCreate(CFE_ES_MemHandle_t *PoolID, uint8 *MemPtr, size_t Size);
+CFE_Status_t CFE_ES_PoolCreate(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t Size);
 
 /*****************************************************************************/
 /**
@@ -1234,14 +1238,15 @@ CFE_Status_t CFE_ES_PoolCreate(CFE_ES_MemHandle_t *PoolID, uint8 *MemPtr, size_t
 **        -# The start address of the pool must be 32-bit aligned
 **        -# 168 bytes are used for internal bookkeeping, therefore, they will not be available for allocation.
 **
-** \param[in, out]   PoolID      A pointer to the variable the caller wishes to have the memory pool handle kept in.
-**                               PoolID is the memory pool handle.
+** \param[in, out]   PoolID    A pointer to the variable the caller wishes to have the memory pool handle kept in.
+**                             PoolID is the memory pool handle.
 **
 ** \param[in]   MemPtr         A Pointer to the pool of memory created by the calling application. This address must
-**                             be on a 32-bit boundary.
+**                             be aligned suitably for the processor architecture.  The #CFE_ES_STATIC_POOL_TYPE
+**                             macro may be used to assist in creating properly aligned memory pools.
 **
-** \param[in]   Size           The size of the pool of memory.  Note that this must be an integral number of 32 bit
-**                             words.
+** \param[in]   Size           The size of the pool of memory.  Note that this must be an integral multiple of the
+**                             memory alignment of the processor architecture.
 **
 ** \param[in]   NumBlockSizes  The number of different block sizes specified in the \c BlockSizes array. If set equal to
 **                             zero or if greater than 17, then default block sizes are used.
@@ -1260,7 +1265,7 @@ CFE_Status_t CFE_ES_PoolCreate(CFE_ES_MemHandle_t *PoolID, uint8 *MemPtr, size_t
 ** \sa #CFE_ES_PoolCreate, #CFE_ES_PoolCreateNoSem, #CFE_ES_GetPoolBuf, #CFE_ES_PutPoolBuf, #CFE_ES_GetMemPoolStats
 **
 ******************************************************************************/
-CFE_Status_t CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t *PoolID, uint8 *MemPtr, size_t Size, uint16 NumBlockSizes,
+CFE_Status_t CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t Size, uint16 NumBlockSizes,
                                  const size_t *BlockSizes, bool UseMutex);
 
 /*****************************************************************************/

--- a/modules/core_api/ut-stubs/src/ut_es_stubs.c
+++ b/modules/core_api/ut-stubs/src/ut_es_stubs.c
@@ -535,7 +535,7 @@ int32 CFE_ES_GetPoolBuf(CFE_ES_MemPoolBuf_t *BufPtr, CFE_ES_MemHandle_t PoolID, 
 **        Returns either a user-defined status flag or OS_SUCCESS.
 **
 ******************************************************************************/
-CFE_Status_t CFE_ES_PoolCreate(CFE_ES_MemHandle_t *PoolID, uint8 *MemPtr, size_t Size)
+CFE_Status_t CFE_ES_PoolCreate(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t Size)
 {
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_PoolCreate), PoolID);
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_PoolCreate), MemPtr);
@@ -568,7 +568,7 @@ CFE_Status_t CFE_ES_PoolCreate(CFE_ES_MemHandle_t *PoolID, uint8 *MemPtr, size_t
 **        Returns OS_SUCCESS.
 **
 ******************************************************************************/
-CFE_Status_t CFE_ES_PoolCreateNoSem(CFE_ES_MemHandle_t *PoolID, uint8 *MemPtr, size_t Size)
+CFE_Status_t CFE_ES_PoolCreateNoSem(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t Size)
 {
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_PoolCreateNoSem), PoolID);
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_PoolCreateNoSem), MemPtr);
@@ -606,7 +606,7 @@ CFE_Status_t CFE_ES_PoolCreateNoSem(CFE_ES_MemHandle_t *PoolID, uint8 *MemPtr, s
 **        Returns either a user-defined status flag or CFE_SUCCESS.
 **
 ******************************************************************************/
-CFE_Status_t CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t *PoolID, uint8 *MemPtr, size_t Size, uint16 NumBlockSizes,
+CFE_Status_t CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t Size, uint16 NumBlockSizes,
                                  const size_t *BlockSizes, bool UseMutex)
 {
     UT_Stub_RegisterContext(UT_KEY(CFE_ES_PoolCreateEx), PoolID);

--- a/modules/es/fsw/src/cfe_es_mempool.c
+++ b/modules/es/fsw/src/cfe_es_mempool.c
@@ -134,7 +134,7 @@ CFE_ES_MemPoolRecord_t *CFE_ES_LocateMemPoolRecordByID(CFE_ES_MemHandle_t PoolID
 /*
 ** CFE_ES_PoolCreateNoSem will initialize a pre-allocated memory pool without using a mutex.
 */
-int32 CFE_ES_PoolCreateNoSem(CFE_ES_MemHandle_t *PoolID, uint8 *MemPtr, size_t Size)
+int32 CFE_ES_PoolCreateNoSem(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t Size)
 {
     return CFE_ES_PoolCreateEx(PoolID, MemPtr, Size, CFE_PLATFORM_ES_POOL_MAX_BUCKETS, &CFE_ES_MemPoolDefSize[0],
                                CFE_ES_NO_MUTEX);
@@ -143,13 +143,13 @@ int32 CFE_ES_PoolCreateNoSem(CFE_ES_MemHandle_t *PoolID, uint8 *MemPtr, size_t S
 /*
 ** CFE_ES_PoolCreate will initialize a pre-allocated memory pool while using a mutex.
 */
-int32 CFE_ES_PoolCreate(CFE_ES_MemHandle_t *PoolID, uint8 *MemPtr, size_t Size)
+int32 CFE_ES_PoolCreate(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t Size)
 {
     return CFE_ES_PoolCreateEx(PoolID, MemPtr, Size, CFE_PLATFORM_ES_POOL_MAX_BUCKETS, &CFE_ES_MemPoolDefSize[0],
                                CFE_ES_USE_MUTEX);
 }
 
-int32 CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t *PoolID, uint8 *MemPtr, size_t Size, uint16 NumBlockSizes,
+int32 CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t Size, uint16 NumBlockSizes,
                           const size_t *BlockSizes, bool UseMutex)
 {
     int32                   Status;


### PR DESCRIPTION
**Describe the contribution**
Changes the type of pointer in the API from `uint8*` to `void*` to be more consistent and easier to use.  Should be backward compatible.

This also updates the doxygen documentation for this parameter, as it was specifying a 32-bit alignment requirement whereas the
alignment requirement is processor dependent - 64 bit processors typically will need 64 bit alignment.  Link to the macro which
is intended to aid in aligning the static pool buffer.

Fixes #1317

**Testing performed**
Build and sanity check CFE, run all unit tests, rebuild documentation.

**Expected behavior changes**
None.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
