### PR TITLE
Fix #1298, add Current Time Functional Test

### DIFF
--- a/modules/cfe_testcase/CMakeLists.txt
+++ b/modules/cfe_testcase/CMakeLists.txt
@@ -5,6 +5,7 @@ add_cfe_app(cfe_testcase
     src/es_info_test.c
     src/es_task_test.c
     src/es_cds_test.c
+    src/fs_header_test.c
 )
 
 # register the dependency on cfe_assert

--- a/modules/cfe_testcase/CMakeLists.txt
+++ b/modules/cfe_testcase/CMakeLists.txt
@@ -6,6 +6,7 @@ add_cfe_app(cfe_testcase
     src/es_task_test.c
     src/es_cds_test.c
     src/fs_header_test.c
+    src/time_current_test.c
 )
 
 # register the dependency on cfe_assert

--- a/modules/cfe_testcase/src/cfe_test.c
+++ b/modules/cfe_testcase/src/cfe_test.c
@@ -54,6 +54,7 @@ void CFE_TestMain(void)
     ESTaskTestSetup();
     ESCDSTestSetup();
     FSHeaderTestSetup();
+    TimeCurrentTestSetup();
 
     /*
      * Execute the tests

--- a/modules/cfe_testcase/src/cfe_test.c
+++ b/modules/cfe_testcase/src/cfe_test.c
@@ -53,6 +53,7 @@ void CFE_TestMain(void)
     ESInfoTestSetup();
     ESTaskTestSetup();
     ESCDSTestSetup();
+    FSHeaderTestSetup();
 
     /*
      * Execute the tests

--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -57,5 +57,6 @@ void ESInfoTestSetup(void);
 void ESTaskTestSetup(void);
 void ESCDSTestSetup(void);
 void FSHeaderTestSetup(void);
+void TimeCurrentTestSetup(void);
 
 #endif /* CFE_TEST_H */

--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -56,5 +56,6 @@ void CFE_TestMain(void);
 void ESInfoTestSetup(void);
 void ESTaskTestSetup(void);
 void ESCDSTestSetup(void);
+void FSHeaderTestSetup(void);
 
 #endif /* CFE_TEST_H */

--- a/modules/cfe_testcase/src/fs_header_test.c
+++ b/modules/cfe_testcase/src/fs_header_test.c
@@ -1,0 +1,111 @@
+/*************************************************************************
+**
+**      GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**      Copyright (c) 2006-2019 United States Government as represented by
+**      the Administrator of the National Aeronautics and Space Administration.
+**      All Rights Reserved.
+**
+**      Licensed under the Apache License, Version 2.0 (the "License");
+**      you may not use this file except in compliance with the License.
+**      You may obtain a copy of the License at
+**
+**        http://www.apache.org/licenses/LICENSE-2.0
+**
+**      Unless required by applicable law or agreed to in writing, software
+**      distributed under the License is distributed on an "AS IS" BASIS,
+**      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**      See the License for the specific language governing permissions and
+**      limitations under the License.
+**
+** File: es_info_test.c
+**
+** Purpose:
+**   Functional test of basic FS Header APIs
+**
+**   Demonstration of how to register and use the UT assert functions.
+**
+*************************************************************************/
+
+/*
+ * Includes
+ */
+
+#include "cfe_test.h"
+
+#define OS_TEST_HEADER_FILENAME "/drive0/header_test.txt"
+char *fsAddrPtr = NULL;
+
+static osal_id_t setup_file(void)
+{
+    osal_id_t id;
+    OS_mkfs(fsAddrPtr, "/ramdev1", "RAM", 512, 20);
+    OS_mount("/ramdev1", "/drive0");
+    UtAssert_INT32_EQ(OS_OpenCreate(&id, OS_TEST_HEADER_FILENAME, OS_FILE_FLAG_CREATE, OS_READ_WRITE), OS_SUCCESS);
+    return id;
+}
+
+void TestCreateHeader(void)
+{
+    CFE_FS_Header_t Header;
+    const char *    TestDescription = "TEST_HEADER";
+    osal_id_t       fd              = setup_file();
+
+    UtPrintf("Testing: CFE_FS_InitHeader, CFE_FS_WriteHeader");
+
+    CFE_FS_InitHeader(&Header, TestDescription, CFE_FS_SubType_ES_ERLOG);
+    UtAssert_INT32_EQ(CFE_FS_WriteHeader(fd, &Header), sizeof(CFE_FS_Header_t));
+
+    OS_close(fd);
+    OS_remove(OS_TEST_HEADER_FILENAME);
+}
+
+void TestReadHeader(void)
+{
+    CFE_FS_Header_t Header;
+    CFE_FS_Header_t ReadHeader;
+    const char *    TestDescription = "TEST_HEADER";
+    osal_id_t       fd              = setup_file();
+
+    UtPrintf("Testing: CFE_FS_ReadHeader");
+
+    CFE_FS_InitHeader(&Header, TestDescription, CFE_FS_SubType_ES_ERLOG);
+    UtAssert_INT32_EQ(CFE_FS_WriteHeader(fd, &Header), sizeof(CFE_FS_Header_t));
+    UtAssert_INT32_EQ(CFE_FS_ReadHeader(&ReadHeader, fd), sizeof(CFE_FS_Header_t));
+
+    UtAssert_INT32_EQ(Header.ContentType, ReadHeader.ContentType);
+    UtAssert_INT32_EQ(Header.SubType, ReadHeader.SubType);
+    UtAssert_StrCmp(TestDescription, ReadHeader.Description, "ReadHeader.Description = %s", ReadHeader.Description);
+
+    OS_close(fd);
+    OS_remove(OS_TEST_HEADER_FILENAME);
+}
+
+void TestTimeStamp(void)
+{
+    CFE_FS_Header_t    Header;
+    CFE_FS_Header_t    ReadHeader;
+    const char *       TestDescription = "TEST_HEADER";
+    CFE_TIME_SysTime_t NewTimestamp    = {10, 10};
+    osal_id_t          fd              = setup_file();
+
+    UtPrintf("Testing: CFE_FS_SetTimestamp");
+
+    CFE_FS_InitHeader(&Header, TestDescription, CFE_FS_SubType_ES_ERLOG);
+    UtAssert_INT32_EQ(CFE_FS_WriteHeader(fd, &Header), sizeof(CFE_FS_Header_t));
+    UtAssert_INT32_EQ(CFE_FS_SetTimestamp(fd, NewTimestamp), OS_SUCCESS);
+    UtAssert_INT32_EQ(CFE_FS_ReadHeader(&ReadHeader, fd), sizeof(CFE_FS_Header_t));
+
+    UtAssert_INT32_EQ(10, ReadHeader.TimeSeconds);
+    UtAssert_INT32_EQ(10, ReadHeader.TimeSubSeconds);
+
+    OS_close(fd);
+    OS_remove(OS_TEST_HEADER_FILENAME);
+}
+
+void FSHeaderTestSetup(void)
+{
+    UtTest_Add(TestCreateHeader, NULL, NULL, "Test Create Header");
+    UtTest_Add(TestReadHeader, NULL, NULL, "Test Read Header");
+    UtTest_Add(TestTimeStamp, NULL, NULL, "Test Time Stamp");
+}

--- a/modules/cfe_testcase/src/time_current_test.c
+++ b/modules/cfe_testcase/src/time_current_test.c
@@ -1,0 +1,126 @@
+/*************************************************************************
+**
+**      GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**      Copyright (c) 2006-2019 United States Government as represented by
+**      the Administrator of the National Aeronautics and Space Administration.
+**      All Rights Reserved.
+**
+**      Licensed under the Apache License, Version 2.0 (the "License");
+**      you may not use this file except in compliance with the License.
+**      You may obtain a copy of the License at
+**
+**        http://www.apache.org/licenses/LICENSE-2.0
+**
+**      Unless required by applicable law or agreed to in writing, software
+**      distributed under the License is distributed on an "AS IS" BASIS,
+**      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**      See the License for the specific language governing permissions and
+**      limitations under the License.
+**
+** File: es_info_test.c
+**
+** Purpose:
+**   Functional test of basic Time Current APIs
+**
+**   Demonstration of how to register and use the UT assert functions.
+**
+*************************************************************************/
+
+/*
+ * Includes
+ */
+
+#include "cfe_test.h"
+
+bool TimeInRange(CFE_TIME_SysTime_t Time, CFE_TIME_SysTime_t Target, OS_time_t difference)
+{
+    OS_time_t Max;
+    OS_time_t TimeT   = OS_TimeAssembleFromSubseconds(Time.Seconds, Time.Subseconds);
+    OS_time_t TargetT = OS_TimeAssembleFromSubseconds(Target.Seconds, Target.Subseconds);
+
+    Max = OS_TimeAdd(TimeT, difference);
+
+    if (TargetT.ticks >= TimeT.ticks && TargetT.ticks <= Max.ticks)
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+void TestGetTime(void)
+{
+    UtPrintf("Testing: CFE_TIME_GetTime, CFE_TIME_GetTAI, CFE_TIME_GetUTC, CFE_TIME_GetMET, CFE_TIME_GetSTCF, "
+             "CFE_TIME_GetLeapSeconds");
+    OS_time_t          start;
+    OS_time_t          end;
+    OS_time_t          difference;
+    CFE_TIME_SysTime_t Time;
+    CFE_TIME_SysTime_t TAI;
+    CFE_TIME_SysTime_t UTC;
+    CFE_TIME_SysTime_t MET;
+    CFE_TIME_SysTime_t STCF;
+    uint32             METSeconds;
+    uint32             METSubSeconds;
+
+    int16              LeapSeconds;
+    CFE_TIME_SysTime_t Buf;
+
+    char timeBuf1[sizeof("yyyy-ddd-hh:mm:ss.xxxxx_")];
+    char timeBuf2[sizeof("yyyy-ddd-hh:mm:ss.xxxxx_")];
+
+    OS_GetLocalTime(&start);
+
+    Time          = CFE_TIME_GetTime();
+    TAI           = CFE_TIME_GetTAI();
+    UTC           = CFE_TIME_GetUTC();
+    MET           = CFE_TIME_GetMET();
+    METSeconds    = CFE_TIME_GetMETseconds();
+    METSubSeconds = CFE_TIME_GetMETsubsecs();
+    STCF          = CFE_TIME_GetSTCF();
+    LeapSeconds   = CFE_TIME_GetLeapSeconds();
+
+    OS_GetLocalTime(&end);
+
+    CFE_TIME_Print(timeBuf1, Time);
+    UtPrintf("The current time is (%d) %s", Time.Seconds, timeBuf1);
+
+    difference = OS_TimeSubtract(end, start);
+
+#if (CFE_MISSION_TIME_CFG_DEFAULT_TAI == true)
+    CFE_TIME_Print(timeBuf2, TAI);
+    UtAssert_True(TimeInRange(Time, TAI, difference), "Get Time (%s) = TAI (%s)", timeBuf1, timeBuf2);
+#else
+    CFE_TIME_Print(timeBuf2, UTC);
+    UtAssert_True(TimeInRange(Time, UTC, difference), "Get Time (%s) = UTC(%s)", timeBuf1, timeBuf2);
+#endif
+
+    CFE_TIME_Print(timeBuf1, TAI);
+    Buf = CFE_TIME_Add(MET, STCF);
+    CFE_TIME_Print(timeBuf2, Buf);
+    UtAssert_True(TimeInRange(TAI, Buf, difference), "TAI (%s) = MET + STCF (%s)", timeBuf1, timeBuf2);
+
+    CFE_TIME_Print(timeBuf1, UTC);
+    Buf.Seconds = Buf.Seconds - LeapSeconds;
+    CFE_TIME_Print(timeBuf2, Buf);
+    UtAssert_True(TimeInRange(UTC, Buf, difference), "UTC (%s) = MET + STCF - Leap Seconds (%s)", timeBuf1, timeBuf2);
+
+    CFE_TIME_Print(timeBuf1, MET);
+    Buf.Seconds    = METSeconds;
+    Buf.Subseconds = MET.Subseconds;
+    CFE_TIME_Print(timeBuf2, Buf);
+    UtAssert_True(TimeInRange(MET, Buf, difference), "MET (%s) = METSeconds (%s)", timeBuf1, timeBuf2);
+
+    Buf.Seconds    = MET.Seconds;
+    Buf.Subseconds = METSubSeconds;
+    CFE_TIME_Print(timeBuf2, Buf);
+    UtAssert_True(TimeInRange(MET, Buf, difference), "MET (%s) = METSubSeconds (%s)", timeBuf1, timeBuf2);
+}
+
+void TimeCurrentTestSetup(void)
+{
+    UtTest_Add(TestGetTime, NULL, NULL, "Test Current Time");
+}


### PR DESCRIPTION
**Describe the contribution**
Fixes #1298
adds new functional tests for Time Current API.

**System(s) tested on**
Ubuntu 20.04

**Additional context**
This is a just testing the nominal cases. More in depth tests will have to be added later.

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC
