### PR TITLE
cFS-Caelum Review, CFS-43: Table Services & Time Services 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,9 @@
 !modules/tbl/CMakeLists.txt
 
 # Time Services (TIME)
-# !modules/core_private/fsw/inc/cfe_time*
-# !modules/core_api/fsw/inc/cfe_time*
+!modules/core_private/fsw/inc/cfe_time*
+!modules/core_api/fsw/inc/cfe_time*
 
-# !modules/time/fsw/**
-# !modules/time/CMakeLists.txt
+!modules/time/fsw/**
+!modules/time/CMakeLists.txt
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,25 @@
+# Ignore everything
+*
+
+# ...even if they are in subdirectories
+!*/
+
+# But not these files...
+!/.gitignore
+!/README.md
+
+
+
+# Table (TBL)
+!modules/core_api/fsw/inc/cfe_tbl*
+
+!modules/tbl/fsw/**
+!modules/tbl/CMakeLists.txt
+
+# Time Services (TIME)
+# !modules/core_private/fsw/inc/cfe_time*
+# !modules/core_api/fsw/inc/cfe_time*
+
+# !modules/time/fsw/**
+# !modules/time/CMakeLists.txt
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,24 @@
-# cFE
+## cFS-Caelum Review: CFS-43
+
+This branch is meant for the cFS-Caelum code review of Time Services and Table Services. The review designation is "CFS-43"
+
+
+The corresponding, fully-working cFE instance matching the code in this branch can be found under the [cFE v7.0.0-rc1 tag](https://github.com/nasa/cFE/releases/tag/v7.0.0-rc1)
+
+### How to add your review comments
+
+Navigate to the ["files changed" tab](https://github.com/nasa/cFE/pull/1420/files) in the [nasa/cFE#1375](https://github.com/nasa/cFE/pull/1420) pull request.
+
+
+<img width="820" alt="github-review-instructions-1of2" src="https://user-images.githubusercontent.com/59618057/113956688-dca76a00-97eb-11eb-99d4-9ec84b459dce.png">
+
+
+You can add comments on any line of code by hovering on the line number and clicking on the plus "+" sign. Once you're finished with the comment click on the green "Start Review" button. To add more comments, just click on the relevant line number in any file, type your comment, and click on "Add review comment".
+
+
+<img width="1229" alt="github-review-instructions-2of2" src="https://user-images.githubusercontent.com/59618057/113956482-8508fe80-97eb-11eb-8197-618d4e25fa51.png">
+
+ If you need to take a break, or if you're done, click the green "Finish Review" button on the top right corner of the
+page, add any overall or summarizing comments and click on "Submit Review". You can always return and add new comments using the same process.
+
+**Thank you!**

--- a/modules/core_api/fsw/inc/cfe_tbl.h
+++ b/modules/core_api/fsw/inc/cfe_tbl.h
@@ -1,0 +1,742 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * @file
+ *
+ *  Title:   Table Services API Application Library Header File
+ *
+ *  Purpose:
+ *     Unit specification for Table services library functions and macros.
+ *
+ *  Design Notes:
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *
+ *  Notes:
+ *
+ */
+
+#ifndef CFE_TBL_H
+#define CFE_TBL_H
+
+/********************* Include Files  ************************/
+#include "common_types.h" /* Basic Data Types */
+#include "cfe_error.h"
+#include "cfe_tbl_api_typedefs.h"
+#include "cfe_sb_api_typedefs.h"
+
+/*************************** Function Prototypes ******************************/
+
+/** \defgroup CFEAPITBLRegistration cFE Registration APIs
+ * @{
+ */
+
+/*****************************************************************************/
+/**
+** \brief Register a table with cFE to obtain Table Management Services
+**
+** \par Description
+**          When an application is created and initialized, it is responsible for creating its table images via
+**          the TBL API.  The application must inform the Table Service of the table name, table size and selection
+**          of optional table features.
+**
+** \par Assumptions, External Events, and Notes:
+**          Note: This function call can block.  Therefore, interrupt service routines should NOT create
+**                their own tables.  An application should create any table(s) and provide the handle(s)
+**                to the interrupt service routine.
+**
+** \param[in, out] TblHandlePtr    a pointer to a #CFE_TBL_Handle_t type variable that will be assigned the table's
+**                                 handle.  The table handle is required for other API calls when accessing the data
+**                                 contained in the table. *TblHandlePtr is the handle used to identify table to cFE
+**                                 when performing Table operations. This value is returned at  ddress specified by
+**                                 TblHandlePtr.
+**
+** \param[in] Name                 The application-specific name.  This name will be combined with the name of the
+**                                 application to produce a processor specific name of the form
+**                                 "ApplicationName.TableName".  The processor specific name will be used in commands
+**                                 for modifying or viewing the contents of the table.
+**
+** \param[in] Size                 The size, in bytes, of the table to be created.  This is the size that will be
+**                                 allocated as a shared memory resource between the Table Management Service and
+**                                 the calling application.
+**
+** \param[in] TblOptionFlags       Flag bits indicating selected options for table.  A bitwise OR of the following
+**                                 option flags:
+**                                 \arg #CFE_TBL_OPT_DEFAULT     - The default setting for table options is a
+**                                                                 combination of #CFE_TBL_OPT_SNGL_BUFFER and
+**                                                                 #CFE_TBL_OPT_LOAD_DUMP.  See below for a
+**                                                                 description of these two options.  This option
+**                                                                 is mutually exclusive with the
+**                                                                 #CFE_TBL_OPT_DBL_BUFFER, #CFE_TBL_OPT_DUMP_ONLY
+**                                                                 and #CFE_TBL_OPT_USR_DEF_ADDR options.
+**                                 \arg #CFE_TBL_OPT_SNGL_BUFFER - When this option is selected, the table will use
+**                                                                 a shared session table for performing table
+**                                                                 modifications and a memory copy from the session
+**                                                                 table to the "active" table buffer will occur
+**                                                                 when the table is updated.  This is the preferred
+**                                                                 option since it will minimize memory usage.
+**                                                                 This option is mutually exclusive with the
+**                                                                 #CFE_TBL_OPT_DBL_BUFFER option
+**                                 \arg #CFE_TBL_OPT_DBL_BUFFER  - When this option is selected, two instances of
+**                                                                 the table are created.   One is considered the
+**                                                                 "active" table and the other the "inactive" table.
+**                                                                 Whenever table modifications occur, they do not
+**                                                                 require the use of a common session table.
+**                                                                 Modifications occur in the "inactive" buffer.
+**                                                                 Then, when it is time to update the table,
+**                                                                 the pointer to the "active" table is changed to
+**                                                                 point to the "inactive" buffer thus making it
+**                                                                 the new "active" buffer.  This feature is most
+**                                                                 useful for time critical applications (ie -
+**                                                                 interrupt service routines, etc).  This option is
+**                                                                 mutually exclusive with the
+**                                                                 #CFE_TBL_OPT_SNGL_BUFFER and #CFE_TBL_OPT_DEFAULT
+**                                                                 option.
+**                                 \arg #CFE_TBL_OPT_LOAD_DUMP   - When this option is selected, the Table Service
+**                                                                 is allowed to perform all operations on the
+**                                                                 specified table.  This option is mutually
+**                                                                 exclusive with the #CFE_TBL_OPT_DUMP_ONLY option.
+**                                 \arg #CFE_TBL_OPT_DUMP_ONLY   - When this option is selected, the Table Service
+**                                                                 will not perform table loads to this table.  This
+**                                                                 does not prevent, however, a task from writing
+**                                                                 to the table via an address obtained with the
+**                                                                 #CFE_TBL_GetAddress API function.  This option is
+**                                                                 mutually exclusive with the #CFE_TBL_OPT_LOAD_DUMP
+**                                                                 and #CFE_TBL_OPT_DEFAULT options. If the Application
+**                                                                 wishes to specify their own block of memory as the
+**                                                                 Dump Only table, they need to also include the
+**                                                                 #CFE_TBL_OPT_USR_DEF_ADDR option explained below.
+**                                 \arg #CFE_TBL_OPT_NOT_USR_DEF - When this option is selected, Table Services
+**                                                                 allocates memory for the table and, in the case of a
+**                                                                 double buffered table, it allocates the same amount
+**                                                                 of memory again for the second buffer.  This option
+**                                                                 is mutually exclusive with the
+**                                                                 #CFE_TBL_OPT_USR_DEF_ADDR option.
+**                                 \arg #CFE_TBL_OPT_USR_DEF_ADDR- When this option is selected, the Table Service
+**                                                                 will not allocate memory for the table.  Table
+**                                                                 Services will require the Application to identify
+**                                                                 the location of the active table buffer via the
+**                                                                 #CFE_TBL_Load function. This option implies the
+**                                                                 #CFE_TBL_OPT_DUMP_ONLY and the
+**                                                                 #CFE_TBL_OPT_SNGL_BUFFER options and is mutually
+**                                                                 exclusive of the #CFE_TBL_OPT_DBL_BUFFER option.
+**                                 \arg #CFE_TBL_OPT_CRITICAL-     When this option is selected, the Table Service
+**                                                                 will automatically allocate space in the Critical
+**                                                                 Data Store (CDS) for the table and insure that the
+**                                                                 contents in the CDS are the same
+**                                                                 as the contents of the currently active buffer for
+**                                                                 the table. This option is mutually exclusive of the
+**                                                                 #CFE_TBL_OPT_USR_DEF_ADDR and #CFE_TBL_OPT_DUMP_ONLY
+**                                                                 options.  It should also be noted that the use of
+**                                                                 this option with double buffered tables will prevent
+**                                                                 the update of the double buffered table from being
+**                                                                 quick and it could be blocked.  Therefore, critical
+**                                                                 tables should not be updated by Interrupt Service
+**                                                                 Routines.
+**
+** \param[in] TblValidationFuncPtr is a pointer to a function that will be executed in the context of the Table
+**                                 Management Service when the contents of a table need to be validated.  If set
+**                                 to NULL, then the Table Management Service will assume any data is valid.  If
+**                                 the value is not NULL, it must be a pointer to a function with the following
+**                                 prototype: <BR>
+**                                 <B> int32 CallbackFunc(void *TblPtr);</B> <BR>
+**                                 where  <BR>
+**                                 <B>TblPtr </B> will be a pointer to the table data that is to be verified.  When the
+**                                 function returns #CFE_SUCCESS, the data is considered valid and ready for a commit.
+**                                 When the function returns a negative value, the data is considered invalid and an
+**                                 Event Message will be issued containing the returned value.  If the function should
+**                                 return a positive number, the table is considered invalid and the return code is
+**                                 considered invalid.  Validation functions \b must return either #CFE_SUCCESS or a
+**                                 negative number (whose value is at the developer's discretion).  The validation
+**                                 function will be executed in the Application's context so that Event Messages
+**                                 describing the validation failure are possible from within the function.
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS                      \copybrief CFE_SUCCESS
+** \retval #CFE_TBL_INFO_RECOVERED_TBL       \copybrief CFE_TBL_INFO_RECOVERED_TBL
+** \retval #CFE_TBL_ERR_DUPLICATE_DIFF_SIZE  \copybrief CFE_TBL_ERR_DUPLICATE_DIFF_SIZE
+** \retval #CFE_TBL_ERR_DUPLICATE_NOT_OWNED  \copybrief CFE_TBL_ERR_DUPLICATE_NOT_OWNED
+** \retval #CFE_TBL_ERR_REGISTRY_FULL        \copybrief CFE_TBL_ERR_REGISTRY_FULL
+** \retval #CFE_TBL_ERR_HANDLES_FULL         \copybrief CFE_TBL_ERR_HANDLES_FULL
+** \retval #CFE_TBL_ERR_INVALID_SIZE         \copybrief CFE_TBL_ERR_INVALID_SIZE
+** \retval #CFE_TBL_ERR_INVALID_NAME         \copybrief CFE_TBL_ERR_INVALID_NAME
+** \retval #CFE_TBL_ERR_BAD_APP_ID           \copybrief CFE_TBL_ERR_BAD_APP_ID
+**
+** \sa #CFE_TBL_Unregister, #CFE_TBL_Share
+**/
+CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *        TblHandlePtr,          /* Returned Handle */
+                              const char *              Name,                  /* Application specific name  */
+                              size_t                    Size,                  /* Size, in bytes, of table   */
+                              uint16                    TblOptionFlags,        /* Tbl Options Settings     */
+                              CFE_TBL_CallbackFuncPtr_t TblValidationFuncPtr); /* Ptr to func that validates tbl */
+
+/*****************************************************************************/
+/**
+** \brief Obtain handle of table registered by another application
+**
+** \par Description
+**        After a table has been created, other applications can gain access
+**        to that table via the table handle.  In order for two or more
+**        applications to share a table, the applications that do not create
+**        the table must obtain the handle using this function.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in, out]  TblHandlePtr  A pointer to a #CFE_TBL_Handle_t type variable
+**                           that will be assigned the table's handle.  The
+**                           table handle is required for other API calls
+**                           when accessing the data contained in the table. *TblHandlePtr is the handle used to
+**                           identify table to cFE when performing Table operations.
+**                           This value is returned at the address specified by TblHandlePtr.
+**
+** \param[in]  TblName       The processor specific name of the table.  It is important to note
+**                           that the processor specific table name is different from the table
+**                           name specified in the #CFE_TBL_Register API call.  The processor
+**                           specific table name includes the name of the application that created
+**                           the table.  The name would be of the form "ApplicationName.TableName".
+**                           An example of this would be "ACS.TamParams" for a table called "TamParams"
+**                           that was registered by the application called "ACS".
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS              \copybrief CFE_SUCCESS
+** \retval #CFE_TBL_ERR_HANDLES_FULL \copybrief CFE_TBL_ERR_HANDLES_FULL
+** \retval #CFE_TBL_ERR_INVALID_NAME \copybrief CFE_TBL_ERR_INVALID_NAME
+** \retval #CFE_TBL_ERR_BAD_APP_ID   \copybrief CFE_TBL_ERR_BAD_APP_ID
+**
+** \sa #CFE_TBL_Unregister, #CFE_TBL_Register
+**
+******************************************************************************/
+CFE_Status_t CFE_TBL_Share(CFE_TBL_Handle_t *TblHandlePtr, const char *TblName);
+
+/*****************************************************************************/
+/**
+** \brief Unregister a previously registered table and free associated resources
+**
+** \par Description
+**        When an application is being removed from the system, it should
+**        unregister those tables that it created.  The application should
+**        call this function as a part of its cleanup process.  The table
+**        will be removed from memory once all table addresses referencing
+**        it have been released.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in] TblHandle Handle, previously obtained from #CFE_TBL_Register or #CFE_TBL_Share,
+**                      that identifies the Table to be unregistered.
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS                \copybrief CFE_SUCCESS
+** \retval #CFE_TBL_ERR_BAD_APP_ID     \copybrief CFE_TBL_ERR_BAD_APP_ID
+** \retval #CFE_TBL_ERR_NO_ACCESS      \copybrief CFE_TBL_ERR_NO_ACCESS
+** \retval #CFE_TBL_ERR_INVALID_HANDLE \copybrief CFE_TBL_ERR_INVALID_HANDLE
+**
+** \sa #CFE_TBL_Share, #CFE_TBL_Register
+**
+******************************************************************************/
+CFE_Status_t CFE_TBL_Unregister(CFE_TBL_Handle_t TblHandle);
+/**@}*/
+
+/** @defgroup CFEAPITBLManage cFE Manage Table Content APIs
+ * @{
+ */
+
+/*****************************************************************************/
+/**
+** \brief Load a specified table with data from specified source
+**
+** \par Description
+**        Once an application has created a table (#CFE_TBL_Register), it must
+**        provide the values that initialize the contents of that table.  The
+**        application accomplishes this with one of two different TBL API calls.
+**        This function call initializes the table with values that are held
+**        in a data structure.
+**
+** \par Assumptions, External Events, and Notes:
+**        This function call can block.  Therefore, interrupt service routines
+**        should NOT initialize their own tables.  An application should initialize
+**        any table(s) prior to providing the handle(s) to the interrupt service routine.
+**
+** \param[in] TblHandle  Handle, previously obtained from #CFE_TBL_Register or #CFE_TBL_Share, that
+**                       identifies the Table to be loaded.
+**
+** \param[in] SrcType    Flag indicating the nature of the given \c SrcDataPtr below.
+**                       This value can be any one of the following:
+**                          \arg #CFE_TBL_SRC_FILE    - \copybrief CFE_TBL_SRC_FILE
+**                          \arg #CFE_TBL_SRC_ADDRESS - \copybrief CFE_TBL_SRC_ADDRESS
+**
+** \param[in] SrcDataPtr Pointer to either a character string specifying a filename or
+**                       a memory address of a block of binary data to be loaded into a table or,
+**                       if the table was registered with the #CFE_TBL_OPT_USR_DEF_ADDR option,
+**                       the address of the active table buffer.
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS                   \copybrief CFE_SUCCESS
+** \retval #CFE_TBL_WARN_SHORT_FILE       \copybrief CFE_TBL_WARN_SHORT_FILE
+** \retval #CFE_TBL_WARN_PARTIAL_LOAD     \copybrief CFE_TBL_WARN_PARTIAL_LOAD
+** \retval #CFE_TBL_ERR_BAD_APP_ID        \copybrief CFE_TBL_ERR_BAD_APP_ID
+** \retval #CFE_TBL_ERR_NO_ACCESS         \copybrief CFE_TBL_ERR_NO_ACCESS
+** \retval #CFE_TBL_ERR_INVALID_HANDLE    \copybrief CFE_TBL_ERR_INVALID_HANDLE
+** \retval #CFE_TBL_ERR_DUMP_ONLY         \copybrief CFE_TBL_ERR_DUMP_ONLY
+** \retval #CFE_TBL_ERR_ILLEGAL_SRC_TYPE  \copybrief CFE_TBL_ERR_ILLEGAL_SRC_TYPE
+** \retval #CFE_TBL_ERR_LOAD_IN_PROGRESS  \copybrief CFE_TBL_ERR_LOAD_IN_PROGRESS
+** \retval #CFE_TBL_ERR_NO_BUFFER_AVAIL   \copybrief CFE_TBL_ERR_NO_BUFFER_AVAIL
+** \retval #CFE_TBL_ERR_FILE_NOT_FOUND    \copybrief CFE_TBL_ERR_FILE_NOT_FOUND
+** \retval #CFE_TBL_ERR_FILE_TOO_LARGE    \copybrief CFE_TBL_ERR_FILE_TOO_LARGE
+** \retval #CFE_TBL_ERR_BAD_CONTENT_ID    \copybrief CFE_TBL_ERR_BAD_CONTENT_ID
+** \retval #CFE_TBL_ERR_PARTIAL_LOAD      \copybrief CFE_TBL_ERR_PARTIAL_LOAD
+**
+** \sa #CFE_TBL_Update, #CFE_TBL_Validate, #CFE_TBL_Manage
+**
+******************************************************************************/
+CFE_Status_t CFE_TBL_Load(CFE_TBL_Handle_t TblHandle, CFE_TBL_SrcEnum_t SrcType, const void *SrcDataPtr);
+
+/*****************************************************************************/
+/**
+** \brief Update contents of a specified table, if an update is pending
+**
+** \par Description
+**        An application is \b required to perform a periodic check for an update
+**        for all the tables that it creates.  Typically, the application that
+**        created the table would call this function at the start or conclusion
+**        of any routine processing cycle or at regular intervals.  To determine
+**        whether an update is pending prior to making this call, the Application
+**        can use the #CFE_TBL_GetStatus API first.  If a table update is pending,
+**        it will take place during this function call.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in] TblHandle  Handle, previously obtained from #CFE_TBL_Register or #CFE_TBL_Share, that
+**                       identifies the Table to be updated.
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS                    \copybrief CFE_SUCCESS
+** \retval #CFE_TBL_INFO_NO_UPDATE_PENDING \copybrief CFE_TBL_INFO_NO_UPDATE_PENDING
+** \retval #CFE_TBL_ERR_BAD_APP_ID         \copybrief CFE_TBL_ERR_BAD_APP_ID
+** \retval #CFE_TBL_ERR_NO_ACCESS          \copybrief CFE_TBL_ERR_NO_ACCESS
+** \retval #CFE_TBL_ERR_INVALID_HANDLE     \copybrief CFE_TBL_ERR_INVALID_HANDLE
+**
+** \sa #CFE_TBL_Load, #CFE_TBL_Validate, #CFE_TBL_Manage
+**
+******************************************************************************/
+CFE_Status_t CFE_TBL_Update(CFE_TBL_Handle_t TblHandle);
+
+/*****************************************************************************/
+/**
+** \brief Perform steps to validate the contents of a table image.
+**
+** \par Description
+**        An application is \b required to perform a periodic check for an update
+**        or a validation request for all the tables that it creates.  Typically,
+**        the application that created the table would call this function at the
+**        start or conclusion of any routine processing cycle.  To determine whether
+**        a validation request is pending prior to making this call, the Application
+**        can use the #CFE_TBL_GetStatus API first.  If a table validation is pending,
+**        the Application would call this function to perform the necessary actions.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in] TblHandle  Handle, previously obtained from #CFE_TBL_Register or #CFE_TBL_Share, that
+**                       identifies the Table to be managed.
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS                        \copybrief CFE_SUCCESS
+** \retval #CFE_TBL_INFO_NO_VALIDATION_PENDING \copybrief CFE_TBL_INFO_NO_VALIDATION_PENDING
+** \retval #CFE_TBL_ERR_BAD_APP_ID             \copybrief CFE_TBL_ERR_BAD_APP_ID
+** \retval #CFE_TBL_ERR_NO_ACCESS              \copybrief CFE_TBL_ERR_NO_ACCESS
+** \retval #CFE_TBL_ERR_INVALID_HANDLE         \copybrief CFE_TBL_ERR_INVALID_HANDLE
+**
+** \sa #CFE_TBL_Update, #CFE_TBL_Manage, #CFE_TBL_Load
+**
+******************************************************************************/
+CFE_Status_t CFE_TBL_Validate(CFE_TBL_Handle_t TblHandle);
+
+/*****************************************************************************/
+/**
+** \brief Perform standard operations to maintain a table.
+**
+** \par Description
+**        An application is \b required to perform a periodic check for an update
+**        or a validation request for all the tables that it creates.  Typically,
+**        the application that created the table would call this function at the
+**        start or conclusion of any routine processing cycle.  If a table update
+**        or validation request is pending, this function would perform either or
+**        both before returning.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in] TblHandle  Handle, previously obtained from #CFE_TBL_Register or #CFE_TBL_Share, that
+**                       identifies the Table to be managed.
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS                \copybrief CFE_SUCCESS
+** \retval #CFE_TBL_INFO_UPDATED       \copybrief CFE_TBL_INFO_UPDATED
+** \retval #CFE_TBL_ERR_BAD_APP_ID     \copybrief CFE_TBL_ERR_BAD_APP_ID
+** \retval #CFE_TBL_ERR_NO_ACCESS      \copybrief CFE_TBL_ERR_NO_ACCESS
+** \retval #CFE_TBL_ERR_INVALID_HANDLE \copybrief CFE_TBL_ERR_INVALID_HANDLE
+**
+** \sa #CFE_TBL_Update, #CFE_TBL_Validate, #CFE_TBL_Load, #CFE_TBL_DumpToBuffer
+**
+******************************************************************************/
+CFE_Status_t CFE_TBL_Manage(CFE_TBL_Handle_t TblHandle);
+
+/*****************************************************************************/
+/**
+** \brief Copies the contents of a Dump Only Table to a shared buffer
+**
+** \par Description
+**        Copies contents of a Dump Only table to a shared buffer so that it
+**        can be written to a file by the Table Services routine.  This function
+**        is called by the Application that owns the table in response to a #CFE_TBL_INFO_DUMP_PENDING
+**        status obtained via #CFE_TBL_GetStatus.
+**
+** \par Assumptions, External Events, and Notes:
+**        -# If the table does not have a dump pending status, nothing will occur (no error, no dump)
+**        -# Applications may wish to use this function in lieu of #CFE_TBL_Manage for their Dump Only tables
+**
+** \param[in]  TblHandle      Handle of Table to be dumped.
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS                \copybrief CFE_SUCCESS
+** \retval #CFE_TBL_ERR_BAD_APP_ID     \copybrief CFE_TBL_ERR_BAD_APP_ID
+** \retval #CFE_TBL_ERR_NO_ACCESS      \copybrief CFE_TBL_ERR_NO_ACCESS
+** \retval #CFE_TBL_ERR_INVALID_HANDLE \copybrief CFE_TBL_ERR_INVALID_HANDLE
+**
+** \sa #CFE_TBL_Manage
+**
+******************************************************************************/
+CFE_Status_t CFE_TBL_DumpToBuffer(CFE_TBL_Handle_t TblHandle);
+
+/*****************************************************************************/
+/**
+** \brief Notify cFE Table Services that table contents have been modified by the Application
+**
+** \par Description
+**        This API notifies Table Services that the contents of the specified table has been
+**        modified by the Application.  This notification is important when a table has been
+**        registered as "Critical" because Table Services can then update the contents of the
+**        table kept in the Critical Data Store.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \param[in]  TblHandle      Handle of Table that was modified.
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS                \copybrief CFE_SUCCESS
+** \retval #CFE_TBL_ERR_BAD_APP_ID     \copybrief CFE_TBL_ERR_BAD_APP_ID
+** \retval #CFE_TBL_ERR_NO_ACCESS      \copybrief CFE_TBL_ERR_NO_ACCESS
+** \retval #CFE_TBL_ERR_INVALID_HANDLE \copybrief CFE_TBL_ERR_INVALID_HANDLE
+**
+** \sa #CFE_TBL_Manage
+**
+******************************************************************************/
+CFE_Status_t CFE_TBL_Modified(CFE_TBL_Handle_t TblHandle);
+/**@}*/
+
+/** @defgroup CFEAPITBLAccess cFE Access Table Content APIs
+ * @{
+ */
+
+/*****************************************************************************/
+/**
+** \brief Obtain the current address of the contents of the specified table
+**
+** \par Description
+**        When a table has been created and initialized, it is available to
+**        any application that can identify it with its unique handle.  In
+**        order to view the data contained in the table, an application must
+**        call this function or #CFE_TBL_GetAddresses.
+**
+** \par Assumptions, External Events, and Notes:
+**        -# This call can be a blocking call when the table is not double buffered
+**           and is shared with another application of lower priority that just happens
+**           to be in the middle of a table update of the specific table.  If this occurs,
+**           the application performing the table update will automatically have its
+**           priority elevated in order to release the resource as soon as possible.
+**        -# An application must always release the returned table address using the
+**           #CFE_TBL_ReleaseAddress or #CFE_TBL_ReleaseAddresses function prior to
+**           either a #CFE_TBL_Update call or any blocking call (e.g. - pending on software
+**           bus message, etc).  Table updates cannot occur while table addresses have not
+**           been released.
+**        -# #CFE_TBL_ERR_NEVER_LOADED will be returned if the table has never been
+**           loaded (either from file or from a block of memory), but the function
+**           will still return a valid table pointer to a table with all zero content.
+**           This pointer mush be released with the #CFE_TBL_ReleaseAddress API before
+**           the table can be loaded with data.
+**
+** \param[in, out]  TblPtr     The address of a pointer that will be loaded with the address of
+**                        the first byte of the table.  This pointer can then be typecast
+**                        by the calling application to the appropriate table data structure. *TblPtr is the address of
+**                        the first byte of data associated with the specified table.
+**
+** \param[in]  TblHandle  Handle, previously obtained from #CFE_TBL_Register or #CFE_TBL_Share, that
+**                        identifies the Table whose address is to be returned.
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS                \copybrief CFE_SUCCESS
+** \retval #CFE_TBL_INFO_UPDATED       \copybrief CFE_TBL_INFO_UPDATED
+** \retval #CFE_TBL_ERR_BAD_APP_ID     \copybrief CFE_TBL_ERR_BAD_APP_ID
+** \retval #CFE_TBL_ERR_NO_ACCESS      \copybrief CFE_TBL_ERR_NO_ACCESS
+** \retval #CFE_TBL_ERR_INVALID_HANDLE \copybrief CFE_TBL_ERR_INVALID_HANDLE
+** \retval #CFE_TBL_ERR_UNREGISTERED   \copybrief CFE_TBL_ERR_UNREGISTERED
+** \retval #CFE_TBL_ERR_NEVER_LOADED   \copybrief CFE_TBL_ERR_NEVER_LOADED
+**
+** \sa #CFE_TBL_ReleaseAddress, #CFE_TBL_GetAddresses, #CFE_TBL_ReleaseAddresses
+**
+******************************************************************************/
+CFE_Status_t CFE_TBL_GetAddress(void **TblPtr, CFE_TBL_Handle_t TblHandle);
+
+/*****************************************************************************/
+/**
+** \brief Release previously obtained pointer to the contents of the specified table
+**
+** \par Description
+**        Each application is \b required to release a table address obtained through
+**        the #CFE_TBL_GetAddress function.
+**
+** \par Assumptions, External Events, and Notes:
+**        An application must always release the returned table address using the
+**        #CFE_TBL_ReleaseAddress function prior to either a #CFE_TBL_Update call
+**        or any blocking call (e.g. - pending on software bus message, etc).
+**        Table updates cannot occur while table addresses have not been released.
+**
+** \param[in] TblHandle  Handle, previously obtained from #CFE_TBL_Register or #CFE_TBL_Share, that
+**                       identifies the Table whose address is to be released.
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS                \copybrief CFE_SUCCESS
+** \retval #CFE_TBL_INFO_UPDATED       \copybrief CFE_TBL_INFO_UPDATED
+** \retval #CFE_TBL_ERR_BAD_APP_ID     \copybrief CFE_TBL_ERR_BAD_APP_ID
+** \retval #CFE_TBL_ERR_NO_ACCESS      \copybrief CFE_TBL_ERR_NO_ACCESS
+** \retval #CFE_TBL_ERR_INVALID_HANDLE \copybrief CFE_TBL_ERR_INVALID_HANDLE
+** \retval #CFE_TBL_ERR_NEVER_LOADED   \copybrief CFE_TBL_ERR_NEVER_LOADED
+**
+** \sa #CFE_TBL_GetAddress, #CFE_TBL_GetAddresses, #CFE_TBL_ReleaseAddresses
+**
+******************************************************************************/
+CFE_Status_t CFE_TBL_ReleaseAddress(CFE_TBL_Handle_t TblHandle);
+
+/*****************************************************************************/
+/**
+** \brief Obtain the current addresses of an array of specified tables
+**
+** \par Description
+**        When a table has been created and initialized, it is available to
+**        any application that can identify it with its unique handle.  In
+**        order to view the data contained in the table, an application must
+**        call this function or #CFE_TBL_GetAddresses.
+**
+** \par Assumptions, External Events, and Notes:
+**        -# This call can be a blocking call when the table is not double buffered
+**           and is shared with another application of lower priority that just happens
+**           to be in the middle of a table update of the specific table.  If this occurs,
+**           the application performing the table update will automatically have its
+**           priority elevated in order to release the resource as soon as possible.
+**        -# An application must always release the returned table address using the
+**           #CFE_TBL_ReleaseAddress or #CFE_TBL_ReleaseAddresses function prior to
+**           either a #CFE_TBL_Update call or any blocking call (e.g. - pending on software
+**           bus message, etc).  Table updates cannot occur while table addresses have not
+**           been released.
+**        -# #CFE_TBL_ERR_NEVER_LOADED will be returned if the table has never been
+**           loaded (either from file or from a block of memory), but the function
+**           will still return a valid table pointer to a table with all zero content.
+**           This pointer mush be released with the #CFE_TBL_ReleaseAddress API before
+**           the table can be loaded with data.
+**
+** \param[in, out] TblPtrs    Array of Pointers to variables that calling Application
+**                       wishes to hold the start addresses of the Tables. *TblPtrs is an array of addresses of the
+**                       first byte of data associated with the specified tables.
+**
+** \param[in] NumTables  Size of TblPtrs and TblHandles arrays.
+**
+** \param[in] TblHandles Array of Table Handles, previously obtained from #CFE_TBL_Register or #CFE_TBL_Share,
+**                       of those tables whose start addresses are to be obtained.
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS                \copybrief CFE_SUCCESS
+** \retval #CFE_TBL_INFO_UPDATED       \copybrief CFE_TBL_INFO_UPDATED
+** \retval #CFE_TBL_ERR_BAD_APP_ID     \copybrief CFE_TBL_ERR_BAD_APP_ID
+** \retval #CFE_TBL_ERR_NO_ACCESS      \copybrief CFE_TBL_ERR_NO_ACCESS
+** \retval #CFE_TBL_ERR_INVALID_HANDLE \copybrief CFE_TBL_ERR_INVALID_HANDLE
+** \retval #CFE_TBL_ERR_UNREGISTERED   \copybrief CFE_TBL_ERR_UNREGISTERED
+** \retval #CFE_TBL_ERR_NEVER_LOADED   \copybrief CFE_TBL_ERR_NEVER_LOADED
+**
+** \sa #CFE_TBL_GetAddress, #CFE_TBL_ReleaseAddress, #CFE_TBL_ReleaseAddresses
+**
+******************************************************************************/
+CFE_Status_t CFE_TBL_GetAddresses(void **TblPtrs[], uint16 NumTables, const CFE_TBL_Handle_t TblHandles[]);
+
+/*****************************************************************************/
+/**
+** \brief Release the addresses of an array of specified tables
+**
+** \par Description
+**        Each application is \b required to release a table address obtained through
+**        the #CFE_TBL_GetAddress function.
+**
+** \par Assumptions, External Events, and Notes:
+**        An application must always release the returned table address using the
+**        #CFE_TBL_ReleaseAddress function prior to either a #CFE_TBL_Update call
+**        or any blocking call (e.g. - pending on software bus message, etc).
+**        Table updates cannot occur while table addresses have not been released.
+**
+** \param[in] NumTables  Size of TblHandles array.
+**
+** \param[in] TblHandles Array of Table Handles, previously obtained from #CFE_TBL_Register or #CFE_TBL_Share,
+**                       of those tables whose start addresses are to be released.
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS                \copybrief CFE_SUCCESS
+** \retval #CFE_TBL_INFO_UPDATED       \copybrief CFE_TBL_INFO_UPDATED
+** \retval #CFE_TBL_ERR_BAD_APP_ID     \copybrief CFE_TBL_ERR_BAD_APP_ID
+** \retval #CFE_TBL_ERR_NO_ACCESS      \copybrief CFE_TBL_ERR_NO_ACCESS
+** \retval #CFE_TBL_ERR_INVALID_HANDLE \copybrief CFE_TBL_ERR_INVALID_HANDLE
+** \retval #CFE_TBL_ERR_NEVER_LOADED   \copybrief CFE_TBL_ERR_NEVER_LOADED
+**
+** \sa #CFE_TBL_GetAddress, #CFE_TBL_ReleaseAddress, #CFE_TBL_GetAddresses
+**
+******************************************************************************/
+CFE_Status_t CFE_TBL_ReleaseAddresses(uint16 NumTables, const CFE_TBL_Handle_t TblHandles[]);
+/**@}*/
+
+/** @defgroup CFEAPITBLInfo cFE Get Table Information APIs
+ * @{
+ */
+
+/*****************************************************************************/
+/**
+** \brief Obtain current status of pending actions for a table.
+**
+** \par Description
+**        An application is \b required to perform a periodic check for an update
+**        or a validation request for all the tables that it creates.  Typically,
+**        the application that created the table would call this function at the
+**        start or conclusion of any routine processing cycle.  If a table update
+**        or validation request is pending, the Application should follow up with
+**        a call to #CFE_TBL_Update or #CFE_TBL_Validate respectively.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in] TblHandle  Handle, previously obtained from #CFE_TBL_Register or #CFE_TBL_Share, that
+**                       identifies the Table to be managed.
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS                     \copybrief CFE_SUCCESS
+** \retval #CFE_TBL_INFO_UPDATE_PENDING     \copybrief CFE_TBL_INFO_UPDATE_PENDING
+** \retval #CFE_TBL_INFO_VALIDATION_PENDING \copybrief CFE_TBL_INFO_VALIDATION_PENDING
+** \retval #CFE_TBL_INFO_DUMP_PENDING       \copybrief CFE_TBL_INFO_DUMP_PENDING
+** \retval #CFE_TBL_ERR_BAD_APP_ID          \copybrief CFE_TBL_ERR_BAD_APP_ID
+** \retval #CFE_TBL_ERR_NO_ACCESS           \copybrief CFE_TBL_ERR_NO_ACCESS
+** \retval #CFE_TBL_ERR_INVALID_HANDLE      \copybrief CFE_TBL_ERR_INVALID_HANDLE
+**
+** \note Some status return codes are "success" while being non-zero. This
+**       behavior will change in the future.
+**
+** \sa #CFE_TBL_Manage, #CFE_TBL_Update, #CFE_TBL_Validate, #CFE_TBL_GetInfo
+**
+******************************************************************************/
+CFE_Status_t CFE_TBL_GetStatus(CFE_TBL_Handle_t TblHandle);
+
+/*****************************************************************************/
+/**
+** \brief Obtain characteristics/information of/about a specified table.
+**
+** \par Description
+**        This API provides the registry information associated with the specified
+**        table.  The function fills the given data structure with the data found
+**        in the Table Registry.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in, out]  TblInfoPtr    A pointer to a CFE_TBL_Info_t data structure that is to be populated
+**                           with table characteristics and information. *TblInfoPtr is the description of the tables
+**                           characteristics and registry information stored in the #CFE_TBL_Info_t data structure
+**                           format.
+**
+** \param[in]  TblName       The processor specific name of the table.  It is important to note
+**                           that the processor specific table name is different from the table
+**                           name specified in the #CFE_TBL_Register API call.  The processor
+**                           specific table name includes the name of the application that created
+**                           the table.  The name would be of the form "ApplicationName.TableName".
+**                           An example of this would be "ACS.TamParams" for a table called "TamParams"
+**                           that was registered by the application called "ACS".
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS              \copybrief CFE_SUCCESS
+** \retval #CFE_TBL_ERR_INVALID_NAME \copybrief CFE_TBL_ERR_INVALID_NAME
+**
+** \sa #CFE_TBL_GetStatus
+**
+******************************************************************************/
+CFE_Status_t CFE_TBL_GetInfo(CFE_TBL_Info_t *TblInfoPtr, const char *TblName);
+
+/*****************************************************************************/
+/**
+** \brief Instruct cFE Table Services to notify Application via message when table requires management
+**
+** \par Description
+**        This API instructs Table Services to send a message to the calling Application
+**        whenever the specified table requires management by the application.  This feature
+**        allows applications to avoid polling table services via the #CFE_TBL_Manage call
+**        to determine whether a table requires updates, validation, etc.  This API should
+**        be called following the #CFE_TBL_Register API whenever the owning application requires
+**        this feature.
+**
+** \par Assumptions, External Events, and Notes:
+**        - Only the application that owns the table is allowed to register a notification message
+**        - Recommend \b NOT using the ground command MID which typically impacts command counters.
+**          The typical approach is to use a unique MID for inter-task communications
+**          similar to how schedulers typically trigger application housekeeping messages.
+**
+** \param[in]  TblHandle      Handle of Table with which the message should be associated.
+**
+** \param[in]  MsgId          Message ID to be used in notification message sent by Table Services.
+**
+** \param[in]  CommandCode    Command Code value to be placed in secondary header of message
+**                            sent by Table Services.
+**
+** \param[in]  Parameter      Application defined value to be passed as a parameter in the
+**                            message sent by Table Services.  Suggested use includes an application's
+**                            table index that allows the same MsgId and Command Code to be used for
+**                            all table management notifications.
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS                \copybrief CFE_SUCCESS
+** \retval #CFE_TBL_ERR_BAD_APP_ID     \copybrief CFE_TBL_ERR_BAD_APP_ID
+** \retval #CFE_TBL_ERR_NO_ACCESS      \copybrief CFE_TBL_ERR_NO_ACCESS
+** \retval #CFE_TBL_ERR_INVALID_HANDLE \copybrief CFE_TBL_ERR_INVALID_HANDLE
+**
+** \sa #CFE_TBL_Register
+**
+******************************************************************************/
+CFE_Status_t CFE_TBL_NotifyByMessage(CFE_TBL_Handle_t TblHandle, CFE_SB_MsgId_t MsgId, CFE_MSG_FcnCode_t CommandCode,
+                                     uint32 Parameter);
+/**@}*/
+
+#endif /* CFE_TBL_H */

--- a/modules/core_api/fsw/inc/cfe_tbl_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_tbl_api_typedefs.h
@@ -1,0 +1,126 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * @file
+ *
+ *  Title:   Table Services API Application Library Header File
+ *
+ *  Purpose:
+ *     Unit specification for Table services library functions and macros.
+ *
+ *  Design Notes:
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *
+ *  Notes:
+ *
+ */
+
+#ifndef CFE_TBL_API_TYPEDEFS_H
+#define CFE_TBL_API_TYPEDEFS_H
+
+/********************* Include Files  ************************/
+#include "common_types.h" /* Basic Data Types */
+#include "cfe_tbl_extern_typedefs.h"
+#include "cfe_time_extern_typedefs.h"
+
+/** @defgroup CFETBLTypeOptions cFE Table Type Defines
+ * @{
+ */
+#define CFE_TBL_OPT_BUFFER_MSK  (0x0001) /**< \brief Table buffer mask */
+#define CFE_TBL_OPT_SNGL_BUFFER (0x0000) /**< \brief Single buffer table */
+#define CFE_TBL_OPT_DBL_BUFFER  (0x0001) /**< \brief Double buffer table */
+
+#define CFE_TBL_OPT_LD_DMP_MSK (0x0002) /**< \brief Table load/dump mask */
+#define CFE_TBL_OPT_LOAD_DUMP  (0x0000) /**< \brief Load/Dump table */
+#define CFE_TBL_OPT_DUMP_ONLY  (0x0002) /**< \brief Dump only table */
+
+#define CFE_TBL_OPT_USR_DEF_MSK (0x0004) /**< \brief Table user defined mask */
+#define CFE_TBL_OPT_NOT_USR_DEF (0x0000) /**< \brief Not user defined table */
+#define CFE_TBL_OPT_USR_DEF_ADDR \
+    (0x0006) /**< \brief User Defined table, @note Automatically includes #CFE_TBL_OPT_DUMP_ONLY option */
+
+#define CFE_TBL_OPT_CRITICAL_MSK (0x0008) /**< \brief Table critical mask */
+#define CFE_TBL_OPT_NOT_CRITICAL (0x0000) /**< \brief Not critical table */
+#define CFE_TBL_OPT_CRITICAL     (0x0008) /**< \brief Critical table */
+
+/** @brief Default table options */
+#define CFE_TBL_OPT_DEFAULT (CFE_TBL_OPT_SNGL_BUFFER | CFE_TBL_OPT_LOAD_DUMP)
+/**@}*/
+
+/**
+ * \brief Table maximum full name length
+ *
+ * The full length of table names is defined at the mission scope.
+ * This is defined here to support applications that depend on cfe_tbl.h
+ * providing this value.
+ */
+#define CFE_TBL_MAX_FULL_NAME_LEN (CFE_MISSION_TBL_MAX_FULL_NAME_LEN)
+
+/** \brief Bad table handle */
+#define CFE_TBL_BAD_TABLE_HANDLE (CFE_TBL_Handle_t)0xFFFF
+
+/******************  Data Type Definitions *********************/
+
+/** \brief Table Callback Function */
+typedef int32 (*CFE_TBL_CallbackFuncPtr_t)(void *TblPtr);
+
+/** \brief Table Handle primitive */
+typedef int16 CFE_TBL_Handle_t;
+
+/** \brief Table Source */
+typedef enum CFE_TBL_SrcEnum
+{
+    CFE_TBL_SRC_FILE = 0, /**< \brief File source
+                               When this option is selected, the \c SrcDataPtr
+                               will be interpreted as a pointer to a null
+                               terminated character string.  The string should
+                               specify the full path and filename of the file
+                               containing the initial data contents of the table. */
+    CFE_TBL_SRC_ADDRESS   /**< \brief Address source
+                               When this option is selected, the \c SrcDataPtr will
+                               be interpreted as a pointer to a memory location
+                               that is the beginning of the initialization data
+                               for loading the table OR, in the case of a "user defined"
+                               dump only table, the address of the active table itself.
+                               The block of memory is assumed to be of the same size
+                               specified in the #CFE_TBL_Register function Size parameter. */
+} CFE_TBL_SrcEnum_t;
+
+/** \brief Table Info */
+typedef struct CFE_TBL_Info
+{
+    size_t             Size;                  /**< \brief Size, in bytes, of Table */
+    uint32             NumUsers;              /**< \brief Number of Apps with access to the table */
+    uint32             FileCreateTimeSecs;    /**< \brief File creation time from last file loaded into table */
+    uint32             FileCreateTimeSubSecs; /**< \brief File creation time from last file loaded into table */
+    uint32             Crc;              /**< \brief Most recently calculated CRC by TBL services on table contents */
+    CFE_TIME_SysTime_t TimeOfLastUpdate; /**< \brief Time when Table was last updated */
+    bool               TableLoadedOnce;  /**< \brief Flag indicating whether table has been loaded once or not */
+    bool               DumpOnly;         /**< \brief Flag indicating Table is NOT to be loaded */
+    bool               DoubleBuffered;   /**< \brief Flag indicating Table has a dedicated inactive buffer */
+    bool               UserDefAddr;      /**< \brief Flag indicating Table address was defined by Owner Application */
+    bool               Critical;         /**< \brief Flag indicating Table contents are maintained in a CDS */
+    char               LastFileLoaded[CFE_MISSION_MAX_PATH_LEN]; /**< \brief Filename of last file loaded into table */
+} CFE_TBL_Info_t;
+
+#endif /* CFE_TBL_API_TYPEDEFS_H */

--- a/modules/core_api/fsw/inc/cfe_tbl_core_internal.h
+++ b/modules/core_api/fsw/inc/cfe_tbl_core_internal.h
@@ -1,0 +1,100 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * @file
+ *
+ *  Title:   Table Services API Application Library Header File
+ *
+ *  Purpose:
+ *     Unit specification for Table services library functions and macros.
+ *
+ *  Design Notes:
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *
+ *  Notes:
+ *
+ */
+
+#ifndef CFE_TBL_CORE_INTERNAL_H
+#define CFE_TBL_CORE_INTERNAL_H
+
+#include "common_types.h"
+#include "cfe_es_extern_typedefs.h"
+
+/*
+ * The internal APIs prototyped within this block are only intended to be invoked from
+ * other CFE core apps.  They still need to be prototyped in the shared header such that
+ * they can be called from other core modules, but applications should not call these.
+ */
+
+/** @defgroup CFEAPITBLCoreInternal cFE Internal Table Service APIs, internal to CFE core
+ * @{
+ */
+
+/*****************************************************************************/
+/**
+** \brief Entry Point for cFE Table Services Core Application
+**
+** \par Description
+**        This is the entry point to the cFE Table Services Core Application.
+**        This Application provides the ground interface to the cFE Table
+**        Services.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+******************************************************************************/
+extern void CFE_TBL_TaskMain(void);
+
+/*****************************************************************************/
+/**
+** \brief Initializes the Table Services API Library
+**
+** \par Description
+**        Initializes the Table Services API Library
+**
+** \par Assumptions, External Events, and Notes:
+**        -# This function MUST be called before any TBL API's are called.
+**
+******************************************************************************/
+extern int32 CFE_TBL_EarlyInit(void);
+
+/*****************************************************************************/
+/**
+** \brief Removes TBL resources associated with specified Application
+**
+** \par Description
+**        This function is called by cFE Executive Services to cleanup after
+**        an Application has been terminated.  It frees TBL services resources
+**        that have been allocated to the specified Application.
+**
+** \par Assumptions, External Events, and Notes:
+**        -# This function DOES NOT remove any critical tables associated with
+**           the specified application from the Critical Data Store.
+**
+******************************************************************************/
+extern int32 CFE_TBL_CleanUpApp(CFE_ES_AppId_t AppId);
+
+/**@}*/
+
+#endif /* CFE_TBL_CORE_INTERNAL_H */

--- a/modules/core_api/fsw/inc/cfe_tbl_extern_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_tbl_extern_typedefs.h
@@ -1,0 +1,83 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * @file
+ *
+ * Declarations and prototypes for cfe_tbl_extern_typedefs module
+ */
+
+#ifndef CFE_TBL_EXTERN_TYPEDEFS_H
+#define CFE_TBL_EXTERN_TYPEDEFS_H
+
+/* This header may be generated from an EDS file,
+ * tools are available and the feature is enabled */
+#ifdef CFE_EDS_ENABLED_BUILD
+
+/* Use the EDS generated version of these types */
+#include "cfe_tbl_eds_typedefs.h"
+
+#else
+/* Use the local definitions of these types */
+
+#include "common_types.h"
+#include "cfe_es_extern_typedefs.h"
+#include "cfe_mission_cfg.h" /* for CFE_MISSION_TBL_MAX_FULL_NAME_LEN */
+
+/**
+ * @brief Label definitions associated with CFE_TBL_BufferSelect_Enum_t
+ */
+enum CFE_TBL_BufferSelect
+{
+
+    /**
+     * @brief Select the Inactive buffer for validate or dump
+     */
+    CFE_TBL_BufferSelect_INACTIVE = 0,
+
+    /**
+     * @brief Select the Active buffer for validate or dump
+     */
+    CFE_TBL_BufferSelect_ACTIVE = 1
+};
+
+/**
+ * @brief Selects the buffer to operate on for validate or dump commands
+ *
+ * @sa enum CFE_TBL_BufferSelect
+ */
+typedef uint16 CFE_TBL_BufferSelect_Enum_t;
+
+/**
+ * @brief The definition of the header fields that are included in CFE Table Data files.
+ *
+ * This header follows the CFE_FS header and precedes the the actual table data.
+ */
+typedef struct CFE_TBL_File_Hdr
+{
+    uint32             Reserved;                                     /**< Future Use: NumTblSegments in File?   */
+    CFE_ES_MemOffset_t Offset;                                       /**< Byte Offset at which load should commence */
+    CFE_ES_MemOffset_t NumBytes;                                     /**< Number of bytes to load into table */
+    char               TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< Fully qualified name of table to load */
+} CFE_TBL_File_Hdr_t;
+
+#endif /* CFE_EDS_ENABLED_BUILD */
+
+#endif /* CFE_TBL_EXTERN_TYPEDEFS_H */

--- a/modules/core_api/fsw/inc/cfe_tbl_filedef.h
+++ b/modules/core_api/fsw/inc/cfe_tbl_filedef.h
@@ -1,0 +1,103 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * @file
+ *
+ *  Title:   ELF2CFETBL Utility Header File for Table Images
+ *
+ *  Purpose:
+ *     This header file provides a data structure definition and macro definition
+ *     required in source code that is intended to be compiled into a cFE compatible
+ *     Table Image file.
+ *
+ *  Design Notes:
+ *
+ *     Typically, a user would include this file in a ".c" file that contains nothing
+ *     but a desired instantiation of values for a table image along with the macro
+ *     defined below.  After compilation, the resultant elf file can be processed using
+ *     the 'elf2cfetbl' utility to generate a file that can be loaded onto a cFE flight
+ *     system and successfully loaded into a table using the cFE Table Services.
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *
+ *  Notes:
+ *
+ */
+
+#ifndef CFE_TBL_FILEDEF_H
+#define CFE_TBL_FILEDEF_H
+
+#include "cfe_mission_cfg.h"
+#include "common_types.h"
+#include "cfe_tbl_extern_typedefs.h" /* for "CFE_TBL_FileHdr_t" definition */
+#include "cfe_fs_extern_typedefs.h"  /* for "CFE_FS_HDR_DESC_MAX_LEN" definition */
+
+/*
+ * The definition of the file definition metadata that can be used by
+ * external tools (e.g. elf2cfetbl) to generate CFE table data files.
+ */
+typedef struct CFE_TBL_FileDef
+{
+    char ObjectName[64]; /**< \brief Name of instantiated variable that contains desired table image */
+    char TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \brief Name of Table as defined onboard */
+    char Description[CFE_FS_HDR_DESC_MAX_LEN];  /**< \brief Description of table image that is included in cFE File
+                                                   Header */
+    char TgtFilename[CFE_MISSION_MAX_FILE_LEN]; /**< \brief Default filename to be used for output of elf2cfetbl utility
+                                                 */
+    uint32 ObjectSize;                          /**< \brief Size, in bytes, of instantiated object */
+} CFE_TBL_FileDef_t;
+
+/** The CFE_TBL_FILEDEF macro can be used to simplify the declaration of a table image when using the elf2cfetbl
+utility.
+**
+**  Note that the macro adds a NULL at the end to ensure that it is null-terminated. (C allows
+**  a struct to be statically initialized with a string exactly the length of the array, which
+**  loses the null terminator.) This means the actual length limit of the fields are the above
+**  LEN - 1.
+**
+**  An example of the source code and how this macro would be used is as follows:
+\code
+
+    #include "cfe_tbl_filedef.h"
+
+   typedef struct MyTblStruct
+   {
+       int     Int1;
+       int     Int2;
+       int     Int3;
+       char    Char1;
+   } MyTblStruct_t;
+
+   MyTblStruct_t MyTblStruct = { 0x01020304, 0x05060708, 0x090A0B0C, 0x0D };
+
+   CFE_TBL_FILEDEF(MyTblStruct, MyApp.TableName, Table Utility Test Table, MyTblDefault.bin )
+
+\endcode
+*/
+
+#define CFE_TBL_FILEDEF(ObjName, TblName, Desc, Filename)                                                         \
+    static OS_USED CFE_TBL_FileDef_t CFE_TBL_FileDef = {#ObjName "\0", #TblName "\0", #Desc "\0", #Filename "\0", \
+                                                        sizeof(ObjName)};
+
+/*************************************************************************/
+
+#endif /* CFE_TBL_FILEDEF_H */

--- a/modules/core_api/fsw/inc/cfe_time.h
+++ b/modules/core_api/fsw/inc/cfe_time.h
@@ -1,0 +1,722 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * @file
+ *
+ * Purpose:  cFE Time Services (TIME) library API header file
+ *
+ * Author:   S.Walling/Microtel
+ *
+ * Notes:
+ *
+ */
+
+#ifndef CFE_TIME_H
+#define CFE_TIME_H
+
+/*
+** Includes
+*/
+#include "common_types.h"
+#include "cfe_error.h"
+#include "cfe_time_api_typedefs.h"
+#include "cfe_es_api_typedefs.h"
+
+/**
+** \brief Time Copy
+**
+** Macro to copy systime into another systime.
+** Preferred to use this macro as it does not require the two arguments to be exactly the same type,
+** it will work with any two structures that define "Seconds" and "Subseconds" members.
+*/
+#define CFE_TIME_Copy(m, t)                \
+    {                                      \
+        (m)->Seconds    = (t)->Seconds;    \
+        (m)->Subseconds = (t)->Subseconds; \
+    }
+
+/*****************************************************************************/
+/*
+** Exported Functions
+*/
+
+/** @defgroup CFEAPITIMEGetCurrent cFE Get Current Time APIs
+ * @{
+ */
+
+/*****************************************************************************/
+/**
+** \brief Get the current spacecraft time
+**
+** \par Description
+**        This routine returns the current spacecraft time.  The time returned
+**        is either TAI (no leap seconds) or UTC (including leap seconds).  This choice
+**        is made in the mission configuration file by defining either #CFE_MISSION_TIME_CFG_DEFAULT_TAI
+**        or #CFE_MISSION_TIME_CFG_DEFAULT_UTC as true at compile time.  To maintain re-usability
+**        across missions, most applications should be using this function
+**        (or #CFE_TIME_GetTime) rather than the specific routines for getting UTC/TAI directly.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \return The current spacecraft time in default format
+**
+** \sa #CFE_TIME_GetTAI, #CFE_TIME_GetUTC, #CFE_TIME_GetMET,
+**     #CFE_TIME_GetMETseconds, #CFE_TIME_GetMETsubsecs
+**
+******************************************************************************/
+CFE_TIME_SysTime_t CFE_TIME_GetTime(void);
+
+/*****************************************************************************/
+/**
+** \brief Get the current TAI (MET + SCTF) time
+**
+** \par Description
+**        This routine returns the current TAI time to the caller.  TAI is an
+**        international time standard that does not include leap seconds.
+**        This routine should only be used in situations where TAI is absolutely
+**        required.  Applications that call #CFE_TIME_GetTAI may not be portable
+**        to all missions.  Maintenance of correct TAI in flight is not guaranteed
+**        under all mission operations scenarios.  To maintain re-usability across
+**        missions, most applications should be using #CFE_TIME_GetTime, rather
+**        than the specific routines for getting UTC/TAI directly.
+**
+** \par Assumptions, External Events, and Notes:
+**          -# The "TAI" time returned is referenced to the mission-defined time epoch,
+**             which may or may not be the same as the standard TAI epoch.
+**          -# Even though TAI does not include leap seconds, the time returned by this
+**             function can still jump forward or backward without warning when the
+**             spacecraft clock is set or adjusted by operators.  Applications using
+**             this function must be able to handle these time discontinuities gracefully.
+**
+** \return The current spacecraft time in TAI
+**
+** \sa #CFE_TIME_GetTime, #CFE_TIME_GetUTC, #CFE_TIME_GetMET,
+**     #CFE_TIME_GetMETseconds, #CFE_TIME_GetMETsubsecs
+**
+******************************************************************************/
+CFE_TIME_SysTime_t CFE_TIME_GetTAI(void);
+
+/*****************************************************************************/
+/**
+** \brief Get the current UTC (MET + SCTF - Leap Seconds) time
+**
+** \par Description
+**        This routine returns the current UTC time to the caller.  This routine
+**        should only be used in situations where UTC is absolutely required.
+**        Applications that call #CFE_TIME_GetUTC may not be portable to all
+**        missions.  Maintenance of correct UTC in flight is not guaranteed under
+**        all mission operations scenarios.  If UTC is maintained in flight, it will
+**        jump backwards occasionally due to leap second adjustments.  To maintain
+**        re-usability across missions, most applications should be using
+**        #CFE_TIME_GetTime, rather than the specific routines for getting
+**        UTC/TAI directly.
+**
+** \par Assumptions, External Events, and Notes:
+**          Note: The "UTC" time returned is referenced to the mission-defined time epoch,
+**                which may or may not be the same as the standard UTC epoch.
+**
+** \return The current spacecraft time in UTC
+**
+** \sa #CFE_TIME_GetTime, #CFE_TIME_GetTAI, #CFE_TIME_GetMET,
+**     #CFE_TIME_GetMETseconds, #CFE_TIME_GetMETsubsecs
+**
+******************************************************************************/
+CFE_TIME_SysTime_t CFE_TIME_GetUTC(void);
+
+/*****************************************************************************/
+/**
+** \brief Get the current value of the Mission Elapsed Time (MET).
+**
+** \par Description
+**        This routine returns the current mission-elapsed time (MET).  MET is
+**        usually derived from a hardware-based clock that is not adjusted
+**        during normal operations.  Callers of this routine should not assume
+**        that the MET return value has any specific relationship to any
+**        ground-based time standard.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \return The current MET
+**
+** \sa #CFE_TIME_GetTime, #CFE_TIME_GetTAI, #CFE_TIME_GetUTC,
+**     #CFE_TIME_GetMETseconds, #CFE_TIME_GetMETsubsecs, #CFE_TIME_MET2SCTime
+**
+******************************************************************************/
+CFE_TIME_SysTime_t CFE_TIME_GetMET(void);
+
+/*****************************************************************************/
+/**
+** \brief Get the current seconds count of the mission-elapsed time.
+**
+** \par Description
+**        This routine is the same as #CFE_TIME_GetMET, except that it
+**        returns only the integer seconds portion of the MET time.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \return The current MET seconds
+**
+** \sa #CFE_TIME_GetTime, #CFE_TIME_GetTAI, #CFE_TIME_GetUTC, #CFE_TIME_GetMET,
+**     #CFE_TIME_GetMETsubsecs, #CFE_TIME_MET2SCTime
+**
+******************************************************************************/
+uint32 CFE_TIME_GetMETseconds(void);
+
+/*****************************************************************************/
+/**
+** \brief Get the current sub-seconds count of the mission-elapsed time.
+**
+** \par Description
+**        This routine is the same as #CFE_TIME_GetMET, except that it
+**        returns only the integer sub-seconds portion of the MET time.
+**        Each count is equal to 2^(-32) seconds.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \return The current MET sub-seconds
+**
+** \sa #CFE_TIME_GetTime, #CFE_TIME_GetTAI, #CFE_TIME_GetUTC, #CFE_TIME_GetMET,
+**     #CFE_TIME_GetMETseconds, #CFE_TIME_MET2SCTime
+**
+******************************************************************************/
+uint32 CFE_TIME_GetMETsubsecs(void);
+/**@}*/
+
+/** @defgroup CFEAPITIMEGetInfo cFE Get Time Information APIs
+ * @{
+ */
+
+/*****************************************************************************/
+/**
+** \brief Get the current value of the spacecraft time correction factor (STCF).
+**
+** \par Description
+**        This routine returns the current value of the spacecraft time correction
+**        factor.  This is the delta time between the MET and the TAI time.
+**        Applications cannot set or adjust the STCF; that can only be done
+**        through ground commands.  However, science applications may want to
+**        include the STCF in their data products to aid in time correlation
+**        during downstream science data processing.
+**
+** \par Assumptions, External Events, and Notes:
+**        Does not include leap seconds
+**
+** \return The current SCTF
+**
+** \sa #CFE_TIME_GetLeapSeconds, #CFE_TIME_GetClockState, #CFE_TIME_GetClockInfo
+**
+******************************************************************************/
+CFE_TIME_SysTime_t CFE_TIME_GetSTCF(void);
+
+/*****************************************************************************/
+/**
+** \brief Get the current value of the leap seconds counter.
+**
+** \par Description
+**        This routine returns the current value of the leap seconds counter.
+**        This is the delta seconds between international atomic time (TAI)
+**        and universal coordinated time (UTC).  Applications cannot set or
+**        adjust the leap seconds; that can only be done through ground commands.
+**        However, science applications may want to include the leap seconds
+**        counter in their data products to aid in time correlation during
+**        downstream science data processing.  Note that some mission operations
+**        teams do not maintain the leap seconds count, preferring to adjust the
+**        STCF instead.  Users of this function should check with their mission
+**        ops team to see how they are planning to handle leap seconds.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \returns The current spacecraft leap seconds.
+**
+** \sa #CFE_TIME_GetSTCF, #CFE_TIME_GetClockState, #CFE_TIME_GetClockInfo
+**
+******************************************************************************/
+int16 CFE_TIME_GetLeapSeconds(void);
+
+/*****************************************************************************/
+/**
+** \brief Get the current state of the spacecraft clock.
+**
+** \par Description
+**        This routine returns the spacecraft clock state.  Applications that
+**        are highly dependent on valid time may want to call this routine
+**        before taking actions based on the times returned by the various
+**        clock routines
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \return The current spacecraft clock state
+**
+** \sa #CFE_TIME_GetSTCF, #CFE_TIME_GetLeapSeconds, #CFE_TIME_GetClockInfo
+**
+******************************************************************************/
+CFE_TIME_ClockState_Enum_t CFE_TIME_GetClockState(void);
+
+/*****************************************************************************/
+/**
+** \brief Provides information about the spacecraft clock.
+**
+** \par Description
+**        This routine returns information on the spacecraft clock in a bit mask.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \return Spacecraft clock information, \ref CFETIMEClkStates.
+**         To extract the information from the
+**         returned value, the flags can be used as in the following: <br>
+**         <tt> if ((ReturnValue & CFE_TIME_FLAG_xxxxxx) == CFE_TIME_FLAG_xxxxxx)</tt> then
+**            the following definition of the \c CFE_TIME_FLAG_xxxxxx is true. <br>
+**
+** \sa #CFE_TIME_GetSTCF, #CFE_TIME_GetLeapSeconds, #CFE_TIME_GetClockState
+**
+******************************************************************************/
+uint16 CFE_TIME_GetClockInfo(void);
+/**@}*/
+
+/** @defgroup CFEAPITIMEArithmetic cFE Time Arithmetic APIs
+ * @{
+ */
+
+/*****************************************************************************/
+/**
+** \brief Adds two time values
+**
+** \par Description
+**        This routine adds the two specified times and returns the result.
+**        Normally, at least one of the input times should be a value representing
+**        a delta time.  Adding two absolute times together will not cause an error,
+**        but the result will probably be meaningless.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in] Time1   The first time to be added.
+**
+** \param[in] Time2   The second time to be added.
+**
+** \return The sum of the two times.
+**         If the sum is greater than the maximum value that can be stored in a
+**         #CFE_TIME_SysTime_t, the result will roll over (this is not considered an error).
+**
+** \sa #CFE_TIME_Subtract, #CFE_TIME_Compare
+**
+******************************************************************************/
+CFE_TIME_SysTime_t CFE_TIME_Add(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2);
+
+/*****************************************************************************/
+/**
+** \brief Subtracts two time values
+**
+** \par Description
+**        This routine subtracts time2 from time1 and returns the result.  The
+**        time values can represent either absolute or delta times, but not all
+**        combinations make sense.
+**           -  AbsTime - AbsTime = DeltaTime
+**           -  AbsTime - DeltaTime = AbsTime
+**           -  DeltaTime - DeltaTime = DeltaTime
+**           -  DeltaTime - AbsTime = garbage
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in] Time1   The base time.
+**
+** \param[in] Time2   The time to be subtracted from the base time.
+**
+** \return The result of subtracting the two times.
+**         If the subtraction results in an underflow, the result will
+**         roll over (this is not considered an error).
+**
+** \sa #CFE_TIME_Add, #CFE_TIME_Compare
+**
+******************************************************************************/
+CFE_TIME_SysTime_t CFE_TIME_Subtract(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2);
+
+/*****************************************************************************/
+/**
+** \brief Compares two time values
+**
+** \par Description
+**        This routine compares two time values to see which is "greater".  It
+**        is important that applications use this function rather than trying
+**        to directly compare the component pieces of times.  This function will
+**        handle roll-over cases seamlessly, which may not be intuitively obvious.
+**        The cFE's internal representation of time "rolls over" when the 32 bit
+**        seconds count reaches 0xFFFFFFFF.  Also, subtracting a delta time from
+**        an absolute time close to the epoch could result in "roll under".  The
+**        strange cases that result from these situations can be handled by defining
+**        the comparison function for times as follows:
+**        Plot the two times on the circumference of a circle where 0 is at the
+**        top and 0x80000000 is at the bottom.  If the shortest arc from time A
+**        to time B runs clockwise around the circle, then time A is less than
+**        time B.  If the shortest arc from A to B runs counter-clockwise, then
+**        time A is greater than time B.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in] TimeA   The first time to compare.
+**
+** \param[in] TimeB   The second time to compare.
+**
+** \return The result of comparing the two times.
+** \retval #CFE_TIME_EQUAL  \copybrief CFE_TIME_EQUAL
+** \retval #CFE_TIME_A_GT_B \copybrief CFE_TIME_A_GT_B
+** \retval #CFE_TIME_A_LT_B \copybrief CFE_TIME_A_LT_B
+**
+** \sa #CFE_TIME_Add, #CFE_TIME_Subtract
+**
+******************************************************************************/
+CFE_TIME_Compare_t CFE_TIME_Compare(CFE_TIME_SysTime_t TimeA, CFE_TIME_SysTime_t TimeB);
+/**@}*/
+
+/** @defgroup CFEAPITIMEConvert cFE Time Conversion APIs
+ * @{
+ */
+
+/*****************************************************************************/
+/**
+** \brief Convert specified MET into Spacecraft Time
+**
+** \par Description
+**        This function returns Spacecraft Time given MET.  Note that Spacecraft
+**        Time is returned as either UTC or TAI depeneding on whether the mission
+**        configuration parameter #CFE_MISSION_TIME_CFG_DEFAULT_UTC or #CFE_MISSION_TIME_CFG_DEFAULT_TAI
+**        was set to true at compile time.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in] METTime      The MET to be converted.
+**
+** \return Spacecraft Time (UTC or TAI) corresponding to the specified MET
+**
+** \sa #CFE_TIME_GetMET, #CFE_TIME_GetMETseconds, #CFE_TIME_GetMETsubsecs,
+**     #CFE_TIME_Sub2MicroSecs, #CFE_TIME_Micro2SubSecs
+**
+******************************************************************************/
+CFE_TIME_SysTime_t CFE_TIME_MET2SCTime(CFE_TIME_SysTime_t METTime);
+
+/*****************************************************************************/
+/**
+** \brief Converts a sub-seconds count to an equivalent number of microseconds
+**
+** \par Description
+**        This routine converts from a sub-seconds count
+**        (each tick is 1 / 2^32 seconds) to microseconds (each tick is 1e-06 seconds).
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in] SubSeconds   The sub-seconds count to convert.
+**
+** \return The equivalent number of microseconds.
+**
+** \sa #CFE_TIME_MET2SCTime, #CFE_TIME_Micro2SubSecs,
+**
+******************************************************************************/
+uint32 CFE_TIME_Sub2MicroSecs(uint32 SubSeconds);
+
+/*****************************************************************************/
+/**
+** \brief Converts a number of microseconds to an equivalent sub-seconds count.
+**
+** \par Description
+**        This routine converts from microseconds (each tick is 1e-06 seconds)
+**        to a subseconds count (each tick is 1 / 2^32 seconds).
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in] MicroSeconds   The sub-seconds count to convert.
+**
+** \return The equivalent number of subseconds.  If the number of microseconds
+**         passed in is greater than one second, (i.e. > 999,999), the return
+**         value is equal to \c 0xffffffff.
+**
+** \sa #CFE_TIME_MET2SCTime, #CFE_TIME_Sub2MicroSecs,
+**
+******************************************************************************/
+uint32 CFE_TIME_Micro2SubSecs(uint32 MicroSeconds);
+
+/**@}*/
+
+/** @defgroup CFEAPITIMEExternSource cFE External Time Source APIs
+ * @{
+ */
+
+/*****************************************************************************/
+/**
+** \brief Provides the 1 Hz signal from an external source
+**
+** \par Description
+**        This routine provides a method for cFE TIME software to be notified
+**        of the occurance of the 1Hz tone signal without knowledge of the
+**        specific hardware design.  Regardless of the source of the tone,
+**        this routine should be called as soon as possible after detection
+**        to allow cFE TIME software the opportunity to latch the local clock
+**        as close as possible to the instant of the tone.
+**
+** \par Assumptions, External Events, and Notes:
+**          - This routine may be called directly from within the context of an
+**            interrupt handler.
+**
+** \sa #CFE_TIME_ExternalMET, #CFE_TIME_ExternalGPS, #CFE_TIME_ExternalTime
+**
+******************************************************************************/
+void CFE_TIME_ExternalTone(void);
+
+/*
+** Function prototypes (external time source)...
+**
+** If a Time Server has been configured to accept external time
+**    data, then one of the following functions will be enabled.
+**
+** If the Time Server has also been commanded to use the external
+**    time data (as opposed to getting time data from a local MET)
+**    then the Time Server will use the external data in computing
+**    time.
+**
+** However, regardless whether the external time data is accepted
+**    by the Time Server, these functions also act as the signal to
+**    create and distribute the "time at the tone" command packet.
+*/
+
+/*****************************************************************************/
+/**
+** \brief Provides the Mission Elapsed Time from an external source
+**
+** \par Description
+**        This routine provides a method to provide cFE TIME with MET acquired
+**        from an external source.  There is a presumption that this function
+**        will be called at the appropriate time (relative to the tone) such
+**        that this call may be used by cFE TIME as the signal to generate the
+**        "time at the tone" data command.  The "time at the tone" data command
+**        must arrive within the configuration parameter specified window for
+**        tone signal and data packet verification. <br> <br>
+**        The MET value at the tone "should" have zero subseconds.  Although the
+**        interface accepts non-zero values for sub-seconds, it may be harmful
+**        to other applications that expect zero subseconds at the moment of the
+**        tone.  Any decision to use non-zero subseconds should be carefully considered.
+**
+** \par Assumptions, External Events, and Notes:
+**          - This routine is included in the API only when 3 specific configuration
+**            parameters are set to true.  The first is #CFE_PLATFORM_TIME_CFG_SERVER which defines
+**            this instantiation of cFE TIME as a time server (not a client).  The
+**            second required configuration parameter is #CFE_PLATFORM_TIME_CFG_SOURCE which
+**            enables time source selection commands to the cFE TIME task, and further
+**            enables configuration definitions for the selected type of external time
+**            data.  The third configuration parameter required for this routine is
+**            #CFE_PLATFORM_TIME_CFG_SRC_MET, which indicates that the external time data consists
+**            of MET.
+**
+** \param[in]  NewMET   The MET value at the next (or previous) 1 Hz tone signal.
+**
+** \sa #CFE_TIME_ExternalTone, #CFE_TIME_ExternalGPS, #CFE_TIME_ExternalTime
+**
+******************************************************************************/
+void CFE_TIME_ExternalMET(CFE_TIME_SysTime_t NewMET);
+
+/*****************************************************************************/
+/**
+** \brief Provide the time from an external source that has data common to GPS receivers.
+**
+** \par Description
+**        This routine provides a method to provide cFE TIME with current time
+**        data acquired from an external source.  There is a presumption that
+**        this function will be called at the appropriate time (relative to the
+**        tone) such that this call may be used by cFE TIME as the signal to
+**        generate the "time at the tone" data command.  The "time at the tone"
+**        data command must arrive within the configuration parameter specified
+**        window for tone signal and data packet verification. <br> <br>
+**        Internally, cFE TIME will calculate a new STCF as the difference between
+**        this new time value and the spacecraft MET value at the tone.  This allows
+**        cFE TIME to always calculate time as the sum of MET and STCF.  The value
+**        of STCF will change only as much as the drift factor between spacecraft
+**        MET and the external time source.
+**
+** \par Assumptions, External Events, and Notes:
+**          - This routine is included in the API only when 3 specific configuration
+**            parameters are set to true.  The first is #CFE_PLATFORM_TIME_CFG_SERVER which defines this
+**            instantiation of cFE TIME as a time server (not a client).  The second
+**            required configuration parameter is #CFE_PLATFORM_TIME_CFG_SOURCE which enables
+**            time source selection commands to the cFE TIME task, and further enables
+**            configuration definitions for the selected type of external time data.
+**            The third configuration parameter required for this routine is
+**            #CFE_PLATFORM_TIME_CFG_SRC_GPS, which indicates that the external time data consists
+**            of a time value relative to a known epoch, plus a leap seconds value.
+**
+** \param[in]  NewTime   The MET value at the next (or previous) 1 Hz tone signal.
+**
+** \param[in]  NewLeaps The Leap Seconds value used to calculate time as UTC.
+**
+** \sa #CFE_TIME_ExternalTone, #CFE_TIME_ExternalMET, #CFE_TIME_ExternalTime
+**
+******************************************************************************/
+void CFE_TIME_ExternalGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps);
+
+/*****************************************************************************/
+/**
+** \brief Provide the time from an external source that measures time relative to a known epoch.
+**
+** \par Description
+**        This routine provides a method to provide cFE TIME with current time
+**        data acquired from an external source.  There is a presumption that
+**        this function will be called at the appropriate time (relative to the
+**        tone) such that this call may be used by cFE TIME as the signal to
+**        generate the "time at the tone" data command.  The "time at the tone"
+**        data command must arrive within the configuration specified window for
+**        tone signal and data packet verification. <br> <br>
+**        Internally, cFE TIME will calculate a new STCF as the difference between
+**        this new time value and the spacecraft MET value at the tone.  This allows
+**        cFE TIME to always calculate time as the sum of MET and STCF.  The value
+**        of STCF will change only as much as the drift factor between spacecraft
+**        MET and the external time source.
+**
+** \par Assumptions, External Events, and Notes:
+**          - This routine is included in the API only when 3 specific configuration
+**            parameters are set to true.  The first is #CFE_PLATFORM_TIME_CFG_SERVER which defines this
+**            instanciation of cFE TIME as a time server (not a client).  The second
+**            required configuration parameter is #CFE_PLATFORM_TIME_CFG_SOURCE which enables
+**            time source selection commands to the cFE TIME task, and further enables
+**            configuration definitions for the selected type of external time data.
+**            The third configuration parameter required for this routine is
+**            #CFE_PLATFORM_TIME_CFG_SRC_TIME, which indicates that the external time data consists
+**            of a time value relative to a known epoch.
+**
+** \param[in]  NewTime   The MET value at the next (or previous) 1 Hz tone signal.
+**
+** \sa #CFE_TIME_ExternalTone, #CFE_TIME_ExternalMET, #CFE_TIME_ExternalGPS
+**
+******************************************************************************/
+void CFE_TIME_ExternalTime(CFE_TIME_SysTime_t NewTime);
+
+/*****************************************************************************/
+/**
+** \brief Registers a callback function that is called whenever time synchronization occurs
+**
+** \par Description
+**        This routine passes a callback function pointer for an Application that wishes to
+**        be notified whenever a legitimate time synchronization signal (typically a 1 Hz)
+**        is received.
+**
+** \par Assumptions, External Events, and Notes:
+**        Only a single callback per application is supported, and this function should only
+**        be called from a single thread within each application (typically the apps main thread).
+**        If an application requires triggering multiple child tasks at 1Hz, it should distribute
+**        the timing signal internally, rather than registering for multiple callbacks.
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS                       \copybrief CFE_SUCCESS
+** \retval #CFE_TIME_TOO_MANY_SYNCH_CALLBACKS \copybrief CFE_TIME_TOO_MANY_SYNCH_CALLBACKS
+**
+** \sa #CFE_TIME_UnregisterSynchCallback
+**
+******************************************************************************/
+CFE_Status_t CFE_TIME_RegisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPtr);
+
+/*****************************************************************************/
+/**
+** \brief Unregisters a callback function that is called whenever time synchronization occurs
+**
+** \par Description
+**        This routine removes the specified callback function pointer from the list
+**        of Callback functions that are called whenever a time synchronization (typically
+**        the 1Hz signal) is received.
+**
+** \par Assumptions, External Events, and Notes:
+**        Only a single callback per application is supported, and this function should only
+**        be called from a single thread within each application (typically the apps main thread).
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS                      \copybrief CFE_SUCCESS
+** \retval #CFE_TIME_CALLBACK_NOT_REGISTERED \copybrief CFE_TIME_CALLBACK_NOT_REGISTERED
+**
+** \sa #CFE_TIME_RegisterSynchCallback
+**
+******************************************************************************/
+CFE_Status_t CFE_TIME_UnregisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPtr);
+/**@}*/
+
+/** @defgroup CFEAPITIMEMisc cFE Miscellaneous Time APIs
+ * @{
+ */
+
+/*****************************************************************************/
+/**
+** \brief Print a time value as a string
+**
+** \par Description
+**        This routine prints the specified time to the specified string buffer
+**        in the following format: <br> <br>
+**           \c yyyy-ddd-hh:mm:ss.xxxxx\\0 <br> <br>
+**        where:
+**           - \c yyyy = year
+**           - \c ddd = Julian day of the year
+**           - \c hh = hour of the day (0 to 23)
+**           - \c mm = minute (0 to 59)
+**           - \c ss = second (0 to 59)
+**           - \c xxxxx = subsecond formatted as a decimal fraction (1/4 second = 0.25000)
+**           - \c \\0 = trailing null
+**
+** \par Assumptions, External Events, and Notes:
+**        - The value of the time argument is simply added to the configuration
+**          definitions for the ground epoch and converted into a fixed length
+**          string in the buffer provided by the caller.
+**        - A loss of data during the string conversion will occur if the
+**          computed year exceeds 9999.  However, a year that large would
+**          require an unrealistic definition for the ground epoch since
+**          the maximum amount of time represented by a CFE_TIME_SysTime
+**          structure is approximately 136 years.
+**
+** \param[in, out]  PrintBuffer   Pointer to a character array of at least
+**                           #CFE_TIME_PRINTED_STRING_SIZE characters in length. *PrintBuffer is the time as a
+**                           character string as described above.
+**
+** \param[in]  TimeToPrint   The time to print into the character array.
+**
+******************************************************************************/
+void CFE_TIME_Print(char *PrintBuffer, CFE_TIME_SysTime_t TimeToPrint);
+
+/*****************************************************************************/
+/**
+** \brief This function should be called from the system PSP layer once per second
+**
+** \par Description
+**        Drives the time processing logic from the system PSP layer.  This must be called
+**        once per second based on a hardware interrupt or OS kernel signal.
+**
+** \par Assumptions, External Events, and Notes:
+**        This will update the global data structures accordingly, incrementing each
+**        by the 1Hz amount.
+**
+******************************************************************************/
+void CFE_TIME_Local1HzISR(void);
+/**@}*/
+
+#endif /* CFE_TIME_H */

--- a/modules/core_api/fsw/inc/cfe_time_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_time_api_typedefs.h
@@ -1,0 +1,79 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * @file
+ *
+ * Purpose:  cFE Time Services (TIME) library API header file
+ *
+ * Author:   S.Walling/Microtel
+ *
+ * Notes:
+ *
+ */
+
+#ifndef CFE_TIME_API_TYPEDEFS_H
+#define CFE_TIME_API_TYPEDEFS_H
+
+/*
+** Includes
+*/
+#include "common_types.h"
+#include "cfe_time_extern_typedefs.h"
+
+/*****************************************************************************/
+/*
+** Macro Definitions
+*/
+
+#define CFE_TIME_PRINTED_STRING_SIZE \
+    24 /**< \brief Required size of buffer to be passed into #CFE_TIME_Print (includes null terminator) */
+
+/*****************************************************************************/
+/*
+** Type Definitions
+*/
+
+/**
+**  \brief Enumerated types identifying the relative relationships of two times
+**
+**  \par Description
+**       Since time fields contain numbers that are relative to an epoch time, then it is possible for a time value
+**       to be "negative".  This can lead to some confusion about what relationship exists between two time values.
+**       To resolve this confusion, the cFE provides the API #CFE_TIME_Compare which returns these enumerated values.
+*/
+typedef enum CFE_TIME_Compare
+{
+    CFE_TIME_A_LT_B = -1, /**< \brief The first specified time is considered to be before the second specified time */
+    CFE_TIME_EQUAL  = 0,  /**< \brief The two specified times are considered to be equal */
+    CFE_TIME_A_GT_B = 1   /**< \brief The first specified time is considered to be after the second specified time */
+} CFE_TIME_Compare_t;
+
+/**
+**   \brief Time Synchronization Callback Function Ptr Type
+**
+**   \par Description
+**        Applications that wish to get direct notification of the receipt of the cFE Time Synchronization signal
+**        (typically a 1 Hz signal), must register a callback function with the following prototype via the
+**        #CFE_TIME_RegisterSynchCallback API.
+*/
+typedef int32 (*CFE_TIME_SynchCallbackPtr_t)(void);
+
+#endif /* CFE_TIME_API_TYPEDEFS_H */

--- a/modules/core_api/fsw/inc/cfe_time_core_internal.h
+++ b/modules/core_api/fsw/inc/cfe_time_core_internal.h
@@ -1,0 +1,88 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * @file
+ *
+ * Purpose:  cFE Time Services (TIME) library API header file
+ *
+ * Author:   S.Walling/Microtel
+ *
+ * Notes:
+ *
+ */
+
+#ifndef CFE_TIME_CORE_INTERNAL_H
+#define CFE_TIME_CORE_INTERNAL_H
+
+#include "common_types.h"
+#include "cfe_es_extern_typedefs.h"
+
+/*
+ * The internal APIs prototyped within this block are only intended to be invoked from
+ * other CFE core apps.  They still need to be prototyped in the shared header such that
+ * they can be called from other core modules, but applications should not call these.
+ */
+
+/** @defgroup CFEAPITIMECoreInternal cFE Internal Time APIs, internal to CFE core
+ * @{
+ */
+
+/*****************************************************************************/
+/**
+** \brief Entry Point for cFE Core Application
+**
+** \par Description
+**        This is the entry point to the cFE TIME Core Application.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+******************************************************************************/
+extern void CFE_TIME_TaskMain(void);
+
+/*****************************************************************************/
+/**
+** \brief Initializes the cFE core module API Library
+**
+** \par Description
+**        Initializes the cFE core module API Library
+**
+** \par Assumptions, External Events, and Notes:
+**        -# This function MUST be called before any module API's are called.
+**
+******************************************************************************/
+extern int32 CFE_TIME_EarlyInit(void);
+
+/*****************************************************************************/
+/**
+** \brief Removes TIME resources associated with specified Application
+**
+** \par Description
+**        This function is called by cFE Executive Services to cleanup after
+**        an Application has been terminated.  It frees resources
+**        that have been allocated to the specified Application.
+**
+******************************************************************************/
+extern int32 CFE_TIME_CleanUpApp(CFE_ES_AppId_t AppId);
+
+/**@}*/
+
+#endif /* CFE_TIME_CORE_INTERNAL_H */

--- a/modules/core_api/fsw/inc/cfe_time_extern_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_time_extern_typedefs.h
@@ -1,0 +1,303 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * @file
+ *
+ * Declarations and prototypes for cfe_time_extern_typedefs module
+ */
+
+#ifndef CFE_TIME_EXTERN_TYPEDEFS_H
+#define CFE_TIME_EXTERN_TYPEDEFS_H
+
+/* This header may be generated from an EDS file,
+ * tools are available and the feature is enabled */
+#ifdef CFE_EDS_ENABLED_BUILD
+
+/* Use the EDS generated version of these types */
+#include "cfe_time_eds_typedefs.h"
+
+#else
+/* Use the local definitions of these types */
+
+#include "common_types.h"
+
+/**
+**  \brief Data structure used to hold system time values
+**
+**  \par Description
+**       The #CFE_TIME_SysTime_t data structure is used to hold time
+**       values.  Time is referred to as the elapsed time (in seconds
+**       and subseconds) since a specified epoch time.  The subseconds
+**       field contains the number of 2^(-32) second intervals that have
+**       elapsed since the epoch.
+**
+*/
+typedef struct CFE_TIME_SysTime
+{
+    uint32 Seconds;    /**< \brief Number of seconds since epoch */
+    uint32 Subseconds; /**< \brief Number of subseconds since epoch (LSB = 2^(-32) seconds) */
+} CFE_TIME_SysTime_t;
+
+/**
+ * @brief Label definitions associated with CFE_TIME_FlagBit_Enum_t
+ */
+enum CFE_TIME_FlagBit
+{
+
+    /**
+     * @brief The spacecraft time has been set
+     */
+    CFE_TIME_FlagBit_CLKSET = 0,
+
+    /**
+     * @brief This instance of Time Services is flywheeling
+     */
+    CFE_TIME_FlagBit_FLYING = 1,
+
+    /**
+     * @brief The clock source is set to internal
+     */
+    CFE_TIME_FlagBit_SRCINT = 2,
+
+    /**
+     * @brief The clock signal is set to primary
+     */
+    CFE_TIME_FlagBit_SIGPRI = 3,
+
+    /**
+     * @brief The Time Server is in flywheel mode
+     */
+    CFE_TIME_FlagBit_SRVFLY = 4,
+
+    /**
+     * @brief This instance of Time Services was commanded into flywheel mode
+     */
+    CFE_TIME_FlagBit_CMDFLY = 5,
+
+    /**
+     * @brief One time STCF Adjustment is to be done in positive direction
+     */
+    CFE_TIME_FlagBit_ADDADJ = 6,
+
+    /**
+     * @brief 1 Hz STCF Adjustment is to be done in a positive direction
+     */
+    CFE_TIME_FlagBit_ADD1HZ = 7,
+
+    /**
+     * @brief Time Client Latency is applied in a positive direction
+     */
+    CFE_TIME_FlagBit_ADDTCL = 8,
+
+    /**
+     * @brief This instance of Time Services is a Time Server
+     */
+    CFE_TIME_FlagBit_SERVER = 9,
+
+    /**
+     * @brief The tone received is good compared to the last tone received
+     */
+    CFE_TIME_FlagBit_GDTONE = 10
+};
+
+/**
+ * @brief Bit positions of the various clock state flags
+ *
+ * @sa enum CFE_TIME_FlagBit
+ */
+typedef uint8 CFE_TIME_FlagBit_Enum_t;
+
+/**
+ * @brief Label definitions associated with CFE_TIME_ClockState_Enum_t
+ */
+enum CFE_TIME_ClockState
+{
+
+    /**
+     *
+     * The spacecraft time has not been set since the last clock
+     * reset.  Times returned by clock routines have no relationship
+     * to any ground-based time reference.
+     *
+     */
+    CFE_TIME_ClockState_INVALID = -1,
+
+    /**
+     *
+     * The spacecraft time has been set at least once since the last
+     * clock reset, and it is synchronized with the primary on-board
+     * time base.  Times returned by clock routines can be trusted.
+     *
+     */
+    CFE_TIME_ClockState_VALID = 0,
+
+    /**
+     *
+     * The spacecraft time has been set at least once since the last
+     * clock reset, but it is not currently synchronized with the
+     * primary on-board time base.  Times returned by clock routines
+     * are a "best guess" based on a non-optimal oscillator.
+     *
+     */
+    CFE_TIME_ClockState_FLYWHEEL = 1
+};
+
+/**
+ * @brief Enumerated types identifying the quality of the current time
+ *
+ * \par Description
+ * The #CFE_TIME_ClockState_Enum_t enumerations identify the three recognized states of the current time.
+ * If the clock has never been successfully synchronized with the primary onboard clock source, the
+ * time is conisdered to be #CFE_TIME_ClockState_INVALID.  If the time is currently synchronized (i.e. - the
+ * primary synchronization mechanism has not been dropped for any significant amount of time), then
+ * the current time is considered to be #CFE_TIME_ClockState_VALID.  If the time had, at some point in the past,
+ * been synchronized, but the synchronization with the primary onboard clock has since been lost, then
+ * the time is considered to be #CFE_TIME_ClockState_FLYWHEEL.  Since different clocks drift at different rates
+ * from one another, the accuracy of the time while in #CFE_TIME_ClockState_FLYWHEEL is dependent upon the time
+ * spent in that state.
+ *
+ * @sa enum CFE_TIME_ClockState
+ */
+typedef int16 CFE_TIME_ClockState_Enum_t;
+
+/**
+ * @brief Label definitions associated with CFE_TIME_SourceSelect_Enum_t
+ */
+enum CFE_TIME_SourceSelect
+{
+
+    /**
+     * @brief Use Internal Source
+     */
+    CFE_TIME_SourceSelect_INTERNAL = 1,
+
+    /**
+     * @brief Use External Source
+     */
+    CFE_TIME_SourceSelect_EXTERNAL = 2
+};
+
+/**
+ * @brief Clock Source Selection Parameters
+ *
+ * @sa enum CFE_TIME_SourceSelect
+ */
+typedef uint8 CFE_TIME_SourceSelect_Enum_t;
+
+/**
+ * @brief Label definitions associated with CFE_TIME_ToneSignalSelect_Enum_t
+ */
+enum CFE_TIME_ToneSignalSelect
+{
+
+    /**
+     * @brief Primary Source
+     */
+    CFE_TIME_ToneSignalSelect_PRIMARY = 1,
+
+    /**
+     * @brief Redundant Source
+     */
+    CFE_TIME_ToneSignalSelect_REDUNDANT = 2
+};
+
+/**
+ * @brief Tone Signal Selection Parameters
+ *
+ * @sa enum CFE_TIME_ToneSignalSelect
+ */
+typedef uint8 CFE_TIME_ToneSignalSelect_Enum_t;
+
+/**
+ * @brief Label definitions associated with CFE_TIME_AdjustDirection_Enum_t
+ */
+enum CFE_TIME_AdjustDirection
+{
+
+    /**
+     * @brief Add time adjustment
+     */
+    CFE_TIME_AdjustDirection_ADD = 1,
+
+    /**
+     * @brief Subtract time adjustment
+     */
+    CFE_TIME_AdjustDirection_SUBTRACT = 2
+};
+
+/**
+ * @brief STCF adjustment direction (for both one-time and 1Hz adjustments)
+ *
+ * @sa enum CFE_TIME_AdjustDirection
+ */
+typedef uint8 CFE_TIME_AdjustDirection_Enum_t;
+
+/**
+ * @brief Label definitions associated with CFE_TIME_FlywheelState_Enum_t
+ */
+enum CFE_TIME_FlywheelState
+{
+
+    /**
+     * @brief Not in flywheel state
+     */
+    CFE_TIME_FlywheelState_NO_FLY = 0,
+
+    /**
+     * @brief In flywheel state
+     */
+    CFE_TIME_FlywheelState_IS_FLY = 1
+};
+
+/**
+ * @brief Fly-wheel status values
+ *
+ * @sa enum CFE_TIME_FlywheelState
+ */
+typedef uint8 CFE_TIME_FlywheelState_Enum_t;
+
+/**
+ * @brief Label definitions associated with CFE_TIME_SetState_Enum_t
+ */
+enum CFE_TIME_SetState
+{
+
+    /**
+     * @brief Spacecraft time has not been set
+     */
+    CFE_TIME_SetState_NOT_SET = 0,
+
+    /**
+     * @brief Spacecraft time has been set
+     */
+    CFE_TIME_SetState_WAS_SET = 1
+};
+
+/**
+ * @brief Clock status values (has the clock been set to correct time)
+ *
+ * @sa enum CFE_TIME_SetState
+ */
+typedef uint8 CFE_TIME_SetState_Enum_t;
+
+#endif /* CFE_EDS_ENABLED_BUILD */
+
+#endif /* CFE_TIME_EXTERN_TYPEDEFS_H */

--- a/modules/core_private/fsw/inc/cfe_time_resetvars_typedef.h
+++ b/modules/core_private/fsw/inc/cfe_time_resetvars_typedef.h
@@ -1,0 +1,57 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * @file
+ *
+ * Definition of the CFE_TIME_ResetVars_t structure type
+ */
+
+#ifndef CFE_TIME_RESETVARS_TYPEDEF_H
+#define CFE_TIME_RESETVARS_TYPEDEF_H
+
+/*
+** Includes
+*/
+#include "common_types.h"
+#include "cfe_time_extern_typedefs.h"
+
+#define CFE_TIME_RESET_SIGNATURE 0xA5A55A5A
+
+/**
+**  \brief Time related variables that are maintained through a Processor Reset
+**
+**  \par Description
+**       The #CFE_TIME_ResetVars_t data structure contains those variables that are maintained
+**       in an area of memory that is not cleared during a Processor Reset.  This allows the
+**       cFE Time Service to maintain time to the best of its ability after a Processor Reset.
+*/
+typedef struct CFE_TIME_ResetVars
+{
+    uint32             Signature;    /**< \brief Data validation signature used to verify data structure contents*/
+    int16              LeapSeconds;  /**< \brief Leap seconds value */
+    uint16             ClockSignal;  /**< \brief Current clock signal selection */
+    CFE_TIME_SysTime_t CurrentMET;   /**< \brief Current Mission Elapsed Time (MET) */
+    CFE_TIME_SysTime_t CurrentSTCF;  /**< \brief Current Spacecraft Time Correlation Factor (STCF) */
+    CFE_TIME_SysTime_t CurrentDelay; /**< \brief Current time client delay value */
+
+} CFE_TIME_ResetVars_t;
+
+#endif /* CFE_TIME_RESETVARS_TYPEDEF_H */

--- a/modules/tbl/CMakeLists.txt
+++ b/modules/tbl/CMakeLists.txt
@@ -1,0 +1,33 @@
+##################################################################
+#
+# cFE Table Services (TBL) module CMake build recipe
+#
+##################################################################
+
+project(CFE_TBL C)
+
+# Table Services source files
+set(tbl_SOURCES
+    fsw/src/cfe_tbl_api.c
+    fsw/src/cfe_tbl_internal.c
+    fsw/src/cfe_tbl_task.c
+    fsw/src/cfe_tbl_task_cmds.c
+    fsw/src/cfe_tbl_api.c
+    fsw/src/cfe_tbl_internal.c
+    fsw/src/cfe_tbl_task.c
+    fsw/src/cfe_tbl_task_cmds.c
+)
+add_library(tbl STATIC ${tbl_SOURCES})
+
+target_include_directories(tbl PUBLIC fsw/inc)
+target_link_libraries(tbl PRIVATE core_private)
+
+# Add unit test coverage subdirectory
+if(ENABLE_UNIT_TESTS)
+    add_subdirectory(ut-coverage)
+endif(ENABLE_UNIT_TESTS)
+
+cfs_app_check_intf(${DEP}
+    cfe_tbl_msg.h
+    cfe_tbl_events.h
+)

--- a/modules/tbl/fsw/inc/cfe_tbl_events.h
+++ b/modules/tbl/fsw/inc/cfe_tbl_events.h
@@ -1,0 +1,1100 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * @file
+ *
+ *  Title:   Table Services API Event ID Header File
+ *
+ *  Purpose:
+ *     Identifies event codes for event messages issued by Table Services.
+ *
+ *  Design Notes:
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *
+ *  Notes:
+ *
+ */
+
+#ifndef CFE_TBL_EVENTS_H
+#define CFE_TBL_EVENTS_H
+
+/* **************************
+** ****** Maximum EID. ******
+** **************************
+** The EID's below may not necessarily be in order, so it can be difficult to
+** determine what the next EID is to use. When you add EID's, start with MAX_EID + 1
+** and when you're done adding, set this to the highest EID you used. It may
+** be worthwhile to, on occasion, re-number the EID's to put them back in order.
+*/
+#define CFE_TBL_MAX_EID 103
+
+/******************* Macro Definitions ***********************/
+/*
+** Event message ID's
+*/
+
+/** \name Informational Event Message IDs */
+/** \{ */
+/** \brief <tt> 'Task Initialized' </tt>
+**  \event <tt> 'Task Initialized' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is always automatically issued when the Table Services
+**  Task completes its Initialization.
+**/
+#define CFE_TBL_INIT_INF_EID 1
+/** \} */
+
+/** \name Command Response Informational Event Message IDs */
+/** \{ */
+
+/** \brief <tt> 'No-op command' </tt>
+**  \event <tt> 'No-op command' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is always automatically issued in response
+**  to a cFE Table Services \link #CFE_TBL_NOOP_CC NO-OP command \endlink
+**/
+#define CFE_TBL_NOOP_INF_EID 10
+
+/** \brief <tt> 'Reset Counters command' </tt>
+**  \event <tt> 'Reset Counters command' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is always automatically issued in response
+**  to a cFE Table Services \link #CFE_TBL_RESET_COUNTERS_CC Reset Counters command \endlink
+**/
+#define CFE_TBL_RESET_INF_EID 11
+
+/** \brief <tt> 'Successful load of '\%s' into '\%s' working buffer' </tt>
+**  \event <tt> 'Successful load of '\%s' into '\%s' working buffer' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is always generated after a successful execution of
+**  a cFE Table Services \link #CFE_TBL_LOAD_CC Load Table command \endlink
+**/
+#define CFE_TBL_FILE_LOADED_INF_EID 12
+
+/** \brief <tt> 'Successfully overwrote '\%s' with Table '\%s'' </tt>
+**  \event <tt> 'Successfully overwrote '\%s' with Table '\%s'' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is always generated after a successful execution of
+**  a cFE Table Services \link #CFE_TBL_DUMP_CC Dump Table command \endlink where
+**  the command specified target filename was the same as a file already present
+**  in the onboard filesystem. If the specified file did not exist, the event
+**  message would have been #CFE_TBL_WRITE_DUMP_INF_EID.
+**/
+#define CFE_TBL_OVERWRITE_DUMP_INF_EID 13
+
+/** \brief <tt> 'Successfully dumped Table '\%s' to '\%s'' </tt>
+**  \event <tt> 'Successfully dumped Table '\%s' to '\%s'' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is always generated after a successful execution of
+**  a cFE Table Services \link #CFE_TBL_DUMP_CC Dump Table command \endlink where
+**  the command specified target filename was a currently non-existent file. If
+**  the file did already exist, the event message would have been
+**  #CFE_TBL_OVERWRITE_DUMP_INF_EID.
+**/
+#define CFE_TBL_WRITE_DUMP_INF_EID 14
+
+/** \brief <tt> 'Successfully overwrote '\%s' with Table Registry' </tt>
+**  \event <tt> 'Successfully overwrote '\%s' with Table Registry' </tt>
+**
+**  \par Type: DEBUG
+**
+**  \par Cause:
+**
+**  This event message is always generated after a successful execution of
+**  a cFE Table Services \link #CFE_TBL_DUMP_REGISTRY_CC Dump Table Registry command \endlink where
+**  the command specified target filename was the same as a file already present
+**  in the onboard filesystem. If the specified file did not exist, the event
+**  message would have been #CFE_TBL_WRITE_REG_DUMP_INF_EID.
+**/
+#define CFE_TBL_OVERWRITE_REG_DUMP_INF_EID 15
+
+/** \brief <tt> 'Tbl Services issued validation request for '\%s'' </tt>
+**  \event <tt> 'Tbl Services issued validation request for '\%s'' </tt>
+**
+**  \par Type: DEBUG
+**
+**  \par Cause:
+**
+**  This event message is generated upon successful execution of
+**  a cFE Table Services \link #CFE_TBL_VALIDATE_CC Validate Table command \endlink.
+**  It should be noted, however, that this Event Message does <em> NOT </em> indicate completion of
+**  the Table Validation.  It is <em> ONLY </em> indicating that the appropriate flag has been
+**  set to <em> NOTIFY </em> the table's owning Application that a Validation has been requested.
+**  Completion of the Validation is indicated by either the #CFE_TBL_VALIDATION_INF_EID or
+**  #CFE_TBL_VALIDATION_ERR_EID event messages.
+**/
+#define CFE_TBL_VAL_REQ_MADE_INF_EID 16
+
+/** \brief <tt> 'Tbl Services notifying App that '\%s' has a load pending' </tt>
+**  \event <tt> 'Tbl Services notifying App that '\%s' has a load pending' </tt>
+**
+**  \par Type: DEBUG
+**
+**  \par Cause:
+**
+**  This event message is generated upon successful execution of
+**  a cFE Table Services \link #CFE_TBL_ACTIVATE_CC Activate Table command \endlink.
+**  It should be noted, however, that this Event Message does <em> NOT </em> indicate completion of
+**  the Table Activation.  It is <em> ONLY </em> indicating that the appropriate flag has been
+**  set to <em> NOTIFY </em> the table's owning Application that an Update has been requested.
+**  Completion of the Update is indicated by either the #CFE_TBL_UPDATE_SUCCESS_INF_EID or
+**  #CFE_TBL_UPDATE_ERR_EID event messages.
+**/
+#define CFE_TBL_LOAD_PEND_REQ_INF_EID 17
+
+/** \brief <tt> 'Table Registry entry for '\%s' will be telemetered' </tt>
+**  \event <tt> 'Table Registry entry for '\%s' will be telemetered' </tt>
+**
+**  \par Type: DEBUG
+**
+**  \par Cause:
+**
+**  This event message is generated upon successful execution of
+**  a cFE Table Services \link #CFE_TBL_SEND_REGISTRY_CC Telemeter Table Registry Entry command \endlink.
+**  Subsequent Table Services Housekeeping Telemetry should contain the desired Table Registry Entry data.
+**/
+#define CFE_TBL_TLM_REG_CMD_INF_EID 18
+
+/** \brief <tt> 'Table Load Aborted for '\%s'' </tt>
+**  \event <tt> 'Table Load Aborted for '\%s'' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is generated upon successful execution of
+**  a cFE Table Services \link #CFE_TBL_ABORT_LOAD_CC Abort Table Load command \endlink.
+**/
+#define CFE_TBL_LOAD_ABORT_INF_EID 21
+
+/** \brief <tt> 'Successfully dumped Table Registry to '\%s':Size=\%d,Entries=\%d' </tt>
+**  \event <tt> 'Successfully dumped Table Registry to '\%s':Size=\%d,Entries=\%d' </tt>
+**
+**  \par Type: DEBUG
+**
+**  \par Cause:
+**
+**  This event message is always generated after a successful execution of
+**  a cFE Table Services \link #CFE_TBL_DUMP_REGISTRY_CC Dump Table Registry command \endlink where
+**  the command specified target filename was a currently non-existent file. If
+**  the file did already exist, the event message would have been
+**  #CFE_TBL_OVERWRITE_REG_DUMP_INF_EID.
+**/
+#define CFE_TBL_WRITE_REG_DUMP_INF_EID 22
+
+/** \brief <tt> 'Tbl Services assumes '\%s' is valid. No Validation Function has been registered' </tt>
+**  \event <tt> 'Tbl Services assumes '\%s' is valid. No Validation Function has been registered' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is generated when Table Services has received a Validation Command
+**  for a table that never specified a Validation Function when it was registered via the
+**  #CFE_TBL_Register API.
+**/
+#define CFE_TBL_ASSUMED_VALID_INF_EID 23
+/** \} */
+
+/** \name Command Error Event Message IDs */
+/** \{ */
+/** \brief <tt> 'Invalid message ID -- ID = 0x\%X' </tt>
+**  \event <tt> 'Invalid message ID -- ID = 0x\%X' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a message has arrived on
+**  the cFE Table Services Application's Message Pipe that has a
+**  Message ID that is neither #CFE_TBL_SEND_HK_MID or #CFE_TBL_CMD_MID.
+**  Most likely, the cFE Software Bus routing table has become corrupt
+**  and is sending messages targeted for other Applications to the cFE
+**  Table Services Application.
+**
+**  The \c ID field in the event message identifies
+**  the message ID (in hex) that was found in the message.
+**/
+#define CFE_TBL_MID_ERR_EID 50
+
+/** \brief <tt> 'Invalid command code -- ID = 0x\%X, CC = \%d' </tt>
+**  \event <tt> 'Invalid command code -- ID = 0x\%X, CC = \%d' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a message with the #CFE_TBL_CMD_MID
+**  message ID has arrived but whose Command Code is not one of the command
+**  codes specified in \link #CFE_TBL_NOOP_CC cfe_tbl_msg.h \endlink.  This
+**  problem is most likely to occur when:
+**    -# A Message ID meant for another Application became corrupted and was
+**       set equal to #CFE_TBL_CMD_MID.
+**    -# The Command Code field in the Message became corrupted.
+**    -# The command database at the ground station has been corrupted.
+**
+**  The \c ID field in the event message specifies the Message ID (in hex) and the
+**  \c CC field specifies the Command Code (in decimal) found in the message.
+**/
+#define CFE_TBL_CC1_ERR_EID 51
+
+/** \brief <tt> 'Invalid cmd pkt -- ID = 0x\%X,  CC = \%d, Len = \%d' </tt>
+**  \event <tt> 'Invalid cmd pkt -- ID = 0x\%X,  CC = \%d, Len = \%d' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a message with the #CFE_TBL_CMD_MID
+**  message ID has arrived but whose packet length does not match the expected
+**  length for the specified command code.
+**
+**  The \c ID field in the event message specifies the Message ID (in hex), the \c CC field
+**  specifies the Command Code (in decimal) and \c Len specifies the message Length (in decimal)
+**  found in the message.
+**/
+#define CFE_TBL_LEN_ERR_EID 52
+
+/** \brief <tt> 'Unable to open file '\%s' for table load, Status = 0x\%08X' </tt>
+**  \event <tt> 'Unable to open file '\%s' for table load, Status = 0x\%08X' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated upon receipt of a
+**  \link #CFE_TBL_LOAD_CC Load Table command \endlink when
+**  the specified file containing the table image to be loaded
+**  cannot be opened.  Possible causes for this are:
+**
+**  -# The filename was misspelled
+**  -# The path to the file was incorrect
+**  -# The length (including terminator) of the filename and/or path exceeds the
+**     allowable length (see #OS_MAX_PATH_LEN and #OS_MAX_FILE_NAME, respectively)
+**
+**  The \c Status field in the event message indicates the error code returned by the #OS_OpenCreate
+**  API.
+**/
+#define CFE_TBL_FILE_ACCESS_ERR_EID 53
+
+/** \brief <tt> 'Unable to read std header for '\%s', Status = 0x\%08X' </tt>
+**  \event <tt> 'Unable to read std header for '\%s', Status = 0x\%08X' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a read failure occurs during the reading of the
+**  \link #CFE_FS_Header_t cFE Standard File Header \endlink of a table image file specified
+**  either by an Application calling the #CFE_TBL_Load API or in response to a command to
+**  Table Services requesting a table image file be loaded into an inactive buffer.
+**
+**  The \c Status field of the event message contains the error code returned by #CFE_FS_ReadHeader.
+**/
+#define CFE_TBL_FILE_STD_HDR_ERR_EID 54
+
+/** \brief <tt> 'Unable to read tbl header for '\%s', Status = 0x\%08X' </tt>
+**  \event <tt> 'Unable to read tbl header for '\%s', Status = 0x\%08X' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a read failure occurs during the reading of the
+**  \link #CFE_TBL_File_Hdr_t cFE Table File Secondary Header \endlink of a table image file specified
+**  either by an Application calling the #CFE_TBL_Load API or in response to a command to
+**  Table Services requesting a table image file be loaded into an inactive buffer.
+**
+**  The \c Status field of the event message contains the error code returned by #OS_read.
+**/
+#define CFE_TBL_FILE_TBL_HDR_ERR_EID 55
+
+/** \brief <tt> 'Unable to send Hk Packet (Status=0x\%08X)' </tt>
+**  \event <tt> 'Unable to send Hk Packet (Status=0x\%08X)' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when failure occurs while attempting to send the
+**  Housekeeping Message over the Software Bus.
+**
+**  The \c Status field of the event message contains the error code.
+**/
+#define CFE_TBL_FAIL_HK_SEND_ERR_EID 56
+
+/** \brief <tt> 'Unable to locate '\%s' in Table Registry' </tt>
+**  \event <tt> 'Unable to locate '\%s' in Table Registry' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a command that specifies a table name
+**  has a table name that is not found in the Table Registry.  Most likely causes
+**  for this are:
+**    -# Table name was misspelled in the command.
+**    -# The Application that Registered the Table has either failed to run or
+**       has been terminated thus removing the Table from the Registry.
+**    -# The Table Registry has become corrupted.
+**/
+#define CFE_TBL_NO_SUCH_TABLE_ERR_EID 57
+
+/** \brief <tt> 'File '\%s' is not a cFE file type, ContentType = 0x\%08X' </tt>
+**  \event <tt> 'File '\%s' is not a cFE file type, ContentType = 0x\%08X' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when either an Application calls the #CFE_TBL_Load API
+**  or a Table Load command has been received and the specified file has a \link #CFE_FS_Header_t
+**  cFE Standard File Header \endlink whose \link #CFE_FS_Header_t::ContentType Content Type \endlink
+**  is not equal to the expected #CFE_FS_FILE_CONTENT_ID. Most likely causes for this are:
+**   -# The specified file is not a cFE compatible file.
+**   -# The specified file has been created with bad "endianess" (headers should always conform to
+**      a big endian format).
+**   -# The specified file has become corrupted.
+**
+**  The \c ContentType field specified in the event message contains the content type that was found
+**  in the specified file.
+**/
+#define CFE_TBL_FILE_TYPE_ERR_EID 58
+
+/** \brief <tt> 'File subtype for '\%s' is wrong. Subtype = 0x\%08X' </tt>
+**  \event <tt> 'File subtype for '\%s' is wrong. Subtype = 0x\%08X' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when either an Application calls the #CFE_TBL_Load API
+**  or a Table Load command has been received and the specified file has a \link #CFE_FS_Header_t
+**  cFE Standard File Header \endlink whose \link #CFE_FS_Header_t::SubType Sub Type \endlink
+**  is not equal to the expected #CFE_FS_SubType_TBL_IMG. Most likely causes for this are:
+**   -# The specified file is not a cFE table image file.
+**   -# The specified file has been created with bad "endianess" (headers should always conform to
+**      a big endian format).
+**   -# The specified file has become corrupted.
+**
+**  The \c SubType field specified in the event message contains the sub type that was found
+**  in the specified file.
+**/
+#define CFE_TBL_FILE_SUBTYPE_ERR_EID 59
+
+/** \brief <tt> 'No working buffers available for table '\%s'' </tt>
+**  \event <tt> 'No working buffers available for table '\%s'' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when either a Table Load Command for a Single Buffered Table
+**  or a Table Dump Command for a Dump Only Table has been sent AND there are no Shared Buffers
+**  available to hold either the load image or the dump image.  To free a Shared Buffer, either
+**  a previously loaded table image must be activated or aborted OR the operator has to wait for
+**  previously dumped Dump Only tables have had a chance to be written to a file (which occurs
+**  whenever the cFE Table Services receives a Housekeeping Request).
+**/
+#define CFE_TBL_NO_WORK_BUFFERS_ERR_EID 60
+
+/** \brief <tt> 'Internal Error (Status=0x\%08X)' </tt>
+**  \event <tt> 'Internal Error (Status=0x\%08X)' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a Table Load command was issued and the cFE Table Services
+**  is unable to allocate a working table buffer for an unexpected reason.
+**
+**  The \c Status field provides the return status from the function that was to provide a working buffer.
+**/
+#define CFE_TBL_INTERNAL_ERROR_ERR_EID 61
+
+/** \brief <tt> 'Error creating dump file '\%s', Status=0x\%08X' </tt>
+**  \event <tt> 'Error creating dump file '\%s', Status=0x\%08X' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a Table Dump or Table Registry Dump command was
+**  received and the cFE Table Services is unable to create the specified file.
+**
+**  The \c Status field provides the return status from the #OS_OpenCreate function call.
+**/
+#define CFE_TBL_CREATING_DUMP_FILE_ERR_EID 62
+
+/** \brief <tt> 'Error writing cFE File Header to '\%s', Status=0x\%08X' </tt>
+**  \event <tt> 'Error writing cFE File Header to '\%s', Status=0x\%08X' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a Table Dump or Table Registry Dump command was
+**  received and the cFE Table Services is unable to write the standard cFE File Header
+**  to the specified file.
+**
+**  The \c Status field provides the return status from the #CFE_FS_WriteHeader function call.
+**/
+#define CFE_TBL_WRITE_CFE_HDR_ERR_EID 63
+
+/** \brief <tt> 'Error writing Tbl image File Header to '\%s', Status=0x\%08X' </tt>
+**  \event <tt> 'Error writing Tbl image File Header to '\%s', Status=0x\%08X' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a Table Dump command was received and the
+**  cFE Table Services is unable to write the standard cFE Table Image Header to the specified file.
+**
+**  The \c Status field provides the return status from the #OS_write function call.
+**/
+#define CFE_TBL_WRITE_TBL_HDR_ERR_EID 64
+
+/** \brief <tt> 'Error writing Tbl image to '\%s', Status=0x\%08X' </tt>
+**  \event <tt> 'Error writing Tbl image to '\%s', Status=0x\%08X' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a Table Dump command was received and the
+**  cFE Table Services is unable to write the contents of the specified Table image to
+**  the specified file.
+**
+**  The \c Status field provides the return status from the #OS_write function call.
+**/
+#define CFE_TBL_WRITE_TBL_IMG_ERR_EID 65
+
+/** \brief <tt> 'No Inactive Buffer for Table '\%s' present' </tt>
+**  \event <tt> 'No Inactive Buffer for Table '\%s' present' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a Table Dump or a Table Validate command for an
+**  Inactive Table Buffer was received and there isn't an Inactive Table Buffer associated
+**  with the specified Table.
+**/
+#define CFE_TBL_NO_INACTIVE_BUFFER_ERR_EID 66
+
+/** \brief <tt> 'Too many Table Validations have been requested' </tt>
+**  \event <tt> 'Too many Table Validations have been requested' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a Table Validate command was received and there are
+**  no more free Validation Result Blocks available.  The number of simultaneous validations that
+**  can be pending is specified by the configuration parameter #CFE_PLATFORM_TBL_MAX_NUM_VALIDATIONS
+**  which is found in the cfe_platform_cfg.h file.
+**
+**  Validation Commands lock one of the Validation Result Blocks upon receipt of the validation
+**  command until the result of the Validation, performed by the table's owning Application, has
+**  been reported in a Table Services Housekeeping Request Message.
+**/
+#define CFE_TBL_TOO_MANY_VALIDATIONS_ERR_EID 67
+
+/** \brief <tt> 'Error writing Registry to '\%s', Status=0x\%08X' </tt>
+**  \event <tt> 'Error writing Registry to '\%s', Status=0x\%08X' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a Table Registry Dump command was received and the
+**  cFE Table Services is unable to write the entire contents of the Table Registry to
+**  the specified file.
+**
+**  The \c Status field provides the return status from the #OS_write function call.
+**/
+#define CFE_TBL_WRITE_TBL_REG_ERR_EID 68
+
+/** \brief <tt> 'Cannot abort load of '\%s'. No load started.' </tt>
+**  \event <tt> 'Cannot abort load of '\%s'. No load started.' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when an Abort Load command is received and the command specified
+**  table is not currently in the process of being loaded.
+**/
+#define CFE_TBL_LOAD_ABORT_ERR_EID 69
+
+/** \brief <tt> 'Cannot activate table '\%s'. No Inactive image available' </tt>
+**  \event <tt> 'Cannot activate table '\%s'. No Inactive image available' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when an Activate Table command is received and the command specified
+**  table does not currently have an inactive buffer associated with it.
+**/
+#define CFE_TBL_ACTIVATE_ERR_EID 70
+
+/** \brief <tt> 'Incomplete load of '\%s' into '\%s' working buffer' </tt>
+**  \event <tt> 'Incomplete load of '\%s' into '\%s' working buffer' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a Load Table command is received and the Table Services
+**  is unable to load the number of bytes specified in the Table Image Header of the command
+**  specified file from the file into the Inactive Buffer.
+**/
+#define CFE_TBL_FILE_INCOMPLETE_ERR_EID 71
+
+/** \brief <tt> 'Cannot load '\%s' (\%d) at offset \%d in '\%s' (\%d)' </tt>
+**  \event <tt> 'Cannot load '\%s' (\%d) at offset \%d in '\%s' (\%d)' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a Load Table command is received and the Table Header in
+**  the specified Table Image file identifies a number of bytes with a specified starting offset
+**  that would exceed the size of the specified table.  For example, if a table had 10 bytes and
+**  the Table Header indicated that the Table Image in the file contains 7 bytes that starts at
+**  offset 5, then the data content would have exceeded the 10 byte limit of the table.
+**
+**  The numbers in parenthesis in the event message text indicate the data size (in bytes) for
+**  the specified load file and the registered size for the specified table.
+**/
+#define CFE_TBL_LOAD_EXCEEDS_SIZE_ERR_EID 72
+
+/** \brief <tt> 'Table Hdr in '\%s' indicates no data in file' </tt>
+**  \event <tt> 'Table Hdr in '\%s' indicates no data in file' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a Load Table command is received and the Table Header in
+**  the specified Table Image file claims the file contains no data.
+**/
+#define CFE_TBL_ZERO_LENGTH_LOAD_ERR_EID 73
+
+/** \brief <tt> ''\%s' has partial load for uninitialized table '\%s'' </tt>
+**  \event <tt> ''\%s' has partial load for uninitialized table '\%s'' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a Load Table command is received and the Table Header in
+**  the specified Table Image file indicates the starting offset for the table is non-zero and the
+**  table has never been previously, completely loaded.  Partial Table loads are only allowed after
+**  the table has had a successful load.
+**/
+#define CFE_TBL_PARTIAL_LOAD_ERR_EID 74
+
+/** \brief <tt> 'File '\%s' has more data than Tbl Hdr indicates (\%d)' </tt>
+**  \event <tt> 'File '\%s' has more data than Tbl Hdr indicates (\%d)' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a Load Table command is received and Table Services is
+**  able to locate more data in the specified Table Image file than the Table Header claims is present.
+**/
+#define CFE_TBL_FILE_TOO_BIG_ERR_EID 75
+
+/** \brief <tt> 'Too many Dump Only Table Dumps have been requested' </tt>
+**  \event <tt> 'Too many Dump Only Table Dumps have been requested' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a Table Dump command for a Dump-Only Table was received and there are
+**  no more free Dump Only Control Blocks available.  The number of simultaneous Dump Only Tables that
+**  can be pending is specified by the configuration parameter  #CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS which
+**  is found in the cfe_platform_cfg.h file.
+**/
+#define CFE_TBL_TOO_MANY_DUMPS_ERR_EID 76
+
+/** \brief <tt> 'A dump for '\%s' is already pending' </tt>
+**  \event <tt> 'A dump for '\%s' is already pending' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a Table Dump command for a Dump-Only Table was received and
+**  Table Services hasn't finished processing the previous Table Dump command for the same Table.
+**/
+#define CFE_TBL_DUMP_PENDING_ERR_EID 77
+
+/** \brief <tt> 'Illegal attempt to activate dump-only table '\%s'' </tt>
+**  \event <tt> 'Illegal attempt to activate dump-only table '\%s'' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a Table Activate command for a Dump-Only Table was received.
+**  By definition, Dump-Only tables are not allowed to be loaded with any new data.
+**/
+#define CFE_TBL_ACTIVATE_DUMP_ONLY_ERR_EID 78
+
+/** \brief <tt> 'Attempted to load DUMP-ONLY table '\%s' from '\%s'' </tt>
+**  \event <tt> 'Attempted to load DUMP-ONLY table '\%s' from '\%s'' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a Table Load command for a Dump-Only Table was received.
+**  By definition, Dump-Only tables are not allowed to be loaded with any new data.
+**/
+#define CFE_TBL_LOADING_A_DUMP_ONLY_ERR_EID 79
+
+/** \brief <tt> 'Cmd for Table '\%s' had illegal buffer parameter (0x\%08X)' </tt>
+**  \event <tt> 'Cmd for Table '\%s' had illegal buffer parameter (0x\%08X)' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when either a Table Validate command or a Table Dump Command
+**  contains a buffer identifier that does not equal either of the valid values
+**  (see #CFE_TBL_DumpCmd_Payload_t::ActiveTableFlag or #CFE_TBL_ValidateCmd_Payload_t::ActiveTableFlag)
+**
+**  The parameter in the Event Message indicates (in hex) the value found for the ActiveTableFlag in the command.
+**/
+#define CFE_TBL_ILLEGAL_BUFF_PARAM_ERR_EID 80
+
+/** \brief <tt> 'Cannot activate table '\%s'. Inactive image not Validated' </tt>
+**  \event <tt> 'Cannot activate table '\%s'. Inactive image not Validated' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a Table Activate command is received specifying
+**  a Table Image that has not been Validated.  If a table has a validation function associated with it
+**  (as defined by the owning Application when the Table is first Registered), then the Inactive Image
+**  MUST be successfully Validated prior to Activation.
+**/
+#define CFE_TBL_UNVALIDATED_ERR_EID 81
+
+/** \brief <tt> ''\%s' found in Table Registry. CDS cannot be deleted until table is unregistered' </tt>
+**  \event <tt> ''\%s' found in Table Registry. CDS cannot be deleted until table is unregistered' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a Table Delete Critical Data Store command is received specifying
+**  a Table Image that is still registered.  Critical Table Images cannot be removed from the CDS until the
+**  table is first removed from the Registry.  Unload the owning application and try again.
+**/
+#define CFE_TBL_IN_REGISTRY_ERR_EID 82
+
+/** \brief <tt> 'Table '\%s' is in Critical Table Registry but CDS is not tagged as a table' </tt>
+**  \event <tt> 'Table '\%s' is in Critical Table Registry but CDS is not tagged as a table' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a Table Delete Critical Data Store command is received specifying
+**  a CDS name for a Critical Data Store that is NOT a critical table image.  To delete CDSs that are not
+**  Critical Table Images, the Executive Services command #CFE_ES_DELETE_CDS_CC must be used.
+**/
+#define CFE_TBL_NOT_CRITICAL_TBL_ERR_EID 83
+
+/** \brief <tt> 'Table '\%s' is not found in Critical Table Registry' </tt>
+**  \event <tt> 'Table '\%s' is not found in Critical Table Registry' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a Table Delete Critical Data Store command is received specifying
+**  a table name that cannot be found in the Critical Table Registry.  If a Critical Data Store exists with
+**  the specified name, then the Critical Table Registry has somehow gotten out of sync with the CDS.
+**  Otherwise, the likely cause of this error is a misspelled table name in the command.
+**/
+#define CFE_TBL_NOT_IN_CRIT_REG_ERR_EID 84
+
+/** \brief <tt> 'Unable to locate '\%s' in CDS Registry' </tt>
+**  \event <tt> 'Unable to locate '\%s' in CDS Registry' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a Table Delete Critical Data Store command is received specifying
+**  a table name that WAS found in the Critical Table Registry but its associated entry in the Critical Data
+**  Store Registry was not found.  Somehow the two entities have become out of synch.
+**/
+#define CFE_TBL_CDS_NOT_FOUND_ERR_EID 85
+
+/** \brief <tt> 'Error while deleting '\%s' from CDS, See SysLog.(Err=0x\%08X)' </tt>
+**  \event <tt> 'Error while deleting '\%s' from CDS, See SysLog.(Err=0x\%08X)' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when an unexpected error was encountered during the deletion of the CDS.
+**  The System Log should have more precise information on the nature of the error.
+**/
+#define CFE_TBL_CDS_DELETE_ERR_EID 86
+
+/** \brief <tt> 'CDS '\%s' owning app is still active' </tt>
+**  \event <tt> 'CDS '\%s' owning app is still active' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when an attempt is made to delete a CDS while an application with the
+**  same name as the CDS Prefix is still registered in the system.  Owning applications must not be active
+**  before an associated CDS can be deleted.
+**/
+#define CFE_TBL_CDS_OWNER_ACTIVE_ERR_EID 87
+
+/** \brief <tt> 'Attempted to load table '\%s' while previous load is still pending' </tt>
+**  \event <tt> 'Attempted to load table '\%s' while previous load is still pending' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when an attempt is made to load a table while a previous load is still
+**  pending.  The most likely cause of this is the owning application is waiting for an appropriate time to
+**  load the table with the specified contents.  In order to override this load, the user would be required
+**  to issue the \link #CFE_TBL_ABORT_LOAD_CC Abort Load Command \endlink.
+**/
+#define CFE_TBL_LOADING_PENDING_ERR_EID 88
+
+/** \brief <tt> 'Manage Notification Pkt Error(MsgId=0x\%08X, CC=0x\%04X, Param=0x\%08X, Status=0x\%08X)' </tt>
+**  \event <tt> 'Manage Notification Pkt Error(MsgId=0x\%08X, CC=0x\%04X, Param=0x\%08X, Status=0x\%08X)' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a table management notification message
+**  fails to be sent via the software bus.
+**
+**  The \c MsgId is the message ID of the table management notification message that was attempted to be sent,
+**  the \c CC is the command code, the \c Param is the application specified command parameter and the \c Status
+**  is the error code returned.
+**/
+#define CFE_TBL_FAIL_NOTIFY_SEND_ERR_EID 89
+/** \} */
+
+/** \name API Informational Event Message IDs */
+/** \{ */
+
+/** \brief <tt> 'Successfully loaded '\%s' from '\%s'' </tt>
+**  \event <tt> 'Successfully loaded '\%s' from '\%s'' </tt>
+**
+**  \par Type: DEBUG (the first time) and INFORMATION (normally)
+**
+**  \par Cause:
+**
+**  This event message is generated when a Table is successfully updated by its owning Application
+**  with the contents of the Application specified file or memory area.  This Event Message only
+**  appears when an Application successfully calls the #CFE_TBL_Load API.
+**/
+#define CFE_TBL_LOAD_SUCCESS_INF_EID 35
+
+/** \brief <tt> '\%s validation successful for Inactive '\%s'' </tt>
+**  \event <tt> '\%s validation successful for Inactive '\%s'' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is generated when a Table Image is successfully validated by its owning
+**  Application via the Validation function specified by the owning Application when the table
+**  was first registered.
+**/
+#define CFE_TBL_VALIDATION_INF_EID 36
+
+/** \brief <tt> '\%s Successfully Updated '\%s'' </tt>
+**  \event <tt> '\%s Successfully Updated '\%s'' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is generated when a Table's Active Buffer is successfully updated with the contents
+**  of its Inactive Buffer.
+**/
+#define CFE_TBL_UPDATE_SUCCESS_INF_EID 37
+
+/** \brief <tt> 'Successfully removed '\%s' from CDS' </tt>
+**  \event <tt> 'Successfully removed '\%s' from CDS' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is generated when a Critical Table's CDS has been successfully deleted.
+**/
+#define CFE_TBL_CDS_DELETED_INFO_EID 38
+/** \} */
+
+/** \name API Error Event Message IDs */
+/** \{ */
+/** \brief <tt> '\%s Failed to Register '\%s', Status=0x\%08X' </tt>
+**  \event <tt> '\%s Failed to Register '\%s', Status=0x\%08X' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when an Application calls #CFE_TBL_Register unsuccessfully.
+**
+**  The \c Status field of the Event Message can be used to identify the reason for the failure
+**  by looking it up in the cfe_error.h file
+**/
+#define CFE_TBL_REGISTER_ERR_EID 90
+
+/** \brief <tt> '\%s Failed to Share '\%s', Status=0x\%08X' </tt>
+**  \event <tt> '\%s Failed to Share '\%s', Status=0x\%08X' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when an Application calls #CFE_TBL_Share unsuccessfully.
+**
+**  The \c Status field of the Event Message can be used to identify the reason for the failure
+**  by looking it up in the cfe_error.h file
+**/
+#define CFE_TBL_SHARE_ERR_EID 91
+
+/** \brief <tt> '\%s Failed to Unregister '\%s', Status=0x\%08X' </tt>
+**  \event <tt> '\%s Failed to Unregister '\%s', Status=0x\%08X' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when an Application calls #CFE_TBL_Unregister unsuccessfully.
+**
+**  The \c Status field of the Event Message can be used to identify the reason for the failure
+**  by looking it up in the cfe_error.h file
+**/
+#define CFE_TBL_UNREGISTER_ERR_EID 92
+
+/* TODO: document see https://github.com/nasa/cFE/issues/661 */
+#define CFE_TBL_LOAD_VAL_ERR_EID 93
+
+/** \brief <tt> '\%s Failed to Load '\%s' (Invalid Source Type)"  </tt>
+**  \event <tt> '\%s Failed to Load '\%s' (Invalid Source Type)"  </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when an Application calls #CFE_TBL_Load with a bad value for
+**  the \c SrcType parameter. The \c SrcType must be one of the values specified by #CFE_TBL_SrcEnum_t.
+**/
+#define CFE_TBL_LOAD_TYPE_ERR_EID 94
+
+/** \brief <tt> '\%s Failed to Update '\%s', Status=0x\%08X"  </tt>
+**  \event <tt> '\%s Failed to Update '\%s', Status=0x\%08X"  </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when an Application calls #CFE_TBL_Update (or, via an internal call,
+**  the #CFE_TBL_Manage) API and the Table fails to properly update.
+**
+**  The \c Status parameter in the Event Message can be used to identify the reason for the failure
+**  by looking it up in the cfe_error.h file.
+**/
+#define CFE_TBL_UPDATE_ERR_EID 95
+
+/** \brief <tt> '\%s validation failed for Inactive '\%s', Status=0x\%08X'  </tt>
+**  \event <tt> '\%s validation failed for Inactive '\%s', Status=0x\%08X'  </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when an Application calls #CFE_TBL_Validate (or, via an internal call,
+**  the #CFE_TBL_Manage) API and the Table fails its Validation.
+**
+**  The \c Status parameter in the Event Message contains the status code returned by the Table's
+**  Validation function as defined by the owning Application when the Table was Registered.
+**/
+#define CFE_TBL_VALIDATION_ERR_EID 96
+
+/** \brief <tt> 'Unable to verify Spacecraft ID for '\%s', ID = 0x\%08X' </tt>
+**  \event <tt> 'Unable to verify Spacecraft ID for '\%s', ID = 0x\%08X' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when either an Application calls the #CFE_TBL_Load API or a Table
+**  Load command has been received and the specified table file has failed Spacecraft ID validation.
+**  Verification of Spacecraft ID in table files is enabled/disabled via #CFE_PLATFORM_TBL_VALID_SCID_COUNT,
+**  defined in the platform configuration header file.  This event message can only be generated if
+**  #CFE_PLATFORM_TBL_VALID_SCID_COUNT has a non-zero value and the table file has a \link #CFE_FS_Header_t
+**  cFE Standard File Header \endlink whose \link #CFE_FS_Header_t::SpacecraftID Spacecraft ID \endlink
+**  does not match one of the values defined for Spacecraft ID verification in the platform config file.
+**  The most likely causes for this error are:
+**   -# The specified table file is not intended for this spacecraft.
+**   -# The specified table file has been created with bad "endianess" (headers should always conform to
+**      a big endian format).
+**   -# The specified table file has become corrupted.
+**   -# The definition for #CFE_PLATFORM_TBL_VALID_SCID_COUNT is not large enough to include all of the valid
+**      Spacecraft ID entries in the platform config file.
+**   -# There is no entry for this Spacecraft ID in the platform config file list of valid Spacecraft ID's.
+**
+**  The \c ID field specified in the event message contains the Spacecraft ID that was found
+**  in the specified table file.
+**/
+#define CFE_TBL_SPACECRAFT_ID_ERR_EID 97
+
+/** \brief <tt> 'Unable to verify Processor ID for '\%s', ID = 0x\%08X' </tt>
+**  \event <tt> 'Unable to verify Processor ID for '\%s', ID = 0x\%08X' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when either an Application calls the #CFE_TBL_Load API or a Table
+**  Load command has been received and the specified table file has failed Processor ID validation.
+**  Verification of Processor ID in table files is enabled/disabled via #CFE_PLATFORM_TBL_VALID_PRID_COUNT,
+**  defined in the platform configuration header file.  This event message can only be generated if
+**  #CFE_PLATFORM_TBL_VALID_PRID_COUNT has a non-zero value and the table file has a \link #CFE_FS_Header_t
+**  cFE Standard File Header \endlink whose \link #CFE_FS_Header_t::ProcessorID Processor ID \endlink
+**  does not match one of the values defined for Processor ID verification in the platform config file.
+**  The most likely causes for this error are:
+**   -# The specified table file is not intended for this processor.
+**   -# The specified table file has been created with bad "endianess" (headers should always conform to
+**      a big endian format).
+**   -# The specified table file has become corrupted.
+**   -# The definition for #CFE_PLATFORM_TBL_VALID_PRID_COUNT is not large enough to include all of the valid
+**      Processor ID entries in the platform config file.
+**   -# There is no entry for this Processor ID in the platform config file list of valid Processor ID's.
+**
+**  The \c ID field specified in the event message contains the Processor ID that was found
+**  in the specified table file.
+**/
+#define CFE_TBL_PROCESSOR_ID_ERR_EID 98
+
+/** \brief <tt> Attempted to load Dump Only Tbl '%s' </tt>
+**  \event <tt> Attempted to load Dump Only Tbl '%s' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when an application attempts to load a dump-only table.
+**/
+#define CFE_TBL_LOAD_DUMPONLY_ERR_EID 99
+
+/** \brief <tt> Load already in progress for '%s' </tt>
+**  \event <tt> Load already in progress for '%s' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when an application attempts to load a table already
+**  in progress. Likely due to a race condition.
+**/
+#define CFE_TBL_LOAD_IN_PROGRESS_ERR_EID 100
+
+/** \brief <tt> Filename is too long ('%s' (%lu) > %lu)  </tt>
+**  \event <tt> Filename is too long ('%s' (%lu) > %lu)  </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  The filename provided for the table file is too long (exceeding OS_MAX_PATH_LEN - 1).
+**/
+#define CFE_TBL_LOAD_FILENAME_LONG_ERR_EID 101
+
+/** \brief <tt> table name mismatch (exp=%s, tblfilhdr=%s) </tt>
+**  \event <tt> table name mismatch (exp=%s, tblfilhdr=%s) </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  The table name in the table file header does not match the specified table name.
+**/
+#define CFE_TBL_LOAD_TBLNAME_MISMATCH_ERR_EID 102
+
+/** \brief <tt> No access to Tbl handle=%d </tt>
+**  \event <tt> No access to Tbl handle=%d </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  The application ID does not have access to the table handle.
+**/
+#define CFE_TBL_HANDLE_ACCESS_ERR_EID 103
+
+/** \} */
+
+#endif /* CFE_TBL_EVENTS_H */

--- a/modules/tbl/fsw/inc/cfe_tbl_msg.h
+++ b/modules/tbl/fsw/inc/cfe_tbl_msg.h
@@ -1,0 +1,839 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * @file
+ *
+ * Purpose:  cFE Table Services (TBL) SB message definitions header file
+ *
+ * Author:   D.Kobe/Hammers
+ *
+ * Notes:
+ *
+ */
+
+#ifndef CFE_TBL_MSG_H
+#define CFE_TBL_MSG_H
+
+/*
+** Required header files...
+*/
+#include "common_types.h" /* Basic data types */
+#include "cfe_msg_hdr.h"  /* for header definitions */
+#include "cfe_tbl_extern_typedefs.h"
+#include "cfe_time_extern_typedefs.h"
+
+/*************************************************************************/
+
+/*
+** Table task command packet command codes
+*/
+/** \name Table Services Command Codes */
+/** \{ */
+
+/** \cfetblcmd Table No-Op
+**
+**  \par Description
+**       This command performs no other function than to increment the
+**       command execution counter. The command may be used to verify
+**       general aliveness of the Table Services task.
+**
+**  \cfecmdmnemonic \TBL_NOOP
+**
+**  \par Command Structure
+**       #CFE_TBL_NoopCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TBL_CMDPC - command execution counter will
+**         increment
+**       - The #CFE_TBL_NOOP_INF_EID informational event message will
+**         be generated
+**
+**  \par Error Conditions
+**       There are no error conditions for this command. If the Table
+**       Services receives the command, the event is sent (although it
+**       may be filtered by EVS) and the counter is incremented
+**       unconditionally.
+**
+**  \par Criticality
+**       None
+**
+**  \sa
+*/
+#define CFE_TBL_NOOP_CC 0
+
+/** \cfetblcmd Table Reset Counters
+**
+**  \par Description
+**       This command resets the following counters within the Table
+**       Services housekeeping telemetry:
+**       - Command Execution Counter (\TBL_CMDPC)
+**       - Command Error Counter (\TBL_CMDEC)
+**       - Successful Table Validations Counter (\TBL_VALSUCCESSCTR)
+**       - Failed Table Validations Counter (\TBL_VALFAILEDCTR)
+**       - Number of Table Validations Requested (\TBL_VALREQCTR)
+**
+**  \cfecmdmnemonic \TBL_RESETCTRS
+**
+**  \par Command Structure
+**       #CFE_TBL_ResetCountersCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with
+**       the following telemetry:
+**       - \b \c \TBL_CMDPC - command execution counter will
+**         increment
+**       - The #CFE_TBL_RESET_INF_EID debug event message will be
+**         generated
+**
+**  \par Error Conditions
+**       There are no error conditions for this command. If the Table
+**       Services receives the command, the event is sent (although it
+**       may be filtered by EVS) and the counter is incremented
+**       unconditionally.
+**
+**  \par Criticality
+**       This command is not inherently dangerous.  However, it is
+**       possible for ground systems and on-board safing procedures
+**       to be designed such that they react to changes in the counter
+**       values that are reset by this command.
+**
+**  \sa
+*/
+#define CFE_TBL_RESET_COUNTERS_CC 1
+
+/** \cfetblcmd Load Table
+**
+**  \par Description
+**       This command loads the contents of the specified file into
+**       an inactive buffer for the table specified within the file.
+**
+**  \cfecmdmnemonic \TBL_LOAD
+**
+**  \par Command Structure
+**       #CFE_TBL_LoadCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with
+**       the following telemetry:
+**       - \b \c \TBL_CMDPC - command execution counter will
+**         increment
+**       - The #CFE_TBL_FILE_LOADED_INF_EID informational event message
+**         will be generated
+**
+**  \par Error Conditions
+**       This command can fail for the following reasons:
+**       - Table name found in table image file's table header is not found
+**         in table registry (ie - The table associated with the table image
+**         in the file has not been registered by an application).
+**       - The table image file's header indicates the file contains 'x'
+**         number of bytes of data but the file contains less.
+**       - No working buffers are available for the load.  This would indicate
+**         that too many single-buffered table loads are in progress at the same
+**         time.
+**       - The table image file's header indicates the data to be loaded is
+**         beyond the size of the table.  Either the number of bytes in the
+**         file are too many or the starting offset into the table is too high.
+**       - The table image file's header indicates there is no data in the
+**         file (ie - Number of bytes to load is zero).
+**       - An attempt is being made to load an uninitialized table with a file
+**         containing only a partial table image.
+**       - The table image file was unable to be opened.  Either the file does
+**         not exist at the specified location, the filename is in error, or
+**         the file system has been corrupted.
+**
+**       Evidence of failure may be found in the following telemetry:
+**       - \b \c \TBL_CMDEC - command error counter will increment
+**       - Command specific error event messages are issued for all error cases
+**
+**  \par Criticality
+**       This command is not inherently dangerous.  It is performing the first
+**       step of loading a table and can be aborted (using the Abort Table Load
+**       command described below) without affecting the contents of the active
+**       table image.
+**
+**  \sa  #CFE_TBL_DUMP_CC, #CFE_TBL_VALIDATE_CC, #CFE_TBL_ACTIVATE_CC, #CFE_TBL_ABORT_LOAD_CC
+*/
+#define CFE_TBL_LOAD_CC 2
+
+/** \cfetblcmd Dump Table
+**
+**  \par Description
+**       This command will cause the Table Services to put the contents
+**       of the specified table buffer into the command specified file.
+**
+**  \cfecmdmnemonic \TBL_DUMP
+**
+**  \par Command Structure
+**       #CFE_TBL_DumpCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TBL_CMDPC - command execution counter will
+**         increment
+**       - Either the #CFE_TBL_OVERWRITE_DUMP_INF_EID OR the
+**         #CFE_TBL_WRITE_DUMP_INF_EID informational event message will
+**         be generated
+**
+**  \par Error Conditions
+**       This command may fail for the following reason(s):
+**       - A single buffered table's inactive buffer was requested to be
+**         dumped and no such buffer is currently allocated.
+**       - Error occurred during write operation to file. Possible causes
+**         might be insufficient space in the file system or the filename
+**         or file path is improperly specified.
+**       - The specified table name was not found in the table registry.
+**
+**       Evidence of failure may be found in the following telemetry:
+**       - \b \c \TBL_CMDEC - command error counter will increment
+**       - A command specific error event message is issued for all error
+**         cases
+**
+**  \par Criticality
+**       This command is not inherently dangerous.  It will create a new
+**       file in the file system and could, if performed repeatedly without
+**       sufficient file management by the operator, fill the file system.
+**
+**  \sa  #CFE_TBL_LOAD_CC, #CFE_TBL_VALIDATE_CC, #CFE_TBL_ACTIVATE_CC, #CFE_TBL_ABORT_LOAD_CC
+*/
+#define CFE_TBL_DUMP_CC 3
+
+/** \cfetblcmd Validate Table
+**
+**  \par Description
+**       This command will cause Table Services to calculate the Data Integrity
+**       Value for the specified table and to notify the owning application that
+**       the table's validation function should be executed.  The results of both
+**       the Data Integrity Value computation and the validation function are
+**       reported in Table Services Housekeeping Telemetry.
+**
+**  \cfecmdmnemonic \TBL_VALIDATE
+**
+**  \par Command Structure
+**       #CFE_TBL_ValidateCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the following
+**       telemetry:
+**       - \b \c \TBL_CMDPC -  command execution counter will increment
+**       - \b \c \TBL_VALREQCTR - table validation request counter will increment
+**       - \b \c \TBL_LASTVALCRC - calculated data integrity value will be updated
+**       - The #CFE_TBL_VAL_REQ_MADE_INF_EID debug event message (indicating the
+**         application is being notified of a validation request)
+**
+**       If the specified table has an associated validation function, then the
+**       following telemetry will also change:
+**       - Either \b \c \TBL_VALSUCCESSCTR OR \b \c \TBL_VALFAILEDCTR will
+**         increment
+**       - \b \c \TBL_VALCOMPLTDCTR - table validations performed counter will
+**         increment
+**       - \b \c \TBL_LASTVALS - table validation function return status will
+**         update
+**       - The #CFE_TBL_VALIDATION_INF_EID informational event message (indicating the
+**         validation function return status) will be generated
+**
+**  \par Error Conditions
+**       This command may fail for the following reason(s):
+**       - A single buffered table's inactive buffer was requested to be dumped
+**         and no such buffer is currently allocated.
+**       - Too many validations have been requested simultaneously.  The operator
+**         must wait for one or more applications to perform their table validation
+**         functions before trying again.
+**       - The specified table name was not found in the table registry.
+**
+**       Evidence of failure may be found in the following telemetry:
+**       - \b \c \TBL_CMDEC - command error counter will increment
+**       - Command specific error event message are issued for all error cases
+**
+**  \par Criticality
+**       The success or failure of a table validation does not have any immediate
+**       impact on table contents.  The results are sent to the operator in telemetry
+**       and the operator must determine whether the results are acceptable and send a
+**       command to activate the validated table image.
+**
+**  \sa  #CFE_TBL_LOAD_CC, #CFE_TBL_DUMP_CC, #CFE_TBL_ACTIVATE_CC, #CFE_TBL_ABORT_LOAD_CC
+*/
+#define CFE_TBL_VALIDATE_CC 4
+
+/** \cfetblcmd Activate Table
+**
+**  \par Description
+**       This command will cause Table Services to notify a table's owner
+**       that an update is pending.  The owning application will then update
+**       the contents of the active table buffer with the contents of the
+**       associated inactive table buffer at a time of their convenience.
+**
+**  \cfecmdmnemonic \TBL_ACTIVATE
+**
+**  \par Command Structure
+**       #CFE_TBL_ActivateCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TBL_CMDPC - command execution counter will
+**         increment
+**       - The #CFE_TBL_UPDATE_SUCCESS_INF_EID informational event message
+**         will be generated
+**
+**  \par Error Conditions
+**       This command may fail for the following reason(s):
+**       - A single buffered table's inactive buffer was requested to be
+**         dumped and no such buffer is currently allocated.
+**       - The specified table name was not found in the table registry.
+**
+**       Evidence of failure may be found in the following telemetry:
+**       - \b \c \TBL_CMDEC - command error counter will increment
+**       - Command specific error event message are issued for all
+**         error cases
+**
+**  \par Criticality
+**       This command will cause the contents of the specified table to be
+**       updated with the contents in the inactive table buffer.
+**
+**  \sa  #CFE_TBL_LOAD_CC, #CFE_TBL_DUMP_CC, #CFE_TBL_VALIDATE_CC, #CFE_TBL_ABORT_LOAD_CC
+*/
+#define CFE_TBL_ACTIVATE_CC 5
+
+/** \cfetblcmd Dump Table Registry
+**
+**  \par Description
+**       This command will cause Table Services to write some of the
+**       contents of the Table Registry to the command specified file.
+**       This allows the operator to see the current state and configuration
+**       of all tables that have been registered with the cFE.
+**
+**  \cfecmdmnemonic \TBL_WRITEREG2FILE
+**
+**  \par Command Structure
+**       #CFE_TBL_DumpRegistryCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TBL_CMDPC -  command execution counter will
+**         increment
+**       - The generation of either #CFE_TBL_OVERWRITE_REG_DUMP_INF_EID
+**         or #CFE_TBL_WRITE_REG_DUMP_INF_EID debug event messages
+**       - The specified file should appear (or be updated) at the
+**         specified location in the file system
+**
+**  \par Error Conditions
+**       This command may fail for the following reason(s):
+**       - Error occurred during write operation to file. Possible
+**         causes might be insufficient space in the file system
+**         or the filename or file path is improperly specified.
+**
+**       Evidence of failure may be found in the following telemetry:
+**       - \b \c \TBL_CMDEC - command error counter will increment
+**       - An Error specific event message
+**
+**  \par Criticality
+**       This command is not inherently dangerous.  It will create a new
+**       file in the file system and could, if performed repeatedly without
+**       sufficient file management by the operator, fill the file system.
+**
+**  \sa  #CFE_TBL_SEND_REGISTRY_CC
+*/
+#define CFE_TBL_DUMP_REGISTRY_CC 6
+
+/** \cfetblcmd Telemeter One Table Registry Entry
+**
+**  \par Description
+**       This command will cause Table Services to telemeter the contents
+**       of the Table Registry for the command specified table.
+**
+**  \cfecmdmnemonic \TBL_TLMREG
+**
+**  \par Command Structure
+**       #CFE_TBL_SendRegistryCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TBL_CMDPC -  command execution counter will increment
+**       - Receipt of a Table Registry Info Packet (see #CFE_TBL_TableRegistryTlm_t)
+**       - The #CFE_TBL_TLM_REG_CMD_INF_EID debug event message will
+**         be generated
+**
+**  \par Error Conditions
+**       This command may fail for the following reason(s):
+**       - The specified table name was not found in the table registry.
+**
+**       Evidence of failure may be found in the following telemetry:
+**       - \b \c \TBL_CMDEC - command error counter will increment
+**       - Error specific event message
+**
+**  \par Criticality
+**       This command is not inherently dangerous.  It will generate
+**       additional telemetry.
+**
+**  \sa  #CFE_TBL_DUMP_REGISTRY_CC
+*/
+#define CFE_TBL_SEND_REGISTRY_CC 7
+
+/** \cfetblcmd Delete Critical Table from Critical Data Store
+**
+**  \par Description
+**       This command will delete the Critical Data Store (CDS) associated
+**       with the specified Critical Table.  Note that any table still
+**       present in the Table Registry is unable to be deleted from
+**       the Critical Data Store.  All Applications that are accessing
+**       the critical table must release and unregister their access
+**       before the CDS can be deleted.
+**
+**  \cfecmdmnemonic \TBL_DELETECDS
+**
+**  \par Command Structure
+**       #CFE_TBL_DeleteCDSCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TBL_CMDPC - command execution counter will
+**         increment
+**       - The #CFE_TBL_CDS_DELETED_INFO_EID informational event message
+**         will be generated
+**
+**  \par Error Conditions
+**       This command may fail for the following reason(s):
+**       - The specified table name was not found in the critical data
+**         store registry
+**       - The specified table name WAS found in the table registry (all
+**         registrations/sharing of the table must be unregistered before
+**         the table's CDS can be deleted)
+**       - The table's owning application is still active
+**
+**       Evidence of failure may be found in the following telemetry:
+**       - \b \c \TBL_CMDEC - command error counter will increment
+**       - Error specific event message
+**
+**  \par Criticality
+**       This command will cause the loss of the specified table's contents
+**       before the owning Application was terminated.
+**
+**  \sa  #CFE_ES_DUMP_CDS_REGISTRY_CC, #CFE_ES_DELETE_CDS_CC
+*/
+#define CFE_TBL_DELETE_CDS_CC 8
+
+/** \cfetblcmd Abort Table Load
+**
+**  \par Description
+**       This command will cause Table Services to discard the contents of
+**       a table buffer that was previously loaded with the data in a file
+**       as specified by a Table Load command.  For single buffered tables,
+**       the allocated shared working buffer is freed and becomes available
+**       for other Table Load commands.
+**
+**  \cfecmdmnemonic \TBL_LOADABORT
+**
+**  \par Command Structure
+**       #CFE_TBL_AbortLoadCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TBL_CMDPC -  command execution counter will increment
+**       - The #CFE_TBL_LOAD_ABORT_INF_EID informational event message
+**         is generated
+**       - If the load was aborted for a single buffered table, the
+**         \b \c \TBL_NUMFREESHRBUF telemetry point should increment
+**
+**  \par Error Conditions
+**       This command may fail for the following reason(s):
+**       - The specified table name was not found in the table registry.
+**       - The specified table did not have a load in progress to be aborted.
+**
+**       Evidence of failure may be found in the following telemetry:
+**       - \b \c \TBL_CMDEC - command error counter will increment
+**       - Error specific event message
+**
+**  \par Criticality
+**       This command will cause the loss of data put into an inactive table buffer.
+**
+**  \sa  #CFE_TBL_LOAD_CC, #CFE_TBL_DUMP_CC, #CFE_TBL_VALIDATE_CC, #CFE_TBL_ACTIVATE_CC
+*/
+#define CFE_TBL_ABORT_LOAD_CC 9
+/** \} */
+
+/*************************************************************************/
+
+/********************************/
+/* Command Message Data Formats */
+/********************************/
+/**
+** \brief Generic "no arguments" command
+**
+** This command structure is used for commands that do not have any parameters.
+** This includes:
+** -# The Housekeeping Request Message
+** -# The No-Op Command (For details, see #CFE_TBL_NOOP_CC)
+** -# The Reset Counters Command (For details, see #CFE_TBL_RESET_COUNTERS_CC)
+*/
+typedef struct CFE_TBL_NoArgsCmd
+{
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+} CFE_TBL_NoArgsCmd_t;
+
+/*
+ * Typedefs for each of the messages that share the command format
+ * Allows each command to evolve independently, while following the command
+ * handler prototype convention
+ */
+typedef CFE_TBL_NoArgsCmd_t CFE_TBL_NoopCmd_t;
+typedef CFE_TBL_NoArgsCmd_t CFE_TBL_ResetCountersCmd_t;
+
+/**
+** \brief Load Table Command Payload
+**
+** For command details, see #CFE_TBL_LOAD_CC
+**
+**/
+typedef struct CFE_TBL_LoadCmd_Payload
+{
+    char LoadFilename[CFE_MISSION_MAX_PATH_LEN]; /**< \brief Filename (and path) of data to be loaded */
+} CFE_TBL_LoadCmd_Payload_t;
+
+/**
+ * \brief Load Table Command
+ */
+typedef struct CFE_TBL_LoadCmd
+{
+    CFE_MSG_CommandHeader_t   CmdHeader; /**< \brief Command header */
+    CFE_TBL_LoadCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TBL_LoadCmd_t;
+
+/**
+** \brief Dump Table Command Payload
+**
+** For command details, see #CFE_TBL_DUMP_CC
+*/
+typedef struct CFE_TBL_DumpCmd_Payload
+{
+    uint16 ActiveTableFlag;                            /**< \brief #CFE_TBL_BufferSelect_INACTIVE=Inactive Table,
+                                                                 #CFE_TBL_BufferSelect_ACTIVE=Active Table */
+                                                       /**< Selects either the "Inactive"
+                                                            (#CFE_TBL_BufferSelect_INACTIVE) buffer or the
+                                                            "Active" (#CFE_TBL_BufferSelect_ACTIVE) buffer
+                                                            to be dumped */
+    char TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \brief Full name of table to be dumped */
+                                                       /**< ASCII string containing full table name
+                                                            identifier of table to be dumped */
+    char DumpFilename[CFE_MISSION_MAX_PATH_LEN];       /**< \brief Full Filename where data is to be written */
+                                                       /**< ASCII string containing full path of filename
+                                                            where data is to be dumped */
+} CFE_TBL_DumpCmd_Payload_t;
+
+/**
+ * /brief Dump Table Command
+ */
+typedef struct CFE_TBL_DumpCmd
+{
+    CFE_MSG_CommandHeader_t   CmdHeader; /**< \brief Command header */
+    CFE_TBL_DumpCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TBL_DumpCmd_t;
+
+/**
+** \brief Validate Table Command Payload
+**
+** For command details, see #CFE_TBL_VALIDATE_CC
+*/
+typedef struct CFE_TBL_ValidateCmd_Payload
+{
+    uint16 ActiveTableFlag;                            /**< \brief #CFE_TBL_BufferSelect_INACTIVE=Inactive Table,
+                                                                 #CFE_TBL_BufferSelect_ACTIVE=Active Table */
+                                                       /**< Selects either the "Inactive"
+                                                            (#CFE_TBL_BufferSelect_INACTIVE) buffer or the
+                                                            "Active" (#CFE_TBL_BufferSelect_ACTIVE) buffer
+                                                            to be validated */
+    char TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \brief Full Name of Table to be validated */
+                                                       /**< ASCII string containing full table name
+                                                            identifier of table to be validated */
+} CFE_TBL_ValidateCmd_Payload_t;
+
+/**
+ * \brief Validate Table Command
+ */
+typedef struct CFE_TBL_ValidateCmd
+{
+    CFE_MSG_CommandHeader_t       CmdHeader; /**< \brief Command header */
+    CFE_TBL_ValidateCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TBL_ValidateCmd_t;
+
+/**
+** \brief Activate Table Command Payload
+**
+** For command details, see #CFE_TBL_ACTIVATE_CC
+*/
+typedef struct CFE_TBL_ActivateCmd_Payload
+{
+    char TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \brief Full Name of Table to be activated */
+                                                       /**< ASCII string containing full table name
+                                                            identifier of table to be activated */
+} CFE_TBL_ActivateCmd_Payload_t;
+
+/**
+ * \brief Activate Table Command
+ */
+typedef struct CFE_TBL_ActivateCmd
+{
+    CFE_MSG_CommandHeader_t       CmdHeader; /**< \brief Command header */
+    CFE_TBL_ActivateCmd_Payload_t Payload;   /**< \brief Command paylod */
+} CFE_TBL_ActivateCmd_t;
+
+/**
+** \brief Dump Registry Command Payload
+**
+** For command details, see #CFE_TBL_DUMP_REGISTRY_CC
+*/
+typedef struct CFE_TBL_DumpRegistryCmd_Payload
+{
+    char DumpFilename[CFE_MISSION_MAX_PATH_LEN]; /**< \brief Full Filename where dumped data is to be
+                                             written */
+                                                 /**< ASCII string containing full path of filename
+                                                      where registry is to be dumped */
+} CFE_TBL_DumpRegistryCmd_Payload_t;
+
+/**
+ * \brief Dump Registry Command
+ */
+typedef struct CFE_TBL_DumpRegistryCmd
+{
+    CFE_MSG_CommandHeader_t           CmdHeader; /**< \brief Command header */
+    CFE_TBL_DumpRegistryCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TBL_DumpRegistryCmd_t;
+
+/**
+** \brief Send Table Registry Command Payload
+**
+** For command details, see #CFE_TBL_SEND_REGISTRY_CC
+*/
+typedef struct CFE_TBL_SendRegistryCmd_Payload
+{
+    char TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \brief Full Name of Table whose registry entry
+                                                    is to be telemetered */
+                                                       /**< ASCII string containing full table name
+                                                            identifier of table whose registry entry is
+                                                            to be telemetered via #CFE_TBL_TableRegistryTlm_t */
+} CFE_TBL_SendRegistryCmd_Payload_t;
+
+/**
+ * \brief Send Table Registry Command
+ */
+typedef struct CFE_TBL_SendRegistryCmd
+{
+    CFE_MSG_CommandHeader_t           CmdHeader; /**< \brief Command header */
+    CFE_TBL_SendRegistryCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TBL_SendRegistryCmd_t;
+
+/**
+** \brief Delete Critical Table CDS Command Payload
+**
+** For command details, see #CFE_TBL_DELETE_CDS_CC
+*/
+typedef struct CFE_TBL_DelCDSCmd_Payload
+{
+    char TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \brief Full Name of Table whose CDS is
+                                                    to be deleted */
+                                                       /**< ASCII string containing full table name
+                                                            identifier of a critical table whose
+                                                            CDS is to be deleted */
+} CFE_TBL_DelCDSCmd_Payload_t;
+
+/**
+ * \brief Delete Critical Table CDS Command
+ */
+typedef struct CFE_TBL_DeleteCDSCmd
+{
+    CFE_MSG_CommandHeader_t     CmdHeader; /**< \brief Command header */
+    CFE_TBL_DelCDSCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TBL_DeleteCDSCmd_t;
+
+/**
+** \brief Abort Load Command Payload
+**
+** For command details, see #CFE_TBL_ABORT_LOAD_CC
+*/
+typedef struct CFE_TBL_AbortLoadCmd_Payload
+{
+    char TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \brief Full Name of Table whose load is to be aborted */
+                                                       /**< ASCII string containing full table name
+                                                            identifier of a table whose load is to be aborted */
+} CFE_TBL_AbortLoadCmd_Payload_t;
+
+/**
+ * \brief Abort Load Command
+ */
+typedef struct CFE_TBL_AbortLoadCmd
+{
+    CFE_MSG_CommandHeader_t        CmdHeader; /**< \brief Command header */
+    CFE_TBL_AbortLoadCmd_Payload_t Payload;   /**< \brief Command paylod */
+} CFE_TBL_AbortLoadCmd_t;
+
+/*************************************************************************/
+/******************************************/
+/* Generated Command Message Data Formats */
+/******************************************/
+/**
+** \brief Table Management Notification Command Payload
+**
+** \par Description
+**      Whenever an application that owns a table calls the #CFE_TBL_NotifyByMessage API
+**      following the table registration, Table services will generate the following
+**      command message with the application specified message ID, command code and
+**      parameter whenever the table requires management (e.g. - loads and validations).
+*/
+typedef struct CFE_TBL_NotifyCmd_Payload
+{
+    uint32 Parameter; /**< \brief Application specified command parameter */
+} CFE_TBL_NotifyCmd_Payload_t;
+
+/**
+ * /brief Table Management Notification Command
+ */
+typedef struct CFE_TBL_NotifyCmd
+{
+    CFE_MSG_CommandHeader_t     CmdHeader; /**< \brief Command header */
+    CFE_TBL_NotifyCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TBL_NotifyCmd_t;
+
+/*************************************************************************/
+/**********************************/
+/* Telemetry Message Data Formats */
+/**********************************/
+/**
+**  \cfetbltlm Table Services Housekeeping Packet
+**/
+typedef struct CFE_TBL_HousekeepingTlm_Payload
+{
+    /*
+    ** Task command interface counters...
+    */
+    uint8 CommandCounter;      /**< \cfetlmmnemonic \TBL_CMDPC
+                                \brief Count of valid commands received */
+    uint8 CommandErrorCounter; /**< \cfetlmmnemonic \TBL_CMDEC
+                           \brief Count of invalid commands received */
+
+    /*
+    ** Table Registry Statistics
+    */
+    uint16 NumTables;      /**< \cfetlmmnemonic \TBL_NUMTABLES
+                                \brief Number of Tables Registered */
+    uint16 NumLoadPending; /**< \cfetlmmnemonic \TBL_NUMUPDATESPEND
+                                \brief Number of Tables pending on Applications for their update */
+
+    /*
+    ** Last Table Validation Results
+    */
+    uint16 ValidationCounter;                                 /**< \cfetlmmnemonic \TBL_VALCOMPLTDCTR
+                                                               \brief Number of completed table validations */
+    uint32 LastValCrc;                                        /**< \cfetlmmnemonic \TBL_LASTVALCRC
+                                                                   \brief Data Integrity Value computed for last table validated */
+    int32 LastValStatus;                                      /**< \cfetlmmnemonic \TBL_LASTVALS
+                                                                   \brief Returned status from validation function for last table validated */
+    bool ActiveBuffer;                                        /**< \cfetlmmnemonic \TBL_LASTVALBUF
+                                                                   \brief Indicator of whether table buffer validated was 0=Inactive, 1=Active */
+    char LastValTableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \cfetlmmnemonic \TBL_LASTVALTBLNAME
+                                                           \brief Name of last table validated */
+    uint8 SuccessValCounter;                                  /**< \cfetlmmnemonic \TBL_VALSUCCESSCTR
+                                                               \brief Total number of successful table validations */
+    uint8 FailedValCounter;                                   /**< \cfetlmmnemonic \TBL_VALFAILEDCTR
+                                                               \brief Total number of unsuccessful table validations */
+    uint8 NumValRequests;                                     /**< \cfetlmmnemonic \TBL_VALREQCTR
+                                                                   \brief Number of times Table Services has requested validations from Apps */
+
+    /*
+    ** Ground system interface information
+    */
+    uint8 NumFreeSharedBufs;                                  /**< \cfetlmmnemonic \TBL_NUMFREESHRBUF
+                                                                   \brief Number of free Shared Working Buffers */
+    uint8 ByteAlignPad1;                                      /**< \cfetlmmnemonic \TBL_BYTEALIGNPAD1
+                                                                   \brief Spare byte to ensure longword alignment */
+    CFE_ES_MemHandle_t MemPoolHandle;                         /**< \cfetlmmnemonic \TBL_MEMPOOLHANDLE
+                                                                   \brief Handle to TBL's memory pool */
+    CFE_TIME_SysTime_t LastUpdateTime;                        /**< \cfetlmmnemonic \TBL_LASTUPDTIME
+                                                                   \brief Time of last table update */
+    char LastUpdatedTable[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \cfetlmmnemonic \TBL_LASTUPDTBLNAME
+                                                         \brief Name of the last table updated */
+    char LastFileLoaded[CFE_MISSION_MAX_PATH_LEN];            /**< \cfetlmmnemonic \TBL_LASTFILELOADED
+                                                          \brief Path and Name of last table image file loaded */
+    char LastFileDumped[CFE_MISSION_MAX_PATH_LEN];            /**< \cfetlmmnemonic \TBL_LASTFILEDUMPED
+                                                          \brief Path and Name of last file dumped to */
+    char LastTableLoaded[CFE_MISSION_TBL_MAX_FULL_NAME_LEN];  /**< \cfetlmmnemonic \TBL_LASTTABLELOADED
+                                                          \brief Name of the last table loaded */
+} CFE_TBL_HousekeepingTlm_Payload_t;
+
+typedef struct CFE_TBL_HousekeepingTlm
+{
+    CFE_MSG_TelemetryHeader_t         TlmHeader; /**< \brief Telemetry header */
+    CFE_TBL_HousekeepingTlm_Payload_t Payload;   /**< \brief Telemetry payload */
+} CFE_TBL_HousekeepingTlm_t;
+
+/**
+**  \cfetbltlm Table Registry Info Packet
+**/
+typedef struct CFE_TBL_TblRegPacket_Payload
+{
+    CFE_ES_MemOffset_t Size;                       /**< \cfetlmmnemonic \TBL_SIZE
+                                                        \brief Size, in bytes, of Table */
+    uint32 Crc;                                    /**< \cfetlmmnemonic \TBL_CRC
+                                                        \brief Most recently calculated CRC of Table */
+    CFE_ES_MemAddress_t ActiveBufferAddr;          /**< \cfetlmmnemonic \TBL_ACTBUFADD
+                                                        \brief Address of Active Buffer */
+    CFE_ES_MemAddress_t InactiveBufferAddr;        /**< \cfetlmmnemonic \TBL_IACTBUFADD
+                                                        \brief Address of Inactive Buffer */
+    CFE_ES_MemAddress_t ValidationFuncPtr;         /**< \cfetlmmnemonic \TBL_VALFUNCPTR
+                                                        \brief Ptr to Owner App's function that validates tbl contents */
+    CFE_TIME_SysTime_t TimeOfLastUpdate;           /**< \cfetlmmnemonic \TBL_TIMELASTUPD
+                                                        \brief Time when Table was last updated */
+    uint32 FileCreateTimeSecs;                     /**< \cfetlmmnemonic \TBL_FILECSECONDS
+                                                        \brief File creation time from last file loaded into table */
+    uint32 FileCreateTimeSubSecs;                  /**< \cfetlmmnemonic \TBL_FILECSUBSECONDS
+                                                        \brief File creation time from last file loaded into table */
+    bool TableLoadedOnce;                          /**< \cfetlmmnemonic \TBL_LOADEDONCE
+                                                        \brief Flag indicating whether table has been loaded once or not */
+    bool LoadPending;                              /**< \cfetlmmnemonic \TBL_UPDATEPNDNG
+                                                        \brief Flag indicating an inactive buffer is ready to be copied */
+    bool DumpOnly;                                 /**< \cfetlmmnemonic \TBL_DUMPONLY
+                                                        \brief Flag indicating Table is NOT to be loaded */
+    bool DoubleBuffered;                           /**< \cfetlmmnemonic \TBL_DBLBUFFERED
+                                                     \brief Flag indicating Table has a dedicated inactive buffer */
+    char Name[CFE_MISSION_TBL_MAX_FULL_NAME_LEN];  /**< \cfetlmmnemonic \TBL_NAME
+                                                \brief Processor specific table name */
+    char LastFileLoaded[CFE_MISSION_MAX_PATH_LEN]; /**< \cfetlmmnemonic \TBL_LASTFILEUPD
+                                               \brief Filename of last file loaded into table */
+    char OwnerAppName[CFE_MISSION_MAX_API_LEN];    /**< \cfetlmmnemonic \TBL_OWNERAPP
+                                                \brief Name of owning application */
+    bool Critical;                                 /**< \cfetlmmnemonic \TBL_CRITICAL
+                                                        \brief Indicates whether table is Critical or not */
+    uint8 ByteAlign4;                              /**< \cfetlmmnemonic \TBL_SPARE4
+                                                        \brief Spare byte to maintain byte alignment */
+} CFE_TBL_TblRegPacket_Payload_t;
+
+typedef struct CFE_TBL_TableRegistryTlm
+{
+    CFE_MSG_TelemetryHeader_t      TlmHeader; /**< \brief Telemetry header */
+    CFE_TBL_TblRegPacket_Payload_t Payload;   /**< \brief Telemetry payload */
+} CFE_TBL_TableRegistryTlm_t;
+
+#endif /* CFE_TBL_MSG_H */

--- a/modules/tbl/fsw/src/cfe_tbl_api.c
+++ b/modules/tbl/fsw/src/cfe_tbl_api.c
@@ -1,0 +1,1554 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/*
+** File: cfe_tbl_api.c
+**
+** Purpose:  cFE Table Services (TBL) library API source file
+**
+** Author:   D. Kobe/the Hammers Company, Inc.
+**
+** Notes:
+**
+*/
+
+/*
+** Required header files...
+*/
+#include "cfe_tbl_module_all.h"
+
+#include <string.h>
+
+/*
+** Local Macros
+*/
+
+/*
+ * Function: CFE_TBL_Register - See API and header file for details
+ */
+int32 CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, size_t Size, uint16 TblOptionFlags,
+                       CFE_TBL_CallbackFuncPtr_t TblValidationFuncPtr)
+{
+    CFE_TBL_AccessDescriptor_t *AccessDescPtr = NULL;
+    CFE_TBL_RegistryRec_t *     RegRecPtr     = NULL;
+    CFE_TBL_LoadBuff_t *        WorkingBufferPtr;
+    CFE_TBL_CritRegRec_t *      CritRegRecPtr = NULL;
+    int32                       Status;
+    size_t                      NameLen;
+    int16                       RegIndx;
+    CFE_ES_AppId_t              ThisAppId;
+    char                        AppName[OS_MAX_API_NAME]           = {"UNKNOWN"};
+    char                        TblName[CFE_TBL_MAX_FULL_NAME_LEN] = {""};
+    CFE_TBL_Handle_t            AccessIndex;
+
+    if (TblHandlePtr == NULL || Name == NULL)
+    {
+        return CFE_TBL_BAD_ARGUMENT;
+    }
+
+    /* Check to make sure calling application is legit */
+    Status = CFE_ES_GetAppID(&ThisAppId);
+
+    if (Status == CFE_SUCCESS)
+    {
+        /* Assume we can't make a table and return a bad handle for now */
+        *TblHandlePtr = CFE_TBL_BAD_TABLE_HANDLE;
+
+        /* Make sure specified table name is not too long or too short */
+        NameLen = strlen(Name);
+        if ((NameLen > CFE_MISSION_TBL_MAX_NAME_LENGTH) || (NameLen == 0))
+        {
+            Status = CFE_TBL_ERR_INVALID_NAME;
+
+            /* Perform a buffer overrun safe copy of name for debug log message */
+            strncpy(TblName, Name, sizeof(TblName) - 1);
+            TblName[sizeof(TblName) - 1] = '\0';
+            CFE_ES_WriteToSysLog("CFE_TBL:Register-Table Name (%s) is bad length (%d)", TblName, (int)NameLen);
+        }
+        else
+        {
+            /* Modify specified name to be processor specific name */
+            /* of the form "AppName.TableName"                     */
+            CFE_TBL_FormTableName(TblName, Name, ThisAppId);
+
+            /* Make sure the specified size is acceptable */
+            /* Single buffered tables are allowed to be up to CFE_PLATFORM_TBL_MAX_SNGL_TABLE_SIZE */
+            /* Double buffered tables are allowed to be up to CFE_PLATFORM_TBL_MAX_DBL_TABLE_SIZE  */
+            if (Size == 0)
+            {
+                Status = CFE_TBL_ERR_INVALID_SIZE;
+
+                CFE_ES_WriteToSysLog("CFE_TBL:Register-Table %s has size of zero\n", Name);
+            }
+            else if ((Size > CFE_PLATFORM_TBL_MAX_SNGL_TABLE_SIZE) &&
+                     ((TblOptionFlags & CFE_TBL_OPT_BUFFER_MSK) == CFE_TBL_OPT_SNGL_BUFFER))
+            {
+                Status = CFE_TBL_ERR_INVALID_SIZE;
+
+                CFE_ES_WriteToSysLog("CFE_TBL:Register-Single Buffered Table '%s' has size %d > %d\n", Name, (int)Size,
+                                     CFE_PLATFORM_TBL_MAX_SNGL_TABLE_SIZE);
+            }
+            else if ((Size > CFE_PLATFORM_TBL_MAX_DBL_TABLE_SIZE) &&
+                     ((TblOptionFlags & CFE_TBL_OPT_BUFFER_MSK) == CFE_TBL_OPT_DBL_BUFFER))
+            {
+                Status = CFE_TBL_ERR_INVALID_SIZE;
+
+                CFE_ES_WriteToSysLog("CFE_TBL:Register-Dbl Buffered Table '%s' has size %d > %d\n", Name, (int)Size,
+                                     CFE_PLATFORM_TBL_MAX_DBL_TABLE_SIZE);
+            }
+
+            /* Verify Table Option settings are legal */
+            /* User defined table addresses are only legal for single buffered, dump-only, non-critical tables */
+            if ((TblOptionFlags & CFE_TBL_OPT_USR_DEF_MSK) == (CFE_TBL_OPT_USR_DEF_ADDR & CFE_TBL_OPT_USR_DEF_MSK))
+            {
+                if (((TblOptionFlags & CFE_TBL_OPT_BUFFER_MSK) == CFE_TBL_OPT_DBL_BUFFER) ||
+                    ((TblOptionFlags & CFE_TBL_OPT_LD_DMP_MSK) == CFE_TBL_OPT_LOAD_DUMP) ||
+                    ((TblOptionFlags & CFE_TBL_OPT_CRITICAL_MSK) == CFE_TBL_OPT_CRITICAL))
+                {
+                    Status = CFE_TBL_ERR_INVALID_OPTIONS;
+
+                    CFE_ES_WriteToSysLog(
+                        "CFE_TBL:Register-User Def tbl '%s' cannot be dbl buff, load/dump or critical\n", Name);
+                }
+            }
+            else if ((TblOptionFlags & CFE_TBL_OPT_LD_DMP_MSK) == CFE_TBL_OPT_DUMP_ONLY)
+            {
+                /* Dump Only tables cannot be double buffered, nor critical */
+                if (((TblOptionFlags & CFE_TBL_OPT_BUFFER_MSK) == CFE_TBL_OPT_DBL_BUFFER) ||
+                    ((TblOptionFlags & CFE_TBL_OPT_CRITICAL_MSK) == CFE_TBL_OPT_CRITICAL))
+                {
+                    Status = CFE_TBL_ERR_INVALID_OPTIONS;
+
+                    CFE_ES_WriteToSysLog("CFE_TBL:Register-Dump Only tbl '%s' cannot be double buffered or critical\n",
+                                         Name);
+                }
+            }
+        }
+    }
+    else /* Application ID was invalid */
+    {
+        CFE_ES_WriteToSysLog("CFE_TBL:Register-Bad AppId(%lu)\n", CFE_RESOURCEID_TO_ULONG(ThisAppId));
+    }
+
+    /* If input parameters appear acceptable, register the table */
+    if (Status == CFE_SUCCESS)
+    {
+        /* Lock Registry for update.  This prevents two applications from        */
+        /* trying to register/share tables at the same location at the same time */
+        CFE_TBL_LockRegistry();
+
+        /* Check for duplicate table name */
+        RegIndx = CFE_TBL_FindTableInRegistry(TblName);
+
+        /* Check to see if table is already in the registry */
+        if (RegIndx != CFE_TBL_NOT_FOUND)
+        {
+            /* Get pointer to Registry Record Entry to speed up processing */
+            RegRecPtr = &CFE_TBL_Global.Registry[RegIndx];
+
+            /* If this app previously owned the table, then allow them to re-register */
+            if (CFE_RESOURCEID_TEST_EQUAL(RegRecPtr->OwnerAppId, ThisAppId))
+            {
+                /* If the new table is the same size as the old, then no need to reallocate memory */
+                if (Size != RegRecPtr->Size)
+                {
+                    /* If the new size is different, the old table must deleted      */
+                    /* but this function can't do that because it is probably shared */
+                    /* and is probably still being accessed.  Someone else will need */
+                    /* to clean up this mess.                                        */
+                    Status = CFE_TBL_ERR_DUPLICATE_DIFF_SIZE;
+
+                    CFE_ES_WriteToSysLog(
+                        "CFE_TBL:Register-Attempt to register existing table ('%s') with different size(%d!=%d)\n",
+                        TblName, (int)Size, (int)RegRecPtr->Size);
+                }
+                else
+                {
+                    /* Warn calling application that this is a duplicate registration */
+                    Status = CFE_TBL_WARN_DUPLICATE;
+
+                    /* Find the existing access descriptor for the table       */
+                    /* and return the same handle that was returned previously */
+                    AccessIndex = RegRecPtr->HeadOfAccessList;
+                    while ((AccessIndex != CFE_TBL_END_OF_LIST) && (*TblHandlePtr == CFE_TBL_BAD_TABLE_HANDLE))
+                    {
+                        if ((CFE_TBL_Global.Handles[AccessIndex].UsedFlag == true) &&
+                            CFE_RESOURCEID_TEST_EQUAL(CFE_TBL_Global.Handles[AccessIndex].AppId, ThisAppId) &&
+                            (CFE_TBL_Global.Handles[AccessIndex].RegIndex == RegIndx))
+                        {
+                            *TblHandlePtr = AccessIndex;
+                        }
+                        else
+                        {
+                            AccessIndex = CFE_TBL_Global.Handles[AccessIndex].NextLink;
+                        }
+                    }
+                }
+            }
+            else /* Duplicate named table owned by another Application */
+            {
+                Status = CFE_TBL_ERR_DUPLICATE_NOT_OWNED;
+
+                CFE_ES_WriteToSysLog("CFE_TBL:Register-App(%lu) Registering Duplicate Table '%s' owned by App(%lu)\n",
+                                     CFE_RESOURCEID_TO_ULONG(ThisAppId), TblName,
+                                     CFE_RESOURCEID_TO_ULONG(RegRecPtr->OwnerAppId));
+            }
+        }
+        else /* Table not already in registry */
+        {
+            /* Locate empty slot in table registry */
+            RegIndx = CFE_TBL_FindFreeRegistryEntry();
+        }
+
+        /* Check to make sure we found a free entry in registry */
+        if (RegIndx == CFE_TBL_NOT_FOUND)
+        {
+            Status = CFE_TBL_ERR_REGISTRY_FULL;
+            CFE_ES_WriteToSysLog("CFE_TBL:Register-Registry full\n");
+        }
+
+        /* If this is a duplicate registration, no other work is required */
+        if (Status != CFE_TBL_WARN_DUPLICATE)
+        {
+            /* Search Access Descriptor Array for free Descriptor */
+            *TblHandlePtr = CFE_TBL_FindFreeHandle();
+
+            /* Check to make sure there was a handle available */
+            if (*TblHandlePtr == CFE_TBL_END_OF_LIST)
+            {
+                Status = CFE_TBL_ERR_HANDLES_FULL;
+                CFE_ES_WriteToSysLog("CFE_TBL:Register-No more free handles\n");
+            }
+
+            /* If no errors, then initialize the table registry entry     */
+            /* and return the registry index to the caller as the handle  */
+            if ((Status & CFE_SEVERITY_BITMASK) != CFE_SEVERITY_ERROR)
+            {
+                /* Get pointer to Registry Record Entry to speed up processing */
+                RegRecPtr = &CFE_TBL_Global.Registry[RegIndx];
+
+                /* Initialize Registry Record to default settings */
+                CFE_TBL_InitRegistryRecord(RegRecPtr);
+
+                if ((TblOptionFlags & CFE_TBL_OPT_USR_DEF_MSK) != (CFE_TBL_OPT_USR_DEF_ADDR & CFE_TBL_OPT_USR_DEF_MSK))
+                {
+                    RegRecPtr->UserDefAddr = false;
+
+                    /* Allocate the memory buffer(s) for the table and inactive table, if necessary */
+                    Status = CFE_ES_GetPoolBuf(&RegRecPtr->Buffers[0].BufferPtr, CFE_TBL_Global.Buf.PoolHdl, Size);
+                    if (Status < 0)
+                    {
+                        CFE_ES_WriteToSysLog(
+                            "CFE_TBL:Register-1st Buf Alloc GetPool fail Stat=0x%08X MemPoolHndl=0x%08lX\n",
+                            (unsigned int)Status, CFE_RESOURCEID_TO_ULONG(CFE_TBL_Global.Buf.PoolHdl));
+                    }
+                    else
+                    {
+                        /* Zero the memory buffer */
+                        Status = CFE_SUCCESS;
+                        memset(RegRecPtr->Buffers[0].BufferPtr, 0x0, Size);
+                    }
+                }
+                else
+                {
+                    /* Set buffer pointer to NULL for user defined address tables */
+                    RegRecPtr->Buffers[0].BufferPtr = NULL;
+                    RegRecPtr->UserDefAddr          = true;
+                }
+
+                if (((TblOptionFlags & CFE_TBL_OPT_DBL_BUFFER) == CFE_TBL_OPT_DBL_BUFFER) &&
+                    ((Status & CFE_SEVERITY_BITMASK) != CFE_SEVERITY_ERROR))
+                {
+                    /* Allocate memory for the dedicated secondary buffer */
+                    Status = CFE_ES_GetPoolBuf(&RegRecPtr->Buffers[1].BufferPtr, CFE_TBL_Global.Buf.PoolHdl, Size);
+                    if (Status < 0)
+                    {
+                        CFE_ES_WriteToSysLog(
+                            "CFE_TBL:Register-2nd Buf Alloc GetPool fail Stat=0x%08X MemPoolHndl=0x%08lX\n",
+                            (unsigned int)Status, CFE_RESOURCEID_TO_ULONG(CFE_TBL_Global.Buf.PoolHdl));
+                    }
+                    else
+                    {
+                        /* Zero the dedicated secondary buffer */
+                        Status = CFE_SUCCESS;
+                        memset(RegRecPtr->Buffers[1].BufferPtr, 0x0, Size);
+                    }
+
+                    RegRecPtr->ActiveBufferIndex = 0;
+                    RegRecPtr->DoubleBuffered    = true;
+                }
+                else /* Single Buffered Table */
+                {
+                    RegRecPtr->DoubleBuffered    = false;
+                    RegRecPtr->ActiveBufferIndex = 0;
+                }
+
+                if ((Status & CFE_SEVERITY_BITMASK) != CFE_SEVERITY_ERROR)
+                {
+                    /* Save the size of the table */
+                    RegRecPtr->Size = Size;
+
+                    /* Save the Callback function pointer */
+                    RegRecPtr->ValidationFuncPtr = TblValidationFuncPtr;
+
+                    /* Save Table Name in Registry */
+                    strncpy(RegRecPtr->Name, TblName, sizeof(RegRecPtr->Name) - 1);
+                    RegRecPtr->Name[sizeof(RegRecPtr->Name) - 1] = '\0';
+
+                    /* Set the "Dump Only" flag to value based upon selected option */
+                    if ((TblOptionFlags & CFE_TBL_OPT_LD_DMP_MSK) == CFE_TBL_OPT_DUMP_ONLY)
+                    {
+                        RegRecPtr->DumpOnly = true;
+                    }
+                    else
+                    {
+                        RegRecPtr->DumpOnly = false;
+                    }
+
+                    /* Initialize the Table Access Descriptor */
+                    AccessDescPtr = &CFE_TBL_Global.Handles[*TblHandlePtr];
+
+                    AccessDescPtr->AppId    = ThisAppId;
+                    AccessDescPtr->LockFlag = false;
+                    AccessDescPtr->Updated  = false;
+
+                    if ((RegRecPtr->DumpOnly) && (!RegRecPtr->UserDefAddr))
+                    {
+                        /* Dump Only Tables are assumed to be loaded at all times    */
+                        /* unless the address is specified by the application. In    */
+                        /* that case, it isn't loaded until the address is specified */
+                        RegRecPtr->TableLoadedOnce = true;
+                    }
+
+                    AccessDescPtr->RegIndex = RegIndx;
+
+                    AccessDescPtr->PrevLink = CFE_TBL_END_OF_LIST; /* We are the head of the list */
+                    AccessDescPtr->NextLink = CFE_TBL_END_OF_LIST; /* We are the end of the list */
+
+                    AccessDescPtr->UsedFlag = true;
+
+                    /* Make sure the Table Registry entry points to First Access Descriptor */
+                    RegRecPtr->HeadOfAccessList = *TblHandlePtr;
+
+                    /* If the table is a critical table, allocate space for it in the Critical Data Store */
+                    /* OR locate its previous incarnation there and extract its previous contents */
+                    if ((TblOptionFlags & CFE_TBL_OPT_CRITICAL_MSK) == CFE_TBL_OPT_CRITICAL)
+                    {
+                        /* Register a CDS under the table name and determine if the table already exists there */
+                        Status = CFE_ES_RegisterCDSEx(&RegRecPtr->CDSHandle, Size, TblName, true);
+
+                        if (Status == CFE_ES_CDS_ALREADY_EXISTS)
+                        {
+                            Status = CFE_TBL_GetWorkingBuffer(&WorkingBufferPtr, RegRecPtr, true);
+
+                            if (Status != CFE_SUCCESS)
+                            {
+                                /* Unable to get a working buffer - this error is not really */
+                                /* possible at this point during table registration.  But we */
+                                /* do need to handle the error case because if the function */
+                                /* call did fail, WorkingBufferPtr would be a NULL pointer. */
+                                CFE_ES_GetAppName(AppName, ThisAppId, sizeof(AppName));
+                                CFE_ES_WriteToSysLog(
+                                    "CFE_TBL:Register-Failed to get work buffer for '%s.%s' (ErrCode=0x%08X)\n",
+                                    AppName, Name, (unsigned int)Status);
+                            }
+                            else
+                            {
+                                /* CDS exists for this table - try to restore the data */
+                                Status = CFE_ES_RestoreFromCDS(WorkingBufferPtr->BufferPtr, RegRecPtr->CDSHandle);
+
+                                if (Status != CFE_SUCCESS)
+                                {
+                                    CFE_ES_GetAppName(AppName, ThisAppId, sizeof(AppName));
+                                    CFE_ES_WriteToSysLog(
+                                        "CFE_TBL:Register-Failed to recover '%s.%s' from CDS (ErrCode=0x%08X)\n",
+                                        AppName, Name, (unsigned int)Status);
+                                }
+                            }
+
+                            if (Status != CFE_SUCCESS)
+                            {
+                                /* Treat a restore from existing CDS error the same as */
+                                /* after a power-on reset (CDS was created but is empty) */
+                                Status = CFE_SUCCESS;
+                            }
+                            else
+                            {
+                                /* Try to locate the associated information in the Critical Table Registry */
+                                CFE_TBL_FindCriticalTblInfo(&CritRegRecPtr, RegRecPtr->CDSHandle);
+
+                                if ((CritRegRecPtr != NULL) && (CritRegRecPtr->TableLoadedOnce))
+                                {
+                                    strncpy(WorkingBufferPtr->DataSource, CritRegRecPtr->LastFileLoaded,
+                                            sizeof(WorkingBufferPtr->DataSource) - 1);
+                                    WorkingBufferPtr->DataSource[sizeof(WorkingBufferPtr->DataSource) - 1] = '\0';
+                                    WorkingBufferPtr->FileCreateTimeSecs    = CritRegRecPtr->FileCreateTimeSecs;
+                                    WorkingBufferPtr->FileCreateTimeSubSecs = CritRegRecPtr->FileCreateTimeSubSecs;
+                                    strncpy(RegRecPtr->LastFileLoaded, CritRegRecPtr->LastFileLoaded,
+                                            sizeof(RegRecPtr->LastFileLoaded) - 1);
+                                    RegRecPtr->LastFileLoaded[sizeof(RegRecPtr->LastFileLoaded) - 1] = '\0';
+                                    RegRecPtr->TimeOfLastUpdate.Seconds    = CritRegRecPtr->TimeOfLastUpdate.Seconds;
+                                    RegRecPtr->TimeOfLastUpdate.Subseconds = CritRegRecPtr->TimeOfLastUpdate.Subseconds;
+                                    RegRecPtr->TableLoadedOnce             = CritRegRecPtr->TableLoadedOnce;
+
+                                    /* Compute the CRC on the specified table buffer */
+                                    WorkingBufferPtr->Crc = CFE_ES_CalculateCRC(
+                                        WorkingBufferPtr->BufferPtr, RegRecPtr->Size, 0, CFE_MISSION_ES_DEFAULT_CRC);
+
+                                    /* Make sure everyone who sees the table knows that it has been updated */
+                                    CFE_TBL_NotifyTblUsersOfUpdate(RegRecPtr);
+
+                                    /* Make sure the caller realizes the contents have been initialized */
+                                    Status = CFE_TBL_INFO_RECOVERED_TBL;
+                                }
+                                else
+                                {
+                                    /* If an error occurred while trying to get the previous contents registry info, */
+                                    /* Log the error in the System Log and pretend like we created a new CDS */
+                                    CFE_ES_GetAppName(AppName, ThisAppId, sizeof(AppName));
+                                    CFE_ES_WriteToSysLog(
+                                        "CFE_TBL:Register-Failed to recover '%s.%s' info from CDS TblReg\n", AppName,
+                                        Name);
+                                    Status = CFE_SUCCESS;
+                                }
+                            }
+
+                            /* Mark the table as critical for future reference */
+                            RegRecPtr->CriticalTable = true;
+                        }
+
+                        if (Status == CFE_SUCCESS)
+                        {
+                            /* Find and initialize a free entry in the Critical Table Registry */
+                            CFE_TBL_FindCriticalTblInfo(&CritRegRecPtr, CFE_ES_CDS_BAD_HANDLE);
+
+                            if (CritRegRecPtr != NULL)
+                            {
+                                CritRegRecPtr->CDSHandle = RegRecPtr->CDSHandle;
+                                strncpy(CritRegRecPtr->Name, TblName, sizeof(CritRegRecPtr->Name) - 1);
+                                CritRegRecPtr->Name[sizeof(CritRegRecPtr->Name) - 1] = '\0';
+                                CritRegRecPtr->FileCreateTimeSecs                    = 0;
+                                CritRegRecPtr->FileCreateTimeSubSecs                 = 0;
+                                CritRegRecPtr->LastFileLoaded[0]                     = '\0';
+                                CritRegRecPtr->TimeOfLastUpdate.Seconds              = 0;
+                                CritRegRecPtr->TimeOfLastUpdate.Subseconds           = 0;
+                                CritRegRecPtr->TableLoadedOnce                       = false;
+
+                                CFE_ES_CopyToCDS(CFE_TBL_Global.CritRegHandle, CFE_TBL_Global.CritReg);
+                            }
+                            else
+                            {
+                                CFE_ES_WriteToSysLog(
+                                    "CFE_TBL:Register-Failed to find a free Crit Tbl Reg Rec for '%s'\n",
+                                    RegRecPtr->Name);
+                            }
+
+                            /* Mark the table as critical for future reference */
+                            RegRecPtr->CriticalTable = true;
+                        }
+                        else if (Status != CFE_TBL_INFO_RECOVERED_TBL)
+                        {
+                            CFE_ES_WriteToSysLog(
+                                "CFE_TBL:Register-Failed to register '%s.%s' as a CDS (ErrCode=0x%08X)\n", AppName,
+                                Name, (unsigned int)Status);
+
+                            /* Notify caller that although they asked for it to be critical, it isn't */
+                            Status = CFE_TBL_WARN_NOT_CRITICAL;
+                        }
+                    }
+
+                    /* The last step of the registration process is claiming ownership.    */
+                    /* By making it the last step, other APIs do not have to lock registry */
+                    /* to share the table or get its address because registry entries that */
+                    /* are unowned are not checked to see if they match names, etc.        */
+                    RegRecPtr->OwnerAppId = ThisAppId;
+                }
+            }
+        }
+
+        /* Unlock Registry for update */
+        CFE_TBL_UnlockRegistry();
+    }
+
+    /* On Error conditions, notify ground of screw up */
+    if (Status < 0)
+    {
+        /* Make sure the returned handle is invalid when an error occurs */
+        *TblHandlePtr = CFE_TBL_BAD_TABLE_HANDLE;
+
+        /* Translate AppID of caller into App Name */
+        CFE_ES_GetAppName(AppName, ThisAppId, sizeof(AppName));
+
+        CFE_EVS_SendEventWithAppID(CFE_TBL_REGISTER_ERR_EID, CFE_EVS_EventType_ERROR, CFE_TBL_Global.TableTaskAppId,
+                                   "%s Failed to Register '%s', Status=0x%08X", AppName, TblName, (unsigned int)Status);
+    }
+
+    return Status;
+} /* End of CFE_TBL_Register() */
+
+/*
+ * Function: CFE_TBL_Share - See API and header file for details
+ */
+int32 CFE_TBL_Share(CFE_TBL_Handle_t *TblHandlePtr, const char *TblName)
+{
+    int32                       Status;
+    CFE_ES_AppId_t              ThisAppId;
+    int16                       RegIndx;
+    CFE_TBL_AccessDescriptor_t *AccessDescPtr            = NULL;
+    CFE_TBL_RegistryRec_t *     RegRecPtr                = NULL;
+    char                        AppName[OS_MAX_API_NAME] = {"UNKNOWN"};
+
+    if (TblHandlePtr == NULL || TblName == NULL)
+    {
+        return CFE_TBL_BAD_ARGUMENT;
+    }
+
+    /* Get a valid Application ID for calling App */
+    Status = CFE_ES_GetAppID(&ThisAppId);
+
+    if (Status == CFE_SUCCESS)
+    {
+        /* Lock Registry for update.  This prevents two applications from        */
+        /* trying to register/share tables at the same location at the same time */
+        CFE_TBL_LockRegistry();
+
+        RegIndx = CFE_TBL_FindTableInRegistry(TblName);
+
+        /* If we found the table, then get a new Access Descriptor and initialize it */
+        if (RegIndx != CFE_TBL_NOT_FOUND)
+        {
+            /* Get pointer to Registry Record Entry to speed up processing */
+            RegRecPtr = &CFE_TBL_Global.Registry[RegIndx];
+
+            /* Search Access Descriptor Array for free Descriptor */
+            *TblHandlePtr = CFE_TBL_FindFreeHandle();
+
+            /* Check to make sure there was a handle available */
+            if (*TblHandlePtr == CFE_TBL_END_OF_LIST)
+            {
+                Status = CFE_TBL_ERR_HANDLES_FULL;
+                CFE_ES_WriteToSysLog("CFE_TBL:Share-No more free handles\n");
+            }
+            else
+            {
+                /* Initialize the Table Access Descriptor */
+                AccessDescPtr = &CFE_TBL_Global.Handles[*TblHandlePtr];
+
+                AccessDescPtr->AppId    = ThisAppId;
+                AccessDescPtr->LockFlag = false;
+                AccessDescPtr->Updated  = false;
+
+                /* Check current state of table in order to set Notification flags properly */
+                if (RegRecPtr->TableLoadedOnce)
+                {
+                    AccessDescPtr->Updated = true;
+                }
+
+                AccessDescPtr->RegIndex = RegIndx;
+                AccessDescPtr->UsedFlag = true;
+
+                AccessDescPtr->PrevLink = CFE_TBL_END_OF_LIST; /* We are the new head of the list */
+                AccessDescPtr->NextLink = RegRecPtr->HeadOfAccessList;
+
+                /* Make sure the old head of the list now sees this as the head */
+                CFE_TBL_Global.Handles[RegRecPtr->HeadOfAccessList].PrevLink = *TblHandlePtr;
+
+                /* Make sure the Registry Record see this as the head of the list */
+                RegRecPtr->HeadOfAccessList = *TblHandlePtr;
+            }
+        }
+        else /* Table could not be found in registry */
+        {
+            Status = CFE_TBL_ERR_INVALID_NAME;
+
+            CFE_ES_WriteToSysLog("CFE_TBL:Share-Table '%s' not found in Registry\n", TblName);
+        }
+
+        CFE_TBL_UnlockRegistry();
+    }
+    else /* Application ID was invalid */
+    {
+        CFE_ES_WriteToSysLog("CFE_TBL:Share-Bad AppId(%lu)\n", CFE_RESOURCEID_TO_ULONG(ThisAppId));
+    }
+
+    /* On Error conditions, notify ground of screw up */
+    if (Status < 0)
+    {
+        /* Translate AppID of caller into App Name */
+        CFE_ES_GetAppName(AppName, ThisAppId, sizeof(AppName));
+
+        CFE_EVS_SendEventWithAppID(CFE_TBL_SHARE_ERR_EID, CFE_EVS_EventType_ERROR, CFE_TBL_Global.TableTaskAppId,
+                                   "%s Failed to Share '%s', Status=0x%08X", AppName, TblName, (unsigned int)Status);
+    }
+
+    return Status;
+} /* End of CFE_TBL_Share() */
+
+/*
+ * Function: CFE_TBL_Unregister - See API and header file for details
+ */
+int32 CFE_TBL_Unregister(CFE_TBL_Handle_t TblHandle)
+{
+    int32                       Status;
+    CFE_ES_AppId_t              ThisAppId;
+    CFE_TBL_RegistryRec_t *     RegRecPtr                = NULL;
+    CFE_TBL_AccessDescriptor_t *AccessDescPtr            = NULL;
+    char                        AppName[OS_MAX_API_NAME] = {"UNKNOWN"};
+
+    /* Verify that this application has the right to perform operation */
+    Status = CFE_TBL_ValidateAccess(TblHandle, &ThisAppId);
+
+    if (Status == CFE_SUCCESS)
+    {
+        /* Get a pointer to the relevant Access Descriptor */
+        AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle];
+
+        /* Get a pointer to the relevant entry in the registry */
+        RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
+
+        /* Verify that the application unregistering the table owns the table */
+        if (CFE_RESOURCEID_TEST_EQUAL(RegRecPtr->OwnerAppId, ThisAppId))
+        {
+            /* Mark table as free, although, technically, it isn't free until the */
+            /* linked list of Access Descriptors has no links in it.              */
+            /* NOTE: Allocated memory is freed when all Access Links have been    */
+            /*       removed.  This allows Applications to continue to use the    */
+            /*       data until they acknowledge that the table has been removed. */
+            RegRecPtr->OwnerAppId = CFE_TBL_NOT_OWNED;
+
+            /* Remove Table Name */
+            RegRecPtr->Name[0] = '\0';
+        }
+
+        /* Remove the Access Descriptor Link from linked list */
+        /* NOTE: If this removes the last access link, then   */
+        /*       memory buffers are set free as well.         */
+        CFE_TBL_RemoveAccessLink(TblHandle);
+    }
+    else
+    {
+        CFE_ES_WriteToSysLog("CFE_TBL:Unregister-App(%lu) does not have access to Tbl Handle=%d\n",
+                             CFE_RESOURCEID_TO_ULONG(ThisAppId), (int)TblHandle);
+    }
+
+    /* On Error conditions, notify ground of screw up */
+    if (Status < 0)
+    {
+        /* Translate AppID of caller into App Name */
+        CFE_ES_GetAppName(AppName, ThisAppId, sizeof(AppName));
+
+        CFE_EVS_SendEventWithAppID(CFE_TBL_UNREGISTER_ERR_EID, CFE_EVS_EventType_ERROR, CFE_TBL_Global.TableTaskAppId,
+                                   "%s Failed to Unregister '?', Status=0x%08X", AppName, (unsigned int)Status);
+    }
+
+    return Status;
+} /* End of CFE_TBL_Unregister() */
+
+/*******************************************************************
+**
+** CFE_TBL_Load() -- Load a specified table with data from the
+**                   specified source
+**
+** NOTE: For complete prolog information, see 'cfe_tbl.h'
+********************************************************************/
+
+int32 CFE_TBL_Load(CFE_TBL_Handle_t TblHandle, CFE_TBL_SrcEnum_t SrcType, const void *SrcDataPtr)
+{
+    int32                       Status;
+    CFE_ES_AppId_t              ThisAppId;
+    CFE_TBL_LoadBuff_t *        WorkingBufferPtr;
+    CFE_TBL_AccessDescriptor_t *AccessDescPtr;
+    CFE_TBL_RegistryRec_t *     RegRecPtr;
+    char                        AppName[OS_MAX_API_NAME] = {"UNKNOWN"};
+    bool                        FirstTime                = false;
+
+    if (SrcDataPtr == NULL)
+    {
+        return CFE_TBL_BAD_ARGUMENT;
+    }
+
+    /* Verify access rights and get a valid Application ID for calling App */
+    Status = CFE_TBL_ValidateAccess(TblHandle, &ThisAppId);
+
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_EVS_SendEventWithAppID(CFE_TBL_HANDLE_ACCESS_ERR_EID, CFE_EVS_EventType_ERROR,
+                                   CFE_TBL_Global.TableTaskAppId, "%s: No access to Tbl Handle=%d", AppName,
+                                   (int)TblHandle);
+
+        return Status;
+    }
+
+    AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle];
+    RegRecPtr     = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
+
+    /* Translate AppID of caller into App Name */
+    CFE_ES_GetAppName(AppName, ThisAppId, sizeof(AppName));
+
+    /* Initialize return pointer to NULL */
+    WorkingBufferPtr = NULL;
+
+    /* Check to see if this is a dump only table */
+    if (RegRecPtr->DumpOnly)
+    {
+        if ((!RegRecPtr->UserDefAddr) || (RegRecPtr->TableLoadedOnce))
+        {
+            CFE_EVS_SendEventWithAppID(CFE_TBL_LOADING_A_DUMP_ONLY_ERR_EID, CFE_EVS_EventType_ERROR,
+                                       CFE_TBL_Global.TableTaskAppId, "%s: Attempted to load Dump Only Tbl '%s'",
+                                       AppName, RegRecPtr->Name);
+
+            return CFE_TBL_ERR_DUMP_ONLY;
+        }
+
+        /* The Application is allowed to call Load once when the address  */
+        /* of the dump only table is being defined by the application.    */
+        RegRecPtr->Buffers[0].BufferPtr = (void *)SrcDataPtr;
+        RegRecPtr->TableLoadedOnce      = true;
+
+        snprintf(RegRecPtr->Buffers[0].DataSource, sizeof(RegRecPtr->Buffers[0].DataSource), "Addr 0x%08lX",
+                 (unsigned long)SrcDataPtr);
+        RegRecPtr->Buffers[0].FileCreateTimeSecs    = 0;
+        RegRecPtr->Buffers[0].FileCreateTimeSubSecs = 0;
+
+        CFE_EVS_SendEventWithAppID(CFE_TBL_LOAD_SUCCESS_INF_EID, CFE_EVS_EventType_DEBUG, CFE_TBL_Global.TableTaskAppId,
+                                   "Successfully loaded '%s' from '%s'", RegRecPtr->Name,
+                                   RegRecPtr->Buffers[0].DataSource);
+
+        return CFE_SUCCESS;
+    }
+
+    /* Loads by an Application are not allowed if a table load is already in progress */
+    if (RegRecPtr->LoadInProgress != CFE_TBL_NO_LOAD_IN_PROGRESS)
+    {
+        CFE_EVS_SendEventWithAppID(CFE_TBL_LOAD_IN_PROGRESS_ERR_EID, CFE_EVS_EventType_ERROR,
+                                   CFE_TBL_Global.TableTaskAppId, "%s: Load already in progress for '%s'", AppName,
+                                   RegRecPtr->Name);
+
+        return CFE_TBL_ERR_LOAD_IN_PROGRESS;
+    }
+
+    /* Obtain a working buffer (either the table's dedicated buffer or one of the shared buffers) */
+    Status = CFE_TBL_GetWorkingBuffer(&WorkingBufferPtr, RegRecPtr, true);
+
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_EVS_SendEventWithAppID(CFE_TBL_NO_WORK_BUFFERS_ERR_EID, CFE_EVS_EventType_ERROR,
+                                   CFE_TBL_Global.TableTaskAppId, "%s: Failed to get Working Buffer (Stat=%u)", AppName,
+                                   (unsigned int)Status);
+
+        return Status;
+    }
+
+    /* Perform appropriate update to working buffer */
+    /* Determine whether the load is to occur from a file or from a block of memory */
+    switch (SrcType)
+    {
+        case CFE_TBL_SRC_FILE:
+            /* Load the data from the file into the specified buffer */
+            Status = CFE_TBL_LoadFromFile(AppName, WorkingBufferPtr, RegRecPtr, (const char *)SrcDataPtr);
+
+            if ((Status == CFE_TBL_WARN_PARTIAL_LOAD) && (!RegRecPtr->TableLoadedOnce))
+            {
+                /* Uninitialized tables cannot be loaded with partial table loads */
+                /* Partial loads can only occur on previously loaded tables.      */
+                CFE_EVS_SendEventWithAppID(CFE_TBL_PARTIAL_LOAD_ERR_EID, CFE_EVS_EventType_ERROR,
+                                           CFE_TBL_Global.TableTaskAppId,
+                                           "%s: Attempted to load from partial Tbl '%s' from '%s' (Stat=%u)", AppName,
+                                           RegRecPtr->Name, (const char *)SrcDataPtr, (unsigned int)Status);
+
+                Status = CFE_TBL_ERR_PARTIAL_LOAD;
+            }
+
+            break;
+        case CFE_TBL_SRC_ADDRESS:
+            /* When the source is a block of memory, it is assumed to be a complete load */
+            memcpy(WorkingBufferPtr->BufferPtr, (uint8 *)SrcDataPtr, RegRecPtr->Size);
+
+            snprintf(WorkingBufferPtr->DataSource, sizeof(WorkingBufferPtr->DataSource), "Addr 0x%08lX",
+                     (unsigned long)SrcDataPtr);
+            WorkingBufferPtr->FileCreateTimeSecs    = 0;
+            WorkingBufferPtr->FileCreateTimeSubSecs = 0;
+
+            /* Compute the CRC on the specified table buffer */
+            WorkingBufferPtr->Crc =
+                CFE_ES_CalculateCRC(WorkingBufferPtr->BufferPtr, RegRecPtr->Size, 0, CFE_MISSION_ES_DEFAULT_CRC);
+
+            break;
+        default:
+            CFE_EVS_SendEventWithAppID(CFE_TBL_LOAD_TYPE_ERR_EID, CFE_EVS_EventType_ERROR,
+                                       CFE_TBL_Global.TableTaskAppId,
+                                       "%s: Attempted to load from illegal source type=%d", AppName, (int)SrcType);
+
+            Status = CFE_TBL_ERR_ILLEGAL_SRC_TYPE;
+    }
+
+    /* If the data was successfully loaded, then validate its contents */
+    if ((Status >= CFE_SUCCESS) && (RegRecPtr->ValidationFuncPtr != NULL))
+    {
+        Status = (RegRecPtr->ValidationFuncPtr)(WorkingBufferPtr->BufferPtr);
+
+        if (Status > CFE_SUCCESS)
+        {
+            CFE_EVS_SendEventWithAppID(CFE_TBL_LOAD_VAL_ERR_EID, CFE_EVS_EventType_ERROR, CFE_TBL_Global.TableTaskAppId,
+                                       "%s: Validation func return code invalid (Stat=%u) for '%s'", AppName,
+                                       (unsigned int)Status, RegRecPtr->Name);
+
+            Status = -1;
+        }
+
+        if (Status < 0)
+        {
+            CFE_EVS_SendEventWithAppID(CFE_TBL_VALIDATION_ERR_EID, CFE_EVS_EventType_ERROR,
+                                       CFE_TBL_Global.TableTaskAppId,
+                                       "%s: Validation func reports table invalid (Stat=%u) for '%s'", AppName,
+                                       (unsigned int)Status, RegRecPtr->Name);
+
+            /* Zero out the buffer to remove any bad data */
+            memset(WorkingBufferPtr->BufferPtr, 0, RegRecPtr->Size);
+        }
+    }
+
+    /* Perform the table update to complete the load */
+    if (Status < CFE_SUCCESS)
+    {
+        /* The load has had a problem, free the working buffer for another attempt */
+        if ((!RegRecPtr->DoubleBuffered) && (RegRecPtr->TableLoadedOnce == true))
+        {
+            /* For single buffered tables, freeing entails resetting flag */
+            CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].Taken = false;
+        }
+
+        /* For double buffered tables, freeing buffer is simple */
+        RegRecPtr->LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
+
+        return Status;
+    }
+
+    FirstTime = !RegRecPtr->TableLoadedOnce;
+
+    /* If this is not the first load, then the data must be moved from the inactive buffer      */
+    /* to the active buffer to complete the load.  First loads are done directly to the active. */
+    if (!FirstTime)
+    {
+        /* Force the table update */
+        RegRecPtr->LoadPending = true;
+
+        Status = CFE_TBL_UpdateInternal(TblHandle, RegRecPtr, AccessDescPtr);
+
+        if (Status != CFE_SUCCESS)
+        {
+            CFE_EVS_SendEventWithAppID(CFE_TBL_UPDATE_ERR_EID, CFE_EVS_EventType_ERROR, CFE_TBL_Global.TableTaskAppId,
+                                       "%s: Failed to update '%s' (Stat=%u)", AppName, RegRecPtr->Name,
+                                       (unsigned int)Status);
+        }
+    }
+    else
+    {
+        /* On initial loads, make sure registry is given file/address of data source */
+        strncpy(RegRecPtr->LastFileLoaded, WorkingBufferPtr->DataSource, sizeof(RegRecPtr->LastFileLoaded) - 1);
+        RegRecPtr->LastFileLoaded[sizeof(RegRecPtr->LastFileLoaded) - 1] = '\0';
+
+        CFE_TBL_NotifyTblUsersOfUpdate(RegRecPtr);
+
+        /* If the table is a critical table, update the appropriate CDS with the new data */
+        if (RegRecPtr->CriticalTable == true)
+        {
+            CFE_TBL_UpdateCriticalTblCDS(RegRecPtr);
+        }
+
+        Status = CFE_SUCCESS;
+    }
+
+    if (Status == CFE_SUCCESS)
+    {
+        /* The first time a table is loaded, the event message is DEBUG */
+        /* to help eliminate a flood of events during a startup         */
+        CFE_EVS_SendEventWithAppID(CFE_TBL_LOAD_SUCCESS_INF_EID,
+                                   FirstTime ? CFE_EVS_EventType_DEBUG : CFE_EVS_EventType_INFORMATION,
+                                   CFE_TBL_Global.TableTaskAppId, "Successfully loaded '%s' from '%s'", RegRecPtr->Name,
+                                   RegRecPtr->LastFileLoaded);
+
+        /* Save the index of the table for housekeeping telemetry */
+        CFE_TBL_Global.LastTblUpdated = AccessDescPtr->RegIndex;
+    }
+
+    return Status;
+} /* End of CFE_TBL_Load() */
+
+/*
+ * Function: CFE_TBL_Update - See API and header file for details
+ */
+int32 CFE_TBL_Update(CFE_TBL_Handle_t TblHandle)
+{
+    int32                       Status;
+    CFE_ES_AppId_t              ThisAppId;
+    CFE_TBL_RegistryRec_t *     RegRecPtr                = NULL;
+    CFE_TBL_AccessDescriptor_t *AccessDescPtr            = NULL;
+    char                        AppName[OS_MAX_API_NAME] = {"UNKNOWN"};
+
+    /* Verify access rights and get a valid Application ID for calling App */
+    Status = CFE_TBL_ValidateAccess(TblHandle, &ThisAppId);
+
+    if (Status == CFE_SUCCESS)
+    {
+        /* Get pointers to pertinent records in registry and handles */
+        AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle];
+        RegRecPtr     = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
+
+        Status = CFE_TBL_UpdateInternal(TblHandle, RegRecPtr, AccessDescPtr);
+
+        if (Status != CFE_SUCCESS)
+        {
+            CFE_ES_WriteToSysLog("CFE_TBL:Update-App(%lu) fail to update Tbl '%s' (Stat=0x%08X)\n",
+                                 CFE_RESOURCEID_TO_ULONG(ThisAppId), RegRecPtr->Name, (unsigned int)Status);
+        }
+    }
+    else
+    {
+        CFE_ES_WriteToSysLog("CFE_TBL:Update-App(%lu) does not have access to Tbl Handle=%d\n",
+                             CFE_RESOURCEID_TO_ULONG(ThisAppId), (int)TblHandle);
+    }
+
+    if (Status != CFE_TBL_ERR_BAD_APP_ID)
+    {
+        /* Translate AppID of caller into App Name */
+        CFE_ES_GetAppName(AppName, ThisAppId, sizeof(AppName));
+    }
+
+    /* On Error conditions, notify ground of screw up */
+    if (Status < 0)
+    {
+        if (RegRecPtr != NULL)
+        {
+            CFE_EVS_SendEventWithAppID(CFE_TBL_UPDATE_ERR_EID, CFE_EVS_EventType_ERROR, CFE_TBL_Global.TableTaskAppId,
+                                       "%s Failed to Update '%s', Status=0x%08X", AppName, RegRecPtr->Name,
+                                       (unsigned int)Status);
+        }
+        else
+        {
+            CFE_EVS_SendEventWithAppID(CFE_TBL_UPDATE_ERR_EID, CFE_EVS_EventType_ERROR, CFE_TBL_Global.TableTaskAppId,
+                                       "%s Failed to Update '?', Status=0x%08X", AppName, (unsigned int)Status);
+        }
+    }
+    else
+    {
+        /* If there was a warning (ie - Table is currently locked), then do not issue a message */
+        if (Status == CFE_SUCCESS)
+        {
+            CFE_EVS_SendEventWithAppID(CFE_TBL_UPDATE_SUCCESS_INF_EID, CFE_EVS_EventType_INFORMATION,
+                                       CFE_TBL_Global.TableTaskAppId, "%s Successfully Updated '%s'", AppName,
+                                       RegRecPtr->Name);
+
+            /* Save the index of the table for housekeeping telemetry */
+            CFE_TBL_Global.LastTblUpdated = AccessDescPtr->RegIndex;
+        }
+    }
+
+    return Status;
+} /* End of CFE_TBL_Update() */
+
+/*
+ * Function: CFE_TBL_GetAddress - See API and header file for details
+ */
+int32 CFE_TBL_GetAddress(void **TblPtr, CFE_TBL_Handle_t TblHandle)
+{
+    int32          Status;
+    CFE_ES_AppId_t ThisAppId;
+
+    if (TblPtr == NULL)
+    {
+        return CFE_TBL_BAD_ARGUMENT;
+    }
+
+    /* Assume failure at returning the table address */
+    *TblPtr = NULL;
+
+    /* Validate the calling application's AppID */
+    Status = CFE_ES_GetAppID(&ThisAppId);
+
+    if (Status == CFE_SUCCESS)
+    {
+        Status = CFE_TBL_GetAddressInternal(TblPtr, TblHandle, ThisAppId);
+
+        /* NOTE: GetAddressInternal calls GetNextNotification which may not */
+        /*       be equal to CFE_SUCCESS and still not be an error.         */
+        /*       Therefore, a write to the SysLog is unnecessary.           */
+    }
+    else
+    {
+        CFE_ES_WriteToSysLog("CFE_TBL:GetAddress-Bad AppId=%lu\n", CFE_RESOURCEID_TO_ULONG(ThisAppId));
+    }
+
+    return Status;
+} /* End of CFE_TBL_GetAddress() */
+
+/*
+ * Function: CFE_TBL_ReleaseAddress - See API and header file for details
+ */
+int32 CFE_TBL_ReleaseAddress(CFE_TBL_Handle_t TblHandle)
+{
+    int32          Status;
+    CFE_ES_AppId_t ThisAppId;
+
+    /* Verify that this application has the right to perform operation */
+    Status = CFE_TBL_ValidateAccess(TblHandle, &ThisAppId);
+
+    if (Status == CFE_SUCCESS)
+    {
+        /* Clear the lock flag */
+        CFE_TBL_Global.Handles[TblHandle].LockFlag = false;
+
+        /* Return any pending warning or info status indicators */
+        Status = CFE_TBL_GetNextNotification(TblHandle);
+
+        /* NOTE: GetNextNotification may not return CFE_SUCCESS  */
+        /*       and still not be an error.                      */
+        /*       Therefore, a write to the SysLog is unnecessary.*/
+    }
+    else
+    {
+        CFE_ES_WriteToSysLog("CFE_TBL:ReleaseAddress-App(%lu) does not have access to Tbl Handle=%u\n",
+                             CFE_RESOURCEID_TO_ULONG(ThisAppId), (unsigned int)TblHandle);
+    }
+
+    return Status;
+} /* End of CFE_TBL_ReleaseAddress() */
+
+/*
+ * Function: CFE_TBL_GetAddresses() - See API and header file for details
+ */
+int32 CFE_TBL_GetAddresses(void **TblPtrs[], uint16 NumTables, const CFE_TBL_Handle_t TblHandles[])
+{
+    uint16         i;
+    int32          Status;
+    CFE_ES_AppId_t ThisAppId;
+
+    if (TblPtrs == NULL)
+    {
+        return CFE_TBL_BAD_ARGUMENT;
+    }
+
+    /* Assume failure at returning the table addresses */
+    for (i = 0; i < NumTables; i++)
+    {
+        *TblPtrs[i] = NULL;
+    }
+
+    /* Validate the calling application's AppID */
+    Status = CFE_ES_GetAppID(&ThisAppId);
+
+    if (Status == CFE_SUCCESS)
+    {
+        for (i = 0; i < NumTables; i++)
+        {
+            /* Continue to get the return status until one returns something other than CFE_SUCCESS */
+            if (Status == CFE_SUCCESS)
+            {
+                Status = CFE_TBL_GetAddressInternal(TblPtrs[i], TblHandles[i], ThisAppId);
+            }
+            else
+            {
+                /* Don't bother getting the status of other tables once one has returned */
+                /* a non CFE_SUCCESS value.                                              */
+                CFE_TBL_GetAddressInternal(TblPtrs[i], TblHandles[i], ThisAppId);
+            }
+        }
+    }
+    else
+    {
+        CFE_ES_WriteToSysLog("CFE_TBL:GetAddresses-Bad AppId=%lu\n", CFE_RESOURCEID_TO_ULONG(ThisAppId));
+    }
+
+    return Status;
+} /* End of CFE_TBL_GetAddresses() */
+
+/*
+ * Function: CFE_TBL_ReleaseAddresses - See API and header file for details
+ */
+int32 CFE_TBL_ReleaseAddresses(uint16 NumTables, const CFE_TBL_Handle_t TblHandles[])
+{
+    int32  Status = CFE_SUCCESS;
+    uint16 i;
+
+    for (i = 0; i < NumTables; i++)
+    {
+        /* Continue to get the return status until one returns something other than CFE_SUCCESS */
+        if (Status == CFE_SUCCESS)
+        {
+            Status = CFE_TBL_ReleaseAddress(TblHandles[i]);
+        }
+        else
+        {
+            /* Don't bother getting the status of other tables once one has returned */
+            /* a non CFE_SUCCESS value.                                              */
+            CFE_TBL_ReleaseAddress(TblHandles[i]);
+        }
+    }
+
+    return Status;
+} /* End of CFE_TBL_ReleaseAddresses() */
+
+/*
+ * Function: CFE_TBL_Validate - See API and header file for details
+ */
+int32 CFE_TBL_Validate(CFE_TBL_Handle_t TblHandle)
+{
+    int32                       Status;
+    CFE_ES_AppId_t              ThisAppId;
+    CFE_TBL_RegistryRec_t *     RegRecPtr;
+    CFE_TBL_AccessDescriptor_t *AccessDescPtr;
+    char                        AppName[OS_MAX_API_NAME] = {"UNKNOWN"};
+
+    /* Verify that this application has the right to perform operation */
+    Status = CFE_TBL_ValidateAccess(TblHandle, &ThisAppId);
+
+    if (Status == CFE_SUCCESS)
+    {
+        /* Get pointers to pertinent records in registry and handles */
+        AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle];
+        RegRecPtr     = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
+
+        CFE_ES_GetAppName(AppName, ThisAppId, sizeof(AppName));
+
+        /* Identify the image to be validated, starting with the Inactive Buffer */
+        if (RegRecPtr->ValidateInactiveIndex != CFE_TBL_NO_VALIDATION_PENDING)
+        {
+            /* Identify whether the Inactive Buffer is a shared buffer or a dedicated one */
+            if (RegRecPtr->DoubleBuffered)
+            {
+                /* Call the Application's Validation function for the Inactive Buffer */
+                Status =
+                    (RegRecPtr->ValidationFuncPtr)(RegRecPtr->Buffers[(1U - RegRecPtr->ActiveBufferIndex)].BufferPtr);
+
+                /* Allow buffer to be activated after passing validation */
+                if (Status == CFE_SUCCESS)
+                {
+                    RegRecPtr->Buffers[(1U - RegRecPtr->ActiveBufferIndex)].Validated = true;
+                }
+            }
+            else
+            {
+                /* Call the Application's Validation function for the appropriate shared buffer */
+                Status = (RegRecPtr->ValidationFuncPtr)(CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].BufferPtr);
+
+                /* Allow buffer to be activated after passing validation */
+                if (Status == CFE_SUCCESS)
+                {
+                    CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].Validated = true;
+                }
+            }
+
+            if (Status == CFE_SUCCESS)
+            {
+                CFE_EVS_SendEventWithAppID(CFE_TBL_VALIDATION_INF_EID, CFE_EVS_EventType_INFORMATION,
+                                           CFE_TBL_Global.TableTaskAppId, "%s validation successful for Inactive '%s'",
+                                           AppName, RegRecPtr->Name);
+            }
+            else
+            {
+                CFE_EVS_SendEventWithAppID(CFE_TBL_VALIDATION_ERR_EID, CFE_EVS_EventType_ERROR,
+                                           CFE_TBL_Global.TableTaskAppId,
+                                           "%s validation failed for Inactive '%s', Status=0x%08X", AppName,
+                                           RegRecPtr->Name, (unsigned int)Status);
+
+                if (Status > CFE_SUCCESS)
+                {
+                    CFE_ES_WriteToSysLog(
+                        "CFE_TBL:Validate-App(%lu) Validation func return code invalid (Stat=0x%08X) for '%s'\n",
+                        CFE_RESOURCEID_TO_ULONG(CFE_TBL_Global.TableTaskAppId), (unsigned int)Status, RegRecPtr->Name);
+                }
+            }
+
+            /* Save the result of the Validation function for the Table Services Task */
+            CFE_TBL_Global.ValidationResults[RegRecPtr->ValidateInactiveIndex].Result = Status;
+
+            /* Once validation is complete, set flags to indicate response is ready */
+            CFE_TBL_Global.ValidationResults[RegRecPtr->ValidateInactiveIndex].State = CFE_TBL_VALIDATION_PERFORMED;
+            RegRecPtr->ValidateInactiveIndex                                         = CFE_TBL_NO_VALIDATION_PENDING;
+
+            /* Since the validation was successfully performed (although maybe not a successful result) */
+            /* return a success status */
+            Status = CFE_SUCCESS;
+        }
+        else if (RegRecPtr->ValidateActiveIndex != CFE_TBL_NO_VALIDATION_PENDING)
+        {
+            /* Perform validation on the currently active table buffer */
+            /* Identify whether the Active Buffer is a shared buffer or a dedicated one */
+            if (RegRecPtr->DoubleBuffered)
+            {
+                /* Call the Application's Validation function for the Dedicated Active Buffer */
+                Status = (RegRecPtr->ValidationFuncPtr)(RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].BufferPtr);
+            }
+            else
+            {
+                /* Call the Application's Validation function for the static buffer */
+                Status = (RegRecPtr->ValidationFuncPtr)(RegRecPtr->Buffers[0].BufferPtr);
+            }
+
+            if (Status == CFE_SUCCESS)
+            {
+                CFE_EVS_SendEventWithAppID(CFE_TBL_VALIDATION_INF_EID, CFE_EVS_EventType_INFORMATION,
+                                           CFE_TBL_Global.TableTaskAppId, "%s validation successful for Active '%s'",
+                                           AppName, RegRecPtr->Name);
+            }
+            else
+            {
+                CFE_EVS_SendEventWithAppID(CFE_TBL_VALIDATION_ERR_EID, CFE_EVS_EventType_ERROR,
+                                           CFE_TBL_Global.TableTaskAppId,
+                                           "%s validation failed for Active '%s', Status=0x%08X", AppName,
+                                           RegRecPtr->Name, (unsigned int)Status);
+
+                if (Status > CFE_SUCCESS)
+                {
+                    CFE_ES_WriteToSysLog(
+                        "CFE_TBL:Validate-App(%lu) Validation func return code invalid (Stat=0x%08X) for '%s'\n",
+                        CFE_RESOURCEID_TO_ULONG(CFE_TBL_Global.TableTaskAppId), (unsigned int)Status, RegRecPtr->Name);
+                }
+            }
+
+            /* Save the result of the Validation function for the Table Services Task */
+            CFE_TBL_Global.ValidationResults[RegRecPtr->ValidateActiveIndex].Result = Status;
+
+            /* Once validation is complete, reset the flags */
+            CFE_TBL_Global.ValidationResults[RegRecPtr->ValidateActiveIndex].State = CFE_TBL_VALIDATION_PERFORMED;
+            RegRecPtr->ValidateActiveIndex                                         = CFE_TBL_NO_VALIDATION_PENDING;
+
+            /* Since the validation was successfully performed (although maybe not a successful result) */
+            /* return a success status */
+            Status = CFE_SUCCESS;
+        }
+        else
+        {
+            Status = CFE_TBL_INFO_NO_VALIDATION_PENDING;
+        }
+    }
+    else
+    {
+        CFE_ES_WriteToSysLog("CFE_TBL:Validate-App(%lu) does not have access to Tbl Handle=%d\n",
+                             CFE_RESOURCEID_TO_ULONG(ThisAppId), (int)TblHandle);
+    }
+
+    return Status;
+} /* End of CFE_TBL_Validate() */
+
+/*
+ * Function: CFE_TBL_Manage - See API and header file for details
+ */
+int32 CFE_TBL_Manage(CFE_TBL_Handle_t TblHandle)
+{
+    int32 Status           = CFE_SUCCESS;
+    bool  FinishedManaging = false;
+
+    while (!FinishedManaging)
+    {
+        /* Determine if the table has a validation or update that needs to be performed */
+        Status = CFE_TBL_GetStatus(TblHandle);
+
+        if (Status == CFE_TBL_INFO_VALIDATION_PENDING)
+        {
+            /* Validate the specified Table */
+            Status = CFE_TBL_Validate(TblHandle);
+
+            if (Status != CFE_SUCCESS)
+            {
+                /* If an error occurred during Validate, then do not perform any more managing */
+                FinishedManaging = true;
+            }
+        }
+        else if (Status == CFE_TBL_INFO_DUMP_PENDING)
+        {
+            /* Dump the specified Table */
+            Status = CFE_TBL_DumpToBuffer(TblHandle);
+
+            /* After a Dump, always assume we are done (Dumps are on DumpOnly tables and cannot be "Updated") */
+            FinishedManaging = true;
+        }
+        else if (Status == CFE_TBL_INFO_UPDATE_PENDING)
+        {
+            /* Update the specified Table */
+            Status = CFE_TBL_Update(TblHandle);
+
+            /* If the update performed nominally, let the caller know the table has changed */
+            if (Status == CFE_SUCCESS)
+            {
+                Status = CFE_TBL_INFO_UPDATED;
+            }
+
+            /* After an Update, always assume we are done and return Update Status */
+            FinishedManaging = true;
+        }
+        else
+        {
+            FinishedManaging = true;
+        }
+    }
+
+    return Status;
+} /* End of CFE_TBL_Manage() */
+
+/*
+ * Function: CFE_TBL_GetStatus - See API and header file for details
+ */
+int32 CFE_TBL_GetStatus(CFE_TBL_Handle_t TblHandle)
+{
+    int32                       Status;
+    CFE_ES_AppId_t              ThisAppId;
+    CFE_TBL_RegistryRec_t *     RegRecPtr;
+    CFE_TBL_AccessDescriptor_t *AccessDescPtr;
+
+    /* Verify that this application has the right to perform operation */
+    Status = CFE_TBL_ValidateAccess(TblHandle, &ThisAppId);
+
+    if (Status == CFE_SUCCESS)
+    {
+        /* Get pointers to pertinent records in registry and handles */
+        AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle];
+        RegRecPtr     = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
+
+        /* Perform validations prior to performing any updates */
+        if (RegRecPtr->LoadPending)
+        {
+            Status = CFE_TBL_INFO_UPDATE_PENDING;
+        }
+        else if ((RegRecPtr->ValidateActiveIndex != CFE_TBL_NO_VALIDATION_PENDING) ||
+                 (RegRecPtr->ValidateInactiveIndex != CFE_TBL_NO_VALIDATION_PENDING))
+        {
+            Status = CFE_TBL_INFO_VALIDATION_PENDING;
+        }
+        else if (RegRecPtr->DumpControlIndex != CFE_TBL_NO_DUMP_PENDING)
+        {
+            Status = CFE_TBL_INFO_DUMP_PENDING;
+        }
+    }
+    else
+    {
+        CFE_ES_WriteToSysLog("CFE_TBL:GetStatus-App(%lu) does not have access to Tbl Handle=%d\n",
+                             CFE_RESOURCEID_TO_ULONG(ThisAppId), (int)TblHandle);
+    }
+
+    return Status;
+} /* End of CFE_TBL_GetStatus() */
+
+/*
+ * Function: CFE_TBL_GetInfo - See API and header file for details
+ */
+int32 CFE_TBL_GetInfo(CFE_TBL_Info_t *TblInfoPtr, const char *TblName)
+{
+    int32                  Status = CFE_SUCCESS;
+    int16                  RegIndx;
+    int32                  NumAccessDescriptors = 0;
+    CFE_TBL_RegistryRec_t *RegRecPtr;
+    CFE_TBL_Handle_t       HandleIterator;
+
+    if (TblInfoPtr == NULL || TblName == NULL)
+    {
+        return CFE_TBL_BAD_ARGUMENT;
+    }
+
+    RegIndx = CFE_TBL_FindTableInRegistry(TblName);
+
+    /* If we found the table, then extract the information from the Registry */
+    if (RegIndx != CFE_TBL_NOT_FOUND)
+    {
+        /* Get pointer to Registry Record Entry to speed up processing */
+        RegRecPtr = &CFE_TBL_Global.Registry[RegIndx];
+
+        /* Return table characteristics */
+        TblInfoPtr->Size            = RegRecPtr->Size;
+        TblInfoPtr->DoubleBuffered  = RegRecPtr->DoubleBuffered;
+        TblInfoPtr->DumpOnly        = RegRecPtr->DumpOnly;
+        TblInfoPtr->UserDefAddr     = RegRecPtr->UserDefAddr;
+        TblInfoPtr->TableLoadedOnce = RegRecPtr->TableLoadedOnce;
+
+        /* Return information on last load and update */
+        TblInfoPtr->TimeOfLastUpdate      = RegRecPtr->TimeOfLastUpdate;
+        TblInfoPtr->FileCreateTimeSecs    = RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].FileCreateTimeSecs;
+        TblInfoPtr->FileCreateTimeSubSecs = RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].FileCreateTimeSubSecs;
+        TblInfoPtr->Crc                   = RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].Crc;
+        strncpy(TblInfoPtr->LastFileLoaded, RegRecPtr->LastFileLoaded, sizeof(TblInfoPtr->LastFileLoaded) - 1);
+        TblInfoPtr->LastFileLoaded[sizeof(TblInfoPtr->LastFileLoaded) - 1] = 0;
+
+        /* Count the number of Access Descriptors to determine the number of users */
+        HandleIterator = RegRecPtr->HeadOfAccessList;
+        while (HandleIterator != CFE_TBL_END_OF_LIST)
+        {
+            NumAccessDescriptors++;
+            HandleIterator = CFE_TBL_Global.Handles[HandleIterator].NextLink;
+        }
+
+        TblInfoPtr->NumUsers = NumAccessDescriptors;
+
+        TblInfoPtr->Critical = RegRecPtr->CriticalTable;
+    }
+    else
+    {
+        Status = CFE_TBL_ERR_INVALID_NAME;
+    }
+
+    return Status;
+} /* End of CFE_TBL_GetInfo() */
+
+/*
+ * Function: CFE_TBL_DumpToBuffer - See API and header file for details
+ */
+int32 CFE_TBL_DumpToBuffer(CFE_TBL_Handle_t TblHandle)
+{
+    int32                       Status;
+    CFE_TBL_AccessDescriptor_t *AccessDescPtr = NULL;
+    CFE_TBL_RegistryRec_t *     RegRecPtr     = NULL;
+    CFE_TBL_DumpControl_t *     DumpCtrlPtr   = NULL;
+    CFE_TIME_SysTime_t          DumpTime;
+
+    /* Make sure the table has been requested to be dumped */
+    Status = CFE_TBL_GetStatus(TblHandle);
+    if (Status == CFE_TBL_INFO_DUMP_PENDING)
+    {
+        AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle];
+        RegRecPtr     = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
+        DumpCtrlPtr   = &CFE_TBL_Global.DumpControlBlocks[RegRecPtr->DumpControlIndex];
+
+        /* Copy the contents of the active buffer to the assigned dump buffer */
+        memcpy(DumpCtrlPtr->DumpBufferPtr->BufferPtr, RegRecPtr->Buffers[0].BufferPtr, DumpCtrlPtr->Size);
+
+        /* Save the current time so that the header in the dump file can have the correct time */
+        DumpTime                                          = CFE_TIME_GetTime();
+        DumpCtrlPtr->DumpBufferPtr->FileCreateTimeSecs    = DumpTime.Seconds;
+        DumpCtrlPtr->DumpBufferPtr->FileCreateTimeSubSecs = DumpTime.Subseconds;
+
+        /* Disassociate the dump request from the table */
+        RegRecPtr->DumpControlIndex = CFE_TBL_NO_DUMP_PENDING;
+
+        /* Notify the Table Services Application that the dump buffer is ready to be written to a file */
+        DumpCtrlPtr->State = CFE_TBL_DUMP_PERFORMED;
+
+        Status = CFE_SUCCESS;
+    }
+
+    return Status;
+} /* End of CFE_TBL_DumpToBuffer() */
+
+/*
+ * Function: CFE_TBL_Modified - See API and header file for details
+ */
+int32 CFE_TBL_Modified(CFE_TBL_Handle_t TblHandle)
+{
+    int32                       Status;
+    CFE_TBL_AccessDescriptor_t *AccessDescPtr = NULL;
+    CFE_TBL_RegistryRec_t *     RegRecPtr     = NULL;
+    CFE_TBL_Handle_t            AccessIterator;
+    CFE_ES_AppId_t              ThisAppId;
+    size_t                      FilenameLen;
+
+    /* Verify that this application has the right to perform operation */
+    Status = CFE_TBL_ValidateAccess(TblHandle, &ThisAppId);
+
+    if (Status == CFE_SUCCESS)
+    {
+        /* Get pointers to pertinent records in registry and handles */
+        AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle];
+        RegRecPtr     = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
+
+        /* If the table is a critical table, update the appropriate CDS with the new data */
+        if (RegRecPtr->CriticalTable == true)
+        {
+            CFE_TBL_UpdateCriticalTblCDS(RegRecPtr);
+        }
+
+        /* Keep a record of change for the ground operators reference */
+        RegRecPtr->TimeOfLastUpdate                                      = CFE_TIME_GetTime();
+        RegRecPtr->LastFileLoaded[sizeof(RegRecPtr->LastFileLoaded) - 1] = '\0';
+
+        /* Update CRC on contents of table */
+        RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].Crc = CFE_ES_CalculateCRC(
+            RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].BufferPtr, RegRecPtr->Size, 0, CFE_MISSION_ES_DEFAULT_CRC);
+
+        FilenameLen = strlen(RegRecPtr->LastFileLoaded);
+        if (FilenameLen < (sizeof(RegRecPtr->LastFileLoaded) - 4))
+        {
+            strncpy(&RegRecPtr->LastFileLoaded[FilenameLen], "(*)", 4);
+        }
+        else
+        {
+            strncpy(&RegRecPtr->LastFileLoaded[sizeof(RegRecPtr->LastFileLoaded) - 4], "(*)", 4);
+        }
+
+        AccessIterator = RegRecPtr->HeadOfAccessList;
+        while (AccessIterator != CFE_TBL_END_OF_LIST)
+        {
+            /* Only notify *OTHER* applications that the contents have changed */
+            if (!CFE_RESOURCEID_TEST_EQUAL(CFE_TBL_Global.Handles[AccessIterator].AppId, ThisAppId))
+            {
+                CFE_TBL_Global.Handles[AccessIterator].Updated = true;
+            }
+
+            AccessIterator = CFE_TBL_Global.Handles[AccessIterator].NextLink;
+        }
+    }
+    else
+    {
+        CFE_ES_WriteToSysLog("CFE_TBL:Modified-App(%lu) does not have access to Tbl Handle=%d\n",
+                             CFE_RESOURCEID_TO_ULONG(ThisAppId), (int)TblHandle);
+    }
+
+    return Status;
+} /* End of CFE_TBL_Modified() */
+
+/*
+ * Function: CFE_TBL_NotifyByMessage - See API and header file for details
+ */
+int32 CFE_TBL_NotifyByMessage(CFE_TBL_Handle_t TblHandle, CFE_SB_MsgId_t MsgId, CFE_MSG_FcnCode_t CommandCode,
+                              uint32 Parameter)
+{
+    int32                       Status;
+    CFE_TBL_AccessDescriptor_t *AccessDescPtr = NULL;
+    CFE_TBL_RegistryRec_t *     RegRecPtr     = NULL;
+    CFE_ES_AppId_t              ThisAppId;
+
+    /* Verify that this application has the right to perform operation */
+    Status = CFE_TBL_ValidateAccess(TblHandle, &ThisAppId);
+
+    if (Status == CFE_SUCCESS)
+    {
+        /* Get pointers to pertinent records in registry and handles */
+        AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle];
+        RegRecPtr     = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
+
+        /* Verify that the calling application is the table owner */
+        if (CFE_RESOURCEID_TEST_EQUAL(RegRecPtr->OwnerAppId, ThisAppId))
+        {
+            RegRecPtr->NotificationMsgId = MsgId;
+            RegRecPtr->NotificationCC    = CommandCode;
+            RegRecPtr->NotificationParam = Parameter;
+            RegRecPtr->NotifyByMsg       = true;
+        }
+        else
+        {
+            Status = CFE_TBL_ERR_NO_ACCESS;
+            CFE_ES_WriteToSysLog("CFE_TBL:NotifyByMsg-App(%lu) does not own Tbl Handle=%d\n",
+                                 CFE_RESOURCEID_TO_ULONG(ThisAppId), (int)TblHandle);
+        }
+    }
+
+    return Status;
+} /* End of CFE_TBL_NotifyByMessage() */
+
+/************************/
+/*  End of File Comment */
+/************************/

--- a/modules/tbl/fsw/src/cfe_tbl_internal.c
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.c
@@ -1,0 +1,1414 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/*
+** File: cfe_tbl_internal.c
+**
+** Purpose:  cFE Table Services (TBL) utility function source file
+**
+** Author:   D. Kobe/the Hammers Company, Inc.
+**
+** Notes:
+**
+*/
+
+/*
+** Required header files...
+*/
+#include "cfe_tbl_module_all.h"
+
+#include <stdio.h>
+#include <string.h>
+
+/*******************************************************************
+**
+** CFE_TBL_EarlyInit
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+/******************************************************************************
+**  Function:  CFE_TBL_EarlyInit()
+**
+**  Purpose:
+**    Initialize the Table Services
+**
+**  Arguments:
+**
+**  Notes:
+**    This function MUST be called before any TBL API's are called.
+**
+**  Return:
+**    none
+*/
+int32 CFE_TBL_EarlyInit(void)
+{
+    uint16 i;
+    uint32 j;
+    int32  Status;
+
+    /* Clear task global */
+    memset(&CFE_TBL_Global, 0, sizeof(CFE_TBL_Global));
+
+    /* Initialize the Table Registry */
+    for (i = 0; i < CFE_PLATFORM_TBL_MAX_NUM_TABLES; i++)
+    {
+        CFE_TBL_InitRegistryRecord(&CFE_TBL_Global.Registry[i]);
+    }
+
+    /* Initialize the Table Access Descriptors nonzero values */
+    for (i = 0; i < CFE_PLATFORM_TBL_MAX_NUM_HANDLES; i++)
+    {
+        CFE_TBL_Global.Handles[i].AppId    = CFE_TBL_NOT_OWNED;
+        CFE_TBL_Global.Handles[i].PrevLink = CFE_TBL_END_OF_LIST;
+        CFE_TBL_Global.Handles[i].NextLink = CFE_TBL_END_OF_LIST;
+    }
+
+    /* Initialize the Table Validation Results Records nonzero values */
+    for (i = 0; i < CFE_PLATFORM_TBL_MAX_NUM_VALIDATIONS; i++)
+    {
+        CFE_TBL_Global.ValidationResults[i].State = CFE_TBL_VALIDATION_FREE;
+    }
+
+    /* Initialize the Dump-Only Table Dump Control Blocks nonzero values */
+    for (i = 0; i < CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS; i++)
+    {
+        CFE_TBL_Global.DumpControlBlocks[i].State = CFE_TBL_DUMP_FREE;
+
+        /* Prevent Shared Buffers from being used until successfully allocated */
+        CFE_TBL_Global.LoadBuffs[i].Taken = true;
+    }
+
+    CFE_TBL_Global.HkTlmTblRegIndex = CFE_TBL_NOT_FOUND;
+    CFE_TBL_Global.LastTblUpdated   = CFE_TBL_NOT_FOUND;
+
+    /*
+    ** Create table registry access mutex
+    */
+    Status = OS_MutSemCreate(&CFE_TBL_Global.RegistryMutex, CFE_TBL_MUT_REG_NAME, CFE_TBL_MUT_REG_VALUE);
+    if (Status != OS_SUCCESS)
+    {
+        return Status;
+    } /* end if */
+
+    /*
+    ** Create working buffer access mutex
+    */
+    Status = OS_MutSemCreate(&CFE_TBL_Global.WorkBufMutex, CFE_TBL_MUT_WORK_NAME, CFE_TBL_MUT_WORK_VALUE);
+    if (Status != OS_SUCCESS)
+    {
+        return Status;
+    } /* end if */
+
+    /* Initialize memory partition and allocate shared table buffers. */
+    Status = CFE_ES_PoolCreate(&CFE_TBL_Global.Buf.PoolHdl, CFE_TBL_Global.Buf.Partition.Data,
+                               sizeof(CFE_TBL_Global.Buf.Partition));
+
+    if (Status < 0)
+    {
+        return Status;
+    }
+    else
+    {
+        /* Initialize each of the shared load buffers */
+        j = 0;
+        do
+        {
+            /* Allocate memory for shared load buffers */
+            Status = CFE_ES_GetPoolBuf(&CFE_TBL_Global.LoadBuffs[j].BufferPtr, CFE_TBL_Global.Buf.PoolHdl,
+                                       CFE_PLATFORM_TBL_MAX_SNGL_TABLE_SIZE);
+
+            if (Status < CFE_PLATFORM_TBL_MAX_SNGL_TABLE_SIZE)
+            {
+                return Status;
+            }
+            else
+            {
+                /* The buffer is successfully created, so allow it to be used */
+                CFE_TBL_Global.LoadBuffs[j].Taken = false;
+            }
+
+            j++;
+        } while (j < CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS);
+    }
+
+    /* Try to obtain a previous image of the Critical Table Registry from the Critical Data Store */
+    Status = CFE_ES_RegisterCDSEx(&CFE_TBL_Global.CritRegHandle,
+                                  (sizeof(CFE_TBL_CritRegRec_t) * CFE_PLATFORM_TBL_MAX_CRITICAL_TABLES),
+                                  "CFE_TBL.CritReg", true);
+
+    /* Assume for the moment that nothing is already in the CDS and zero out the Critical Table Registry */
+    for (i = 0; i < CFE_PLATFORM_TBL_MAX_CRITICAL_TABLES; i++)
+    {
+        CFE_TBL_Global.CritReg[i].CDSHandle = CFE_ES_CDS_BAD_HANDLE;
+    }
+
+    if (Status == CFE_ES_CDS_ALREADY_EXISTS)
+    {
+        /* Try to recover the Critical Table Registry from the CDS */
+        Status = CFE_ES_RestoreFromCDS(CFE_TBL_Global.CritReg, CFE_TBL_Global.CritRegHandle);
+
+        if (Status != CFE_SUCCESS)
+        {
+            /* Note if we were unable to recover error free Critical Table Registry from the CDS */
+            CFE_ES_WriteToSysLog("CFE_TBL:EarlyInit-Failed to recover Critical Table Registry (Err=0x%08X)\n",
+                                 (unsigned int)Status);
+        }
+
+        /* Whether we recovered the Critical Table Registry or not, we are successful with initialization */
+        Status = CFE_SUCCESS;
+    }
+    else if (Status != CFE_SUCCESS)
+    {
+        /* Not being able to support Critical Tables is not the end of the world */
+        /* Note the problem and move on */
+        CFE_ES_WriteToSysLog("CFE_TBL:EarlyInit-Failed to create Critical Table Registry (Err=0x%08X)\n",
+                             (unsigned int)Status);
+
+        /* Failure to support critical tables is not a good enough reason to exit the cFE on start up */
+        Status = CFE_SUCCESS;
+    }
+    else
+    {
+        /* Save the initial version of the Critical Table Registry in the CDS */
+        Status = CFE_ES_CopyToCDS(CFE_TBL_Global.CritRegHandle, CFE_TBL_Global.CritReg);
+
+        if (Status != CFE_SUCCESS)
+        {
+            /* Not being able to support Critical Tables is not the end of the world */
+            /* Note the problem and move on */
+            CFE_ES_WriteToSysLog("CFE_TBL:EarlyInit-Failed to save Critical Table Registry (Err=0x%08X)\n",
+                                 (unsigned int)Status);
+
+            /* Failure to support critical tables is not a good enough reason to exit the cFE on start up */
+            Status = CFE_SUCCESS;
+        }
+    }
+
+    return Status;
+
+} /* End CFE_TBL_EarlyInit */
+
+/*******************************************************************
+**
+** CFE_TBL_InitRegistryRecord
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+void CFE_TBL_InitRegistryRecord(CFE_TBL_RegistryRec_t *RegRecPtr)
+{
+    memset(RegRecPtr, 0, sizeof(*RegRecPtr));
+
+    RegRecPtr->OwnerAppId            = CFE_TBL_NOT_OWNED;
+    RegRecPtr->NotificationMsgId     = CFE_SB_INVALID_MSG_ID;
+    RegRecPtr->HeadOfAccessList      = CFE_TBL_END_OF_LIST;
+    RegRecPtr->LoadInProgress        = CFE_TBL_NO_LOAD_IN_PROGRESS;
+    RegRecPtr->ValidateActiveIndex   = CFE_TBL_NO_VALIDATION_PENDING;
+    RegRecPtr->ValidateInactiveIndex = CFE_TBL_NO_VALIDATION_PENDING;
+    RegRecPtr->CDSHandle             = CFE_ES_CDS_BAD_HANDLE;
+    RegRecPtr->DumpControlIndex      = CFE_TBL_NO_DUMP_PENDING;
+} /* End CFE_TBL_InitRegistryRecord */
+
+/*******************************************************************
+**
+** CFE_TBL_ValidateHandle
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+
+int32 CFE_TBL_ValidateHandle(CFE_TBL_Handle_t TblHandle)
+{
+    /* Is the handle out of range? */
+    if (TblHandle >= CFE_PLATFORM_TBL_MAX_NUM_HANDLES)
+    {
+        return CFE_TBL_ERR_INVALID_HANDLE;
+    }
+    else
+    {
+        /* Check to see if the Handle is no longer valid for this Table */
+        if (CFE_TBL_Global.Handles[TblHandle].UsedFlag == false)
+        {
+            return CFE_TBL_ERR_INVALID_HANDLE;
+        }
+    }
+    return CFE_SUCCESS;
+} /* End of CFE_TBL_ValidateHandle() */
+
+/*******************************************************************
+**
+** CFE_TBL_ValidateAccess
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+
+int32 CFE_TBL_ValidateAccess(CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t *AppIdPtr)
+{
+    int32 Status;
+
+    /* Check to make sure App ID is legit */
+    Status = CFE_ES_GetAppID(AppIdPtr);
+
+    if (Status != CFE_SUCCESS)
+    {
+        return Status;
+    }
+
+    /* Check table handle validity */
+    Status = CFE_TBL_ValidateHandle(TblHandle);
+
+    if (Status != CFE_SUCCESS)
+    {
+        return Status;
+    }
+
+    Status = CFE_TBL_CheckAccessRights(TblHandle, *AppIdPtr);
+
+    return Status;
+} /* End of CFE_TBL_ValidateAccess() */
+
+/*******************************************************************
+**
+** CFE_TBL_CheckAccessRights
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+
+int32 CFE_TBL_CheckAccessRights(CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t ThisAppId)
+{
+    int32 Status = CFE_SUCCESS;
+
+    if (!CFE_RESOURCEID_TEST_EQUAL(ThisAppId, CFE_TBL_Global.Handles[TblHandle].AppId))
+    {
+        /* The Table Service Task always has access rights so that tables */
+        /* can be manipulated via ground command                          */
+        if (!CFE_RESOURCEID_TEST_EQUAL(ThisAppId, CFE_TBL_Global.TableTaskAppId))
+        {
+            Status = CFE_TBL_ERR_NO_ACCESS;
+        }
+    }
+
+    return Status;
+} /* End of CFE_TBL_CheckAccessRights() */
+
+/*******************************************************************
+**
+** CFE_TBL_RemoveAccessLink
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+
+int32 CFE_TBL_RemoveAccessLink(CFE_TBL_Handle_t TblHandle)
+{
+    int32                       Status        = CFE_SUCCESS;
+    CFE_TBL_AccessDescriptor_t *AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle];
+    CFE_TBL_RegistryRec_t *     RegRecPtr     = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
+
+    /* Lock Access to the table while we modify the linked list */
+    CFE_TBL_LockRegistry();
+
+    /* If we are removing the head of the linked list, then point */
+    /* the head pointer to the link after this one                */
+    if (AccessDescPtr->PrevLink == CFE_TBL_END_OF_LIST)
+    {
+        RegRecPtr->HeadOfAccessList = AccessDescPtr->NextLink;
+
+        /* Update the next link, if there is one, to be the new head of the list */
+        if (AccessDescPtr->NextLink != CFE_TBL_END_OF_LIST)
+        {
+            CFE_TBL_Global.Handles[AccessDescPtr->NextLink].PrevLink = CFE_TBL_END_OF_LIST;
+        }
+    }
+    else /* Access Descriptor is not the head of the list */
+    {
+        /* Set the next link on the previous link to the next link of the link being removed */
+        CFE_TBL_Global.Handles[AccessDescPtr->PrevLink].NextLink = AccessDescPtr->NextLink;
+
+        /* If this link is not the end of the list, then complete two way linkage */
+        /* by setting the next link's previous link to the previous link of the link being removed */
+        if (AccessDescPtr->NextLink != CFE_TBL_END_OF_LIST)
+        {
+            CFE_TBL_Global.Handles[AccessDescPtr->NextLink].PrevLink = AccessDescPtr->PrevLink;
+        }
+    }
+
+    /* Return the Access Descriptor to the pool */
+    AccessDescPtr->UsedFlag = false;
+
+    /* If this was the last Access Descriptor for this table, we can free the memory buffers as well */
+    if (RegRecPtr->HeadOfAccessList == CFE_TBL_END_OF_LIST)
+    {
+        /* Only free memory that we have allocated.  If the image is User Defined, then don't bother */
+        if (RegRecPtr->UserDefAddr == false)
+        {
+            /* Free memory allocated to buffers */
+            Status = CFE_ES_PutPoolBuf(CFE_TBL_Global.Buf.PoolHdl, RegRecPtr->Buffers[0].BufferPtr);
+            RegRecPtr->Buffers[0].BufferPtr = NULL;
+
+            if (Status < 0)
+            {
+                CFE_ES_WriteToSysLog(
+                    "CFE_TBL:RemoveAccessLink-PutPoolBuf[0] Fail Stat=0x%08X, Hndl=0x%08lX, Buf=0x%08lX\n",
+                    (unsigned int)Status, CFE_RESOURCEID_TO_ULONG(CFE_TBL_Global.Buf.PoolHdl),
+                    (unsigned long)RegRecPtr->Buffers[0].BufferPtr);
+            }
+
+            /* If a double buffered table, then free the second buffer as well */
+            if (RegRecPtr->DoubleBuffered)
+            {
+                Status = CFE_ES_PutPoolBuf(CFE_TBL_Global.Buf.PoolHdl, RegRecPtr->Buffers[1].BufferPtr);
+                RegRecPtr->Buffers[1].BufferPtr = NULL;
+
+                if (Status < 0)
+                {
+                    CFE_ES_WriteToSysLog(
+                        "CFE_TBL:RemoveAccessLink-PutPoolBuf[1] Fail Stat=0x%08X, Hndl=0x%08lX, Buf=0x%08lX\n",
+                        (unsigned int)Status, CFE_RESOURCEID_TO_ULONG(CFE_TBL_Global.Buf.PoolHdl),
+                        (unsigned long)RegRecPtr->Buffers[1].BufferPtr);
+                }
+            }
+            else
+            {
+                /* If a shared buffer has been allocated to the table, then release it as well */
+                if (RegRecPtr->LoadInProgress != CFE_TBL_NO_LOAD_IN_PROGRESS)
+                {
+                    /* Free the working buffer */
+                    CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].Taken = false;
+                    RegRecPtr->LoadInProgress                                 = CFE_TBL_NO_LOAD_IN_PROGRESS;
+                }
+            }
+        }
+    }
+
+    /* Unlock the registry to allow others to modify it */
+    CFE_TBL_UnlockRegistry();
+
+    return Status;
+} /* End of CFE_TBL_RemoveAccessLink() */
+
+/*******************************************************************
+**
+** CFE_TBL_GetAddressInternal
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+
+int32 CFE_TBL_GetAddressInternal(void **TblPtr, CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t ThisAppId)
+{
+    int32                       Status;
+    CFE_TBL_AccessDescriptor_t *AccessDescPtr;
+    CFE_TBL_RegistryRec_t *     RegRecPtr;
+
+    /* Check table handle validity */
+    Status = CFE_TBL_ValidateHandle(TblHandle);
+
+    if (Status == CFE_SUCCESS)
+    {
+        /* Get a pointer to the Access Descriptor */
+        AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle];
+
+        /* Verify that we are allowed access to the table */
+        Status = CFE_TBL_CheckAccessRights(TblHandle, ThisAppId);
+
+        if (Status == CFE_SUCCESS)
+        {
+            /* Get a pointer to the Table Registry entry */
+            RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
+
+            /* If table is unowned, then owner must have unregistered it when we weren't looking */
+            if (CFE_RESOURCEID_TEST_EQUAL(RegRecPtr->OwnerAppId, CFE_TBL_NOT_OWNED))
+            {
+                Status = CFE_TBL_ERR_UNREGISTERED;
+
+                CFE_ES_WriteToSysLog("CFE_TBL:GetAddressInternal-App(%lu) attempt to access unowned Tbl Handle=%d\n",
+                                     CFE_RESOURCEID_TO_ULONG(ThisAppId), (int)TblHandle);
+            }
+            else /* Table Registry Entry is valid */
+            {
+                /* Lock the table and return the current pointer */
+                AccessDescPtr->LockFlag = true;
+
+                /* Save the buffer we are using in the access descriptor */
+                /* This is used to ensure that if the buffer becomes inactive while */
+                /* we are using it, no one will modify it until we are done */
+                AccessDescPtr->BufferIndex = RegRecPtr->ActiveBufferIndex;
+
+                *TblPtr = RegRecPtr->Buffers[AccessDescPtr->BufferIndex].BufferPtr;
+
+                /* Return any pending warning or info status indicators */
+                Status = CFE_TBL_GetNextNotification(TblHandle);
+
+                /* Clear Table Updated Notify Bit so that caller only gets it once */
+                AccessDescPtr->Updated = false;
+            }
+        }
+        else
+        {
+            CFE_ES_WriteToSysLog("CFE_TBL:GetAddressInternal-App(%lu) does not have access to Tbl Handle=%d\n",
+                                 CFE_RESOURCEID_TO_ULONG(ThisAppId), (int)TblHandle);
+        }
+    }
+    else
+    {
+        CFE_ES_WriteToSysLog("CFE_TBL:GetAddressInternal-App(%lu) using invalid Tbl Handle=%d\n",
+                             CFE_RESOURCEID_TO_ULONG(ThisAppId), (int)TblHandle);
+    }
+
+    return Status;
+} /* End of CFE_TBL_GetAddressInternal() */
+
+/*******************************************************************
+**
+** CFE_TBL_GetNextNotification
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+
+int32 CFE_TBL_GetNextNotification(CFE_TBL_Handle_t TblHandle)
+{
+    int32                       Status        = CFE_SUCCESS;
+    CFE_TBL_AccessDescriptor_t *AccessDescPtr = &CFE_TBL_Global.Handles[TblHandle];
+    CFE_TBL_RegistryRec_t *     RegRecPtr     = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
+
+    if (!RegRecPtr->TableLoadedOnce)
+    {
+        /* If the table has never been loaded, return an error code for the address */
+        Status = CFE_TBL_ERR_NEVER_LOADED;
+    }
+    else if (AccessDescPtr->Updated)
+    {
+        /* If the table has been updated recently, return the update status */
+        Status = CFE_TBL_INFO_UPDATED;
+    }
+
+    return Status;
+} /* End of CFE_TBL_GetNextNotification() */
+
+/*******************************************************************
+**
+** CFE_TBL_FindTableInRegistry
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+
+int16 CFE_TBL_FindTableInRegistry(const char *TblName)
+{
+    int16 RegIndx = CFE_TBL_NOT_FOUND;
+    int16 i       = -1;
+
+    do
+    {
+        /* Point to next record in the Table Registry */
+        i++;
+
+        /* Check to see if the record is currently being used */
+        if (!CFE_RESOURCEID_TEST_EQUAL(CFE_TBL_Global.Registry[i].OwnerAppId, CFE_TBL_NOT_OWNED))
+        {
+            /* Perform a case sensitive name comparison */
+            if (strcmp(TblName, CFE_TBL_Global.Registry[i].Name) == 0)
+            {
+                /* If the names match, then return the index */
+                RegIndx = i;
+            }
+        }
+    } while ((RegIndx == CFE_TBL_NOT_FOUND) && (i < (CFE_PLATFORM_TBL_MAX_NUM_TABLES - 1)));
+
+    return RegIndx;
+} /* End of CFE_TBL_FindTableInRegistry() */
+
+/*******************************************************************
+**
+** CFE_TBL_FindFreeRegistryEntry
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+
+int16 CFE_TBL_FindFreeRegistryEntry(void)
+{
+    int16 RegIndx = CFE_TBL_NOT_FOUND;
+    int16 i       = 0;
+
+    while ((RegIndx == CFE_TBL_NOT_FOUND) && (i < CFE_PLATFORM_TBL_MAX_NUM_TABLES))
+    {
+        /* A Table Registry is only "Free" when there isn't an owner AND */
+        /* all other applications are not sharing or locking the table   */
+        if (CFE_RESOURCEID_TEST_EQUAL(CFE_TBL_Global.Registry[i].OwnerAppId, CFE_TBL_NOT_OWNED) &&
+            (CFE_TBL_Global.Registry[i].HeadOfAccessList == CFE_TBL_END_OF_LIST))
+        {
+            RegIndx = i;
+        }
+        else
+        {
+            i++;
+        }
+    }
+
+    return RegIndx;
+} /* End of CFE_TBL_FindFreeRegistryEntry() */
+
+/*******************************************************************
+**
+** CFE_TBL_FindFreeHandle
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+
+CFE_TBL_Handle_t CFE_TBL_FindFreeHandle(void)
+{
+    CFE_TBL_Handle_t HandleIndx = CFE_TBL_END_OF_LIST;
+    int16            i          = 0;
+
+    while ((HandleIndx == CFE_TBL_END_OF_LIST) && (i < CFE_PLATFORM_TBL_MAX_NUM_HANDLES))
+    {
+        if (CFE_TBL_Global.Handles[i].UsedFlag == false)
+        {
+            HandleIndx = i;
+        }
+        else
+        {
+            i++;
+        }
+    }
+
+    return HandleIndx;
+} /* End of CFE_TBL_FindFreeHandle() */
+
+/*******************************************************************
+**
+** CFE_TBL_FormTableName
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+
+void CFE_TBL_FormTableName(char *FullTblName, const char *TblName, CFE_ES_AppId_t ThisAppId)
+{
+    char AppName[OS_MAX_API_NAME];
+
+    CFE_ES_GetAppName(AppName, ThisAppId, sizeof(AppName));
+
+    /* Ensure that AppName is null terminated */
+    AppName[OS_MAX_API_NAME - 1] = '\0';
+
+    /* Complete formation of processor specific table name */
+    sprintf(FullTblName, "%s.%s", AppName, TblName);
+
+    return;
+} /* End of CFE_TBL_FormTableName() */
+
+/*******************************************************************
+**
+** CFE_TBL_LockRegistry
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+
+int32 CFE_TBL_LockRegistry(void)
+{
+    int32 Status;
+
+    Status = OS_MutSemTake(CFE_TBL_Global.RegistryMutex);
+
+    if (Status == OS_SUCCESS)
+    {
+        Status = CFE_SUCCESS;
+    }
+
+    return Status;
+
+} /* End of CFE_TBL_LockRegistry() */
+
+/*******************************************************************
+**
+** CFE_TBL_UnlockRegistry
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+
+int32 CFE_TBL_UnlockRegistry(void)
+{
+    int32 Status;
+
+    Status = OS_MutSemGive(CFE_TBL_Global.RegistryMutex);
+
+    if (Status == OS_SUCCESS)
+    {
+        Status = CFE_SUCCESS;
+    }
+
+    return Status;
+
+} /* End of CFE_TBL_UnlockRegistry() */
+
+/*******************************************************************
+**
+** CFE_TBL_GetWorkingBuffer
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+
+int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr, CFE_TBL_RegistryRec_t *RegRecPtr,
+                               bool CalledByApp)
+{
+    int32            Status = CFE_SUCCESS;
+    int32            i;
+    int32            InactiveBufferIndex;
+    CFE_TBL_Handle_t AccessIterator;
+
+    /* Initialize return pointer to NULL */
+    *WorkingBufferPtr = NULL;
+
+    /* If a load is already in progress, return the previously allocated working buffer */
+    if (RegRecPtr->LoadInProgress != CFE_TBL_NO_LOAD_IN_PROGRESS)
+    {
+        if (RegRecPtr->DoubleBuffered)
+        {
+            *WorkingBufferPtr = &RegRecPtr->Buffers[(1U - RegRecPtr->ActiveBufferIndex)];
+        }
+        else
+        {
+            *WorkingBufferPtr = &CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress];
+        }
+    }
+    else
+    {
+        /* If the table is uninitialized and the function is called by an application (rather than       */
+        /* by the Table Services application), then use the current active buffer as the working buffer. */
+        /* This allows many tasks with many tables to perform the initialization without conflict        */
+        /* over the accessibility of the shared working buffers.                                         */
+        if ((RegRecPtr->TableLoadedOnce == false) && (CalledByApp == true))
+        {
+            if (RegRecPtr->DoubleBuffered)
+            {
+                *WorkingBufferPtr = &RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex];
+            }
+            else
+            {
+                *WorkingBufferPtr = &RegRecPtr->Buffers[0];
+            }
+        }
+        else
+        {
+            /* If the table is a double buffered table, then check to make sure the */
+            /* inactive buffer has been freed by any Applications that may have been using it */
+            if (RegRecPtr->DoubleBuffered)
+            {
+                /* Determine the index of the Inactive Buffer Pointer */
+                InactiveBufferIndex = 1 - RegRecPtr->ActiveBufferIndex;
+
+                /* Scan the access descriptor table to determine if anyone is still using the inactive buffer */
+                AccessIterator = RegRecPtr->HeadOfAccessList;
+                while ((AccessIterator != CFE_TBL_END_OF_LIST) && (Status == CFE_SUCCESS))
+                {
+                    if ((CFE_TBL_Global.Handles[AccessIterator].BufferIndex == InactiveBufferIndex) &&
+                        (CFE_TBL_Global.Handles[AccessIterator].LockFlag))
+                    {
+                        Status = CFE_TBL_ERR_NO_BUFFER_AVAIL;
+
+                        CFE_ES_WriteToSysLog(
+                            "CFE_TBL:GetWorkingBuffer-Inactive Dbl Buff Locked for '%s' by AppId=%lu\n",
+                            RegRecPtr->Name, CFE_RESOURCEID_TO_ULONG(CFE_TBL_Global.Handles[AccessIterator].AppId));
+                    }
+
+                    /* Move to next access descriptor in linked list */
+                    AccessIterator = CFE_TBL_Global.Handles[AccessIterator].NextLink;
+                }
+
+                /* If buffer is free, then return the pointer to it */
+                if (Status == CFE_SUCCESS)
+                {
+                    *WorkingBufferPtr         = &RegRecPtr->Buffers[InactiveBufferIndex];
+                    RegRecPtr->LoadInProgress = InactiveBufferIndex;
+                }
+            }
+            else /* Single Buffered Table */
+            {
+                /* Take Mutex to make sure we are not trying to grab a working buffer that some */
+                /* other application is also trying to grab. */
+                Status = OS_MutSemTake(CFE_TBL_Global.WorkBufMutex);
+
+                /* Make note of any errors but continue and hope for the best */
+                if (Status != OS_SUCCESS)
+                {
+                    CFE_ES_WriteToSysLog("CFE_TBL:GetWorkBuf-Internal error taking WorkBuf Mutex (Status=0x%08X)\n",
+                                         (unsigned int)Status);
+                }
+
+                /* Determine if there are any common buffers available */
+                i = 0;
+                while ((i < CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS) && (CFE_TBL_Global.LoadBuffs[i].Taken == true))
+                {
+                    i++;
+                }
+
+                /* If a free buffer was found, then return the address to the associated shared buffer */
+                if (i < CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS)
+                {
+                    CFE_TBL_Global.LoadBuffs[i].Taken = true;
+                    *WorkingBufferPtr                 = &CFE_TBL_Global.LoadBuffs[i];
+                    RegRecPtr->LoadInProgress         = i;
+
+                    /* Translate OS_SUCCESS into CFE_SUCCESS */
+                    Status = CFE_SUCCESS;
+                }
+                else
+                {
+                    Status = CFE_TBL_ERR_NO_BUFFER_AVAIL;
+
+                    CFE_ES_WriteToSysLog("CFE_TBL:GetWorkingBuffer-All shared buffers are locked\n");
+                }
+
+                /* Allow others to obtain a shared working buffer */
+                OS_MutSemGive(CFE_TBL_Global.WorkBufMutex);
+            }
+
+            if ((*WorkingBufferPtr) != NULL &&
+                (*WorkingBufferPtr)->BufferPtr != RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].BufferPtr)
+            {
+                /* In case the file contains a partial table load, get the active buffer contents first */
+                memcpy((*WorkingBufferPtr)->BufferPtr, RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].BufferPtr,
+                       RegRecPtr->Size);
+            }
+        }
+    }
+
+    return Status;
+
+} /* End of CFE_TBL_GetWorkingBuffer() */
+
+/*******************************************************************
+**
+** CFE_TBL_LoadFromFile
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+
+int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBufferPtr, CFE_TBL_RegistryRec_t *RegRecPtr,
+                           const char *Filename)
+{
+    int32              Status = CFE_SUCCESS;
+    CFE_FS_Header_t    StdFileHeader;
+    CFE_TBL_File_Hdr_t TblFileHeader;
+    osal_id_t          FileDescriptor;
+    size_t             FilenameLen = strlen(Filename);
+    uint32             NumBytes;
+    uint8              ExtraByte;
+
+    if (FilenameLen > (OS_MAX_PATH_LEN - 1))
+    {
+        CFE_EVS_SendEventWithAppID(CFE_TBL_LOAD_FILENAME_LONG_ERR_EID, CFE_EVS_EventType_ERROR,
+                                   CFE_TBL_Global.TableTaskAppId, "%s: Filename is too long ('%s' (%lu) > %lu)",
+                                   AppName, Filename, (long unsigned int)FilenameLen,
+                                   (long unsigned int)OS_MAX_PATH_LEN - 1);
+
+        return CFE_TBL_ERR_FILENAME_TOO_LONG;
+    }
+
+    /* Try to open the specified table file */
+    Status = OS_OpenCreate(&FileDescriptor, Filename, OS_FILE_FLAG_NONE, OS_READ_ONLY);
+
+    if (Status < 0)
+    {
+        CFE_EVS_SendEventWithAppID(CFE_TBL_FILE_ACCESS_ERR_EID, CFE_EVS_EventType_ERROR, CFE_TBL_Global.TableTaskAppId,
+                                   "%s: Unable to open file (FileDescriptor=%d)", AppName, (int)Status);
+
+        return CFE_TBL_ERR_ACCESS;
+    }
+
+    Status = CFE_TBL_ReadHeaders(FileDescriptor, &StdFileHeader, &TblFileHeader, Filename);
+
+    if (Status != CFE_SUCCESS)
+    {
+        /* CFE_TBL_ReadHeaders() generates its own events */
+
+        OS_close(FileDescriptor);
+        return Status;
+    }
+
+    /* Verify that the specified file has compatible data for specified table */
+    if (strcmp(RegRecPtr->Name, TblFileHeader.TableName) != 0)
+    {
+        CFE_EVS_SendEventWithAppID(CFE_TBL_LOAD_TBLNAME_MISMATCH_ERR_EID, CFE_EVS_EventType_ERROR,
+                                   CFE_TBL_Global.TableTaskAppId, "%s: Table name mismatch (exp=%s, tblfilhdr=%s)",
+                                   AppName, RegRecPtr->Name, TblFileHeader.TableName);
+
+        OS_close(FileDescriptor);
+        return CFE_TBL_ERR_FILE_FOR_WRONG_TABLE;
+    }
+
+    if ((TblFileHeader.Offset + TblFileHeader.NumBytes) > RegRecPtr->Size)
+    {
+        CFE_EVS_SendEventWithAppID(
+            CFE_TBL_LOAD_EXCEEDS_SIZE_ERR_EID, CFE_EVS_EventType_ERROR, CFE_TBL_Global.TableTaskAppId,
+            "%s: File reports size larger than expected (file=%lu, exp=%lu)", AppName,
+            (long unsigned int)(TblFileHeader.Offset + TblFileHeader.NumBytes), (long unsigned int)RegRecPtr->Size);
+
+        OS_close(FileDescriptor);
+        return CFE_TBL_ERR_FILE_TOO_LARGE;
+    }
+
+    /* Any Table load that starts beyond the first byte is a "partial load" */
+    /* But a file that starts with the first byte and ends before filling   */
+    /* the whole table is just considered "short".                          */
+    if (TblFileHeader.Offset > 0)
+    {
+        Status = CFE_TBL_WARN_PARTIAL_LOAD;
+    }
+    else if (TblFileHeader.NumBytes < RegRecPtr->Size)
+    {
+        Status = CFE_TBL_WARN_SHORT_FILE;
+    }
+
+    NumBytes =
+        OS_read(FileDescriptor, ((uint8 *)WorkingBufferPtr->BufferPtr) + TblFileHeader.Offset, TblFileHeader.NumBytes);
+
+    if (NumBytes != TblFileHeader.NumBytes)
+    {
+        CFE_EVS_SendEventWithAppID(CFE_TBL_FILE_INCOMPLETE_ERR_EID, CFE_EVS_EventType_ERROR,
+                                   CFE_TBL_Global.TableTaskAppId, "%s: File load incomplete (exp=%lu, read=%lu)",
+                                   AppName, (long unsigned int)TblFileHeader.NumBytes, (long unsigned int)NumBytes);
+
+        OS_close(FileDescriptor);
+        return CFE_TBL_ERR_LOAD_INCOMPLETE;
+    }
+
+    /* Check to see if the file is too large (ie - more data than header claims) */
+    NumBytes = OS_read(FileDescriptor, &ExtraByte, 1);
+
+    /* If successfully read another byte, then file must have too much data */
+    if (NumBytes == 1)
+    {
+        CFE_EVS_SendEventWithAppID(CFE_TBL_FILE_TOO_BIG_ERR_EID, CFE_EVS_EventType_ERROR, CFE_TBL_Global.TableTaskAppId,
+                                   "%s: File load too long (file length > %lu)", AppName,
+                                   (long unsigned int)TblFileHeader.NumBytes);
+
+        OS_close(FileDescriptor);
+        return CFE_TBL_ERR_FILE_TOO_LARGE;
+    }
+
+    memset(WorkingBufferPtr->DataSource, 0, sizeof(WorkingBufferPtr->DataSource));
+    strncpy(WorkingBufferPtr->DataSource, Filename, sizeof(WorkingBufferPtr->DataSource) - 1);
+
+    /* Save file creation time for later storage into Registry */
+    WorkingBufferPtr->FileCreateTimeSecs    = StdFileHeader.TimeSeconds;
+    WorkingBufferPtr->FileCreateTimeSubSecs = StdFileHeader.TimeSubSeconds;
+
+    /* Compute the CRC on the specified table buffer */
+    WorkingBufferPtr->Crc =
+        CFE_ES_CalculateCRC(WorkingBufferPtr->BufferPtr, RegRecPtr->Size, 0, CFE_MISSION_ES_DEFAULT_CRC);
+
+    OS_close(FileDescriptor);
+
+    return Status;
+} /* End of CFE_TBL_LoadFromFile() */
+
+/*******************************************************************
+**
+** CFE_TBL_UpdateInternal
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+
+int32 CFE_TBL_UpdateInternal(CFE_TBL_Handle_t TblHandle, CFE_TBL_RegistryRec_t *RegRecPtr,
+                             CFE_TBL_AccessDescriptor_t *AccessDescPtr)
+{
+    int32            Status = CFE_SUCCESS;
+    CFE_TBL_Handle_t AccessIterator;
+    bool             LockStatus = false;
+
+    if ((!RegRecPtr->LoadPending) || (RegRecPtr->LoadInProgress == CFE_TBL_NO_LOAD_IN_PROGRESS))
+    {
+        /* Question: Should calling CFE_TBL_Update on a table with no load pending */
+        /* be considered an error?  Currently assuming it is not an error.         */
+        Status = CFE_TBL_INFO_NO_UPDATE_PENDING;
+    }
+    else
+    {
+        if (RegRecPtr->DoubleBuffered)
+        {
+            /* To update a double buffered table only requires a pointer swap */
+            RegRecPtr->ActiveBufferIndex = (uint8)RegRecPtr->LoadInProgress;
+
+            /* Source description in buffer should already have been updated by either */
+            /* the LoadFromFile function or the Load function (when a memory load).    */
+            /* However, we need to copy it into active registry area */
+            strncpy(RegRecPtr->LastFileLoaded, RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].DataSource,
+                    sizeof(RegRecPtr->LastFileLoaded) - 1);
+            RegRecPtr->LastFileLoaded[sizeof(RegRecPtr->LastFileLoaded) - 1] = '\0';
+
+            CFE_TBL_NotifyTblUsersOfUpdate(RegRecPtr);
+
+            /* If the table is a critical table, update the appropriate CDS with the new data */
+            if (RegRecPtr->CriticalTable == true)
+            {
+                CFE_TBL_UpdateCriticalTblCDS(RegRecPtr);
+            }
+        }
+        else
+        {
+            /* Check to see if the Table is locked by anyone */
+            AccessIterator = RegRecPtr->HeadOfAccessList;
+            while (AccessIterator != CFE_TBL_END_OF_LIST)
+            {
+                LockStatus = (LockStatus || CFE_TBL_Global.Handles[AccessIterator].LockFlag);
+
+                AccessIterator = CFE_TBL_Global.Handles[AccessIterator].NextLink;
+            }
+
+            if (LockStatus)
+            {
+                Status = CFE_TBL_INFO_TABLE_LOCKED;
+
+                CFE_ES_WriteToSysLog("CFE_TBL:UpdateInternal-Unable to update locked table Handle=%d\n", TblHandle);
+            }
+            else
+            {
+                /* To update a single buffered table requires a memcpy from working buffer */
+                if (RegRecPtr->Buffers[0].BufferPtr != CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].BufferPtr)
+                {
+                    memcpy(RegRecPtr->Buffers[0].BufferPtr,
+                           CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].BufferPtr, RegRecPtr->Size);
+                }
+
+                /* Save source description with active buffer */
+                strncpy(RegRecPtr->Buffers[0].DataSource,
+                        CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].DataSource,
+                        sizeof(RegRecPtr->Buffers[0].DataSource) - 1);
+                RegRecPtr->Buffers[0].DataSource[sizeof(RegRecPtr->Buffers[0].DataSource) - 1] = 0;
+                strncpy(RegRecPtr->LastFileLoaded, CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].DataSource,
+                        sizeof(RegRecPtr->LastFileLoaded) - 1);
+                RegRecPtr->LastFileLoaded[sizeof(RegRecPtr->LastFileLoaded) - 1] = 0;
+
+                /* Save the file creation time from the loaded file into the Table Registry */
+                RegRecPtr->Buffers[0].FileCreateTimeSecs =
+                    CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].FileCreateTimeSecs;
+                RegRecPtr->Buffers[0].FileCreateTimeSubSecs =
+                    CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].FileCreateTimeSubSecs;
+
+                /* Save the previously computed CRC into the new buffer */
+                RegRecPtr->Buffers[0].Crc = CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].Crc;
+
+                /* Free the working buffer */
+                CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].Taken = false;
+
+                CFE_TBL_NotifyTblUsersOfUpdate(RegRecPtr);
+
+                /* If the table is a critical table, update the appropriate CDS with the new data */
+                if (RegRecPtr->CriticalTable == true)
+                {
+                    CFE_TBL_UpdateCriticalTblCDS(RegRecPtr);
+                }
+            }
+        }
+    }
+
+    return Status;
+} /* End of CFE_TBL_UpdateInternal() */
+
+/*******************************************************************
+**
+** CFE_TBL_NotifyTblUsersOfUpdate
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+
+void CFE_TBL_NotifyTblUsersOfUpdate(CFE_TBL_RegistryRec_t *RegRecPtr)
+{
+    CFE_TBL_Handle_t AccessIterator;
+
+    /* Reset Load in Progress Values */
+    RegRecPtr->LoadInProgress   = CFE_TBL_NO_LOAD_IN_PROGRESS;
+    RegRecPtr->TimeOfLastUpdate = CFE_TIME_GetTime();
+
+    /* Clear notification of pending load (as well as NO LOAD) and notify everyone of update */
+    RegRecPtr->LoadPending     = false;
+    RegRecPtr->TableLoadedOnce = true;
+    AccessIterator             = RegRecPtr->HeadOfAccessList;
+    while (AccessIterator != CFE_TBL_END_OF_LIST)
+    {
+        CFE_TBL_Global.Handles[AccessIterator].Updated = true;
+
+        AccessIterator = CFE_TBL_Global.Handles[AccessIterator].NextLink;
+    }
+} /* End of CFE_TBL_NotifyTblUsersOfUpdate() */
+
+/*******************************************************************
+**
+** CFE_TBL_ReadHeaders
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+
+int32 CFE_TBL_ReadHeaders(osal_id_t FileDescriptor, CFE_FS_Header_t *StdFileHeaderPtr,
+                          CFE_TBL_File_Hdr_t *TblFileHeaderPtr, const char *LoadFilename)
+{
+    int32 Status;
+    int32 EndianCheck = 0x01020304;
+
+#if (CFE_PLATFORM_TBL_VALID_SCID_COUNT > 0)
+    static uint32 ListSC[2] = {CFE_PLATFORM_TBL_VALID_SCID_1, CFE_PLATFORM_TBL_VALID_SCID_2};
+    uint32        IndexSC;
+#endif
+
+#if (CFE_PLATFORM_TBL_VALID_PRID_COUNT > 0)
+    static uint32 ListPR[4] = {CFE_PLATFORM_TBL_VALID_PRID_1, CFE_PLATFORM_TBL_VALID_PRID_2,
+                               CFE_PLATFORM_TBL_VALID_PRID_3, CFE_PLATFORM_TBL_VALID_PRID_4};
+    uint32        IndexPR;
+#endif
+
+    /* Once the file is open, read the headers to determine the target Table */
+    Status = CFE_FS_ReadHeader(StdFileHeaderPtr, FileDescriptor);
+
+    /* Verify successful read of standard cFE File Header */
+    if (Status != sizeof(CFE_FS_Header_t))
+    {
+        CFE_EVS_SendEventWithAppID(CFE_TBL_FILE_STD_HDR_ERR_EID, CFE_EVS_EventType_ERROR, CFE_TBL_Global.TableTaskAppId,
+                                   "Unable to read std header for '%s', Status = 0x%08X", LoadFilename,
+                                   (unsigned int)Status);
+
+        Status = CFE_TBL_ERR_NO_STD_HEADER;
+    }
+    else
+    {
+        /* Verify the file type is a cFE compatible file */
+        if (StdFileHeaderPtr->ContentType != CFE_FS_FILE_CONTENT_ID)
+        {
+            CFE_EVS_SendEventWithAppID(CFE_TBL_FILE_TYPE_ERR_EID, CFE_EVS_EventType_ERROR,
+                                       CFE_TBL_Global.TableTaskAppId,
+                                       "File '%s' is not a cFE file type, ContentType = 0x%08X", LoadFilename,
+                                       (unsigned int)StdFileHeaderPtr->ContentType);
+
+            Status = CFE_TBL_ERR_BAD_CONTENT_ID;
+        }
+        else
+        {
+            /* Verify the SubType to ensure that it is a Table Image File */
+            if (StdFileHeaderPtr->SubType != CFE_FS_SubType_TBL_IMG)
+            {
+                CFE_EVS_SendEventWithAppID(CFE_TBL_FILE_SUBTYPE_ERR_EID, CFE_EVS_EventType_ERROR,
+                                           CFE_TBL_Global.TableTaskAppId,
+                                           "File subtype for '%s' is wrong. Subtype = 0x%08X", LoadFilename,
+                                           (unsigned int)StdFileHeaderPtr->SubType);
+
+                Status = CFE_TBL_ERR_BAD_SUBTYPE_ID;
+            }
+            else
+            {
+                Status = OS_read(FileDescriptor, TblFileHeaderPtr, sizeof(CFE_TBL_File_Hdr_t));
+
+                /* Verify successful read of cFE Table File Header */
+                if (Status != sizeof(CFE_TBL_File_Hdr_t))
+                {
+                    CFE_EVS_SendEventWithAppID(
+                        CFE_TBL_FILE_TBL_HDR_ERR_EID, CFE_EVS_EventType_ERROR, CFE_TBL_Global.TableTaskAppId,
+                        "Unable to read tbl header for '%s', Status = 0x%08X", LoadFilename, (unsigned int)Status);
+
+                    Status = CFE_TBL_ERR_NO_TBL_HEADER;
+                }
+                else
+                {
+                    /* All "required" checks have passed and we are pointing at the data */
+                    Status = CFE_SUCCESS;
+
+                    if ((*(char *)&EndianCheck) == 0x04)
+                    {
+                        /* If this is a little endian processor, then the standard cFE Table Header,   */
+                        /* which is in big endian format, must be swapped so that the data is readable */
+                        CFE_TBL_ByteSwapTblHeader(TblFileHeaderPtr);
+                    }
+
+                    /*
+                     * Ensure termination of all local strings. These were read from a file, so they
+                     * must be treated with appropriate care.  This could happen in case the file got
+                     * damaged in transit or simply was not written properly to begin with.
+                     *
+                     * Since the "TblFileHeaderPtr" is a local buffer, this can be done directly.
+                     */
+                    TblFileHeaderPtr->TableName[sizeof(TblFileHeaderPtr->TableName) - 1] = '\0';
+
+/* Verify Spacecraft ID contained in table file header [optional] */
+#if (CFE_PLATFORM_TBL_VALID_SCID_COUNT > 0)
+                    if (Status == CFE_SUCCESS)
+                    {
+                        Status = CFE_TBL_ERR_BAD_SPACECRAFT_ID;
+                        for (IndexSC = 0; IndexSC < CFE_PLATFORM_TBL_VALID_SCID_COUNT; IndexSC++)
+                        {
+                            if (StdFileHeaderPtr->SpacecraftID == ListSC[IndexSC])
+                            {
+                                Status = CFE_SUCCESS;
+                            }
+                        }
+
+                        if (Status == CFE_TBL_ERR_BAD_SPACECRAFT_ID)
+                        {
+                            CFE_EVS_SendEventWithAppID(CFE_TBL_SPACECRAFT_ID_ERR_EID, CFE_EVS_EventType_ERROR,
+                                                       CFE_TBL_Global.TableTaskAppId,
+                                                       "Unable to verify Spacecraft ID for '%s', ID = 0x%08X",
+                                                       LoadFilename, (unsigned int)StdFileHeaderPtr->SpacecraftID);
+                        }
+                    }
+#endif
+
+/* Verify Processor ID contained in table file header [optional] */
+#if (CFE_PLATFORM_TBL_VALID_PRID_COUNT > 0)
+                    if (Status == CFE_SUCCESS)
+                    {
+                        Status = CFE_TBL_ERR_BAD_PROCESSOR_ID;
+                        for (IndexPR = 0; IndexPR < CFE_PLATFORM_TBL_VALID_PRID_COUNT; IndexPR++)
+                        {
+                            if (StdFileHeaderPtr->ProcessorID == ListPR[IndexPR])
+                            {
+                                Status = CFE_SUCCESS;
+                            }
+                        }
+
+                        if (Status == CFE_TBL_ERR_BAD_PROCESSOR_ID)
+                        {
+                            CFE_EVS_SendEventWithAppID(CFE_TBL_PROCESSOR_ID_ERR_EID, CFE_EVS_EventType_ERROR,
+                                                       CFE_TBL_Global.TableTaskAppId,
+                                                       "Unable to verify Processor ID for '%s', ID = 0x%08X",
+                                                       LoadFilename, (unsigned int)StdFileHeaderPtr->ProcessorID);
+                        }
+                    }
+#endif
+                }
+            }
+        }
+    }
+
+    return Status;
+} /* End of CFE_TBL_ReadHeaders() */
+
+/*******************************************************************
+**
+** CFE_TBL_ByteSwapTblHeader
+**
+** NOTE: For complete prolog information, see above
+********************************************************************/
+
+void CFE_TBL_ByteSwapTblHeader(CFE_TBL_File_Hdr_t *HdrPtr)
+{
+    CFE_TBL_ByteSwapUint32(&HdrPtr->Reserved);
+    CFE_TBL_ByteSwapUint32(&HdrPtr->Offset);
+    CFE_TBL_ByteSwapUint32(&HdrPtr->NumBytes);
+} /* End of CFE_TBL_ByteSwapTblHeader() */
+
+/*******************************************************************
+**
+** CFE_TBL_ByteSwapUint32
+**
+** NOTE: For complete prolog information, see above
+********************************************************************/
+
+void CFE_TBL_ByteSwapUint32(uint32 *Uint32ToSwapPtr)
+{
+    int32 Temp   = *Uint32ToSwapPtr;
+    char *InPtr  = (char *)&Temp;
+    char *OutPtr = (char *)Uint32ToSwapPtr;
+
+    OutPtr[0] = InPtr[3];
+    OutPtr[1] = InPtr[2];
+    OutPtr[2] = InPtr[1];
+    OutPtr[3] = InPtr[0];
+} /* End of CFE_TBL_ByteSwapUint32() */
+
+/*******************************************************************
+**
+** CFE_TBL_CleanUpApp
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+
+int32 CFE_TBL_CleanUpApp(CFE_ES_AppId_t AppId)
+{
+    uint32                      i;
+    CFE_TBL_RegistryRec_t *     RegRecPtr     = NULL;
+    CFE_TBL_AccessDescriptor_t *AccessDescPtr = NULL;
+
+    /* Scan Dump Requests to determine if any of the tables that */
+    /* were to be dumped will be deleted */
+    for (i = 0; i < CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS; i++)
+    {
+        /* Check to see if the table to be dumped is owned by the App to be deleted */
+        if ((CFE_TBL_Global.DumpControlBlocks[i].State != CFE_TBL_DUMP_FREE) &&
+            CFE_RESOURCEID_TEST_EQUAL(CFE_TBL_Global.DumpControlBlocks[i].RegRecPtr->OwnerAppId, AppId))
+        {
+            /* If so, then remove the dump request */
+            CFE_TBL_Global.DumpControlBlocks[i].State = CFE_TBL_DUMP_FREE;
+        }
+    }
+
+    /* Scan Access Descriptors to determine if the Application had access to any tables */
+    for (i = 0; i < CFE_PLATFORM_TBL_MAX_NUM_HANDLES; i++)
+    {
+        /* Check to see if the Handle belongs to the Application being deleted */
+        if (CFE_RESOURCEID_TEST_EQUAL(CFE_TBL_Global.Handles[i].AppId, AppId) &&
+            CFE_TBL_Global.Handles[i].UsedFlag == true)
+        {
+            /* Delete the handle (and the table, if the App owned it) */
+            /* Get a pointer to the relevant Access Descriptor */
+            AccessDescPtr = &CFE_TBL_Global.Handles[i];
+
+            /* Get a pointer to the relevant entry in the registry */
+            RegRecPtr = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
+
+            /* Determine if the Application owned this particular table */
+            if (CFE_RESOURCEID_TEST_EQUAL(RegRecPtr->OwnerAppId, AppId))
+            {
+                /* Mark table as free, although, technically, it isn't free until the */
+                /* linked list of Access Descriptors has no links in it.              */
+                /* NOTE: Allocated memory is freed when all Access Links have been    */
+                /*       removed.  This allows Applications to continue to use the    */
+                /*       data until they acknowledge that the table has been removed. */
+                RegRecPtr->OwnerAppId = CFE_TBL_NOT_OWNED;
+
+                /* Remove Table Name */
+                RegRecPtr->Name[0] = '\0';
+            }
+
+            /* Remove the Access Descriptor Link from linked list */
+            /* NOTE: If this removes the last access link, then   */
+            /*       memory buffers are set free as well.         */
+            CFE_TBL_RemoveAccessLink(i);
+
+            CFE_TBL_Global.Handles[i].AppId = CFE_TBL_NOT_OWNED;
+        }
+    }
+
+    return CFE_SUCCESS;
+} /* End of CFE_TBL_CleanUpApp() */
+
+/*******************************************************************
+**
+** CFE_TBL_FindCriticalTblInfo
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+
+void CFE_TBL_FindCriticalTblInfo(CFE_TBL_CritRegRec_t **CritRegRecPtr, CFE_ES_CDSHandle_t CDSHandleToFind)
+{
+    uint32 i;
+
+    /* Assume the record is never found */
+    *CritRegRecPtr = NULL;
+
+    for (i = 0; i < CFE_PLATFORM_TBL_MAX_CRITICAL_TABLES; i++)
+    {
+        if (CFE_RESOURCEID_TEST_EQUAL(CFE_TBL_Global.CritReg[i].CDSHandle, CDSHandleToFind))
+        {
+            *CritRegRecPtr = &CFE_TBL_Global.CritReg[i];
+            break;
+        }
+    }
+} /* End of CFE_TBL_FindCriticalTblInfo() */
+
+/*******************************************************************
+**
+** CFE_TBL_UpdateCriticalTblCDS
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+
+void CFE_TBL_UpdateCriticalTblCDS(CFE_TBL_RegistryRec_t *RegRecPtr)
+{
+    CFE_TBL_CritRegRec_t *CritRegRecPtr = NULL;
+
+    int32 Status;
+
+    /* Copy an image of the updated table to the CDS for safekeeping */
+    Status = CFE_ES_CopyToCDS(RegRecPtr->CDSHandle, RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].BufferPtr);
+
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("CFE_TBL:UpdateCritTbl-Unable to update Critical Table '%s' in CDS (Err=0x%08X)\n",
+                             RegRecPtr->Name, (unsigned int)Status);
+    }
+    else
+    {
+        /* Locate entry in Critical Table Registry */
+        CFE_TBL_FindCriticalTblInfo(&CritRegRecPtr, RegRecPtr->CDSHandle);
+        if (CritRegRecPtr != NULL)
+        {
+            /* Save information related to the source of the data stored in the table in Critical Table Registry */
+            CritRegRecPtr->FileCreateTimeSecs = RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].FileCreateTimeSecs;
+            CritRegRecPtr->FileCreateTimeSubSecs =
+                RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].FileCreateTimeSubSecs;
+            strncpy(CritRegRecPtr->LastFileLoaded, RegRecPtr->LastFileLoaded,
+                    sizeof(CritRegRecPtr->LastFileLoaded) - 1);
+            CritRegRecPtr->LastFileLoaded[sizeof(CritRegRecPtr->LastFileLoaded) - 1] = '\0';
+            CritRegRecPtr->TimeOfLastUpdate                                          = RegRecPtr->TimeOfLastUpdate;
+            CritRegRecPtr->TableLoadedOnce                                           = RegRecPtr->TableLoadedOnce;
+
+            /* Update copy of Critical Table Registry in the CDS */
+            Status = CFE_ES_CopyToCDS(CFE_TBL_Global.CritRegHandle, CFE_TBL_Global.CritReg);
+
+            if (Status != CFE_SUCCESS)
+            {
+                CFE_ES_WriteToSysLog(
+                    "CFE_TBL:UpdateCritTbl-Unable to update Critical Table Registry in CDS (Err=0x%08X)\n",
+                    (unsigned int)Status);
+            }
+        }
+        else
+        {
+            CFE_ES_WriteToSysLog("CFE_TBL:UpdateCritTbl-Error finding '%s' in Critical Table Registry\n",
+                                 RegRecPtr->Name);
+        }
+    }
+
+    /* Don't bother notifying the caller of the problem since the active table is still legitimate */
+} /* End of CFE_TBL_UpdateCriticalTblCDS() */
+
+/*******************************************************************
+**
+** CFE_TBL_SendNotificationMsg
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
+********************************************************************/
+
+int32 CFE_TBL_SendNotificationMsg(CFE_TBL_RegistryRec_t *RegRecPtr)
+{
+    int32 Status = CFE_SUCCESS;
+
+    /* First, determine if a message should be sent */
+    if (RegRecPtr->NotifyByMsg)
+    {
+        /* Set the message ID */
+        CFE_MSG_SetMsgId(&CFE_TBL_Global.NotifyMsg.CmdHeader.Msg, RegRecPtr->NotificationMsgId);
+
+        /* Set the command code */
+        CFE_MSG_SetFcnCode(&CFE_TBL_Global.NotifyMsg.CmdHeader.Msg, RegRecPtr->NotificationCC);
+
+        /* Set the command parameter */
+        CFE_TBL_Global.NotifyMsg.Payload.Parameter = RegRecPtr->NotificationParam;
+
+        CFE_SB_TimeStampMsg(&CFE_TBL_Global.NotifyMsg.CmdHeader.Msg);
+        Status = CFE_SB_TransmitMsg(&CFE_TBL_Global.NotifyMsg.CmdHeader.Msg, false);
+
+        if (Status != CFE_SUCCESS)
+        {
+            CFE_EVS_SendEvent(CFE_TBL_FAIL_NOTIFY_SEND_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Manage Notification Pkt Error(Status=0x%08X)", (unsigned int)Status);
+        }
+    }
+
+    return Status;
+} /* End of CFE_TBL_SendNotificationMsg() */
+
+/************************/
+/*  End of File Comment */
+/************************/

--- a/modules/tbl/fsw/src/cfe_tbl_internal.h
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.h
@@ -1,0 +1,574 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * @file
+ *
+ * Purpose:  cFE Table Services (TBL) utility function interface file
+ *
+ * Author:   D. Kobe/the Hammers Company, Inc.
+ *
+ * Notes:
+ *
+ */
+
+#ifndef CFE_TBL_INTERNAL_H
+#define CFE_TBL_INTERNAL_H
+
+/*
+** Required header files...
+*/
+#include "cfe.h"
+#include "cfe_platform_cfg.h"
+#include "cfe_msgids.h"
+#include "cfe_perfids.h"
+#include "cfe_tbl_task.h"
+#include "cfe_tbl_task_cmds.h"
+#include "cfe_tbl_events.h"
+#include "cfe_tbl_msg.h"
+
+/*********************  Macro and Constant Type Definitions   ***************************/
+
+#define CFE_TBL_NOT_OWNED   CFE_ES_APPID_UNDEFINED
+#define CFE_TBL_NOT_FOUND   (-1)
+#define CFE_TBL_END_OF_LIST (CFE_TBL_Handle_t)0xFFFF
+
+/*****************************  Function Prototypes   **********************************/
+
+/*****************************************************************************/
+/**
+** \brief Validates specified handle to ensure legality
+**
+** \par Description
+**        Validates handle given by calling App to Table API. Validation
+**        includes ensuring the value is within an acceptable range and
+**        the Access Descriptor that it identifies is being "used".
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in]  TblHandle  - Handle to be validated
+**
+** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
+** \retval #CFE_TBL_ERR_INVALID_HANDLE      \copydoc CFE_TBL_ERR_INVALID_HANDLE
+**
+******************************************************************************/
+int32 CFE_TBL_ValidateHandle(CFE_TBL_Handle_t TblHandle);
+
+/*****************************************************************************/
+/**
+** \brief Determines whether handle is associated with calling Application
+**
+** \par Description
+**        Validates whether the calling application has the right to
+**        access the table identified with the given TblHandle.  Validation
+**        consists of verifying the calling Application's AppID, verifying
+**        the legitimacy of the given TblHandle, and checking to make sure
+**        the Access Descriptor identified by the TblHandle is associated
+**        with the calling Application.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in]  TblHandle Handle of table whose access is desired.
+**
+** \param[in, out]  AppIdPtr  Pointer to value that will hold AppID on return. *AppIdPtr is the AppID as obtained from
+*#CFE_ES_GetAppID
+**
+** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
+** \retval #CFE_TBL_ERR_BAD_APP_ID          \copydoc CFE_TBL_ERR_BAD_APP_ID
+** \retval #CFE_TBL_ERR_INVALID_HANDLE      \copydoc CFE_TBL_ERR_INVALID_HANDLE
+** \retval #CFE_TBL_ERR_NO_ACCESS           \copydoc CFE_TBL_ERR_NO_ACCESS
+**
+******************************************************************************/
+int32 CFE_TBL_ValidateAccess(CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t *AppIdPtr);
+
+/*****************************************************************************/
+/**
+** \brief Determines if calling application has the right to access specified table
+**
+** \par Description
+**        Validates whether the calling application has the right to
+**        access the table identified with the given TblHandle.  Validation
+**        consists of checking to make sure the Access Descriptor identified
+**        by the TblHandle is associated with the calling Application.
+**
+** \par Assumptions, External Events, and Notes:
+**        Note: The TblHandle and ThisAppId parameters are assumed to be valid.
+**
+** \param[in]  TblHandle Handle of table whose access is desired.
+**
+** \param[in]  ThisAppId Application ID of Application making the call
+**
+** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
+** \retval #CFE_TBL_ERR_NO_ACCESS           \copydoc CFE_TBL_ERR_NO_ACCESS
+**
+******************************************************************************/
+int32 CFE_TBL_CheckAccessRights(CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t ThisAppId);
+
+/*****************************************************************************/
+/**
+** \brief Removes Access Descriptor from Table's linked list of Access Descriptors
+**
+** \par Description
+**        Removes the given Access Descriptor from the Linked List
+**        of Access Descriptors associated with the table specified
+**        in the Access Descriptor itself.
+**
+** \par Assumptions, External Events, and Notes:
+**        -# This function CAN block and should not be called by ISRs.
+**        -# This function assumes the Access Descriptor is completely
+**           filled out and the TblHandle has been validated.
+**
+** \param[in]  TblHandle Handle of Access Descriptor to be removed.
+**
+** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
+**
+******************************************************************************/
+int32 CFE_TBL_RemoveAccessLink(CFE_TBL_Handle_t TblHandle);
+
+/*****************************************************************************/
+/**
+** \brief Obtains the data address for the specified table
+**
+** \par Description
+**        Validates the given TblHandle, finds the location of the
+**        Table data and returns the address to the data to the caller.
+**
+** \par Assumptions, External Events, and Notes:
+**        -# It is possible that an Application that was sharing a table
+**           would discover, upon making this call, that the table has
+**           been unregistered by another Application.  In this situation,
+**           this function would return #CFE_TBL_ERR_UNREGISTERED.
+**        -# ThisAppId parameter is assumed to be validated.
+**
+** \param[in, out]  TblPtr    Pointer to pointer that will hold address of data upon return. *TblPtr is the address of
+**                            the Table Data.
+** \param[in]  TblHandle Handle of Table whose address is needed.
+** \param[in]  ThisAppId AppID of application making the address request.
+**
+** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
+** \retval #CFE_TBL_ERR_INVALID_HANDLE      \copydoc CFE_TBL_ERR_INVALID_HANDLE
+** \retval #CFE_TBL_ERR_NO_ACCESS           \copydoc CFE_TBL_ERR_NO_ACCESS
+** \retval #CFE_TBL_ERR_UNREGISTERED        \copydoc CFE_TBL_ERR_UNREGISTERED
+**
+******************************************************************************/
+int32 CFE_TBL_GetAddressInternal(void **TblPtr, CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t ThisAppId);
+
+/*****************************************************************************/
+/**
+** \brief Returns any pending non-error status code for the specified table.
+**
+** \par Description
+**        Returns any pending non-error status code for the specified table.
+**
+** \par Assumptions, External Events, and Notes:
+**        Note: This function assumes the TblHandle has been validated.
+**
+** \param[in]  TblHandle Handle of Table whose pending notifications are
+**                       to be returned.
+**
+** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
+** \retval #CFE_TBL_INFO_UPDATE_PENDING     \copydoc CFE_TBL_INFO_UPDATE_PENDING
+** \retval #CFE_TBL_INFO_UPDATED            \copydoc CFE_TBL_INFO_UPDATED
+**
+******************************************************************************/
+int32 CFE_TBL_GetNextNotification(CFE_TBL_Handle_t TblHandle);
+
+/*****************************************************************************/
+/**
+** \brief Returns the Registry Index for the specified Table Name
+**
+** \par Description
+**        Locates given Table Name in the Table Registry and
+**        returns the appropriate Registry Index.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in]  TblName - Pointer to character string containing complete
+**                       Table Name (of the format "AppName.TblName").
+**
+** \retval #CFE_TBL_NOT_FOUND or the Index into Registry for Table with specified name
+**
+******************************************************************************/
+int16 CFE_TBL_FindTableInRegistry(const char *TblName);
+
+/*****************************************************************************/
+/**
+** \brief Locates a free slot in the Table Registry.
+**
+** \par Description
+**        Locates a free slot in the Table Registry.
+**
+** \par Assumptions, External Events, and Notes:
+**        Note: This function assumes the registry has been locked.
+**
+** \retval #CFE_TBL_NOT_FOUND or Index into Table Registry of unused entry
+******************************************************************************/
+int16 CFE_TBL_FindFreeRegistryEntry(void);
+
+/*****************************************************************************/
+/**
+** \brief Locates a free Access Descriptor in the Table Handles Array.
+**
+** \par Description
+**        Locates a free Access Descriptor in the Table Handles Array.
+**
+** \par Assumptions, External Events, and Notes:
+**        Note: This function assumes the registry has been locked.
+**
+** \retval #CFE_TBL_END_OF_LIST or Table Handle of unused Access Descriptor
+******************************************************************************/
+CFE_TBL_Handle_t CFE_TBL_FindFreeHandle(void);
+
+/*****************************************************************************/
+/**
+** \brief Creates a Full Table name from application name and table name
+**
+** \par Description
+**        Takes a given Table Name and combines it with the calling
+**        Application's name to make a processor specific name of the
+**        form: "AppName.TblName"
+**
+** \par Assumptions, External Events, and Notes:
+**        Note: AppName portion will be truncated to OS_MAX_API_NAME.
+**
+** \param[in, out]  FullTblName pointer to character buffer of #CFE_TBL_MAX_FULL_NAME_LEN size that will be filled with
+**                  the processor specific Table Name. *FullTblName is the processor specific Table Name of the form
+**                  "AppName.TblName".
+**
+** \param[in]  TblName pointer to character string containing the Application's local name for
+**                     the Table.
+**
+** \param[in]  ThisAppId the Application ID of the Application making the call.
+**
+******************************************************************************/
+void CFE_TBL_FormTableName(char *FullTblName, const char *TblName, CFE_ES_AppId_t ThisAppId);
+
+/*****************************************************************************/
+/**
+** \brief Locks access to the Table Registry
+**
+** \par Description
+**        Locks the Table Registry to prevent multiple tasks/threads
+**        from modifying it at once.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
+******************************************************************************/
+int32 CFE_TBL_LockRegistry(void);
+
+/*****************************************************************************/
+/**
+** \brief Unlocks access to the Table Registry
+**
+** \par Description
+**        Unlocks Table Registry to allow other tasks/threads to
+**        modify the Table Registry contents.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
+**
+******************************************************************************/
+int32 CFE_TBL_UnlockRegistry(void);
+
+/*****************************************************************************/
+/**
+** \brief Finds the address of a buffer compatible with the specified table
+**
+** \par Description
+**        Checks to see if the specified table has a dedicated working
+**        buffer (i.e. - is a double buffered table) or requires one
+**        from the common table buffer pool.  If it requires one from
+**        the pool, it locates, locks and returns its address.  If the
+**        table is double buffered, the access list is scanned to ensure
+**        that nobody is currently using the inactive buffer.
+**
+** \par Assumptions, External Events, and Notes:
+**        -# This function assumes the TblHandle and MinBufferSize values
+**           are legitimate.
+**
+** \param[in, out]  WorkingBufferPtr  Pointer to variable that will contain the
+**                                    address of the first byte of the working buffer. *WorkingBufferPtr is the address
+**                                    of the first byte of the working buffer
+**
+** \param[in]  RegRecPtr         Pointer to Table Registry Entry for Table for whom
+**                               a working buffer is to be obtained
+**
+** \param[in]  CalledByApp       Boolean that identifies whether this internal API
+**                               function is being called by a user Application (true)
+**                               or by the Table Services Application (false)
+**
+** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
+** \retval #CFE_TBL_ERR_NO_BUFFER_AVAIL     \copydoc CFE_TBL_ERR_NO_BUFFER_AVAIL
+**
+******************************************************************************/
+int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr, CFE_TBL_RegistryRec_t *RegRecPtr,
+                               bool CalledByApp);
+
+/*****************************************************************************/
+/**
+** \brief Loads a table buffer with data from a specified file
+**
+** \par Description
+**        Locates the specified filename in the onboard filesystem
+**        and loads its contents into the specified working buffer.
+**
+** \par Assumptions, External Events, and Notes:
+**        -# This function assumes parameters have been verified.
+**
+** \param[in]  AppName          The name of the application loading the table.
+**
+** \param[in]  WorkingBufferPtr Pointer to a working buffer that is to be loaded
+**                              with the contents of the specified file
+**
+** \param[in]  RegRecPtr        Pointer to Table Registry record for table whose
+**                              buffer is to filled with data from the specified file
+**
+** \param[in]  Filename         Pointer to ASCII string containing full path and filename
+**                              of table image file to be loaded
+**
+** \retval #CFE_SUCCESS                      \copydoc CFE_SUCCESS
+** \retval #OS_INVALID_POINTER               \copydoc OS_INVALID_POINTER
+** \retval #OS_FS_ERR_PATH_TOO_LONG          \copydoc OS_FS_ERR_PATH_TOO_LONG
+** \retval #OS_FS_ERR_PATH_INVALID           \copydoc OS_FS_ERR_PATH_INVALID
+** \retval #OS_FS_ERR_NAME_TOO_LONG          \copydoc OS_FS_ERR_NAME_TOO_LONG
+** \retval #OS_ERR_NO_FREE_IDS               \copydoc OS_ERR_NO_FREE_IDS
+** \retval #OS_ERROR                         \copydoc OS_ERROR
+** \retval #CFE_TBL_ERR_FILE_TOO_LARGE       \copydoc CFE_TBL_ERR_FILE_TOO_LARGE
+** \retval #CFE_TBL_WARN_SHORT_FILE          \copydoc CFE_TBL_WARN_SHORT_FILE
+** \retval #CFE_TBL_WARN_PARTIAL_LOAD        \copydoc CFE_TBL_WARN_PARTIAL_LOAD
+** \retval #CFE_TBL_ERR_FILENAME_TOO_LONG    \copydoc CFE_TBL_ERR_FILENAME_TOO_LONG
+** \retval #CFE_TBL_ERR_FILE_FOR_WRONG_TABLE \copydoc CFE_TBL_ERR_FILE_FOR_WRONG_TABLE
+** \retval #CFE_TBL_ERR_NO_STD_HEADER        \copydoc CFE_TBL_ERR_NO_STD_HEADER
+** \retval #CFE_TBL_ERR_NO_TBL_HEADER        \copydoc CFE_TBL_ERR_NO_TBL_HEADER
+** \retval #CFE_TBL_ERR_BAD_CONTENT_ID       \copydoc CFE_TBL_ERR_BAD_CONTENT_ID
+** \retval #CFE_TBL_ERR_BAD_SUBTYPE_ID       \copydoc CFE_TBL_ERR_BAD_SUBTYPE_ID
+**
+******************************************************************************/
+int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBufferPtr, CFE_TBL_RegistryRec_t *RegRecPtr,
+                           const char *Filename);
+
+/*****************************************************************************/
+/**
+** \brief Updates the active table buffer with contents of inactive buffer
+**
+** \par Description
+**        Copies pertinent data from working buffer (inactive buffer)
+**        to the active buffer (for single buffered tables) or just
+**        changes index to identifying the active buffer (for double
+**        buffered tables).
+**
+** \par Assumptions, External Events, and Notes:
+**        -# All parameters are assumed to be verified before function
+**           is called.
+**
+** \param[in]  TblHandle      Handle of Table to be updated.
+**
+** \param[in]  RegRecPtr      Pointer to Table Registry Entry for table to be updated
+**
+** \param[in]  AccessDescPtr  Pointer to appropriate access descriptor for table-application interface
+**
+** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
+******************************************************************************/
+int32 CFE_TBL_UpdateInternal(CFE_TBL_Handle_t TblHandle, CFE_TBL_RegistryRec_t *RegRecPtr,
+                             CFE_TBL_AccessDescriptor_t *AccessDescPtr);
+
+/*****************************************************************************/
+/**
+** \brief Sets flags in access descriptors associated with specified table
+**
+** \par Description
+**        Sets the flag in each access descriptor for a table to indicate the
+**        contents of the table have been updated.
+**
+** \par Assumptions, External Events, and Notes:
+**        -# All parameters are assumed to be verified before function
+**           is called.
+**
+** \param[in]  RegRecPtr      Pointer to Table Registry Entry for table to be updated
+******************************************************************************/
+void CFE_TBL_NotifyTblUsersOfUpdate(CFE_TBL_RegistryRec_t *RegRecPtr);
+
+/*****************************************************************************/
+/**
+** \brief Reads Table File Headers
+**
+** \par Description
+**        Reads Table File Headers and performs rudimentary checks
+**        on header contents to ensure the acceptability of the
+**        file format.
+**
+** \par Assumptions, External Events, and Notes:
+**        -# FileDescriptor is assumed to be valid
+**
+** \param[in]  FileDescriptor    File Descriptor, as provided by OS_fopen
+**
+** \param[in, out]  StdFileHeaderPtr  Pointer to buffer to be filled with the contents
+**                                    of the file's standard cFE Header. *StdFileHeaderPtr is the contents of the
+**                                    standard cFE File Header
+**
+** \param[in, out]  TblFileHeaderPtr  Pointer to buffer to be filled with the contents
+**                                    of the file's standard cFE Table Header. *TblFileHeaderPtr is the contents of the
+**                                    standard cFE Table File Header
+**
+** \param[in]  LoadFilename      Pointer to character string containing full path
+**                               and filename of table image to be loaded
+**
+** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
+** \retval #CFE_TBL_ERR_NO_STD_HEADER       \copydoc CFE_TBL_ERR_NO_STD_HEADER
+** \retval #CFE_TBL_ERR_NO_TBL_HEADER       \copydoc CFE_TBL_ERR_NO_TBL_HEADER
+** \retval #CFE_TBL_ERR_BAD_CONTENT_ID      \copydoc CFE_TBL_ERR_BAD_CONTENT_ID
+** \retval #CFE_TBL_ERR_BAD_SUBTYPE_ID      \copydoc CFE_TBL_ERR_BAD_SUBTYPE_ID
+** \retval #CFE_TBL_ERR_BAD_SPACECRAFT_ID   \copydoc CFE_TBL_ERR_BAD_SPACECRAFT_ID
+** \retval #CFE_TBL_ERR_BAD_PROCESSOR_ID    \copydoc CFE_TBL_ERR_BAD_PROCESSOR_ID
+**
+******************************************************************************/
+int32 CFE_TBL_ReadHeaders(osal_id_t FileDescriptor, CFE_FS_Header_t *StdFileHeaderPtr,
+                          CFE_TBL_File_Hdr_t *TblFileHeaderPtr, const char *LoadFilename);
+
+/*****************************************************************************/
+/**
+** \brief Initializes the entries of a single Table Registry Record
+**
+** \par Description
+**        Initializes the contents of a single Table Registry Record to default values
+**
+** \par Assumptions, External Events, and Notes:
+**        -# This function is intended to be called before populating a table registry record
+**
+******************************************************************************/
+void CFE_TBL_InitRegistryRecord(CFE_TBL_RegistryRec_t *RegRecPtr);
+
+/*****************************************************************************/
+/**
+** \brief Byte swaps a CFE_TBL_File_Hdr_t structure
+**
+** \par Description
+**        Converts a big-endian version of a CFE_TBL_File_Hdr_t structure to
+**        a little-endian version and vice-versa.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in, out]  HdrPtr   Pointer to table header that needs to be swapped. *HdrPtr provides the swapped header
+**
+******************************************************************************/
+void CFE_TBL_ByteSwapTblHeader(CFE_TBL_File_Hdr_t *HdrPtr);
+
+/*****************************************************************************/
+/**
+** \brief Searches the Critical Table Registry for the given handle
+**
+** \par Description
+**        This function scans the Critical Table Registry to find the specified
+**        handle.  Once located, the function returns a pointer to the appropriate
+**        Critical Table Registry Record that contains information on where the
+**        contents of the Table came from and when.  If a matching record is not
+**        found, the pointer returned is NULL.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \param[in, out] **CritRegRecPtr    Pointer to a pointer that should be initialized with
+**                               the start address of the located Critical Table Registry
+**                               Record. *CritRegRecPtr is the pointer to the start address of the located Critical
+**                               Table Registry Record.  \c NULL if the record is not
+**                               found.
+**
+** \param[in]  CDSHandleToFind   CDS Handle to be located in Critical Table Registry.
+**
+******************************************************************************/
+void CFE_TBL_FindCriticalTblInfo(CFE_TBL_CritRegRec_t **CritRegRecPtr, CFE_ES_CDSHandle_t CDSHandleToFind);
+
+/*****************************************************************************/
+/**
+** \brief Updates a CDS associated with a Critical Table
+**
+** \par Description
+**        Copies the contents of the active buffer into a previously allocated
+**        CDS associated with the table.  The Critical Table Registry is also
+**        updated and copied into the CDS to keep relevant information on the
+**        source of the data contained in the table.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in]  RegRecPtr Pointer to Registry Record of Critical Table whose CDS
+**                       needs to be updated.
+**
+******************************************************************************/
+void CFE_TBL_UpdateCriticalTblCDS(CFE_TBL_RegistryRec_t *RegRecPtr);
+
+/*****************************************************************************/
+/**
+** \brief When enabled, will send a manage notification command message
+**
+** \par Description
+**        Whenever an application uses the #CFE_TBL_NotifyByMessage API, Table services
+**        will call this routine whenever a table requires management by the owning
+**        Application.  This routine will then issue the appropriate message to the
+**        software bus.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in]  RegRecPtr Pointer to Registry Record of Table whose owner needs notifying.
+**
+******************************************************************************/
+int32 CFE_TBL_SendNotificationMsg(CFE_TBL_RegistryRec_t *RegRecPtr);
+
+/*****************************************************************************/
+/**
+** \brief Performs a byte swap on a uint32 integer
+**
+** \par Description
+**        Converts a big-endian uint32 integer to a little-endian uint32 integer
+**        and vice-versa.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in, out]  Uint32ToSwapPtr Pointer to uint32 value to be swapped. *Uint32ToSwapPtr is the swapped uint32 value
+**
+******************************************************************************/
+extern void CFE_TBL_ByteSwapUint32(uint32 *Uint32ToSwapPtr);
+
+/*
+ * Internal helper functions for Table Registry dump
+ *
+ * These callbacks are used with the FS background write request API
+ * and are implemented per that specification.
+ */
+void CFE_TBL_DumpRegistryEventHandler(void *Meta, CFE_FS_FileWriteEvent_t Event, int32 Status, uint32 RecordNum,
+                                      size_t BlockSize, size_t Position);
+bool CFE_TBL_DumpRegistryGetter(void *Meta, uint32 RecordNum, void **Buffer, size_t *BufSize);
+
+/*
+** Globals specific to the TBL module
+*/
+extern CFE_TBL_Global_t CFE_TBL_Global;
+
+#endif /* CFE_TBL_INTERNAL_H */

--- a/modules/tbl/fsw/src/cfe_tbl_module_all.h
+++ b/modules/tbl/fsw/src/cfe_tbl_module_all.h
@@ -1,0 +1,55 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * @file
+ *
+ * Encapsulates all TBL module internal header files, as well
+ * as the public API from all other CFE core modules, OSAL, and PSP.
+ *
+ * This simplifies the set of include files that need to be put at the
+ * start of every source file.
+ */
+
+#ifndef CFE_TBL_MODULE_ALL_H
+#define CFE_TBL_MODULE_ALL_H
+
+/*
+** Includes
+*/
+#include "cfe.h"
+#include "cfe_platform_cfg.h"
+#include "cfe_msgids.h"
+#include "cfe_perfids.h"
+
+#include "cfe_tbl_core_internal.h"
+
+#include "cfe_tbl_events.h"
+#include "cfe_tbl_msg.h"
+#include "cfe_tbl_internal.h"
+#include "cfe_tbl_task.h"
+#include "cfe_tbl_task_cmds.h"
+
+/*
+ * Additionally TBL needs to use special/extra CDS APIs that are not in the normal API
+ */
+#include "cfe_es_core_internal.h"
+
+#endif /* CFE_TBL_MODULE_ALL_H */

--- a/modules/tbl/fsw/src/cfe_tbl_task.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task.c
@@ -1,0 +1,368 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/*
+** File: cfe_tbl_task.c
+**
+** Subsystem: cFE TBL Task
+**
+** Author: David Kobe (the Hammers Company, Inc.)
+**
+** Notes:
+**
+*/
+
+/*
+** Required header files
+*/
+#include "cfe_tbl_module_all.h"
+#include "cfe_version.h"
+
+#include <string.h>
+
+/*
+** Table task global data
+*/
+CFE_TBL_Global_t CFE_TBL_Global;
+
+/*
+ * Macros to assist in building the CFE_TBL_CmdHandlerTbl -
+ *  For generic message entries, which only have a MID and a handler function (no command payload)
+ */
+#define CFE_TBL_MESSAGE_ENTRY(mid, handlerfunc)                                                                  \
+    {                                                                                                            \
+        CFE_SB_MSGID_WRAP_VALUE(mid), 0, sizeof(CFE_MSG_CommandHeader_t), (CFE_TBL_MsgProcFuncPtr_t)handlerfunc, \
+            CFE_TBL_MSG_MSGTYPE                                                                                  \
+    }
+
+/*
+ * Macros to assist in building the CFE_TBL_CmdHandlerTbl -
+ *  For command handler entries, which have a command code, payload type, and a handler function
+ */
+#define CFE_TBL_COMMAND_ENTRY(ccode, paramtype, handlerfunc)                                                       \
+    {                                                                                                              \
+        CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_CMD_MID), ccode, sizeof(paramtype), (CFE_TBL_MsgProcFuncPtr_t)handlerfunc, \
+            CFE_TBL_CMD_MSGTYPE                                                                                    \
+    }
+
+/* Constant Data */
+
+const CFE_TBL_CmdHandlerTblRec_t CFE_TBL_CmdHandlerTbl[] = {
+    /* message entries (SEND_HK) */
+    CFE_TBL_MESSAGE_ENTRY(CFE_TBL_SEND_HK_MID, CFE_TBL_HousekeepingCmd),
+
+    /* command entries (everything else) */
+    CFE_TBL_COMMAND_ENTRY(CFE_TBL_NOOP_CC, CFE_TBL_NoopCmd_t, CFE_TBL_NoopCmd),
+    CFE_TBL_COMMAND_ENTRY(CFE_TBL_RESET_COUNTERS_CC, CFE_TBL_ResetCountersCmd_t, CFE_TBL_ResetCountersCmd),
+    CFE_TBL_COMMAND_ENTRY(CFE_TBL_LOAD_CC, CFE_TBL_LoadCmd_t, CFE_TBL_LoadCmd),
+    CFE_TBL_COMMAND_ENTRY(CFE_TBL_DUMP_CC, CFE_TBL_DumpCmd_t, CFE_TBL_DumpCmd),
+    CFE_TBL_COMMAND_ENTRY(CFE_TBL_VALIDATE_CC, CFE_TBL_ValidateCmd_t, CFE_TBL_ValidateCmd),
+    CFE_TBL_COMMAND_ENTRY(CFE_TBL_ACTIVATE_CC, CFE_TBL_ActivateCmd_t, CFE_TBL_ActivateCmd),
+    CFE_TBL_COMMAND_ENTRY(CFE_TBL_DUMP_REGISTRY_CC, CFE_TBL_DumpRegistryCmd_t, CFE_TBL_DumpRegistryCmd),
+    CFE_TBL_COMMAND_ENTRY(CFE_TBL_SEND_REGISTRY_CC, CFE_TBL_SendRegistryCmd_t, CFE_TBL_SendRegistryCmd),
+    CFE_TBL_COMMAND_ENTRY(CFE_TBL_DELETE_CDS_CC, CFE_TBL_DeleteCDSCmd_t, CFE_TBL_DeleteCDSCmd),
+    CFE_TBL_COMMAND_ENTRY(CFE_TBL_ABORT_LOAD_CC, CFE_TBL_AbortLoadCmd_t, CFE_TBL_AbortLoadCmd),
+
+    /* list terminator (keep last) */
+    {CFE_SB_MSGID_RESERVED, 0, 0, NULL, CFE_TBL_TERM_MSGTYPE}};
+
+/******************************************************************************/
+
+void CFE_TBL_TaskMain(void)
+{
+    int32            Status;
+    CFE_SB_Buffer_t *SBBufPtr;
+
+    CFE_ES_PerfLogEntry(CFE_MISSION_TBL_MAIN_PERF_ID);
+
+    Status = CFE_TBL_TaskInit();
+
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("TBL:Application Init Failed,RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_PerfLogExit(CFE_MISSION_TBL_MAIN_PERF_ID);
+        /* Note: CFE_ES_ExitApp will not return */
+        CFE_ES_ExitApp(CFE_ES_RunStatus_CORE_APP_INIT_ERROR);
+    } /* end if */
+
+    /*
+     * Wait for other apps to start.
+     * It is important that the core apps are present before this starts receiving
+     * messages from the command pipe, as some of those handlers might depend on
+     * the other core apps.
+     */
+    CFE_ES_WaitForSystemState(CFE_ES_SystemState_CORE_READY, CFE_PLATFORM_CORE_MAX_STARTUP_MSEC);
+
+    /* Main loop */
+    while (Status == CFE_SUCCESS)
+    {
+        /* Increment the Main task Execution Counter */
+        CFE_ES_IncrementTaskCounter();
+
+        CFE_ES_PerfLogExit(CFE_MISSION_TBL_MAIN_PERF_ID);
+
+        /* Pend on receipt of packet */
+        Status = CFE_SB_ReceiveBuffer(&SBBufPtr, CFE_TBL_Global.CmdPipe, CFE_SB_PEND_FOREVER);
+
+        CFE_ES_PerfLogEntry(CFE_MISSION_TBL_MAIN_PERF_ID);
+
+        if (Status == CFE_SUCCESS)
+        {
+            /* Process cmd pipe msg */
+            CFE_TBL_TaskPipe(SBBufPtr);
+        }
+        else
+        {
+            CFE_ES_WriteToSysLog("TBL:Error reading cmd pipe,RC=0x%08X\n", (unsigned int)Status);
+        } /* end if */
+
+    } /* end while */
+
+    /* while loop exits only if CFE_SB_ReceiveBuffer returns error */
+    CFE_ES_ExitApp(CFE_ES_RunStatus_CORE_APP_RUNTIME_ERROR);
+
+} /* end CFE_TBL_TaskMain() */
+
+/******************************************************************************/
+
+int32 CFE_TBL_TaskInit(void)
+{
+    int32 Status;
+
+    /*
+    ** Initialize global Table Services data
+    */
+    CFE_TBL_InitData();
+
+    /*
+    ** Register event filter table
+    */
+    Status = CFE_EVS_Register(NULL, 0, 0);
+
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("TBL:Call to CFE_EVS_Register Failed:RC=0x%08X\n", (unsigned int)Status);
+        return Status;
+    } /* end if */
+
+    /*
+    ** Create Software Bus message pipe
+    */
+    Status = CFE_SB_CreatePipe(&CFE_TBL_Global.CmdPipe, CFE_TBL_TASK_PIPE_DEPTH, CFE_TBL_TASK_PIPE_NAME);
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("TBL:Error creating cmd pipe:RC=0x%08X\n", (unsigned int)Status);
+        return Status;
+    } /* end if */
+
+    /*
+    ** Subscribe to Housekeeping request commands
+    */
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TBL_SEND_HK_MID), CFE_TBL_Global.CmdPipe);
+
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("TBL:Error subscribing to HK Request:RC=0x%08X\n", (unsigned int)Status);
+        return Status;
+    } /* end if */
+
+    /*
+    ** Subscribe to Table task ground command packets
+    */
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TBL_CMD_MID), CFE_TBL_Global.CmdPipe);
+
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("TBL:Error subscribing to gnd cmds:RC=0x%08X\n", (unsigned int)Status);
+        return Status;
+    } /* end if */
+
+    /*
+    ** Task startup event message
+    */
+    Status = CFE_EVS_SendEvent(CFE_TBL_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "cFE TBL Initialized.%s",
+                               CFE_VERSION_STRING);
+
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("TBL:Error sending init event:RC=0x%08X\n", (unsigned int)Status);
+        return Status;
+    } /* end if */
+
+    return CFE_SUCCESS;
+
+} /* End of CFE_TBL_TaskInit() */
+
+/******************************************************************************/
+
+void CFE_TBL_InitData(void)
+{
+
+    /* Get the assigned Application ID for the Table Services Task */
+    CFE_ES_GetAppID(&CFE_TBL_Global.TableTaskAppId);
+
+    /* Initialize Packet Headers */
+    CFE_MSG_Init(&CFE_TBL_Global.HkPacket.TlmHeader.Msg, CFE_SB_ValueToMsgId(CFE_TBL_HK_TLM_MID),
+                 sizeof(CFE_TBL_Global.HkPacket));
+
+    CFE_MSG_Init(&CFE_TBL_Global.TblRegPacket.TlmHeader.Msg, CFE_SB_ValueToMsgId(CFE_TBL_REG_TLM_MID),
+                 sizeof(CFE_TBL_Global.TblRegPacket));
+
+    /* Message ID is set when sent, so OK as 0 here */
+    CFE_MSG_Init(&CFE_TBL_Global.NotifyMsg.CmdHeader.Msg, CFE_SB_ValueToMsgId(0), sizeof(CFE_TBL_Global.NotifyMsg));
+
+} /* End of CFE_TBL_InitData() */
+
+/******************************************************************************/
+
+void CFE_TBL_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
+{
+    CFE_SB_MsgId_t       MessageID   = CFE_SB_INVALID_MSG_ID;
+    CFE_MSG_FcnCode_t    CommandCode = 0;
+    int16                CmdIndx;
+    CFE_MSG_Size_t       ActualLength = 0;
+    CFE_TBL_CmdProcRet_t CmdStatus    = CFE_TBL_INC_ERR_CTR; /* Assume a failed command */
+
+    CFE_MSG_GetMsgId(&SBBufPtr->Msg, &MessageID);
+    CFE_MSG_GetFcnCode(&SBBufPtr->Msg, &CommandCode);
+
+    /* Search the Command Handler Table for a matching message */
+    CmdIndx = CFE_TBL_SearchCmdHndlrTbl(MessageID, CommandCode);
+
+    /* Check to see if a matching command was found */
+    if (CmdIndx >= 0)
+    {
+        /* Verify Message Length before processing */
+        CFE_MSG_GetSize(&SBBufPtr->Msg, &ActualLength);
+        if (ActualLength == CFE_TBL_CmdHandlerTbl[CmdIndx].ExpectedLength)
+        {
+            /* All checks have passed, call the appropriate message handler */
+            CmdStatus = (CFE_TBL_CmdHandlerTbl[CmdIndx].MsgProcFuncPtr)(SBBufPtr);
+        }
+        else /* Bad Message Length */
+        {
+            CFE_EVS_SendEvent(CFE_TBL_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Invalid msg length -- ID = 0x%X, CC = %u, Len = %u, Expected = %u",
+                              (unsigned int)CFE_SB_MsgIdToValue(MessageID), (unsigned int)CommandCode,
+                              (unsigned int)ActualLength, (unsigned int)CFE_TBL_CmdHandlerTbl[CmdIndx].ExpectedLength);
+        }
+
+        /* Only update command counters when message has a command code */
+        if (CFE_TBL_CmdHandlerTbl[CmdIndx].MsgTypes == CFE_TBL_CMD_MSGTYPE)
+        {
+            if (CmdStatus == CFE_TBL_INC_CMD_CTR)
+            {
+                CFE_TBL_Global.CommandCounter++;
+            }
+            else if (CmdStatus == CFE_TBL_INC_ERR_CTR)
+            {
+                CFE_TBL_Global.CommandErrorCounter++;
+            }
+        }
+    }
+    else
+    {
+        /* Determine whether event message should be */
+        /* "Bad Command Code" or "Bad Message ID"    */
+        if (CmdIndx == CFE_TBL_BAD_CMD_CODE)
+        {
+            CFE_EVS_SendEvent(CFE_TBL_CC1_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Invalid command code -- ID = 0x%X, CC = %u",
+                              (unsigned int)CFE_SB_MsgIdToValue(MessageID), (unsigned int)CommandCode);
+
+            /* Update the command error counter */
+            CFE_TBL_Global.CommandErrorCounter++;
+        }
+        else /* CmdIndx == CFE_TBL_BAD_MSG_ID */
+        {
+            CFE_EVS_SendEvent(CFE_TBL_MID_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid message ID -- ID = 0x%X",
+                              (unsigned int)CFE_SB_MsgIdToValue(MessageID));
+            /*
+            ** Note: we only increment the command error counter when
+            **    processing messages with command codes
+            */
+        }
+    }
+
+    return;
+
+} /* End of CFE_TBL_TaskPipe() */
+
+/******************************************************************************/
+
+int16 CFE_TBL_SearchCmdHndlrTbl(CFE_SB_MsgId_t MessageID, uint16 CommandCode)
+{
+    int16 TblIndx    = CFE_TBL_BAD_CMD_CODE;
+    bool  FoundMsg   = false;
+    bool  FoundMatch = false;
+
+    do
+    {
+        /* Point to next entry in Command Handler Table */
+        TblIndx++;
+
+        /* Check to see if we found a matching Message ID */
+        if (CFE_SB_MsgId_Equal(CFE_TBL_CmdHandlerTbl[TblIndx].MsgId, MessageID) &&
+            (CFE_TBL_CmdHandlerTbl[TblIndx].MsgTypes != CFE_TBL_TERM_MSGTYPE))
+        {
+            /* Flag any found message IDs so that if there is an error,        */
+            /* we can determine if it was a bad message ID or bad command code */
+            FoundMsg = true;
+
+            /* If entry in the Command Handler Table is a command entry, */
+            /* then check for a matching command code                    */
+            if (CFE_TBL_CmdHandlerTbl[TblIndx].MsgTypes == CFE_TBL_CMD_MSGTYPE)
+            {
+                if (CFE_TBL_CmdHandlerTbl[TblIndx].CmdCode == CommandCode)
+                {
+                    /* Found matching message ID and Command Code */
+                    FoundMatch = true;
+                }
+            }
+            else /* Message is not a command message with specific command code */
+            {
+                /* Automatically assume a match when legit */
+                /* Message ID is all that is required      */
+                FoundMatch = true;
+            }
+        }
+    } while ((!FoundMatch) && (CFE_TBL_CmdHandlerTbl[TblIndx].MsgTypes != CFE_TBL_TERM_MSGTYPE));
+
+    /* If we failed to find a match, return a negative index */
+    if (!FoundMatch)
+    {
+        /* Determine if the message ID was bad or the command code */
+        if (FoundMsg)
+        {
+            /* A matching message ID was found, so the command code must be bad */
+            TblIndx = CFE_TBL_BAD_CMD_CODE;
+        }
+        else /* No matching message ID was found */
+        {
+            TblIndx = CFE_TBL_BAD_MSG_ID;
+        }
+    }
+
+    return TblIndx;
+} /* End of CFE_TBL_SearchCmdHndlrTbl() */
+
+/************************/
+/*  End of File Comment */
+/************************/

--- a/modules/tbl/fsw/src/cfe_tbl_task.h
+++ b/modules/tbl/fsw/src/cfe_tbl_task.h
@@ -1,0 +1,423 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * @file
+ *
+ * Purpose:  cFE Table Services (TBL) task header file
+ *
+ * Author:   David Kobe (the Hammers Company, Inc.)
+ *
+ * Notes:
+ *
+ */
+
+#ifndef CFE_TBL_TASK_H
+#define CFE_TBL_TASK_H
+
+/*
+** Required header files
+*/
+#include "cfe_tbl_msg.h"
+
+/*************************************************************************/
+
+/*
+** Registry mutex definitions
+*/
+/** \name Registry Mutex Definitions */
+/**  \{ */
+#define CFE_TBL_MUT_REG_NAME   "TBL_REG_MUT" /**< \brief Name of Mutex controlling Registry Access */
+#define CFE_TBL_MUT_REG_VALUE  0             /**< \brief Initial Value of Registry Access Mutex */
+#define CFE_TBL_MUT_WORK_NAME  "TBL_WRK_MUT" /**< \brief Name of Mutex controlling Working Buffer Assignment */
+#define CFE_TBL_MUT_WORK_VALUE 0             /**< \brief Initial Value of Working Buffer Assignment Mutex */
+/** \} */
+
+/** \name Table Services Task Pipe Characteristics */
+/**  \{ */
+#define CFE_TBL_TASK_PIPE_NAME  "TBL_CMD_PIPE" /**< \brief Name of TBL Task Command Pipe */
+#define CFE_TBL_TASK_PIPE_DEPTH 12             /**< \brief Number of Commands that can be queued */
+/** \} */
+
+/** \brief Value indicating when no load is in progress */
+/**
+**  This macro is used to indicate no Load is in Progress by assigning it to
+**  #CFE_TBL_RegistryRec_t::LoadInProgress
+*/
+#define CFE_TBL_NO_LOAD_IN_PROGRESS (-1)
+
+/** \brief Value indicating when no Validation is Pending */
+/**
+**  This macro is used to indicate no Validation is Pending by assigning it to
+**  #CFE_TBL_RegistryRec_t::ValidateActiveIndex or #CFE_TBL_RegistryRec_t::ValidateInactiveIndex
+*/
+#define CFE_TBL_NO_VALIDATION_PENDING (-1)
+
+/** \brief Value indicating when no Dump is Pending on a Dump-Only Table */
+/**
+**  This macro is used to indicate no Dump is Pending by assigning it to
+**  #CFE_TBL_RegistryRec_t::DumpControlIndex
+*/
+#define CFE_TBL_NO_DUMP_PENDING (-1)
+
+/************************  Internal Structure Definitions  *****************************/
+
+/*******************************************************************************/
+/**  \brief Identifies the current state of a validation sequence.
+ */
+typedef enum
+{
+    CFE_TBL_VALIDATION_FREE = 0, /**< \brief Validation Result Block is Free */
+    CFE_TBL_VALIDATION_PENDING,  /**< \brief Validation Result Block waiting for Application */
+    CFE_TBL_VALIDATION_PERFORMED /**< \brief Validation Result Block contains Validation Results */
+} CFE_TBL_ValidationState_t;
+
+/*******************************************************************************/
+/**  \brief Identifies the current state of a dump request.
+ */
+typedef enum
+{
+    CFE_TBL_DUMP_FREE = 0, /**< \brief Dump Request Block is Free */
+    CFE_TBL_DUMP_PENDING,  /**< \brief Dump Request Block waiting for Application */
+    CFE_TBL_DUMP_PERFORMED /**< \brief Dump Request Block processed by Application */
+} CFE_TBL_DumpState_t;
+
+/*******************************************************************************/
+/**   \brief Validation Result Block
+**
+**    This structure holds the data to be returned to the Operator via telemetry
+**    on the results of a Validation request.
+*/
+typedef struct
+{
+    CFE_TBL_ValidationState_t State;      /**< \brief Current state of this block of data */
+    int32                     Result;     /**< \brief Result returned by Application's Validation function */
+    uint32                    CrcOfTable; /**< \brief Data Integrity Value computed on Table Buffer */
+    bool ActiveBuffer;                    /**< \brief Flag indicating whether Validation is on Active/Inactive Buffer */
+    char TableName[CFE_TBL_MAX_FULL_NAME_LEN]; /**< \brief Name of Table being Validated */
+} CFE_TBL_ValidationResult_t;
+
+/*******************************************************************************/
+/**   \brief Memory Pool Data Structure
+**
+**     This structure defines the variables related to the TBL buffers.
+*/
+typedef struct
+{
+    CFE_ES_MemHandle_t PoolHdl;
+    CFE_ES_STATIC_POOL_TYPE(CFE_PLATFORM_TBL_BUF_MEMORY_BYTES) Partition;
+} CFE_TBL_BufParams_t;
+
+/*******************************************************************************/
+/**   \brief Load Buffer Description Data
+**
+**     This structure holds a pointer to a table buffer along with its associated
+**     data such as the time from the file that was loaded into the buffer, whether
+**     the buffer has been allocated and a string describing the source of the data.
+*/
+typedef struct
+{
+    void * BufferPtr;             /**< \brief Pointer to Load Buffer */
+    uint32 FileCreateTimeSecs;    /**< \brief File creation time from last file loaded into table */
+    uint32 FileCreateTimeSubSecs; /**< \brief File creation time from last file loaded into table */
+    uint32 Crc;                   /**< \brief Last calculated CRC for this buffer's contents */
+    bool   Taken;                 /**< \brief Flag indicating whether buffer is in use */
+    bool   Validated;             /**< \brief Flag indicating whether the buffer has been successfully validated */
+    char   DataSource[OS_MAX_PATH_LEN]; /**< \brief Source of data put into buffer (filename or memory address) */
+} CFE_TBL_LoadBuff_t;
+
+/*******************************************************************************/
+/**   \brief Application to Table Access Descriptor
+**
+**     Table Access Descriptor data structure that contains information necessary
+**     to access the table without interfering with other threads.  TblHandles are
+**     an index into an array of Access Descriptors, thus identifying a specific
+**     AccessDescriptor for a particular Application for a table.
+*/
+typedef struct
+{
+    CFE_ES_AppId_t   AppId;       /**< \brief Application ID to verify access */
+    int16            RegIndex;    /**< \brief Index into Table Registry (a.k.a. - Global Table #) */
+    CFE_TBL_Handle_t PrevLink;    /**< \brief Index of previous access descriptor in linked list */
+    CFE_TBL_Handle_t NextLink;    /**< \brief Index of next access descriptor in linked list */
+    bool             UsedFlag;    /**< \brief Indicates whether this descriptor is being used or not  */
+    bool             LockFlag;    /**< \brief Indicates whether thread is currently accessing table data */
+    bool             Updated;     /**< \brief Indicates table has been updated since last GetAddress call */
+    uint8            BufferIndex; /**< \brief Index of buffer currently being used */
+} CFE_TBL_AccessDescriptor_t;
+
+/*******************************************************************************/
+/**   \brief Table Registry Record
+**
+**     Table Registry Record that contains all information associated
+**     with a particular table.
+*/
+typedef struct
+{
+    CFE_ES_AppId_t     OwnerAppId;        /**< \brief Application ID of App that Registered Table */
+    size_t             Size;              /**< \brief Size, in bytes, of Table */
+    CFE_SB_MsgId_t     NotificationMsgId; /**< \brief Message ID of an associated management notification message */
+    uint32             NotificationParam; /**< \brief Parameter of an associated management notification message */
+    CFE_TBL_LoadBuff_t Buffers[2];        /**< \brief Active and Inactive Buffer Pointers */
+    CFE_TBL_CallbackFuncPtr_t ValidationFuncPtr; /**< \brief Ptr to Owner App's function that validates tbl contents */
+    CFE_TIME_SysTime_t        TimeOfLastUpdate;  /**< \brief Time when Table was last updated */
+    CFE_TBL_Handle_t          HeadOfAccessList;  /**< \brief Index into Handles Array that starts Access Linked List */
+    int32              LoadInProgress;      /**< \brief Flag identifies inactive buffer and whether load in progress */
+    int32              ValidateActiveIndex; /**< \brief Index to Validation Request on Active Table Result data */
+    int32              ValidateInactiveIndex; /**< \brief Index to Validation Request on Inactive Table Result data */
+    int32              DumpControlIndex;      /**< \brief Index to Dump Control Block */
+    CFE_ES_CDSHandle_t CDSHandle;             /**< \brief Handle to Critical Data Store for Critical Tables */
+    CFE_MSG_FcnCode_t  NotificationCC;  /**< \brief Command Code of an associated management notification message */
+    bool               CriticalTable;   /**< \brief Flag indicating whether table is a Critical Table */
+    bool               TableLoadedOnce; /**< \brief Flag indicating whether table has been loaded once or not */
+    bool               LoadPending;     /**< \brief Flag indicating an inactive buffer is ready to be copied */
+    bool               DumpOnly;        /**< \brief Flag indicating Table is NOT to be loaded */
+    bool               DoubleBuffered;  /**< \brief Flag indicating Table has a dedicated inactive buffer */
+    bool               UserDefAddr;     /**< \brief Flag indicating Table address was defined by Owner Application */
+    bool               NotifyByMsg;     /**< \brief Flag indicating Table Services should notify owning App via message
+                                                    when table requires management */
+    uint8 ActiveBufferIndex;            /**< \brief Index identifying which buffer is the active buffer */
+    char  Name[CFE_TBL_MAX_FULL_NAME_LEN]; /**< \brief Processor specific table name */
+    char  LastFileLoaded[OS_MAX_PATH_LEN]; /**< \brief Filename of last file loaded into table */
+} CFE_TBL_RegistryRec_t;
+
+/*******************************************************************************/
+/**   \brief Critical Table Registry Record
+**
+**     Critical Table Registry Record that contains information about a Critical
+**     Table that must survive the reboot and repopulation of the Table Registry.
+*/
+typedef struct
+{
+    CFE_ES_CDSHandle_t CDSHandle;             /**< \brief Handle to Critical Data Store for Critical Tables */
+    uint32             FileCreateTimeSecs;    /**< \brief File creation time from last file loaded into table */
+    uint32             FileCreateTimeSubSecs; /**< \brief File creation time from last file loaded into table */
+    CFE_TIME_SysTime_t TimeOfLastUpdate;      /**< \brief Time when Table was last updated */
+    char               LastFileLoaded[OS_MAX_PATH_LEN]; /**< \brief Filename of last file loaded into table */
+    char               Name[CFE_TBL_MAX_FULL_NAME_LEN]; /**< \brief Processor specific table name */
+    bool               TableLoadedOnce; /**< \brief Flag indicating whether table has been loaded once or not */
+} CFE_TBL_CritRegRec_t;
+
+/*******************************************************************************/
+/**   \brief Dump Control Block
+**
+**    This structure holds the data associated with a dump request.
+*/
+typedef struct
+{
+    CFE_TBL_DumpState_t    State;         /**< \brief Current state of this block of data */
+    size_t                 Size;          /**< \brief Number of bytes to be dumped */
+    CFE_TBL_LoadBuff_t *   DumpBufferPtr; /**< \brief Address where dumped data is to be stored temporarily */
+    CFE_TBL_RegistryRec_t *RegRecPtr;     /**< \brief Ptr to dumped table's registry record */
+    char                   TableName[CFE_TBL_MAX_FULL_NAME_LEN]; /**< \brief Name of Table being Dumped */
+} CFE_TBL_DumpControl_t;
+
+/*******************************************************************************/
+/**   \brief Table Registry Dump Record
+**
+**     Shortened Table Registry Record that is used when dumping a table
+**     registry entry to a file.
+*/
+typedef struct
+{
+    CFE_ES_MemOffset_t Size;               /**< \brief Size, in bytes, of Table */
+    CFE_TIME_SysTime_t TimeOfLastUpdate;   /**< \brief Time when Table was last updated */
+    uint32             NumUsers;           /**< \brief Number of applications that are sharing the table */
+    int32              LoadInProgress;     /**< \brief Flag identifies inactive buffer and whether load in progress */
+    uint32             FileCreateTimeSecs; /**< \brief File creation time from last file loaded into table */
+    uint32             FileCreateTimeSubSecs; /**< \brief File creation time from last file loaded into table */
+    uint32             Crc;                   /**< \brief Most recent CRC computed by TBL Services on table contents */
+    bool               ValidationFunc;  /**< \brief Flag indicating whether table has an associated Validation func*/
+    bool               TableLoadedOnce; /**< \brief Flag indicating whether table has been loaded once or not */
+    bool               LoadPending;     /**< \brief Flag indicating an inactive buffer is ready to be copied */
+    bool               DumpOnly;        /**< \brief Flag indicating Table is NOT to be loaded */
+    bool               DoubleBuffered;  /**< \brief Flag indicating Table has a dedicated inactive buffer */
+    char               Name[CFE_TBL_MAX_FULL_NAME_LEN]; /**< \brief Processor specific table name */
+    char               LastFileLoaded[OS_MAX_PATH_LEN]; /**< \brief Filename of last file loaded into table */
+    char               OwnerAppName[OS_MAX_API_NAME];   /**< \brief Application Name of App that Registered Table */
+    bool               CriticalTable;                   /**< \brief Identifies whether table is Critical or Not */
+} CFE_TBL_RegDumpRec_t;
+
+/*******************************************************************************/
+/**   \brief Table Registry Dump background state information
+**
+**    State info for background table registry dump process and one temporary data record.
+*/
+typedef struct
+{
+    CFE_FS_FileWriteMetaData_t FileWrite; /**< FS state data - must be first */
+
+    bool                 FileExisted; /**< Set true if the file already existed at the time of request */
+    CFE_TBL_RegDumpRec_t DumpRecord;  /**< Current record buffer (reused each entry) */
+} CFE_TBL_RegDumpStateInfo_t;
+
+/*******************************************************************************/
+/**   \brief Table Task Global Data
+**
+**     Structure used to ensure Table Task Global Data is maintained as a single
+**     block of memory.  This improves Table Maintenance by simplifying the memory
+**     map and helps to keep the code in an "object oriented" style.
+*/
+typedef struct
+{
+    /*
+    ** Task command interface counters...
+    */
+    uint8 CommandCounter;      /**< \brief Counts number of valid commands received */
+    uint8 CommandErrorCounter; /**< \brief Counts number of invalid commands received */
+
+    /*
+    ** Table Validation Result counters...
+    */
+    uint8 SuccessValCounter; /**< \brief Counts number of successful table validations */
+    uint8 FailedValCounter;  /**< \brief Counts number of unsuccessful table validations */
+    uint8 NumValRequests;    /**< \brief Counts number of table validation requests made */
+
+    /*
+    ** Ground Interface Information
+    */
+    int16 LastTblUpdated; /**< \brief Index into Registry of last table updated */
+
+    /*
+    ** Task housekeeping and diagnostics telemetry packets...
+    */
+    CFE_TBL_HousekeepingTlm_t  HkPacket;     /**< \brief Housekeping Telemetry Packet */
+    CFE_TBL_TableRegistryTlm_t TblRegPacket; /**< \brief Table Registry Entry Telemetry Packet */
+    CFE_TBL_NotifyCmd_t        NotifyMsg;    /**< \brief Table management notification command message */
+
+    /*
+    ** Task operational data (not reported in housekeeping)...
+    */
+    CFE_SB_PipeId_t CmdPipe; /**< \brief Table Task command pipe ID as obtained from Software Bus */
+
+    /*
+    ** Task initialization data (not reported in housekeeping)...
+    */
+    CFE_ES_AppId_t TableTaskAppId; /**< \brief Contains Table Task Application ID as assigned by OS AL */
+
+    int16  HkTlmTblRegIndex; /**< \brief Index of table registry entry to be telemetered with Housekeeping */
+    uint16 ValidationCounter;
+
+    /*
+    ** Registry Access Mutex and Load Buffer Semaphores
+    */
+    osal_id_t          RegistryMutex; /**< \brief Mutex that controls access to Table Registry */
+    osal_id_t          WorkBufMutex;  /**< \brief Mutex that controls assignment of Working Buffers */
+    CFE_ES_CDSHandle_t CritRegHandle; /**< \brief Handle to Critical Table Registry in CDS */
+    CFE_TBL_LoadBuff_t LoadBuffs[CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS]; /**< \brief Working table buffers shared by
+                                                                              single buffered tables */
+
+    /*
+    ** Registry Data
+    */
+    CFE_TBL_AccessDescriptor_t Handles[CFE_PLATFORM_TBL_MAX_NUM_HANDLES]; /**< \brief Array of Access Descriptors */
+    CFE_TBL_RegistryRec_t      Registry[CFE_PLATFORM_TBL_MAX_NUM_TABLES]; /**< \brief Array of Table Registry Records */
+    CFE_TBL_CritRegRec_t
+                        CritReg[CFE_PLATFORM_TBL_MAX_CRITICAL_TABLES]; /**< \brief Array of Critical Table Registry Records */
+    CFE_TBL_BufParams_t Buf; /**< \brief Parameters associated with Table Task's Memory Pool */
+    CFE_TBL_ValidationResult_t
+                          ValidationResults[CFE_PLATFORM_TBL_MAX_NUM_VALIDATIONS]; /**< \brief Array of Table Validation Requests */
+    CFE_TBL_DumpControl_t DumpControlBlocks[CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS]; /**< \brief Array of Dump-Only
+                                                                                         Dump Control Blocks */
+
+    /*
+     * Registry dump state info (background job)
+     */
+    CFE_TBL_RegDumpStateInfo_t RegDumpState;
+
+} CFE_TBL_Global_t;
+
+/*************************************************************************/
+/*
+ * Functions
+ */
+
+/*****************************************************************************/
+/**
+** \brief Compares message with #CFE_TBL_CmdHandlerTbl to identify the message
+**
+** \par Description
+**          Searches the Command Handler Table for an entry matching the
+**          message ID and, if necessary, the Command Code.  If an entry
+**          is not located, an error code is returned.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in] MessageID message ID of command message received on command pipe
+**
+** \param[in] CommandCode command code from command message received on command pipe
+**
+** \retval #CFE_SUCCESS          \copydoc CFE_SUCCESS
+** \retval #CFE_TBL_BAD_CMD_CODE \copydoc CFE_TBL_BAD_CMD_CODE
+** \retval #CFE_TBL_BAD_MSG_ID   \copydoc CFE_TBL_BAD_MSG_ID
+**
+******************************************************************************/
+extern int16 CFE_TBL_SearchCmdHndlrTbl(CFE_SB_MsgId_t MessageID, uint16 CommandCode);
+
+/*****************************************************************************/
+/**
+** \brief cFE Table Services Core Application Initialization
+**
+** \par Description
+**        This function initializes all data associated with the cFE Table
+**        Services Core Application.  It is only called when the Application
+**        is first started.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \return #CFE_SUCCESS  \copydoc CFE_SUCCESS
+** \return Any of the return values from #CFE_EVS_Register
+** \return Any of the return values from #CFE_SB_CreatePipe
+** \return Any of the return values from #CFE_SB_Subscribe
+** \return Any of the return values from #CFE_EVS_SendEvent
+******************************************************************************/
+int32 CFE_TBL_TaskInit(void);
+
+/*****************************************************************************/
+/**
+** \brief Processes command pipe messages
+**
+** \par Description
+**          Processes messages obtained from the command pipe.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in] MessagePtr a pointer to the message received from the command pipe
+**
+******************************************************************************/
+void CFE_TBL_TaskPipe(CFE_SB_Buffer_t *SBBufPtr);
+
+/*****************************************************************************/
+/**
+** \brief Table Service Application Data Initialization
+**
+** \par Description
+**          Initializes all data necessary for the Table Service Application.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+******************************************************************************/
+void CFE_TBL_InitData(void);
+
+#endif /* CFE_TBL_TASK_H */

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
@@ -1,0 +1,1487 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/*
+** File: cfe_tbl_task_cmds.c
+**
+** Subsystem: cFE TBL Task Command Processing Functions
+**
+** Author: David Kobe (the Hammers Company, Inc.)
+**
+** Notes:
+**
+*/
+
+/*
+** Required header files
+*/
+#include "cfe_tbl_module_all.h"
+#include "cfe_version.h"
+
+#include <string.h>
+
+/*******************************************************************
+**
+** CFE_TBL_HousekeepingCmd() -- Process Housekeeping Request Message
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
+********************************************************************/
+
+int32 CFE_TBL_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
+{
+    int32                  Status;
+    uint32                 i;
+    CFE_TBL_DumpControl_t *DumpCtrlPtr;
+    CFE_TIME_SysTime_t     DumpTime;
+    osal_id_t              FileDescriptor;
+
+    /*
+    ** Collect housekeeping data from Table Services
+    */
+    CFE_TBL_GetHkData();
+
+    /*
+    ** Send housekeeping telemetry packet
+    */
+    CFE_SB_TimeStampMsg(&CFE_TBL_Global.HkPacket.TlmHeader.Msg);
+    Status = CFE_SB_TransmitMsg(&CFE_TBL_Global.HkPacket.TlmHeader.Msg, true);
+
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_EVS_SendEvent(CFE_TBL_FAIL_HK_SEND_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Unable to send Hk Packet (Status=0x%08X)", (unsigned int)Status);
+    }
+
+    /* If a table's registry entry has been requested for telemetry, then pack it and send it */
+    if (CFE_TBL_Global.HkTlmTblRegIndex != CFE_TBL_NOT_FOUND)
+    {
+        CFE_TBL_GetTblRegData();
+
+        /*
+        ** Send Table Registry Info Packet
+        */
+        CFE_SB_TimeStampMsg(&CFE_TBL_Global.TblRegPacket.TlmHeader.Msg);
+        CFE_SB_TransmitMsg(&CFE_TBL_Global.TblRegPacket.TlmHeader.Msg, true);
+
+        /* Once the data has been sent, clear the index so that we don't send it again and again */
+        CFE_TBL_Global.HkTlmTblRegIndex = CFE_TBL_NOT_FOUND;
+    }
+
+    /* Check to see if there are any dump-only table dumps pending */
+    for (i = 0; i < CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS; i++)
+    {
+        if (CFE_TBL_Global.DumpControlBlocks[i].State == CFE_TBL_DUMP_PERFORMED)
+        {
+            DumpCtrlPtr = &CFE_TBL_Global.DumpControlBlocks[i];
+            Status      = CFE_TBL_DumpToFile(DumpCtrlPtr->DumpBufferPtr->DataSource, DumpCtrlPtr->TableName,
+                                        DumpCtrlPtr->DumpBufferPtr->BufferPtr, DumpCtrlPtr->Size);
+
+            /* If dump file was successfully written, update the file header so that the timestamp */
+            /* is the time of the actual capturing of the data, NOT the time when it was written to the file */
+            if (Status == CFE_TBL_INC_CMD_CTR)
+            {
+                DumpTime.Seconds    = DumpCtrlPtr->DumpBufferPtr->FileCreateTimeSecs;
+                DumpTime.Subseconds = DumpCtrlPtr->DumpBufferPtr->FileCreateTimeSubSecs;
+
+                Status = OS_OpenCreate(&FileDescriptor, DumpCtrlPtr->DumpBufferPtr->DataSource, OS_FILE_FLAG_NONE,
+                                       OS_READ_WRITE);
+
+                if (Status >= 0)
+                {
+                    Status = CFE_FS_SetTimestamp(FileDescriptor, DumpTime);
+
+                    if (Status != OS_SUCCESS)
+                    {
+                        CFE_ES_WriteToSysLog("CFE_TBL:HkCmd-Unable to update timestamp in dump file '%s'\n",
+                                             DumpCtrlPtr->DumpBufferPtr->DataSource);
+                    }
+
+                    OS_close(FileDescriptor);
+                }
+                else
+                {
+                    CFE_ES_WriteToSysLog("CFE_TBL:HkCmd-Unable to open dump file '%s' to update timestamp\n",
+                                         DumpCtrlPtr->DumpBufferPtr->DataSource);
+                }
+            }
+
+            /* Free the shared working buffer */
+            CFE_TBL_Global.LoadBuffs[DumpCtrlPtr->RegRecPtr->LoadInProgress].Taken = false;
+            DumpCtrlPtr->RegRecPtr->LoadInProgress                                 = CFE_TBL_NO_LOAD_IN_PROGRESS;
+
+            /* Free the Dump Control Block for later use */
+            DumpCtrlPtr->State = CFE_TBL_DUMP_FREE;
+        }
+    }
+
+    return CFE_TBL_DONT_INC_CTR;
+
+} /* End of CFE_TBL_HousekeepingCmd() */
+
+/*******************************************************************
+**
+** CFE_TBL_GetHkData() -- Collect data and store it into the Housekeeping Message
+**
+** NOTE: For complete prolog information, see prototype above
+********************************************************************/
+
+void CFE_TBL_GetHkData(void)
+{
+    uint32                      i;
+    uint16                      Count;
+    CFE_TBL_ValidationResult_t *ValPtr = NULL;
+
+    /* Copy command counter data */
+    CFE_TBL_Global.HkPacket.Payload.CommandCounter      = CFE_TBL_Global.CommandCounter;
+    CFE_TBL_Global.HkPacket.Payload.CommandErrorCounter = CFE_TBL_Global.CommandErrorCounter;
+    CFE_TBL_Global.HkPacket.Payload.FailedValCounter    = CFE_TBL_Global.FailedValCounter;
+    CFE_TBL_Global.HkPacket.Payload.NumLoadPending      = 0;
+    CFE_TBL_Global.HkPacket.Payload.MemPoolHandle       = CFE_TBL_Global.Buf.PoolHdl;
+
+    /* Determine the number of tables currently registered and Number of Load Pending Tables */
+    Count = 0;
+    for (i = 0; i < CFE_PLATFORM_TBL_MAX_NUM_TABLES; i++)
+    {
+        if (!CFE_RESOURCEID_TEST_EQUAL(CFE_TBL_Global.Registry[i].OwnerAppId, CFE_TBL_NOT_OWNED))
+        {
+            Count++;
+
+            if (CFE_TBL_Global.Registry[i].LoadPending)
+            {
+                CFE_TBL_Global.HkPacket.Payload.NumLoadPending++;
+            }
+        }
+    }
+    CFE_TBL_Global.HkPacket.Payload.NumTables = Count;
+
+    /* Determine the number of free shared buffers */
+    CFE_TBL_Global.HkPacket.Payload.NumFreeSharedBufs = CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS;
+    for (i = 0; i < CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS; i++)
+    {
+        if (CFE_TBL_Global.LoadBuffs[i].Taken)
+        {
+            CFE_TBL_Global.HkPacket.Payload.NumFreeSharedBufs--;
+        }
+    }
+
+    /* Locate a completed, but unreported, validation request */
+    i = 0;
+    while ((i < CFE_PLATFORM_TBL_MAX_NUM_VALIDATIONS) && (ValPtr == NULL))
+    {
+        if (CFE_TBL_Global.ValidationResults[i].State == CFE_TBL_VALIDATION_PERFORMED)
+        {
+            ValPtr = &CFE_TBL_Global.ValidationResults[i];
+        }
+        else
+        {
+            i++;
+        }
+    }
+
+    if (ValPtr != NULL)
+    {
+        CFE_TBL_Global.HkPacket.Payload.LastValCrc    = ValPtr->CrcOfTable;
+        CFE_TBL_Global.HkPacket.Payload.LastValStatus = ValPtr->Result;
+        CFE_TBL_Global.HkPacket.Payload.ActiveBuffer  = ValPtr->ActiveBuffer;
+
+        /* Keep track of the number of failed and successful validations */
+        if (ValPtr->Result == CFE_SUCCESS)
+        {
+            CFE_TBL_Global.SuccessValCounter++;
+        }
+        else
+        {
+            CFE_TBL_Global.FailedValCounter++;
+        }
+
+        CFE_SB_MessageStringSet(CFE_TBL_Global.HkPacket.Payload.LastValTableName, ValPtr->TableName,
+                                sizeof(CFE_TBL_Global.HkPacket.Payload.LastValTableName), sizeof(ValPtr->TableName));
+        CFE_TBL_Global.ValidationCounter++;
+
+        /* Free the Validation Response Block for next time */
+        ValPtr->Result       = 0;
+        ValPtr->CrcOfTable   = 0;
+        ValPtr->TableName[0] = '\0';
+        ValPtr->ActiveBuffer = false;
+        ValPtr->State        = CFE_TBL_VALIDATION_FREE;
+    }
+
+    CFE_TBL_Global.HkPacket.Payload.ValidationCounter = CFE_TBL_Global.ValidationCounter;
+    CFE_TBL_Global.HkPacket.Payload.SuccessValCounter = CFE_TBL_Global.SuccessValCounter;
+    CFE_TBL_Global.HkPacket.Payload.FailedValCounter  = CFE_TBL_Global.FailedValCounter;
+    CFE_TBL_Global.HkPacket.Payload.NumValRequests    = CFE_TBL_Global.NumValRequests;
+
+    /* Validate the index of the last table updated before using it */
+    if ((CFE_TBL_Global.LastTblUpdated >= 0) && (CFE_TBL_Global.LastTblUpdated < CFE_PLATFORM_TBL_MAX_NUM_TABLES))
+    {
+        /* Check to make sure the Registry Entry is still valid */
+        if (!CFE_RESOURCEID_TEST_EQUAL(CFE_TBL_Global.Registry[CFE_TBL_Global.LastTblUpdated].OwnerAppId,
+                                       CFE_TBL_NOT_OWNED))
+        {
+            /* Get the time at the last table update */
+            CFE_TBL_Global.HkPacket.Payload.LastUpdateTime =
+                CFE_TBL_Global.Registry[CFE_TBL_Global.LastTblUpdated].TimeOfLastUpdate;
+
+            /* Get the table name used for the last table update */
+            CFE_SB_MessageStringSet(CFE_TBL_Global.HkPacket.Payload.LastUpdatedTable,
+                                    CFE_TBL_Global.Registry[CFE_TBL_Global.LastTblUpdated].Name,
+                                    sizeof(CFE_TBL_Global.HkPacket.Payload.LastUpdatedTable),
+                                    sizeof(CFE_TBL_Global.Registry[CFE_TBL_Global.LastTblUpdated].Name));
+        }
+    }
+} /* End of CFE_TBL_GetHkData() */
+
+/*******************************************************************
+**
+** CFE_TBL_GetTblRegData() -- Convert Table Registry Entry for a Table into a Message
+**
+** NOTE: For complete prolog information, see prototype above
+********************************************************************/
+
+void CFE_TBL_GetTblRegData(void)
+{
+    CFE_TBL_RegistryRec_t *RegRecPtr;
+
+    RegRecPtr = &CFE_TBL_Global.Registry[CFE_TBL_Global.HkTlmTblRegIndex];
+
+    CFE_TBL_Global.TblRegPacket.Payload.Size = CFE_ES_MEMOFFSET_C(RegRecPtr->Size);
+    CFE_TBL_Global.TblRegPacket.Payload.ActiveBufferAddr =
+        CFE_ES_MEMADDRESS_C(RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].BufferPtr);
+
+    if (RegRecPtr->DoubleBuffered)
+    {
+        /* For a double buffered table, the inactive is the other allocated buffer */
+        CFE_TBL_Global.TblRegPacket.Payload.InactiveBufferAddr =
+            CFE_ES_MEMADDRESS_C(RegRecPtr->Buffers[(1U - RegRecPtr->ActiveBufferIndex)].BufferPtr);
+    }
+    else
+    {
+        /* Check to see if an inactive buffer has currently been allocated to the single buffered table */
+        if (RegRecPtr->LoadInProgress != CFE_TBL_NO_LOAD_IN_PROGRESS)
+        {
+            CFE_TBL_Global.TblRegPacket.Payload.InactiveBufferAddr =
+                CFE_ES_MEMADDRESS_C(CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].BufferPtr);
+        }
+        else
+        {
+            CFE_TBL_Global.TblRegPacket.Payload.InactiveBufferAddr = CFE_ES_MEMADDRESS_C(0);
+        }
+    }
+
+    CFE_TBL_Global.TblRegPacket.Payload.ValidationFuncPtr = CFE_ES_MEMADDRESS_C(RegRecPtr->ValidationFuncPtr);
+    CFE_TBL_Global.TblRegPacket.Payload.TimeOfLastUpdate  = RegRecPtr->TimeOfLastUpdate;
+    CFE_TBL_Global.TblRegPacket.Payload.TableLoadedOnce   = RegRecPtr->TableLoadedOnce;
+    CFE_TBL_Global.TblRegPacket.Payload.LoadPending       = RegRecPtr->LoadPending;
+    CFE_TBL_Global.TblRegPacket.Payload.DumpOnly          = RegRecPtr->DumpOnly;
+    CFE_TBL_Global.TblRegPacket.Payload.DoubleBuffered    = RegRecPtr->DoubleBuffered;
+    CFE_TBL_Global.TblRegPacket.Payload.FileCreateTimeSecs =
+        RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].FileCreateTimeSecs;
+    CFE_TBL_Global.TblRegPacket.Payload.FileCreateTimeSubSecs =
+        RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].FileCreateTimeSubSecs;
+    CFE_TBL_Global.TblRegPacket.Payload.Crc      = RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].Crc;
+    CFE_TBL_Global.TblRegPacket.Payload.Critical = RegRecPtr->CriticalTable;
+
+    CFE_SB_MessageStringSet(CFE_TBL_Global.TblRegPacket.Payload.Name, RegRecPtr->Name,
+                            sizeof(CFE_TBL_Global.TblRegPacket.Payload.Name), sizeof(RegRecPtr->Name));
+    CFE_SB_MessageStringSet(CFE_TBL_Global.TblRegPacket.Payload.LastFileLoaded, RegRecPtr->LastFileLoaded,
+                            sizeof(CFE_TBL_Global.TblRegPacket.Payload.LastFileLoaded),
+                            sizeof(RegRecPtr->LastFileLoaded));
+    CFE_ES_GetAppName(CFE_TBL_Global.TblRegPacket.Payload.OwnerAppName, RegRecPtr->OwnerAppId,
+                      sizeof(CFE_TBL_Global.TblRegPacket.Payload.OwnerAppName));
+} /* End of CFE_TBL_GetTblRegData() */
+
+/*******************************************************************
+**
+** CFE_TBL_NoopCmd() -- Process NO-Op Command Message
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
+********************************************************************/
+
+int32 CFE_TBL_NoopCmd(const CFE_TBL_NoopCmd_t *data)
+{
+    /* Acknowledge receipt of NOOP with Event Message */
+    CFE_EVS_SendEvent(CFE_TBL_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op command. %s", CFE_VERSION_STRING);
+
+    return CFE_TBL_INC_CMD_CTR;
+
+} /* End of CFE_TBL_NoopCmd() */
+
+/*******************************************************************
+**
+** CFE_TBL_ResetCountersCmd() -- Process Reset Counters Command Message
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
+********************************************************************/
+
+int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCountersCmd_t *data)
+{
+    CFE_TBL_Global.CommandCounter      = 0;
+    CFE_TBL_Global.CommandErrorCounter = 0;
+    CFE_TBL_Global.SuccessValCounter   = 0;
+    CFE_TBL_Global.FailedValCounter    = 0;
+    CFE_TBL_Global.NumValRequests      = 0;
+    CFE_TBL_Global.ValidationCounter   = 0;
+
+    CFE_EVS_SendEvent(CFE_TBL_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "Reset Counters command");
+
+    return CFE_TBL_DONT_INC_CTR;
+
+} /* End of CFE_TBL_ResetCountersCmd() */
+
+/*******************************************************************
+**
+** CFE_TBL_LoadCmd() -- Process Load Table File to Buffer Command Message
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
+********************************************************************/
+
+int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
+{
+    CFE_TBL_CmdProcRet_t             ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
+    const CFE_TBL_LoadCmd_Payload_t *CmdPtr     = &data->Payload;
+    CFE_FS_Header_t                  StdFileHeader;
+    CFE_TBL_File_Hdr_t               TblFileHeader;
+    osal_id_t                        FileDescriptor;
+    int32                            Status;
+    int16                            RegIndex;
+    CFE_TBL_RegistryRec_t *          RegRecPtr;
+    CFE_TBL_LoadBuff_t *             WorkingBufferPtr;
+    char                             LoadFilename[OS_MAX_PATH_LEN];
+    uint8                            ExtraByte;
+
+    /* Make sure all strings are null terminated before attempting to process them */
+    CFE_SB_MessageStringGet(LoadFilename, (char *)CmdPtr->LoadFilename, NULL, sizeof(LoadFilename),
+                            sizeof(CmdPtr->LoadFilename));
+
+    /* Try to open the specified table file */
+    Status = OS_OpenCreate(&FileDescriptor, LoadFilename, OS_FILE_FLAG_NONE, OS_READ_ONLY);
+
+    if (Status >= 0)
+    {
+        Status = CFE_TBL_ReadHeaders(FileDescriptor, &StdFileHeader, &TblFileHeader, &LoadFilename[0]);
+
+        if (Status == CFE_SUCCESS)
+        {
+            /* Locate specified table in registry */
+            RegIndex = CFE_TBL_FindTableInRegistry(TblFileHeader.TableName);
+
+            if (RegIndex == CFE_TBL_NOT_FOUND)
+            {
+                CFE_EVS_SendEvent(CFE_TBL_NO_SUCH_TABLE_ERR_EID, CFE_EVS_EventType_ERROR,
+                                  "Unable to locate '%s' in Table Registry", TblFileHeader.TableName);
+            }
+            else
+            {
+                /* Translate the registry index into a record pointer */
+                RegRecPtr = &CFE_TBL_Global.Registry[RegIndex];
+
+                if (RegRecPtr->DumpOnly)
+                {
+                    CFE_EVS_SendEvent(CFE_TBL_LOADING_A_DUMP_ONLY_ERR_EID, CFE_EVS_EventType_ERROR,
+                                      "Attempted to load DUMP-ONLY table '%s' from '%s'", TblFileHeader.TableName,
+                                      LoadFilename);
+                }
+                else if (RegRecPtr->LoadPending)
+                {
+                    CFE_EVS_SendEvent(CFE_TBL_LOADING_PENDING_ERR_EID, CFE_EVS_EventType_ERROR,
+                                      "Attempted to load table '%s' while previous load is still pending",
+                                      TblFileHeader.TableName);
+                }
+                else
+                {
+                    /* Make sure of the following:                                               */
+                    /*    1) If table has not been loaded previously, then make sure the current */
+                    /*       load starts with the first byte                                     */
+                    /*    2) The number of bytes to load is greater than zero                    */
+                    /*    3) The offset plus the number of bytes does not exceed the table size  */
+                    if (((RegRecPtr->TableLoadedOnce) || (TblFileHeader.Offset == 0)) && (TblFileHeader.NumBytes > 0) &&
+                        ((TblFileHeader.NumBytes + TblFileHeader.Offset) <= RegRecPtr->Size))
+                    {
+                        /* Get a working buffer, either a free one or one allocated with previous load command */
+                        Status = CFE_TBL_GetWorkingBuffer(&WorkingBufferPtr, RegRecPtr, false);
+
+                        if (Status == CFE_SUCCESS)
+                        {
+                            /* Copy data from file into working buffer */
+                            Status =
+                                OS_read(FileDescriptor, ((uint8 *)WorkingBufferPtr->BufferPtr) + TblFileHeader.Offset,
+                                        TblFileHeader.NumBytes);
+
+                            /* Make sure the appropriate number of bytes were read */
+                            if (Status == (int32)TblFileHeader.NumBytes)
+                            {
+                                /* Check to ensure the file does not have any extra data at the end */
+                                Status = OS_read(FileDescriptor, &ExtraByte, 1);
+
+                                /* If another byte was successfully read, then file contains more data than header
+                                 * claims */
+                                if (Status == 1)
+                                {
+                                    CFE_EVS_SendEvent(CFE_TBL_FILE_TOO_BIG_ERR_EID, CFE_EVS_EventType_ERROR,
+                                                      "File '%s' has more data than Tbl Hdr indicates (%d)",
+                                                      LoadFilename, (int)TblFileHeader.NumBytes);
+                                }
+                                else /* If error reading file or zero bytes read, assume it was the perfect size */
+                                {
+                                    CFE_EVS_SendEvent(CFE_TBL_FILE_LOADED_INF_EID, CFE_EVS_EventType_INFORMATION,
+                                                      "Successful load of '%s' into '%s' working buffer", LoadFilename,
+                                                      TblFileHeader.TableName);
+
+                                    /* Save file information statistics for later use in registry */
+                                    memcpy(WorkingBufferPtr->DataSource, LoadFilename, OS_MAX_PATH_LEN);
+
+                                    /* Save file creation time for later storage into Registry */
+                                    WorkingBufferPtr->FileCreateTimeSecs    = StdFileHeader.TimeSeconds;
+                                    WorkingBufferPtr->FileCreateTimeSubSecs = StdFileHeader.TimeSubSeconds;
+
+                                    /* Compute the CRC on the specified table buffer */
+                                    WorkingBufferPtr->Crc = CFE_ES_CalculateCRC(
+                                        WorkingBufferPtr->BufferPtr, RegRecPtr->Size, 0, CFE_MISSION_ES_DEFAULT_CRC);
+
+                                    /* Initialize validation flag with true if no Validation Function is required to be
+                                     * called */
+                                    WorkingBufferPtr->Validated = (RegRecPtr->ValidationFuncPtr == NULL);
+
+                                    /* Save file information statistics for housekeeping telemetry */
+                                    strncpy(CFE_TBL_Global.HkPacket.Payload.LastFileLoaded, LoadFilename,
+                                            sizeof(CFE_TBL_Global.HkPacket.Payload.LastFileLoaded) - 1);
+                                    CFE_TBL_Global.HkPacket.Payload
+                                        .LastFileLoaded[sizeof(CFE_TBL_Global.HkPacket.Payload.LastFileLoaded) - 1] =
+                                        '\0';
+                                    strncpy(CFE_TBL_Global.HkPacket.Payload.LastTableLoaded, TblFileHeader.TableName,
+                                            sizeof(CFE_TBL_Global.HkPacket.Payload.LastTableLoaded) - 1);
+                                    CFE_TBL_Global.HkPacket.Payload
+                                        .LastTableLoaded[sizeof(CFE_TBL_Global.HkPacket.Payload.LastTableLoaded) - 1] =
+                                        '\0';
+
+                                    /* Increment successful command completion counter */
+                                    ReturnCode = CFE_TBL_INC_CMD_CTR;
+                                }
+                            }
+                            else
+                            {
+                                /* A file whose header claims has 'x' amount of data but it only has 'y' */
+                                /* is considered a fatal error during a load process                     */
+                                CFE_EVS_SendEvent(CFE_TBL_FILE_INCOMPLETE_ERR_EID, CFE_EVS_EventType_ERROR,
+                                                  "Incomplete load of '%s' into '%s' working buffer", LoadFilename,
+                                                  TblFileHeader.TableName);
+                            }
+                        }
+                        else if (Status == CFE_TBL_ERR_NO_BUFFER_AVAIL)
+                        {
+                            CFE_EVS_SendEvent(CFE_TBL_NO_WORK_BUFFERS_ERR_EID, CFE_EVS_EventType_ERROR,
+                                              "No working buffers available for table '%s'", TblFileHeader.TableName);
+                        }
+                        else
+                        {
+                            CFE_EVS_SendEvent(CFE_TBL_INTERNAL_ERROR_ERR_EID, CFE_EVS_EventType_ERROR,
+                                              "Internal Error (Status=0x%08X)", (unsigned int)Status);
+                        }
+                    }
+                    else
+                    {
+                        if ((TblFileHeader.NumBytes + TblFileHeader.Offset) > RegRecPtr->Size)
+                        {
+                            CFE_EVS_SendEvent(CFE_TBL_LOAD_EXCEEDS_SIZE_ERR_EID, CFE_EVS_EventType_ERROR,
+                                              "Cannot load '%s' (%d) at offset %d in '%s' (%d)", LoadFilename,
+                                              (int)TblFileHeader.NumBytes, (int)TblFileHeader.Offset,
+                                              TblFileHeader.TableName, (int)RegRecPtr->Size);
+                        }
+                        else if (TblFileHeader.NumBytes == 0)
+                        {
+                            CFE_EVS_SendEvent(CFE_TBL_ZERO_LENGTH_LOAD_ERR_EID, CFE_EVS_EventType_ERROR,
+                                              "Table Hdr in '%s' indicates no data in file", LoadFilename);
+                        }
+                        else
+                        {
+                            CFE_EVS_SendEvent(CFE_TBL_PARTIAL_LOAD_ERR_EID, CFE_EVS_EventType_ERROR,
+                                              "'%s' has partial load for uninitialized table '%s'", LoadFilename,
+                                              TblFileHeader.TableName);
+                        }
+                    }
+                }
+            }
+        } /* No need to issue event messages in response to errors reading headers */
+          /* because the function that read the headers will generate messages     */
+
+        /* Close the file now that the contents have been read */
+        OS_close(FileDescriptor);
+    }
+    else
+    {
+        /* Error opening specified file */
+        CFE_EVS_SendEvent(CFE_TBL_FILE_ACCESS_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Unable to open file '%s' for table load, Status = 0x%08X", LoadFilename,
+                          (unsigned int)Status);
+    }
+
+    return ReturnCode;
+
+} /* End of CFE_TBL_LoadCmd() */
+
+/*******************************************************************
+**
+** CFE_TBL_DumpCmd() -- Process Dump Table to File Command Message
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
+********************************************************************/
+
+int32 CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data)
+{
+    CFE_TBL_CmdProcRet_t             ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
+    int16                            RegIndex;
+    const CFE_TBL_DumpCmd_Payload_t *CmdPtr = &data->Payload;
+    char                             DumpFilename[OS_MAX_PATH_LEN];
+    char                             TableName[CFE_TBL_MAX_FULL_NAME_LEN];
+    CFE_TBL_RegistryRec_t *          RegRecPtr;
+    void *                           DumpDataAddr = NULL;
+    CFE_TBL_LoadBuff_t *             WorkingBufferPtr;
+    int32                            DumpIndex;
+    int32                            Status;
+    CFE_TBL_DumpControl_t *          DumpCtrlPtr;
+
+    /* Make sure all strings are null terminated before attempting to process them */
+    CFE_SB_MessageStringGet(DumpFilename, (char *)CmdPtr->DumpFilename, NULL, sizeof(DumpFilename),
+                            sizeof(CmdPtr->DumpFilename));
+
+    CFE_SB_MessageStringGet(TableName, (char *)CmdPtr->TableName, NULL, sizeof(TableName), sizeof(CmdPtr->TableName));
+
+    /* Before doing anything, lets make sure the table that is to be dumped exists */
+    RegIndex = CFE_TBL_FindTableInRegistry(TableName);
+
+    if (RegIndex != CFE_TBL_NOT_FOUND)
+    {
+        /* Obtain a pointer to registry information about specified table */
+        RegRecPtr = &CFE_TBL_Global.Registry[RegIndex];
+
+        /* Determine what data is to be dumped */
+        if (CmdPtr->ActiveTableFlag == CFE_TBL_BufferSelect_ACTIVE)
+        {
+            DumpDataAddr = RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].BufferPtr;
+        }
+        else if (CmdPtr->ActiveTableFlag == CFE_TBL_BufferSelect_INACTIVE) /* Dumping Inactive Buffer */
+        {
+            /* If this is a double buffered table, locating the inactive buffer is trivial */
+            if (RegRecPtr->DoubleBuffered)
+            {
+                DumpDataAddr = RegRecPtr->Buffers[(1U - RegRecPtr->ActiveBufferIndex)].BufferPtr;
+            }
+            else
+            {
+                /* For single buffered tables, the index to the inactive buffer is kept in 'LoadInProgress' */
+                /* Unless this is a table whose address was defined by the owning Application.              */
+                if ((RegRecPtr->LoadInProgress != CFE_TBL_NO_LOAD_IN_PROGRESS) && (!RegRecPtr->UserDefAddr))
+                {
+                    DumpDataAddr = CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].BufferPtr;
+                }
+                else
+                {
+                    CFE_EVS_SendEvent(CFE_TBL_NO_INACTIVE_BUFFER_ERR_EID, CFE_EVS_EventType_ERROR,
+                                      "No Inactive Buffer for Table '%s' present", TableName);
+                }
+            }
+        }
+        else
+        {
+            CFE_EVS_SendEvent(CFE_TBL_ILLEGAL_BUFF_PARAM_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Cmd for Table '%s' had illegal buffer parameter (0x%08X)", TableName,
+                              (unsigned int)CmdPtr->ActiveTableFlag);
+        }
+
+        /* If we have located the data to be dumped, then proceed with creating the file and dumping the data */
+        if (DumpDataAddr != NULL)
+        {
+            /* If this is not a dump only table, then we can perform the dump immediately */
+            if (!RegRecPtr->DumpOnly)
+            {
+                ReturnCode = CFE_TBL_DumpToFile(DumpFilename, TableName, DumpDataAddr, RegRecPtr->Size);
+            }
+            else /* Dump Only tables need to synchronize their dumps with the owner's execution */
+            {
+                /* Make sure a dump is not already in progress */
+                if (RegRecPtr->DumpControlIndex == CFE_TBL_NO_DUMP_PENDING)
+                {
+                    /* Find a free Dump Control Block */
+                    DumpIndex = 0;
+                    while ((DumpIndex < CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS) &&
+                           (CFE_TBL_Global.DumpControlBlocks[DumpIndex].State != CFE_TBL_DUMP_FREE))
+                    {
+                        DumpIndex++;
+                    }
+
+                    if (DumpIndex < CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS)
+                    {
+                        /* Allocate a shared memory buffer for storing the data to be dumped */
+                        Status = CFE_TBL_GetWorkingBuffer(&WorkingBufferPtr, RegRecPtr, false);
+
+                        if (Status == CFE_SUCCESS)
+                        {
+                            DumpCtrlPtr            = &CFE_TBL_Global.DumpControlBlocks[DumpIndex];
+                            DumpCtrlPtr->State     = CFE_TBL_DUMP_PENDING;
+                            DumpCtrlPtr->RegRecPtr = RegRecPtr;
+
+                            /* Save the name of the desired dump filename, table name and size for later */
+                            DumpCtrlPtr->DumpBufferPtr = WorkingBufferPtr;
+                            memcpy(DumpCtrlPtr->DumpBufferPtr->DataSource, DumpFilename, OS_MAX_PATH_LEN);
+                            memcpy(DumpCtrlPtr->TableName, TableName, CFE_TBL_MAX_FULL_NAME_LEN);
+                            DumpCtrlPtr->Size = RegRecPtr->Size;
+
+                            /* Notify the owning application that a dump is pending */
+                            RegRecPtr->DumpControlIndex = DumpIndex;
+
+                            /* If application requested notification by message, then do so */
+                            CFE_TBL_SendNotificationMsg(RegRecPtr);
+
+                            /* Consider the command completed successfully */
+                            ReturnCode = CFE_TBL_INC_CMD_CTR;
+                        }
+                        else
+                        {
+                            CFE_EVS_SendEvent(CFE_TBL_NO_WORK_BUFFERS_ERR_EID, CFE_EVS_EventType_ERROR,
+                                              "No working buffers available for table '%s'", TableName);
+                        }
+                    }
+                    else
+                    {
+                        CFE_EVS_SendEvent(CFE_TBL_TOO_MANY_DUMPS_ERR_EID, CFE_EVS_EventType_ERROR,
+                                          "Too many Dump Only Table Dumps have been requested");
+                    }
+                }
+                else
+                {
+                    CFE_EVS_SendEvent(CFE_TBL_DUMP_PENDING_ERR_EID, CFE_EVS_EventType_ERROR,
+                                      "A dump for '%s' is already pending", TableName);
+                }
+            }
+        }
+    }
+    else /* Table could not be found in Registry */
+    {
+        CFE_EVS_SendEvent(CFE_TBL_NO_SUCH_TABLE_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Unable to locate '%s' in Table Registry", TableName);
+    }
+
+    return ReturnCode;
+
+} /* End of CFE_TBL_DumpCmd() */
+
+/*******************************************************************
+**
+** CFE_TBL_DumpToFile() -- Write table data to a file
+**
+** NOTE: For complete prolog information, see prototype above
+********************************************************************/
+
+CFE_TBL_CmdProcRet_t CFE_TBL_DumpToFile(const char *DumpFilename, const char *TableName, const void *DumpDataAddr,
+                                        size_t TblSizeInBytes)
+{
+    CFE_TBL_CmdProcRet_t ReturnCode      = CFE_TBL_INC_ERR_CTR; /* Assume failure */
+    bool                 FileExistedPrev = false;
+    CFE_FS_Header_t      StdFileHeader;
+    CFE_TBL_File_Hdr_t   TblFileHeader;
+    osal_id_t            FileDescriptor;
+    int32                Status;
+    int32                EndianCheck = 0x01020304;
+
+    /* Clear Header of any garbage before copying content */
+    memset(&TblFileHeader, 0, sizeof(CFE_TBL_File_Hdr_t));
+
+    /* Check to see if the dump file already exists */
+    Status = OS_OpenCreate(&FileDescriptor, DumpFilename, OS_FILE_FLAG_NONE, OS_READ_ONLY);
+
+    if (Status >= 0)
+    {
+        FileExistedPrev = true;
+        OS_close(FileDescriptor);
+    }
+
+    /* Create a new dump file, overwriting anything that may have existed previously */
+    Status = OS_OpenCreate(&FileDescriptor, DumpFilename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
+
+    if (Status >= OS_SUCCESS)
+    {
+        /* Initialize the standard cFE File Header for the Dump File */
+        CFE_FS_InitHeader(&StdFileHeader, "Table Dump Image", CFE_FS_SubType_TBL_IMG);
+
+        /* Output the Standard cFE File Header to the Dump File */
+        Status = CFE_FS_WriteHeader(FileDescriptor, &StdFileHeader);
+
+        if (Status == sizeof(CFE_FS_Header_t))
+        {
+            /* Initialize the Table Image Header for the Dump File */
+            strncpy(TblFileHeader.TableName, TableName, sizeof(TblFileHeader.TableName) - 1);
+            TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = 0;
+            TblFileHeader.Offset                                         = CFE_ES_MEMOFFSET_C(0);
+            TblFileHeader.NumBytes                                       = CFE_ES_MEMOFFSET_C(TblSizeInBytes);
+            TblFileHeader.Reserved                                       = 0;
+
+            /* Determine if this is a little endian processor */
+            if ((*(char *)&EndianCheck) == 0x04)
+            {
+                /* If this is a little endian processor, then byte swap the header to a big endian format */
+                /* to maintain the cFE Header standards */
+                /* NOTE: FOR THE REMAINDER OF THIS FUNCTION, THE CONTENTS OF THE HEADER IS UNREADABLE BY */
+                /*       THIS PROCESSOR!  THE DATA WOULD NEED TO BE SWAPPED BACK BEFORE READING.         */
+                CFE_TBL_ByteSwapTblHeader(&TblFileHeader);
+            }
+
+            /* Output the Table Image Header to the Dump File */
+            Status = OS_write(FileDescriptor, &TblFileHeader, sizeof(CFE_TBL_File_Hdr_t));
+
+            /* Make sure the header was output completely */
+            if (Status == sizeof(CFE_TBL_File_Hdr_t))
+            {
+                /* Output the requested data to the dump file */
+                /* Output the active table image data to the dump file */
+                Status = OS_write(FileDescriptor, DumpDataAddr, TblSizeInBytes);
+
+                if (Status == TblSizeInBytes)
+                {
+                    if (FileExistedPrev)
+                    {
+                        CFE_EVS_SendEvent(CFE_TBL_OVERWRITE_DUMP_INF_EID, CFE_EVS_EventType_INFORMATION,
+                                          "Successfully overwrote '%s' with Table '%s'", DumpFilename, TableName);
+                    }
+                    else
+                    {
+                        CFE_EVS_SendEvent(CFE_TBL_WRITE_DUMP_INF_EID, CFE_EVS_EventType_INFORMATION,
+                                          "Successfully dumped Table '%s' to '%s'", TableName, DumpFilename);
+                    }
+
+                    /* Save file information statistics for housekeeping telemetry */
+                    strncpy(CFE_TBL_Global.HkPacket.Payload.LastFileDumped, DumpFilename,
+                            sizeof(CFE_TBL_Global.HkPacket.Payload.LastFileDumped) - 1);
+                    CFE_TBL_Global.HkPacket.Payload
+                        .LastFileDumped[sizeof(CFE_TBL_Global.HkPacket.Payload.LastFileDumped) - 1] = 0;
+
+                    /* Increment Successful Command Counter */
+                    ReturnCode = CFE_TBL_INC_CMD_CTR;
+                }
+                else
+                {
+                    CFE_EVS_SendEvent(CFE_TBL_WRITE_TBL_IMG_ERR_EID, CFE_EVS_EventType_ERROR,
+                                      "Error writing Tbl image to '%s', Status=0x%08X", DumpFilename,
+                                      (unsigned int)Status);
+                }
+            }
+            else
+            {
+                CFE_EVS_SendEvent(CFE_TBL_WRITE_TBL_HDR_ERR_EID, CFE_EVS_EventType_ERROR,
+                                  "Error writing Tbl image File Header to '%s', Status=0x%08X", DumpFilename,
+                                  (unsigned int)Status);
+            }
+        }
+        else
+        {
+            CFE_EVS_SendEvent(CFE_TBL_WRITE_CFE_HDR_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Error writing cFE File Header to '%s', Status=0x%08X", DumpFilename,
+                              (unsigned int)Status);
+        }
+
+        /* We are done outputting data to the dump file.  Close it. */
+        OS_close(FileDescriptor);
+    }
+    else
+    {
+        CFE_EVS_SendEvent(CFE_TBL_CREATING_DUMP_FILE_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Error creating dump file '%s', Status=0x%08X", DumpFilename, (unsigned int)Status);
+    }
+
+    return ReturnCode;
+} /* End of CFE_TBL_DumpToFile() */
+
+/*******************************************************************
+**
+** CFE_TBL_ValidateCmd() -- Process Validate Table Command Message
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
+********************************************************************/
+
+int32 CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data)
+{
+    CFE_TBL_CmdProcRet_t                 ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
+    int16                                RegIndex;
+    const CFE_TBL_ValidateCmd_Payload_t *CmdPtr = &data->Payload;
+    CFE_TBL_RegistryRec_t *              RegRecPtr;
+    void *                               ValidationDataPtr = NULL;
+    char                                 TableName[CFE_TBL_MAX_FULL_NAME_LEN];
+    uint32                               CrcOfTable;
+    int32                                ValIndex;
+
+    /* Make sure all strings are null terminated before attempting to process them */
+    CFE_SB_MessageStringGet(TableName, (char *)CmdPtr->TableName, NULL, sizeof(TableName), sizeof(CmdPtr->TableName));
+
+    /* Before doing anything, lets make sure the table that is to be dumped exists */
+    RegIndex = CFE_TBL_FindTableInRegistry(TableName);
+
+    if (RegIndex != CFE_TBL_NOT_FOUND)
+    {
+        /* Obtain a pointer to registry information about specified table */
+        RegRecPtr = &CFE_TBL_Global.Registry[RegIndex];
+
+        /* Determine what data is to be validated */
+        if (CmdPtr->ActiveTableFlag == CFE_TBL_BufferSelect_ACTIVE)
+        {
+            ValidationDataPtr = RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].BufferPtr;
+        }
+        else if (CmdPtr->ActiveTableFlag == CFE_TBL_BufferSelect_INACTIVE) /* Validating Inactive Buffer */
+        {
+            /* If this is a double buffered table, locating the inactive buffer is trivial */
+            if (RegRecPtr->DoubleBuffered)
+            {
+                ValidationDataPtr = RegRecPtr->Buffers[(1U - RegRecPtr->ActiveBufferIndex)].BufferPtr;
+            }
+            else
+            {
+                /* For single buffered tables, the index to the inactive buffer is kept in 'LoadInProgress' */
+                if (RegRecPtr->LoadInProgress != CFE_TBL_NO_LOAD_IN_PROGRESS)
+                {
+                    ValidationDataPtr = CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].BufferPtr;
+                }
+                else
+                {
+                    CFE_EVS_SendEvent(CFE_TBL_NO_INACTIVE_BUFFER_ERR_EID, CFE_EVS_EventType_ERROR,
+                                      "No Inactive Buffer for Table '%s' present", TableName);
+                }
+            }
+        }
+        else
+        {
+            CFE_EVS_SendEvent(CFE_TBL_ILLEGAL_BUFF_PARAM_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Cmd for Table '%s' had illegal buffer parameter (0x%08X)", TableName,
+                              (unsigned int)CmdPtr->ActiveTableFlag);
+        }
+
+        /* If we have located the data to be validated, then proceed with notifying the application, if */
+        /* necessary, and computing the CRC value for the block of memory                               */
+        if (ValidationDataPtr != NULL)
+        {
+            /* Find a free Validation Response Block */
+            ValIndex = 0;
+            while ((ValIndex < CFE_PLATFORM_TBL_MAX_NUM_VALIDATIONS) &&
+                   (CFE_TBL_Global.ValidationResults[ValIndex].State != CFE_TBL_VALIDATION_FREE))
+            {
+                ValIndex++;
+            }
+
+            if (ValIndex < CFE_PLATFORM_TBL_MAX_NUM_VALIDATIONS)
+            {
+                /* Allocate this Validation Response Block */
+                CFE_TBL_Global.ValidationResults[ValIndex].State  = CFE_TBL_VALIDATION_PENDING;
+                CFE_TBL_Global.ValidationResults[ValIndex].Result = 0;
+                memcpy(CFE_TBL_Global.ValidationResults[ValIndex].TableName, TableName, CFE_TBL_MAX_FULL_NAME_LEN);
+
+                /* Compute the CRC on the specified table buffer */
+                CrcOfTable = CFE_ES_CalculateCRC(ValidationDataPtr, RegRecPtr->Size, 0, CFE_MISSION_ES_DEFAULT_CRC);
+
+                CFE_TBL_Global.ValidationResults[ValIndex].CrcOfTable   = CrcOfTable;
+                CFE_TBL_Global.ValidationResults[ValIndex].ActiveBuffer = (CmdPtr->ActiveTableFlag != 0);
+
+                /* If owner has a validation function, then notify the  */
+                /* table owner that there is data to be validated       */
+                if (RegRecPtr->ValidationFuncPtr != NULL)
+                {
+                    if (CmdPtr->ActiveTableFlag)
+                    {
+                        RegRecPtr->ValidateActiveIndex = ValIndex;
+                    }
+                    else
+                    {
+                        RegRecPtr->ValidateInactiveIndex = ValIndex;
+                    }
+
+                    /* If application requested notification by message, then do so */
+                    if (CFE_TBL_SendNotificationMsg(RegRecPtr) == CFE_SUCCESS)
+                    {
+                        /* Notify ground that validation request has been made */
+                        CFE_EVS_SendEvent(CFE_TBL_VAL_REQ_MADE_INF_EID, CFE_EVS_EventType_DEBUG,
+                                          "Tbl Services issued validation request for '%s'", TableName);
+                    }
+
+                    /* Maintain statistic on number of validation requests given to applications */
+                    CFE_TBL_Global.NumValRequests++;
+                }
+                else
+                {
+                    /* If there isn't a validation function pointer, then the process is complete  */
+                    /* By setting this value, we are letting the Housekeeping process recognize it */
+                    /* as data to be sent to the ground in telemetry.                              */
+                    CFE_TBL_Global.ValidationResults[ValIndex].State = CFE_TBL_VALIDATION_PERFORMED;
+
+                    CFE_EVS_SendEvent(CFE_TBL_ASSUMED_VALID_INF_EID, CFE_EVS_EventType_INFORMATION,
+                                      "Tbl Services assumes '%s' is valid. No Validation Function has been registered",
+                                      TableName);
+                }
+
+                /* Increment Successful Command Counter */
+                ReturnCode = CFE_TBL_INC_CMD_CTR;
+            }
+            else
+            {
+                CFE_EVS_SendEvent(CFE_TBL_TOO_MANY_VALIDATIONS_ERR_EID, CFE_EVS_EventType_ERROR,
+                                  "Too many Table Validations have been requested");
+            }
+        }
+    }
+    else /* Table could not be found in Registry */
+    {
+        CFE_EVS_SendEvent(CFE_TBL_NO_SUCH_TABLE_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Unable to locate '%s' in Table Registry", TableName);
+    }
+
+    return ReturnCode;
+
+} /* End of CFE_TBL_ValidateCmd() */
+
+/*******************************************************************
+**
+** CFE_TBL_ActivateCmd() -- Process Activate Table Command Message
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
+********************************************************************/
+
+int32 CFE_TBL_ActivateCmd(const CFE_TBL_ActivateCmd_t *data)
+{
+    CFE_TBL_CmdProcRet_t                 ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
+    int16                                RegIndex;
+    const CFE_TBL_ActivateCmd_Payload_t *CmdPtr = &data->Payload;
+    char                                 TableName[CFE_TBL_MAX_FULL_NAME_LEN];
+    CFE_TBL_RegistryRec_t *              RegRecPtr;
+    bool                                 ValidationStatus;
+
+    /* Make sure all strings are null terminated before attempting to process them */
+    CFE_SB_MessageStringGet(TableName, (char *)CmdPtr->TableName, NULL, sizeof(TableName), sizeof(CmdPtr->TableName));
+
+    /* Before doing anything, lets make sure the table that is to be dumped exists */
+    RegIndex = CFE_TBL_FindTableInRegistry(TableName);
+
+    if (RegIndex != CFE_TBL_NOT_FOUND)
+    {
+        /* Obtain a pointer to registry information about specified table */
+        RegRecPtr = &CFE_TBL_Global.Registry[RegIndex];
+
+        if (RegRecPtr->DumpOnly)
+        {
+            CFE_EVS_SendEvent(CFE_TBL_ACTIVATE_DUMP_ONLY_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Illegal attempt to activate dump-only table '%s'", TableName);
+        }
+        else if (RegRecPtr->LoadInProgress != CFE_TBL_NO_LOAD_IN_PROGRESS)
+        {
+            /* Determine if the inactive buffer has been successfully validated or not */
+            if (RegRecPtr->DoubleBuffered)
+            {
+                ValidationStatus = RegRecPtr->Buffers[(1U - RegRecPtr->ActiveBufferIndex)].Validated;
+            }
+            else
+            {
+                ValidationStatus = CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].Validated;
+            }
+
+            if (ValidationStatus == true)
+            {
+                CFE_TBL_Global.Registry[RegIndex].LoadPending = true;
+
+                /* If application requested notification by message, then do so */
+                if (CFE_TBL_SendNotificationMsg(RegRecPtr) == CFE_SUCCESS)
+                {
+                    CFE_EVS_SendEvent(CFE_TBL_LOAD_PEND_REQ_INF_EID, CFE_EVS_EventType_DEBUG,
+                                      "Tbl Services notifying App that '%s' has a load pending", TableName);
+                }
+
+                /* Increment Successful Command Counter */
+                ReturnCode = CFE_TBL_INC_CMD_CTR;
+            }
+            else
+            {
+                CFE_EVS_SendEvent(CFE_TBL_UNVALIDATED_ERR_EID, CFE_EVS_EventType_ERROR,
+                                  "Cannot activate table '%s'. Inactive image not Validated", TableName);
+            }
+        }
+        else
+        {
+            CFE_EVS_SendEvent(CFE_TBL_ACTIVATE_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Cannot activate table '%s'. No Inactive image available", TableName);
+        }
+    }
+    else /* Table could not be found in Registry */
+    {
+        CFE_EVS_SendEvent(CFE_TBL_NO_SUCH_TABLE_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Unable to locate '%s' in Table Registry", TableName);
+    }
+
+    return ReturnCode;
+
+} /* End of CFE_TBL_ActivateCmd() */
+
+/*******************************************************************
+**
+** CFE_TBL_DumpRegistryGetter() -- Helper function for dumping table registry
+**
+********************************************************************/
+
+bool CFE_TBL_DumpRegistryGetter(void *Meta, uint32 RecordNum, void **Buffer, size_t *BufSize)
+{
+    CFE_TBL_RegDumpStateInfo_t *StatePtr = (CFE_TBL_RegDumpStateInfo_t *)Meta;
+    CFE_TBL_RegistryRec_t *     RegRecPtr;
+    CFE_TBL_Handle_t            HandleIterator;
+    CFE_ES_AppId_t              OwnerAppId;
+    bool                        IsValidEntry;
+
+    IsValidEntry = false;
+    OwnerAppId   = CFE_ES_APPID_UNDEFINED;
+
+    if (RecordNum < CFE_PLATFORM_TBL_MAX_NUM_TABLES)
+    {
+        /* Make a pointer to simplify code look and to remove redundant indexing into registry */
+        RegRecPtr = &CFE_TBL_Global.Registry[RecordNum];
+
+        /* should lock registry while copying out data to ensure its in consistent state */
+        CFE_TBL_LockRegistry();
+
+        /* Check to see if the Registry entry is empty */
+        if (!CFE_RESOURCEID_TEST_EQUAL(RegRecPtr->OwnerAppId, CFE_TBL_NOT_OWNED) ||
+            (RegRecPtr->HeadOfAccessList != CFE_TBL_END_OF_LIST))
+        {
+            IsValidEntry = true;
+            OwnerAppId   = RegRecPtr->OwnerAppId;
+
+            /* Fill Registry Dump Record with relevant information */
+            StatePtr->DumpRecord.Size             = CFE_ES_MEMOFFSET_C(RegRecPtr->Size);
+            StatePtr->DumpRecord.TimeOfLastUpdate = RegRecPtr->TimeOfLastUpdate;
+            StatePtr->DumpRecord.LoadInProgress   = RegRecPtr->LoadInProgress;
+            StatePtr->DumpRecord.ValidationFunc   = (RegRecPtr->ValidationFuncPtr != NULL);
+            StatePtr->DumpRecord.TableLoadedOnce  = RegRecPtr->TableLoadedOnce;
+            StatePtr->DumpRecord.LoadPending      = RegRecPtr->LoadPending;
+            StatePtr->DumpRecord.DumpOnly         = RegRecPtr->DumpOnly;
+            StatePtr->DumpRecord.DoubleBuffered   = RegRecPtr->DoubleBuffered;
+            StatePtr->DumpRecord.FileCreateTimeSecs =
+                RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].FileCreateTimeSecs;
+            StatePtr->DumpRecord.FileCreateTimeSubSecs =
+                RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].FileCreateTimeSubSecs;
+            StatePtr->DumpRecord.Crc           = RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].Crc;
+            StatePtr->DumpRecord.CriticalTable = RegRecPtr->CriticalTable;
+
+            /* Convert LoadInProgress flag into more meaningful information */
+            /* When a load is in progress, identify which buffer is being used as the inactive buffer */
+            if (StatePtr->DumpRecord.LoadInProgress != CFE_TBL_NO_LOAD_IN_PROGRESS)
+            {
+                if (StatePtr->DumpRecord.DoubleBuffered)
+                {
+                    /* For double buffered tables, the value of LoadInProgress, when a load is actually in progress, */
+                    /* should identify either buffer #0 or buffer #1.  Convert these to enumerated value for ground  */
+                    /* display.  LoadInProgress = -2 means Buffer #1, LoadInProgress = -3 means Buffer #0.           */
+                    StatePtr->DumpRecord.LoadInProgress = StatePtr->DumpRecord.LoadInProgress - 3;
+                }
+                /* For single buffered tables, the value of LoadInProgress, when a load is actually in progress,     */
+                /* indicates which shared buffer is allocated for the inactive buffer.  Since the number of inactive */
+                /* buffers is a platform configuration parameter, then 0 on up merely identifies the buffer number.  */
+                /* No translation is necessary for single buffered tables.                                           */
+            }
+
+            strncpy(StatePtr->DumpRecord.Name, RegRecPtr->Name, sizeof(StatePtr->DumpRecord.Name) - 1);
+            StatePtr->DumpRecord.Name[sizeof(StatePtr->DumpRecord.Name) - 1] = 0;
+
+            strncpy(StatePtr->DumpRecord.LastFileLoaded, RegRecPtr->LastFileLoaded,
+                    sizeof(StatePtr->DumpRecord.LastFileLoaded) - 1);
+            StatePtr->DumpRecord.LastFileLoaded[sizeof(StatePtr->DumpRecord.LastFileLoaded) - 1] = 0;
+
+            /* Walk the access descriptor list to determine the number of users */
+            StatePtr->DumpRecord.NumUsers = 0;
+            HandleIterator                = RegRecPtr->HeadOfAccessList;
+            while (HandleIterator != CFE_TBL_END_OF_LIST)
+            {
+                StatePtr->DumpRecord.NumUsers++;
+                HandleIterator = CFE_TBL_Global.Handles[HandleIterator].NextLink;
+            }
+        }
+
+        /* Unlock now - remainder of data gathering uses ES */
+        CFE_TBL_UnlockRegistry();
+    }
+
+    /*
+     * If table record had data, then export now.
+     * Need to also get the App name from ES to complete the record.
+     */
+    if (IsValidEntry)
+    {
+        /* Determine the name of the owning application */
+        if (!CFE_RESOURCEID_TEST_EQUAL(OwnerAppId, CFE_TBL_NOT_OWNED))
+        {
+            CFE_ES_GetAppName(StatePtr->DumpRecord.OwnerAppName, OwnerAppId, sizeof(StatePtr->DumpRecord.OwnerAppName));
+        }
+        else
+        {
+            strncpy(StatePtr->DumpRecord.OwnerAppName, "--UNOWNED--", sizeof(StatePtr->DumpRecord.OwnerAppName) - 1);
+            StatePtr->DumpRecord.OwnerAppName[sizeof(StatePtr->DumpRecord.OwnerAppName) - 1] = 0;
+        }
+
+        /* export data to caller */
+        *Buffer  = &StatePtr->DumpRecord;
+        *BufSize = sizeof(StatePtr->DumpRecord);
+    }
+    else
+    {
+        /* No data to write for this record */
+        *BufSize = 0;
+        *Buffer  = NULL;
+    }
+
+    /* Check for EOF (last entry) */
+    return (RecordNum >= (CFE_PLATFORM_TBL_MAX_NUM_TABLES - 1));
+}
+
+/*******************************************************************
+**
+** CFE_TBL_DumpRegistryEventHandler() -- Helper function for dumping table registry
+**
+********************************************************************/
+
+void CFE_TBL_DumpRegistryEventHandler(void *Meta, CFE_FS_FileWriteEvent_t Event, int32 Status, uint32 RecordNum,
+                                      size_t BlockSize, size_t Position)
+{
+    CFE_TBL_RegDumpStateInfo_t *StatePtr = (CFE_TBL_RegDumpStateInfo_t *)Meta;
+
+    /*
+     * Note that this runs in the context of ES background task (file writer background job)
+     * It does NOT run in the context of the CFE_TBL app task.
+     *
+     * Events should use CFE_EVS_SendEventWithAppID() rather than CFE_EVS_SendEvent()
+     * to get proper association with TBL task.
+     */
+    switch (Event)
+    {
+        case CFE_FS_FileWriteEvent_COMPLETE:
+            if (StatePtr->FileExisted)
+            {
+                CFE_EVS_SendEventWithAppID(CFE_TBL_OVERWRITE_REG_DUMP_INF_EID, CFE_EVS_EventType_DEBUG,
+                                           CFE_TBL_Global.TableTaskAppId,
+                                           "Successfully overwrote '%s' with Table Registry:Size=%d,Entries=%d",
+                                           StatePtr->FileWrite.FileName, (int)Position, (int)RecordNum);
+            }
+            else
+            {
+                CFE_EVS_SendEventWithAppID(CFE_TBL_WRITE_REG_DUMP_INF_EID, CFE_EVS_EventType_DEBUG,
+                                           CFE_TBL_Global.TableTaskAppId,
+                                           "Successfully dumped Table Registry to '%s':Size=%d,Entries=%d",
+                                           StatePtr->FileWrite.FileName, (int)Position, (int)RecordNum);
+            }
+            break;
+
+        case CFE_FS_FileWriteEvent_RECORD_WRITE_ERROR:
+            CFE_EVS_SendEventWithAppID(CFE_TBL_WRITE_TBL_REG_ERR_EID, CFE_EVS_EventType_ERROR,
+                                       CFE_TBL_Global.TableTaskAppId, "Error writing Registry to '%s', Status=0x%08X",
+                                       StatePtr->FileWrite.FileName, (unsigned int)Status);
+            break;
+
+        case CFE_FS_FileWriteEvent_HEADER_WRITE_ERROR:
+            CFE_EVS_SendEventWithAppID(CFE_TBL_WRITE_CFE_HDR_ERR_EID, CFE_EVS_EventType_ERROR,
+                                       CFE_TBL_Global.TableTaskAppId,
+                                       "Error writing cFE File Header to '%s', Status=0x%08X",
+                                       StatePtr->FileWrite.FileName, (unsigned int)Status);
+            break;
+
+        case CFE_FS_FileWriteEvent_CREATE_ERROR:
+            CFE_EVS_SendEventWithAppID(CFE_TBL_CREATING_DUMP_FILE_ERR_EID, CFE_EVS_EventType_ERROR,
+                                       CFE_TBL_Global.TableTaskAppId, "Error creating dump file '%s', Status=0x%08X",
+                                       StatePtr->FileWrite.FileName, (unsigned int)Status);
+            break;
+
+        default:
+            /* unhandled event - ignore */
+            break;
+    }
+}
+
+/*******************************************************************
+**
+** CFE_TBL_DumpRegistryCmd() -- Process Dump Table Registry to file Command Message
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
+********************************************************************/
+
+int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data)
+{
+    CFE_TBL_CmdProcRet_t                     ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
+    int32                                    Status;
+    const CFE_TBL_DumpRegistryCmd_Payload_t *CmdPtr = &data->Payload;
+    os_fstat_t                               FileStat;
+
+    CFE_TBL_RegDumpStateInfo_t *StatePtr;
+
+    StatePtr = &CFE_TBL_Global.RegDumpState;
+
+    /* If a reg dump was already pending, do not overwrite the current request */
+    if (!CFE_FS_BackgroundFileDumpIsPending(&StatePtr->FileWrite))
+    {
+        /*
+         * Fill out the remainder of meta data.
+         * This data is currently the same for every request
+         */
+        StatePtr->FileWrite.FileSubType = CFE_FS_SubType_TBL_REG;
+        snprintf(StatePtr->FileWrite.Description, sizeof(StatePtr->FileWrite.Description), "Table Registry");
+
+        StatePtr->FileWrite.GetData = CFE_TBL_DumpRegistryGetter;
+        StatePtr->FileWrite.OnEvent = CFE_TBL_DumpRegistryEventHandler;
+
+        /*
+        ** Copy the filename into local buffer with default name/path/extension if not specified
+        */
+        Status = CFE_FS_ParseInputFileNameEx(StatePtr->FileWrite.FileName, CmdPtr->DumpFilename,
+                                             sizeof(StatePtr->FileWrite.FileName), sizeof(CmdPtr->DumpFilename),
+                                             CFE_PLATFORM_TBL_DEFAULT_REG_DUMP_FILE,
+                                             CFE_FS_GetDefaultMountPoint(CFE_FS_FileCategory_BINARY_DATA_DUMP),
+                                             CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_BINARY_DATA_DUMP));
+
+        if (Status == CFE_SUCCESS)
+        {
+            /*
+             * Before submitting the background request, use OS_stat() to check if the file exists already.
+             *
+             * This is because TBL services issued a different event ID in some cases if
+             * it is overwriting a file vs. creating a new file.
+             */
+            StatePtr->FileExisted = (OS_stat(StatePtr->FileWrite.FileName, &FileStat) == OS_SUCCESS);
+
+            Status = CFE_FS_BackgroundFileDumpRequest(&StatePtr->FileWrite);
+            if (Status == CFE_SUCCESS)
+            {
+                /* Increment the TBL generic command counter (successfully queued for background job) */
+                ReturnCode = CFE_TBL_INC_CMD_CTR;
+            }
+        }
+    }
+
+    return ReturnCode;
+
+} /* End of CFE_TBL_DumpRegistryCmd() */
+
+/*******************************************************************
+**
+** CFE_TBL_SendRegistryCmd() -- Process Telemeter Table Registry Entry Command Message
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
+********************************************************************/
+
+int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data)
+{
+    CFE_TBL_CmdProcRet_t                     ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
+    int16                                    RegIndex;
+    const CFE_TBL_SendRegistryCmd_Payload_t *CmdPtr = &data->Payload;
+    char                                     TableName[CFE_TBL_MAX_FULL_NAME_LEN];
+
+    /* Make sure all strings are null terminated before attempting to process them */
+    CFE_SB_MessageStringGet(TableName, (char *)CmdPtr->TableName, NULL, sizeof(TableName), sizeof(CmdPtr->TableName));
+
+    /* Before doing anything, lets make sure the table registry entry that is to be telemetered exists */
+    RegIndex = CFE_TBL_FindTableInRegistry(TableName);
+
+    if (RegIndex != CFE_TBL_NOT_FOUND)
+    {
+        /* Change the index used to identify what data is to be telemetered */
+        CFE_TBL_Global.HkTlmTblRegIndex = RegIndex;
+
+        CFE_EVS_SendEvent(CFE_TBL_TLM_REG_CMD_INF_EID, CFE_EVS_EventType_DEBUG,
+                          "Table Registry entry for '%s' will be telemetered", TableName);
+
+        /* Increment Successful Command Counter */
+        ReturnCode = CFE_TBL_INC_CMD_CTR;
+    }
+    else /* Table could not be found in Registry */
+    {
+        CFE_EVS_SendEvent(CFE_TBL_NO_SUCH_TABLE_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Unable to locate '%s' in Table Registry", TableName);
+    }
+
+    return ReturnCode;
+
+} /* End of CFE_TBL_SendRegistryCmd() */
+
+/*******************************************************************
+**
+** CFE_TBL_DeleteCDSCmd() -- Process Delete Critical Table's CDS Command Message
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
+********************************************************************/
+
+int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data)
+{
+    CFE_TBL_CmdProcRet_t               ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
+    const CFE_TBL_DelCDSCmd_Payload_t *CmdPtr     = &data->Payload;
+    char                               TableName[CFE_TBL_MAX_FULL_NAME_LEN];
+    CFE_TBL_CritRegRec_t *             CritRegRecPtr = NULL;
+    uint32                             i;
+    int16                              RegIndex;
+    int32                              Status;
+
+    /* Make sure all strings are null terminated before attempting to process them */
+    CFE_SB_MessageStringGet(TableName, (char *)CmdPtr->TableName, NULL, sizeof(TableName), sizeof(CmdPtr->TableName));
+
+    /* Before doing anything, lets make sure the table is no longer in the registry */
+    /* This would imply that the owning application has been terminated and that it */
+    /* is safe to delete the associated critical table image in the CDS. */
+    RegIndex = CFE_TBL_FindTableInRegistry(TableName);
+
+    if (RegIndex == CFE_TBL_NOT_FOUND)
+    {
+        /* Find table in the Critical Table Registry */
+        for (i = 0; i < CFE_PLATFORM_TBL_MAX_CRITICAL_TABLES; i++)
+        {
+            if (strncmp(CFE_TBL_Global.CritReg[i].Name, TableName, CFE_TBL_MAX_FULL_NAME_LEN) == 0)
+            {
+                CritRegRecPtr = &CFE_TBL_Global.CritReg[i];
+                break;
+            }
+        }
+
+        if (CritRegRecPtr != NULL)
+        {
+            Status = CFE_ES_DeleteCDS(TableName, true);
+
+            if (Status == CFE_ES_CDS_WRONG_TYPE_ERR)
+            {
+                CFE_EVS_SendEvent(CFE_TBL_NOT_CRITICAL_TBL_ERR_EID, CFE_EVS_EventType_ERROR,
+                                  "Table '%s' is in Critical Table Registry but CDS is not tagged as a table",
+                                  TableName);
+            }
+            else if (Status == CFE_ES_CDS_OWNER_ACTIVE_ERR)
+            {
+                CFE_EVS_SendEvent(CFE_TBL_CDS_OWNER_ACTIVE_ERR_EID, CFE_EVS_EventType_ERROR,
+                                  "CDS '%s' owning app is still active", TableName);
+            }
+            else if (Status == CFE_ES_ERR_NAME_NOT_FOUND)
+            {
+                CFE_EVS_SendEvent(CFE_TBL_CDS_NOT_FOUND_ERR_EID, CFE_EVS_EventType_ERROR,
+                                  "Unable to locate '%s' in CDS Registry", TableName);
+            }
+            else if (Status != CFE_SUCCESS)
+            {
+                CFE_EVS_SendEvent(CFE_TBL_CDS_DELETE_ERR_EID, CFE_EVS_EventType_ERROR,
+                                  "Error while deleting '%s' from CDS, See SysLog.(Err=0x%08X)", TableName,
+                                  (unsigned int)Status);
+            }
+            else
+            {
+                CFE_EVS_SendEvent(CFE_TBL_CDS_DELETED_INFO_EID, CFE_EVS_EventType_INFORMATION,
+                                  "Successfully removed '%s' from CDS", TableName);
+
+                /* Free the entry in the Critical Table Registry */
+                CritRegRecPtr->CDSHandle = CFE_ES_CDS_BAD_HANDLE;
+
+                /* Increment Successful Command Counter */
+                ReturnCode = CFE_TBL_INC_CMD_CTR;
+            }
+        }
+        else
+        {
+            CFE_EVS_SendEvent(CFE_TBL_NOT_IN_CRIT_REG_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Table '%s' is not found in Critical Table Registry", TableName);
+        }
+    }
+    else /* Table was found in Registry */
+    {
+        CFE_EVS_SendEvent(CFE_TBL_IN_REGISTRY_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "'%s' found in Table Registry. CDS cannot be deleted until table is unregistered", TableName);
+    }
+    return ReturnCode;
+
+} /* End of CFE_TBL_DeleteCDSCmd() */
+
+/*******************************************************************
+**
+** CFE_TBL_AbortLoadCmd() -- Process Abort Load Command Message
+**
+** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
+********************************************************************/
+
+int32 CFE_TBL_AbortLoadCmd(const CFE_TBL_AbortLoadCmd_t *data)
+{
+    CFE_TBL_CmdProcRet_t                  ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
+    int16                                 RegIndex;
+    const CFE_TBL_AbortLoadCmd_Payload_t *CmdPtr = &data->Payload;
+    CFE_TBL_RegistryRec_t *               RegRecPtr;
+    char                                  TableName[CFE_TBL_MAX_FULL_NAME_LEN];
+
+    /* Make sure all strings are null terminated before attempting to process them */
+    CFE_SB_MessageStringGet(TableName, (char *)CmdPtr->TableName, NULL, sizeof(TableName), sizeof(CmdPtr->TableName));
+
+    /* Before doing anything, lets make sure the table registry entry that is to be telemetered exists */
+    RegIndex = CFE_TBL_FindTableInRegistry(TableName);
+
+    if (RegIndex != CFE_TBL_NOT_FOUND)
+    {
+        /* Make a pointer to simplify code look and to remove redundant indexing into registry */
+        RegRecPtr = &CFE_TBL_Global.Registry[RegIndex];
+
+        /* Check to make sure a load was in progress before trying to abort it */
+        /* NOTE: LoadInProgress contains index of buffer when dumping a dump-only table */
+        /* so we must ensure the table is not a dump-only table, otherwise, we would be aborting a dump */
+        if ((RegRecPtr->LoadInProgress != CFE_TBL_NO_LOAD_IN_PROGRESS) && (!RegRecPtr->DumpOnly))
+        {
+            CFE_TBL_AbortLoad(RegRecPtr);
+
+            /* Increment Successful Command Counter */
+            ReturnCode = CFE_TBL_INC_CMD_CTR;
+        }
+        else
+        {
+            CFE_EVS_SendEvent(CFE_TBL_LOAD_ABORT_ERR_EID, CFE_EVS_EventType_ERROR,
+                              "Cannot abort load of '%s'. No load started.", TableName);
+        }
+    }
+    else /* Table could not be found in Registry */
+    {
+        CFE_EVS_SendEvent(CFE_TBL_NO_SUCH_TABLE_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Unable to locate '%s' in Table Registry", TableName);
+    }
+
+    return ReturnCode;
+
+} /* End of CFE_TBL_AbortLoadCmd() */
+
+/*******************************************************************
+**
+** CFE_TBL_AbortLoad() -- Abort load, free buffers, issue event message
+**
+** NOTE: For complete prolog information, see above
+********************************************************************/
+
+void CFE_TBL_AbortLoad(CFE_TBL_RegistryRec_t *RegRecPtr)
+{
+    /* The ground has aborted the load, free the working buffer for another attempt */
+    if (!RegRecPtr->DoubleBuffered)
+    {
+        /* For single buffered tables, freeing shared buffer entails resetting flag */
+        CFE_TBL_Global.LoadBuffs[RegRecPtr->LoadInProgress].Taken = false;
+    }
+
+    /* For double buffered tables, freeing buffer is simple */
+    RegRecPtr->LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
+
+    /* Make sure the load was not already pending */
+    RegRecPtr->LoadPending = false;
+
+    CFE_EVS_SendEvent(CFE_TBL_LOAD_ABORT_INF_EID, CFE_EVS_EventType_INFORMATION, "Table Load Aborted for '%s'",
+                      RegRecPtr->Name);
+} /* End of CFE_TBL_AbortLoad() */
+
+/************************/
+/*  End of File Comment */
+/************************/

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.h
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.h
@@ -1,0 +1,355 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * @file
+ *
+ * Subsystem: cFE TBL Task Command Handler Interface Definition File
+ *
+ * Author: David Kobe (the Hammers Company, Inc.)
+ *
+ * Notes:
+ *
+ */
+
+#ifndef CFE_TBL_TASK_CMDS_H
+#define CFE_TBL_TASK_CMDS_H
+
+/*
+** Required header files
+*/
+#include "common_types.h"
+#include "cfe_tbl_task.h"
+#include "cfe_tbl_msg.h"
+#include "cfe_error.h"
+
+#include "cfe_sb_extern_typedefs.h"
+
+/*********************  Macro and Constant Type Definitions   ***************************/
+
+/*
+ * For backward compatibility, keep this enumeration for now but map the
+ * values to the globally-defined codes in cfe_error.h, so it won't be confusing
+ * if intermixed with a typical CFE int32 return code.
+ */
+typedef enum
+{
+    CFE_TBL_INC_ERR_CTR =
+        CFE_TBL_MESSAGE_ERROR, /**< Error detected in (or while processing) message, increment command error counter */
+    CFE_TBL_DONT_INC_CTR =
+        CFE_STATUS_NO_COUNTER_INCREMENT, /**< No errors detected but don't increment command counter */
+    CFE_TBL_INC_CMD_CTR = CFE_SUCCESS    /**< No errors detected and increment command counter */
+} CFE_TBL_CmdProcRet_t;
+
+typedef int32 (*CFE_TBL_MsgProcFuncPtr_t)(const void *MsgPtr);
+
+#define CFE_TBL_BAD_CMD_CODE (-1) /**< Command Code found in Message does not match any in #CFE_TBL_CmdHandlerTbl */
+#define CFE_TBL_BAD_MSG_ID   (-2) /**< Message ID found in Message does not match any in #CFE_TBL_CmdHandlerTbl */
+
+/*
+** Table task const data
+*/
+
+typedef enum
+{
+    CFE_TBL_TERM_MSGTYPE = 0, /**< \brief Command Handler Table Terminator Type */
+    CFE_TBL_MSG_MSGTYPE,      /**< \brief Message Type (requires Message ID match) */
+    CFE_TBL_CMD_MSGTYPE       /**< \brief Command Type (requires Message ID and Command Code match) */
+} CFE_TBL_MsgType_t;
+
+/**
+** Data structure of a single record in #CFE_TBL_CmdHandlerTbl
+*/
+typedef struct
+{
+    CFE_SB_MsgId_t           MsgId;          /**< \brief Acceptable Message ID */
+    CFE_MSG_FcnCode_t        CmdCode;        /**< \brief Acceptable Command Code (if necessary) */
+    size_t                   ExpectedLength; /**< \brief Expected Message Length (in bytes) including message header */
+    CFE_TBL_MsgProcFuncPtr_t MsgProcFuncPtr; /**< \brief Pointer to function to handle message  */
+    CFE_TBL_MsgType_t        MsgTypes;       /**< \brief Message Type (i.e. - with/without Cmd Code)   */
+} CFE_TBL_CmdHandlerTblRec_t;
+
+/* Command Message Processing Functions */
+/*****************************************************************************/
+/**
+** \brief Gathers data and puts it into the Housekeeping Message format
+**
+** \par Description
+**        Gathers data from the Table Services Application, computes necessary data values and identifies
+**        what Table Validation information needs to be reported in Housekeeping Telemetry.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+******************************************************************************/
+extern void CFE_TBL_GetHkData(void);
+
+/*****************************************************************************/
+/**
+** \brief Convert Table Registry Entry for a Table into a Message
+**
+** \par Description
+**        Extracts the Table Registry information for the table specified by the
+**        #CFE_TBL_Global_t::HkTlmTblRegIndex variable.  It then formats the
+**        Registry contents into a format appropriate for downlink.
+**
+** \par Assumptions, External Events, and Notes:
+**        #CFE_TBL_Global_t::HkTlmTblRegIndex is assumed to be a valid index into
+**           the Table Registry.
+**
+******************************************************************************/
+extern void CFE_TBL_GetTblRegData(void);
+
+/*****************************************************************************/
+/**
+** \brief Process Housekeeping Request Message
+**
+** \par Description
+**        Constructs a Housekeeping Packet (#CFE_TBL_HousekeepingTlm_t) from task data and sends it out
+**
+** \par Assumptions, External Events, and Notes:
+**          The message pointed to by data has been identified as a Housekeeping Request Message
+**
+** \param[in] data points to the message received via command pipe that needs processing
+**
+** \retval #CFE_TBL_DONT_INC_CTR \copydoc CFE_TBL_DONT_INC_CTR
+******************************************************************************/
+int32 CFE_TBL_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data);
+
+/*****************************************************************************/
+/**
+** \brief Process NO OP Command Message
+**
+** \par Description
+**        Responds to the NOOP command by issuing an Event Message
+**
+** \par Assumptions, External Events, and Notes:
+**          The message pointed to by data has been identified as a NO OP Command Message
+**
+** \param[in] data points to the message received via command pipe that needs processing
+**
+** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
+** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
+******************************************************************************/
+int32 CFE_TBL_NoopCmd(const CFE_TBL_NoopCmd_t *data);
+
+/*****************************************************************************/
+/**
+** \brief Process Reset Counters Command Message
+**
+** \par Description
+**        Resets command counters and validation request counters
+**
+** \par Assumptions, External Events, and Notes:
+**          The message pointed to by data has been identified as a Reset Counters Command Message
+**
+** \param[in] data points to the message received via command pipe that needs processing
+**
+** \retval #CFE_TBL_DONT_INC_CTR \copydoc CFE_TBL_DONT_INC_CTR
+******************************************************************************/
+int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCountersCmd_t *data);
+
+/*****************************************************************************/
+/**
+** \brief Process Load Table Command Message
+**
+** \par Description
+**        Locates the file specified in the command message and loads the contents of the file into
+**        a buffer that is associated with the table specified within the file header.
+**
+** \par Assumptions, External Events, and Notes:
+**          The message pointed to by data has been identified as a Load Table Command Message
+**
+** \param[in] data points to the message received via command pipe that needs processing
+**
+** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
+** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
+******************************************************************************/
+int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data);
+
+/*****************************************************************************/
+/**
+** \brief Process Dump Table Command Message
+**
+** \par Description
+**        Locates the memory associated with the table identified in the command message and copies
+**        the data contents to the command message specified file.
+**
+** \par Assumptions, External Events, and Notes:
+**          The message pointed to by data has been identified as a Dump Table Command Message
+**
+** \param[in] data points to the message received via command pipe that needs processing
+**
+** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
+** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
+******************************************************************************/
+int32 CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data);
+
+/*****************************************************************************/
+/**
+** \brief Process Validate Table Command Message
+**
+** \par Description
+**        Computes a Data Integrity Check Value for the command message specified table and notifies
+**        the table's parent Application, if it has an associated validation function, that a validation
+**        of the buffer's contents is required.
+**
+** \par Assumptions, External Events, and Notes:
+**          The message pointed to by data has been identified as a Validate Table Command Message
+**
+** \param[in] data points to the message received via command pipe that needs processing
+**
+** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
+** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
+******************************************************************************/
+int32 CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data);
+
+/*****************************************************************************/
+/**
+** \brief Process Activate Table Command Message
+**
+** \par Description
+**        Notifies the table's owner Application that a new version of the table is pending and should
+**        be used.
+**
+** \par Assumptions, External Events, and Notes:
+**          The message pointed to by data has been identified as an Activate Table Command Message
+**
+** \param[in] data points to the message received via command pipe that needs processing
+**
+** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
+** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
+******************************************************************************/
+int32 CFE_TBL_ActivateCmd(const CFE_TBL_ActivateCmd_t *data);
+
+/*****************************************************************************/
+/**
+** \brief Process Dump Table Registry Command Message
+**
+** \par Description
+**        Copies the contents of the Table Registry to a command message specified file.
+**
+** \par Assumptions, External Events, and Notes:
+**          The message pointed to by data has been identified as a Dump Table Registry Command Message
+**
+** \param[in] data points to the message received via command pipe that needs processing
+**
+** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
+** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
+******************************************************************************/
+int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data);
+
+/*****************************************************************************/
+/**
+** \brief Process Telemeter Table Registry Entry Command Message
+**
+** \par Description
+**        Extracts the Table Registry information for a command message specified table and puts it into
+**        a message that is sent out.
+**
+** \par Assumptions, External Events, and Notes:
+**          The message pointed to by data has been identified as a Telemeter Table Registry Entry Command Message
+**
+** \param[in] data points to the message received via command pipe that needs processing
+**
+** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
+** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
+******************************************************************************/
+int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data);
+
+/*****************************************************************************/
+/**
+** \brief Delete Critical Table's CDS Command message
+**
+** \par Description
+**        Deletes a Critical Data Store used to hold a Critical Table's image
+**
+** \par Assumptions, External Events, and Notes:
+**          The message pointed to by data has been identified as a Delete CDS Command Message
+**
+** \param[in] data points to the message received via command pipe that needs processing
+**
+** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
+** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
+******************************************************************************/
+int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data);
+
+/*****************************************************************************/
+/**
+** \brief Process Abort Load Command message
+**
+** \par Description
+**        Frees any resources associated with a previously loaded table.
+**
+** \par Assumptions, External Events, and Notes:
+**          The message pointed to by data has been identified as an Abort Load Command Message
+**
+** \param[in] data points to the message received via command pipe that needs processing
+**
+** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
+** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
+******************************************************************************/
+int32 CFE_TBL_AbortLoadCmd(const CFE_TBL_AbortLoadCmd_t *data);
+
+/*****************************************************************************/
+/**
+** \brief Output block of data to file with standard cFE Table Image Headers
+**
+** \par Description
+**        Writes the specified block of data in memory to the specified file
+**        with the standard cFE File and cFE Table Image Headers.
+**
+** \par Assumptions, External Events, and Notes:
+**          None
+**
+** \param[in] DumpFilename    Character string containing the full path of the file
+**                            to which the contents of the table are to be written
+**
+** \param[in] TableName       Name of table being dumped to a file
+**
+** \param[in] DumpDataAddr    Address of data buffer whose contents are to be written
+**                            to the specified file
+**
+** \param[in] TblSizeInBytes  Size of block of data to be written to the file
+**
+** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
+** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
+******************************************************************************/
+extern CFE_TBL_CmdProcRet_t CFE_TBL_DumpToFile(const char *DumpFilename, const char *TableName,
+                                               const void *DumpDataAddr, size_t TblSizeInBytes);
+
+/*****************************************************************************/
+/**
+** \brief Aborts load by freeing associated inactive buffers and sending event message
+**
+** \par Description
+**        This function aborts the load for the table whose registry entry is identified
+**        by the registry record pointer given as an argument.  Aborting the load consists
+**        of freeing any associated inactive buffer and issuing an event message.
+**
+** \par Assumptions, External Events, and Notes:
+**        The given registry record pointer is assumed to be valid.
+**
+** \param[in] RegRecPtr   Pointer to registry record entry for the table whose load is to be aborted
+**
+******************************************************************************/
+void CFE_TBL_AbortLoad(CFE_TBL_RegistryRec_t *RegRecPtr);
+
+#endif /* CFE_TBL_TASK_CMDS_H */

--- a/modules/tbl/fsw/src/cfe_tbl_verify.h
+++ b/modules/tbl/fsw/src/cfe_tbl_verify.h
@@ -1,0 +1,94 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * @file
+ *
+ *  Purpose:
+ *    This header file performs compile time checking for TBL configuration
+ *    parameters.
+ *
+ */
+
+#ifndef CFE_TBL_VERIFY_H
+#define CFE_TBL_VERIFY_H
+
+#include "cfe_platform_cfg.h"
+
+#if (2 * CFE_PLATFORM_TBL_MAX_DBL_TABLE_SIZE) > CFE_PLATFORM_TBL_BUF_MEMORY_BYTES
+#error Two buffers of size CFE_PLATFORM_TBL_MAX_DBL_TABLE_SIZE cannot be greater than memory pool size of CFE_PLATFORM_TBL_BUF_MEMORY_BYTES!
+#endif
+
+#if ((CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS + 1) * CFE_PLATFORM_TBL_MAX_SNGL_TABLE_SIZE) > \
+    CFE_PLATFORM_TBL_BUF_MEMORY_BYTES
+#error Shared buffers and table of size CFE_PLATFORM_TBL_MAX_SNGL_TABLE_SIZE cannot be greater than memory pool size of CFE_PLATFORM_TBL_BUF_MEMORY_BYTES!
+#endif
+
+#if CFE_PLATFORM_TBL_MAX_NUM_HANDLES < CFE_PLATFORM_TBL_MAX_NUM_TABLES
+#error CFE_PLATFORM_TBL_MAX_NUM_HANDLES cannot be set less than CFE_PLATFORM_TBL_MAX_NUM_TABLES!
+#endif
+
+#if CFE_PLATFORM_TBL_MAX_CRITICAL_TABLES > CFE_PLATFORM_ES_CDS_MAX_NUM_ENTRIES
+#error CFE_PLATFORM_TBL_MAX_CRITICAL_TABLES cannot be greater than CFE_PLATFORM_ES_CDS_MAX_NUM_ENTRIES!
+#endif
+
+/*
+** Any modifications to the "_VALID_" limits defined below must match
+** source code changes made to the function CFE_TBL_ReadHeaders() in
+** the file "cfe_tbl_internal.c".
+*/
+#if CFE_PLATFORM_TBL_VALID_SCID_COUNT < 0
+#error CFE_PLATFORM_TBL_VALID_SCID_COUNT must be greater than or equal to zero
+#elif CFE_PLATFORM_TBL_VALID_SCID_COUNT > 2
+#error CFE_PLATFORM_TBL_VALID_SCID_COUNT must be less than or equal to 2
+#endif
+
+#if CFE_PLATFORM_TBL_VALID_PRID_COUNT < 0
+#error CFE_PLATFORM_TBL_VALID_PRID_COUNT must be greater than or equal to zero
+#elif CFE_PLATFORM_TBL_VALID_PRID_COUNT > 4
+#error CFE_PLATFORM_TBL_VALID_PRID_COUNT must be less than or equal to 4
+#endif
+
+/*
+** Validate task stack size...
+*/
+#if CFE_PLATFORM_TBL_START_TASK_STACK_SIZE < 2048
+#error CFE_PLATFORM_TBL_START_TASK_STACK_SIZE must be greater than or equal to 2048
+#endif
+
+/* the following check is removed because some compilers cannot handle the sizeof operator in a #if statement */
+/*
+#if sizeof(CFE_PLATFORM_TBL_DEFAULT_REG_DUMP_FILE) > OS_MAX_PATH_LEN
+    #error The length (including NULL terminator) of CFE_PLATFORM_TBL_DEFAULT_REG_DUMP_FILE cannot be greater than
+OS_MAX_PATH_LEN #endif
+*/
+
+/*
+ * For configuration values that should be multiples of 4
+ * as noted in the documentation, this confirms that they are.
+ */
+#if ((CFE_MISSION_TBL_MAX_NAME_LENGTH % 4) != 0)
+#error CFE_MISSION_TBL_MAX_NAME_LENGTH must be a multiple of 4
+#endif
+#if ((CFE_MISSION_TBL_MAX_FULL_NAME_LEN % 4) != 0)
+#error CFE_MISSION_TBL_MAX_FULL_NAME_LEN must be a multiple of 4
+#endif
+
+#endif /* CFE_TBL_VERIFY_H */

--- a/modules/time/CMakeLists.txt
+++ b/modules/time/CMakeLists.txt
@@ -1,0 +1,33 @@
+##################################################################
+#
+# cFE Time Services (TIME) module CMake build recipe
+#
+##################################################################
+
+project(CFE_TIME C)
+
+# Time Services source files
+set(time_SOURCES
+    fsw/src/cfe_time_api.c
+    fsw/src/cfe_time_task.c
+    fsw/src/cfe_time_tone.c
+    fsw/src/cfe_time_utils.c
+    fsw/src/cfe_time_api.c
+    fsw/src/cfe_time_task.c
+    fsw/src/cfe_time_tone.c
+    fsw/src/cfe_time_utils.c
+)
+add_library(time STATIC ${time_SOURCES})
+
+target_include_directories(time PUBLIC fsw/inc)
+target_link_libraries(time PRIVATE core_private)
+
+# Add unit test coverage subdirectory
+if(ENABLE_UNIT_TESTS)
+    add_subdirectory(ut-coverage)
+endif(ENABLE_UNIT_TESTS)
+
+cfs_app_check_intf(${DEP}
+    cfe_time_events.h
+    cfe_time_msg.h
+)

--- a/modules/time/fsw/inc/cfe_time_events.h
+++ b/modules/time/fsw/inc/cfe_time_events.h
@@ -1,0 +1,622 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * @file
+ *
+ *  Purpose:
+ *	           cFE Time Services (Time) Event IDs
+ *
+ *  Design Notes:
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *
+ */
+
+#ifndef CFE_TIME_EVENTS_H
+#define CFE_TIME_EVENTS_H
+
+/* **************************
+** ****** Maximum EID. ******
+** **************************
+** The EID's below may not necessarily be in order, so it can be difficult to
+** determine what the next EID is to use. When you add EID's, start with MAX_EID + 1
+** and when you're done adding, set this to the highest EID you used. It may
+** be worthwhile to, on occasion, re-number the EID's to put them back in order.
+*/
+#define CFE_TIME_MAX_EID 49
+
+/*
+** Event message ID's...
+*/
+/** \brief <tt> 'cFE TIME Initialized' </tt>
+**  \event <tt> 'cFE TIME Initialized' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is always automatically issued when the Time Services
+**  Task completes its Initialization.
+**/
+#define CFE_TIME_INIT_EID 1 /* start up message "informational" */
+
+/** \brief <tt> 'No-op command' </tt>
+**  \event <tt> 'No-op command' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is always automatically issued in response
+**  to a cFE Time Services \link #CFE_TIME_NOOP_CC NO-OP command \endlink
+**/
+#define CFE_TIME_NOOP_EID 4 /* processed command "informational" */
+
+/** \brief <tt> 'Reset Counters command' </tt>
+**  \event <tt> 'Reset Counters command' </tt>
+**
+**  \par Type: DEBUG
+**
+**  \par Cause:
+**
+**  This event message is always automatically issued in response
+**  to a cFE Time Services \link #CFE_TIME_RESET_COUNTERS_CC Reset Counters command \endlink
+**/
+#define CFE_TIME_RESET_EID 5
+
+/** \brief <tt> 'Request diagnostics command' </tt>
+**  \event <tt> 'Request diagnostics command' </tt>
+**
+**  \par Type: DEBUG
+**
+**  \par Cause:
+**
+**  This event message is always automatically issued in response
+**  to a cFE Time Services \link #CFE_TIME_SEND_DIAGNOSTIC_TLM_CC Request Diagnostics command \endlink
+**/
+#define CFE_TIME_DIAG_EID 6
+
+/** \brief <tt> 'Set Clock State = \%s' </tt>
+**  \event <tt> 'Set Clock State = \%s' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is generated upon successful completion
+**  of a cFE Time Services \link #CFE_TIME_SET_STATE_CC Set Time State command \endlink
+**
+**  The \c '\%s' field will identify whether the command specified
+**  \c VALID, \c INVALID, or \c FLYWHEEL.
+**/
+#define CFE_TIME_STATE_EID 7
+
+/** \brief <tt> 'Set Time Source = \%s' </tt>
+**  \event <tt> 'Set Time Source = \%s' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is generated upon successful completion
+**  of a cFE Time Services \link #CFE_TIME_SET_SOURCE_CC Set Time Source command \endlink
+**
+**  The \c '\%s' field will identify whether the command specified
+**  \c INTERNAL, or \c EXTERNAL.
+**/
+#define CFE_TIME_SOURCE_EID 8
+
+/** \brief <tt> 'Set Tone Source = \%s' </tt>
+**  \event <tt> 'Set Tone Source = \%s' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is generated upon successful completion
+**  of a cFE Time Services \link #CFE_TIME_SET_SIGNAL_CC Set Clock Signal command \endlink
+**
+**  The \c '\%s' field will identify whether the command specified
+**  \c PRIMARY, or \c REDUNDANT.
+**/
+#define CFE_TIME_SIGNAL_EID 9
+
+/** \brief <tt> 'Set Tone Delay -- secs = \%d, usecs = \%d, ssecs = 0x\%X, dir = \%d' </tt>
+**  \event <tt> 'Set Tone Delay -- secs = \%d, usecs = \%d, ssecs = 0x\%X, dir = \%d' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is generated upon successful completion
+**  of either a cFE Time Services
+**  \link #CFE_TIME_ADD_DELAY_CC Add Time Delay \endlink OR a
+**  \link #CFE_TIME_SUB_DELAY_CC Subtract Time Delay command \endlink
+**
+**  The \c secs field specifies the new delay (in seconds), the \c usecs
+**  field specifies the delay in micro-seconds, the \c ssecs field is
+**  the micro-seconds field converted to Spacecraft Time sub-seconds and
+**  the \c dir field identifies the direction of the delay.  The direction
+**  can be either #CFE_TIME_AdjustDirection_ADD or #CFE_TIME_AdjustDirection_SUBTRACT.
+**/
+#define CFE_TIME_DELAY_EID 11
+
+/** \brief <tt> 'Set Time -- secs = \%d, usecs = \%d, ssecs = 0x\%X' </tt>
+**  \event <tt> 'Set Time -- secs = \%d, usecs = \%d, ssecs = 0x\%X' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is generated upon successful completion
+**  of a cFE Time Services \link #CFE_TIME_SET_TIME_CC Set Time command \endlink
+**
+**  The \c secs field specifies the new spacecraft time (in seconds), the \c usecs
+**  field specifies the spacecraft time micro-seconds, the \c ssecs field is
+**  the micro-seconds field converted to Spacecraft Time sub-seconds
+**/
+#define CFE_TIME_TIME_EID 12
+
+/** \brief <tt> 'Set MET -- secs = \%d, usecs = \%d, ssecs = 0x\%X' </tt>
+**  \event <tt> 'Set MET -- secs = \%d, usecs = \%d, ssecs = 0x\%X' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is generated upon successful completion
+**  of a cFE Time Services \link #CFE_TIME_SET_MET_CC Set Mission Elapsed Time command \endlink
+**
+**  The \c secs field specifies the new MET (in seconds), the \c usecs
+**  field specifies the MET micro-seconds, the \c ssecs field is
+**  the micro-seconds field converted to Spacecraft Time sub-seconds
+**/
+#define CFE_TIME_MET_EID 13
+
+/** \brief <tt> 'Set STCF -- secs = \%d, usecs = \%d, ssecs = 0x\%X' </tt>
+**  \event <tt> 'Set STCF -- secs = \%d, usecs = \%d, ssecs = 0x\%X' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is generated upon successful completion
+**  of a cFE Time Services \link #CFE_TIME_SET_STCF_CC Set Spacecraft Time
+**  Correlation Factor command \endlink
+**
+**  The \c secs field specifies the new STCF (in seconds), the \c usecs
+**  field specifies the STCF micro-seconds, the \c ssecs field is
+**  the micro-seconds field converted to Spacecraft Time sub-seconds.
+**/
+#define CFE_TIME_STCF_EID 14
+
+/** \brief <tt> 'STCF Adjust -- secs = \%d, usecs = \%d, ssecs = 0x\%X, dir[1=Positive, 2=Negative] = \%d' </tt>
+**  \event <tt> 'STCF Adjust -- secs = \%d, usecs = \%d, ssecs = 0x\%X, dir[1=Positive, 2=Negative] = \%d' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is generated upon successful completion
+**  of any of the following cFE Time Services STCF Adjustment Commands:
+**   - \link #CFE_TIME_ADD_ADJUST_CC Add Single STCF Adjustment command \endlink
+**   - \link #CFE_TIME_SUB_ADJUST_CC Subtract Single STCF Adjustment command \endlink
+**
+**  The \c secs field specifies the number of seconds the STCF is to be adjusted by,
+**  the \c usecs field specifies the number of micro-seconds, the \c ssecs field is
+**  the micro-seconds field converted to Spacecraft Time sub-seconds and the \c dir
+**  field identifies whether the adjustment was added or subtracted. The direction
+**  can be either #CFE_TIME_AdjustDirection_ADD or #CFE_TIME_AdjustDirection_SUBTRACT.
+**/
+#define CFE_TIME_DELTA_EID 15
+
+/** \brief <tt> 'STCF 1Hz Adjust -- secs = \%d, ssecs = 0x\%X, dir = \%d' </tt>
+**  \event <tt> 'STCF 1Hz Adjust -- secs = \%d, ssecs = 0x\%X, dir = \%d' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is generated upon successful completion
+**  of any of the following cFE Time Services STCF Adjustment Commands:
+**   - \link #CFE_TIME_ADD_1HZ_ADJUSTMENT_CC Add STCF Adjustment each second command \endlink
+**   - \link #CFE_TIME_SUB_1HZ_ADJUSTMENT_CC Subtract STCF Adjustment each second command \endlink
+**
+**  The \c secs field specifies the number of seconds the STCF is to be adjusted by,
+**  the \c ssecs field specifies the number of sub-seconds (1/2^32 seconds) the STCF
+**  is to be adjusted by and the \c dir field identifies whether the adjustment was
+**  added or subtracted. The direction value can be either #CFE_TIME_AdjustDirection_ADD or
+**  #CFE_TIME_AdjustDirection_SUBTRACT.
+**/
+#define CFE_TIME_1HZ_EID 16
+
+/** \brief <tt> 'Set Leap Seconds = \%d' </tt>
+**  \event <tt> 'Set Leap Seconds = \%d' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is generated upon successful completion
+**  of the \link #CFE_TIME_SET_LEAP_SECONDS_CC Set Leap Seconds command \endlink
+**
+**  The \c \%d field contains the number of seconds the Spacecraft's Leap Seconds
+**  has been set to.
+**/
+#define CFE_TIME_LEAPS_EID 17
+
+/** \brief <tt> 'Start FLYWHEEL' </tt>
+**  \event <tt> 'Start FLYWHEEL' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is generated whenever the Time Services enters FLYWHEEL mode.
+**/
+#define CFE_TIME_FLY_ON_EID 20 /* flywheel state "informational" */
+
+/** \brief <tt> 'Stop FLYWHEEL' </tt>
+**  \event <tt> 'Stop FLYWHEEL' </tt>
+**
+**  \par Type: INFORMATION
+**
+**  \par Cause:
+**
+**  This event message is generated whenever the Time Services exits FLYWHEEL mode.
+**/
+#define CFE_TIME_FLY_OFF_EID 21
+
+#define CFE_TIME_EXIT_ERR_EID 25 /* task termination "error" */
+
+/** \brief <tt> 'Invalid message ID -- ID = 0x\%X' </tt>
+**  \event <tt> 'Invalid message ID -- ID = 0x\%X' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated whenever Time Services receives
+**  a message from the software bus that is not one of Time Services
+**  recognized messages.
+**
+**  The \c ID field specifies, in hex, the message ID of the inappropriately
+**  received message.
+**/
+#define CFE_TIME_ID_ERR_EID 26 /* invalid command packet "error" */
+
+/** \brief <tt> 'Invalid command code -- ID = 0x\%X, CC = \%d' </tt>
+**  \event <tt> 'Invalid command code -- ID = 0x\%X, CC = \%d' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated whenever Time Services receives
+**  a message from the software bus that contains a unrecognized command
+**  code in its header..
+**
+**  The \c ID field specifies, in hex, the message ID of the message containing
+**  the unrecognized command code, identified, in decimal, by the \c CC field.
+**/
+#define CFE_TIME_CC_ERR_EID 27
+
+/** \brief <tt> 'Invalid Clock State = 0x\%X' </tt>
+**  \event <tt> 'Invalid Clock State = 0x\%X' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated whenever Time Services receives
+**  a \link #CFE_TIME_SET_STATE_CC Set Clock State Command \endlink
+**  that contains a desired clock state that is none of the following:
+**  - #CFE_TIME_ClockState_INVALID
+**  - #CFE_TIME_ClockState_VALID
+**  - #CFE_TIME_ClockState_FLYWHEEL
+**
+**  The \c State field specifies, in hex, the state value received
+**  in the command message.
+**/
+#define CFE_TIME_STATE_ERR_EID 30 /* processed command "error" */
+
+/** \brief <tt> 'Invalid Time Source = 0x\%X' </tt>
+**  \event <tt> 'Invalid Time Source = 0x\%X' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated whenever Time Services receives
+**  a \link #CFE_TIME_SET_SOURCE_CC Set Clock Source Command \endlink
+**  that contains a desired clock source that is none of the following:
+**  - #CFE_TIME_SourceSelect_INTERNAL
+**  - #CFE_TIME_SourceSelect_EXTERNAL
+**
+**  The \c Source field specifies, in hex, the source value received
+**  in the command message.
+**/
+#define CFE_TIME_SOURCE_ERR_EID 31
+
+/** \brief <tt> 'Invalid Tone Source = 0x\%X' </tt>
+**  \event <tt> 'Invalid Tone Source = 0x\%X' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated whenever Time Services receives
+**  a \link #CFE_TIME_SET_SIGNAL_CC Set Clock Signal Command \endlink
+**  that contains a desired clock source that is none of the following:
+**  - #CFE_TIME_ToneSignalSelect_PRIMARY
+**  - #CFE_TIME_ToneSignalSelect_REDUNDANT
+**
+**  The \c Source field specifies, in hex, the signal source value received
+**  in the command message.
+**/
+#define CFE_TIME_SIGNAL_ERR_EID 32
+
+/** \brief <tt> 'Invalid Tone Delay -- secs = \%d, usecs = \%d' </tt>
+**  \event <tt> 'Invalid Tone Delay -- secs = \%d, usecs = \%d' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated whenever Time Services receives
+**  either a \link #CFE_TIME_ADD_DELAY_CC Add Tone Delay Command \endlink
+**  OR a \link #CFE_TIME_SUB_DELAY_CC Subtract Tone Delay Command \endlink
+**  that contains a microsecond field that is greater than or equal to
+**  1000000.
+**
+**  The \c secs field specifies, in decimal, the tone signal delay in seconds
+**  and the \c usecs field specifies, in decimal, the micro-second delay that
+**  was in error.
+**/
+#define CFE_TIME_DELAY_ERR_EID 33
+
+/** \brief <tt> 'Invalid Time -- secs = \%d, usecs = \%d' </tt>
+**  \event <tt> 'Invalid Time -- secs = \%d, usecs = \%d' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated whenever Time Services receives
+**  a \link #CFE_TIME_SET_TIME_CC Set Spacecraft Time Command \endlink
+**  that contains a microsecond field that is greater than or equal to
+**  1,000,000.
+**
+**  The \c secs field specifies, in decimal, the spacecraft time in seconds
+**  and the \c usecs field specifies, in decimal, the micro-second field of
+**  the spacecraft time that was in error.
+**/
+#define CFE_TIME_TIME_ERR_EID 34
+
+/** \brief <tt> 'Invalid MET -- secs = \%d, usecs = \%d' </tt>
+**  \event <tt> 'Invalid MET -- secs = \%d, usecs = \%d' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated whenever Time Services receives
+**  a \link #CFE_TIME_SET_MET_CC Set Mission Elapsed Time Command \endlink
+**  that contains a microsecond field that is greater than or equal to
+**  1,000,000.
+**
+**  The \c secs field specifies, in decimal, the MET in seconds
+**  and the \c usecs field specifies, in decimal, the micro-second field of
+**  the MET that was in error.
+**/
+#define CFE_TIME_MET_ERR_EID 35
+
+/** \brief <tt> 'Invalid STCF -- secs = \%d, usecs = \%d' </tt>
+**  \event <tt> 'Invalid STCF -- secs = \%d, usecs = \%d' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated whenever Time Services receives
+**  a \link #CFE_TIME_SET_STCF_CC Set Spacecraft Time Correlation Factor Command \endlink
+**  that contains a microsecond field that is greater than or equal to
+**  1,000,000.
+**
+**  The \c secs field specifies, in decimal, the STCF in seconds
+**  and the \c usecs field specifies, in decimal, the micro-second field of
+**  the STCF that was in error.
+**/
+#define CFE_TIME_STCF_ERR_EID 36
+
+/** \brief <tt> 'Invalid STCF Adjust -- secs = \%d, usecs = \%d, dir[1=Positive, 2=Negative] = \%d' </tt>
+**  \event <tt> 'Invalid STCF Adjust -- secs = \%d, usecs = \%d, dir[1=Positive, 2=Negative] = \%d' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated whenever Time Services receives
+**  either a \link #CFE_TIME_ADD_ADJUST_CC Add Single STCF Adjustment Command \endlink
+**  OR a \link #CFE_TIME_SUB_ADJUST_CC Subtract Single STCF Adjustment command \endlink
+**  that contains a microsecond field that is greater than or equal to
+**  1,000,000.
+**
+**  The \c secs field specifies the number of seconds the STCF is to be adjusted by,
+**  the \c usecs field specifies the number of micro-seconds that was in error, the \c dir
+**  field identifies whether the adjustment was to be added or subtracted. The direction
+**  can be either #CFE_TIME_AdjustDirection_ADD or #CFE_TIME_AdjustDirection_SUBTRACT.
+**/
+#define CFE_TIME_DELTA_ERR_EID 37
+
+/** (obsolete - unused)
+ **/
+#define CFE_TIME_1HZ_ERR_EID 38
+
+/** \brief <tt> 'Set Source commands invalid without CFE_PLATFORM_TIME_CFG_SOURCE set to true' </tt>
+**  \event <tt> 'Set Source commands invalid without CFE_PLATFORM_TIME_CFG_SOURCE set to true' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated whenever Time Services receives
+**  a \link #CFE_TIME_SET_SOURCE_CC Set Clock Source Command \endlink
+**  and the Time Services configuration parameter #CFE_PLATFORM_TIME_CFG_SOURCE has
+**  not been set to true in the cfe_platform_cfg.h file.
+**/
+#define CFE_TIME_SOURCE_CFG_EID 40 /* cmd disabled per cfg "error" */
+
+/** \brief <tt> 'Set Signal commands invalid without CFE_PLATFORM_TIME_CFG_SIGNAL set to true' </tt>
+**  \event <tt> 'Set Signal commands invalid without CFE_PLATFORM_TIME_CFG_SIGNAL set to true' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated whenever Time Services receives
+**  a \link #CFE_TIME_SET_SIGNAL_CC Set Clock Signal Command \endlink
+**  and the Time Services configuration parameter #CFE_PLATFORM_TIME_CFG_SIGNAL has
+**  not been set to true in the cfe_platform_cfg.h file.
+**/
+#define CFE_TIME_SIGNAL_CFG_EID 41
+
+/** \brief <tt> 'Set Delay commands invalid without CFE_PLATFORM_TIME_CFG_CLIENT set to true' </tt>
+**  \event <tt> 'Set Delay commands invalid without CFE_PLATFORM_TIME_CFG_CLIENT set to true' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated whenever Time Services receives
+**  either a \link #CFE_TIME_ADD_DELAY_CC Add Tone Delay Command \endlink
+**  OR a \link #CFE_TIME_SUB_DELAY_CC Subtract Tone Delay Command \endlink
+**  and the Time Services configuration parameter #CFE_PLATFORM_TIME_CFG_CLIENT has
+**  not been set to true in the cfe_platform_cfg.h file.
+**/
+#define CFE_TIME_DELAY_CFG_EID 42
+
+/** \brief <tt> 'Set Time commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to true' </tt>
+**  \event <tt> 'Set Time commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to true' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated whenever Time Services receives
+**  a \link #CFE_TIME_SET_TIME_CC Set Spacecraft Time Command \endlink
+**  and the Time Services configuration parameter #CFE_PLATFORM_TIME_CFG_SERVER has
+**  not been set to true in the cfe_platform_cfg.h file.
+**/
+#define CFE_TIME_TIME_CFG_EID 43
+
+/** \brief <tt> 'Set MET commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to true' </tt>
+**  \event <tt> 'Set MET commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to true' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated whenever Time Services receives
+**  a \link #CFE_TIME_SET_MET_CC Set Mission Elapsed Time Command \endlink
+**  and the Time Services configuration parameter #CFE_PLATFORM_TIME_CFG_SERVER has
+**  not been set to true in the cfe_platform_cfg.h file.
+**/
+#define CFE_TIME_MET_CFG_EID 44
+
+/** \brief <tt> 'Set STCF commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to true' </tt>
+**  \event <tt> 'Set STCF commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to true' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated whenever Time Services receives
+**  a \link #CFE_TIME_SET_STCF_CC Set Spacecraft Time Correlation Factor Command \endlink
+**  and the Time Services configuration parameter #CFE_PLATFORM_TIME_CFG_SERVER has
+**  not been set to true in the cfe_platform_cfg.h file.
+**/
+#define CFE_TIME_STCF_CFG_EID 45
+
+/** \brief <tt> 'Set Leaps commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to true' </tt>
+**  \event <tt> 'Set Leaps commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to true' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated whenever Time Services receives
+**  a \link #CFE_TIME_SET_LEAP_SECONDS_CC Set Leap Seconds Command \endlink
+**  and the Time Services configuration parameter #CFE_PLATFORM_TIME_CFG_SERVER has
+**  not been set to true in the cfe_platform_cfg.h file.
+**/
+#define CFE_TIME_LEAPS_CFG_EID 46
+
+/** \brief <tt> 'STCF Adjust commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to true' </tt>
+**  \event <tt> 'STCF Adjust commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to true' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated whenever Time Services receives
+**  either a \link #CFE_TIME_ADD_ADJUST_CC Add Single STCF Adjustment Command \endlink
+**  OR a \link #CFE_TIME_SUB_ADJUST_CC Subtract Single STCF Adjustment command \endlink
+**  and the Time Services configuration parameter #CFE_PLATFORM_TIME_CFG_SERVER has
+**  not been set to true in the cfe_platform_cfg.h file.
+**/
+#define CFE_TIME_DELTA_CFG_EID 47
+
+/** \brief <tt> '1Hz Adjust commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to true' </tt>
+**  \event <tt> '1Hz Adjust commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to true' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated whenever Time Services receives
+**  either a \link #CFE_TIME_ADD_1HZ_ADJUSTMENT_CC Add STCF Adjustment each second Command \endlink
+**  OR a \link #CFE_TIME_SUB_1HZ_ADJUSTMENT_CC Subtract STCF Adjustment each second command \endlink
+**  and the Time Services configuration parameter #CFE_PLATFORM_TIME_CFG_SERVER has
+**  not been set to true in the cfe_platform_cfg.h file.
+**/
+#define CFE_TIME_1HZ_CFG_EID 48
+
+/** \brief <tt> 'Invalid cmd length: ID = 0x\%X, CC = \%d, Exp Len = \%d, Len = \%d' </tt>
+**  \event <tt> 'Invalid cmd length: ID = 0x\%X, CC = \%d, Exp Len = \%d, Len = \%d' </tt>
+**
+**  \par Type: ERROR
+**
+**  \par Cause:
+**
+**  This event message is generated when a message with the #CFE_TIME_CMD_MID
+**  message ID has arrived but whose packet length does not match the expected
+**  length for the specified command code.
+**
+**  The \c ID field in the event message specifies the Message ID (in hex), the \c CC field
+**  specifies the Command Code (in decimal), the \c Exp Len field specified the Expected
+**  Length (in decimal ), and \c Len specifies the message Length (in decimal)
+**  found in the message.
+**/
+#define CFE_TIME_LEN_ERR_EID 49
+
+#endif /* CFE_TIME_EVENTS_H */

--- a/modules/time/fsw/inc/cfe_time_msg.h
+++ b/modules/time/fsw/inc/cfe_time_msg.h
@@ -1,0 +1,1126 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * @file
+ *
+ * Purpose:  cFE Time Services (TIME) SB message definitions header file
+ *
+ * Author:   S.Walling/Microtel
+ *
+ * Notes:
+ *
+ */
+
+#ifndef CFE_TIME_MSG_H
+#define CFE_TIME_MSG_H
+
+/*
+** Required header files...
+*/
+#include "common_types.h" /* Basic data types */
+#include "cfe_msg_hdr.h"  /* for header definitions */
+#include "cfe_time_extern_typedefs.h"
+
+/*************************************************************************/
+
+/*
+** Time task command packet command codes...
+*/
+/** \name Time Services Command Codes */
+/** \{ */
+
+/** \cfetimecmd Time No-Op
+**
+**  \par Description
+**       This command performs no other function than to increment the
+**       command execution counter. The command may be used to verify
+**       general aliveness of the Time Services task.
+**
+**  \cfecmdmnemonic \TIME_NOOP
+**
+**  \par Command Structure
+**       #CFE_TIME_NoopCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TIME_CMDPC - command execution counter will increment
+**       - The #CFE_TIME_NOOP_EID informational event message will be generated
+**
+**  \par Error Conditions
+**       There are no error conditions for this command. If the Time
+**       Services receives the command, the event is sent (although it
+**       may be filtered by EVS) and the counter is incremented
+**       unconditionally.
+**
+**  \par Criticality
+**       None
+**
+**  \sa
+*/
+#define CFE_TIME_NOOP_CC 0 /* no-op command */
+
+/** \cfetimecmd Time Reset Counters
+**
+**  \par Description
+**       This command resets the following counters within the Time
+**       Services \link CFE_TIME_HousekeepingTlm_t Housekeeping Telemetry \endlink:
+**       - Command Execution Counter (\TIME_CMDPC)
+**       - Command Error Counter (\TIME_CMDEC)
+**       This command also resets the following counters within the
+**       Time Services \link CFE_TIME_DiagnosticTlm_t Diagnostic Telemetry \endlink:
+**       - Tone Signal Detected Software Bus Message Counter (\TIME_TSDETCNT)
+**       - Time at the Tone Data Software Bus Message Counter (\TIME_TATTCNT)
+**       - Tone Signal/Data Verify Counter (\TIME_VERIFYCNT)
+**       - Tone Signal/Data Error Counter (\TIME_VERIFYER)
+**       - Tone Signal Interrupt Counter (\TIME_TSISRCNT)
+**       - Tone Signal Interrupt Error Counter (\TIME_TSISRERR)
+**       - Tone Signal Task Counter (\TIME_TSTASKCNT)
+**       - Local 1 Hz Interrupt Counter (\TIME_1HZISRCNT)
+**       - Local 1 Hz Task Counter (\TIME_1HZTASKCNT)
+**       - Reference Time Version Counter (\TIME_VERSIONCNT)
+**
+**  \cfecmdmnemonic \TIME_RESETCTRS
+**
+**  \par Command Structure
+**       #CFE_TIME_ResetCountersCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TIME_CMDPC - command execution counter will increment
+**       - The #CFE_TIME_RESET_EID informational event message will be generated
+**
+**  \par Error Conditions
+**       There are no error conditions for this command. If the Time
+**       Services receives the command, the event is sent (although it
+**       may be filtered by EVS) and the counter is incremented
+**       unconditionally.
+**
+**  \par Criticality
+**       None
+**
+**  \sa
+*/
+#define CFE_TIME_RESET_COUNTERS_CC 1 /* reset counters */
+
+/** \cfetimecmd Request TIME Diagnostic Telemetry
+**
+**  \par Description
+**       This command requests that the Time Service generate a message
+**       containing various data values not included in the normal Time
+**       Service housekeeping message.  The command requests only a single
+**       copy of the diagnostic message.  Refer to #CFE_TIME_DiagnosticTlm_t for
+**       a description of the Time Service diagnostic message contents.
+**
+**  \cfecmdmnemonic \TIME_REQUESTDIAG
+**
+**  \par Command Structure
+**       #CFE_TIME_SendDiagnosticCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TIME_CMDPC - command execution counter will increment
+**       - Sequence Counter for #CFE_TIME_DiagnosticTlm_t will increment
+**       - The #CFE_TIME_DIAG_EID debug event message will be generated
+**
+**  \par Error Conditions
+**       There are no error conditions for this command. If the Time
+**       Services receives the command, the event and telemetry is sent
+**       (although one or both may be filtered by EVS and TO) and the
+**       counter is incremented unconditionally.
+**
+**  \par Criticality
+**       None
+**
+**  \sa
+*/
+#define CFE_TIME_SEND_DIAGNOSTIC_TLM_CC 2 /* request diagnostic hk telemetry */
+
+/** \cfetimecmd Set Time Source
+**
+**  \par Description
+**       This command selects the Time Service clock source.  Although the
+**       list of potential clock sources is mission specific and defined
+**       via configuration parameters, this command provides a common method
+**       for switching between the local processor clock and an external
+**       source for time data.<BR><BR>
+**       When commanded to accept external time data (GPS, MET, spacecraft
+**       time, etc.), the Time Server will enable input via an API function
+**       specific to the configuration definitions for the particular source.
+**       When commanded to use internal time data, the Time Server will ignore
+**       the external data.  However, the Time Server will continue to use the
+**       API function as the trigger to generate a "time at the tone" command
+**       packet regardless of the internal/external command selection.<BR><BR>
+**       Notes:
+**       - Operating in FLYWHEEL mode is not considered a choice related
+**         to clock source, but rather an element of the clock state.  See below
+**         for a description of the #CFE_TIME_SET_STATE_CC command.
+**       - This command is only valid when the #CFE_PLATFORM_TIME_CFG_SOURCE configuration
+**         parameter in the cfe_platform_cfg.h file has been set to true.
+**
+**  \cfecmdmnemonic \TIME_SETSOURCE
+**
+**  \par Command Structure
+**       #CFE_TIME_SetSourceCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TIME_CMDPC - command execution counter will increment
+**       - \b \c \TIME_SOURCE - Diagnostic Telemetry point will indicate the
+**         command specified value
+**       - The #CFE_TIME_SOURCE_EID informational event message will be generated
+**
+**  \par Error Conditions
+**       - Invalid Source selection
+**         (a value other than #CFE_TIME_SourceSelect_INTERNAL or #CFE_TIME_SourceSelect_EXTERNAL was specified)
+**       - Time source selection not allowed on this platform
+**       <BR><BR>Evidence of failure may be found in the following telemetry:
+**       - \b \c \TIME_CMDEC - Command Error counter will increment
+**       - Error specific event message (either #CFE_TIME_SOURCE_CFG_EID or #CFE_TIME_SOURCE_ERR_EID)
+**
+**  \par Criticality
+**       Although clock source selection is important, this command is not critical.
+**
+**  \sa #CFE_TIME_SET_STATE_CC, #CFE_TIME_SET_SIGNAL_CC
+*/
+#define CFE_TIME_SET_SOURCE_CC 3 /* set clock source (int vs ext) */
+
+/** \cfetimecmd Set Time State
+**
+**  \par Description
+**       This command indirectly affects the Time Service on-board determination
+**       of clock state.  Clock state is a combination of factors, most significantly
+**       whether the spacecraft time has been accurately set, and whether Time Service
+**       is operating in FLYWHEEL mode.<BR><BR>
+**       This command may be used to notify the Time Server that spacecraft time is
+**       now correct, or that time is no longer correct.  This information will be
+**       distributed to Time Clients, and in turn, to any interested sub-systems.<BR><BR>
+**       Also, this command may be used to force a Time Server or Time Client into
+**       FLYWHEEL mode.  Use of FLYWHEEL mode is mainly for debug purposes although
+**       in extreme circumstances, it may be of value to force Time Service not to rely
+**       on normal time updates.  Note that when commanded into FLYWHEEL mode, the Time
+**       Service will remain so until receipt of another "set state" command setting the
+**       state into a mode other than FLYWHEEL.<BR><BR>
+**       Note also that setting the clock state to VALID or INVALID on a Time Client that
+**       is currently getting time updates from the Time Server will have very limited
+**       effect.  As soon as the Time Client receives the next time update, the VALID/INVALID
+**       selection will be set to that of the Time Server.  However, setting a Time Client
+**       to FLYWHEEL cannot be overridden by the Time Server since the Time Client will
+**       ignore time updates from the Time Server while in FLYWHEEL mode.
+**
+**  \cfecmdmnemonic \TIME_SETSTATE
+**
+**  \par Command Structure
+**       #CFE_TIME_SetStateCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TIME_CMDPC - command execution counter will increment
+**       - \b \c \TIME_STATEFLG - Housekeeping Telemetry point "may"l indicate the
+**         command specified value (see above)
+**       - The #CFE_TIME_STATE_EID informational event message will be generated
+**
+**  \par Error Conditions
+**       - Invalid State selection
+**         (a value other than #CFE_TIME_ClockState_INVALID, #CFE_TIME_ClockState_VALID or
+**         #CFE_TIME_ClockState_FLYWHEEL was specified)
+**       - Time source selection not allowed on this platform
+**       <BR><BR>Evidence of failure may be found in the following telemetry:
+**       - \b \c \TIME_CMDEC - Command Error counter will increment
+**       - Error specific event message (#CFE_TIME_STATE_ERR_EID)
+**
+**  \par Criticality
+**       Setting Time Service into FLYWHEEL mode is not particularly hazardous, as
+**       the result may be that the calculation of spacecraft time is done using a
+**       less than optimal timer.  However, inappropriately setting the clock state
+**       to VALID (indicating that spacecraft time is accurate) may result in other
+**       sub-systems performing incorrect time based calculations.  The specific risk
+**       is dependent upon the behavior of those sub-systems.
+**
+**  \sa #CFE_TIME_SET_SOURCE_CC, #CFE_TIME_SET_SIGNAL_CC
+*/
+#define CFE_TIME_SET_STATE_CC 4 /* set clock state */
+
+/** \cfetimecmd Add Time to Tone Time Delay
+**
+**  \par Description
+**       This command is used to factor out a known, predictable latency between the
+**       Time Server and a particular Time Client.  The correction is applied (added)
+**       to the current time calculation for Time Clients, so this command has no
+**       meaning for Time Servers.  Each Time Client can have a unique latency setting.
+**       The latency value is a positive number of seconds and microseconds that represent
+**       the deviation from the time maintained by the Time Server.
+**
+**  \cfecmdmnemonic \TIME_ADDCLOCKLAT
+**
+**  \par Command Structure
+**       #CFE_TIME_AddDelayCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TIME_CMDPC - command execution counter will increment
+**       - \b \c \TIME_LATENTS - Housekeeping Telemetry point indicating command specified values
+**       - \b \c \TIME_LATENTDIR - Diagnostic Telemetry point indicating commanded latency direction
+**       - The #CFE_TIME_DELAY_EID informational event message will be generated
+**
+**  \par Error Conditions
+**       - An invalid number of microseconds was specified (must be less than 1 million)
+**       - Platorm receiving the command is not a Time Client
+**       <BR><BR>Evidence of Failure may be found in the following telemetry:
+**       - \b \c \TIME_CMDEC - command error counter will increment
+**       - Error specific event messages will be issued (#CFE_TIME_DELAY_CFG_EID or #CFE_TIME_DELAY_ERR_EID)
+**
+**  \par Criticality
+**       Inappropriately setting the clock may result in other sub-systems performing incorrect
+**       time based calculations.  The specific risk is dependent upon the behavior of those sub-systems.
+**
+**  \sa #CFE_TIME_SUB_DELAY_CC
+*/
+#define CFE_TIME_ADD_DELAY_CC 5 /* add tone delay value */
+
+/** \cfetimecmd Subtract Time from Tone Time Delay
+**
+**  \par Description
+**       This command is used to factor out a known, predictable latency between the Time Server
+**       and a particular Time Client.  The correction is applied (subtracted) to the current time
+**       calculation for Time Clients, so this command has no meaning for Time Servers.  Each Time
+**       Client can have a unique latency setting.  The latency value is a positive number of seconds
+**       and microseconds that represent the deviation from the time maintained by the Time Server.<BR><BR>
+**       Note that it is unimaginable that the seconds value will ever be anything but zero.
+**
+**  \cfecmdmnemonic \TIME_SUBCLOCKLAT
+**
+**  \par Command Structure
+**       #CFE_TIME_SubDelayCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TIME_CMDPC - command execution counter will increment
+**       - \b \c \TIME_LATENTS - Housekeeping Telemetry point indicating command specified values
+**       - \b \c \TIME_LATENTDIR - Diagnostic Telemetry point indicating commanded latency direction
+**       - The #CFE_TIME_DELAY_EID informational event message will be generated
+**
+**  \par Error Conditions
+**       - An invalid number of microseconds was specified (must be less than 1 million)
+**       - Platorm receiving the command is not a Time Client
+**       <BR><BR>Evidence of Failure may be found in the following telemetry:
+**       - \b \c \TIME_CMDEC - command error counter will increment
+**       - Error specific event messages will be issued (#CFE_TIME_DELAY_CFG_EID or #CFE_TIME_DELAY_ERR_EID)
+**
+**  \par Criticality
+**       Inappropriately setting the clock may result in other sub-systems performing incorrect
+**       time based calculations.  The specific risk is dependent upon the behavior of those sub-systems.
+**
+**  \sa #CFE_TIME_ADD_DELAY_CC
+*/
+#define CFE_TIME_SUB_DELAY_CC 6 /* sub tone delay value */
+
+/** \cfetimecmd Set Spacecraft Time
+**
+**  \par Description
+**       This command sets the spacecraft clock to a new value,
+**       regardless of the current setting (time jam). The new time
+**       value represents the desired offset from the mission-defined
+**       time epoch and takes effect immediately upon execution of
+**       this command.  Time Service will calculate a new STCF value
+**       based on the current MET and the desired new time using one
+**       of the following: <BR><BR>
+**       If Time Service is configured to compute current time as TAI<BR>
+**       - <B> STCF = (new time) - (current MET) </B>
+**       - <B> (current time) = (current MET) + STCF </B>
+**       <BR><BR>If Time Service is configured to compute current time as UTC
+**       - <B> STCF = ((new time) - (current MET)) + (Leap Seconds) </B>
+**       - <B> (current time) = ((curent MET) + STCF) - (Leap Seconds) </B>
+**
+**  \cfecmdmnemonic \TIME_SETCLOCK
+**
+**  \par Command Structure
+**       #CFE_TIME_SetTimeCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TIME_CMDPC - command execution counter will increment
+**       - \b \c \TIME_STCFSECS - Housekeeping Telemetry point indicating newly calculated STCF seconds value
+**       - \b \c \TIME_STCFSUBSECS - Housekeeping Telemetry point indicating newly calculated STCF subseconds value
+**       - The #CFE_TIME_TIME_EID informational event message will be generated
+**
+**  \par Error Conditions
+**       - An invalid number of microseconds was specified (must be less than 1 million)
+**       - Platorm receiving the command is not a Time Server
+**       <BR><BR>Evidence of Failure may be found in the following telemetry:
+**       - \b \c \TIME_CMDEC - command error counter will increment
+**       - Error specific event messages will be issued (#CFE_TIME_TIME_CFG_EID or #CFE_TIME_TIME_ERR_EID)
+**
+**  \par Criticality
+**       Inappropriately setting the clock may result in other sub-systems performing incorrect
+**       time based calculations.  The specific risk is dependent upon the behavior of those sub-systems.
+**
+**  \sa #CFE_TIME_SET_MET_CC, #CFE_TIME_SET_STCF_CC, #CFE_TIME_SET_LEAP_SECONDS_CC
+*/
+#define CFE_TIME_SET_TIME_CC 7 /* set time */
+
+/** \cfetimecmd Set Mission Elapsed Time
+**
+**  \par Description
+**       This command sets the Mission Elapsed Timer (MET) to the specified value.<BR><BR>
+**       Note that the MET (as implemented for cFE Time Service) is a logical representation
+**       and not a physical timer.  Thus, setting the MET is not dependent on whether the
+**       hardware supports a MET register that can be written to.<BR><BR>
+**       Note also that Time Service "assumes" that during normal operation, the MET is
+**       synchronized to the tone signal.  Therefore, unless operating in FLYWHEEL mode,
+**       the sub-seconds portion of the MET will be set to zero at the next tone signal interrupt.<BR><BR>
+**       The new MET takes effect immediately upon execution of this command.
+**
+**  \cfecmdmnemonic \TIME_SETCLOCKMET
+**
+**  \par Command Structure
+**       #CFE_TIME_SetMETCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TIME_CMDPC - command execution counter will increment
+**       - \b \c \TIME_METSECS - Housekeeping Telemetry point indicating new MET seconds value
+**       - \b \c \TIME_METSUBSECS - Housekeeping Telemetry point indicating new MET subseconds value
+**       - The #CFE_TIME_MET_EID informational event message will be generated
+**
+**  \par Error Conditions
+**       - An invalid number of microseconds was specified (must be less than 1 million)
+**       - Platorm receiving the command is not a Time Server
+**       <BR><BR>Evidence of Failure may be found in the following telemetry:
+**       - \b \c \TIME_CMDEC - command error counter will increment
+**       - Error specific event messages will be issued (#CFE_TIME_MET_CFG_EID or #CFE_TIME_MET_ERR_EID)
+**
+**  \par Criticality
+**       Inappropriately setting the clock may result in other sub-systems performing incorrect
+**       time based calculations.  The specific risk is dependent upon the behavior of those sub-systems.
+**
+**  \sa #CFE_TIME_SET_TIME_CC, #CFE_TIME_SET_STCF_CC, #CFE_TIME_SET_LEAP_SECONDS_CC
+*/
+#define CFE_TIME_SET_MET_CC 8 /* set MET */
+
+/** \cfetimecmd Set Spacecraft Time Correlation Factor
+**
+**  \par Description
+**       This command sets the Spacecraft Time Correlation Factor (STCF) to the specified value.
+**       This command differs from the previously described SET CLOCK in the nature of the command
+**       argument.  This command sets the STCF value directly, rather than extracting the STCF
+**       from a value representing the total of MET, STCF and optionally, Leap Seconds.  The new
+**       STCF takes effect immediately upon execution of this command.
+**
+**  \cfecmdmnemonic \TIME_SETCLOCKSTCF
+**
+**  \par Command Structure
+**       #CFE_TIME_SetSTCFCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TIME_CMDPC - command execution counter will increment
+**       - \b \c \TIME_STCFSECS - Housekeeping Telemetry point indicating new  STCF seconds value
+**       - \b \c \TIME_STCFSUBSECS - Housekeeping Telemetry point indicating new  STCF subseconds value
+**       - The #CFE_TIME_STCF_EID informational event message will be generated
+**
+**  \par Error Conditions
+**       - An invalid number of microseconds was specified (must be less than 1 million)
+**       - Platorm receiving the command is not a Time Server
+**       <BR><BR>Evidence of Failure may be found in the following telemetry:
+**       - \b \c \TIME_CMDEC - command error counter will increment
+**       - Error specific event messages will be issued (#CFE_TIME_STCF_CFG_EID or #CFE_TIME_STCF_ERR_EID)
+**
+**  \par Criticality
+**       Inappropriately setting the clock may result in other sub-systems performing incorrect
+**       time based calculations.  The specific risk is dependent upon the behavior of those sub-systems.
+**
+**  \sa #CFE_TIME_SET_TIME_CC, #CFE_TIME_SET_MET_CC, #CFE_TIME_SET_LEAP_SECONDS_CC
+*/
+#define CFE_TIME_SET_STCF_CC 9 /* set STCF */
+
+/** \cfetimecmd Set Leap Seconds
+**
+**  \par Description
+**       This command sets the spacecraft Leap Seconds to the specified value.
+**       Leap Seconds may be positive or negative, and there is no limit to the
+**       value except, of course, the limit imposed by the 16 bit signed integer
+**       data type.  The new Leap Seconds value takes effect immediately upon
+**       execution of this command.
+**
+**  \cfecmdmnemonic \TIME_SETCLOCKLEAP
+**
+**  \par Command Structure
+**       #CFE_TIME_SetLeapSecondsCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TIME_CMDPC - command execution counter will increment
+**       - \b \c \TIME_LEAPSECS - Housekeeping Telemetry point indicating new Leap seconds value
+**       - The #CFE_TIME_LEAPS_EID informational event message will be generated
+**
+**  \par Error Conditions
+**       - Platorm receiving the command is not a Time Server
+**       <BR><BR>Evidence of Failure may be found in the following telemetry:
+**       - \b \c \TIME_CMDEC - command error counter will increment
+**       - Error specific event messages will be issued (#CFE_TIME_LEAPS_CFG_EID)
+**
+**  \par Criticality
+**       Inappropriately setting the clock may result in other sub-systems performing incorrect
+**       time based calculations.  The specific risk is dependent upon the behavior of those sub-systems.
+**
+**  \sa #CFE_TIME_SET_TIME_CC, #CFE_TIME_SET_MET_CC, #CFE_TIME_SET_STCF_CC
+*/
+#define CFE_TIME_SET_LEAP_SECONDS_CC 10 /* set Leap Seconds */
+
+/** \cfetimecmd Add Delta to Spacecraft Time Correlation Factor
+**
+**  \par Description
+**       This command adjusts the Spacecraft Time Correlation Factor (STCF) by
+**       adding the specified value.  The new STCF takes effect immediately upon
+**       execution of this command.
+**
+**  \cfecmdmnemonic \TIME_ADDSTCFADJ
+**
+**  \par Command Structure
+**       #CFE_TIME_AddAdjustCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TIME_CMDPC - command execution counter will increment
+**       - \b \c \TIME_STCFSECS - Housekeeping Telemetry point indicating new STCF seconds value
+**       - \b \c \TIME_STCFSUBSECS - Housekeeping Telemetry point indicating new STCF subseconds value
+**       - The #CFE_TIME_DELTA_EID informational event message will be generated
+**
+**  \par Error Conditions
+**       - An invalid number of microseconds was specified (must be less than 1 million)
+**       - Platorm receiving the command is not a Time Server
+**       <BR><BR>Evidence of Failure may be found in the following telemetry:
+**       - \b \c \TIME_CMDEC - command error counter will increment
+**       - Error specific event messages will be issued (#CFE_TIME_DELTA_ERR_EID or #CFE_TIME_DELTA_CFG_EID)
+**
+**  \par Criticality
+**       Inappropriately setting the clock may result in other sub-systems performing incorrect
+**       time based calculations.  The specific risk is dependent upon the behavior of those sub-systems.
+**
+**  \sa #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_SUB_ADJUST_CC, #CFE_TIME_ADD_1HZ_ADJUSTMENT_CC,
+*#CFE_TIME_SUB_1HZ_ADJUSTMENT_CC
+*/
+#define CFE_TIME_ADD_ADJUST_CC 11 /* add one time STCF adjustment */
+
+/** \cfetimecmd Subtract Delta from Spacecraft Time Correlation Factor
+**
+**  \par Description
+**       This command adjusts the Spacecraft Time Correlation Factor (STCF) by subtracting the specified
+**       value.  The new STCF takes effect immediately upon execution of this command.
+**
+**  \cfecmdmnemonic \TIME_SUBSTCFADJ
+**
+**  \par Command Structure
+**       #CFE_TIME_SubAdjustCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TIME_CMDPC - command execution counter will increment
+**       - \b \c \TIME_STCFSECS - Housekeeping Telemetry point indicating new STCF seconds value
+**       - \b \c \TIME_STCFSUBSECS - Housekeeping Telemetry point indicating new STCF subseconds value
+**       - The #CFE_TIME_DELTA_EID informational event message will be generated
+**
+**  \par Error Conditions
+**       - An invalid number of microseconds was specified (must be less than 1 million)
+**       - Platorm receiving the command is not a Time Server
+**       <BR><BR>Evidence of Failure may be found in the following telemetry:
+**       - \b \c \TIME_CMDEC - command error counter will increment
+**       - Error specific event messages will be issued (#CFE_TIME_DELTA_ERR_EID or #CFE_TIME_DELTA_CFG_EID)
+**
+**  \par Criticality
+**       Inappropriately setting the clock may result in other sub-systems performing incorrect
+**       time based calculations.  The specific risk is dependent upon the behavior of those sub-systems.
+**
+**  \sa #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_ADD_1HZ_ADJUSTMENT_CC, #CFE_TIME_SUB_1HZ_ADJUSTMENT_CC
+*/
+#define CFE_TIME_SUB_ADJUST_CC 12 /* subtract one time STCF adjustment */
+
+/** \cfetimecmd Add Delta to Spacecraft Time Correlation Factor each 1Hz
+**
+**  \par Description
+**       This command has been updated to take actual sub-seconds (1/2^32 seconds)
+**       rather than micro-seconds as an input argument.  This change occurred
+**       after the determination was made that one micro-second is too large an
+**       increment for a constant 1Hz adjustment.<BR><BR>
+**       This command continuously adjusts the Spacecraft Time Correlation Factor (STCF)
+**       every second, by adding the specified value.  The adjustment to the STCF is
+**       applied in the Time Service local 1Hz interrupt handler.  As the local 1Hz
+**       interrupt is not synchronized to the tone signal, one cannot say when the
+**       adjustment will occur, other than once a second, at about the same time
+**       relative to the tone.<BR><BR>
+**       There was some debate about whether the maximum 1Hz clock drift correction
+**       factor would ever need to exceed some small fraction of a second.  But, the
+**       decision was made to provide the capability to make 1Hz adjustments greater
+**       than one second and leave it to the ground system to provide mission specific
+**       limits.
+**
+**  \cfecmdmnemonic \TIME_ADD1HZSTCF
+**
+**  \par Command Structure
+**       #CFE_TIME_Add1HZAdjustmentCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TIME_CMDPC - command execution counter will increment
+**       - \b \c \TIME_STCFSECS - Housekeeping Telemetry point indicating new STCF seconds value
+**       - \b \c \TIME_STCFSUBSECS - Housekeeping Telemetry point indicating new STCF subseconds value
+**       - The #CFE_TIME_1HZ_EID informational event message will be generated
+**
+**  \par Error Conditions
+**       - Platorm receiving the command is not a Time Server
+**       <BR><BR>Evidence of Failure may be found in the following telemetry:
+**       - \b \c \TIME_CMDEC - command error counter will increment
+**       - Error specific event message will be issued (#CFE_TIME_1HZ_CFG_EID)
+**
+**  \par Criticality
+**       Inappropriately setting the clock may result in other sub-systems performing incorrect
+**       time based calculations.  The specific risk is dependent upon the behavior of those sub-systems.
+**
+**  \sa #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_SUB_ADJUST_CC, #CFE_TIME_SUB_1HZ_ADJUSTMENT_CC
+*/
+#define CFE_TIME_ADD_1HZ_ADJUSTMENT_CC 13 /* add 1Hz STCF adjustment */
+
+/** \cfetimecmd Subtract Delta from Spacecraft Time Correlation Factor each 1Hz
+**
+**  \par Description
+**       This command has been updated to take actual sub-seconds (1/2^32 seconds)
+**       rather than micro-seconds as an input argument.  This change occurred
+**       after the determination was made that one micro-second is too large an
+**       increment for a constant 1Hz adjustment.<BR><BR>
+**       This command continuously adjusts the Spacecraft Time Correlation Factor (STCF)
+**       every second, by subtracting the specified value.  The adjustment to the STCF
+**       is applied in the Time Service local 1Hz interrupt handler.  As the local 1Hz
+**       interrupt is not synchronized to the tone signal, one cannot say when the
+**       adjustment will occur, other than once a second, at about the same time
+**       relative to the tone.<BR><BR>
+**       There was some debate about whether the maximum 1Hz clock drift correction
+**       factor would ever need to exceed some small fraction of a second.  But, the
+**       decision was made to provide the capability to make 1Hz adjustments greater
+**       than one second and leave it to the ground system to provide mission specific
+**       limits.
+**
+**  \cfecmdmnemonic \TIME_SUB1HZSTCF
+**
+**  \par Command Structure
+**       #CFE_TIME_Sub1HZAdjustmentCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TIME_CMDPC - command execution counter will increment
+**       - \b \c \TIME_STCFSECS - Housekeeping Telemetry point indicating new STCF seconds value
+**       - \b \c \TIME_STCFSUBSECS - Housekeeping Telemetry point indicating new STCF subseconds value
+**       - The #CFE_TIME_1HZ_EID informational event message will be generated
+**
+**  \par Error Conditions
+**       - Platorm receiving the command is not a Time Server
+**       <BR><BR>Evidence of Failure may be found in the following telemetry:
+**       - \b \c \TIME_CMDEC - command error counter will increment
+**       - Error specific event message will be issued (#CFE_TIME_1HZ_CFG_EID)
+**
+**  \par Criticality
+**       Inappropriately setting the clock may result in other sub-systems performing incorrect
+**       time based calculations.  The specific risk is dependent upon the behavior of those sub-systems.
+**
+**  \sa #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_SUB_ADJUST_CC, #CFE_TIME_ADD_1HZ_ADJUSTMENT_CC
+*/
+#define CFE_TIME_SUB_1HZ_ADJUSTMENT_CC 14 /* subtract 1Hz STCF adjustment */
+
+/** \cfetimecmd Set Tone Signal Source
+**
+**  \par Description
+**       This command selects the Time Service tone signal source.  Although the
+**       list of potential tone signal sources is mission specific, a common
+**       choice is the selection of primary or redundant tone signal.  The selection
+**       may be available to both the Time Server and Time Clients, depending on
+**       hardware configuration.<BR><BR>
+**       Notes:
+**       - This command is only valid when the #CFE_PLATFORM_TIME_CFG_SIGNAL configuration
+**         parameter in the cfe_platform_cfg.h file has been set to true.
+**
+**  \cfecmdmnemonic \TIME_SETSIGNAL
+**
+**  \par Command Structure
+**       #CFE_TIME_SetSignalCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified with the
+**       following telemetry:
+**       - \b \c \TIME_CMDPC - command execution counter will
+**         increment
+**       - \b \c \TIME_SIGNAL - Diagnostic Telemetry point will indicate the
+**         command specified value
+**       - The #CFE_TIME_SIGNAL_EID informational event message will
+**         be generated
+**
+**  \par Error Conditions
+**       - Invalid Signal selection
+**         (a value other than #CFE_TIME_ToneSignalSelect_PRIMARY or #CFE_TIME_ToneSignalSelect_REDUNDANT was specified)
+**       - Multiple Tone Signal Sources not available on this platform
+**       <BR><BR>Evidence of failure may be found in the following telemetry:
+**       - \b \c \TIME_CMDEC - Command Error counter will increment
+**       - Error specific event message (either #CFE_TIME_SIGNAL_CFG_EID or #CFE_TIME_SIGNAL_ERR_EID)
+**
+**  \par Criticality
+**       Although tone signal source selection is important, this command is not critical
+**
+**  \sa #CFE_TIME_SET_STATE_CC, #CFE_TIME_SET_SOURCE_CC
+*/
+#define CFE_TIME_SET_SIGNAL_CC 15 /* set clock signal (pri vs red) */
+/** \} */
+
+/** \defgroup CFETIMEClkStates cFE Clock State Flag Defines
+ * \{
+ */
+#define CFE_TIME_FLAG_CLKSET 0x8000 /**< \brief The spacecraft time has been set */
+#define CFE_TIME_FLAG_FLYING 0x4000 /**< \brief This instance of Time Services is flywheeling */
+#define CFE_TIME_FLAG_SRCINT 0x2000 /**< \brief The clock source is set to "internal" */
+#define CFE_TIME_FLAG_SIGPRI 0x1000 /**< \brief The clock signal is set to "primary" */
+#define CFE_TIME_FLAG_SRVFLY 0x0800 /**< \brief The Time Server is in flywheel mode */
+#define CFE_TIME_FLAG_CMDFLY 0x0400 /**< \brief This instance of Time Services was commanded into flywheel mode */
+#define CFE_TIME_FLAG_ADDADJ 0x0200 /**< \brief One time STCF Adjustment is to be done in positive direction */
+#define CFE_TIME_FLAG_ADD1HZ 0x0100 /**< \brief 1 Hz STCF Adjustment is to be done in a positive direction */
+#define CFE_TIME_FLAG_ADDTCL 0x0080 /**< \brief Time Client Latency is applied in a positive direction */
+#define CFE_TIME_FLAG_SERVER 0x0040 /**< \brief This instance of Time Services is a Time Server */
+#define CFE_TIME_FLAG_GDTONE 0x0020 /**< \brief The tone received is good compared to the last tone received */
+#define CFE_TIME_FLAG_UNUSED 0x001F /**< \brief Reserved flags - should be zero */
+/** \} */
+
+/*************************************************************************/
+
+/**
+ * \brief Generic no argument command
+ */
+typedef struct CFE_TIME_NoArgsCmd
+{
+    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+
+} CFE_TIME_NoArgsCmd_t;
+
+/*
+ * A separate typedef for each of the commands that share this definition
+ * This follows the convention for command handler prototypes and allows
+ * each one to independently evolve as necessary.
+ */
+typedef CFE_TIME_NoArgsCmd_t CFE_TIME_NoopCmd_t;
+typedef CFE_TIME_NoArgsCmd_t CFE_TIME_ResetCountersCmd_t;
+typedef CFE_TIME_NoArgsCmd_t CFE_TIME_SendDiagnosticCmd_t;
+typedef CFE_TIME_NoArgsCmd_t CFE_TIME_1HzCmd_t;
+typedef CFE_TIME_NoArgsCmd_t CFE_TIME_ToneSignalCmd_t;
+typedef CFE_TIME_NoArgsCmd_t CFE_TIME_FakeToneCmd_t;
+
+/**
+ * \brief Set leap seconds command payload
+ */
+typedef struct CFE_TIME_LeapsCmd_Payload
+{
+    int16 LeapSeconds;
+} CFE_TIME_LeapsCmd_Payload_t;
+
+/**
+ * \brief Set leap seconds command
+ */
+typedef struct CFE_TIME_SetLeapSecondsCmd
+{
+    CFE_MSG_CommandHeader_t     CmdHeader; /**< \brief Command header */
+    CFE_TIME_LeapsCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TIME_SetLeapSecondsCmd_t;
+
+/**
+ * \brief Set clock state command payload
+ */
+typedef struct CFE_TIME_StateCmd_Payload
+{
+    int16 ClockState; /**< \brief #CFE_TIME_ClockState_INVALID=Spacecraft time has not been accurately set,
+                                  #CFE_TIME_ClockState_VALID=Spacecraft clock has been accurately set,
+                                  #CFE_TIME_ClockState_FLYWHEEL=Force into FLYWHEEL mode   */
+                      /**< Selects the current clock state */
+} CFE_TIME_StateCmd_Payload_t;
+
+/**
+ * \brief Set clock state command
+ */
+typedef struct CFE_TIME_SetStateCmd
+{
+    CFE_MSG_CommandHeader_t     CmdHeader; /**< \brief Command header */
+    CFE_TIME_StateCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TIME_SetStateCmd_t;
+
+/**
+ * \brief Set time data source command payload
+ */
+typedef struct CFE_TIME_SourceCmd_Payload
+{
+    int16 TimeSource; /**< \brief #CFE_TIME_SourceSelect_INTERNAL=Internal Source,
+                                  #CFE_TIME_SourceSelect_EXTERNAL=External Source   */
+                      /**< Selects either the "Internal" and "External" clock source */
+} CFE_TIME_SourceCmd_Payload_t;
+
+/**
+ * \brief Set time data source command
+ */
+typedef struct CFE_TIME_SetSourceCmd
+{
+    CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
+    CFE_TIME_SourceCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TIME_SetSourceCmd_t;
+
+/**
+ * \brief Set tone signal source command payload
+ */
+typedef struct CFE_TIME_SignalCmd_Payload
+{
+    int16 ToneSource; /**< \brief #CFE_TIME_ToneSignalSelect_PRIMARY=Primary Source,
+                                  #CFE_TIME_ToneSignalSelect_REDUNDANT=Redundant Source   */
+                      /**< Selects either the "Primary" or "Redundant" tone signal source */
+} CFE_TIME_SignalCmd_Payload_t;
+
+/**
+ * \brief Set tone signal source command
+ */
+typedef struct CFE_TIME_SetSignalCmd
+{
+    CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
+    CFE_TIME_SignalCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TIME_SetSignalCmd_t;
+
+/**
+ * \brief Generic seconds, microseconds command payload
+ */
+typedef struct CFE_TIME_TimeCmd_Payload
+{
+    uint32 Seconds;
+    uint32 MicroSeconds;
+} CFE_TIME_TimeCmd_Payload_t;
+
+/**
+ * \brief Generic seconds, microseconds argument command
+ */
+typedef struct CFE_TIME_TimeCmd
+{
+    CFE_MSG_CommandHeader_t    CmdHeader; /**< \brief Command header */
+    CFE_TIME_TimeCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TIME_TimeCmd_t;
+
+/*
+ * A separate typedef for each of the commands that share this definition
+ * This follows the convention for command handler prototypes and allows
+ * each one to independently evolve as necessary.
+ */
+typedef CFE_TIME_TimeCmd_t CFE_TIME_AddDelayCmd_t;
+typedef CFE_TIME_TimeCmd_t CFE_TIME_SubDelayCmd_t;
+typedef CFE_TIME_TimeCmd_t CFE_TIME_SetMETCmd_t;
+typedef CFE_TIME_TimeCmd_t CFE_TIME_SetSTCFCmd_t;
+typedef CFE_TIME_TimeCmd_t CFE_TIME_AddAdjustCmd_t;
+typedef CFE_TIME_TimeCmd_t CFE_TIME_SubAdjustCmd_t;
+typedef CFE_TIME_TimeCmd_t CFE_TIME_SetTimeCmd_t;
+
+/**
+ * \brief Generic seconds, subseconds command payload
+ */
+typedef struct CFE_TIME_OneHzAdjustmentCmd_Payload
+{
+    uint32 Seconds;
+    uint32 Subseconds;
+
+} CFE_TIME_OneHzAdjustmentCmd_Payload_t;
+
+/**
+ * \brief Generic seconds, subseconds adjustment command
+ */
+typedef struct CFE_TIME_OneHzAdjustmentCmd
+{
+    CFE_MSG_CommandHeader_t               CmdHeader; /**< \brief Command header */
+    CFE_TIME_OneHzAdjustmentCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TIME_OneHzAdjustmentCmd_t;
+
+/*
+ * A separate typedef for each of the commands that share this definition
+ * This follows the convention for command handler prototypes and allows
+ * each one to independently evolve as necessary.
+ */
+typedef CFE_TIME_OneHzAdjustmentCmd_t CFE_TIME_Add1HZAdjustmentCmd_t;
+typedef CFE_TIME_OneHzAdjustmentCmd_t CFE_TIME_Sub1HZAdjustmentCmd_t;
+
+/**
+ * \brief Time at tone data command payload
+ */
+typedef struct CFE_TIME_ToneDataCmd_Payload
+{
+    CFE_TIME_SysTime_t AtToneMET;         /**< \brief MET at time of tone */
+    CFE_TIME_SysTime_t AtToneSTCF;        /**< \brief STCF at time of tone */
+    int16              AtToneLeapSeconds; /**< \brief Leap Seconds at time of tone */
+    int16              AtToneState;       /**< \brief Clock state at time of tone */
+} CFE_TIME_ToneDataCmd_Payload_t;
+
+/**
+ * \brief Time at tone data command
+ */
+typedef struct CFE_TIME_ToneDataCmd
+{
+    CFE_MSG_CommandHeader_t        CmdHeader; /**< \brief Command header */
+    CFE_TIME_ToneDataCmd_Payload_t Payload;   /**< \brief Command payload */
+} CFE_TIME_ToneDataCmd_t;
+
+/*************************************************************************/
+
+/**
+**  \cfetimetlm Time Services Housekeeping Packet
+**/
+typedef struct CFE_TIME_HousekeepingTlm_Payload
+{
+    /*
+    ** Task command interface counters...
+    */
+    uint8 CommandCounter;      /**< \cfetlmmnemonic \TIME_CMDPC
+                                \brief Time Command Execution Counter */
+    uint8 CommandErrorCounter; /**< \cfetlmmnemonic \TIME_CMDEC
+                           \brief Time Command Error Counter */
+
+    /*
+    ** Clock state flags and "as calculated" clock state...
+    */
+    uint16 ClockStateFlags; /**< \cfetlmmnemonic \TIME_STATEFLG
+                                 \brief State Flags */
+    int16 ClockStateAPI;    /**< \cfetlmmnemonic \TIME_APISTATE
+                                 \brief API State */
+
+    /*
+    ** Leap Seconds...
+    */
+    int16 LeapSeconds; /**< \cfetlmmnemonic \TIME_LEAPSECS
+                            \brief Current Leaps Seconds */
+
+    /*
+    ** Current MET and STCF time values...
+    */
+    uint32 SecondsMET; /**< \cfetlmmnemonic \TIME_METSECS
+                            \brief Current MET (seconds) */
+    uint32 SubsecsMET; /**< \cfetlmmnemonic \TIME_METSUBSECS
+                            \brief Current MET (sub-seconds) */
+
+    uint32 SecondsSTCF; /**< \cfetlmmnemonic \TIME_STCFSECS
+                             \brief Current STCF (seconds) */
+    uint32 SubsecsSTCF; /**< \cfetlmmnemonic \TIME_STCFSUBSECS
+                             \brief Current STCF (sub-seconds) */
+
+/*
+** 1Hz STCF adjustment values (server only)...
+*/
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+    uint32 Seconds1HzAdj; /**< \cfetlmmnemonic \TIME_1HZADJSECS
+                               \brief Current 1 Hz SCTF adjustment (seconds) */
+    uint32 Subsecs1HzAdj; /**< \cfetlmmnemonic \TIME_1HZADJSSECS
+                               \brief Current 1 Hz SCTF adjustment (sub-seconds) */
+#endif
+
+/*
+** Time at tone delay values (client only)...
+*/
+#if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
+    uint32 SecondsDelay; /**< \cfetlmmnemonic \TIME_1HZDLYSECS
+                              \brief Current 1 Hz SCTF Delay (seconds) */
+    uint32 SubsecsDelay; /**< \cfetlmmnemonic \TIME_1HZDLYSSECS
+                              \brief Current 1 Hz SCTF Delay (sub-seconds) */
+#endif
+
+} CFE_TIME_HousekeepingTlm_Payload_t;
+
+typedef struct CFE_TIME_HousekeepingTlm
+{
+    CFE_MSG_TelemetryHeader_t          TlmHeader; /**< \brief Telemetry header */
+    CFE_TIME_HousekeepingTlm_Payload_t Payload;   /**< \brief Telemetry payload */
+} CFE_TIME_HousekeepingTlm_t;
+
+/*************************************************************************/
+
+/**
+**  \cfetimetlm Time Services Diagnostics Packet
+**/
+typedef struct CFE_TIME_DiagnosticTlm_Payload
+{
+    /*
+     ** Data values used to compute time (in reference to "tone")...
+     */
+    CFE_TIME_SysTime_t AtToneMET;   /**< \cfetlmmnemonic \TIME_TMETS
+                                               \brief MET at time of tone */
+    CFE_TIME_SysTime_t AtToneSTCF;  /**< \cfetlmmnemonic \TIME_STCFS
+                                               \brief STCF at time of tone */
+    CFE_TIME_SysTime_t AtToneDelay; /**< \cfetlmmnemonic \TIME_LATENTS
+                                               \brief Adjustment for slow tone detection */
+    CFE_TIME_SysTime_t AtToneLatch; /**< \cfetlmmnemonic \TIME_TVALIDS
+                                               \brief Local clock latched at time of tone */
+
+    int16 AtToneLeapSeconds; /**< \cfetlmmnemonic \TIME_LEAPS
+                                  \brief Leap Seconds at time of tone */
+    int16 ClockStateAPI;     /**< \cfetlmmnemonic \TIME_APISTATE
+                                        \brief Clock state as per API */
+
+    /*
+     ** Data values that reflect the time (right now)...
+     */
+    CFE_TIME_SysTime_t TimeSinceTone; /**< \cfetlmmnemonic \TIME_ELAPSEDS
+                                                 \brief Time elapsed since the tone */
+    CFE_TIME_SysTime_t CurrentLatch;  /**< \cfetlmmnemonic \TIME_LOCALS
+                                                 \brief Local clock latched just "now" */
+    CFE_TIME_SysTime_t CurrentMET;    /**< \cfetlmmnemonic \TIME_METS
+                                                 \brief MET at this instant */
+    CFE_TIME_SysTime_t CurrentTAI;    /**< \cfetlmmnemonic \TIME_TAIS
+                                                 \brief TAI at this instant */
+    CFE_TIME_SysTime_t CurrentUTC;    /**< \cfetlmmnemonic \TIME_UTCS
+                                                 \brief UTC at this instant */
+
+    /*
+     ** Data values used to define the current clock state...
+     */
+    int16 ClockSetState;  /**< \cfetlmmnemonic \TIME_VALID
+                                     \brief Time has been "set" */
+    int16 ClockFlyState;  /**< \cfetlmmnemonic \TIME_FLYWHEEL
+                                     \brief Current fly-wheel state */
+    int16 ClockSource;    /**< \cfetlmmnemonic \TIME_SOURCE
+                                     \brief Internal vs external, etc. */
+    int16 ClockSignal;    /**< \cfetlmmnemonic \TIME_SIGNAL
+                                     \brief Primary vs redundant, etc. */
+    int16 ServerFlyState; /**< \cfetlmmnemonic \TIME_SRVFLY
+                                     \brief Used by clients only */
+    int16 Forced2Fly;     /**< \cfetlmmnemonic \TIME_CMD2FLY
+                                     \brief Commanded into fly-wheel */
+
+    /*
+     ** Clock state flags...
+     */
+    uint16 ClockStateFlags; /**< \cfetlmmnemonic \TIME_STATEFLAGS
+                                       \brief Clock State Flags */
+
+    /*
+     ** STCF adjustment direction values...
+     */
+    int16 OneTimeDirection; /**< \cfetlmmnemonic \TIME_ADJUSTDIR
+                                       \brief One time STCF adjustment direction (Add = 1,  Sub = 2) */
+    int16 OneHzDirection;   /**< \cfetlmmnemonic \TIME_1HZADJDIR
+                                       \brief 1Hz STCF adjustment direction */
+    int16 DelayDirection;   /**< \cfetlmmnemonic \TIME_LATENTDIR
+                                       \brief Client latency adjustment direction */
+
+    /*
+     ** STCF adjustment values...
+     */
+    CFE_TIME_SysTime_t OneTimeAdjust; /**< \cfetlmmnemonic \TIME_ADJUSTS
+                                                 \brief Previous one-time STCF adjustment */
+    CFE_TIME_SysTime_t OneHzAdjust;   /**< \cfetlmmnemonic \TIME_1HZADJS
+                                                 \brief Current 1Hz STCF adjustment */
+
+    /*
+     ** Most recent local clock latch values...
+     */
+    CFE_TIME_SysTime_t ToneSignalLatch; /**< \cfetlmmnemonic \TIME_TTS
+                                                   \brief  Local Clock latched at most recent tone signal */
+    CFE_TIME_SysTime_t ToneDataLatch;   /**< \cfetlmmnemonic \TIME_TDS
+                                                   \brief  Local Clock latched at arrival of tone data */
+
+    /*
+     ** Miscellaneous counters (subject to reset command)...
+     */
+    uint32 ToneMatchCounter;      /**< \cfetlmmnemonic \TIME_VERIFYCNT
+                                           \brief  Tone signal / data verification count */
+    uint32 ToneMatchErrorCounter; /**< \cfetlmmnemonic \TIME_VERIFYER
+                                       \brief  Tone signal / data verification error count */
+    uint32 ToneSignalCounter;     /**< \cfetlmmnemonic \TIME_TSDETCNT
+                                           \brief  Tone signal detected SB message count */
+    uint32 ToneDataCounter;       /**< \cfetlmmnemonic \TIME_TATTCNT
+                                           \brief  Time at the tone data SB message count */
+    uint32 ToneIntCounter;        /**< \cfetlmmnemonic \TIME_TSISRCNT
+                                           \brief  Tone signal ISR execution count */
+    uint32 ToneIntErrorCounter;   /**< \cfetlmmnemonic \TIME_TSISRERR
+                                       \brief  Tone signal ISR error count */
+    uint32 ToneTaskCounter;       /**< \cfetlmmnemonic \TIME_TSTASKCNT
+                                           \brief  Tone task execution count */
+    uint32 VersionCounter;        /**< \cfetlmmnemonic \TIME_VERSIONCNT
+                                           \brief  Count of mods to time at tone reference data (version) */
+    uint32 LocalIntCounter;       /**< \cfetlmmnemonic \TIME_1HZISRCNT
+                                           \brief  Local 1Hz ISR execution count */
+    uint32 LocalTaskCounter;      /**< \cfetlmmnemonic \TIME_1HZTASKCNT
+                                           \brief  Local 1Hz task execution count */
+
+    /*
+     ** Miscellaneous counters (not subject to reset command)...
+     */
+    uint32 VirtualMET; /**< \cfetlmmnemonic \TIME_LOGICALMET
+                                  \brief  Software MET */
+
+    /*
+     ** Time window verification values (converted from micro-secs)...
+     **
+     ** Regardless of whether the tone follows the time packet, or vice
+     **    versa, these values define the acceptable window of time for
+     **    the second event to follow the first.  The minimum value may
+     **    be as little as zero, and the maximum must be something less
+     **    than a second.
+     */
+    uint32 MinElapsed; /**< \cfetlmmnemonic \TIME_MINWINDOW
+                                  \brief Min tone signal / data pkt arrival window (Sub-seconds) */
+    uint32 MaxElapsed; /**< \cfetlmmnemonic \TIME_MAXWINDOW
+                                  \brief Max tone signal / data pkt arrival window (Sub-seconds) */
+
+    /*
+     ** Maximum local clock value (before roll-over)...
+     */
+    CFE_TIME_SysTime_t MaxLocalClock; /**< \cfetlmmnemonic \TIME_WRAPS
+                                                 \brief Max local clock value before rollover */
+
+    /*
+     ** Tone signal tolerance limits...
+     */
+    uint32 ToneOverLimit;  /**< \cfetlmmnemonic \TIME_MAXSS
+                                      \brief Max between tone signal interrupts */
+    uint32 ToneUnderLimit; /**< \cfetlmmnemonic \TIME_MINSS
+                                      \brief Min between tone signal interrupts */
+
+    /*
+     ** Reset Area...
+     */
+    uint32 DataStoreStatus; /**< \cfetlmmnemonic \TIME_ATASTSTAT
+                                       \brief Data Store status (preserved across processor reset) */
+} CFE_TIME_DiagnosticTlm_Payload_t;
+
+typedef struct CFE_TIME_DiagnosticTlm
+{
+    CFE_MSG_TelemetryHeader_t        TlmHeader; /**< \brief Telemetry header */
+    CFE_TIME_DiagnosticTlm_Payload_t Payload;   /**< \brief Telemetry payload */
+} CFE_TIME_DiagnosticTlm_t;
+
+#endif /* CFE_TIME_MSG_H */

--- a/modules/time/fsw/src/cfe_time_api.c
+++ b/modules/time/fsw/src/cfe_time_api.c
@@ -1,0 +1,808 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/*
+** File: cfe_time_api.c
+**
+** Purpose:  cFE Time Services (TIME) library API source file
+**
+** Author:   S.Walling/Microtel
+**
+** Notes:    Partially derived from SDO source code
+**
+*/
+
+/*
+** Required header files...
+*/
+#include "cfe_time_module_all.h"
+
+#include <string.h>
+
+/*
+ * Function: CFE_TIME_GetTime - See API and header file for details
+ */
+CFE_TIME_SysTime_t CFE_TIME_GetTime(void)
+{
+    CFE_TIME_SysTime_t CurrentTime;
+
+#if (CFE_MISSION_TIME_CFG_DEFAULT_TAI == true)
+
+    CurrentTime = CFE_TIME_GetTAI();
+
+#else
+
+    CurrentTime = CFE_TIME_GetUTC();
+
+#endif
+
+    return (CurrentTime);
+
+} /* End of CFE_TIME_GetTime() */
+
+/*
+ * Function: CFE_TIME_GetTAI - See API and header file for details
+ */
+CFE_TIME_SysTime_t CFE_TIME_GetTAI(void)
+{
+    CFE_TIME_Reference_t Reference;
+    CFE_TIME_SysTime_t   tai;
+
+    /* Zero out the Reference variable because we pass it into
+     * a function before using it
+     * */
+    memset(&Reference, 0, sizeof(CFE_TIME_Reference_t));
+
+    /*
+    ** Get reference time values (local time, time at tone, etc.)...
+    */
+    CFE_TIME_GetReference(&Reference);
+
+    /*
+    ** Calculate current TAI...
+    */
+    tai = CFE_TIME_CalculateTAI(&Reference);
+
+    return (tai);
+
+} /* End of CFE_TIME_GetTAI() */
+
+/*
+ * Function: CFE_TIME_GetUTC - See API and header file for details
+ */
+CFE_TIME_SysTime_t CFE_TIME_GetUTC(void)
+{
+    CFE_TIME_Reference_t Reference;
+    CFE_TIME_SysTime_t   utc;
+
+    /* Zero out the Reference variable because we pass it into
+     * a function before using it
+     * */
+    memset(&Reference, 0, sizeof(CFE_TIME_Reference_t));
+    /*
+    ** Get reference time values (local time, time at tone, etc.)...
+    */
+    CFE_TIME_GetReference(&Reference);
+
+    /*
+    ** Calculate current UTC...
+    */
+    utc = CFE_TIME_CalculateUTC(&Reference);
+
+    return (utc);
+
+} /* End of CFE_TIME_GetUTC() */
+
+/*
+ * Function: CFE_TIME_MET2SCTime - See API and header file for details
+ */
+CFE_TIME_SysTime_t CFE_TIME_MET2SCTime(CFE_TIME_SysTime_t METTime)
+{
+
+    CFE_TIME_SysTime_t STCF;
+    CFE_TIME_SysTime_t TIATime;
+    CFE_TIME_SysTime_t ReturnTime;
+#if (CFE_MISSION_TIME_CFG_DEFAULT_TAI != true)
+    CFE_TIME_SysTime_t LeapSecsAsSysTime;
+#endif
+
+    STCF = CFE_TIME_GetSTCF();
+
+    /* TIA = MET + STCF */
+    TIATime = CFE_TIME_Add(METTime, STCF);
+
+#if (CFE_MISSION_TIME_CFG_DEFAULT_TAI == true)
+
+    ReturnTime = TIATime;
+
+#else
+
+    /* Put leap seconds in correct format */
+    LeapSecsAsSysTime.Seconds    = CFE_TIME_GetLeapSeconds();
+    LeapSecsAsSysTime.Subseconds = 0;
+
+    /* UTC Time = TIA Time - Leap Seconds */
+    ReturnTime = CFE_TIME_Subtract(TIATime, LeapSecsAsSysTime);
+
+#endif
+
+    return (ReturnTime);
+} /* end CFE_TIME_MET2SCTime() */
+
+/*
+ * Function: CFE_TIME_GetClockState - See API and header file for details
+ */
+CFE_TIME_ClockState_Enum_t CFE_TIME_GetClockState(void)
+{
+    CFE_TIME_Reference_t       Reference;
+    CFE_TIME_ClockState_Enum_t state;
+
+    /* Zero out the Reference variable because we pass it into
+     * a function before using it
+     * */
+    memset(&Reference, 0, sizeof(CFE_TIME_Reference_t));
+    /*
+    ** Get reference time values (local time, time at tone, etc.)...
+    */
+    CFE_TIME_GetReference(&Reference);
+
+    /*
+    ** Determine the current clock state...
+    */
+    state = (CFE_TIME_ClockState_Enum_t)CFE_TIME_CalculateState(&Reference);
+
+    return (state);
+
+} /* End of CFE_TIME_GetClockState() */
+
+/*
+ * Function: CFE_TIME_GetClockInfo - See API and header file for details
+ */
+uint16 CFE_TIME_GetClockInfo(void)
+{
+    uint16                              StateFlags = 0;
+    volatile CFE_TIME_ReferenceState_t *RefState   = CFE_TIME_GetReferenceState();
+
+    /*
+    ** Spacecraft time has been set...
+    */
+    if (RefState->ClockSetState == CFE_TIME_SetState_WAS_SET)
+    {
+        StateFlags |= CFE_TIME_FLAG_CLKSET;
+    }
+    /*
+    ** This instance of Time Service is in FLYWHEEL mode...
+    */
+    if (RefState->ClockFlyState == CFE_TIME_FlywheelState_IS_FLY)
+    {
+        StateFlags |= CFE_TIME_FLAG_FLYING;
+    }
+    /*
+    ** Clock source set to "internal"...
+    */
+    if (CFE_TIME_Global.ClockSource == CFE_TIME_SourceSelect_INTERNAL)
+    {
+        StateFlags |= CFE_TIME_FLAG_SRCINT;
+    }
+    /*
+    ** Clock signal set to "primary"...
+    */
+    if (CFE_TIME_Global.ClockSignal == CFE_TIME_ToneSignalSelect_PRIMARY)
+    {
+        StateFlags |= CFE_TIME_FLAG_SIGPRI;
+    }
+    /*
+    ** Time Server is in FLYWHEEL mode...
+    */
+    if (CFE_TIME_Global.ServerFlyState == CFE_TIME_FlywheelState_IS_FLY)
+    {
+        StateFlags |= CFE_TIME_FLAG_SRVFLY;
+    }
+    /*
+    ** This instance of Time Services commanded into FLYWHEEL...
+    */
+    if (CFE_TIME_Global.Forced2Fly)
+    {
+        StateFlags |= CFE_TIME_FLAG_CMDFLY;
+    }
+    /*
+    ** One time STCF adjustment direction...
+    */
+    if (CFE_TIME_Global.OneTimeDirection == CFE_TIME_AdjustDirection_ADD)
+    {
+        StateFlags |= CFE_TIME_FLAG_ADDADJ;
+    }
+    /*
+    ** 1 Hz STCF adjustment direction...
+    */
+    if (CFE_TIME_Global.OneHzDirection == CFE_TIME_AdjustDirection_ADD)
+    {
+        StateFlags |= CFE_TIME_FLAG_ADD1HZ;
+    }
+    /*
+    ** Time Client Latency adjustment direction...
+    */
+    if (RefState->DelayDirection == CFE_TIME_AdjustDirection_ADD)
+    {
+        StateFlags |= CFE_TIME_FLAG_ADDTCL;
+    }
+/*
+** This instance of Time Service is a "server"...
+*/
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+    StateFlags |= CFE_TIME_FLAG_SERVER;
+#endif
+
+    /*
+    ** The tone is good
+    */
+    if (CFE_TIME_Global.IsToneGood == true)
+    {
+        StateFlags |= CFE_TIME_FLAG_GDTONE;
+    }
+
+    return (StateFlags);
+
+} /* End of CFE_TIME_GetClockInfo() */
+
+/*
+ * Function: CFE_TIME_GetLeapSeconds - See API and header file for details
+ */
+int16 CFE_TIME_GetLeapSeconds(void)
+{
+    CFE_TIME_Reference_t Reference;
+
+    /* Zero out the Reference variable because we pass it into
+     * a function before using it
+     * */
+    memset(&Reference, 0, sizeof(CFE_TIME_Reference_t));
+
+    /*
+    ** Get reference time values (local time, time at tone, etc.)...
+    */
+    CFE_TIME_GetReference(&Reference);
+
+    return (Reference.AtToneLeapSeconds);
+
+} /* End of CFE_TIME_GetLeapSeconds() */
+
+/*
+ * Function: CFE_TIME_GetSTCF - See API and header file for details
+ */
+CFE_TIME_SysTime_t CFE_TIME_GetSTCF(void)
+{
+    CFE_TIME_Reference_t Reference;
+
+    /* Zero out the Reference variable because we pass it into
+     * a function before using it
+     * */
+    memset(&Reference, 0, sizeof(CFE_TIME_Reference_t));
+
+    /*
+    ** Get reference time values (local time, time at tone, etc.)...
+    */
+    CFE_TIME_GetReference(&Reference);
+
+    return (Reference.AtToneSTCF);
+
+} /* End of CFE_TIME_GetSTCF() */
+
+/*
+ * Function: CFE_TIME_GetMET - See API and header file for details
+ */
+CFE_TIME_SysTime_t CFE_TIME_GetMET(void)
+{
+    CFE_TIME_Reference_t Reference;
+
+    /* Zero out the Reference variable because we pass it into
+     * a function before using it
+     */
+    memset(&Reference, 0, sizeof(CFE_TIME_Reference_t));
+
+    /*
+    ** Get reference time values (local time, time at tone, etc.)...
+    */
+    CFE_TIME_GetReference(&Reference);
+
+    return (Reference.CurrentMET);
+
+} /* End of CFE_TIME_GetMET() */
+
+/*
+ * Function: CFE_TIME_GetMETseconds - See API and header file for details
+ */
+uint32 CFE_TIME_GetMETseconds(void)
+{
+    CFE_TIME_Reference_t Reference;
+
+    /* Zero out the Reference variable because we pass it into
+     * a function before using it
+     * */
+    memset(&Reference, 0, sizeof(CFE_TIME_Reference_t));
+
+    /*
+    ** Get reference time values (local time, time at tone, etc.)...
+    */
+    CFE_TIME_GetReference(&Reference);
+
+    return (Reference.CurrentMET.Seconds);
+
+} /* End of CFE_TIME_GetMETseconds() */
+
+/*
+ * Function: CFE_TIME_GetMETsubsecs - See API and header file for details
+ */
+uint32 CFE_TIME_GetMETsubsecs(void)
+{
+    CFE_TIME_Reference_t Reference;
+
+    /* Zero out the Reference variable because we pass it into
+     * a function before using it
+     * */
+    memset(&Reference, 0, sizeof(CFE_TIME_Reference_t));
+
+    /*
+    ** Get reference time values (local time, time at tone, etc.)...
+    */
+    CFE_TIME_GetReference(&Reference);
+
+    return (Reference.CurrentMET.Subseconds);
+
+} /* End of CFE_TIME_GetMETsubsecs() */
+
+/*
+ * Function: CFE_TIME_Add - See API and header file for details
+ */
+CFE_TIME_SysTime_t CFE_TIME_Add(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2)
+{
+    CFE_TIME_SysTime_t Result;
+
+    Result.Subseconds = Time1.Subseconds + Time2.Subseconds;
+
+    /*
+    ** Check for sub-seconds roll-over
+    */
+    if (Result.Subseconds < Time1.Subseconds)
+    {
+        Result.Seconds = (Time1.Seconds + Time2.Seconds) + 1;
+    }
+    else
+    {
+        Result.Seconds = Time1.Seconds + Time2.Seconds;
+    }
+
+    return (Result);
+
+} /* End of CFE_TIME_Add() */
+
+/*
+ * Function: CFE_TIME_Subtract - See API and header file for details
+ */
+CFE_TIME_SysTime_t CFE_TIME_Subtract(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2)
+{
+    CFE_TIME_SysTime_t Result;
+
+    Result.Subseconds = Time1.Subseconds - Time2.Subseconds;
+
+    if (Result.Subseconds > Time1.Subseconds)
+    {
+        Result.Seconds = (Time1.Seconds - Time2.Seconds) - 1;
+    }
+    else
+    {
+        Result.Seconds = Time1.Seconds - Time2.Seconds;
+    }
+
+    return (Result);
+
+} /* End of CFE_TIME_Subtract() */
+
+/*
+ * Function: CFE_TIME_Compare - See API and header file for details
+ */
+CFE_TIME_Compare_t CFE_TIME_Compare(CFE_TIME_SysTime_t TimeA, CFE_TIME_SysTime_t TimeB)
+{
+    CFE_TIME_Compare_t Result;
+
+    if (TimeA.Seconds > TimeB.Seconds)
+    {
+        /*
+        ** Assume rollover if difference is too large...
+        */
+        if ((TimeA.Seconds - TimeB.Seconds) > CFE_TIME_NEGATIVE)
+        {
+            Result = CFE_TIME_A_LT_B;
+        }
+        else
+        {
+            Result = CFE_TIME_A_GT_B;
+        }
+    }
+    else if (TimeA.Seconds < TimeB.Seconds)
+    {
+        /*
+        ** Assume rollover if difference is too large...
+        */
+        if ((TimeB.Seconds - TimeA.Seconds) > CFE_TIME_NEGATIVE)
+        {
+            Result = CFE_TIME_A_GT_B;
+        }
+        else
+        {
+            Result = CFE_TIME_A_LT_B;
+        }
+    }
+    else
+    {
+        /*
+        ** Seconds are equal, check sub-seconds
+        */
+        if (TimeA.Subseconds > TimeB.Subseconds)
+        {
+            Result = CFE_TIME_A_GT_B;
+        }
+        else if (TimeA.Subseconds < TimeB.Subseconds)
+        {
+            Result = CFE_TIME_A_LT_B;
+        }
+        else
+        {
+            Result = CFE_TIME_EQUAL;
+        }
+    }
+
+    return (Result);
+
+} /* End of CFE_TIME_Compare() */
+
+/*
+ * Function: CFE_TIME_Sub2MicroSecs - See API and header file for details
+ */
+uint32 CFE_TIME_Sub2MicroSecs(uint32 SubSeconds)
+{
+    OS_time_t tm;
+
+    /*
+    ** Convert using the OSAL method.  Note that there
+    ** is no range check here because any uint32 value is valid,
+    ** and OSAL will handle and properly convert any input.
+    */
+    tm = OS_TimeAssembleFromSubseconds(0, SubSeconds);
+
+    return OS_TimeGetMicrosecondsPart(tm);
+
+} /* End of CFE_TIME_Sub2MicroSecs() */
+
+/*
+ * Function: CFE_TIME_Micro2SubSecs - See API and header file for details
+ */
+uint32 CFE_TIME_Micro2SubSecs(uint32 MicroSeconds)
+{
+    OS_time_t tm;
+    uint32    SubSeconds;
+
+    /*
+    ** Conversion amount must be less than one second
+    ** (preserves existing behavior where output saturates at max value)
+    */
+    if (MicroSeconds > 999999)
+    {
+        SubSeconds = 0xFFFFFFFF;
+    }
+    else
+    {
+        /*
+        ** Convert micro-seconds count to sub-seconds (1/2^32) count using OSAL
+        */
+        tm         = OS_TimeAssembleFromNanoseconds(0, MicroSeconds * 1000);
+        SubSeconds = OS_TimeGetSubsecondsPart(tm);
+    }
+
+    return (SubSeconds);
+
+} /* End of CFE_TIME_Micro2SubSecs() */
+
+/*
+ * Function: CFE_TIME_Print - See API and header file for details
+ */
+void CFE_TIME_Print(char *PrintBuffer, CFE_TIME_SysTime_t TimeToPrint)
+{
+    uint32 NumberOfYears;
+    uint32 NumberOfDays;
+    uint32 NumberOfHours;
+    uint32 NumberOfMinutes;
+    uint32 NumberOfSeconds;
+    uint32 NumberOfMicros;
+    uint32 DaysInThisYear;
+
+    bool StillCountingYears = true;
+
+    if (PrintBuffer == NULL)
+    {
+        CFE_ES_WriteToSysLog("CFE_TIME:Print-Failed invalid arguments\n");
+        return;
+    }
+
+    /*
+    ** Convert the cFE time (offset from epoch) into calendar time...
+    */
+    NumberOfMinutes = (TimeToPrint.Seconds / 60) + CFE_MISSION_TIME_EPOCH_MINUTE;
+    NumberOfSeconds = (TimeToPrint.Seconds % 60) + CFE_MISSION_TIME_EPOCH_SECOND;
+
+    /*
+    ** Adding the epoch "seconds" after computing the minutes avoids
+    **    overflow problems when the input time value (seconds) is
+    **    at, or near, 0xFFFFFFFF...
+    */
+    while (NumberOfSeconds >= 60)
+    {
+        NumberOfMinutes++;
+        NumberOfSeconds -= 60;
+    }
+
+    /*
+    ** Compute the years/days/hours/minutes...
+    */
+    NumberOfHours   = (NumberOfMinutes / 60) + CFE_MISSION_TIME_EPOCH_HOUR;
+    NumberOfMinutes = (NumberOfMinutes % 60);
+
+    /*
+    ** Unlike hours and minutes, epoch days are counted as Jan 1 = day 1...
+    */
+    NumberOfDays  = (NumberOfHours / 24) + (CFE_MISSION_TIME_EPOCH_DAY - 1);
+    NumberOfHours = (NumberOfHours % 24);
+
+    NumberOfYears = CFE_MISSION_TIME_EPOCH_YEAR;
+
+    /*
+    ** Convert total number of days into years and remainder days...
+    */
+    while (StillCountingYears)
+    {
+        /*
+        ** Set number of days in this year (leap year?)...
+        */
+        DaysInThisYear = 365;
+
+        if ((NumberOfYears % 4) == 0)
+        {
+            if ((NumberOfYears % 100) != 0)
+            {
+                DaysInThisYear = 366;
+            }
+            else if ((NumberOfYears % 400) == 0)
+            {
+                DaysInThisYear = 366;
+            }
+            else
+            {
+                /* Do Nothing. Non-leap year. */
+            }
+        }
+
+        /*
+        ** When we have less than a years worth of days, we're done...
+        */
+        if (NumberOfDays < DaysInThisYear)
+        {
+            StillCountingYears = false;
+        }
+        else
+        {
+            /*
+            ** Add a year and remove the number of days in that year...
+            */
+            NumberOfYears++;
+            NumberOfDays -= DaysInThisYear;
+        }
+    }
+
+    /*
+    ** Unlike hours and minutes, days are displayed as Jan 1 = day 1...
+    */
+    NumberOfDays++;
+
+    /*
+    ** After computing microseconds, convert to 5 digits from 6 digits...
+    */
+    NumberOfMicros = CFE_TIME_Sub2MicroSecs(TimeToPrint.Subseconds) / 10;
+
+    /*
+    ** Build formatted output string (yyyy-ddd-hh:mm:ss.xxxxx)...
+    */
+    *PrintBuffer++ = '0' + (char)(NumberOfYears / 1000);
+    NumberOfYears  = NumberOfYears % 1000;
+    *PrintBuffer++ = '0' + (char)(NumberOfYears / 100);
+    NumberOfYears  = NumberOfYears % 100;
+    *PrintBuffer++ = '0' + (char)(NumberOfYears / 10);
+    *PrintBuffer++ = '0' + (char)(NumberOfYears % 10);
+    *PrintBuffer++ = '-';
+
+    *PrintBuffer++ = '0' + (char)(NumberOfDays / 100);
+    NumberOfDays   = NumberOfDays % 100;
+    *PrintBuffer++ = '0' + (char)(NumberOfDays / 10);
+    *PrintBuffer++ = '0' + (char)(NumberOfDays % 10);
+    *PrintBuffer++ = '-';
+
+    *PrintBuffer++ = '0' + (char)(NumberOfHours / 10);
+    *PrintBuffer++ = '0' + (char)(NumberOfHours % 10);
+    *PrintBuffer++ = ':';
+
+    *PrintBuffer++ = '0' + (char)(NumberOfMinutes / 10);
+    *PrintBuffer++ = '0' + (char)(NumberOfMinutes % 10);
+    *PrintBuffer++ = ':';
+
+    *PrintBuffer++ = '0' + (char)(NumberOfSeconds / 10);
+    *PrintBuffer++ = '0' + (char)(NumberOfSeconds % 10);
+    *PrintBuffer++ = '.';
+
+    *PrintBuffer++ = '0' + (char)(NumberOfMicros / 10000);
+    NumberOfMicros = NumberOfMicros % 10000;
+    *PrintBuffer++ = '0' + (char)(NumberOfMicros / 1000);
+    NumberOfMicros = NumberOfMicros % 1000;
+    *PrintBuffer++ = '0' + (char)(NumberOfMicros / 100);
+    NumberOfMicros = NumberOfMicros % 100;
+    *PrintBuffer++ = '0' + (char)(NumberOfMicros / 10);
+    *PrintBuffer++ = '0' + (char)(NumberOfMicros % 10);
+    *PrintBuffer++ = '\0';
+
+    return;
+
+} /* End of CFE_TIME_Print() */
+
+/*
+ * Function: CFE_TIME_ExternalTone - See API and header file for details
+ */
+void CFE_TIME_ExternalTone(void)
+{
+    /*
+    ** Call tone signal ISR (OK if called from non-ISR context)...
+    */
+    CFE_TIME_Tone1HzISR();
+
+    return;
+
+} /* End of CFE_TIME_ExternalTone() */
+
+/*
+ * Function: CFE_TIME_RegisterSynchCallback - See API and header file for details
+ */
+int32 CFE_TIME_RegisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPtr)
+{
+    int32          Status;
+    CFE_ES_AppId_t AppId;
+    uint32         AppIndex;
+
+    if (CallbackFuncPtr == NULL)
+    {
+        return CFE_TIME_BAD_ARGUMENT;
+    }
+
+    Status = CFE_ES_GetAppID(&AppId);
+    if (Status == CFE_SUCCESS)
+    {
+        Status = CFE_ES_AppID_ToIndex(AppId, &AppIndex);
+
+        if (Status == CFE_SUCCESS)
+        {
+
+            if (AppIndex >= (sizeof(CFE_TIME_Global.SynchCallback) / sizeof(CFE_TIME_Global.SynchCallback[0])) ||
+                CFE_TIME_Global.SynchCallback[AppIndex].Ptr != NULL)
+            {
+                Status = CFE_TIME_TOO_MANY_SYNCH_CALLBACKS;
+            }
+            else
+            {
+                CFE_TIME_Global.SynchCallback[AppIndex].Ptr = CallbackFuncPtr;
+            }
+        }
+    }
+
+    return Status;
+} /* End of CFE_TIME_RegisterSynchCallback() */
+
+/*
+ * Function: CFE_TIME_UnregisterSynchCallback - See API and header file for details
+ */
+int32 CFE_TIME_UnregisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPtr)
+{
+    int32          Status;
+    CFE_ES_AppId_t AppId;
+    uint32         AppIndex;
+
+    if (CallbackFuncPtr == NULL)
+    {
+        return CFE_TIME_BAD_ARGUMENT;
+    }
+
+    Status = CFE_ES_GetAppID(&AppId);
+    if (Status == CFE_SUCCESS)
+    {
+        Status = CFE_ES_AppID_ToIndex(AppId, &AppIndex);
+
+        if (Status == CFE_SUCCESS)
+        {
+
+            if (AppIndex >= (sizeof(CFE_TIME_Global.SynchCallback) / sizeof(CFE_TIME_Global.SynchCallback[0])) ||
+                CFE_TIME_Global.SynchCallback[AppIndex].Ptr != CallbackFuncPtr)
+            {
+                Status = CFE_TIME_CALLBACK_NOT_REGISTERED;
+            }
+            else
+            {
+                CFE_TIME_Global.SynchCallback[AppIndex].Ptr = NULL;
+            }
+        }
+    }
+
+    return Status;
+} /* End of CFE_TIME_UnregisterSynchCallback() */
+
+/*
+ * Function: CFE_TIME_ExternalMET - See API and header file for details
+ */
+#if (CFE_PLATFORM_TIME_CFG_SRC_MET == true)
+void CFE_TIME_ExternalMET(CFE_TIME_SysTime_t NewMET)
+{
+    /*
+    ** Process external MET data...
+    */
+    CFE_TIME_ToneSendMET(NewMET);
+
+    return;
+
+} /* End of CFE_TIME_ExternalMET() */
+#endif /* CFE_PLATFORM_TIME_CFG_SRC_MET  */
+
+/*
+ * Function: CFE_TIME_ExternalGPS - See API and header file for details
+ */
+#if (CFE_PLATFORM_TIME_CFG_SRC_GPS == true)
+void CFE_TIME_ExternalGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps)
+{
+    /*
+    ** Process external GPS time data...
+    */
+    CFE_TIME_ToneSendGPS(NewTime, NewLeaps);
+
+    return;
+
+} /* End of CFE_TIME_ExternalGPS() */
+#endif /* CFE_PLATFORM_TIME_CFG_SRC_GPS */
+
+/*
+ * Function: CFE_TIME_ExternalTime - See API and header file for details
+ */
+#if (CFE_PLATFORM_TIME_CFG_SRC_TIME == true)
+void CFE_TIME_ExternalTime(CFE_TIME_SysTime_t NewTime)
+{
+    /*
+    ** Process external time data...
+    */
+    CFE_TIME_ToneSendTime(NewTime);
+
+    return;
+
+} /* End of CFE_TIME_ExternalTime() */
+#endif /* CFE_PLATFORM_TIME_CFG_SRC_TIME */
+
+/************************/
+/*  End of File Comment */
+/************************/

--- a/modules/time/fsw/src/cfe_time_module_all.h
+++ b/modules/time/fsw/src/cfe_time_module_all.h
@@ -1,0 +1,48 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * @file
+ *
+ * Encapsulates all TIME module internal header files, as well
+ * as the public API from all other CFE core modules, OSAL, and PSP.
+ *
+ * This simplifies the set of include files that need to be put at the
+ * start of every source file.
+ */
+
+#ifndef CFE_TIME_MODULE_ALL_H
+#define CFE_TIME_MODULE_ALL_H
+
+/********************* Include Files  ************************/
+
+#include "cfe.h" /* All CFE+OSAL public API definitions */
+#include "cfe_platform_cfg.h"
+
+#include "cfe_msgids.h"
+#include "cfe_perfids.h"
+
+#include "cfe_time_core_internal.h"
+
+#include "cfe_time_msg.h"
+#include "cfe_time_events.h"
+#include "cfe_time_utils.h"
+
+#endif /* CFE_TIME_MODULE_ALL_H */

--- a/modules/time/fsw/src/cfe_time_task.c
+++ b/modules/time/fsw/src/cfe_time_task.c
@@ -1,0 +1,1438 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/*
+** File: cfe_time_task.c
+**
+** Subsystem: cFE TIME Task
+**
+** Author: S. Walling (Microtel)
+**
+** Notes:
+**
+*/
+
+/*
+** Required header files...
+*/
+#include "cfe_time_module_all.h"
+#include "cfe_version.h"
+
+/*
+** Time task global data...
+*/
+CFE_TIME_Global_t CFE_TIME_Global;
+
+/*
+** Command handler for "HK request"...
+*/
+int32 CFE_TIME_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data);
+
+/*
+** Command handler for "tone signal detected"...
+*/
+int32 CFE_TIME_ToneSignalCmd(const CFE_TIME_ToneSignalCmd_t *data);
+
+/*
+** Command handler for "time at the tone"...
+*/
+int32 CFE_TIME_ToneDataCmd(const CFE_TIME_ToneDataCmd_t *data);
+
+/*
+** Command handler for 1Hz signal...
+*/
+int32 CFE_TIME_OneHzCmd(const CFE_TIME_1HzCmd_t *data);
+
+/*
+** Command handler for "request time at the tone"...
+**
+** Note: This command (sent by the scheduler) is used to
+**       signal that now is the right time (in relation
+**       to the "real" tone signal) for a Time Server to
+**       send the "time at the tone" data packet.  We do
+**       not need (or want) this command if we are not a
+**       Time Server.
+**
+**       In "fake tone" mode this command is locally generated
+**       however it is still sent via the software bus, thereby
+**       utilizing (mostly) the same code path as the
+**       non-fake tone mode.
+*/
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+int32 CFE_TIME_ToneSendCmd(const CFE_TIME_FakeToneCmd_t *data);
+#endif
+
+/*
+ * Ground command helper functions
+ */
+void CFE_TIME_SetDelayImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_AdjustDirection_Enum_t Direction);
+void CFE_TIME_1HzAdjImpl(const CFE_TIME_OneHzAdjustmentCmd_Payload_t *CommandPtr,
+                         CFE_TIME_AdjustDirection_Enum_t              Direction);
+void CFE_TIME_AdjustImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_AdjustDirection_Enum_t Direction);
+
+/*
+** Ground command handlers...
+*/
+int32 CFE_TIME_Add1HZAdjustmentCmd(const CFE_TIME_Add1HZAdjustmentCmd_t *data);
+int32 CFE_TIME_AddAdjustCmd(const CFE_TIME_AddAdjustCmd_t *data);
+int32 CFE_TIME_AddDelayCmd(const CFE_TIME_AddDelayCmd_t *data);
+int32 CFE_TIME_SendDiagnosticTlm(const CFE_TIME_SendDiagnosticCmd_t *data);
+int32 CFE_TIME_NoopCmd(const CFE_TIME_NoopCmd_t *data);
+int32 CFE_TIME_ResetCountersCmd(const CFE_TIME_ResetCountersCmd_t *data);
+int32 CFE_TIME_SetLeapSecondsCmd(const CFE_TIME_SetLeapSecondsCmd_t *data);
+int32 CFE_TIME_SetMETCmd(const CFE_TIME_SetMETCmd_t *data);
+int32 CFE_TIME_SetSignalCmd(const CFE_TIME_SetSignalCmd_t *data);
+int32 CFE_TIME_SetSourceCmd(const CFE_TIME_SetSourceCmd_t *data);
+int32 CFE_TIME_SetStateCmd(const CFE_TIME_SetStateCmd_t *data);
+int32 CFE_TIME_SetSTCFCmd(const CFE_TIME_SetSTCFCmd_t *data);
+int32 CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data);
+int32 CFE_TIME_Sub1HZAdjustmentCmd(const CFE_TIME_Sub1HZAdjustmentCmd_t *data);
+int32 CFE_TIME_SubAdjustCmd(const CFE_TIME_SubAdjustCmd_t *data);
+int32 CFE_TIME_SubDelayCmd(const CFE_TIME_SubDelayCmd_t *data);
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_EarlyInit() -- API initialization before any tasks     */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int32 CFE_TIME_EarlyInit(void)
+{
+    /*
+    ** Initialize global Time Services nonzero data...
+    */
+    CFE_TIME_InitData();
+
+    return (CFE_SUCCESS);
+
+} /* End of CFE_TIME_EarlyInit() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_TaskMain() -- Task entry point and main process loop   */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void CFE_TIME_TaskMain(void)
+{
+    int32            Status;
+    CFE_SB_Buffer_t *SBBufPtr;
+
+    CFE_ES_PerfLogEntry(CFE_MISSION_TIME_MAIN_PERF_ID);
+
+    Status = CFE_TIME_TaskInit();
+
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("TIME:Application Init Failed,RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_PerfLogExit(CFE_MISSION_TIME_MAIN_PERF_ID);
+        /* Note: CFE_ES_ExitApp will not return */
+        CFE_ES_ExitApp(CFE_ES_RunStatus_CORE_APP_INIT_ERROR);
+    } /* end if */
+
+    /*
+     * Wait for other apps to start.
+     * It is important that the core apps are present before this starts receiving
+     * messages from the command pipe, as some of those handlers might depend on
+     * the other core apps.
+     */
+    CFE_ES_WaitForSystemState(CFE_ES_SystemState_CORE_READY, CFE_PLATFORM_CORE_MAX_STARTUP_MSEC);
+
+    /* Main loop */
+    while (Status == CFE_SUCCESS)
+    {
+
+        /* Increment the Main task Execution Counter */
+        CFE_ES_IncrementTaskCounter();
+
+        CFE_ES_PerfLogExit(CFE_MISSION_TIME_MAIN_PERF_ID);
+
+        /* Pend on receipt of packet */
+        Status = CFE_SB_ReceiveBuffer(&SBBufPtr, CFE_TIME_Global.CmdPipe, CFE_SB_PEND_FOREVER);
+
+        CFE_ES_PerfLogEntry(CFE_MISSION_TIME_MAIN_PERF_ID);
+
+        if (Status == CFE_SUCCESS)
+        {
+            /* Process cmd pipe msg */
+            CFE_TIME_TaskPipe(SBBufPtr);
+        }
+        else
+        {
+            CFE_ES_WriteToSysLog("TIME:Error reading cmd pipe,RC=0x%08X\n", (unsigned int)Status);
+        } /* end if */
+
+    } /* end while */
+
+    /* while loop exits only if CFE_SB_ReceiveBuffer returns error */
+    CFE_ES_ExitApp(CFE_ES_RunStatus_CORE_APP_RUNTIME_ERROR);
+
+} /* end CFE_TIME_TaskMain */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_TaskInit() -- Time task initialization                 */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int32 CFE_TIME_TaskInit(void)
+{
+    int32     Status;
+    osal_id_t TimeBaseId;
+    osal_id_t TimerId;
+
+    Status = CFE_EVS_Register(NULL, 0, 0);
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("TIME:Call to CFE_EVS_Register Failed:RC=0x%08X\n", (unsigned int)Status);
+        return Status;
+    } /* end if */
+
+    Status = OS_BinSemCreate(&CFE_TIME_Global.ToneSemaphore, CFE_TIME_SEM_TONE_NAME, CFE_TIME_SEM_VALUE,
+                             CFE_TIME_SEM_OPTIONS);
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("TIME:Error creating tone semaphore:RC=0x%08X\n", (unsigned int)Status);
+        return Status;
+    } /* end if */
+
+    Status = OS_BinSemCreate(&CFE_TIME_Global.LocalSemaphore, CFE_TIME_SEM_1HZ_NAME, CFE_TIME_SEM_VALUE,
+                             CFE_TIME_SEM_OPTIONS);
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("TIME:Error creating local semaphore:RC=0x%08X\n", (unsigned int)Status);
+        return Status;
+    } /* end if */
+
+    Status = CFE_ES_CreateChildTask(&CFE_TIME_Global.ToneTaskID, CFE_TIME_TASK_TONE_NAME, CFE_TIME_Tone1HzTask,
+                                    CFE_TIME_TASK_STACK_PTR, CFE_PLATFORM_TIME_TONE_TASK_STACK_SIZE,
+                                    CFE_PLATFORM_TIME_TONE_TASK_PRIORITY, CFE_TIME_TASK_FLAGS);
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("TIME:Error creating tone 1Hz child task:RC=0x%08X\n", (unsigned int)Status);
+        return Status;
+    } /* end if */
+
+    Status = CFE_ES_CreateChildTask(&CFE_TIME_Global.LocalTaskID, CFE_TIME_TASK_1HZ_NAME, CFE_TIME_Local1HzTask,
+                                    CFE_TIME_TASK_STACK_PTR, CFE_PLATFORM_TIME_1HZ_TASK_STACK_SIZE,
+                                    CFE_PLATFORM_TIME_1HZ_TASK_PRIORITY, CFE_TIME_TASK_FLAGS);
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("TIME:Error creating local 1Hz child task:RC=0x%08X\n", (unsigned int)Status);
+        return Status;
+    } /* end if */
+
+    Status = CFE_SB_CreatePipe(&CFE_TIME_Global.CmdPipe, CFE_TIME_TASK_PIPE_DEPTH, CFE_TIME_TASK_PIPE_NAME);
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("TIME:Error creating cmd pipe:RC=0x%08X\n", (unsigned int)Status);
+        return Status;
+    } /* end if */
+
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_SEND_HK_MID), CFE_TIME_Global.CmdPipe);
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("TIME:Error subscribing to HK Request:RC=0x%08X\n", (unsigned int)Status);
+        return Status;
+    } /* end if */
+
+/*
+** Subscribe to time at the tone "signal" commands...
+*/
+#if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_TONE_CMD_MID), CFE_TIME_Global.CmdPipe);
+#endif
+
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+    Status = CFE_SB_SubscribeLocal(CFE_SB_ValueToMsgId(CFE_TIME_TONE_CMD_MID), CFE_TIME_Global.CmdPipe, 4);
+#endif
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("TIME:Error subscribing to tone cmd:RC=0x%08X\n", (unsigned int)Status);
+        return Status;
+    } /* end if */
+
+/*
+** Subscribe to time at the tone "data" commands...
+*/
+#if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_DATA_CMD_MID), CFE_TIME_Global.CmdPipe);
+#endif
+
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+    Status = CFE_SB_SubscribeLocal(CFE_SB_ValueToMsgId(CFE_TIME_DATA_CMD_MID), CFE_TIME_Global.CmdPipe, 4);
+#endif
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("TIME:Error subscribing to time data cmd:RC=0x%08X\n", (unsigned int)Status);
+        return Status;
+    } /* end if */
+
+/*
+** Subscribe to 1Hz signal commands...
+*/
+#if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_1HZ_CMD_MID), CFE_TIME_Global.CmdPipe);
+#endif
+
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+    Status = CFE_SB_SubscribeLocal(CFE_SB_ValueToMsgId(CFE_TIME_1HZ_CMD_MID), CFE_TIME_Global.CmdPipe, 4);
+#endif
+
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("TIME:Error subscribing to fake tone signal cmds:RC=0x%08X\n", (unsigned int)Status);
+        return Status;
+    } /* end if */
+
+/*
+** Subscribe to time at the tone "request data" commands...
+*/
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_SEND_CMD_MID), CFE_TIME_Global.CmdPipe);
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("TIME:Error subscribing to time at the tone request data cmds:RC=0x%08X\n",
+                             (unsigned int)Status);
+        return Status;
+    } /* end if */
+#endif
+
+    /*
+    ** Subscribe to Time task ground command packets...
+    */
+    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_CMD_MID), CFE_TIME_Global.CmdPipe);
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("TIME:Error subscribing to time task gnd cmds:RC=0x%08X\n", (unsigned int)Status);
+        return Status;
+    } /* end if */
+
+    Status = CFE_EVS_SendEvent(CFE_TIME_INIT_EID, CFE_EVS_EventType_INFORMATION, "cFE TIME Initialized");
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("TIME:Error sending init event:RC=0x%08X\n", (unsigned int)Status);
+        return Status;
+    } /* end if */
+
+/*
+** Select primary vs redundant tone interrupt signal...
+*/
+#if (CFE_PLATFORM_TIME_CFG_SIGNAL == true)
+    OS_SelectTone(CFE_TIME_Global.ClockSignal);
+#endif
+
+    /*
+     * Check to see if the OSAL in use implements the TimeBase API
+     * and if the PSP has set up a system time base.  If so, then create
+     * a 1Hz callback based on that system time base.  This call should
+     * return OS_ERR_NOT_IMPLEMENTED if the OSAL does not support this,
+     * or OS_ERR_NAME_NOT_FOUND if the PSP didn't set this up.  Either
+     * way any error here means the PSP must use the "old way" and call
+     * the 1hz function directly.
+     */
+    Status = OS_TimeBaseGetIdByName(&TimeBaseId, "cFS-Master");
+    if (Status == OS_SUCCESS)
+    {
+        /* Create the 1Hz callback */
+        Status = OS_TimerAdd(&TimerId, "cFS-1Hz", TimeBaseId, CFE_TIME_Local1HzTimerCallback, NULL);
+        if (Status == OS_SUCCESS)
+        {
+            Status = OS_TimerSet(TimerId, 500000, 1000000);
+            if (Status != OS_SUCCESS)
+            {
+                CFE_ES_WriteToSysLog("TIME:1Hz OS_TimerSet failed:RC=0x%08X\n", (unsigned int)Status);
+            }
+        }
+        else
+        {
+            CFE_ES_WriteToSysLog("TIME:1Hz OS_TimerAdd failed:RC=0x%08X\n", (unsigned int)Status);
+        }
+    }
+
+    return CFE_SUCCESS;
+
+} /* End of CFE_TIME_TaskInit() */
+
+/******************************************************************************
+**  Function:  CFE_TIME_VerifyCmdLength()
+**
+**  Purpose:
+**    Function to verify the length of incoming TIME command packets
+**
+**  Arguments:
+**    Message pointer and expected length
+**
+**  Return:
+**    true if length is acceptable
+*/
+bool CFE_TIME_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
+{
+    bool              result       = true;
+    CFE_MSG_Size_t    ActualLength = 0;
+    CFE_MSG_FcnCode_t FcnCode      = 0;
+    CFE_SB_MsgId_t    MsgId        = CFE_SB_INVALID_MSG_ID;
+
+    CFE_MSG_GetSize(MsgPtr, &ActualLength);
+
+    /*
+    ** Verify the command packet length
+    */
+    if (ExpectedLength != ActualLength)
+    {
+        CFE_MSG_GetMsgId(MsgPtr, &MsgId);
+        CFE_MSG_GetFcnCode(MsgPtr, &FcnCode);
+
+        CFE_EVS_SendEvent(CFE_TIME_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Invalid msg length: ID = 0x%X,  CC = %u, Len = %u, Expected = %u",
+                          (unsigned int)CFE_SB_MsgIdToValue(MsgId), (unsigned int)FcnCode, (unsigned int)ActualLength,
+                          (unsigned int)ExpectedLength);
+        result = false;
+        ++CFE_TIME_Global.CommandErrorCounter;
+    }
+
+    return (result);
+
+} /* End of CFE_TIME_VerifyCmdLength() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_TaskPipe() -- Process command pipe message             */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void CFE_TIME_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
+{
+    CFE_SB_MsgId_t    MessageID   = CFE_SB_INVALID_MSG_ID;
+    CFE_MSG_FcnCode_t CommandCode = 0;
+
+    CFE_MSG_GetMsgId(&SBBufPtr->Msg, &MessageID);
+
+    switch (CFE_SB_MsgIdToValue(MessageID))
+    {
+        /*
+        ** Housekeeping telemetry request...
+        */
+        case CFE_TIME_SEND_HK_MID:
+            CFE_TIME_HousekeepingCmd((CFE_MSG_CommandHeader_t *)SBBufPtr);
+            break;
+
+        /*
+        ** Time at the tone "signal"...
+        */
+        case CFE_TIME_TONE_CMD_MID:
+            CFE_TIME_ToneSignalCmd((CFE_TIME_ToneSignalCmd_t *)SBBufPtr);
+            break;
+
+        /*
+        ** Time at the tone "data"...
+        */
+        case CFE_TIME_DATA_CMD_MID:
+            CFE_TIME_ToneDataCmd((CFE_TIME_ToneDataCmd_t *)SBBufPtr);
+            break;
+
+        /*
+        ** Run time state machine at 1Hz...
+        */
+        case CFE_TIME_1HZ_CMD_MID:
+            CFE_TIME_OneHzCmd((CFE_TIME_1HzCmd_t *)SBBufPtr);
+            break;
+
+/*
+** Request for time at the tone "data"...
+*/
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+        case CFE_TIME_SEND_CMD_MID:
+            CFE_TIME_ToneSendCmd((CFE_TIME_FakeToneCmd_t *)SBBufPtr);
+            break;
+#endif
+
+        /*
+        ** Time task ground commands...
+        */
+        case CFE_TIME_CMD_MID:
+
+            CFE_MSG_GetFcnCode(&SBBufPtr->Msg, &CommandCode);
+            switch (CommandCode)
+            {
+                case CFE_TIME_NOOP_CC:
+                    if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_NoopCmd_t)))
+                    {
+                        CFE_TIME_NoopCmd((CFE_TIME_NoopCmd_t *)SBBufPtr);
+                    }
+                    break;
+
+                case CFE_TIME_RESET_COUNTERS_CC:
+                    if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_ResetCountersCmd_t)))
+                    {
+                        CFE_TIME_ResetCountersCmd((CFE_TIME_ResetCountersCmd_t *)SBBufPtr);
+                    }
+                    break;
+
+                case CFE_TIME_SEND_DIAGNOSTIC_TLM_CC:
+                    if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SendDiagnosticCmd_t)))
+                    {
+                        CFE_TIME_SendDiagnosticTlm((CFE_TIME_SendDiagnosticCmd_t *)SBBufPtr);
+                    }
+                    break;
+
+                case CFE_TIME_SET_STATE_CC:
+                    if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SetStateCmd_t)))
+                    {
+                        CFE_TIME_SetStateCmd((CFE_TIME_SetStateCmd_t *)SBBufPtr);
+                    }
+                    break;
+
+                case CFE_TIME_SET_SOURCE_CC:
+                    if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SetSourceCmd_t)))
+                    {
+                        CFE_TIME_SetSourceCmd((CFE_TIME_SetSourceCmd_t *)SBBufPtr);
+                    }
+                    break;
+
+                case CFE_TIME_SET_SIGNAL_CC:
+                    if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SetSignalCmd_t)))
+                    {
+                        CFE_TIME_SetSignalCmd((CFE_TIME_SetSignalCmd_t *)SBBufPtr);
+                    }
+                    break;
+
+                /*
+                ** Time Clients process "tone delay" commands...
+                */
+                case CFE_TIME_ADD_DELAY_CC:
+                    if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_AddDelayCmd_t)))
+                    {
+                        CFE_TIME_AddDelayCmd((CFE_TIME_AddDelayCmd_t *)SBBufPtr);
+                    }
+                    break;
+
+                case CFE_TIME_SUB_DELAY_CC:
+                    if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SubDelayCmd_t)))
+                    {
+                        CFE_TIME_SubDelayCmd((CFE_TIME_SubDelayCmd_t *)SBBufPtr);
+                    }
+                    break;
+
+                /*
+                ** Time Servers process "set time" commands...
+                */
+                case CFE_TIME_SET_TIME_CC:
+                    if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SetTimeCmd_t)))
+                    {
+                        CFE_TIME_SetTimeCmd((CFE_TIME_SetTimeCmd_t *)SBBufPtr);
+                    }
+                    break;
+
+                case CFE_TIME_SET_MET_CC:
+                    if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SetMETCmd_t)))
+                    {
+                        CFE_TIME_SetMETCmd((CFE_TIME_SetMETCmd_t *)SBBufPtr);
+                    }
+                    break;
+
+                case CFE_TIME_SET_STCF_CC:
+                    if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SetSTCFCmd_t)))
+                    {
+                        CFE_TIME_SetSTCFCmd((CFE_TIME_SetSTCFCmd_t *)SBBufPtr);
+                    }
+                    break;
+
+                case CFE_TIME_SET_LEAP_SECONDS_CC:
+                    if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SetLeapSecondsCmd_t)))
+                    {
+                        CFE_TIME_SetLeapSecondsCmd((CFE_TIME_SetLeapSecondsCmd_t *)SBBufPtr);
+                    }
+                    break;
+
+                case CFE_TIME_ADD_ADJUST_CC:
+                    if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_AddAdjustCmd_t)))
+                    {
+                        CFE_TIME_AddAdjustCmd((CFE_TIME_AddAdjustCmd_t *)SBBufPtr);
+                    }
+                    break;
+
+                case CFE_TIME_SUB_ADJUST_CC:
+                    if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SubAdjustCmd_t)))
+                    {
+                        CFE_TIME_SubAdjustCmd((CFE_TIME_SubAdjustCmd_t *)SBBufPtr);
+                    }
+                    break;
+
+                case CFE_TIME_ADD_1HZ_ADJUSTMENT_CC:
+                    if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_Add1HZAdjustmentCmd_t)))
+                    {
+                        CFE_TIME_Add1HZAdjustmentCmd((CFE_TIME_Add1HZAdjustmentCmd_t *)SBBufPtr);
+                    }
+                    break;
+
+                case CFE_TIME_SUB_1HZ_ADJUSTMENT_CC:
+                    if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_Sub1HZAdjustmentCmd_t)))
+                    {
+                        CFE_TIME_Sub1HZAdjustmentCmd((CFE_TIME_Sub1HZAdjustmentCmd_t *)SBBufPtr);
+                    }
+                    break;
+
+                default:
+
+                    CFE_TIME_Global.CommandErrorCounter++;
+                    CFE_EVS_SendEvent(CFE_TIME_CC_ERR_EID, CFE_EVS_EventType_ERROR,
+                                      "Invalid command code -- ID = 0x%X, CC = %d",
+                                      (unsigned int)CFE_SB_MsgIdToValue(MessageID), (int)CommandCode);
+                    break;
+            } /* switch (CFE_TIME_CMD_MID -- command code)*/
+            break;
+
+        default:
+
+            /*
+            ** Note: we only increment the command error counter when
+            **    processing CFE_TIME_CMD_MID commands...
+            */
+            CFE_EVS_SendEvent(CFE_TIME_ID_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid message ID -- ID = 0x%X",
+                              (unsigned int)CFE_SB_MsgIdToValue(MessageID));
+            break;
+
+    } /* switch (message ID) */
+
+    return;
+
+} /* End of CFE_TIME_TaskPipe() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_HousekeepingCmd() -- On-board command (HK request)     */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int32 CFE_TIME_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
+{
+    CFE_TIME_Reference_t Reference;
+
+    /*
+    ** Get reference time values (local time, time at tone, etc.)...
+    */
+    CFE_TIME_GetReference(&Reference);
+
+    /*
+    ** Update TIME portion of Critical Data Store...
+    */
+    CFE_TIME_UpdateResetVars(&Reference);
+
+    /*
+    ** Collect housekeeping data from Time Services utilities...
+    */
+    CFE_TIME_GetHkData(&Reference);
+
+    /*
+    ** Send housekeeping telemetry packet...
+    */
+    CFE_SB_TimeStampMsg(&CFE_TIME_Global.HkPacket.TlmHeader.Msg);
+    CFE_SB_TransmitMsg(&CFE_TIME_Global.HkPacket.TlmHeader.Msg, true);
+
+    /*
+    ** Note: we only increment the command execution counter when
+    **   processing CFE_TIME_CMD_MID commands...
+    */
+    return CFE_SUCCESS;
+
+} /* End of CFE_TIME_HousekeepingCmd() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_ToneSignalCmd() -- Time at tone command (signal)       */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int32 CFE_TIME_ToneSignalCmd(const CFE_TIME_ToneSignalCmd_t *data)
+{
+    /*
+    ** Indication that tone signal occurred recently...
+    */
+    CFE_TIME_ToneSignal();
+
+    /*
+    ** Note: we only increment the command execution counter when
+    **   processing CFE_TIME_CMD_MID commands...
+    */
+    return CFE_SUCCESS;
+
+} /* End of CFE_TIME_ToneSignalCmd() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_ToneDataCmd() -- Time at tone command (data)           */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int32 CFE_TIME_ToneDataCmd(const CFE_TIME_ToneDataCmd_t *data)
+{
+    /*
+    ** This command packet contains "time at the tone" data...
+    */
+    CFE_TIME_ToneData(&data->Payload);
+
+    /*
+    ** Note: we only increment the command execution counter when
+    **   processing CFE_TIME_CMD_MID commands...
+    */
+    return CFE_SUCCESS;
+
+} /* End of CFE_TIME_ToneDataCmd() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+ *
+ * CFE_TIME_OneHzCmd() -- Execute state machine tasks required at 1Hz
+ *
+ * Service the "1Hz" notification message, and perform any state machine
+ * tasks that are intended to be executed at local 1Hz intervals.
+ *
+ * This also implements the "fake tone" functionality when that is enabled,
+ * as we do not need a separate MID for this job.
+ *
+ * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+int32 CFE_TIME_OneHzCmd(const CFE_TIME_1HzCmd_t *data)
+{
+    /*
+     * Run the state machine updates required at 1Hz.
+     *
+     * This task used to be performed as part of the 1Hz ISR, but this was unsafe on SMP
+     * as the updates cannot be synchronized with the command handlers in this environment
+     */
+    CFE_TIME_Local1HzStateMachine();
+
+#if (CFE_MISSION_TIME_CFG_FAKE_TONE == true)
+    /*
+    ** Fake the call-back from the "real" h/w ISR...
+    */
+    CFE_TIME_Tone1HzISR();
+#endif /* CFE_MISSION_TIME_CFG_FAKE_TONE */
+
+    /*
+    ** Note: we only increment the command execution counter when
+    **   processing CFE_TIME_CMD_MID commands...
+    */
+    return CFE_SUCCESS;
+
+} /* End of CFE_TIME_OneHzCmd() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_ToneSendCmd() -- Time at tone command (send data)      */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+int32 CFE_TIME_ToneSendCmd(const CFE_TIME_FakeToneCmd_t *data)
+{
+    /*
+    ** Request for "time at tone" data packet (probably scheduler)...
+    */
+    CFE_TIME_ToneSend();
+
+    /*
+    ** Note: we only increment the command execution counter when
+    **   processing CFE_TIME_CMD_MID commands...
+    */
+    return CFE_SUCCESS;
+
+} /* End of CFE_TIME_SendCmd() */
+#endif /* CFE_PLATFORM_TIME_CFG_SERVER */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_NoopCmd() -- Time task ground command (NO-OP)          */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int32 CFE_TIME_NoopCmd(const CFE_TIME_NoopCmd_t *data)
+{
+
+    CFE_TIME_Global.CommandCounter++;
+
+    CFE_EVS_SendEvent(CFE_TIME_NOOP_EID, CFE_EVS_EventType_INFORMATION, "No-op command.%s", CFE_VERSION_STRING);
+
+    return CFE_SUCCESS;
+
+} /* End of CFE_TIME_NoopCmd() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                         */
+/* CFE_TIME_ResetCountersCmd() -- Time task ground command (reset counters)*/
+/*                                                                         */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int32 CFE_TIME_ResetCountersCmd(const CFE_TIME_ResetCountersCmd_t *data)
+{
+
+    CFE_TIME_Global.CommandCounter      = 0;
+    CFE_TIME_Global.CommandErrorCounter = 0;
+
+    CFE_TIME_Global.ToneMatchCounter      = 0;
+    CFE_TIME_Global.ToneMatchErrorCounter = 0;
+
+    CFE_TIME_Global.ToneSignalCounter = 0;
+    CFE_TIME_Global.ToneDataCounter   = 0;
+
+    CFE_TIME_Global.ToneIntCounter      = 0;
+    CFE_TIME_Global.ToneIntErrorCounter = 0;
+    CFE_TIME_Global.ToneTaskCounter     = 0;
+
+    /*
+     * Note: Not resetting "LastVersion" counter here, that might
+     * disturb access to the time reference data by other tasks
+     */
+    CFE_TIME_Global.ResetVersionCounter = CFE_TIME_Global.LastVersionCounter;
+
+    CFE_TIME_Global.LocalIntCounter  = 0;
+    CFE_TIME_Global.LocalTaskCounter = 0;
+
+    CFE_TIME_Global.InternalCount = 0;
+    CFE_TIME_Global.ExternalCount = 0;
+
+    CFE_EVS_SendEvent(CFE_TIME_RESET_EID, CFE_EVS_EventType_DEBUG, "Reset Counters command");
+
+    return CFE_SUCCESS;
+
+} /* End of CFE_TIME_ResetCountersCmd() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_DiagCmd() -- Time task ground command (diagnostics)    */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int32 CFE_TIME_SendDiagnosticTlm(const CFE_TIME_SendDiagnosticCmd_t *data)
+{
+    CFE_TIME_Global.CommandCounter++;
+
+    /*
+    ** Collect diagnostics data from Time Services utilities...
+    */
+    CFE_TIME_GetDiagData();
+
+    /*
+    ** Send diagnostics telemetry packet...
+    */
+    CFE_SB_TimeStampMsg(&CFE_TIME_Global.DiagPacket.TlmHeader.Msg);
+    CFE_SB_TransmitMsg(&CFE_TIME_Global.DiagPacket.TlmHeader.Msg, true);
+
+    CFE_EVS_SendEvent(CFE_TIME_DIAG_EID, CFE_EVS_EventType_DEBUG, "Request diagnostics command");
+
+    return CFE_SUCCESS;
+
+} /* End of CFE_TIME_DiagCmd() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_SetStateCmd() -- Time task command (set clock state)   */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int32 CFE_TIME_SetStateCmd(const CFE_TIME_SetStateCmd_t *data)
+{
+    const CFE_TIME_StateCmd_Payload_t *CommandPtr = &data->Payload;
+    const char *                       ClockStateText;
+
+    /*
+    ** Verify command argument value (clock state)...
+    */
+    if ((CommandPtr->ClockState == CFE_TIME_ClockState_INVALID) ||
+        (CommandPtr->ClockState == CFE_TIME_ClockState_VALID) ||
+        (CommandPtr->ClockState == CFE_TIME_ClockState_FLYWHEEL))
+    {
+        CFE_TIME_SetState(CommandPtr->ClockState);
+
+        /*
+        ** Select appropriate text for event message...
+        */
+        if (CommandPtr->ClockState == CFE_TIME_ClockState_INVALID)
+        {
+            ClockStateText = "INVALID";
+        }
+        else if (CommandPtr->ClockState == CFE_TIME_ClockState_VALID)
+        {
+            ClockStateText = "VALID";
+        }
+        else
+        {
+            ClockStateText = "FLYWHEEL";
+        }
+
+        CFE_TIME_Global.CommandCounter++;
+        CFE_EVS_SendEvent(CFE_TIME_STATE_EID, CFE_EVS_EventType_INFORMATION, "Set Clock State = %s", ClockStateText);
+    }
+    else
+    {
+        CFE_TIME_Global.CommandErrorCounter++;
+        CFE_EVS_SendEvent(CFE_TIME_STATE_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid Clock State = 0x%X",
+                          (unsigned int)CommandPtr->ClockState);
+    }
+
+    return CFE_SUCCESS;
+
+} /* End of CFE_TIME_SetStateCmd() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_SetSourceCmd() -- Time task command (set time source)  */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int32 CFE_TIME_SetSourceCmd(const CFE_TIME_SetSourceCmd_t *data)
+{
+    const CFE_TIME_SourceCmd_Payload_t *CommandPtr = &data->Payload;
+
+#if (CFE_PLATFORM_TIME_CFG_SOURCE == true)
+    const char *TimeSourceText;
+#endif
+
+    /*
+    ** Verify command argument value (time data source)...
+    */
+    if ((CommandPtr->TimeSource == CFE_TIME_SourceSelect_INTERNAL) ||
+        (CommandPtr->TimeSource == CFE_TIME_SourceSelect_EXTERNAL))
+    {
+#if (CFE_PLATFORM_TIME_CFG_SOURCE == true)
+        /*
+        ** Only systems configured to select source of time data...
+        */
+        CFE_TIME_Global.CommandCounter++;
+
+        CFE_TIME_SetSource(CommandPtr->TimeSource);
+
+        /*
+        ** Select appropriate text for event message...
+        */
+        if (CommandPtr->TimeSource == CFE_TIME_SourceSelect_INTERNAL)
+        {
+            TimeSourceText = "INTERNAL";
+        }
+        else
+        {
+            TimeSourceText = "EXTERNAL";
+        }
+
+        CFE_EVS_SendEvent(CFE_TIME_SOURCE_EID, CFE_EVS_EventType_INFORMATION, "Set Time Source = %s", TimeSourceText);
+
+#else /* not CFE_PLATFORM_TIME_CFG_SOURCE */
+        /*
+        ** We want to know if disabled commands are being sent...
+        */
+        CFE_TIME_Global.CommandErrorCounter++;
+
+        CFE_EVS_SendEvent(CFE_TIME_SOURCE_CFG_EID, CFE_EVS_EventType_ERROR,
+                          "Set Source commands invalid without CFE_PLATFORM_TIME_CFG_SOURCE set to TRUE");
+
+#endif /* CFE_PLATFORM_TIME_CFG_SOURCE */
+    }
+    else
+    {
+        /*
+        ** Ground system database will prevent most of these errors...
+        */
+        CFE_TIME_Global.CommandErrorCounter++;
+
+        CFE_EVS_SendEvent(CFE_TIME_SOURCE_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid Time Source = 0x%X",
+                          (unsigned int)CommandPtr->TimeSource);
+    }
+
+    return CFE_SUCCESS;
+
+} /* End of CFE_TIME_SetSourceCmd() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_SetSignalCmd() -- Time task command (set tone source)  */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+int32 CFE_TIME_SetSignalCmd(const CFE_TIME_SetSignalCmd_t *data)
+{
+    const CFE_TIME_SignalCmd_Payload_t *CommandPtr = &data->Payload;
+
+#if (CFE_PLATFORM_TIME_CFG_SIGNAL == true)
+    const char *ToneSourceText;
+#endif
+
+    /*
+    ** Verify command argument value (tone source)...
+    */
+    if ((CommandPtr->ToneSource == CFE_TIME_ToneSignalSelect_PRIMARY) ||
+        (CommandPtr->ToneSource == CFE_TIME_ToneSignalSelect_REDUNDANT))
+    {
+#if (CFE_PLATFORM_TIME_CFG_SIGNAL == true)
+        /*
+        ** Only systems configured to select tone signal...
+        */
+        CFE_TIME_Global.CommandCounter++;
+
+        CFE_TIME_SetSignal(CommandPtr->ToneSource);
+
+        /*
+        ** Select appropriate text for event message...
+        */
+        if (CommandPtr->ToneSource == CFE_TIME_ToneSignalSelect_PRIMARY)
+        {
+            ToneSourceText = "PRIMARY";
+        }
+        else
+        {
+            ToneSourceText = "REDUNDANT";
+        }
+
+        CFE_EVS_SendEvent(CFE_TIME_SIGNAL_EID, CFE_EVS_EventType_INFORMATION, "Set Tone Source = %s", ToneSourceText);
+
+#else /* not CFE_PLATFORM_TIME_CFG_SIGNAL */
+        /*
+        ** We want to know if disabled commands are being sent...
+        */
+        CFE_TIME_Global.CommandErrorCounter++;
+
+        CFE_EVS_SendEvent(CFE_TIME_SIGNAL_CFG_EID, CFE_EVS_EventType_ERROR,
+                          "Set Signal commands invalid without CFE_PLATFORM_TIME_CFG_SIGNAL set to TRUE");
+
+#endif /* CFE_PLATFORM_TIME_CFG_SIGNAL */
+    }
+    else
+    {
+        /*
+        ** Ground system database will prevent most of these errors...
+        */
+        CFE_TIME_Global.CommandErrorCounter++;
+
+        CFE_EVS_SendEvent(CFE_TIME_SIGNAL_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid Tone Source = 0x%X",
+                          (unsigned int)CommandPtr->ToneSource);
+    }
+
+    return CFE_SUCCESS;
+
+} /* End of CFE_TIME_SetSignalCmd() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_SetDelayImpl() -- Time task ground command (tone delay)*/
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void CFE_TIME_SetDelayImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_AdjustDirection_Enum_t Direction)
+{
+    /*
+    ** Verify "micro-seconds" command argument...
+    */
+    if (CommandPtr->MicroSeconds < 1000000)
+    {
+#if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
+
+        CFE_TIME_SysTime_t Delay;
+
+        Delay.Seconds    = CommandPtr->Seconds;
+        Delay.Subseconds = CFE_TIME_Micro2SubSecs(CommandPtr->MicroSeconds);
+
+        CFE_TIME_SetDelay(Delay, Direction);
+
+        CFE_TIME_Global.CommandCounter++;
+        CFE_EVS_SendEvent(CFE_TIME_DELAY_EID, CFE_EVS_EventType_INFORMATION,
+                          "Set Tone Delay -- secs = %u, usecs = %u, ssecs = 0x%X, dir = %d",
+                          (unsigned int)CommandPtr->Seconds, (unsigned int)CommandPtr->MicroSeconds,
+                          (unsigned int)CFE_TIME_Micro2SubSecs(CommandPtr->MicroSeconds), (int)Direction);
+
+#else /* not CFE_PLATFORM_TIME_CFG_CLIENT */
+        /*
+        ** We want to know if disabled commands are being sent...
+        */
+        CFE_TIME_Global.CommandErrorCounter++;
+
+        CFE_EVS_SendEvent(CFE_TIME_DELAY_CFG_EID, CFE_EVS_EventType_ERROR,
+                          "Set Delay commands invalid without CFE_PLATFORM_TIME_CFG_CLIENT set to TRUE");
+
+#endif /* CFE_PLATFORM_TIME_CFG_CLIENT */
+    }
+    else
+    {
+        CFE_TIME_Global.CommandErrorCounter++;
+        CFE_EVS_SendEvent(CFE_TIME_DELAY_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Invalid Tone Delay -- secs = %u, usecs = %u", (unsigned int)CommandPtr->Seconds,
+                          (unsigned int)CommandPtr->MicroSeconds);
+    }
+
+} /* End of CFE_TIME_SetDelayImpl() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                     */
+/* CFE_TIME_AddSubDelayCmd() -- Time task ground command (tone delay)  */
+/*                                                                     */
+/* Wrapper around CFE_TIME_SetDelayImpl() for add/subtract operations  */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int32 CFE_TIME_AddDelayCmd(const CFE_TIME_AddDelayCmd_t *data)
+{
+    CFE_TIME_SetDelayImpl(&data->Payload, CFE_TIME_AdjustDirection_ADD);
+    return CFE_SUCCESS;
+}
+int32 CFE_TIME_SubDelayCmd(const CFE_TIME_SubDelayCmd_t *data)
+{
+    CFE_TIME_SetDelayImpl(&data->Payload, CFE_TIME_AdjustDirection_SUBTRACT);
+    return CFE_SUCCESS;
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_SetTimeCmd() -- Time task ground command (calc STCF)   */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int32 CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data)
+{
+    const CFE_TIME_TimeCmd_Payload_t *CommandPtr = &data->Payload;
+
+    /*
+    ** Verify "micro-seconds" command argument...
+    */
+    if (CommandPtr->MicroSeconds < 1000000)
+    {
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+
+        CFE_TIME_SysTime_t NewTime;
+
+        NewTime.Seconds    = CommandPtr->Seconds;
+        NewTime.Subseconds = CFE_TIME_Micro2SubSecs(CommandPtr->MicroSeconds);
+
+        CFE_TIME_SetTime(NewTime);
+
+        CFE_TIME_Global.CommandCounter++;
+        CFE_EVS_SendEvent(CFE_TIME_TIME_EID, CFE_EVS_EventType_INFORMATION,
+                          "Set Time -- secs = %u, usecs = %u, ssecs = 0x%X", (unsigned int)CommandPtr->Seconds,
+                          (unsigned int)CommandPtr->MicroSeconds,
+                          (unsigned int)CFE_TIME_Micro2SubSecs(CommandPtr->MicroSeconds));
+
+#else /* not CFE_PLATFORM_TIME_CFG_SERVER */
+        /*
+        ** We want to know if disabled commands are being sent...
+        */
+        CFE_TIME_Global.CommandErrorCounter++;
+
+        CFE_EVS_SendEvent(CFE_TIME_TIME_CFG_EID, CFE_EVS_EventType_ERROR,
+                          "Set Time commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to TRUE");
+
+#endif /* CFE_PLATFORM_TIME_CFG_SERVER */
+    }
+    else
+    {
+        CFE_TIME_Global.CommandErrorCounter++;
+        CFE_EVS_SendEvent(CFE_TIME_TIME_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid Time -- secs = %u, usecs = %u",
+                          (unsigned int)CommandPtr->Seconds, (unsigned int)CommandPtr->MicroSeconds);
+    }
+
+    return CFE_SUCCESS;
+
+} /* End of CFE_TIME_SetTimeCmd() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_SetMETCmd() -- Time task ground command (set MET)      */
+/*                                                                 */
+/* Note: This command will not have lasting effect if configured   */
+/*       to get external time of type MET.  Also, there cannot     */
+/*       be a local h/w MET and an external MET since both would   */
+/*       need to be synchronized to the same tone signal.          */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int32 CFE_TIME_SetMETCmd(const CFE_TIME_SetMETCmd_t *data)
+{
+    const CFE_TIME_TimeCmd_Payload_t *CommandPtr = &data->Payload;
+
+    /*
+    ** Verify "micro-seconds" command argument...
+    */
+    if (CommandPtr->MicroSeconds < 1000000)
+    {
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+
+        CFE_TIME_SysTime_t NewMET;
+
+        NewMET.Seconds    = CommandPtr->Seconds;
+        NewMET.Subseconds = CFE_TIME_Micro2SubSecs(CommandPtr->MicroSeconds);
+
+        CFE_TIME_SetMET(NewMET);
+
+        CFE_TIME_Global.CommandCounter++;
+        CFE_EVS_SendEvent(CFE_TIME_MET_EID, CFE_EVS_EventType_INFORMATION,
+                          "Set MET -- secs = %u, usecs = %u, ssecs = 0x%X", (unsigned int)CommandPtr->Seconds,
+                          (unsigned int)CommandPtr->MicroSeconds,
+                          (unsigned int)CFE_TIME_Micro2SubSecs(CommandPtr->MicroSeconds));
+
+#else /* not CFE_PLATFORM_TIME_CFG_SERVER */
+        /*
+        ** We want to know if disabled commands are being sent...
+        */
+        CFE_TIME_Global.CommandErrorCounter++;
+
+        CFE_EVS_SendEvent(CFE_TIME_MET_CFG_EID, CFE_EVS_EventType_ERROR,
+                          "Set MET commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to TRUE");
+
+#endif /* CFE_PLATFORM_TIME_CFG_SERVER */
+    }
+    else
+    {
+        CFE_TIME_Global.CommandErrorCounter++;
+        CFE_EVS_SendEvent(CFE_TIME_MET_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid MET -- secs = %u, usecs = %u",
+                          (unsigned int)CommandPtr->Seconds, (unsigned int)CommandPtr->MicroSeconds);
+    }
+
+    return CFE_SUCCESS;
+
+} /* End of CFE_TIME_SetMETCmd() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_SetSTCFCmd() -- Time task ground command (set STCF)    */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int32 CFE_TIME_SetSTCFCmd(const CFE_TIME_SetSTCFCmd_t *data)
+{
+    const CFE_TIME_TimeCmd_Payload_t *CommandPtr = &data->Payload;
+
+    /*
+    ** Verify "micro-seconds" command argument...
+    */
+    if (CommandPtr->MicroSeconds < 1000000)
+    {
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+
+        CFE_TIME_SysTime_t NewSTCF;
+
+        NewSTCF.Seconds    = CommandPtr->Seconds;
+        NewSTCF.Subseconds = CFE_TIME_Micro2SubSecs(CommandPtr->MicroSeconds);
+
+        CFE_TIME_SetSTCF(NewSTCF);
+
+        CFE_TIME_Global.CommandCounter++;
+        CFE_EVS_SendEvent(CFE_TIME_STCF_EID, CFE_EVS_EventType_INFORMATION,
+                          "Set STCF -- secs = %u, usecs = %u, ssecs = 0x%X", (unsigned int)CommandPtr->Seconds,
+                          (unsigned int)CommandPtr->MicroSeconds,
+                          (unsigned int)CFE_TIME_Micro2SubSecs(CommandPtr->MicroSeconds));
+
+#else /* not CFE_PLATFORM_TIME_CFG_SERVER */
+        /*
+        ** We want to know if disabled commands are being sent...
+        */
+        CFE_TIME_Global.CommandErrorCounter++;
+
+        CFE_EVS_SendEvent(CFE_TIME_STCF_CFG_EID, CFE_EVS_EventType_ERROR,
+                          "Set STCF commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to TRUE");
+
+#endif /* CFE_PLATFORM_TIME_CFG_SERVER */
+    }
+    else
+    {
+        CFE_TIME_Global.CommandErrorCounter++;
+        CFE_EVS_SendEvent(CFE_TIME_STCF_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid STCF -- secs = %u, usecs = %u",
+                          (unsigned int)CommandPtr->Seconds, (unsigned int)CommandPtr->MicroSeconds);
+    }
+
+    return CFE_SUCCESS;
+
+} /* End of CFE_TIME_SetSTCFCmd() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                       */
+/* CFE_TIME_SetLeapSecondsCmd() -- Time task ground command (set leaps)  */
+/*                                                                       */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int32 CFE_TIME_SetLeapSecondsCmd(const CFE_TIME_SetLeapSecondsCmd_t *data)
+{
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+
+    const CFE_TIME_LeapsCmd_Payload_t *CommandPtr = &data->Payload;
+
+    /*
+    ** No value checking (leaps may be positive or negative)...
+    */
+    CFE_TIME_SetLeapSeconds(CommandPtr->LeapSeconds);
+
+    CFE_TIME_Global.CommandCounter++;
+
+    CFE_EVS_SendEvent(CFE_TIME_LEAPS_EID, CFE_EVS_EventType_INFORMATION, "Set Leap Seconds = %d",
+                      (int)CommandPtr->LeapSeconds);
+
+#else /* not CFE_PLATFORM_TIME_CFG_SERVER */
+    /*
+    ** We want to know if disabled commands are being sent...
+    */
+    CFE_TIME_Global.CommandErrorCounter++;
+
+    CFE_EVS_SendEvent(CFE_TIME_LEAPS_CFG_EID, CFE_EVS_EventType_ERROR,
+                      "Set Leaps commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to TRUE");
+
+#endif /* CFE_PLATFORM_TIME_CFG_SERVER */
+
+    return CFE_SUCCESS;
+
+} /* End of CFE_TIME_SetLeapSecondsCmd() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_AdjustImpl() -- Time task ground command (adjust STCF) */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void CFE_TIME_AdjustImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_AdjustDirection_Enum_t Direction)
+{
+    /*
+    ** Verify command arguments...
+    */
+    if (CommandPtr->MicroSeconds < 1000000)
+    {
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+
+        CFE_TIME_SysTime_t Adjust;
+
+        Adjust.Seconds    = CommandPtr->Seconds;
+        Adjust.Subseconds = CFE_TIME_Micro2SubSecs(CommandPtr->MicroSeconds);
+
+        CFE_TIME_SetAdjust(Adjust, Direction);
+
+        CFE_TIME_Global.CommandCounter++;
+        CFE_EVS_SendEvent(CFE_TIME_DELTA_EID, CFE_EVS_EventType_INFORMATION,
+                          "STCF Adjust -- secs = %u, usecs = %u, ssecs = 0x%X, dir[1=Pos, 2=Neg] = %d",
+                          (unsigned int)CommandPtr->Seconds, (unsigned int)CommandPtr->MicroSeconds,
+                          (unsigned int)CFE_TIME_Micro2SubSecs(CommandPtr->MicroSeconds), (int)Direction);
+
+#else /* not CFE_PLATFORM_TIME_CFG_SERVER */
+        /*
+        ** We want to know if disabled commands are being sent...
+        */
+        CFE_TIME_Global.CommandErrorCounter++;
+
+        CFE_EVS_SendEvent(CFE_TIME_DELTA_CFG_EID, CFE_EVS_EventType_ERROR,
+                          "STCF Adjust commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to TRUE");
+
+#endif /* CFE_PLATFORM_TIME_CFG_SERVER */
+    }
+    else
+    {
+        CFE_TIME_Global.CommandErrorCounter++;
+        CFE_EVS_SendEvent(CFE_TIME_DELTA_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Invalid STCF Adjust -- secs = %u, usecs = %u, dir[1=Pos, 2=Neg] = %d",
+                          (unsigned int)CommandPtr->Seconds, (unsigned int)CommandPtr->MicroSeconds, (int)Direction);
+    }
+
+} /* End of CFE_TIME_AdjustImpl() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                     */
+/* CFE_TIME_AddAdjustCmd() -- Time task ground command (1Hz adjust)    */
+/*                                                                     */
+/* This is a wrapper around CFE_TIME_AdjustImpl()                      */
+/*                                                                     */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int32 CFE_TIME_AddAdjustCmd(const CFE_TIME_AddAdjustCmd_t *data)
+{
+    CFE_TIME_AdjustImpl(&data->Payload, CFE_TIME_AdjustDirection_ADD);
+    return CFE_SUCCESS;
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                     */
+/* CFE_TIME_SubAdjustCmd() -- Time task ground command (1Hz adjust)    */
+/*                                                                     */
+/* This is a wrapper around CFE_TIME_AdjustImpl()                      */
+/*                                                                     */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int32 CFE_TIME_SubAdjustCmd(const CFE_TIME_SubAdjustCmd_t *data)
+{
+    CFE_TIME_AdjustImpl(&data->Payload, CFE_TIME_AdjustDirection_SUBTRACT);
+    return CFE_SUCCESS;
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_1HzAdjImpl() -- Time task ground command (1Hz adjust)  */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void CFE_TIME_1HzAdjImpl(const CFE_TIME_OneHzAdjustmentCmd_Payload_t *CommandPtr,
+                         CFE_TIME_AdjustDirection_Enum_t              Direction)
+{
+/*
+** 1Hz adjustments are only valid for "Time Servers"...
+*/
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+
+    CFE_TIME_SysTime_t Adjust;
+
+    CFE_TIME_Copy(&Adjust, CommandPtr);
+
+    CFE_TIME_Set1HzAdj(Adjust, Direction);
+
+    CFE_TIME_Global.CommandCounter++;
+    CFE_EVS_SendEvent(CFE_TIME_1HZ_EID, CFE_EVS_EventType_INFORMATION,
+                      "STCF 1Hz Adjust -- secs = %d, ssecs = 0x%X, dir[1=Pos, 2=Neg] = %d", (int)CommandPtr->Seconds,
+                      (unsigned int)CommandPtr->Subseconds, (int)Direction);
+
+#else /* not CFE_PLATFORM_TIME_CFG_SERVER */
+    /*
+    ** We want to know if disabled commands are being sent...
+    */
+    CFE_TIME_Global.CommandErrorCounter++;
+
+    CFE_EVS_SendEvent(CFE_TIME_1HZ_CFG_EID, CFE_EVS_EventType_ERROR,
+                      "1Hz Adjust commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to TRUE");
+
+#endif /* CFE_PLATFORM_TIME_CFG_SERVER */
+
+} /* End of CFE_TIME_1HzAdjImpl() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                         */
+/* CFE_TIME_Add1HZAdjustmentCmd() -- Time task ground command (1Hz adjust) */
+/*                                                                         */
+/* This is a wrapper around CFE_TIME_1HzAdjImpl()                          */
+/*                                                                         */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int32 CFE_TIME_Add1HZAdjustmentCmd(const CFE_TIME_Add1HZAdjustmentCmd_t *data)
+{
+    CFE_TIME_1HzAdjImpl(&data->Payload, CFE_TIME_AdjustDirection_ADD);
+    return CFE_SUCCESS;
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                         */
+/* CFE_TIME_Sub1HZAdjustmentCmd() -- Time task ground command (1Hz adjust) */
+/*                                                                         */
+/* This is a wrapper around CFE_TIME_1HzAdjImpl()                          */
+/*                                                                         */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int32 CFE_TIME_Sub1HZAdjustmentCmd(const CFE_TIME_Sub1HZAdjustmentCmd_t *data)
+{
+    CFE_TIME_1HzAdjImpl(&data->Payload, CFE_TIME_AdjustDirection_SUBTRACT);
+    return CFE_SUCCESS;
+}
+
+/************************/
+/*  End of File Comment */
+/************************/

--- a/modules/time/fsw/src/cfe_time_tone.c
+++ b/modules/time/fsw/src/cfe_time_tone.c
@@ -1,0 +1,1433 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/*
+** File: cfe_time_tone.c
+**
+** Purpose:  cFE Time Services (TIME) library utilities source file
+**
+** Author:   S.Walling/Microtel
+**
+** Notes:    This module was created from a portion of the source file
+**           "cfe_time_utils.c" because that file had grown too large.
+**
+**           This module contains functions related to the detection
+**           and processing of the "time at the tone" event signal.
+**
+**           This module contains functions related to the detection
+**           and processing of the local 1Hz interrupt.
+**
+*/
+
+/*
+** Required header files...
+*/
+#include "cfe_time_module_all.h"
+
+#include <string.h>
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_ToneSend() -- Send "time at the tone" (local time)     */
+/*                                                                 */
+/* There is a presumption that this function will be called at     */
+/*    the appropriate time (relative to the tone) such that the    */
+/*    "time at the tone" data command will arrive within the       */
+/*    specified window for tone and data packet verification.      */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+void CFE_TIME_ToneSend(void)
+{
+    CFE_TIME_Reference_t Reference;
+    CFE_TIME_SysTime_t   NewMET;
+
+    /* Zero out the Reference variable because we pass it into
+     * a function before using it
+     * */
+    memset(&Reference, 0, sizeof(CFE_TIME_Reference_t));
+
+    /*
+    ** Get reference time values (local time, time at tone, etc.)...
+    */
+    CFE_TIME_GetReference(&Reference);
+
+    /*
+    ** Get the new MET from the appropriate source...
+    */
+    if (Reference.ClockFlyState == CFE_TIME_FlywheelState_IS_FLY)
+    {
+        /*
+        ** At least one of the following conditions is true...
+        **
+        **  1) loss of tone signal
+        **  2) loss of "time at the tone" data packet
+        **  3) signal and packet not within valid window
+        **  4) we were commanded into fly-wheel mode
+        **
+        ** Set the new MET to our fly-wheel best guess...
+        */
+        NewMET.Seconds = Reference.CurrentMET.Seconds;
+    }
+    else
+    {
+/*
+** MET seconds is the count of tone interrupts...
+*/
+#if (CFE_PLATFORM_TIME_CFG_VIRTUAL == true)
+        NewMET.Seconds = CFE_TIME_Global.VirtualMET;
+#endif
+
+/*
+** Read MET seconds from a h/w register...
+*/
+#if (CFE_PLATFORM_TIME_CFG_VIRTUAL != true)
+        OS_GetLocalMET(&NewMET.Seconds);
+#endif
+    }
+
+/*
+** Add a second if the tone has not yet occurred...
+*/
+#if (CFE_MISSION_TIME_AT_TONE_WILL_BE == true)
+    NewMET.Seconds++;
+#endif
+
+    /*
+    ** Need to fix this if the tone is not 1Hz...
+    */
+    NewMET.Subseconds = 0;
+
+    /*
+    ** Current clock state is a combination of factors...
+    */
+
+#ifdef CFE_PLATFORM_TIME_CFG_BIGENDIAN
+
+    /*
+    ** Current clock state is a combination of factors...
+    */
+    uint16 AtToneState = CFE_TIME_CalculateState(&Reference);
+
+    /*
+    ** Payload must be big-endian.
+    */
+
+    CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Seconds     = CFE_MAKE_BIG32(NewMET.Seconds);
+    CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Subseconds  = CFE_MAKE_BIG32(NewMET.Subseconds);
+    CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF.Seconds    = CFE_MAKE_BIG32(Reference.AtToneSTCF.Seconds);
+    CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF.Subseconds = CFE_MAKE_BIG32(Reference.AtToneSTCF.Subseconds);
+    CFE_TIME_Global.ToneDataCmd.Payload.AtToneLeapSeconds     = CFE_MAKE_BIG16(Reference.AtToneLeapSeconds);
+    CFE_TIME_Global.ToneDataCmd.Payload.AtToneState           = CFE_MAKE_BIG16(AtToneState);
+
+#else /* !CFE_PLATFORM_TIME_CFG_BIGENDIAN */
+
+    /*
+    ** Remainder of time values are unchanged...
+    */
+    CFE_TIME_Copy(&CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET, &NewMET);
+    CFE_TIME_Copy(&CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF, &Reference.AtToneSTCF);
+    CFE_TIME_Global.ToneDataCmd.Payload.AtToneLeapSeconds = Reference.AtToneLeapSeconds;
+
+    /*
+    ** Current clock state is a combination of factors...
+    */
+    CFE_TIME_Global.ToneDataCmd.Payload.AtToneState = CFE_TIME_CalculateState(&Reference);
+
+#endif /* CFE_PLATFORM_TIME_CFG_BIGENDIAN */
+
+    /*
+    ** Send "time at the tone" command data packet...
+    */
+    CFE_SB_TransmitMsg(&CFE_TIME_Global.ToneDataCmd.CmdHeader.Msg, false);
+
+    /*
+    ** Count of "time at the tone" commands sent with internal data...
+    */
+    CFE_TIME_Global.InternalCount++;
+
+    return;
+
+} /* End of CFE_TIME_ToneSend() */
+#endif /* CFE_PLATFORM_TIME_CFG_SERVER */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_ToneSendMET() -- Send "time at tone" (external MET)    */
+/*                                                                 */
+/* There is a presumption that this function will be called at     */
+/*    the appropriate time (relative to the tone) such that the    */
+/*    "time at the tone" data command will arrive within the       */
+/*    specified window for tone and data packet verification.      */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#if (CFE_PLATFORM_TIME_CFG_SRC_MET == true)
+int32 CFE_TIME_ToneSendMET(CFE_TIME_SysTime_t NewMET)
+{
+    CFE_TIME_Reference_t Reference;
+    CFE_TIME_SysTime_t   Expected;
+    CFE_TIME_SysTime_t   MinValid;
+    CFE_TIME_SysTime_t   MaxValid;
+    CFE_TIME_Compare_t   MinResult;
+    CFE_TIME_Compare_t   MaxResult;
+
+    int16 ClockState;
+    int32 Result = CFE_SUCCESS;
+
+    /* Start Performance Monitoring */
+    CFE_ES_PerfLogEntry(CFE_MISSION_TIME_SENDMET_PERF_ID);
+
+    /* Zero out the Reference variable because we pass it into
+     * a function before using it
+     * */
+    memset(&Reference, 0, sizeof(CFE_TIME_Reference_t));
+
+    /*
+    ** Ignore external time data if commanded to use local MET...
+    */
+    if (CFE_TIME_Global.ClockSource == CFE_TIME_SourceSelect_INTERNAL)
+    {
+        Result = CFE_TIME_INTERNAL_ONLY;
+
+        /*
+        ** Use internal clock but still send "time at the tone"...
+        */
+        CFE_TIME_ToneSend();
+    }
+    else
+    {
+        /*
+        ** Get reference time values (local time, time at tone, etc.)...
+        */
+        CFE_TIME_GetReference(&Reference);
+
+        /*
+        ** cFE defines MET as being synchronized to the tone signal...
+        */
+        Expected.Seconds    = Reference.CurrentMET.Seconds;
+        Expected.Subseconds = 0;
+
+/*
+** Add a second if the tone has not yet occurred...
+*/
+#if (CFE_MISSION_TIME_AT_TONE_WILL_BE == true)
+        Expected.Seconds++;
+#endif
+
+        /*
+        ** Compute minimum and maximum values for valid MET...
+        */
+        MinValid = CFE_TIME_Subtract(Expected, CFE_TIME_Global.MaxDelta);
+        MaxValid = CFE_TIME_Add(Expected, CFE_TIME_Global.MaxDelta);
+
+        /*
+        ** Compare new MET to minimum and maximum MET...
+        */
+        MinResult = CFE_TIME_Compare(NewMET, MinValid);
+        MaxResult = CFE_TIME_Compare(NewMET, MaxValid);
+
+        /*
+        ** Ignore bad external time data only if clock state is valid...
+        */
+        if ((Reference.ClockSetState == CFE_TIME_SetState_WAS_SET) &&
+            ((MinResult == CFE_TIME_A_LT_B) || (MaxResult == CFE_TIME_A_GT_B)))
+        {
+            Result = CFE_TIME_OUT_OF_RANGE;
+
+            /*
+            ** Use internal clock but still send "time at the tone"...
+            */
+            CFE_TIME_ToneSend();
+        }
+        else
+        {
+            ClockState = CFE_TIME_CalculateState(&Reference);
+
+            /*
+            ** Set "time at the tone" command data packet arguments...
+            */
+
+#ifdef CFE_PLATFORM_TIME_CFG_BIGENDIAN
+
+            /*
+            ** Payload must be big-endian.
+            */
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Seconds     = CFE_MAKE_BIG32(NewMET.Seconds);
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Subseconds  = CFE_MAKE_BIG32(NewMET.Subseconds);
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF.Seconds    = CFE_MAKE_BIG32(Reference.AtToneSTCF.Seconds);
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF.Subseconds = CFE_MAKE_BIG32(Reference.AtToneSTCF.Subseconds);
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneLeapSeconds     = CFE_MAKE_BIG16(Reference.AtToneLeapSeconds);
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneState           = CFE_MAKE_BIG16(ClockState);
+
+#else /* !CFE_PLATFORM_TIME_CFG_BIGENDIAN */
+
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET         = NewMET;
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF        = Reference.AtToneSTCF;
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneLeapSeconds = Reference.AtToneLeapSeconds;
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneState       = ClockState;
+
+#endif /* CFE_PLATFORM_TIME_CFG_BIGENDIAN */
+
+            /*
+            ** Send "time at the tone" command data packet...
+            */
+            CFE_SB_TransmitMsg(&CFE_TIME_Global.ToneDataCmd.CmdHeader.Msg, false);
+
+            /*
+            ** Count of "time at the tone" commands sent with external data...
+            */
+            CFE_TIME_Global.ExternalCount++;
+        }
+    }
+
+    /* Exit performance monitoring */
+    CFE_ES_PerfLogExit(CFE_MISSION_TIME_SENDMET_PERF_ID);
+    return (Result);
+
+} /* End of CFE_TIME_ToneSendMET() */
+#endif /* CFE_PLATFORM_TIME_CFG_SRC_MET */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_ToneSendGPS() -- Send "time at tone" (external GPS)    */
+/*                                                                 */
+/* There is a presumption that this function will be called at     */
+/*    the appropriate time (relative to the tone) such that the    */
+/*    "time at the tone" data command will arrive within the       */
+/*    specified window for tone and data packet verification.      */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#if (CFE_PLATFORM_TIME_CFG_SRC_GPS == true)
+int32 CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps)
+{
+    CFE_TIME_Reference_t Reference;
+    CFE_TIME_SysTime_t   NewSTCF;
+    CFE_TIME_SysTime_t   NewMET;
+    CFE_TIME_SysTime_t   MinValid;
+    CFE_TIME_SysTime_t   MaxValid;
+    CFE_TIME_Compare_t   MinResult;
+    CFE_TIME_Compare_t   MaxResult;
+
+    int16 ClockState;
+    int32 Result = CFE_SUCCESS;
+
+    /* Zero out the Reference variable because we pass it into
+     * a function before using it
+     * */
+    memset(&Reference, 0, sizeof(CFE_TIME_Reference_t));
+
+    /*
+    ** Ignore external time data if commanded to use local MET...
+    */
+    if (CFE_TIME_Global.ClockSource == CFE_TIME_SourceSelect_INTERNAL)
+    {
+        Result = CFE_TIME_INTERNAL_ONLY;
+
+        /*
+        ** Use internal clock but still send "time at the tone"...
+        */
+        CFE_TIME_ToneSend();
+    }
+    else
+    {
+        /*
+        ** Get reference time values (local time, time at tone, etc.)...
+        */
+        CFE_TIME_GetReference(&Reference);
+
+        /*
+        ** cFE defines MET as being synchronized to the tone signal...
+        */
+        NewMET.Seconds    = Reference.CurrentMET.Seconds;
+        NewMET.Subseconds = 0;
+
+/*
+** Add a second if the tone has not yet occurred...
+*/
+#if (CFE_MISSION_TIME_AT_TONE_WILL_BE == true)
+        NewMET.Seconds++;
+#endif
+
+        /*
+        ** Remove MET from the new time value (leaves STCF)...
+        */
+        NewSTCF = CFE_TIME_Subtract(NewTime, NewMET);
+
+/*
+** Restore leap seconds if default time format is UTC...
+*/
+#if (CFE_MISSION_TIME_CFG_DEFAULT_UTC == true)
+        NewSTCF.Seconds += NewLeaps;
+#endif
+
+        /*
+        ** Compute minimum and maximum values for valid STCF...
+        */
+        MinValid = CFE_TIME_Subtract(Reference.AtToneSTCF, CFE_TIME_Global.MaxDelta);
+        MaxValid = CFE_TIME_Add(Reference.AtToneSTCF, CFE_TIME_Global.MaxDelta);
+
+        /*
+        ** Compare new STCF to minimum and maximum STCF...
+        */
+        MinResult = CFE_TIME_Compare(NewSTCF, MinValid);
+        MaxResult = CFE_TIME_Compare(NewSTCF, MaxValid);
+
+        /*
+        ** If state is valid then ignore bad external time data...
+        */
+        if ((Reference.ClockSetState == CFE_TIME_SetState_WAS_SET) &&
+            ((MinResult == CFE_TIME_A_LT_B) || (MaxResult == CFE_TIME_A_GT_B)))
+        {
+            Result = CFE_TIME_OUT_OF_RANGE;
+
+            /*
+            ** Use internal clock but still send "time at the tone"...
+            */
+            CFE_TIME_ToneSend();
+        }
+        else
+        {
+            ClockState = CFE_TIME_CalculateState(&Reference);
+            /*
+            ** Set "time at the tone" command data packet arguments...
+            */
+
+#ifdef CFE_PLATFORM_TIME_CFG_BIGENDIAN
+
+            /*
+            ** Payload must be big-endian.
+            */
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Seconds     = CFE_MAKE_BIG32(NewMET.Seconds);
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Subseconds  = CFE_MAKE_BIG32(NewMET.Subseconds);
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF.Seconds    = CFE_MAKE_BIG32(NewSTCF.Seconds);
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF.Subseconds = CFE_MAKE_BIG32(NewSTCF.Subseconds);
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneLeapSeconds     = CFE_MAKE_BIG16(NewLeaps);
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneState           = CFE_MAKE_BIG16(ClockState);
+
+#else /* !CFE_PLATFORM_TIME_CFG_BIGENDIAN */
+
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET         = NewMET;
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF        = NewSTCF;
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneLeapSeconds = NewLeaps;
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneState       = ClockState;
+
+#endif /* CFE_PLATFORM_TIME_CFG_BIGENDIAN */
+
+            /*
+            ** Send "time at the tone" command data packet...
+            */
+            CFE_SB_TransmitMsg(&CFE_TIME_Global.ToneDataCmd.CmdHeader.Msg, false);
+
+            /*
+            ** Count of "time at the tone" commands sent with external data...
+            */
+            CFE_TIME_Global.ExternalCount++;
+        }
+    }
+
+    return (Result);
+
+} /* End of CFE_TIME_ToneSendGPS() */
+#endif /* CFE_PLATFORM_TIME_CFG_SRC_GPS */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_ToneSendTime() -- Send "time at tone" (external time)  */
+/*                                                                 */
+/* There is a presumption that this function will be called at     */
+/*    the appropriate time (relative to the tone) such that the    */
+/*    "time at the tone" data command will arrive within the       */
+/*    specified window for tone and data packet verification.      */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#if (CFE_PLATFORM_TIME_CFG_SRC_TIME == true)
+int32 CFE_TIME_ToneSendTime(CFE_TIME_SysTime_t NewTime)
+{
+    CFE_TIME_Reference_t Reference;
+    CFE_TIME_SysTime_t   NewSTCF;
+    CFE_TIME_SysTime_t   NewMET;
+    CFE_TIME_SysTime_t   MinValid;
+    CFE_TIME_SysTime_t   MaxValid;
+    CFE_TIME_Compare_t   MinResult;
+    CFE_TIME_Compare_t   MaxResult;
+
+    int16 ClockState;
+    int32 Result = CFE_SUCCESS;
+
+    /* Zero out the Reference variable because we pass it into
+     * a function before using it
+     * */
+    memset(&Reference, 0, sizeof(CFE_TIME_Reference_t));
+
+    /*
+    ** Ignore external time data if commanded to use local MET...
+    */
+    if (CFE_TIME_Global.ClockSource == CFE_TIME_SourceSelect_INTERNAL)
+    {
+        Result = CFE_TIME_INTERNAL_ONLY;
+
+        /*
+        ** Use internal clock but still send "time at the tone"...
+        */
+        CFE_TIME_ToneSend();
+    }
+    else
+    {
+        /*
+        ** Get reference time values (local time, time at tone, etc.)...
+        */
+        CFE_TIME_GetReference(&Reference);
+
+        /*
+        ** cFE defines MET as being synchronized to the tone signal...
+        */
+        NewMET.Seconds    = Reference.CurrentMET.Seconds;
+        NewMET.Subseconds = 0;
+
+/*
+** Add a second if the tone has not yet occurred...
+*/
+#if (CFE_MISSION_TIME_AT_TONE_WILL_BE == true)
+        NewMET.Seconds++;
+#endif
+
+        /*
+        ** Remove MET from the new time value (leaves STCF)...
+        */
+        NewSTCF = CFE_TIME_Subtract(NewTime, NewMET);
+
+/*
+** Restore leap seconds if default time format is UTC...
+*/
+#if (CFE_MISSION_TIME_CFG_DEFAULT_UTC == true)
+        NewSTCF.Seconds += Reference.AtToneLeapSeconds;
+#endif
+
+        /*
+        ** Compute minimum and maximum values for valid STCF...
+        */
+        MinValid = CFE_TIME_Subtract(Reference.AtToneSTCF, CFE_TIME_Global.MaxDelta);
+        MaxValid = CFE_TIME_Add(Reference.AtToneSTCF, CFE_TIME_Global.MaxDelta);
+
+        /*
+        ** Compare new STCF to minimum and maximum STCF...
+        */
+        MinResult = CFE_TIME_Compare(NewSTCF, MinValid);
+        MaxResult = CFE_TIME_Compare(NewSTCF, MaxValid);
+
+        /*
+        ** If state is valid then ignore bad external time data...
+        */
+        if ((Reference.ClockSetState == CFE_TIME_SetState_WAS_SET) &&
+            ((MinResult == CFE_TIME_A_LT_B) || (MaxResult == CFE_TIME_A_GT_B)))
+        {
+            Result = CFE_TIME_OUT_OF_RANGE;
+
+            /*
+            ** Use internal clock but still send "time at the tone"...
+            */
+            CFE_TIME_ToneSend();
+        }
+        else
+        {
+            ClockState = CFE_TIME_CalculateState(&Reference);
+
+            /*
+            ** Set "time at the tone" command data packet arguments...
+            */
+
+#ifdef CFE_PLATFORM_TIME_CFG_BIGENDIAN
+
+            /*
+            ** Payload must be big-endian.
+            */
+
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Seconds     = CFE_MAKE_BIG32(NewMET.Seconds);
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET.Subseconds  = CFE_MAKE_BIG32(NewMET.Subseconds);
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF.Seconds    = CFE_MAKE_BIG32(NewSTCF.Seconds);
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF.Subseconds = CFE_MAKE_BIG32(NewSTCF.Subseconds);
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneLeapSeconds     = CFE_MAKE_BIG16(Reference.AtToneLeapSeconds);
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneState           = CFE_MAKE_BIG16(ClockState);
+
+#else /* !CFE_PLATFORM_TIME_CFG_BIGENDIAN */
+
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneMET         = NewMET;
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneSTCF        = NewSTCF;
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneLeapSeconds = Reference.AtToneLeapSeconds;
+            CFE_TIME_Global.ToneDataCmd.Payload.AtToneState       = ClockState;
+
+#endif /* CFE_PLATFORM_TIME_CFG_BIGENDIAN */
+
+            /*
+            ** Send "time at the tone" command data packet...
+            */
+            CFE_SB_TransmitMsg(&CFE_TIME_Global.ToneDataCmd.CmdHeader.Msg, false);
+
+            /*
+            ** Count of "time at the tone" commands sent with external data...
+            */
+            CFE_TIME_Global.ExternalCount++;
+        }
+    }
+
+    return (Result);
+
+} /* End of CFE_TIME_ToneSendTime() */
+#endif /* CFE_PLATFORM_TIME_CFG_SRC_TIME */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_ToneData() -- process "time at tone" data packet       */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void CFE_TIME_ToneData(const CFE_TIME_ToneDataCmd_Payload_t *ToneDataCmd)
+{
+    /*
+    ** Save the time when the data packet was received...
+    */
+    CFE_TIME_Global.ToneDataLatch = CFE_TIME_LatchClock();
+
+    /*
+    ** Save the data packet (may be a while before the data is used)...
+    */
+
+#ifdef CFE_PLATFORM_TIME_CFG_BIGENDIAN
+
+    /*
+    ** Tone data will be big-endian, convert to platform-endian.
+    */
+    CFE_TIME_Global.PendingMET.Seconds     = CFE_MAKE_BIG32(ToneDataCmd->AtToneMET.Seconds);
+    CFE_TIME_Global.PendingMET.Subseconds  = CFE_MAKE_BIG32(ToneDataCmd->AtToneMET.Subseconds);
+    CFE_TIME_Global.PendingSTCF.Seconds    = CFE_MAKE_BIG32(ToneDataCmd->AtToneSTCF.Seconds);
+    CFE_TIME_Global.PendingSTCF.Subseconds = CFE_MAKE_BIG32(ToneDataCmd->AtToneSTCF.Subseconds);
+    CFE_TIME_Global.PendingLeaps           = CFE_MAKE_BIG16(ToneDataCmd->AtToneLeapSeconds);
+    CFE_TIME_Global.PendingState           = CFE_MAKE_BIG16(ToneDataCmd->AtToneState);
+
+#else /* !CFE_PLATFORM_TIME_CFG_BIGENDIAN */
+
+    CFE_TIME_Copy(&CFE_TIME_Global.PendingMET, &ToneDataCmd->AtToneMET);
+    CFE_TIME_Copy(&CFE_TIME_Global.PendingSTCF, &ToneDataCmd->AtToneSTCF);
+    CFE_TIME_Global.PendingLeaps = ToneDataCmd->AtToneLeapSeconds;
+    CFE_TIME_Global.PendingState = ToneDataCmd->AtToneState;
+
+#endif /* CFE_PLATFORM_TIME_CFG_BIGENDIAN */
+
+/*
+** If the data packet is designed to arrive after the tone...
+**
+** Check to see if the most recent tone signal matches this
+**    data packet.  If so, we have a matched pair and can
+**    now start using the new data to compute time.
+*/
+#if (CFE_MISSION_TIME_AT_TONE_WAS == true)
+    CFE_TIME_ToneVerify(CFE_TIME_Global.ToneSignalLatch, CFE_TIME_Global.ToneDataLatch);
+#endif
+
+/*
+** If the data packet is designed to arrive before the tone...
+**
+** We don't really need to do anything except to save the time
+**    and contents of this data packet.  (above)
+**
+** Note that we do not immediately start using the data packet
+**    values to compute current time.  We continue to use the
+**    old tone/data combo until we get a new matched pair.
+*/
+#if (CFE_MISSION_TIME_AT_TONE_WILL_BE == true)
+#endif
+
+    /*
+    ** Maintain a count of tone data packets...
+    */
+    CFE_TIME_Global.ToneDataCounter++;
+
+    return;
+
+} /* End of CFE_TIME_ToneData() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_ToneSignal() -- "tone signal" occurred recently        */
+/*                                                                 */
+/* This function is called upon receipt of a command indicating    */
+/*    that a time at the tone signal was detected.  The mission    */
+/*    dependent h/w or s/w that detected the tone signal latched   */
+/*    the local clock and generated this command.  The use of a    */
+/*    command announcing the tone signal ensures that this code    */
+/*    is not called from within an interrupt handler.              */
+/*                                                                 */
+/* It is not a concern that some amount of time has elapsed since  */
+/*    the tone actually occurred.  We are currently computing      */
+/*    time as a delta (as measured on our local clock) from a      */
+/*    previously latched tone.  It just doesn't matter if the      */
+/*    size of the delta slightly exceeds a second.  The quality    */
+/*    of our local clock will always be sufficient to measure      */
+/*    time for a couple of seconds.                                */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void CFE_TIME_ToneSignal(void)
+{
+/*
+** If the data packet is designed to arrive after the tone signal...
+**
+** We don't really need to do anything except latch the local clock
+**    at the moment of the tone.  And that has already happened at
+**    the time when the tone was detected.
+**
+** Note that we do not immediately start using this latched value to
+**    compute current time.  We continue to use the old tone/data
+**    combo until we get a new matched pair.
+*/
+#if (CFE_MISSION_TIME_AT_TONE_WAS == true)
+#endif
+
+/*
+** If the data packet is designed to arrive before the tone signal...
+**
+** Check to see if the most recent data packet matches this
+**    tone signal.  If so, we have a matched pair and can
+**    now start using the new data to compute time.
+*/
+#if (CFE_MISSION_TIME_AT_TONE_WILL_BE == true)
+    CFE_TIME_ToneVerify(CFE_TIME_Global.ToneDataLatch, CFE_TIME_Global.ToneSignalLatch);
+#endif
+
+    /*
+    ** Maintain a count of tone signal packets...
+    */
+    CFE_TIME_Global.ToneSignalCounter++;
+
+    return;
+
+} /* End of CFE_TIME_ToneSignal() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_ToneVerify() -- validate tone and data packet          */
+/*                                                                 */
+/*                                                                 */
+/* If the data packet is designed to arrive after the tone, then   */
+/*                                                                 */
+/*    Time1 = local clock latched at the detection of the tone     */
+/*    Time2 = local clock latched at the arrival of the packet     */
+/*                                                                 */
+/*                                                                 */
+/* If the data packet is designed to arrive before the tone, then  */
+/*                                                                 */
+/*    Time1 = local clock latched at the arrival of the packet     */
+/*    Time2 = local clock latched at the detection of the tone     */
+/*                                                                 */
+/*                                                                 */
+/* In either case, Time1 occurred before Time2                     */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void CFE_TIME_ToneVerify(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2)
+{
+    CFE_TIME_Compare_t result;
+    CFE_TIME_SysTime_t elapsed;
+
+    static CFE_TIME_SysTime_t PrevTime1 = {0, 0};
+    static CFE_TIME_SysTime_t PrevTime2 = {0, 0};
+
+    /*
+    ** It is possible to call this func with static time value...
+    */
+    result = CFE_TIME_Compare(PrevTime1, Time1);
+    if (result == CFE_TIME_EQUAL)
+    {
+        CFE_TIME_Global.ToneMatchErrorCounter++;
+    }
+    else
+    {
+        result = CFE_TIME_Compare(PrevTime2, Time2);
+        if (result == CFE_TIME_EQUAL)
+        {
+            CFE_TIME_Global.ToneMatchErrorCounter++;
+        }
+        else
+        {
+            /*
+            ** Compute elapsed time between tone and data packet...
+            */
+            result = CFE_TIME_Compare(Time1, Time2);
+            if (result == CFE_TIME_A_GT_B)
+            {
+                /*
+                ** Local clock has rolled over...
+                */
+                elapsed = CFE_TIME_Subtract(CFE_TIME_Global.MaxLocalClock, Time1);
+                elapsed = CFE_TIME_Add(elapsed, Time2);
+            }
+            else
+            {
+                /*
+                ** Normal case...
+                */
+                elapsed = CFE_TIME_Subtract(Time2, Time1);
+            }
+
+            /*
+            ** Ensure that time between packet and tone is within limits...
+            */
+            if ((elapsed.Seconds != 0) || (elapsed.Subseconds < CFE_TIME_Global.MinElapsed) ||
+                (elapsed.Subseconds > CFE_TIME_Global.MaxElapsed))
+            {
+                /*
+                ** Maintain count of tone vs data packet mis-matches...
+                */
+                CFE_TIME_Global.ToneMatchErrorCounter++;
+            }
+            else
+            {
+                CFE_TIME_Global.ToneMatchCounter++;
+
+                /*
+                ** Skip tone packet update if commanded into "flywheel" mode...
+                */
+                if (!CFE_TIME_Global.Forced2Fly)
+                {
+                    /*
+                    ** Process "matching" tone and data packet...
+                    */
+                    CFE_TIME_ToneUpdate();
+                }
+            }
+        }
+    }
+
+    PrevTime1 = Time1;
+    PrevTime2 = Time2;
+
+    return;
+
+} /* End of CFE_TIME_ToneVerify() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_ToneUpdate() -- process "matching" tone & data packet  */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void CFE_TIME_ToneUpdate(void)
+{
+    CFE_TIME_Reference_t                Reference;
+    bool                                NewFlywheelStatus = false;
+    volatile CFE_TIME_ReferenceState_t *NextState;
+
+    /*
+    ** Get current reference state before starting any update
+    **
+    ** If we have been flywheeling, VirtualMET may be incorrect
+    **  (e.g. missing tone signals -- VirtualMET is tone count)
+    */
+    CFE_TIME_GetReference(&Reference);
+
+    /*
+    ** Ensure that reader(s) know of the pending update
+    */
+    NextState = CFE_TIME_StartReferenceUpdate();
+
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+    /*
+    ** Time servers cannot always use the new time data from the
+    **    packet (saved as "pending" when the packet arrived).
+    **
+    ** If the time source is "internal" then the time data came
+    **    from the same values that we would be updating, hence
+    **    there is no need to do the update.  And if there has
+    **    been a command to set new values during the moment
+    **    between making the time at the tone packet and now,
+    **    then we would want to use the command values anyway.
+    **
+    ** If the time source is "external" then things get complex.
+    **    If the external data is MET then we only want to take
+    **    the MET from the packet.  But, if the external data
+    **    is "time" then we only want to take the STCF from the
+    **    packet.  And, if the external data is GPS then we
+    **    need to take both the STCF and the leap seconds from
+    **    the packet.  Also, by definition, we cannot have both
+    **    external data and a local h/w MET - so we don't need
+    **    to worry about updating a local MET to external time.
+    */
+    NextState->AtToneLatch = CFE_TIME_Global.ToneSignalLatch;
+
+    if (CFE_TIME_Global.ClockSource == CFE_TIME_SourceSelect_INTERNAL)
+    {
+        /*
+        ** If we have been flywheeling, VirtualMET may be incorrect
+        **  (flywheel state is changed later in this function)
+        */
+        if (NextState->ClockFlyState == CFE_TIME_FlywheelState_IS_FLY)
+        {
+            CFE_TIME_Global.VirtualMET = Reference.CurrentMET.Seconds;
+        }
+
+        /*
+        ** Update "time at tone" to match virtual MET counter...
+        **
+        ** Note: It is OK to not bother with reading the h/w MET
+        **       since we sync'ed them at the moment of the tone.
+        */
+        NextState->AtToneMET.Seconds    = CFE_TIME_Global.VirtualMET;
+        NextState->AtToneMET.Subseconds = 0;
+    }
+    else
+    {
+/*
+** Update "time at tone" with external MET data...
+*/
+#if (CFE_PLATFORM_TIME_CFG_SRC_MET == true)
+        NextState->AtToneMET       = CFE_TIME_Global.PendingMET;
+        CFE_TIME_Global.VirtualMET = CFE_TIME_Global.PendingMET.Seconds;
+#endif
+
+/*
+** Update "time at tone" with external GPS data...
+**
+**  STCF = GPS time at the tone - local MET at the tone
+**  Leaps = GPS leaps
+**
+** It is possible that a command changed the MET after it was used
+**    to calculate the pending STCF -- in which case the current
+**    time will jump next second when the STCF gets calculated
+**    again with the new MET value.  This (small) possibility can
+**    be prevented by switching to "internal" mode before sending
+**    set time commands...
+*/
+#if (CFE_PLATFORM_TIME_CFG_SRC_GPS == true)
+        NextState->AtToneMET.Seconds    = CFE_TIME_Global.VirtualMET;
+        NextState->AtToneMET.Subseconds = 0;
+        NextState->AtToneSTCF           = CFE_TIME_Global.PendingSTCF;
+        NextState->AtToneLeapSeconds    = CFE_TIME_Global.PendingLeaps;
+#endif
+
+/*
+** Update "time at tone" with external time data...
+**
+**  STCF = external time at the tone - local MET at the tone
+*/
+#if (CFE_PLATFORM_TIME_CFG_SRC_TIME == true)
+        NextState->AtToneMET.Seconds    = CFE_TIME_Global.VirtualMET;
+        NextState->AtToneMET.Subseconds = 0;
+        NextState->AtToneSTCF           = CFE_TIME_Global.PendingSTCF;
+#endif
+    }
+
+    /*
+    ** With a "time" update, this server cannot be "flywheeling"
+    **  (we won't get this update if commanded to flywheel)
+    */
+    if (NextState->ClockFlyState == CFE_TIME_FlywheelState_IS_FLY)
+    {
+        NextState->ClockFlyState       = CFE_TIME_FlywheelState_NO_FLY;
+        CFE_TIME_Global.ServerFlyState = CFE_TIME_FlywheelState_NO_FLY;
+        NewFlywheelStatus              = true;
+    }
+#endif /* CFE_PLATFORM_TIME_CFG_SERVER */
+
+#if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
+    /*
+    ** Set local clock latch time that matches the tone...
+    */
+    NextState->AtToneLatch = CFE_TIME_Global.ToneSignalLatch;
+
+    /*
+    ** Time clients need all the "time at the tone" command data...
+    */
+    NextState->AtToneMET         = CFE_TIME_Global.PendingMET;
+    NextState->AtToneSTCF        = CFE_TIME_Global.PendingSTCF;
+    NextState->AtToneLeapSeconds = CFE_TIME_Global.PendingLeaps;
+
+    /*
+    ** Convert the server clock state into its component parts...
+    */
+    if (CFE_TIME_Global.PendingState == CFE_TIME_ClockState_INVALID)
+    {
+        NextState->ClockSetState       = CFE_TIME_SetState_NOT_SET;
+        CFE_TIME_Global.ServerFlyState = CFE_TIME_FlywheelState_NO_FLY;
+    }
+    else
+    {
+        NextState->ClockSetState = CFE_TIME_SetState_WAS_SET;
+
+        /*
+        ** If the server is fly-wheel then the client must also
+        **    report fly-wheel (even if it is not)...
+        */
+        if (CFE_TIME_Global.PendingState == CFE_TIME_ClockState_FLYWHEEL)
+        {
+            CFE_TIME_Global.ServerFlyState = CFE_TIME_FlywheelState_IS_FLY;
+        }
+        else
+        {
+            CFE_TIME_Global.ServerFlyState = CFE_TIME_FlywheelState_NO_FLY;
+        }
+    }
+
+    /*
+    ** With a "time" update, this client cannot be "flywheeling"...
+    **  (we won't get this update if commanded to flywheel)
+    */
+    if (NextState->ClockFlyState == CFE_TIME_FlywheelState_IS_FLY)
+    {
+        NextState->ClockFlyState = CFE_TIME_FlywheelState_NO_FLY;
+        NewFlywheelStatus        = true;
+    }
+#endif /* CFE_PLATFORM_TIME_CFG_CLIENT */
+
+    /*
+    ** Complete the time update.
+    */
+    CFE_TIME_FinishReferenceUpdate(NextState);
+
+    /*
+    ** Wait until after interrupts are enabled to send event...
+    */
+    if (NewFlywheelStatus)
+    {
+        CFE_EVS_SendEvent(CFE_TIME_FLY_OFF_EID, CFE_EVS_EventType_INFORMATION, "Stop FLYWHEEL");
+    }
+
+    return;
+
+} /* End of CFE_TIME_ToneUpdate() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_Local1HzTimerCallback() -- 1Hz callback routine        */
+/*                                                                 */
+/* This is a wrapper around CFE_TIME_Local1HzISR that conforms to  */
+/* the prototype of an OSAL Timer callback routine.                */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void CFE_TIME_Local1HzTimerCallback(osal_id_t TimerId, void *Arg)
+{
+    CFE_TIME_Local1HzISR();
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_Tone1HzISR() -- Tone signal ISR                        */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void CFE_TIME_Tone1HzISR(void)
+{
+
+    CFE_TIME_SysTime_t ToneSignalLatch;
+    CFE_TIME_SysTime_t Elapsed;
+    CFE_TIME_Compare_t Result;
+
+    /* Start Performance Monitoring */
+    CFE_ES_PerfLogEntry(CFE_MISSION_TIME_TONE1HZISR_PERF_ID);
+
+    /*
+    ** Latch the local clock when the tone signal occurred...
+    */
+    ToneSignalLatch = CFE_TIME_LatchClock();
+
+    /*
+    ** Compute elapsed time since the previous tone signal...
+    */
+    Result = CFE_TIME_Compare(ToneSignalLatch, CFE_TIME_Global.ToneSignalLatch);
+
+    if (Result == CFE_TIME_A_LT_B)
+    {
+        /*
+        ** Local clock has rolled over...
+        */
+        Elapsed = CFE_TIME_Subtract(CFE_TIME_Global.MaxLocalClock, CFE_TIME_Global.ToneSignalLatch);
+        Elapsed = CFE_TIME_Add(Elapsed, ToneSignalLatch);
+    }
+    else
+    {
+        /*
+        ** Normal case...
+        */
+        Elapsed = CFE_TIME_Subtract(ToneSignalLatch, CFE_TIME_Global.ToneSignalLatch);
+    }
+
+    /*
+    ** Verify that tone occurred ~1 second after previous tone...
+    */
+    if (((Elapsed.Seconds == 1) && (Elapsed.Subseconds < CFE_TIME_Global.ToneOverLimit)) ||
+        ((Elapsed.Seconds == 0) && (Elapsed.Subseconds > CFE_TIME_Global.ToneUnderLimit)))
+    {
+        /*
+        ** Maintain count of valid tone signal interrupts...
+        **   (set to zero by reset command)
+        */
+        CFE_TIME_Global.ToneIntCounter++;
+
+        /* Since the tone occured ~1 seonds after the previous one, we
+        ** can mark this tone as 'good'
+        */
+        CFE_TIME_Global.IsToneGood = true;
+
+/*
+** Maintain virtual MET as count of valid tone signal interrupts...
+**   (not set to zero by reset command)
+*/
+#if (CFE_PLATFORM_TIME_CFG_VIRTUAL == true)
+        CFE_TIME_Global.VirtualMET++;
+#endif
+
+/*
+** Maintain virtual MET as count read from h/w MET register...
+*/
+#if (CFE_PLATFORM_TIME_CFG_VIRTUAL != true)
+        OS_GetLocalMET(&CFE_TIME_Global.VirtualMET);
+#endif
+
+        /*
+        ** Enable tone task (we can't send a SB message from here)...
+        */
+        OS_BinSemGive(CFE_TIME_Global.ToneSemaphore);
+    }
+    else
+    {
+        /*
+        ** Maintain count of invalid tone signal interrupts...
+        **   (set to zero by reset command)
+        */
+        CFE_TIME_Global.ToneIntErrorCounter++;
+
+        /* Since the tone didn't occur ~1 seonds after the previous one, we
+        ** can mark this tone as 'not good'
+        */
+        CFE_TIME_Global.IsToneGood = false;
+    }
+
+    /*
+    ** Save local time latch of most recent tone signal...
+    */
+    CFE_TIME_Global.ToneSignalLatch = ToneSignalLatch;
+
+    /* Notify registered time synchronization applications */
+    CFE_TIME_NotifyTimeSynchApps();
+
+    /* Exit performance monitoring */
+    CFE_ES_PerfLogExit(CFE_MISSION_TIME_TONE1HZISR_PERF_ID);
+
+    return;
+
+} /* End of CFE_TIME_Tone1HzISR() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_Tone1HzTask() -- Tone 1Hz task                         */
+/*                                                                 */
+/* This task exists solely to generate the tone signal command.    */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void CFE_TIME_Tone1HzTask(void)
+{
+    int32 Result;
+
+    while (true)
+    {
+        /* Increment the Main task Execution Counter */
+        CFE_ES_IncrementTaskCounter();
+
+        /*
+        ** Pend on semaphore given by tone ISR (above)...
+        */
+        Result = OS_BinSemTake(CFE_TIME_Global.ToneSemaphore);
+        if (Result != OS_SUCCESS)
+        {
+            break;
+        }
+
+        /* Start Performance Monitoring */
+        CFE_ES_PerfLogEntry(CFE_MISSION_TIME_TONE1HZTASK_PERF_ID);
+
+        /*
+        ** Send tone signal command packet...
+        */
+        CFE_SB_TransmitMsg(&CFE_TIME_Global.ToneSignalCmd.CmdHeader.Msg, false);
+
+#if (CFE_MISSION_TIME_CFG_FAKE_TONE == true)
+        /*
+        ** If we are simulating the tone signal, also generate the message
+        ** to send the tone to other time clients.
+        ** (this is done by scheduler in non-fake mode)
+        */
+        CFE_SB_TransmitMsg(&CFE_TIME_Global.ToneSendCmd.CmdHeader.Msg, false);
+#endif
+
+        /*
+        ** Maintain count of tone task wake-ups...
+        */
+        CFE_TIME_Global.ToneTaskCounter++;
+
+        /* Exit performance monitoring */
+        CFE_ES_PerfLogExit(CFE_MISSION_TIME_TONE1HZTASK_PERF_ID);
+    }
+
+    /*
+    ** This should never happen - but during development we
+    **    had an error in the creation of the semaphore.
+    */
+    return;
+
+} /* End of CFE_TIME_Tone1HzTask() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_Local1HzStateMachine() --                              */
+/*    Update the TIME state, should be called at 1Hz               */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void CFE_TIME_Local1HzStateMachine(void)
+{
+
+    CFE_TIME_Reference_t                Reference;
+    volatile CFE_TIME_ReferenceState_t *NextState;
+
+    /* Start Performance Monitoring */
+    CFE_ES_PerfLogEntry(CFE_MISSION_TIME_LOCAL1HZISR_PERF_ID);
+
+    /* Zero out the Reference variable because we pass it into
+     * a function before using it
+     * */
+    memset(&Reference, 0, sizeof(CFE_TIME_Reference_t));
+
+/*
+** Apply 1Hz adjustment to STCF...
+*/
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+    if ((CFE_TIME_Global.OneHzAdjust.Seconds != 0) || (CFE_TIME_Global.OneHzAdjust.Subseconds != 0))
+    {
+        CFE_TIME_SysTime_t NewSTCF;
+        NextState = CFE_TIME_StartReferenceUpdate();
+
+        if (CFE_TIME_Global.OneHzDirection == CFE_TIME_AdjustDirection_ADD)
+        {
+            NewSTCF = CFE_TIME_Add(NextState->AtToneSTCF, CFE_TIME_Global.OneHzAdjust);
+        }
+        else
+        {
+            NewSTCF = CFE_TIME_Subtract(NextState->AtToneSTCF, CFE_TIME_Global.OneHzAdjust);
+        }
+
+        NextState->AtToneSTCF = NewSTCF;
+
+        /*
+        ** Time has changed, force anyone reading time to retry...
+        */
+        CFE_TIME_FinishReferenceUpdate(NextState);
+    }
+#endif /* CFE_PLATFORM_TIME_CFG_SERVER */
+
+    /*
+    ** Get reference time (calculates time since tone, etc.)...
+    */
+    CFE_TIME_GetReference(&Reference);
+
+    /*
+    ** See if it has been long enough without receiving a time update
+    **    to autonomously start "fly-wheel" mode...
+    */
+    if (Reference.ClockFlyState == CFE_TIME_FlywheelState_NO_FLY)
+    {
+        if (Reference.TimeSinceTone.Seconds >= CFE_PLATFORM_TIME_CFG_START_FLY)
+        {
+            NextState = CFE_TIME_StartReferenceUpdate();
+
+            /*
+            ** Change current state to "fly-wheel"...
+            */
+            NextState->ClockFlyState = CFE_TIME_FlywheelState_IS_FLY;
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+            CFE_TIME_Global.ServerFlyState = CFE_TIME_FlywheelState_IS_FLY;
+#endif
+
+            CFE_TIME_Global.AutoStartFly = true;
+
+            /*
+            ** Force anyone currently reading time to retry...
+            */
+            CFE_TIME_FinishReferenceUpdate(NextState);
+        }
+    }
+
+    /*
+    ** See if it has been long enough without receiving a time update
+    **    (or since last doing this update) to autonomously update the
+    **    MET at the tone and local clock latched at the tone...
+    */
+    if (Reference.ClockFlyState == CFE_TIME_FlywheelState_IS_FLY)
+    {
+        if (Reference.TimeSinceTone.Seconds >= CFE_PLATFORM_TIME_CFG_LATCH_FLY)
+        {
+            NextState = CFE_TIME_StartReferenceUpdate();
+
+            /*
+            ** Update MET at tone and local clock latched at tone...
+            **
+            ** This does not increase the accuracy of the local clock,
+            **    but it does avoid some problems.  It is not uncommon
+            **    for a local clock to roll over after only a few
+            **    seconds, so we try and keep the elapsed time since
+            **    the "tone" to a relatively small number of seconds.
+            **    We can handle a simple roll-over but need to prevent
+            **    the local clock from completely wrapping around the
+            **    time latched at the tone.
+            */
+            NextState->AtToneMET   = Reference.CurrentMET;
+            NextState->AtToneLatch = Reference.CurrentLatch;
+
+            /*
+            ** Force anyone currently reading time to retry...
+            */
+            CFE_TIME_FinishReferenceUpdate(NextState);
+        }
+    }
+
+    /* Exit performance monitoring */
+    CFE_ES_PerfLogExit(CFE_MISSION_TIME_LOCAL1HZISR_PERF_ID);
+}
+
+/*
+ * Function: CFE_TIME_Local1HzISR - See API and header file for details
+ */
+void CFE_TIME_Local1HzISR(void)
+{
+
+    CFE_TIME_Global.LocalIntCounter++;
+
+    /*
+    ** Enable 1Hz task (we can't send a SB message from here)...
+    */
+    OS_BinSemGive(CFE_TIME_Global.LocalSemaphore);
+
+    return;
+
+} /* End of CFE_TIME_Local1HzISR() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_Local1HzTask() -- Local 1Hz task (not the tone)        */
+/*                                                                 */
+/* This task exists solely to generate the 1Hz wake-up command.    */
+/*                                                                 */
+/* This is a temporary solution until a scheduler is implemented.  */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void CFE_TIME_Local1HzTask(void)
+{
+    int32 Result;
+
+    while (true)
+    {
+
+        /* Increment the Main task Execution Counter */
+        CFE_ES_IncrementTaskCounter();
+
+        /*
+        ** Pend on the 1HZ semaphore (given by local 1Hz ISR)...
+        */
+        Result = OS_BinSemTake(CFE_TIME_Global.LocalSemaphore);
+        if (Result != OS_SUCCESS)
+        {
+            break;
+        }
+
+        /* Start Performance Monitoring */
+        CFE_ES_PerfLogEntry(CFE_MISSION_TIME_LOCAL1HZTASK_PERF_ID);
+
+        /*
+        ** Send "info" event if we just started flywheel mode...
+        */
+        if (CFE_TIME_Global.AutoStartFly)
+        {
+            CFE_TIME_Global.AutoStartFly = false;
+
+            CFE_EVS_SendEvent(CFE_TIME_FLY_ON_EID, CFE_EVS_EventType_INFORMATION, "Start FLYWHEEL");
+        }
+
+        /*
+        ** Send 1Hz timing packet...
+        ** This used to be optional in previous CFE versions, but it is now required
+        ** as TIME subscribes to this itself to do state machine tasks.
+        */
+        CFE_SB_TransmitMsg(&CFE_TIME_Global.Local1HzCmd.CmdHeader.Msg, false);
+
+        CFE_TIME_Global.LocalTaskCounter++;
+
+        /* Exit performance monitoring */
+        CFE_ES_PerfLogExit(CFE_MISSION_TIME_LOCAL1HZTASK_PERF_ID);
+    }
+
+    /*
+    ** This should never happen - but during development we had an
+    **    error in the creation of the semaphore.
+    */
+    return;
+
+} /* End of CFE_TIME_Local1HzTask() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_NotifyTimeSynchApps() -- Call App Synch Callback Funcs */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void CFE_TIME_NotifyTimeSynchApps(void)
+{
+    uint32                      i;
+    CFE_TIME_SynchCallbackPtr_t Func;
+
+    /*
+    ** Notify applications that have requested tone synchronization
+    */
+    if (CFE_TIME_Global.IsToneGood)
+    {
+        for (i = 0; i < (sizeof(CFE_TIME_Global.SynchCallback) / sizeof(CFE_TIME_Global.SynchCallback[0])); ++i)
+        {
+            /* IMPORTANT:
+             * Read the global pointer only once, since a thread could be unregistering
+             * the same pointer in parallel with this action.
+             */
+            Func = CFE_TIME_Global.SynchCallback[i].Ptr;
+            if (Func != NULL)
+            {
+                Func();
+            }
+        }
+    }
+
+    return;
+}
+
+/************************/
+/*  End of File Comment */
+/************************/

--- a/modules/time/fsw/src/cfe_time_utils.c
+++ b/modules/time/fsw/src/cfe_time_utils.c
@@ -1,0 +1,1074 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/*
+** File: cfe_time_utils.c
+**
+** Purpose:  cFE Time Services (TIME) library utilities source file
+**
+** Author:   S.Walling/Microtel
+**
+** Notes:
+**
+*/
+
+/*
+** Required header files...
+*/
+#include "cfe_time_utils.h"
+#include "cfe_msgids.h"
+#include "cfe_es_resetdata_typedef.h"
+
+#include "cfe_es.h"
+#include "cfe_msg.h"
+#include "cfe_sb.h"
+
+#include <string.h>
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_StartReferenceUpdate()                                 */
+/* Initiate an update to the global time reference data            */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+volatile CFE_TIME_ReferenceState_t *CFE_TIME_StartReferenceUpdate(void)
+{
+    uint32                              Version = CFE_TIME_Global.LastVersionCounter;
+    volatile CFE_TIME_ReferenceState_t *CurrState;
+    volatile CFE_TIME_ReferenceState_t *NextState;
+
+    CurrState = &CFE_TIME_Global.ReferenceState[Version & CFE_TIME_REFERENCE_BUF_MASK];
+    ++Version;
+    NextState = &CFE_TIME_Global.ReferenceState[Version & CFE_TIME_REFERENCE_BUF_MASK];
+
+    NextState->StateVersion = Version;
+
+    /* initially propagate all previous values to next values */
+    NextState->AtToneLeapSeconds = CurrState->AtToneLeapSeconds;
+    NextState->ClockSetState     = CurrState->ClockSetState;
+    NextState->ClockFlyState     = CurrState->ClockFlyState;
+    NextState->DelayDirection    = CurrState->DelayDirection;
+    NextState->AtToneMET         = CurrState->AtToneMET;
+    NextState->AtToneSTCF        = CurrState->AtToneSTCF;
+    NextState->AtToneDelay       = CurrState->AtToneDelay;
+    NextState->AtToneLatch       = CurrState->AtToneLatch;
+
+    return NextState;
+}
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_LatchClock() -- query local clock                      */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+CFE_TIME_SysTime_t CFE_TIME_LatchClock(void)
+{
+    CFE_TIME_SysTime_t LatchTime;
+    OS_time_t          LocalTime;
+
+    /*
+    ** Get time in O/S format (seconds : microseconds)...
+    */
+    CFE_PSP_GetTime(&LocalTime);
+
+    /*
+    ** Convert time to cFE format (seconds : 1/2^32 subseconds)...
+    */
+    LatchTime.Seconds    = OS_TimeGetTotalSeconds(LocalTime);
+    LatchTime.Subseconds = OS_TimeGetSubsecondsPart(LocalTime);
+
+    return (LatchTime);
+
+} /* End of CFE_TIME_LatchClock() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_QueryResetVars() -- query contents of Reset Variables  */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void CFE_TIME_QueryResetVars(void)
+{
+
+    CFE_TIME_ResetVars_t                LocalResetVars;
+    uint32                              DefSubsMET;
+    uint32                              DefSubsSTCF;
+    int32                               status;
+    volatile CFE_TIME_ReferenceState_t *RefState;
+    uint32                              resetAreaSize;
+    cpuaddr                             resetAreaAddr;
+    CFE_ES_ResetData_t *                CFE_TIME_ResetDataPtr;
+
+    RefState = CFE_TIME_StartReferenceUpdate();
+
+    /*
+    ** Get the pointer to the Reset area from the BSP
+    */
+    status = CFE_PSP_GetResetArea(&(resetAreaAddr), &(resetAreaSize));
+
+    if (status != CFE_PSP_SUCCESS)
+    {
+        /* There is something wrong with the Reset Area */
+        CFE_TIME_Global.DataStoreStatus = CFE_TIME_RESET_AREA_BAD;
+    }
+
+    else
+    {
+        CFE_TIME_ResetDataPtr = (CFE_ES_ResetData_t *)resetAreaAddr;
+
+        /* Get the structure from the Reset Area */
+        LocalResetVars = CFE_TIME_ResetDataPtr->TimeResetVars;
+
+        /*
+        ** Verify TIME data signature and clock signal selection...
+        **    (other data fields have no verifiable limits)
+        */
+        if ((LocalResetVars.Signature == CFE_TIME_RESET_SIGNATURE) &&
+            ((LocalResetVars.ClockSignal == CFE_TIME_ToneSignalSelect_PRIMARY) ||
+             (LocalResetVars.ClockSignal == CFE_TIME_ToneSignalSelect_REDUNDANT)))
+        {
+            /*
+            ** Initialize TIME to valid  Reset Area values...
+            */
+            RefState->AtToneMET         = LocalResetVars.CurrentMET;
+            RefState->AtToneSTCF        = LocalResetVars.CurrentSTCF;
+            RefState->AtToneDelay       = LocalResetVars.CurrentDelay;
+            RefState->AtToneLeapSeconds = LocalResetVars.LeapSeconds;
+            CFE_TIME_Global.ClockSignal = LocalResetVars.ClockSignal;
+
+            CFE_TIME_Global.DataStoreStatus = CFE_TIME_RESET_AREA_EXISTING;
+        }
+        else
+        {
+            /*
+            ** We got a blank area from the reset variables
+            */
+            CFE_TIME_Global.DataStoreStatus = CFE_TIME_RESET_AREA_NEW;
+        }
+    }
+    /*
+    ** Initialize TIME to default values if no valid Reset data...
+    */
+    if (CFE_TIME_Global.DataStoreStatus != CFE_TIME_RESET_AREA_EXISTING)
+    {
+        DefSubsMET  = CFE_TIME_Micro2SubSecs(CFE_MISSION_TIME_DEF_MET_SUBS);
+        DefSubsSTCF = CFE_TIME_Micro2SubSecs(CFE_MISSION_TIME_DEF_STCF_SUBS);
+
+        RefState->AtToneMET.Seconds      = CFE_MISSION_TIME_DEF_MET_SECS;
+        RefState->AtToneMET.Subseconds   = DefSubsMET;
+        RefState->AtToneSTCF.Seconds     = CFE_MISSION_TIME_DEF_STCF_SECS;
+        RefState->AtToneSTCF.Subseconds  = DefSubsSTCF;
+        RefState->AtToneLeapSeconds      = CFE_MISSION_TIME_DEF_LEAPS;
+        CFE_TIME_Global.ClockSignal      = CFE_TIME_ToneSignalSelect_PRIMARY;
+        RefState->AtToneDelay.Seconds    = 0;
+        RefState->AtToneDelay.Subseconds = 0;
+    }
+
+    CFE_TIME_FinishReferenceUpdate(RefState);
+
+    return;
+
+} /* End of CFE_TIME_QueryResetVars() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_UpdateResetVars() -- update contents of Reset Variables*/
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void CFE_TIME_UpdateResetVars(const CFE_TIME_Reference_t *Reference)
+{
+    CFE_TIME_ResetVars_t LocalResetVars;
+    uint32               resetAreaSize;
+    cpuaddr              resetAreaAddr;
+    CFE_ES_ResetData_t * CFE_TIME_ResetDataPtr;
+    /*
+    ** Update the data only if our Reset Area is valid...
+    */
+    if (CFE_TIME_Global.DataStoreStatus != CFE_TIME_RESET_AREA_ERROR)
+    {
+
+        /* Store all of our critical variables to a ResetVars_t
+         * then copy that to the Reset Area */
+        LocalResetVars.Signature = CFE_TIME_RESET_SIGNATURE;
+
+        LocalResetVars.CurrentMET   = Reference->CurrentMET;
+        LocalResetVars.CurrentSTCF  = Reference->AtToneSTCF;
+        LocalResetVars.CurrentDelay = Reference->AtToneDelay;
+        LocalResetVars.LeapSeconds  = Reference->AtToneLeapSeconds;
+
+        LocalResetVars.ClockSignal = CFE_TIME_Global.ClockSignal;
+
+        /*
+        ** Get the pointer to the Reset area from the BSP
+        */
+        if (CFE_PSP_GetResetArea(&(resetAreaAddr), &(resetAreaSize)) == CFE_PSP_SUCCESS)
+        {
+            CFE_TIME_ResetDataPtr                = (CFE_ES_ResetData_t *)resetAreaAddr;
+            CFE_TIME_ResetDataPtr->TimeResetVars = LocalResetVars;
+        }
+    }
+
+    return;
+
+} /* End of CFE_TIME_UpdateResetVars() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_InitData() -- initialize global time task nonzero data */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void CFE_TIME_InitData(void)
+{
+    uint32                              i;
+    volatile CFE_TIME_ReferenceState_t *RefState;
+
+    /* Clear task global */
+    memset(&CFE_TIME_Global, 0, sizeof(CFE_TIME_Global));
+
+    /*
+    ** Initialize task configuration data...
+    */
+    for (i = 0; i < CFE_TIME_REFERENCE_BUF_DEPTH; ++i)
+    {
+        CFE_TIME_Global.ReferenceState[i].StateVersion = 0xFFFFFFFF;
+    }
+
+    /*
+    ** Try to get values used to compute time from Reset Area...
+    */
+    CFE_TIME_QueryResetVars();
+
+    RefState = CFE_TIME_StartReferenceUpdate();
+
+    /*
+    ** Remaining data values used to compute time...
+    */
+    RefState->AtToneLatch = CFE_TIME_LatchClock();
+
+    /*
+    ** Data values used to define the current clock state...
+    */
+    RefState->ClockSetState = CFE_TIME_SetState_NOT_SET;
+    RefState->ClockFlyState = CFE_TIME_FlywheelState_IS_FLY;
+
+#if (CFE_PLATFORM_TIME_CFG_SOURCE == true)
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_EXTERNAL;
+#else
+    CFE_TIME_Global.ClockSource = CFE_TIME_SourceSelect_INTERNAL;
+#endif
+    CFE_TIME_Global.ServerFlyState = CFE_TIME_FlywheelState_IS_FLY;
+
+    /*
+    ** Pending data values (from "time at tone" command data packet)...
+    */
+    CFE_TIME_Global.PendingState = CFE_TIME_ClockState_INVALID;
+
+    /*
+    ** Nonzero adjustment values...
+    */
+    CFE_TIME_Global.OneTimeDirection = CFE_TIME_AdjustDirection_ADD;
+    CFE_TIME_Global.OneHzDirection   = CFE_TIME_AdjustDirection_ADD;
+    RefState->DelayDirection         = CFE_TIME_AdjustDirection_ADD;
+
+    /*
+    ** Miscellaneous counters...
+    */
+    CFE_TIME_Global.VirtualMET = RefState->AtToneMET.Seconds;
+
+    /*
+    ** Time window verification values...
+    */
+    CFE_TIME_Global.MinElapsed = CFE_TIME_Micro2SubSecs(CFE_MISSION_TIME_MIN_ELAPSED);
+    CFE_TIME_Global.MaxElapsed = CFE_TIME_Micro2SubSecs(CFE_MISSION_TIME_MAX_ELAPSED);
+
+/*
+** Range checking for external time source data...
+*/
+#if (CFE_PLATFORM_TIME_CFG_SOURCE == true)
+    CFE_TIME_Global.MaxDelta.Seconds    = CFE_PLATFORM_TIME_MAX_DELTA_SECS;
+    CFE_TIME_Global.MaxDelta.Subseconds = CFE_TIME_Micro2SubSecs(CFE_PLATFORM_TIME_MAX_DELTA_SUBS);
+#endif
+
+    /*
+    ** Maximum local clock value (before roll-over)...
+    */
+    CFE_TIME_Global.MaxLocalClock.Seconds    = CFE_PLATFORM_TIME_MAX_LOCAL_SECS;
+    CFE_TIME_Global.MaxLocalClock.Subseconds = CFE_PLATFORM_TIME_MAX_LOCAL_SUBS;
+
+    /*
+    ** Range limits for time between tone signal interrupts...
+    */
+    CFE_TIME_Global.ToneOverLimit  = CFE_TIME_Micro2SubSecs(CFE_PLATFORM_TIME_CFG_TONE_LIMIT);
+    CFE_TIME_Global.ToneUnderLimit = CFE_TIME_Micro2SubSecs((1000000 - CFE_PLATFORM_TIME_CFG_TONE_LIMIT));
+
+    CFE_TIME_FinishReferenceUpdate(RefState);
+
+    /*
+    ** Initialize housekeeping packet (clear user data area)...
+    */
+    CFE_MSG_Init(&CFE_TIME_Global.HkPacket.TlmHeader.Msg, CFE_SB_ValueToMsgId(CFE_TIME_HK_TLM_MID),
+                 sizeof(CFE_TIME_Global.HkPacket));
+
+    /*
+    ** Initialize diagnostic packet (clear user data area)...
+    */
+    CFE_MSG_Init(&CFE_TIME_Global.DiagPacket.TlmHeader.Msg, CFE_SB_ValueToMsgId(CFE_TIME_DIAG_TLM_MID),
+                 sizeof(CFE_TIME_Global.DiagPacket));
+
+    /*
+    ** Initialize "time at the tone" signal command packet...
+    */
+    CFE_MSG_Init(&CFE_TIME_Global.ToneSignalCmd.CmdHeader.Msg, CFE_SB_ValueToMsgId(CFE_TIME_TONE_CMD_MID),
+                 sizeof(CFE_TIME_Global.ToneSignalCmd));
+
+/*
+** Initialize "time at the tone" data command packet...
+*/
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+    CFE_MSG_Init(&CFE_TIME_Global.ToneDataCmd.CmdHeader.Msg, CFE_SB_ValueToMsgId(CFE_TIME_DATA_CMD_MID),
+                 sizeof(CFE_TIME_Global.ToneDataCmd));
+#endif
+
+    /*
+    ** Initialize simulated tone send message ("fake tone" mode only)...
+    */
+#if (CFE_MISSION_TIME_CFG_FAKE_TONE == true)
+    CFE_MSG_Init(&CFE_TIME_Global.ToneSendCmd.CmdHeader.Msg, CFE_SB_ValueToMsgId(CFE_TIME_SEND_CMD_MID),
+                 sizeof(CFE_TIME_Global.ToneSendCmd));
+#endif
+
+    /*
+    ** Initialize local 1Hz "wake-up" command packet (optional)...
+    */
+    CFE_MSG_Init(&CFE_TIME_Global.Local1HzCmd.CmdHeader.Msg, CFE_SB_ValueToMsgId(CFE_TIME_1HZ_CMD_MID),
+                 sizeof(CFE_TIME_Global.Local1HzCmd));
+
+    return;
+
+} /* End of CFE_TIME_InitData() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_GetHkData() -- Report local housekeeping data          */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void CFE_TIME_GetHkData(const CFE_TIME_Reference_t *Reference)
+{
+
+    /*
+    ** Get command execution counters...
+    */
+    CFE_TIME_Global.HkPacket.Payload.CommandCounter      = CFE_TIME_Global.CommandCounter;
+    CFE_TIME_Global.HkPacket.Payload.CommandErrorCounter = CFE_TIME_Global.CommandErrorCounter;
+
+    /*
+    ** Current "as calculated" clock state...
+    */
+    CFE_TIME_Global.HkPacket.Payload.ClockStateAPI = (int16)CFE_TIME_CalculateState(Reference);
+
+    /*
+    ** Current clock state flags...
+    */
+    CFE_TIME_Global.HkPacket.Payload.ClockStateFlags = CFE_TIME_GetClockInfo();
+
+    /*
+    ** Leap Seconds...
+    */
+    CFE_TIME_Global.HkPacket.Payload.LeapSeconds = Reference->AtToneLeapSeconds;
+
+    /*
+    ** Current MET and STCF time values...
+    */
+    CFE_TIME_Global.HkPacket.Payload.SecondsMET = Reference->CurrentMET.Seconds;
+    CFE_TIME_Global.HkPacket.Payload.SubsecsMET = Reference->CurrentMET.Subseconds;
+
+    CFE_TIME_Global.HkPacket.Payload.SecondsSTCF = Reference->AtToneSTCF.Seconds;
+    CFE_TIME_Global.HkPacket.Payload.SubsecsSTCF = Reference->AtToneSTCF.Subseconds;
+
+/*
+** 1Hz STCF adjustment values (server only)...
+*/
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+    CFE_TIME_Global.HkPacket.Payload.Seconds1HzAdj = CFE_TIME_Global.OneHzAdjust.Seconds;
+    CFE_TIME_Global.HkPacket.Payload.Subsecs1HzAdj = CFE_TIME_Global.OneHzAdjust.Subseconds;
+#endif
+
+/*
+** Time at tone delay values (client only)...
+*/
+#if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
+    CFE_TIME_Global.HkPacket.Payload.SecondsDelay = Reference->AtToneDelay.Seconds;
+    CFE_TIME_Global.HkPacket.Payload.SubsecsDelay = Reference->AtToneDelay.Subseconds;
+#endif
+
+    return;
+
+} /* End of CFE_TIME_GetHkData() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_GetDiagData() -- Report diagnostics data               */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void CFE_TIME_GetDiagData(void)
+{
+    CFE_TIME_Reference_t Reference;
+    CFE_TIME_SysTime_t   TempTime;
+
+    /*
+    ** Get reference time values (local time, time at tone, etc.)...
+    */
+    CFE_TIME_GetReference(&Reference);
+
+    CFE_TIME_Copy(&CFE_TIME_Global.DiagPacket.Payload.AtToneMET, &Reference.AtToneMET);
+    CFE_TIME_Copy(&CFE_TIME_Global.DiagPacket.Payload.AtToneSTCF, &Reference.AtToneSTCF);
+    CFE_TIME_Copy(&CFE_TIME_Global.DiagPacket.Payload.AtToneDelay, &Reference.AtToneDelay);
+    CFE_TIME_Copy(&CFE_TIME_Global.DiagPacket.Payload.AtToneLatch, &Reference.AtToneLatch);
+
+    CFE_TIME_Global.DiagPacket.Payload.AtToneLeapSeconds = Reference.AtToneLeapSeconds;
+    CFE_TIME_Global.DiagPacket.Payload.ClockStateAPI     = CFE_TIME_CalculateState(&Reference);
+
+    /*
+    ** Data values that reflect the time (right now)...
+    */
+    CFE_TIME_Copy(&CFE_TIME_Global.DiagPacket.Payload.TimeSinceTone, &Reference.TimeSinceTone);
+    CFE_TIME_Copy(&CFE_TIME_Global.DiagPacket.Payload.CurrentLatch, &Reference.CurrentLatch);
+    CFE_TIME_Copy(&CFE_TIME_Global.DiagPacket.Payload.CurrentMET, &Reference.CurrentMET);
+    TempTime = CFE_TIME_CalculateTAI(&Reference);
+    CFE_TIME_Copy(&CFE_TIME_Global.DiagPacket.Payload.CurrentTAI, &TempTime);
+    TempTime = CFE_TIME_CalculateUTC(&Reference);
+    CFE_TIME_Copy(&CFE_TIME_Global.DiagPacket.Payload.CurrentUTC, &TempTime);
+
+    /*
+    ** Data values used to define the current clock state...
+    */
+    CFE_TIME_Global.DiagPacket.Payload.ClockSetState  = Reference.ClockSetState;
+    CFE_TIME_Global.DiagPacket.Payload.ClockFlyState  = Reference.ClockFlyState;
+    CFE_TIME_Global.DiagPacket.Payload.ClockSource    = CFE_TIME_Global.ClockSource;
+    CFE_TIME_Global.DiagPacket.Payload.ClockSignal    = CFE_TIME_Global.ClockSignal;
+    CFE_TIME_Global.DiagPacket.Payload.ServerFlyState = CFE_TIME_Global.ServerFlyState;
+    CFE_TIME_Global.DiagPacket.Payload.Forced2Fly     = (int16)CFE_TIME_Global.Forced2Fly;
+
+    /*
+    ** Clock state flags...
+    */
+    CFE_TIME_Global.DiagPacket.Payload.ClockStateFlags = CFE_TIME_GetClockInfo();
+
+    /*
+    ** STCF adjustment direction values...
+    */
+    CFE_TIME_Global.DiagPacket.Payload.OneTimeDirection = CFE_TIME_Global.OneTimeDirection;
+    CFE_TIME_Global.DiagPacket.Payload.OneHzDirection   = CFE_TIME_Global.OneHzDirection;
+    CFE_TIME_Global.DiagPacket.Payload.DelayDirection   = Reference.DelayDirection;
+
+    /*
+    ** STCF adjustment values...
+    */
+    CFE_TIME_Copy(&CFE_TIME_Global.DiagPacket.Payload.OneTimeAdjust, &CFE_TIME_Global.OneTimeAdjust);
+    CFE_TIME_Copy(&CFE_TIME_Global.DiagPacket.Payload.OneHzAdjust, &CFE_TIME_Global.OneHzAdjust);
+
+    /*
+    ** Most recent local clock latch values...
+    */
+    CFE_TIME_Copy(&CFE_TIME_Global.DiagPacket.Payload.ToneSignalLatch, &CFE_TIME_Global.ToneSignalLatch);
+    CFE_TIME_Copy(&CFE_TIME_Global.DiagPacket.Payload.ToneDataLatch, &CFE_TIME_Global.ToneDataLatch);
+
+    /*
+    ** Miscellaneous counters (subject to reset command)...
+    */
+    CFE_TIME_Global.DiagPacket.Payload.ToneMatchCounter      = CFE_TIME_Global.ToneMatchCounter;
+    CFE_TIME_Global.DiagPacket.Payload.ToneMatchErrorCounter = CFE_TIME_Global.ToneMatchErrorCounter;
+    CFE_TIME_Global.DiagPacket.Payload.ToneSignalCounter     = CFE_TIME_Global.ToneSignalCounter;
+    CFE_TIME_Global.DiagPacket.Payload.ToneDataCounter       = CFE_TIME_Global.ToneDataCounter;
+    CFE_TIME_Global.DiagPacket.Payload.ToneIntCounter        = CFE_TIME_Global.ToneIntCounter;
+    CFE_TIME_Global.DiagPacket.Payload.ToneIntErrorCounter   = CFE_TIME_Global.ToneIntErrorCounter;
+    CFE_TIME_Global.DiagPacket.Payload.ToneTaskCounter       = CFE_TIME_Global.ToneTaskCounter;
+    CFE_TIME_Global.DiagPacket.Payload.VersionCounter =
+        CFE_TIME_Global.LastVersionCounter - CFE_TIME_Global.ResetVersionCounter;
+    CFE_TIME_Global.DiagPacket.Payload.LocalIntCounter  = CFE_TIME_Global.LocalIntCounter;
+    CFE_TIME_Global.DiagPacket.Payload.LocalTaskCounter = CFE_TIME_Global.LocalTaskCounter;
+
+    /*
+    ** Miscellaneous counters (not subject to reset command)...
+    */
+    CFE_TIME_Global.DiagPacket.Payload.VirtualMET = CFE_TIME_Global.VirtualMET;
+
+    /*
+    ** Time window verification values (converted from micro-secs)...
+    **
+    ** Regardless of whether the tone follows the time packet, or vice
+    **    versa, these values define the acceptable window of time for
+    **    the second event to follow the first.  The minimum value may
+    **    be as little as zero, and the maximum must be something less
+    **    than a second.
+    */
+    CFE_TIME_Global.DiagPacket.Payload.MinElapsed = CFE_TIME_Global.MinElapsed;
+    CFE_TIME_Global.DiagPacket.Payload.MaxElapsed = CFE_TIME_Global.MaxElapsed;
+
+    /*
+    ** Maximum local clock value (before roll-over)...
+    */
+    CFE_TIME_Copy(&CFE_TIME_Global.DiagPacket.Payload.MaxLocalClock, &CFE_TIME_Global.MaxLocalClock);
+
+    /*
+    ** Tone signal tolerance limits...
+    */
+    CFE_TIME_Global.DiagPacket.Payload.ToneOverLimit  = CFE_TIME_Global.ToneOverLimit;
+    CFE_TIME_Global.DiagPacket.Payload.ToneUnderLimit = CFE_TIME_Global.ToneUnderLimit;
+
+    /*
+    ** Reset Area access status...
+    */
+    CFE_TIME_Global.DiagPacket.Payload.DataStoreStatus = CFE_TIME_Global.DataStoreStatus;
+
+    return;
+
+} /* End of CFE_TIME_GetDiagData() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_GetReference() -- get reference data (time at "tone")  */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void CFE_TIME_GetReference(CFE_TIME_Reference_t *Reference)
+{
+    CFE_TIME_SysTime_t                  TimeSinceTone;
+    CFE_TIME_SysTime_t                  CurrentMET;
+    uint32                              VersionCounter;
+    uint32                              RetryCount = 4;
+    volatile CFE_TIME_ReferenceState_t *RefState;
+
+    /*
+    ** VersionCounter is incremented when reference data is modified...
+    */
+    while (true)
+    {
+        VersionCounter = CFE_TIME_Global.LastVersionCounter;
+        RefState       = &CFE_TIME_Global.ReferenceState[VersionCounter & CFE_TIME_REFERENCE_BUF_MASK];
+
+        Reference->CurrentLatch = CFE_TIME_LatchClock();
+
+        Reference->AtToneMET         = RefState->AtToneMET;
+        Reference->AtToneSTCF        = RefState->AtToneSTCF;
+        Reference->AtToneLeapSeconds = RefState->AtToneLeapSeconds;
+        Reference->AtToneDelay       = RefState->AtToneDelay;
+        Reference->AtToneLatch       = RefState->AtToneLatch;
+
+        Reference->ClockSetState  = RefState->ClockSetState;
+        Reference->ClockFlyState  = RefState->ClockFlyState;
+        Reference->DelayDirection = RefState->DelayDirection;
+
+        /*
+         * If the version counter inside the state record
+         * is the same value as the global _after_ copying the
+         * data, then the value is considered valid.
+         */
+        if (VersionCounter == RefState->StateVersion)
+        {
+            /* successful read */
+            break;
+        }
+
+        /*
+         * The value was caught mid-update, so the reference data
+         * might not be consistent.  Try again to read it.
+         *
+         * The number of retries is limited, to prevent getting
+         * stuck in this loop forever.  There is currently no
+         * way to handle the inability to read the time reference.
+         */
+        if (RetryCount == 0)
+        {
+            /* unsuccessful read */
+            break;
+        }
+
+        --RetryCount;
+    }
+
+    /*
+    ** Compute the amount of time "since" the tone...
+    */
+    if (CFE_TIME_Compare(Reference->CurrentLatch, Reference->AtToneLatch) == CFE_TIME_A_LT_B)
+    {
+        /*
+        ** Local clock has rolled over since last tone...
+        */
+        TimeSinceTone = CFE_TIME_Subtract(CFE_TIME_Global.MaxLocalClock, Reference->AtToneLatch);
+        TimeSinceTone = CFE_TIME_Add(TimeSinceTone, Reference->CurrentLatch);
+    }
+    else
+    {
+        /*
+        ** Normal case -- local clock is greater than latch at tone...
+        */
+        TimeSinceTone = CFE_TIME_Subtract(Reference->CurrentLatch, Reference->AtToneLatch);
+    }
+
+    Reference->TimeSinceTone = TimeSinceTone;
+
+    /*
+    ** Add in the MET at the tone...
+    */
+    CurrentMET = CFE_TIME_Add(TimeSinceTone, Reference->AtToneMET);
+
+/*
+** Synchronize "this" time client to the time server...
+*/
+#if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
+    if (Reference->DelayDirection == CFE_TIME_AdjustDirection_ADD)
+    {
+        CurrentMET = CFE_TIME_Add(CurrentMET, Reference->AtToneDelay);
+    }
+    else
+    {
+        CurrentMET = CFE_TIME_Subtract(CurrentMET, Reference->AtToneDelay);
+    }
+#endif
+
+    Reference->CurrentMET = CurrentMET;
+
+    return;
+
+} /* End of CFE_TIME_GetReference() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_CalculateTAI() -- calculate TAI from reference data    */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+CFE_TIME_SysTime_t CFE_TIME_CalculateTAI(const CFE_TIME_Reference_t *Reference)
+{
+    CFE_TIME_SysTime_t TimeAsTAI;
+
+    TimeAsTAI = CFE_TIME_Add(Reference->CurrentMET, Reference->AtToneSTCF);
+
+    return (TimeAsTAI);
+
+} /* End of CFE_TIME_CalculateTAI() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_CalculateUTC() -- calculate UTC from reference data    */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+CFE_TIME_SysTime_t CFE_TIME_CalculateUTC(const CFE_TIME_Reference_t *Reference)
+{
+    CFE_TIME_SysTime_t TimeAsUTC;
+
+    TimeAsUTC = CFE_TIME_Add(Reference->CurrentMET, Reference->AtToneSTCF);
+    TimeAsUTC.Seconds -= Reference->AtToneLeapSeconds;
+
+    return (TimeAsUTC);
+
+} /* End of CFE_TIME_CalculateUTC() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                         */
+/* CFE_TIME_CalculateState() -- determine current time state (per API)     */
+/*                                                                         */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int16 CFE_TIME_CalculateState(const CFE_TIME_Reference_t *Reference)
+{
+    int16 ClockState;
+
+    /*
+    ** Determine the current clock state...
+    */
+    if (Reference->ClockSetState == CFE_TIME_SetState_WAS_SET)
+    {
+        if (Reference->ClockFlyState == CFE_TIME_FlywheelState_NO_FLY)
+        {
+            /*
+            ** CFE_TIME_ClockState_VALID = clock set and not fly-wheeling...
+            */
+            ClockState = CFE_TIME_ClockState_VALID;
+
+/*
+** If the server is fly-wheel then the client must also
+**    report fly-wheel (even if it is not)...
+*/
+#if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
+            if (CFE_TIME_Global.ServerFlyState == CFE_TIME_FlywheelState_IS_FLY)
+            {
+                ClockState = CFE_TIME_ClockState_FLYWHEEL;
+            }
+#endif
+        }
+        else
+        {
+            /*
+            ** CFE_TIME_ClockState_FLYWHEEL = clock set and fly-wheeling...
+            */
+            ClockState = CFE_TIME_ClockState_FLYWHEEL;
+        }
+    }
+    else
+    {
+        /*
+        ** CFE_TIME_ClockState_INVALID = clock not set...
+        */
+        ClockState = CFE_TIME_ClockState_INVALID;
+    }
+
+    return (ClockState);
+
+} /* End of CFE_TIME_CalculateState() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_SetState() -- set clock state                          */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+void CFE_TIME_SetState(int16 NewState)
+{
+    volatile CFE_TIME_ReferenceState_t *RefState;
+
+    RefState = CFE_TIME_StartReferenceUpdate();
+
+    /*
+    ** If we get a command to set the clock to "flywheel" mode, then
+    **    set a global flag so that we can choose to ignore time
+    **    updates until we get another clock state command...
+    */
+    if (NewState == CFE_TIME_ClockState_FLYWHEEL)
+    {
+        CFE_TIME_Global.Forced2Fly = true;
+        RefState->ClockFlyState    = CFE_TIME_FlywheelState_IS_FLY;
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+        CFE_TIME_Global.ServerFlyState = CFE_TIME_FlywheelState_IS_FLY;
+#endif
+    }
+    else if (NewState == CFE_TIME_ClockState_VALID)
+    {
+        CFE_TIME_Global.Forced2Fly = false;
+        RefState->ClockSetState    = CFE_TIME_SetState_WAS_SET;
+    }
+    else
+    {
+        CFE_TIME_Global.Forced2Fly = false;
+        RefState->ClockSetState    = CFE_TIME_SetState_NOT_SET;
+    }
+
+    /*
+    ** Time has changed, force anyone reading time to retry...
+    */
+    CFE_TIME_FinishReferenceUpdate(RefState);
+
+    return;
+
+} /* End of CFE_TIME_SetState() */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_SetSource() -- set clock source                        */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#if (CFE_PLATFORM_TIME_CFG_SOURCE == true)
+void CFE_TIME_SetSource(int16 NewSource)
+{
+    CFE_TIME_Global.ClockSource = NewSource;
+
+} /* End of CFE_TIME_SetSource() */
+#endif /* CFE_PLATFORM_TIME_CFG_SOURCE */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_SetSignal() -- set tone signal (pri vs red)            */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#if (CFE_PLATFORM_TIME_CFG_SIGNAL == true)
+void CFE_TIME_SetSignal(int16 NewSignal)
+{
+    /*
+    ** Maintain current tone signal selection for telemetry...
+    */
+    CFE_TIME_Global.ClockSignal = NewSignal;
+
+} /* End of CFE_TIME_SetSignal() */
+#endif /* CFE_PLATFORM_TIME_CFG_SIGNAL */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_SetDelay() -- set tone delay (time client only)        */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
+void CFE_TIME_SetDelay(CFE_TIME_SysTime_t NewDelay, int16 Direction)
+{
+    volatile CFE_TIME_ReferenceState_t *RefState;
+
+    RefState = CFE_TIME_StartReferenceUpdate();
+
+    RefState->AtToneDelay    = NewDelay;
+    RefState->DelayDirection = Direction;
+
+    /*
+    ** Time has changed, force anyone reading time to retry...
+    */
+    CFE_TIME_FinishReferenceUpdate(RefState);
+
+    return;
+
+} /* End of CFE_TIME_SetDelay() */
+#endif /* CFE_PLATFORM_TIME_CFG_CLIENT */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_SetTime() -- set time (time server only)               */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+void CFE_TIME_SetTime(CFE_TIME_SysTime_t NewTime)
+{
+    volatile CFE_TIME_ReferenceState_t *RefState;
+
+    /*
+    ** The input to this function is a time value that includes MET
+    **     and STCF.  If the default time format is UTC, the input
+    **     time value has had leaps seconds removed from the total.
+    */
+    CFE_TIME_Reference_t Reference;
+    CFE_TIME_SysTime_t   NewSTCF;
+
+    /*
+    ** Get reference time values (local time, time at tone, etc.)...
+    */
+    CFE_TIME_GetReference(&Reference);
+
+    /*
+    ** Remove current MET from the new time value (leaves STCF)...
+    */
+    NewSTCF = CFE_TIME_Subtract(NewTime, Reference.CurrentMET);
+
+/*
+** Restore leap seconds if default time format is UTC...
+*/
+#if (CFE_MISSION_TIME_CFG_DEFAULT_UTC == true)
+    NewSTCF.Seconds += Reference.AtToneLeapSeconds;
+#endif
+
+    RefState = CFE_TIME_StartReferenceUpdate();
+
+    RefState->AtToneSTCF = NewSTCF;
+
+    /*
+    ** Time has changed, force anyone reading time to retry...
+    */
+    CFE_TIME_FinishReferenceUpdate(RefState);
+
+    return;
+
+} /* End of CFE_TIME_SetTime() */
+#endif /* CFE_PLATFORM_TIME_CFG_SERVER */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_SetMET() -- set MET (time server only)                 */
+/*                                                                 */
+/* Note: This command will not have lasting effect if configured   */
+/*       to get external time of type MET.  Also, there cannot     */
+/*       be a local h/w MET and an external MET since both would   */
+/*       need to be synchronized to the same tone signal.          */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+void CFE_TIME_SetMET(CFE_TIME_SysTime_t NewMET)
+{
+    volatile CFE_TIME_ReferenceState_t *RefState;
+
+    RefState = CFE_TIME_StartReferenceUpdate();
+
+    /*
+    ** Update reference values used to compute current time...
+    */
+    RefState->AtToneMET        = NewMET;
+    CFE_TIME_Global.VirtualMET = NewMET.Seconds;
+    RefState->AtToneLatch      = CFE_TIME_LatchClock();
+
+/*
+** Update h/w MET register...
+*/
+#if (CFE_PLATFORM_TIME_CFG_VIRTUAL != true)
+    OS_SetLocalMET(NewMET.Seconds);
+#endif
+
+    /*
+    ** Time has changed, force anyone reading time to retry...
+    */
+    CFE_TIME_FinishReferenceUpdate(RefState);
+
+    return;
+
+} /* End of CFE_TIME_SetMET() */
+#endif /* CFE_PLATFORM_TIME_CFG_SERVER */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_SetSTCF() -- set STCF (time server only)               */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+void CFE_TIME_SetSTCF(CFE_TIME_SysTime_t NewSTCF)
+{
+    volatile CFE_TIME_ReferenceState_t *RefState;
+
+    RefState = CFE_TIME_StartReferenceUpdate();
+
+    RefState->AtToneSTCF = NewSTCF;
+
+    /*
+    ** Time has changed, force anyone reading time to retry...
+    */
+    CFE_TIME_FinishReferenceUpdate(RefState);
+
+    return;
+
+} /* End of CFE_TIME_SetSTCF() */
+#endif /* CFE_PLATFORM_TIME_CFG_SERVER */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_SetLeapSeconds() -- set leap seconds (time server only)      */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+void CFE_TIME_SetLeapSeconds(int16 NewLeaps)
+{
+    volatile CFE_TIME_ReferenceState_t *RefState;
+
+    RefState = CFE_TIME_StartReferenceUpdate();
+
+    RefState->AtToneLeapSeconds = NewLeaps;
+
+    /*
+    ** Time has changed, force anyone reading time to retry...
+    */
+    CFE_TIME_FinishReferenceUpdate(RefState);
+
+    return;
+
+} /* End of CFE_TIME_SetLeapSeconds() */
+#endif /* CFE_PLATFORM_TIME_CFG_SERVER */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_SetAdjust() -- one time STCF adjustment (server only)  */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+void CFE_TIME_SetAdjust(CFE_TIME_SysTime_t NewAdjust, int16 Direction)
+{
+    CFE_TIME_SysTime_t                  NewSTCF;
+    volatile CFE_TIME_ReferenceState_t *RefState;
+
+    RefState = CFE_TIME_StartReferenceUpdate();
+
+    CFE_TIME_Global.OneTimeAdjust    = NewAdjust;
+    CFE_TIME_Global.OneTimeDirection = Direction;
+
+    if (Direction == CFE_TIME_AdjustDirection_ADD)
+    {
+        NewSTCF = CFE_TIME_Add(RefState->AtToneSTCF, NewAdjust);
+    }
+    else
+    {
+        NewSTCF = CFE_TIME_Subtract(RefState->AtToneSTCF, NewAdjust);
+    }
+
+    RefState->AtToneSTCF = NewSTCF;
+
+    /*
+    ** Time has changed, force anyone reading time to retry...
+    */
+    CFE_TIME_FinishReferenceUpdate(RefState);
+
+    return;
+
+} /* End of CFE_TIME_SetAdjust() */
+#endif /* CFE_PLATFORM_TIME_CFG_SERVER */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_Set1HzAdj() -- 1Hz STCF adjustment (time server only)  */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+void CFE_TIME_Set1HzAdj(CFE_TIME_SysTime_t NewAdjust, int16 Direction)
+{
+    /*
+    ** Store values for 1Hz adjustment...
+    */
+    CFE_TIME_Global.OneHzAdjust    = NewAdjust;
+    CFE_TIME_Global.OneHzDirection = Direction;
+
+} /* End of CFE_TIME_Set1HzAdj() */
+#endif /* CFE_PLATFORM_TIME_CFG_SERVER */
+
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*                                                                 */
+/* CFE_TIME_CleanUpApp() -- Free resources associated with App     */
+/*                                                                 */
+/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+
+int32 CFE_TIME_CleanUpApp(CFE_ES_AppId_t AppId)
+{
+    int32  Status;
+    uint32 AppIndex;
+
+    Status = CFE_ES_AppID_ToIndex(AppId, &AppIndex);
+    if (Status != CFE_SUCCESS)
+    {
+        /* Do nothing */
+    }
+    else if (AppIndex < (sizeof(CFE_TIME_Global.SynchCallback) / sizeof(CFE_TIME_Global.SynchCallback[0])))
+    {
+        CFE_TIME_Global.SynchCallback[AppIndex].Ptr = NULL;
+    }
+    else
+    {
+        Status = CFE_TIME_CALLBACK_NOT_REGISTERED;
+    }
+
+    return Status;
+}
+
+/************************/
+/*  End of File Comment */
+/************************/

--- a/modules/time/fsw/src/cfe_time_utils.h
+++ b/modules/time/fsw/src/cfe_time_utils.h
@@ -1,0 +1,451 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * @file
+ *
+ * Purpose:  cFE Time Services (TIME) library utilities header file
+ *
+ * Author:   S.Walling/Microtel
+ *
+ * Notes:
+ *
+ */
+
+#ifndef CFE_TIME_UTILS_H
+#define CFE_TIME_UTILS_H
+
+/*
+** Required header files...
+*/
+#include "cfe_time_module_all.h"
+
+/*************************************************************************/
+
+#define CFE_TIME_NEGATIVE 0x80000000 /* ~ 68 * 31,536,000 seconds */
+
+/*************************************************************************/
+
+/*
+** Main task definitions...
+*/
+#define CFE_TIME_TASK_NAME "CFE_TIME"
+
+/*
+** Interrupt task definitions...
+*/
+#define CFE_TIME_TASK_TONE_NAME "TIME_TONE_TASK"
+#define CFE_TIME_TASK_1HZ_NAME  "TIME_1HZ_TASK"
+#define CFE_TIME_TASK_STACK_PTR CFE_ES_TASK_STACK_ALLOCATE
+#define CFE_TIME_TASK_FLAGS     0
+
+/*
+** Interrupt semaphore definitions...
+*/
+#define CFE_TIME_SEM_TONE_NAME "TIME_TONE_SEM"
+#define CFE_TIME_SEM_1HZ_NAME  "TIME_1HZ_SEM"
+#define CFE_TIME_SEM_VALUE     0
+#define CFE_TIME_SEM_OPTIONS   0
+
+/*
+** Main Task Pipe definitions...
+*/
+
+#define CFE_TIME_TASK_PIPE_NAME  "TIME_CMD_PIPE"
+#define CFE_TIME_TASK_PIPE_DEPTH 12
+
+/*
+** Reset Area state state at startup...
+*/
+
+#define CFE_TIME_RESET_AREA_ERROR    1 /* no mem available */
+#define CFE_TIME_RESET_AREA_BAD      2 /* had invalid data */
+#define CFE_TIME_RESET_AREA_NEW      3 /* new memory block */
+#define CFE_TIME_RESET_AREA_EXISTING 4 /* had valid data   */
+
+/*
+ * Definitions for time reference multi-buffering
+ *
+ * To allow higher priority tasks and ISRs to get the time reference,
+ * it must be buffered in case the ISR occurs mid-update.
+ *
+ * This controls the depth of the buffer.  Higher values will be
+ * more resilient to concurrent updates at the cost of using more
+ * memory.
+ *
+ * Note that the 1Hz state machine can make several updates to this
+ * in rapid succession, and the "fake tone" processing tied to 1Hz
+ * might make another update.
+ *
+ * This must be a power of 2.
+ */
+#define CFE_TIME_REFERENCE_BUF_DEPTH 4
+#define CFE_TIME_REFERENCE_BUF_MASK  (CFE_TIME_REFERENCE_BUF_DEPTH - 1)
+
+/*************************************************************************/
+
+/*
+** Type definition (time reference data)...
+*/
+typedef struct
+{
+
+    CFE_TIME_SysTime_t AtToneMET;         /* MET at time of tone */
+    CFE_TIME_SysTime_t AtToneSTCF;        /* STCF at time of tone */
+    int16              AtToneLeapSeconds; /* Leap Seconds at time of tone */
+    int16              ClockSetState;     /* Time has been "set" */
+    int16              ClockFlyState;     /* Current fly-wheel state */
+    int16              DelayDirection;    /* Wheter "AtToneDelay" is add or subtract */
+    CFE_TIME_SysTime_t AtToneDelay;       /* Adjustment for slow tone detection */
+    CFE_TIME_SysTime_t AtToneLatch;       /* Local clock latched at time of tone */
+    CFE_TIME_SysTime_t CurrentLatch;      /* Local clock latched just "now" */
+    CFE_TIME_SysTime_t TimeSinceTone;     /* Time elapsed since the tone */
+    CFE_TIME_SysTime_t CurrentMET;        /* MET at this instant */
+
+} CFE_TIME_Reference_t;
+
+/*
+** Time Synchronization Callback Registry Information
+*/
+typedef struct
+{
+    volatile CFE_TIME_SynchCallbackPtr_t Ptr; /**< \brief Pointer to Callback function */
+} CFE_TIME_SynchCallbackRegEntry_t;
+
+/*
+** Data values used to compute time (in reference to "tone")...
+**
+** These are all the global values used during CFE_TIME_GetReference()
+** to compute the current reference time.  They are kept in a separate
+** structure so every update can be synchronized.
+*/
+typedef struct
+{
+    uint32 StateVersion;
+
+    int16 AtToneLeapSeconds;
+    int16 ClockSetState;
+    int16 ClockFlyState;
+    int16 DelayDirection;
+
+    CFE_TIME_SysTime_t AtToneMET;
+    CFE_TIME_SysTime_t AtToneSTCF;
+    CFE_TIME_SysTime_t AtToneDelay;
+    CFE_TIME_SysTime_t AtToneLatch;
+
+} CFE_TIME_ReferenceState_t;
+
+/*************************************************************************/
+
+/*
+** Type definition (time task global data)...
+*/
+typedef struct
+{
+    /*
+    ** Task command interface counters...
+    */
+    uint8 CommandCounter;
+    uint8 CommandErrorCounter;
+
+    /*
+    ** Task housekeeping and diagnostics telemetry packets...
+    */
+    CFE_TIME_HousekeepingTlm_t HkPacket;
+    CFE_TIME_DiagnosticTlm_t   DiagPacket;
+
+    /*
+    ** Task operational data (not reported in housekeeping)...
+    */
+    CFE_SB_PipeId_t CmdPipe;
+
+    /*
+    ** Task initialization data (not reported in housekeeping)...
+    */
+    int16 ClockSource;
+    int16 ClockSignal;
+    int16 ServerFlyState;
+
+    /*
+    ** Pending data values (from "time at tone" command data)...
+    */
+    CFE_TIME_SysTime_t PendingMET;
+    CFE_TIME_SysTime_t PendingSTCF;
+    int16              PendingLeaps;
+    int16              PendingState;
+
+    /*
+    ** STCF adjustment values...
+    */
+    CFE_TIME_SysTime_t OneTimeAdjust;
+    CFE_TIME_SysTime_t OneHzAdjust;
+
+    int16 OneTimeDirection; /* Add = true */
+    int16 OneHzDirection;
+
+    /*
+    ** Most recent local clock latch values...
+    */
+    CFE_TIME_SysTime_t ToneSignalLatch; /* Latched at tone */
+    CFE_TIME_SysTime_t ToneDataLatch;   /* Latched at packet */
+
+    /*
+    ** Miscellaneous counters...
+    */
+    uint32 ToneMatchCounter;      /* Tone and data match */
+    uint32 ToneMatchErrorCounter; /* Tone and data mismatch */
+    uint32 ToneSignalCounter;     /* Tone signal commands */
+    uint32 ToneDataCounter;       /* Tone data commands */
+    uint32 ToneIntCounter;        /* Tone interrupts (valid) */
+    uint32 ToneIntErrorCounter;   /* Tone interrupts (invalid) */
+    uint32 ToneTaskCounter;       /* Tone task wake-ups */
+    uint32 VirtualMET;            /* Software MET */
+    uint32 LocalIntCounter;       /* Local 1Hz interrupts */
+    uint32 LocalTaskCounter;      /* Local 1Hz task wake-ups */
+    uint32 InternalCount;         /* Time from internal data */
+    uint32 ExternalCount;         /* Time from external data */
+
+    volatile CFE_TIME_ReferenceState_t ReferenceState[CFE_TIME_REFERENCE_BUF_DEPTH];
+    volatile uint32                    LastVersionCounter;  /* Completed Updates to "AtTone" values */
+    uint32                             ResetVersionCounter; /* Version counter at last counter reset */
+
+    /*
+    ** Time window verification values (converted from micro-secs)...
+    **
+    ** Regardless of whether the tone follows the time packet, or vice
+    **    versa, these values define the acceptable window of time for
+    **    the second event to follow the first.  The minimum value may
+    **    be as little as zero, and the maximum must be something less
+    **    than a second.
+    */
+    uint32 MinElapsed;
+    uint32 MaxElapsed;
+
+    /*
+    ** Maximum local clock value (before roll-over)...
+    */
+    CFE_TIME_SysTime_t MaxLocalClock;
+
+    /*
+    ** Clock state has been commanded into (CFE_TIME_ClockState_FLYWHEEL)...
+    */
+    bool Forced2Fly;
+
+    /*
+    ** Clock state has just transitioned into (CFE_TIME_ClockState_FLYWHEEL)...
+    **   (not in HK since it won't be true long enough to detect)
+    */
+
+    bool AutoStartFly;
+    bool IsToneGood;
+
+    /*
+    ** Spare byte for alignment
+    */
+    bool Spare;
+
+    /*
+    ** Local 1Hz wake-up command packet (not related to time at tone)...
+    */
+    CFE_TIME_1HzCmd_t Local1HzCmd;
+
+    /*
+    ** Time at the tone command packets (sent by time servers)...
+    */
+    CFE_TIME_ToneDataCmd_t   ToneDataCmd;
+    CFE_TIME_ToneSignalCmd_t ToneSignalCmd;
+
+    /*
+     * Normally "tone send" commands come from the scheduler based on the
+     * configured action table, so it occurs at the right point between tones.
+     *
+     * However when "fake tone" mode is enabled, then we will locally generate the
+     * "tone send" message as part of the Tone task, in addition to the regular
+     * "tone signal" message above.
+     */
+#if (CFE_MISSION_TIME_CFG_FAKE_TONE == true)
+    CFE_TIME_FakeToneCmd_t ToneSendCmd;
+#endif
+
+    /*
+    ** Interrupt task semaphores...
+    */
+    osal_id_t LocalSemaphore;
+    osal_id_t ToneSemaphore;
+    /*
+    ** Interrupt task ID's...
+    */
+    CFE_ES_TaskId_t LocalTaskID;
+    CFE_ES_TaskId_t ToneTaskID;
+
+    /*
+    ** Maximum difference from expected for external time sources...
+    */
+
+    CFE_TIME_SysTime_t MaxDelta;
+
+    /*
+    ** Tone signal tolerance limits...
+    */
+    uint32 ToneOverLimit;
+    uint32 ToneUnderLimit;
+
+    /*
+    ** Reset Area ...
+    */
+    uint32 DataStoreStatus;
+
+    /*
+    ** Synchronization Callback Registry
+    ** One callback per app is allowed
+    */
+    CFE_TIME_SynchCallbackRegEntry_t SynchCallback[CFE_PLATFORM_ES_MAX_APPLICATIONS];
+
+} CFE_TIME_Global_t;
+
+/*
+** Time task global data (from "cfe_time_task.c")...
+*/
+extern CFE_TIME_Global_t CFE_TIME_Global;
+
+/*************************************************************************/
+/*
+** Function prototypes (get local clock)...
+*/
+CFE_TIME_SysTime_t CFE_TIME_LatchClock(void);
+
+/*
+** Function prototypes (Time Services utilities data)...
+*/
+int32 CFE_TIME_TaskInit(void);
+void  CFE_TIME_TaskPipe(CFE_SB_Buffer_t *SBBufPtr);
+void  CFE_TIME_InitData(void);
+void  CFE_TIME_QueryResetVars(void);
+void  CFE_TIME_UpdateResetVars(const CFE_TIME_Reference_t *Reference);
+void  CFE_TIME_GetDiagData(void);
+void  CFE_TIME_GetHkData(const CFE_TIME_Reference_t *Reference);
+
+/*
+** Function prototypes (reference)...
+*/
+void CFE_TIME_GetReference(CFE_TIME_Reference_t *Reference);
+
+/*
+** Function prototypes (calculate TAI/UTC)...
+*/
+CFE_TIME_SysTime_t CFE_TIME_CalculateTAI(const CFE_TIME_Reference_t *Reference);
+CFE_TIME_SysTime_t CFE_TIME_CalculateUTC(const CFE_TIME_Reference_t *Reference);
+
+int16 CFE_TIME_CalculateState(const CFE_TIME_Reference_t *Reference);
+
+/*
+** Function prototypes (set time globals)...
+*/
+void CFE_TIME_SetState(int16 NewState);
+#if (CFE_PLATFORM_TIME_CFG_SOURCE == true)
+void CFE_TIME_SetSource(int16 NewSource);
+#endif
+
+#if (CFE_PLATFORM_TIME_CFG_SIGNAL == true)
+void CFE_TIME_SetSignal(int16 NewSignal);
+#endif
+
+#if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
+void CFE_TIME_SetDelay(CFE_TIME_SysTime_t NewDelay, int16 Direction);
+#endif
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+void CFE_TIME_SetTime(CFE_TIME_SysTime_t NewTime);
+void CFE_TIME_SetMET(CFE_TIME_SysTime_t NewMET);
+void CFE_TIME_SetSTCF(CFE_TIME_SysTime_t NewSTCF);
+void CFE_TIME_SetLeapSeconds(int16 NewLeaps);
+void CFE_TIME_SetAdjust(CFE_TIME_SysTime_t NewAdjust, int16 Direction);
+void CFE_TIME_Set1HzAdj(CFE_TIME_SysTime_t NewAdjust, int16 Direction);
+#endif
+
+/*
+** Function prototypes (send time at tone data packet -- local MET)...
+*/
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+void CFE_TIME_ToneSend(void); /* signal to send time at tone packet */
+#endif
+
+/*
+** Function prototypes (send time at tone data packet -- external time)...
+*/
+#if (CFE_PLATFORM_TIME_CFG_SRC_MET == true)
+int32 CFE_TIME_ToneSendMET(CFE_TIME_SysTime_t NewMET);
+#endif
+
+#if (CFE_PLATFORM_TIME_CFG_SRC_GPS == true)
+int32 CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps);
+#endif
+
+#if (CFE_PLATFORM_TIME_CFG_SRC_TIME == true)
+int32 CFE_TIME_ToneSendTime(CFE_TIME_SysTime_t NewTime);
+#endif
+
+/*
+ * Helper function for updating the "Reference" value
+ * This is the local replacement for "OS_IntLock()"
+ */
+volatile CFE_TIME_ReferenceState_t *CFE_TIME_StartReferenceUpdate(void);
+
+/*
+ * Helper function for updating the "Reference" value
+ * This is the local replacement for "OS_IntUnlock()"
+ */
+static inline void CFE_TIME_FinishReferenceUpdate(volatile CFE_TIME_ReferenceState_t *NextState)
+{
+    CFE_TIME_Global.LastVersionCounter = NextState->StateVersion;
+}
+
+/*
+ * Helper function for getting the "Reference" value
+ * This is the replacement for direct memory reads of
+ * the state info from the global data structure.
+ */
+static inline volatile CFE_TIME_ReferenceState_t *CFE_TIME_GetReferenceState(void)
+{
+    return &CFE_TIME_Global.ReferenceState[CFE_TIME_Global.LastVersionCounter & CFE_TIME_REFERENCE_BUF_MASK];
+}
+
+/*
+** Function prototypes (process time at the tone signal and data packet)...
+*/
+void CFE_TIME_ToneSignal(void);
+void CFE_TIME_ToneData(const CFE_TIME_ToneDataCmd_Payload_t *ToneDataCmd);
+void CFE_TIME_ToneVerify(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2);
+void CFE_TIME_ToneUpdate(void);
+
+/*
+** Function prototypes (tone 1Hz interrupt)...
+*/
+void CFE_TIME_Tone1HzISR(void);
+void CFE_TIME_Tone1HzTask(void);
+void CFE_TIME_NotifyTimeSynchApps(void);
+
+/*
+** Function prototypes (local 1Hz interrupt)...
+*/
+void CFE_TIME_Local1HzTask(void);
+void CFE_TIME_Local1HzStateMachine(void);
+void CFE_TIME_Local1HzTimerCallback(osal_id_t TimerId, void *Arg);
+
+#endif /* CFE_TIME_UTILS_H */

--- a/modules/time/fsw/src/cfe_time_verify.h
+++ b/modules/time/fsw/src/cfe_time_verify.h
@@ -1,0 +1,187 @@
+/*
+**  GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**  Copyright (c) 2006-2019 United States Government as represented by
+**  the Administrator of the National Aeronautics and Space Administration.
+**  All Rights Reserved.
+**
+**  Licensed under the Apache License, Version 2.0 (the "License");
+**  you may not use this file except in compliance with the License.
+**  You may obtain a copy of the License at
+**
+**    http://www.apache.org/licenses/LICENSE-2.0
+**
+**  Unless required by applicable law or agreed to in writing, software
+**  distributed under the License is distributed on an "AS IS" BASIS,
+**  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**  See the License for the specific language governing permissions and
+**  limitations under the License.
+*/
+
+/**
+ * @file
+ *
+ * Purpose:  cFE Time Services (TIME) configuration verification
+ *
+ * Author:   S.Walling/Microtel
+ *
+ * Notes:
+ *
+ */
+
+#ifndef CFE_TIME_VERIFY_H
+#define CFE_TIME_VERIFY_H
+
+#include "cfe_mission_cfg.h"
+#include "cfe_platform_cfg.h"
+
+/*************************************************************************/
+
+/*
+** Validate default time client/server selection...
+*/
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+#if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
+#error Cannot define both CFE_PLATFORM_TIME_CFG_SERVER and CFE_PLATFORM_TIME_CFG_CLIENT as true!
+#endif
+#else
+#if (CFE_PLATFORM_TIME_CFG_CLIENT != true)
+#error Must define either CFE_PLATFORM_TIME_CFG_SERVER or CFE_PLATFORM_TIME_CFG_CLIENT as true!
+#endif
+#endif
+
+/*
+** Validate default time format selection...
+*/
+#if (CFE_MISSION_TIME_CFG_DEFAULT_TAI == true)
+#if (CFE_MISSION_TIME_CFG_DEFAULT_UTC == true)
+#error Cannot define both CFE_MISSION_TIME_CFG_DEFAULT_UTC and CFE_MISSION_TIME_CFG_DEFAULT_TAI as true!
+#endif
+#else
+#if (CFE_MISSION_TIME_CFG_DEFAULT_UTC != true)
+#error Must define either CFE_MISSION_TIME_CFG_DEFAULT_UTC or CFE_MISSION_TIME_CFG_DEFAULT_TAI as true!
+#endif
+#endif
+
+/*
+** Validate time source selection...
+*/
+#if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
+#if (CFE_PLATFORM_TIME_CFG_SOURCE == true)
+#error Cannot define both CFE_PLATFORM_TIME_CFG_CLIENT and CFE_PLATFORM_TIME_CFG_SOURCE as true!
+#endif
+#endif
+
+#if (CFE_PLATFORM_TIME_CFG_SOURCE == true)
+#if (CFE_PLATFORM_TIME_CFG_VIRTUAL != true)
+#error Cannot define CFE_PLATFORM_TIME_CFG_SOURCE as true without defining CFE_PLATFORM_TIME_CFG_VIRTUAL as true!
+#endif
+#endif
+
+/*
+** Validate local MET selections...
+*/
+#if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
+#if (CFE_PLATFORM_TIME_CFG_VIRTUAL != true)
+#error Cannot define CFE_PLATFORM_TIME_CFG_CLIENT as true without defining CFE_PLATFORM_TIME_CFG_VIRTUAL as true!
+#endif
+#endif
+
+/*
+** Validate time source type selection...
+*/
+#if (CFE_PLATFORM_TIME_CFG_SRC_MET == true)
+#if (CFE_PLATFORM_TIME_CFG_SOURCE != true)
+#error Cannot define CFE_PLATFORM_TIME_CFG_SRC_MET as true without defining CFE_PLATFORM_TIME_CFG_SOURCE as true!
+#endif
+#if (CFE_PLATFORM_TIME_CFG_SRC_GPS == true)
+#error Cannot define both CFE_PLATFORM_TIME_CFG_SRC_MET and CFE_PLATFORM_TIME_CFG_SRC_GPS as true!
+#endif
+#if (CFE_PLATFORM_TIME_CFG_SRC_TIME == true)
+#error Cannot define both CFE_PLATFORM_TIME_CFG_SRC_MET and CFE_PLATFORM_TIME_CFG_SRC_TIME as true!
+#endif
+#endif
+
+#if (CFE_PLATFORM_TIME_CFG_SRC_GPS == true)
+#if (CFE_PLATFORM_TIME_CFG_SOURCE != true)
+#error Cannot define CFE_PLATFORM_TIME_CFG_SRC_GPS as true without defining CFE_PLATFORM_TIME_CFG_SOURCE as true!
+#endif
+#if (CFE_PLATFORM_TIME_CFG_SRC_TIME == true)
+#error Cannot define both CFE_PLATFORM_TIME_CFG_SRC_GPS and CFE_PLATFORM_TIME_CFG_SRC_TIME as true!
+#endif
+#endif
+
+#if (CFE_PLATFORM_TIME_CFG_SRC_TIME == true)
+#if (CFE_PLATFORM_TIME_CFG_SOURCE != true)
+#error Cannot define CFE_PLATFORM_TIME_CFG_SRC_TIME as true without defining CFE_PLATFORM_TIME_CFG_SOURCE as true!
+#endif
+#endif
+
+/*
+** Validate tone signal and data packet arrival selection...
+*/
+#if (CFE_MISSION_TIME_AT_TONE_WAS == true)
+#if (CFE_MISSION_TIME_AT_TONE_WILL_BE == true)
+#error Both CFE_MISSION_TIME_AT_TONE_WAS and CFE_MISSION_TIME_AT_TONE_WILL_BE have been defined as true!
+#endif
+#else
+#if (CFE_MISSION_TIME_AT_TONE_WILL_BE != true)
+#error Either CFE_MISSION_TIME_AT_TONE_WAS or CFE_MISSION_TIME_AT_TONE_WILL_BE must be defined as true!
+#endif
+#endif
+
+/*
+** Validate simulated tone signal and external time source selection...
+*/
+#if (CFE_MISSION_TIME_CFG_FAKE_TONE == true)
+#if (CFE_PLATFORM_TIME_CFG_SOURCE == true)
+#error Cannot define both CFE_MISSION_TIME_CFG_FAKE_TONE and CFE_PLATFORM_TIME_CFG_SOURCE as true!
+#endif
+#endif
+
+/*
+** Validate simulated tone signal and data packet arrival selection...
+*/
+#if (CFE_MISSION_TIME_CFG_FAKE_TONE == true)
+#if (CFE_MISSION_TIME_AT_TONE_WILL_BE == true)
+#error Cannot define both CFE_MISSION_TIME_CFG_FAKE_TONE and CFE_MISSION_TIME_AT_TONE_WILL_BE as true!
+#endif
+#endif
+
+/*
+** Validate task priorities...
+*/
+#if CFE_PLATFORM_TIME_START_TASK_PRIORITY < 0
+#error CFE_PLATFORM_TIME_START_TASK_PRIORITY must be greater than or equal to zero
+#elif CFE_PLATFORM_TIME_START_TASK_PRIORITY > 255
+#error CFE_PLATFORM_TIME_START_TASK_PRIORITY must be less than or equal to 255
+#endif
+#if CFE_PLATFORM_TIME_TONE_TASK_PRIORITY < 0
+#error CFE_PLATFORM_TIME_TONE_TASK_PRIORITY must be greater than or equal to zero
+#elif CFE_PLATFORM_TIME_TONE_TASK_PRIORITY > 255
+#error CFE_PLATFORM_TIME_TONE_TASK_PRIORITY must be less than or equal to 255
+#endif
+#if CFE_PLATFORM_TIME_1HZ_TASK_PRIORITY < 0
+#error CFE_PLATFORM_TIME_1HZ_TASK_PRIORITY must be greater than or equal to zero
+#elif CFE_PLATFORM_TIME_1HZ_TASK_PRIORITY > 255
+#error CFE_PLATFORM_TIME_1HZ_TASK_PRIORITY must be less than or equal to 255
+#endif
+
+/*
+** Validate task stack sizes...
+*/
+#if CFE_PLATFORM_TIME_START_TASK_STACK_SIZE < 2048
+#error CFE_PLATFORM_TIME_START_TASK_STACK_SIZE must be greater than or equal to 2048
+#endif
+
+#if CFE_PLATFORM_TIME_TONE_TASK_STACK_SIZE < 2048
+#error CFE_PLATFORM_TIME_TONE_TASK_STACK_SIZE must be greater than or equal to 2048
+#endif
+
+#if CFE_PLATFORM_TIME_1HZ_TASK_STACK_SIZE < 2048
+#error CFE_PLATFORM_TIME_1HZ_TASK_STACK_SIZE must be greater than or equal to 2048
+#endif
+
+/*************************************************************************/
+
+#endif /* CFE_TIME_VERIFY_H */


### PR DESCRIPTION
## Description

This is a "bookkeeping" Pull Request meant for the cFS-Caelum Review code inspection (full-scale code review). 

This PR is solely focused on "CFS-43". For more info see [this readme](https://github.com/astrogeco/cFE/blob/caelum-code-review-cfs43/README.md)

The Included files are

```.gitignore

# Table (TBL)
!modules/core_api/fsw/inc/cfe_tbl*

!modules/tbl/fsw/**
!modules/tbl/CMakeLists.txt

# Time Services (TIME)
!modules/core_private/fsw/inc/cfe_time*
!modules/core_api/fsw/inc/cfe_time*

!modules/time/fsw/**
!modules/time/CMakeLists.txt
```

## Objectives

1. This review starts on **04/26/2021** and ends on **04/30/2021**.

2. Dispositions of findings is on **05/03/2021.**

3. Reviewers only need to review source files, header files & build files.
4. Use .ppt, .pdf, .txt & .xlsx files for background information about the code.
5. See the Attachments section for Peer Review Data Package.

6. See also "The Power of 10" rules for safety-critical code. https://en.wikipedia.org/wiki/The_Power_of_10:_Rules_for_Developing_Safety-Critical_Code#:~:text=The%20Power%20of%2010%20Rules,to%20review%20or%20statically%20analyze

7. NOTE: Don't spend too much time over coding standard violations. The Static Code Analysis tool will enforce the coding standards. This code is developed by GSFC, so GSFC coding standards will be enforced for this code base.

### Notes

Note a few already existing issues (no need to individually comment on occurrences):

Doxygen event documentation doesn't match code: https://github.com/nasa/cFE/issues/508
End of function comments out of date (generalized/paraphrased version of https://github.com/nasa/cFE/issues/275)
Update code/unit tests to use CFE_Status_t: https://github.com/nasa/cFE/issues/921


If there's anything else that is observed as a repeated pattern, feel free to document as a general comment

There are several places that would trigger warnings with some common compilers/warning options. It would be nice to follow #10 rule in "The Power of 10".

Quick summary/references for currently enforced settings on the FSW
Compiler options (note -Wall and -Werror) - https://github.com/nasa/cFE/blob/0850b19a09417dd7730e9c1b44e0f5687ef0f721/cmake/sample_defs/arch_build_custom.cmake#L28-L37

cppcheck - https://github.com/nasa/cFE/blob/0850b19a09417dd7730e9c1b44e0f5687ef0f721/.github/workflows/run_fsw_cppcheck.sh#L3

CodeQL - https://github.com/nasa/cFE/blob/0850b19a09417dd7730e9c1b44e0f5687ef0f721/.github/workflows/codeql-build.yml#L35-L39

CodeSonar - currently using default set for cFE, extending to JPL and MISRA is future work

For CodeQL and CodeSonar we don't eliminate all warnings, but we do analyze and disposition them all (plan to report dispositions as part of certification package)

This approach is compliant with the latest GSFC 582 standard (that is still going through review). Happy to discuss any additional settings that you have concerns about.
