### PR TITLE
Fix #1336, function block comments

### DIFF
--- a/modules/core_api/fsw/inc/cfe_es.h
+++ b/modules/core_api/fsw/inc/cfe_es.h
@@ -1449,7 +1449,9 @@ CFE_Status_t CFE_ES_GetMemPoolStats(CFE_ES_MemPoolStats_t *BufPtr, CFE_ES_MemHan
 
 /*****************************************************************************/
 /**
-** \brief Function called by #CFE_ES_PerfLogEntry and #CFE_ES_PerfLogExit macros
+** \brief Adds a new entry to the data buffer
+**
+** Function called by #CFE_ES_PerfLogEntry and #CFE_ES_PerfLogExit macros
 **
 ** \par Description
 **        This function logs the entry and exit marker for the specified
@@ -1457,7 +1459,16 @@ CFE_Status_t CFE_ES_GetMemPoolStats(CFE_ES_MemPoolStats_t *BufPtr, CFE_ES_MemHan
 **        tool (see section 5.15).
 **
 ** \par Assumptions, External Events, and Notes:
-**        None
+
+**  This function implements a circular buffer using an array.
+**      DataStart points to first stored entry
+**      DataEnd points to next available entry
+**      if DataStart == DataEnd then the buffer is either empty or full
+**      depending on the value of the DataCount
+**
+**  Time is stored as 2 32 bit integers, (TimerLower32, TimerUpper32):
+**      TimerLower32 is the curent value of the hardware timer register.
+**      TimerUpper32 is the number of times the timer has rolled over.
 **
 ** \param[in]   Marker          Identifier of the specific event or marker.
 ** \param[in]   EntryExit       Used to specify Entry(0) or Exit(1)

--- a/modules/core_api/fsw/inc/cfe_fs_core_internal.h
+++ b/modules/core_api/fsw/inc/cfe_fs_core_internal.h
@@ -47,7 +47,7 @@
 ** \brief Initializes the cFE core module API Library
 **
 ** \par Description
-**        Initializes the cFE core module API Library
+**      Initialize the FS data structures before the cFE runs.
 **
 ** \par Assumptions, External Events, and Notes:
 **        -# This function MUST be called before any module API's are called.

--- a/modules/es/fsw/src/cfe_es_api.c
+++ b/modules/es/fsw/src/cfe_es_api.c
@@ -42,9 +42,14 @@
 #include <stdio.h>
 #include <stdarg.h>
 
-/*
-** Function: CFE_ES_GetResetType - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GetResetType
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GetResetType(uint32 *ResetSubtypePtr)
 {
     if (ResetSubtypePtr != NULL)
@@ -53,12 +58,16 @@ int32 CFE_ES_GetResetType(uint32 *ResetSubtypePtr)
     }
 
     return (CFE_ES_Global.ResetDataPtr->ResetVars.ResetType);
+}
 
-} /* End of CFE_ES_GetResetType() */
-
-/*
-** Function: CFE_ES_ResetCFE - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_ResetCFE
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_ResetCFE(uint32 ResetType)
 {
     int32 ReturnCode;
@@ -146,12 +155,16 @@ int32 CFE_ES_ResetCFE(uint32 ResetType)
     }
 
     return (ReturnCode);
+}
 
-} /* End of CFE_ES_ResetCFE() */
-
-/*
-** Function: CFE_ES_RestartApp - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_RestartApp
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_RestartApp(CFE_ES_AppId_t AppID)
 {
     int32               ReturnCode = CFE_SUCCESS;
@@ -211,12 +224,16 @@ int32 CFE_ES_RestartApp(CFE_ES_AppId_t AppID)
     } /* end if */
 
     return (ReturnCode);
+}
 
-} /* End of CFE_ES_RestartApp() */
-
-/*
-** Function: CFE_ES_ReloadApp - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_ReloadApp
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_ReloadApp(CFE_ES_AppId_t AppID, const char *AppFileName)
 {
     int32               ReturnCode = CFE_SUCCESS;
@@ -270,12 +287,16 @@ int32 CFE_ES_ReloadApp(CFE_ES_AppId_t AppID, const char *AppFileName)
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
     return (ReturnCode);
+}
 
-} /* End of CFE_ES_ReloadApp() */
-
-/*
-** Function: CFE_ES_DeleteApp - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_DeleteApp
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_DeleteApp(CFE_ES_AppId_t AppID)
 {
     int32               ReturnCode = CFE_SUCCESS;
@@ -313,12 +334,16 @@ int32 CFE_ES_DeleteApp(CFE_ES_AppId_t AppID)
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
     return (ReturnCode);
+}
 
-} /* End of CFE_ES_DeleteApp() */
-
-/*
-** Function: CFE_ES_ExitApp - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_ExitApp
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_ExitApp(uint32 ExitStatus)
 {
     int32               ReturnCode;
@@ -442,12 +467,16 @@ void CFE_ES_ExitApp(uint32 ExitStatus)
     } /* end if ReturnCode == CFE_SUCCESS */
 
     CFE_ES_UnlockSharedData(__func__, __LINE__);
+}
 
-} /* End of CFE_ES_ExitApp() */
-
-/*
-** Function: CFE_ES_RunLoop - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_RunLoop
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_ES_RunLoop(uint32 *RunStatus)
 {
     bool                ReturnCode;
@@ -529,12 +558,16 @@ bool CFE_ES_RunLoop(uint32 *RunStatus)
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
     return (ReturnCode);
+}
 
-} /* End of CFE_ES_RunLoop() */
-
-/*
-** Function: CFE_ES_WaitForSystemState - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_WaitForSystemState
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_WaitForSystemState(uint32 MinSystemState, uint32 TimeOutMilliseconds)
 {
     int32               Status = CFE_SUCCESS;
@@ -629,20 +662,29 @@ int32 CFE_ES_WaitForSystemState(uint32 MinSystemState, uint32 TimeOutMillisecond
     }
 
     return Status;
+}
 
-} /* End of CFE_ES_WaitForSystemState() */
-
-/*
-** Function: CFE_ES_WaitForStartupSync - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_WaitForStartupSync
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_WaitForStartupSync(uint32 TimeOutMilliseconds)
 {
     CFE_ES_WaitForSystemState(CFE_ES_SystemState_OPERATIONAL, TimeOutMilliseconds);
 }
 
-/*
-** Function: CFE_ES_GetAppIDByName - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GetAppIDByName
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GetAppIDByName(CFE_ES_AppId_t *AppIdPtr, const char *AppName)
 {
     CFE_ES_AppRecord_t *AppRecPtr;
@@ -674,12 +716,16 @@ int32 CFE_ES_GetAppIDByName(CFE_ES_AppId_t *AppIdPtr, const char *AppName)
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
     return (Result);
+}
 
-} /* End of CFE_ES_GetAppIDByName() */
-
-/*
-** Function: CFE_ES_GetLibIDByName - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GetLibIDByName
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GetLibIDByName(CFE_ES_LibId_t *LibIdPtr, const char *LibName)
 {
     CFE_ES_LibRecord_t *LibRecPtr;
@@ -711,11 +757,16 @@ int32 CFE_ES_GetLibIDByName(CFE_ES_LibId_t *LibIdPtr, const char *LibName)
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
     return (Result);
-} /* End of CFE_ES_GetLibIDByName() */
+}
 
-/*
-** Function: CFE_ES_GetTaskIDByName - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GetTaskIDByName
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_GetTaskIDByName(CFE_ES_TaskId_t *TaskIdPtr, const char *TaskName)
 {
     osal_id_t    OsalId;
@@ -741,11 +792,16 @@ CFE_Status_t CFE_ES_GetTaskIDByName(CFE_ES_TaskId_t *TaskIdPtr, const char *Task
     }
 
     return (Result);
-} /* End of CFE_ES_GetTaskIDByName() */
+}
 
-/*
-** Function: CFE_ES_GetAppID  - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GetAppID
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GetAppID(CFE_ES_AppId_t *AppIdPtr)
 {
     CFE_ES_AppRecord_t *AppRecPtr;
@@ -774,12 +830,16 @@ int32 CFE_ES_GetAppID(CFE_ES_AppId_t *AppIdPtr)
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
     return (Result);
+}
 
-} /* End of CFE_ES_GetAppID() */
-
-/*
-** Function: CFE_ES_GetTaskID  - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GetTaskID
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GetTaskID(CFE_ES_TaskId_t *TaskIdPtr)
 {
     int32                Result;
@@ -806,9 +866,14 @@ int32 CFE_ES_GetTaskID(CFE_ES_TaskId_t *TaskIdPtr)
     return Result;
 }
 
-/*
-** Function: CFE_ES_GetAppName - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GetAppName
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GetAppName(char *AppName, CFE_ES_AppId_t AppId, size_t BufferLength)
 {
     int32               Result;
@@ -845,12 +910,16 @@ int32 CFE_ES_GetAppName(char *AppName, CFE_ES_AppId_t AppId, size_t BufferLength
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
     return (Result);
+}
 
-} /* End of CFE_ES_GetAppName() */
-
-/*
-** Function: CFE_ES_GetLibName - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GetLibName
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GetLibName(char *LibName, CFE_ES_LibId_t LibId, size_t BufferLength)
 {
     int32               Result;
@@ -887,12 +956,16 @@ int32 CFE_ES_GetLibName(char *LibName, CFE_ES_LibId_t LibId, size_t BufferLength
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
     return (Result);
+}
 
-} /* End of CFE_ES_GetLibName() */
-
-/*
-** Function: CFE_ES_GetTaskName - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GetTaskName
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GetTaskName(char *TaskName, CFE_ES_TaskId_t TaskId, size_t BufferLength)
 {
     int32     Result;
@@ -920,12 +993,16 @@ int32 CFE_ES_GetTaskName(char *TaskName, CFE_ES_TaskId_t TaskId, size_t BufferLe
     }
 
     return CFE_SUCCESS;
+}
 
-} /* End of CFE_ES_GetTaskName() */
-
-/*
-** Function: CFE_ES_GetAppInfo - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GetAppInfo
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, CFE_ES_AppId_t AppId)
 {
     CFE_ES_AppRecord_t * AppRecPtr;
@@ -1015,9 +1092,14 @@ int32 CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, CFE_ES_AppId_t AppId)
     return Status;
 }
 
-/*
-** Function: CFE_ES_GetLibInfo - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GetLibInfo
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GetLibInfo(CFE_ES_AppInfo_t *LibInfo, CFE_ES_LibId_t LibId)
 {
     int32               Status;
@@ -1074,9 +1156,14 @@ int32 CFE_ES_GetLibInfo(CFE_ES_AppInfo_t *LibInfo, CFE_ES_LibId_t LibId)
     return Status;
 }
 
-/*
-** Function: CFE_ES_GetModuleInfo - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GetModuleInfo
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GetModuleInfo(CFE_ES_AppInfo_t *ModuleInfo, CFE_ResourceId_t ResourceId)
 {
     int32 Status;
@@ -1100,12 +1187,16 @@ int32 CFE_ES_GetModuleInfo(CFE_ES_AppInfo_t *ModuleInfo, CFE_ResourceId_t Resour
     }
 
     return (Status);
+}
 
-} /* End of CFE_ES_GetModuleInfo() */
-
-/*
-** Function: CFE_ES_GetTaskInfo - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GetTaskInfo
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GetTaskInfo(CFE_ES_TaskInfo_t *TaskInfo, CFE_ES_TaskId_t TaskId)
 {
     CFE_ES_TaskRecord_t *TaskRecPtr;
@@ -1172,12 +1263,16 @@ int32 CFE_ES_GetTaskInfo(CFE_ES_TaskInfo_t *TaskInfo, CFE_ES_TaskId_t TaskId)
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
     return (Status);
+}
 
-} /* End of CFE_ES_GetTaskInfo() */
-
-/*
-** Function: CFE_ES_CreateChildTask - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_CreateChildTask
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_CreateChildTask(CFE_ES_TaskId_t *TaskIdPtr, const char *TaskName,
                              CFE_ES_ChildTaskMainFuncPtr_t FunctionPtr, CFE_ES_StackPointer_t StackPtr,
                              size_t StackSize, CFE_ES_TaskPriority_Atom_t Priority, uint32 Flags)
@@ -1266,12 +1361,16 @@ int32 CFE_ES_CreateChildTask(CFE_ES_TaskId_t *TaskIdPtr, const char *TaskName,
     }
 
     return (ReturnCode);
+}
 
-} /* End of CFE_ES_CreateChildTask() */
-
-/*
-** Function: CFE_ES_IncrementTaskCounter - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_IncrementTaskCounter
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_IncrementTaskCounter(void)
 {
     CFE_ES_TaskRecord_t *TaskRecPtr;
@@ -1294,12 +1393,16 @@ void CFE_ES_IncrementTaskCounter(void)
     {
         TaskRecPtr->ExecutionCounter++;
     }
+}
 
-} /* End of CFE_ES_IncrementTaskCounter() */
-
-/*
-** Function: CFE_ES_DeleteChildTask - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_DeleteChildTask
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_DeleteChildTask(CFE_ES_TaskId_t TaskId)
 {
     CFE_ES_TaskRecord_t *TaskRecPtr;
@@ -1407,15 +1510,16 @@ int32 CFE_ES_DeleteChildTask(CFE_ES_TaskId_t TaskId)
         ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
     }
     return (ReturnCode);
+}
 
-} /* End of CFE_ES_DeleteTask() */
-
-/*
-** Function: CFE_ES_ExitChildTask
-**
-** Purpose:  Stop execution of a child task.
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_ExitChildTask
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_ExitChildTask(void)
 {
     CFE_ES_AppRecord_t * AppRecPtr;
@@ -1464,12 +1568,16 @@ void CFE_ES_ExitChildTask(void)
     } /* end if GetAppId */
 
     CFE_ES_UnlockSharedData(__func__, __LINE__);
+}
 
-} /* End of CFE_ES_ExitChildTask() */
-
-/*
-** Function: CFE_ES_WriteToSysLog - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_WriteToSysLog
+ *
+ * Application-scope internal function
+ * See description in cfe_es_log.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_WriteToSysLog(const char *SpecStringPtr, ...)
 {
     char    TmpString[CFE_ES_MAX_SYSLOG_MSG_SIZE];
@@ -1497,12 +1605,16 @@ int32 CFE_ES_WriteToSysLog(const char *SpecStringPtr, ...)
     OS_printf("%s", TmpString);
 
     return (ReturnCode);
+}
 
-} /* End of CFE_ES_WriteToSysLog() */
-
-/*
-** Function: CFE_ES_CalculateCRC - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_CalculateCRC
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 uint32 CFE_ES_CalculateCRC(const void *DataPtr, size_t DataLength, uint32 InputCRC, uint32 TypeCRC)
 {
     uint32       i;
@@ -1571,15 +1683,16 @@ uint32 CFE_ES_CalculateCRC(const void *DataPtr, size_t DataLength, uint32 InputC
             break;
     }
     return (Crc);
+}
 
-} /* End of CFE_ES_CalculateCRC() */
-
-/*
-** Function: CFE_ES_RegisterCDS
-**
-** Purpose:  Allocate a data block for a Critical Data Store.
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_RegisterCDS
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *CDSHandlePtr, size_t BlockSize, const char *Name)
 {
     int32          Status;
@@ -1654,14 +1767,16 @@ int32 CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *CDSHandlePtr, size_t BlockSize, con
     }
 
     return Status;
-} /* End of CFE_ES_RegisterCDS */
+}
 
-/*
+/*----------------------------------------------------------------
+ *
  * Function: CFE_ES_GetCDSBlockIDByName
  *
- * Purpose: Obtain CDS Block ID from name
- * See full API description in header file
- */
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_GetCDSBlockIDByName(CFE_ES_CDSHandle_t *BlockIdPtr, const char *BlockName)
 {
     CFE_Status_t         Status;
@@ -1696,12 +1811,14 @@ CFE_Status_t CFE_ES_GetCDSBlockIDByName(CFE_ES_CDSHandle_t *BlockIdPtr, const ch
     return Status;
 }
 
-/*
+/*----------------------------------------------------------------
+ *
  * Function: CFE_ES_GetCDSBlockName
  *
- * Purpose: Obtain CDS Block Name from ID
- * See full API description in header file
- */
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_GetCDSBlockName(char *BlockName, CFE_ES_CDSHandle_t BlockId, size_t BufferLength)
 {
     CFE_Status_t         Status;
@@ -1737,12 +1854,14 @@ CFE_Status_t CFE_ES_GetCDSBlockName(char *BlockName, CFE_ES_CDSHandle_t BlockId,
     return Status;
 }
 
-/*
-** Function: CFE_ES_CopyToCDS
-**
-** Purpose:  Copies a data block to a Critical Data Store.
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_CopyToCDS
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, void *DataToCopy)
 {
     if (DataToCopy == NULL)
@@ -1751,14 +1870,16 @@ int32 CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, void *DataToCopy)
     }
 
     return CFE_ES_CDSBlockWrite(Handle, DataToCopy);
-} /* End of CFE_ES_CopyToCDS() */
+}
 
-/*
-** Function: CFE_ES_RestoreFromCDS
-**
-** Purpose:  Restores a data block from a Critical Data Store.
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_RestoreFromCDS
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_RestoreFromCDS(void *RestoreToMemory, CFE_ES_CDSHandle_t Handle)
 {
     if (RestoreToMemory == NULL)
@@ -1767,13 +1888,16 @@ int32 CFE_ES_RestoreFromCDS(void *RestoreToMemory, CFE_ES_CDSHandle_t Handle)
     }
 
     return CFE_ES_CDSBlockRead(RestoreToMemory, Handle);
-} /* End of CFE_ES_RestoreFromCDS() */
+}
 
-/*
-** Function: CFE_ES_RegisterGenCounter
-**
-** Purpose:  Allocates a generic counter resource and assigns ID
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_RegisterGenCounter
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_RegisterGenCounter(CFE_ES_CounterId_t *CounterIdPtr, const char *CounterName)
 {
     CFE_ES_GenCounterRecord_t *CountRecPtr;
@@ -1831,12 +1955,14 @@ int32 CFE_ES_RegisterGenCounter(CFE_ES_CounterId_t *CounterIdPtr, const char *Co
     return Status;
 }
 
-/*
-** Function: CFE_ES_DeleteGenCounter
-**
-** Purpose:  Delete a Generic Counter.
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_DeleteGenCounter
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_DeleteGenCounter(CFE_ES_CounterId_t CounterId)
 {
     CFE_ES_GenCounterRecord_t *CountRecPtr;
@@ -1856,15 +1982,16 @@ int32 CFE_ES_DeleteGenCounter(CFE_ES_CounterId_t CounterId)
     }
 
     return Status;
+}
 
-} /* End of CFE_ES_DeleteGenCounter() */
-
-/*
-** Function: CFE_ES_IncrementGenCounter
-**
-** Purpose:  Increment a Generic Counter.
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_IncrementGenCounter
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_IncrementGenCounter(CFE_ES_CounterId_t CounterId)
 {
     int32                      Status = CFE_ES_BAD_ARGUMENT;
@@ -1877,15 +2004,16 @@ int32 CFE_ES_IncrementGenCounter(CFE_ES_CounterId_t CounterId)
         Status = CFE_SUCCESS;
     }
     return Status;
+}
 
-} /* End of CFE_ES_IncrementGenCounter() */
-
-/*
-** Function: CFE_ES_SetGenCount
-**
-** Purpose:  Sets a Generic Counter's count.
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_SetGenCount
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_SetGenCount(CFE_ES_CounterId_t CounterId, uint32 Count)
 {
     int32                      Status = CFE_ES_BAD_ARGUMENT;
@@ -1898,14 +2026,16 @@ int32 CFE_ES_SetGenCount(CFE_ES_CounterId_t CounterId, uint32 Count)
         Status               = CFE_SUCCESS;
     }
     return Status;
-} /* End of CFE_ES_SetGenCount() */
+}
 
-/*
-** Function: CFE_ES_GetGenCount
-**
-** Purpose:  Gets the value of a Generic Counter.
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GetGenCount
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GetGenCount(CFE_ES_CounterId_t CounterId, uint32 *Count)
 {
     int32                      Status = CFE_ES_BAD_ARGUMENT;
@@ -1918,8 +2048,16 @@ int32 CFE_ES_GetGenCount(CFE_ES_CounterId_t CounterId, uint32 *Count)
         Status = CFE_SUCCESS;
     }
     return Status;
-} /* End of CFE_ES_GetGenCount() */
+}
 
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GetGenCounterIDByName
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GetGenCounterIDByName(CFE_ES_CounterId_t *CounterIdPtr, const char *CounterName)
 {
     CFE_ES_GenCounterRecord_t *CounterRecPtr;
@@ -1954,15 +2092,16 @@ int32 CFE_ES_GetGenCounterIDByName(CFE_ES_CounterId_t *CounterIdPtr, const char 
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
     return (Result);
+}
 
-} /* End of CFE_ES_GetGenCounterIDByName() */
-
-/*
+/*----------------------------------------------------------------
+ *
  * Function: CFE_ES_GetGenCounterName
  *
- * Purpose: Obtain Counter Name from ID
- * See full API description in header file
- */
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_GetGenCounterName(char *CounterName, CFE_ES_CounterId_t CounterId, size_t BufferLength)
 {
     CFE_ES_GenCounterRecord_t *CountRecPtr;
@@ -1994,32 +2133,41 @@ CFE_Status_t CFE_ES_GetGenCounterName(char *CounterName, CFE_ES_CounterId_t Coun
     return Status;
 }
 
-/*
- * A conversion function to obtain an index value correlating to an AppID
- * This is a zero based value that can be used for indexing into a table.
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_AppID_ToIndex
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_AppID_ToIndex(CFE_ES_AppId_t AppID, uint32 *Idx)
 {
     return CFE_ResourceId_ToIndex(CFE_RESOURCEID_UNWRAP(AppID), CFE_ES_APPID_BASE, CFE_PLATFORM_ES_MAX_APPLICATIONS,
                                   Idx);
 }
 
-/*
- * A conversion function to obtain an index value correlating to a LibID
- * This is a zero based value that can be used for indexing into a table.
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_LibID_ToIndex
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_LibID_ToIndex(CFE_ES_LibId_t LibId, uint32 *Idx)
 {
     return CFE_ResourceId_ToIndex(CFE_RESOURCEID_UNWRAP(LibId), CFE_ES_LIBID_BASE, CFE_PLATFORM_ES_MAX_LIBRARIES, Idx);
 }
 
-/*
- * A conversion function to obtain an index value correlating to an TaskID
- * This is a zero based value that can be used for indexing into a table.
+/*----------------------------------------------------------------
  *
- * Task IDs come from OSAL, so this is currently a wrapper around the OSAL converter.
- * This is an alias for consistency with the ES AppID paradigm.
- */
+ * Function: CFE_ES_TaskID_ToIndex
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_TaskID_ToIndex(CFE_ES_TaskId_t TaskID, uint32 *Idx)
 {
     osal_id_t    OsalID;
@@ -2041,10 +2189,14 @@ int32 CFE_ES_TaskID_ToIndex(CFE_ES_TaskId_t TaskID, uint32 *Idx)
     return CFE_SUCCESS;
 }
 
-/*
- * A conversion function to obtain an index value correlating to a CounterID
- * This is a zero based value that can be used for indexing into a table.
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_CounterID_ToIndex
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_CounterID_ToIndex(CFE_ES_CounterId_t CounterId, uint32 *Idx)
 {
     return CFE_ResourceId_ToIndex(CFE_RESOURCEID_UNWRAP(CounterId), CFE_ES_COUNTID_BASE,
@@ -2055,20 +2207,14 @@ int32 CFE_ES_CounterID_ToIndex(CFE_ES_CounterId_t CounterId, uint32 *Idx)
 ** Private API functions
 */
 
-/******************************************************************************
-**  Function:  CFE_ES_LockSharedData()
-**
-**  Purpose:
-**    ES internal function to take the Shared Data Mutex and handle
-**    error conditions.
-**
-**  Arguments:
-**    FunctionName   - the name of the function containing the code that generated the error.
-**    LineNumber     - the file line number of the code that generated the error.
-**
-**  Return:
-**    None
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_LockSharedData
+ *
+ * Application-scope internal function
+ * See description in cfe_es_global.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_LockSharedData(const char *FunctionName, int32 LineNumber)
 {
     int32 Status;
@@ -2086,23 +2232,16 @@ void CFE_ES_LockSharedData(const char *FunctionName, int32 LineNumber)
     } /* end if */
 
     return;
+}
 
-} /* end CFE_ES_LockSharedData */
-
-/******************************************************************************
-**  Function:  CFE_ES_UnlockSharedData()
-**
-**  Purpose:
-**    ES internal function to Release the shared data mutex and handle error
-**    conditions.
-**
-**  Arguments:
-**    FunctionName   - the name of the function containing the code that generated the error.
-**    LineNumber     - the file line number of the code that generated the error.
-**
-**  Return:
-**    None
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_UnlockSharedData
+ *
+ * Application-scope internal function
+ * See description in cfe_es_global.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_UnlockSharedData(const char *FunctionName, int32 LineNumber)
 {
     int32 Status;
@@ -2120,15 +2259,16 @@ void CFE_ES_UnlockSharedData(const char *FunctionName, int32 LineNumber)
     } /* end if */
 
     return;
+}
 
-} /* end CFE_ES_UnlockSharedData */
-
-/******************************************************************************
-**  Function:  CFE_ES_ProcessAsyncEvent()
-**
-**  Purpose:
-**    Called by the PSP to notify CFE ES that an asynchronous event occurred.
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_ProcessAsyncEvent
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_ProcessAsyncEvent(void)
 {
     /* This just wakes up the background task to log/handle the event. */

--- a/modules/es/fsw/src/cfe_es_api.c
+++ b/modules/es/fsw/src/cfe_es_api.c
@@ -47,7 +47,7 @@
  * Function: CFE_ES_GetResetType
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GetResetType(uint32 *ResetSubtypePtr)
@@ -65,7 +65,7 @@ int32 CFE_ES_GetResetType(uint32 *ResetSubtypePtr)
  * Function: CFE_ES_ResetCFE
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_ResetCFE(uint32 ResetType)
@@ -162,7 +162,7 @@ int32 CFE_ES_ResetCFE(uint32 ResetType)
  * Function: CFE_ES_RestartApp
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_RestartApp(CFE_ES_AppId_t AppID)
@@ -231,7 +231,7 @@ int32 CFE_ES_RestartApp(CFE_ES_AppId_t AppID)
  * Function: CFE_ES_ReloadApp
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_ReloadApp(CFE_ES_AppId_t AppID, const char *AppFileName)
@@ -294,7 +294,7 @@ int32 CFE_ES_ReloadApp(CFE_ES_AppId_t AppID, const char *AppFileName)
  * Function: CFE_ES_DeleteApp
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_DeleteApp(CFE_ES_AppId_t AppID)
@@ -341,7 +341,7 @@ int32 CFE_ES_DeleteApp(CFE_ES_AppId_t AppID)
  * Function: CFE_ES_ExitApp
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_ExitApp(uint32 ExitStatus)
@@ -474,7 +474,7 @@ void CFE_ES_ExitApp(uint32 ExitStatus)
  * Function: CFE_ES_RunLoop
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 bool CFE_ES_RunLoop(uint32 *RunStatus)
@@ -565,7 +565,7 @@ bool CFE_ES_RunLoop(uint32 *RunStatus)
  * Function: CFE_ES_WaitForSystemState
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_WaitForSystemState(uint32 MinSystemState, uint32 TimeOutMilliseconds)
@@ -669,7 +669,7 @@ int32 CFE_ES_WaitForSystemState(uint32 MinSystemState, uint32 TimeOutMillisecond
  * Function: CFE_ES_WaitForStartupSync
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_WaitForStartupSync(uint32 TimeOutMilliseconds)
@@ -682,7 +682,7 @@ void CFE_ES_WaitForStartupSync(uint32 TimeOutMilliseconds)
  * Function: CFE_ES_GetAppIDByName
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GetAppIDByName(CFE_ES_AppId_t *AppIdPtr, const char *AppName)
@@ -723,7 +723,7 @@ int32 CFE_ES_GetAppIDByName(CFE_ES_AppId_t *AppIdPtr, const char *AppName)
  * Function: CFE_ES_GetLibIDByName
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GetLibIDByName(CFE_ES_LibId_t *LibIdPtr, const char *LibName)
@@ -764,7 +764,7 @@ int32 CFE_ES_GetLibIDByName(CFE_ES_LibId_t *LibIdPtr, const char *LibName)
  * Function: CFE_ES_GetTaskIDByName
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_GetTaskIDByName(CFE_ES_TaskId_t *TaskIdPtr, const char *TaskName)
@@ -799,7 +799,7 @@ CFE_Status_t CFE_ES_GetTaskIDByName(CFE_ES_TaskId_t *TaskIdPtr, const char *Task
  * Function: CFE_ES_GetAppID
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GetAppID(CFE_ES_AppId_t *AppIdPtr)
@@ -837,7 +837,7 @@ int32 CFE_ES_GetAppID(CFE_ES_AppId_t *AppIdPtr)
  * Function: CFE_ES_GetTaskID
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GetTaskID(CFE_ES_TaskId_t *TaskIdPtr)
@@ -871,7 +871,7 @@ int32 CFE_ES_GetTaskID(CFE_ES_TaskId_t *TaskIdPtr)
  * Function: CFE_ES_GetAppName
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GetAppName(char *AppName, CFE_ES_AppId_t AppId, size_t BufferLength)
@@ -917,7 +917,7 @@ int32 CFE_ES_GetAppName(char *AppName, CFE_ES_AppId_t AppId, size_t BufferLength
  * Function: CFE_ES_GetLibName
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GetLibName(char *LibName, CFE_ES_LibId_t LibId, size_t BufferLength)
@@ -963,7 +963,7 @@ int32 CFE_ES_GetLibName(char *LibName, CFE_ES_LibId_t LibId, size_t BufferLength
  * Function: CFE_ES_GetTaskName
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GetTaskName(char *TaskName, CFE_ES_TaskId_t TaskId, size_t BufferLength)
@@ -1000,7 +1000,7 @@ int32 CFE_ES_GetTaskName(char *TaskName, CFE_ES_TaskId_t TaskId, size_t BufferLe
  * Function: CFE_ES_GetAppInfo
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, CFE_ES_AppId_t AppId)
@@ -1097,7 +1097,7 @@ int32 CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, CFE_ES_AppId_t AppId)
  * Function: CFE_ES_GetLibInfo
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GetLibInfo(CFE_ES_AppInfo_t *LibInfo, CFE_ES_LibId_t LibId)
@@ -1161,7 +1161,7 @@ int32 CFE_ES_GetLibInfo(CFE_ES_AppInfo_t *LibInfo, CFE_ES_LibId_t LibId)
  * Function: CFE_ES_GetModuleInfo
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GetModuleInfo(CFE_ES_AppInfo_t *ModuleInfo, CFE_ResourceId_t ResourceId)
@@ -1194,7 +1194,7 @@ int32 CFE_ES_GetModuleInfo(CFE_ES_AppInfo_t *ModuleInfo, CFE_ResourceId_t Resour
  * Function: CFE_ES_GetTaskInfo
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GetTaskInfo(CFE_ES_TaskInfo_t *TaskInfo, CFE_ES_TaskId_t TaskId)
@@ -1270,7 +1270,7 @@ int32 CFE_ES_GetTaskInfo(CFE_ES_TaskInfo_t *TaskInfo, CFE_ES_TaskId_t TaskId)
  * Function: CFE_ES_CreateChildTask
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_CreateChildTask(CFE_ES_TaskId_t *TaskIdPtr, const char *TaskName,
@@ -1368,7 +1368,7 @@ int32 CFE_ES_CreateChildTask(CFE_ES_TaskId_t *TaskIdPtr, const char *TaskName,
  * Function: CFE_ES_IncrementTaskCounter
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_IncrementTaskCounter(void)
@@ -1400,7 +1400,7 @@ void CFE_ES_IncrementTaskCounter(void)
  * Function: CFE_ES_DeleteChildTask
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_DeleteChildTask(CFE_ES_TaskId_t TaskId)
@@ -1517,7 +1517,7 @@ int32 CFE_ES_DeleteChildTask(CFE_ES_TaskId_t TaskId)
  * Function: CFE_ES_ExitChildTask
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_ExitChildTask(void)
@@ -1575,7 +1575,7 @@ void CFE_ES_ExitChildTask(void)
  * Function: CFE_ES_WriteToSysLog
  *
  * Application-scope internal function
- * See description in cfe_es_log.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_WriteToSysLog(const char *SpecStringPtr, ...)
@@ -1612,7 +1612,7 @@ int32 CFE_ES_WriteToSysLog(const char *SpecStringPtr, ...)
  * Function: CFE_ES_CalculateCRC
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 uint32 CFE_ES_CalculateCRC(const void *DataPtr, size_t DataLength, uint32 InputCRC, uint32 TypeCRC)
@@ -1690,7 +1690,7 @@ uint32 CFE_ES_CalculateCRC(const void *DataPtr, size_t DataLength, uint32 InputC
  * Function: CFE_ES_RegisterCDS
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *CDSHandlePtr, size_t BlockSize, const char *Name)
@@ -1774,7 +1774,7 @@ int32 CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *CDSHandlePtr, size_t BlockSize, con
  * Function: CFE_ES_GetCDSBlockIDByName
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_GetCDSBlockIDByName(CFE_ES_CDSHandle_t *BlockIdPtr, const char *BlockName)
@@ -1816,7 +1816,7 @@ CFE_Status_t CFE_ES_GetCDSBlockIDByName(CFE_ES_CDSHandle_t *BlockIdPtr, const ch
  * Function: CFE_ES_GetCDSBlockName
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_GetCDSBlockName(char *BlockName, CFE_ES_CDSHandle_t BlockId, size_t BufferLength)
@@ -1859,7 +1859,7 @@ CFE_Status_t CFE_ES_GetCDSBlockName(char *BlockName, CFE_ES_CDSHandle_t BlockId,
  * Function: CFE_ES_CopyToCDS
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, void *DataToCopy)
@@ -1877,7 +1877,7 @@ int32 CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, void *DataToCopy)
  * Function: CFE_ES_RestoreFromCDS
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_RestoreFromCDS(void *RestoreToMemory, CFE_ES_CDSHandle_t Handle)
@@ -1895,7 +1895,7 @@ int32 CFE_ES_RestoreFromCDS(void *RestoreToMemory, CFE_ES_CDSHandle_t Handle)
  * Function: CFE_ES_RegisterGenCounter
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_RegisterGenCounter(CFE_ES_CounterId_t *CounterIdPtr, const char *CounterName)
@@ -1960,7 +1960,7 @@ int32 CFE_ES_RegisterGenCounter(CFE_ES_CounterId_t *CounterIdPtr, const char *Co
  * Function: CFE_ES_DeleteGenCounter
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_DeleteGenCounter(CFE_ES_CounterId_t CounterId)
@@ -1989,7 +1989,7 @@ int32 CFE_ES_DeleteGenCounter(CFE_ES_CounterId_t CounterId)
  * Function: CFE_ES_IncrementGenCounter
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_IncrementGenCounter(CFE_ES_CounterId_t CounterId)
@@ -2011,7 +2011,7 @@ int32 CFE_ES_IncrementGenCounter(CFE_ES_CounterId_t CounterId)
  * Function: CFE_ES_SetGenCount
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_SetGenCount(CFE_ES_CounterId_t CounterId, uint32 Count)
@@ -2033,7 +2033,7 @@ int32 CFE_ES_SetGenCount(CFE_ES_CounterId_t CounterId, uint32 Count)
  * Function: CFE_ES_GetGenCount
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GetGenCount(CFE_ES_CounterId_t CounterId, uint32 *Count)
@@ -2055,7 +2055,7 @@ int32 CFE_ES_GetGenCount(CFE_ES_CounterId_t CounterId, uint32 *Count)
  * Function: CFE_ES_GetGenCounterIDByName
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GetGenCounterIDByName(CFE_ES_CounterId_t *CounterIdPtr, const char *CounterName)
@@ -2099,7 +2099,7 @@ int32 CFE_ES_GetGenCounterIDByName(CFE_ES_CounterId_t *CounterIdPtr, const char 
  * Function: CFE_ES_GetGenCounterName
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_GetGenCounterName(char *CounterName, CFE_ES_CounterId_t CounterId, size_t BufferLength)
@@ -2138,7 +2138,7 @@ CFE_Status_t CFE_ES_GetGenCounterName(char *CounterName, CFE_ES_CounterId_t Coun
  * Function: CFE_ES_AppID_ToIndex
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_AppID_ToIndex(CFE_ES_AppId_t AppID, uint32 *Idx)
@@ -2152,7 +2152,7 @@ int32 CFE_ES_AppID_ToIndex(CFE_ES_AppId_t AppID, uint32 *Idx)
  * Function: CFE_ES_LibID_ToIndex
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_LibID_ToIndex(CFE_ES_LibId_t LibId, uint32 *Idx)
@@ -2165,7 +2165,7 @@ int32 CFE_ES_LibID_ToIndex(CFE_ES_LibId_t LibId, uint32 *Idx)
  * Function: CFE_ES_TaskID_ToIndex
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_TaskID_ToIndex(CFE_ES_TaskId_t TaskID, uint32 *Idx)
@@ -2194,7 +2194,7 @@ int32 CFE_ES_TaskID_ToIndex(CFE_ES_TaskId_t TaskID, uint32 *Idx)
  * Function: CFE_ES_CounterID_ToIndex
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_CounterID_ToIndex(CFE_ES_CounterId_t CounterId, uint32 *Idx)
@@ -2212,7 +2212,7 @@ int32 CFE_ES_CounterID_ToIndex(CFE_ES_CounterId_t CounterId, uint32 *Idx)
  * Function: CFE_ES_LockSharedData
  *
  * Application-scope internal function
- * See description in cfe_es_global.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_LockSharedData(const char *FunctionName, int32 LineNumber)
@@ -2239,7 +2239,7 @@ void CFE_ES_LockSharedData(const char *FunctionName, int32 LineNumber)
  * Function: CFE_ES_UnlockSharedData
  *
  * Application-scope internal function
- * See description in cfe_es_global.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_UnlockSharedData(const char *FunctionName, int32 LineNumber)
@@ -2266,7 +2266,7 @@ void CFE_ES_UnlockSharedData(const char *FunctionName, int32 LineNumber)
  * Function: CFE_ES_ProcessAsyncEvent
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_ProcessAsyncEvent(void)

--- a/modules/es/fsw/src/cfe_es_apps.c
+++ b/modules/es/fsw/src/cfe_es_apps.c
@@ -64,14 +64,14 @@
 ***************************************************************************
 */
 
-/*
-** Name:
-**   CFE_ES_StartApplications
-**
-** Purpose:
-**   This routine loads/starts cFE applications.
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_StartApplications
+ *
+ * Application-scope internal function
+ * See description in cfe_es_apps.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath)
 {
     char        ES_AppLoadBuffer[ES_START_BUFF_SIZE]; /* A buffer of for a line in a file */
@@ -269,14 +269,14 @@ void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath)
     }
 }
 
-/*
-**---------------------------------------------------------------------------------------
-** Name: CFE_ES_ParseFileEntry
-**
-**   Purpose: This function parses the startup file line for an individual
-**            cFE application.
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_ParseFileEntry
+ *
+ * Application-scope internal function
+ * See description in cfe_es_apps.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens)
 {
     const char *  ModuleName;
@@ -380,16 +380,14 @@ int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens)
     return (Status);
 }
 
-/*
-**-------------------------------------------------------------------------------------
-** Name: CFE_ES_LoadModule
-**
-** Helper function to load + configure (but not start) a new app/lib module
-**
-** Loads the module file via OSAL and stores all relevant info in the table entry as necessary.
-**
-**-------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_LoadModule
+ *
+ * Application-scope internal function
+ * See description in cfe_es_apps.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_LoadModule(CFE_ResourceId_t ParentResourceId, const char *ModuleName,
                         const CFE_ES_ModuleLoadParams_t *LoadParams, CFE_ES_ModuleLoadStatus_t *LoadStatus)
 {
@@ -484,17 +482,14 @@ int32 CFE_ES_LoadModule(CFE_ResourceId_t ParentResourceId, const char *ModuleNam
     return ReturnCode;
 }
 
-/*
-**-------------------------------------------------------------------------------------
-** Name: CFE_ES_GetTaskFunction
-**
-** Helper function to act as the intermediate entry point of an app
-** This is to support starting apps before having a fully completed entry in the
-** global app table.  The app startup will delay until the app creation is completed
-** and verified, then the actual entry point will be determined.
-**
-**-------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GetTaskFunction
+ *
+ * Application-scope internal function
+ * See description in cfe_es_apps.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GetTaskFunction(CFE_ES_TaskEntryFuncPtr_t *FuncPtr)
 {
     CFE_ES_TaskRecord_t *     TaskRecPtr;
@@ -543,17 +538,14 @@ int32 CFE_ES_GetTaskFunction(CFE_ES_TaskEntryFuncPtr_t *FuncPtr)
     return (ReturnCode);
 }
 
-/*
-**-------------------------------------------------------------------------------------
-** Name: CFE_ES_TaskEntryPoint
-**
-** Helper function to act as the intermediate entry point of an app
-** This is to support starting apps before having a fully completed entry in the
-** global app table.  The app startup will delay until the app creation is completed
-** and verified, then the actual entry point will be determined.
-**
-**-------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_TaskEntryPoint
+ *
+ * Application-scope internal function
+ * See description in cfe_es_apps.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_TaskEntryPoint(void)
 {
     CFE_ES_TaskEntryFuncPtr_t RealEntryFunc;
@@ -576,22 +568,14 @@ void CFE_ES_TaskEntryPoint(void)
     }
 }
 
-/*
-**-------------------------------------------------------------------------------------
-** Name: CFE_ES_StartMainTask
-**
-** Helper function to start (but not load) a new app/lib module
-**
-** Note that OSAL does not separate the action of creating and start a task, providing
-** only OS_TaskCreate which does both.  But there is a potential race condition if
-** the real task code starts and calls any function that depends on having an AppID
-** context before its fully registered in the global app table.
-**
-** Therefore this calls a dedicated CFE_ES_AppEntryPoint which then will wait until
-** the task is fully registered in the global, before calling the actual app entry point.
-**
-**-------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_StartAppTask
+ *
+ * Application-scope internal function
+ * See description in cfe_es_apps.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_StartAppTask(CFE_ES_TaskId_t *TaskIdPtr, const char *TaskName, CFE_ES_TaskEntryFuncPtr_t EntryFunc,
                           const CFE_ES_TaskStartParams_t *Params, CFE_ES_AppId_t ParentAppId)
 {
@@ -664,17 +648,14 @@ int32 CFE_ES_StartAppTask(CFE_ES_TaskId_t *TaskIdPtr, const char *TaskName, CFE_
     return ReturnCode;
 }
 
-/*
-**---------------------------------------------------------------------------------------
-** Name: ES_AppCreate
-**
-**   Purpose: This function loads and creates a cFE Application.
-**            This function can be called from the ES startup code when it
-**            loads the cFE Applications from the disk using the startup script, or it
-**            can be called when the ES Start Application command is executed.
-**
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_AppCreate
+ *
+ * Application-scope internal function
+ * See description in cfe_es_apps.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_AppCreate(CFE_ES_AppId_t *ApplicationIdPtr, const char *AppName, const CFE_ES_AppStartParams_t *Params)
 {
     CFE_Status_t        Status;
@@ -830,17 +811,16 @@ int32 CFE_ES_AppCreate(CFE_ES_AppId_t *ApplicationIdPtr, const char *AppName, co
     *ApplicationIdPtr = CFE_ES_APPID_C(PendingResourceId);
 
     return Status;
+}
 
-} /* End Function */
-
-/*
-**---------------------------------------------------------------------------------------
-** Name: CFE_ES_LoadLibrary
-**
-**   Purpose: This function loads and initializes a cFE Shared Library.
-**
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_LoadLibrary
+ *
+ * Application-scope internal function
+ * See description in cfe_es_apps.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_LoadLibrary(CFE_ES_LibId_t *LibraryIdPtr, const char *LibName, const CFE_ES_ModuleLoadParams_t *Params)
 {
     CFE_ES_LibraryEntryFuncPtr_t FunctionPointer;
@@ -987,18 +967,16 @@ int32 CFE_ES_LoadLibrary(CFE_ES_LibId_t *LibraryIdPtr, const char *LibName, cons
     *LibraryIdPtr = CFE_ES_LIBID_C(PendingResourceId);
 
     return (Status);
+}
 
-} /* End Function */
-
-/*
-**---------------------------------------------------------------------------------------
-** Name: CFE_ES_RunAppTableScan
-**
-**   Purpose: This function scans the ES Application table and acts on the changes
-**             in application states. This is where the external cFE Applications are
-**             restarted, reloaded, or deleted.
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_RunAppTableScan
+ *
+ * Application-scope internal function
+ * See description in cfe_es_apps.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_ES_RunAppTableScan(uint32 ElapsedTime, void *Arg)
 {
     CFE_ES_AppTableScanState_t *State = (CFE_ES_AppTableScanState_t *)Arg;
@@ -1112,16 +1090,16 @@ bool CFE_ES_RunAppTableScan(uint32 ElapsedTime, void *Arg)
      * to be called from the background task at a faster interval.
      */
     return (State->PendingAppStateChanges != 0);
+}
 
-} /* End Function */
-
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_ProcessControlRequest
-**
-**   Purpose: This function will perform the requested control action for an application.
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_ProcessControlRequest
+ *
+ * Application-scope internal function
+ * See description in cfe_es_apps.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_ProcessControlRequest(CFE_ES_AppId_t AppId)
 {
     CFE_ES_AppRecord_t *     AppRecPtr;
@@ -1338,16 +1316,16 @@ void CFE_ES_ProcessControlRequest(CFE_ES_AppId_t AppId)
     }
 
     CFE_EVS_SendEvent(EventID, EventType, "%s Application %s %s", ReqName, OrigAppName, MessageDetail);
+}
 
-} /* End Function */
-
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_CleanUpApp
-**
-**   Purpose: Delete an application by cleaning up all of it's resources.
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_CleanUpApp
+ *
+ * Application-scope internal function
+ * See description in cfe_es_apps.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId)
 {
     uint32                  i;
@@ -1569,8 +1547,7 @@ int32 CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId)
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
     return (ReturnCode);
-
-} /* end function */
+}
 
 /*
  * Simple state structure used when cleaning up objects associated with tasks
@@ -1586,15 +1563,16 @@ typedef struct
     int32  OverallStatus;
 } CFE_ES_CleanupState_t;
 
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_CleanupObjectCallback
-**
-**   Purpose: Helper function clean up all objects.
-**
-**   NOTE: This is called while holding the ES global lock
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_CleanupObjectCallback
+ *
+ * Internal helper routine only, not part of API.
+ *
+ * Purpose: clean up all objects.
+ * NOTE: This is called while holding the ES global lock
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_CleanupObjectCallback(osal_id_t ObjectId, void *arg)
 {
     CFE_ES_CleanupState_t *CleanState;
@@ -1686,15 +1664,14 @@ void CFE_ES_CleanupObjectCallback(osal_id_t ObjectId, void *arg)
     }
 }
 
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_CleanupTaskResources
-**
-**   Purpose: Clean up the OS resources associated with an individual Task
-**   Note: This is called when the ES global is UNLOCKED - so it should not touch
-**         any ES global data structures.  It should only clean up at the OSAL level.
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_CleanupTaskResources
+ *
+ * Application-scope internal function
+ * See description in cfe_es_apps.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_CleanupTaskResources(CFE_ES_TaskId_t TaskId)
 {
     CFE_ES_CleanupState_t CleanState;
@@ -1754,16 +1731,14 @@ int32 CFE_ES_CleanupTaskResources(CFE_ES_TaskId_t TaskId)
     return (Result);
 }
 
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_CopyModuleBasicInfo
-**
-**   Purpose: Populate the cFE_ES_AppInfo structure with the data for an app.
-**
-**   This internal function does not log any errors/events.  The caller is expected
-**   to check the return code and log any relevant errors based on the context.
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_CopyModuleBasicInfo
+ *
+ * Application-scope internal function
+ * See description in cfe_es_apps.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_CopyModuleBasicInfo(const CFE_ES_ModuleLoadParams_t *ParamsPtr, CFE_ES_AppInfo_t *AppInfoPtr)
 {
     strncpy(AppInfoPtr->EntryPoint, ParamsPtr->InitSymbolName, sizeof(AppInfoPtr->EntryPoint) - 1);
@@ -1773,31 +1748,27 @@ void CFE_ES_CopyModuleBasicInfo(const CFE_ES_ModuleLoadParams_t *ParamsPtr, CFE_
     AppInfoPtr->FileName[sizeof(AppInfoPtr->FileName) - 1] = '\0';
 }
 
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_CopyModuleStatusInfo
-**
-**   Purpose: Populate the cFE_ES_AppInfo structure with the data for an app.
-**
-**   This internal function does not log any errors/events.  The caller is expected
-**   to check the return code and log any relevant errors based on the context.
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_CopyModuleStatusInfo
+ *
+ * Application-scope internal function
+ * See description in cfe_es_apps.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_CopyModuleStatusInfo(const CFE_ES_ModuleLoadStatus_t *StatusPtr, CFE_ES_AppInfo_t *AppInfoPtr)
 {
     AppInfoPtr->StartAddress = CFE_ES_MEMADDRESS_C(StatusPtr->InitSymbolAddress);
 }
 
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_CopyModuleAddressInfo
-**
-**   Purpose: Populate the cFE_ES_AppInfo structure with the data for an app.
-**
-**   This internal function does not log any errors/events.  The caller is expected
-**   to check the return code and log any relevant errors based on the context.
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_CopyModuleAddressInfo
+ *
+ * Application-scope internal function
+ * See description in cfe_es_apps.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_CopyModuleAddressInfo(osal_id_t ModuleId, CFE_ES_AppInfo_t *AppInfoPtr)
 {
     OS_module_prop_t ModuleInfo;

--- a/modules/es/fsw/src/cfe_es_apps.c
+++ b/modules/es/fsw/src/cfe_es_apps.c
@@ -69,7 +69,7 @@
  * Function: CFE_ES_StartApplications
  *
  * Application-scope internal function
- * See description in cfe_es_apps.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath)
@@ -274,7 +274,7 @@ void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath)
  * Function: CFE_ES_ParseFileEntry
  *
  * Application-scope internal function
- * See description in cfe_es_apps.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens)
@@ -385,7 +385,7 @@ int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens)
  * Function: CFE_ES_LoadModule
  *
  * Application-scope internal function
- * See description in cfe_es_apps.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_LoadModule(CFE_ResourceId_t ParentResourceId, const char *ModuleName,
@@ -487,7 +487,7 @@ int32 CFE_ES_LoadModule(CFE_ResourceId_t ParentResourceId, const char *ModuleNam
  * Function: CFE_ES_GetTaskFunction
  *
  * Application-scope internal function
- * See description in cfe_es_apps.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GetTaskFunction(CFE_ES_TaskEntryFuncPtr_t *FuncPtr)
@@ -543,7 +543,7 @@ int32 CFE_ES_GetTaskFunction(CFE_ES_TaskEntryFuncPtr_t *FuncPtr)
  * Function: CFE_ES_TaskEntryPoint
  *
  * Application-scope internal function
- * See description in cfe_es_apps.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_TaskEntryPoint(void)
@@ -573,7 +573,7 @@ void CFE_ES_TaskEntryPoint(void)
  * Function: CFE_ES_StartAppTask
  *
  * Application-scope internal function
- * See description in cfe_es_apps.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_StartAppTask(CFE_ES_TaskId_t *TaskIdPtr, const char *TaskName, CFE_ES_TaskEntryFuncPtr_t EntryFunc,
@@ -653,7 +653,7 @@ int32 CFE_ES_StartAppTask(CFE_ES_TaskId_t *TaskIdPtr, const char *TaskName, CFE_
  * Function: CFE_ES_AppCreate
  *
  * Application-scope internal function
- * See description in cfe_es_apps.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_AppCreate(CFE_ES_AppId_t *ApplicationIdPtr, const char *AppName, const CFE_ES_AppStartParams_t *Params)
@@ -818,7 +818,7 @@ int32 CFE_ES_AppCreate(CFE_ES_AppId_t *ApplicationIdPtr, const char *AppName, co
  * Function: CFE_ES_LoadLibrary
  *
  * Application-scope internal function
- * See description in cfe_es_apps.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_LoadLibrary(CFE_ES_LibId_t *LibraryIdPtr, const char *LibName, const CFE_ES_ModuleLoadParams_t *Params)
@@ -974,7 +974,7 @@ int32 CFE_ES_LoadLibrary(CFE_ES_LibId_t *LibraryIdPtr, const char *LibName, cons
  * Function: CFE_ES_RunAppTableScan
  *
  * Application-scope internal function
- * See description in cfe_es_apps.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 bool CFE_ES_RunAppTableScan(uint32 ElapsedTime, void *Arg)
@@ -1097,7 +1097,7 @@ bool CFE_ES_RunAppTableScan(uint32 ElapsedTime, void *Arg)
  * Function: CFE_ES_ProcessControlRequest
  *
  * Application-scope internal function
- * See description in cfe_es_apps.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_ProcessControlRequest(CFE_ES_AppId_t AppId)
@@ -1323,7 +1323,7 @@ void CFE_ES_ProcessControlRequest(CFE_ES_AppId_t AppId)
  * Function: CFE_ES_CleanUpApp
  *
  * Application-scope internal function
- * See description in cfe_es_apps.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId)
@@ -1669,7 +1669,7 @@ void CFE_ES_CleanupObjectCallback(osal_id_t ObjectId, void *arg)
  * Function: CFE_ES_CleanupTaskResources
  *
  * Application-scope internal function
- * See description in cfe_es_apps.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_CleanupTaskResources(CFE_ES_TaskId_t TaskId)
@@ -1736,7 +1736,7 @@ int32 CFE_ES_CleanupTaskResources(CFE_ES_TaskId_t TaskId)
  * Function: CFE_ES_CopyModuleBasicInfo
  *
  * Application-scope internal function
- * See description in cfe_es_apps.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_CopyModuleBasicInfo(const CFE_ES_ModuleLoadParams_t *ParamsPtr, CFE_ES_AppInfo_t *AppInfoPtr)
@@ -1753,7 +1753,7 @@ void CFE_ES_CopyModuleBasicInfo(const CFE_ES_ModuleLoadParams_t *ParamsPtr, CFE_
  * Function: CFE_ES_CopyModuleStatusInfo
  *
  * Application-scope internal function
- * See description in cfe_es_apps.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_CopyModuleStatusInfo(const CFE_ES_ModuleLoadStatus_t *StatusPtr, CFE_ES_AppInfo_t *AppInfoPtr)
@@ -1766,7 +1766,7 @@ void CFE_ES_CopyModuleStatusInfo(const CFE_ES_ModuleLoadStatus_t *StatusPtr, CFE
  * Function: CFE_ES_CopyModuleAddressInfo
  *
  * Application-scope internal function
- * See description in cfe_es_apps.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_CopyModuleAddressInfo(osal_id_t ModuleId, CFE_ES_AppInfo_t *AppInfoPtr)

--- a/modules/es/fsw/src/cfe_es_backgroundtask.c
+++ b/modules/es/fsw/src/cfe_es_backgroundtask.c
@@ -88,18 +88,14 @@ const CFE_ES_BackgroundJobEntry_t CFE_ES_BACKGROUND_JOB_TABLE[] = {
 
 #define CFE_ES_BACKGROUND_NUM_JOBS (sizeof(CFE_ES_BACKGROUND_JOB_TABLE) / sizeof(CFE_ES_BACKGROUND_JOB_TABLE[0]))
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/* Name: CFE_ES_BackgroundTask                                                   */
-/*                                                                               */
-/* Purpose: A helper task for low priority routines that may take time to        */
-/* execute, such as writing log files.                                           */
-/*                                                                               */
-/* Assumptions and Notes: This is started from the ES initialization, and        */
-/* pends on a semaphore until a work request comes in.  This is intended to      */
-/* avoid the need to create a child task "on demand" when work items arrive,     */
-/* which is a form of dynamic allocation.                                        */
-/*                                                                               */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_BackgroundTask
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_BackgroundTask(void)
 {
     int32                              status;
@@ -166,12 +162,14 @@ void CFE_ES_BackgroundTask(void)
     }
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/* Name: CFE_ES_BackgroundInit                                                   */
-/*                                                                               */
-/* Purpose: Initialize the background task                                       */
-/*                                                                               */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_BackgroundInit
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_BackgroundInit(void)
 {
     int32 status;
@@ -198,12 +196,14 @@ int32 CFE_ES_BackgroundInit(void)
     return CFE_SUCCESS;
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/* Name: CFE_ES_BackgroundCleanup                                                */
-/*                                                                               */
-/* Purpose: Exit/Stop the background task                                        */
-/*                                                                               */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_BackgroundCleanup
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_BackgroundCleanup(void)
 {
     CFE_ES_DeleteChildTask(CFE_ES_Global.BackgroundTask.TaskID);
@@ -213,13 +213,14 @@ void CFE_ES_BackgroundCleanup(void)
     CFE_ES_Global.BackgroundTask.WorkSem = OS_OBJECT_ID_UNDEFINED;
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/* Name: CFE_ES_BackgroundWakeup                                                 */
-/*                                                                               */
-/* Purpose: Wake up the background task                                          */
-/* Notifies the background task to perform an extra poll for new work            */
-/*                                                                               */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_BackgroundWakeup
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_BackgroundWakeup(void)
 {
     /* wake up the background task by giving the sem.

--- a/modules/es/fsw/src/cfe_es_backgroundtask.c
+++ b/modules/es/fsw/src/cfe_es_backgroundtask.c
@@ -93,7 +93,7 @@ const CFE_ES_BackgroundJobEntry_t CFE_ES_BACKGROUND_JOB_TABLE[] = {
  * Function: CFE_ES_BackgroundTask
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_BackgroundTask(void)
@@ -167,7 +167,7 @@ void CFE_ES_BackgroundTask(void)
  * Function: CFE_ES_BackgroundInit
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_BackgroundInit(void)
@@ -201,7 +201,7 @@ int32 CFE_ES_BackgroundInit(void)
  * Function: CFE_ES_BackgroundCleanup
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_BackgroundCleanup(void)
@@ -218,7 +218,7 @@ void CFE_ES_BackgroundCleanup(void)
  * Function: CFE_ES_BackgroundWakeup
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_BackgroundWakeup(void)

--- a/modules/es/fsw/src/cfe_es_cds.c
+++ b/modules/es/fsw/src/cfe_es_cds.c
@@ -49,7 +49,7 @@
  * Function: CFE_ES_CDS_EarlyInit
  *
  * Application-scope internal function
- * See description in cfe_es_cds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_CDS_EarlyInit(void)
@@ -153,7 +153,7 @@ int32 CFE_ES_CDS_EarlyInit(void)
  * Function: CFE_ES_CDSHandle_ToIndex
  *
  * Application-scope internal function
- * See description in cfe_es_cds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_CDSHandle_ToIndex(CFE_ES_CDSHandle_t BlockID, uint32 *Idx)
@@ -167,7 +167,7 @@ int32 CFE_ES_CDSHandle_ToIndex(CFE_ES_CDSHandle_t BlockID, uint32 *Idx)
  * Function: CFE_ES_CheckCDSHandleSlotUsed
  *
  * Application-scope internal function
- * See description in cfe_es_cds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 bool CFE_ES_CheckCDSHandleSlotUsed(CFE_ResourceId_t CheckId)
@@ -187,7 +187,7 @@ bool CFE_ES_CheckCDSHandleSlotUsed(CFE_ResourceId_t CheckId)
  * Function: CFE_ES_LocateCDSBlockRecordByID
  *
  * Application-scope internal function
- * See description in cfe_es_cds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_ES_CDS_RegRec_t *CFE_ES_LocateCDSBlockRecordByID(CFE_ES_CDSHandle_t BlockID)
@@ -213,7 +213,7 @@ CFE_ES_CDS_RegRec_t *CFE_ES_LocateCDSBlockRecordByID(CFE_ES_CDSHandle_t BlockID)
  * Function: CFE_ES_CDS_CacheFetch
  *
  * Application-scope internal function
- * See description in cfe_es_cds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_CDS_CacheFetch(CFE_ES_CDS_AccessCache_t *Cache, size_t Offset, size_t Size)
@@ -248,7 +248,7 @@ int32 CFE_ES_CDS_CacheFetch(CFE_ES_CDS_AccessCache_t *Cache, size_t Offset, size
  * Function: CFE_ES_CDS_CacheFlush
  *
  * Application-scope internal function
- * See description in cfe_es_cds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_CDS_CacheFlush(CFE_ES_CDS_AccessCache_t *Cache)
@@ -281,7 +281,7 @@ int32 CFE_ES_CDS_CacheFlush(CFE_ES_CDS_AccessCache_t *Cache)
  * Function: CFE_ES_CDS_CachePreload
  *
  * Application-scope internal function
- * See description in cfe_es_cds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_CDS_CachePreload(CFE_ES_CDS_AccessCache_t *Cache, const void *Source, size_t Offset, size_t Size)
@@ -317,7 +317,7 @@ int32 CFE_ES_CDS_CachePreload(CFE_ES_CDS_AccessCache_t *Cache, const void *Sourc
  * Function: CFE_ES_RegisterCDSEx
  *
  * Implemented per public API
- * See description in cfe_es_core_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr, size_t UserBlockSize, const char *Name, bool CriticalTbl)
@@ -477,7 +477,7 @@ int32 CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr, size_t UserBlockSize, 
  * Function: CFE_ES_ValidateCDS
  *
  * Application-scope internal function
- * See description in cfe_es_cds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_ValidateCDS(void)
@@ -528,7 +528,7 @@ int32 CFE_ES_ValidateCDS(void)
  * Function: CFE_ES_ClearCDS
  *
  * Application-scope internal function
- * See description in cfe_es_cds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_ClearCDS(void)
@@ -575,7 +575,7 @@ int32 CFE_ES_ClearCDS(void)
  * Function: CFE_ES_InitCDSSignatures
  *
  * Application-scope internal function
- * See description in cfe_es_cds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_InitCDSSignatures(void)
@@ -616,7 +616,7 @@ int32 CFE_ES_InitCDSSignatures(void)
  * Function: CFE_ES_InitCDSRegistry
  *
  * Application-scope internal function
- * See description in cfe_es_cds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_InitCDSRegistry(void)
@@ -650,7 +650,7 @@ int32 CFE_ES_InitCDSRegistry(void)
  * Function: CFE_ES_UpdateCDSRegistry
  *
  * Application-scope internal function
- * See description in cfe_es_cds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_UpdateCDSRegistry(void)
@@ -675,7 +675,7 @@ int32 CFE_ES_UpdateCDSRegistry(void)
  * Function: CFE_ES_FormCDSName
  *
  * Application-scope internal function
- * See description in cfe_es_cds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_FormCDSName(char *FullCDSName, const char *CDSName, CFE_ES_AppId_t ThisAppId)
@@ -698,7 +698,7 @@ void CFE_ES_FormCDSName(char *FullCDSName, const char *CDSName, CFE_ES_AppId_t T
  * Function: CFE_ES_LockCDS
  *
  * Application-scope internal function
- * See description in cfe_es_cds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_LockCDS(void)
@@ -726,7 +726,7 @@ int32 CFE_ES_LockCDS(void)
  * Function: CFE_ES_UnlockCDS
  *
  * Application-scope internal function
- * See description in cfe_es_cds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_UnlockCDS(void)
@@ -754,7 +754,7 @@ int32 CFE_ES_UnlockCDS(void)
  * Function: CFE_ES_LocateCDSBlockRecordByName
  *
  * Application-scope internal function
- * See description in cfe_es_cds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_ES_CDS_RegRec_t *CFE_ES_LocateCDSBlockRecordByName(const char *CDSName)
@@ -795,7 +795,7 @@ CFE_ES_CDS_RegRec_t *CFE_ES_LocateCDSBlockRecordByName(const char *CDSName)
  * Function: CFE_ES_RebuildCDS
  *
  * Application-scope internal function
- * See description in cfe_es_cds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_RebuildCDS(void)
@@ -844,7 +844,7 @@ int32 CFE_ES_RebuildCDS(void)
  * Function: CFE_ES_DeleteCDS
  *
  * Implemented per public API
- * See description in cfe_es_core_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_DeleteCDS(const char *CDSName, bool CalledByTblServices)

--- a/modules/es/fsw/src/cfe_es_cds.c
+++ b/modules/es/fsw/src/cfe_es_cds.c
@@ -44,13 +44,14 @@
 #include <stdio.h>
 #include <stdarg.h>
 
-/*****************************************************************************/
-/*
- * CFE_ES_CDS_EarlyInit
+/*----------------------------------------------------------------
  *
- * NOTE: For complete prolog information, see 'cfe_es_cds.h'
- */
-/*****************************************************************************/
+ * Function: CFE_ES_CDS_EarlyInit
+ *
+ * Application-scope internal function
+ * See description in cfe_es_cds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_CDS_EarlyInit(void)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
@@ -145,29 +146,30 @@ int32 CFE_ES_CDS_EarlyInit(void)
     }
 
     return Status;
+}
 
-} /* End of CFE_ES_CDS_EarlyInit() */
-
-/*******************************************************************/
-/*
- * CFE_ES_LocateCDSBlockRecordByID
+/*----------------------------------------------------------------
  *
- * NOTE: For complete prolog information, see 'cfe_es_cds.h'
- */
-/*******************************************************************/
+ * Function: CFE_ES_CDSHandle_ToIndex
+ *
+ * Application-scope internal function
+ * See description in cfe_es_cds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_CDSHandle_ToIndex(CFE_ES_CDSHandle_t BlockID, uint32 *Idx)
 {
     return CFE_ResourceId_ToIndex(CFE_RESOURCEID_UNWRAP(BlockID), CFE_ES_CDSBLOCKID_BASE,
                                   CFE_PLATFORM_ES_CDS_MAX_NUM_ENTRIES, Idx);
 }
 
-/*---------------------------------------------------------------------------------------
+/*----------------------------------------------------------------
+ *
  * Function: CFE_ES_CheckCDSHandleSlotUsed
  *
- * Purpose: Helper function, Aids in allocating a new ID by checking if
- * a given ID is available.  Must be called while locked.
- *---------------------------------------------------------------------------------------
- */
+ * Application-scope internal function
+ * See description in cfe_es_cds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_ES_CheckCDSHandleSlotUsed(CFE_ResourceId_t CheckId)
 {
     CFE_ES_CDS_RegRec_t *CDSRegRecPtr;
@@ -180,13 +182,14 @@ bool CFE_ES_CheckCDSHandleSlotUsed(CFE_ResourceId_t CheckId)
     return (CDSRegRecPtr == NULL || CFE_ES_CDSBlockRecordIsUsed(CDSRegRecPtr));
 }
 
-/*******************************************************************/
-/*
- * CFE_ES_LocateCDSBlockRecordByID
+/*----------------------------------------------------------------
  *
- * NOTE: For complete prolog information, see 'cfe_es_cds.h'
- */
-/*******************************************************************/
+ * Function: CFE_ES_LocateCDSBlockRecordByID
+ *
+ * Application-scope internal function
+ * See description in cfe_es_cds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_ES_CDS_RegRec_t *CFE_ES_LocateCDSBlockRecordByID(CFE_ES_CDSHandle_t BlockID)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
@@ -205,13 +208,14 @@ CFE_ES_CDS_RegRec_t *CFE_ES_LocateCDSBlockRecordByID(CFE_ES_CDSHandle_t BlockID)
     return CDSRegRecPtr;
 }
 
-/*******************************************************************/
-/*
- * CFE_ES_CacheRead()
+/*----------------------------------------------------------------
  *
- * NOTE: For complete prolog information, see 'cfe_es_cds.h'
- */
-/*******************************************************************/
+ * Function: CFE_ES_CDS_CacheFetch
+ *
+ * Application-scope internal function
+ * See description in cfe_es_cds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_CDS_CacheFetch(CFE_ES_CDS_AccessCache_t *Cache, size_t Offset, size_t Size)
 {
     int32 Status;
@@ -239,13 +243,14 @@ int32 CFE_ES_CDS_CacheFetch(CFE_ES_CDS_AccessCache_t *Cache, size_t Offset, size
     return Status;
 }
 
-/*******************************************************************/
-/*
- * CFE_ES_CDS_CacheFlush()
+/*----------------------------------------------------------------
  *
- * NOTE: For complete prolog information, see 'cfe_es_cds.h'
- */
-/*******************************************************************/
+ * Function: CFE_ES_CDS_CacheFlush
+ *
+ * Application-scope internal function
+ * See description in cfe_es_cds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_CDS_CacheFlush(CFE_ES_CDS_AccessCache_t *Cache)
 {
     int32 Status;
@@ -271,13 +276,14 @@ int32 CFE_ES_CDS_CacheFlush(CFE_ES_CDS_AccessCache_t *Cache)
     return Status;
 }
 
-/*******************************************************************/
-/*
- * CFE_ES_CDS_CachePreload()
+/*----------------------------------------------------------------
  *
- * NOTE: For complete prolog information, see 'cfe_es_cds.h'
- */
-/*******************************************************************/
+ * Function: CFE_ES_CDS_CachePreload
+ *
+ * Application-scope internal function
+ * See description in cfe_es_cds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_CDS_CachePreload(CFE_ES_CDS_AccessCache_t *Cache, const void *Source, size_t Offset, size_t Size)
 {
     int32 Status;
@@ -306,13 +312,14 @@ int32 CFE_ES_CDS_CachePreload(CFE_ES_CDS_AccessCache_t *Cache, const void *Sourc
     return Status;
 }
 
-/*******************************************************************
-**
-** CFE_ES_RegisterCDSEx
-**
-** NOTE: For complete prolog information, see 'cfe_es_cds.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_RegisterCDSEx
+ *
+ * Implemented per public API
+ * See description in cfe_es_core_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr, size_t UserBlockSize, const char *Name, bool CriticalTbl)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
@@ -463,16 +470,16 @@ int32 CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr, size_t UserBlockSize, 
     *HandlePtr = CFE_ES_CDSHANDLE_C(PendingBlockId);
 
     return (Status);
+}
 
-} /* End of CFE_ES_RegisterCDSEx() */
-
-/*******************************************************************
-**
-** CFE_ES_ValidateCDS
-**
-** NOTE: For complete prolog information, see prototype above
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_ValidateCDS
+ *
+ * Application-scope internal function
+ * See description in cfe_es_cds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_ValidateCDS(void)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
@@ -514,15 +521,16 @@ int32 CFE_ES_ValidateCDS(void)
 
     /* All sanity checks passed */
     return CFE_SUCCESS;
-} /* End of CFE_ES_ValidateCDS() */
+}
 
-/*******************************************************************
-**
-** CFE_ES_ClearCDS
-**
-** NOTE: For complete prolog information, see prototype above
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_ClearCDS
+ *
+ * Application-scope internal function
+ * See description in cfe_es_cds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_ClearCDS(void)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
@@ -562,13 +570,14 @@ int32 CFE_ES_ClearCDS(void)
     return Status;
 }
 
-/*******************************************************************
-**
-** CFE_ES_InitCDSSignatures
-**
-** NOTE: For complete prolog information, see prototype above
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_InitCDSSignatures
+ *
+ * Application-scope internal function
+ * See description in cfe_es_cds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_InitCDSSignatures(void)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
@@ -600,15 +609,16 @@ int32 CFE_ES_InitCDSSignatures(void)
     }
 
     return Status;
-} /* End of CFE_ES_InitCDSSignatures() */
+}
 
-/*******************************************************************
-**
-** CFE_ES_InitCDSRegistry
-**
-** NOTE: For complete prolog information, see prototype above
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_InitCDSRegistry
+ *
+ * Application-scope internal function
+ * See description in cfe_es_cds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_InitCDSRegistry(void)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
@@ -633,15 +643,16 @@ int32 CFE_ES_InitCDSRegistry(void)
     }
 
     return Status;
-} /* End of CFE_ES_InitCDSRegistry() */
+}
 
-/*******************************************************************
-**
-** CFE_ES_UpdateCDSRegistry
-**
-** NOTE: For complete prolog information, see 'cfe_es_cds.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_UpdateCDSRegistry
+ *
+ * Application-scope internal function
+ * See description in cfe_es_cds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_UpdateCDSRegistry(void)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
@@ -659,13 +670,14 @@ int32 CFE_ES_UpdateCDSRegistry(void)
     return Status;
 }
 
-/*******************************************************************
-**
-** CFE_ES_FormCDSName
-**
-** NOTE: For complete prolog information, see 'cfe_es_cds.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_FormCDSName
+ *
+ * Application-scope internal function
+ * See description in cfe_es_cds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_FormCDSName(char *FullCDSName, const char *CDSName, CFE_ES_AppId_t ThisAppId)
 {
     char AppName[OS_MAX_API_NAME];
@@ -679,15 +691,16 @@ void CFE_ES_FormCDSName(char *FullCDSName, const char *CDSName, CFE_ES_AppId_t T
     sprintf(FullCDSName, "%s.%s", AppName, CDSName);
 
     return;
-} /* End of CFE_ES_FormCDSName() */
+}
 
-/*******************************************************************
-**
-** CFE_ES_LockCDSRegistry
-**
-** NOTE: For complete prolog information, see 'cfe_es_cds.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_LockCDS
+ *
+ * Application-scope internal function
+ * See description in cfe_es_cds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_LockCDS(void)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
@@ -706,16 +719,16 @@ int32 CFE_ES_LockCDS(void)
     }
 
     return Status;
+}
 
-} /* End of CFE_ES_LockCDSRegistry() */
-
-/*******************************************************************
-**
-** CFE_ES_UnlockCDSRegistry
-**
-** NOTE: For complete prolog information, see 'cfe_es_cds.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_UnlockCDS
+ *
+ * Application-scope internal function
+ * See description in cfe_es_cds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_UnlockCDS(void)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
@@ -734,16 +747,16 @@ int32 CFE_ES_UnlockCDS(void)
     }
 
     return Status;
+}
 
-} /* End of CFE_ES_UnlockCDSRegistry() */
-
-/*******************************************************************
-**
-** CFE_ES_LocateCDSBlockRecordByName
-**
-** NOTE: For complete prolog information, see 'cfe_es_cds.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_LocateCDSBlockRecordByName
+ *
+ * Application-scope internal function
+ * See description in cfe_es_cds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_ES_CDS_RegRec_t *CFE_ES_LocateCDSBlockRecordByName(const char *CDSName)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
@@ -775,15 +788,16 @@ CFE_ES_CDS_RegRec_t *CFE_ES_LocateCDSBlockRecordByName(const char *CDSName)
     }
 
     return CDSRegRecPtr;
-} /* End of CFE_ES_LocateCDSBlockRecordByName() */
+}
 
-/*******************************************************************
-**
-** CFE_ES_RebuildCDS
-**
-** NOTE: For complete prolog information, see above
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_RebuildCDS
+ *
+ * Application-scope internal function
+ * See description in cfe_es_cds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_RebuildCDS(void)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
@@ -825,13 +839,14 @@ int32 CFE_ES_RebuildCDS(void)
     return Status;
 }
 
-/*******************************************************************
-**
-** CFE_ES_DeleteCDS
-**
-** NOTE: For complete prolog information, see 'cfe_es_cds.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_DeleteCDS
+ *
+ * Implemented per public API
+ * See description in cfe_es_core_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_DeleteCDS(const char *CDSName, bool CalledByTblServices)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
@@ -926,6 +941,4 @@ int32 CFE_ES_DeleteCDS(const char *CDSName, bool CalledByTblServices)
     }
 
     return Status;
-} /* End of CFE_ES_DeleteCDS() */
-
-/* end of file */
+}

--- a/modules/es/fsw/src/cfe_es_cds.h
+++ b/modules/es/fsw/src/cfe_es_cds.h
@@ -194,6 +194,7 @@ typedef struct CFE_ES_CDS_PersistentTrailer
 ** Function prototypes
 */
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Fetch data from the non-volatile storage and store in RAM cache
  *
@@ -211,6 +212,7 @@ typedef struct CFE_ES_CDS_PersistentTrailer
  */
 int32 CFE_ES_CDS_CacheFetch(CFE_ES_CDS_AccessCache_t *Cache, size_t Offset, size_t Size);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Write data from the RAM cache back to non-volatile storage
  *
@@ -227,6 +229,7 @@ int32 CFE_ES_CDS_CacheFetch(CFE_ES_CDS_AccessCache_t *Cache, size_t Offset, size
  */
 int32 CFE_ES_CDS_CacheFlush(CFE_ES_CDS_AccessCache_t *Cache);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Preload the cache data from a local buffer
  *
@@ -251,6 +254,7 @@ int32 CFE_ES_CDS_CacheFlush(CFE_ES_CDS_AccessCache_t *Cache);
  */
 int32 CFE_ES_CDS_CachePreload(CFE_ES_CDS_AccessCache_t *Cache, const void *Source, size_t Offset, size_t Size);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Get the registry array index correlating with a CDS block ID
  *
@@ -264,6 +268,7 @@ int32 CFE_ES_CDS_CachePreload(CFE_ES_CDS_AccessCache_t *Cache, const void *Sourc
  */
 int32 CFE_ES_CDSHandle_ToIndex(CFE_ES_CDSHandle_t BlockID, uint32 *Idx);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Get a registry record within the CDS, given a block ID/handle
  *
@@ -291,6 +296,7 @@ int32 CFE_ES_CDSHandle_ToIndex(CFE_ES_CDSHandle_t BlockID, uint32 *Idx);
  */
 CFE_ES_CDS_RegRec_t *CFE_ES_LocateCDSBlockRecordByID(CFE_ES_CDSHandle_t BlockID);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Check if a Memory Pool record is in use or free/empty
  *
@@ -310,6 +316,7 @@ static inline bool CFE_ES_CDSBlockRecordIsUsed(const CFE_ES_CDS_RegRec_t *CDSBlo
     return CFE_RESOURCEID_TEST_DEFINED(CDSBlockRecPtr->BlockID);
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Get the ID value from a Memory Pool table entry
  *
@@ -326,6 +333,7 @@ static inline CFE_ES_CDSHandle_t CFE_ES_CDSBlockRecordGetID(const CFE_ES_CDS_Reg
     return (CDSBlockRecPtr->BlockID);
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Marks a Memory Pool table entry as used (not free)
  *
@@ -343,6 +351,7 @@ static inline void CFE_ES_CDSBlockRecordSetUsed(CFE_ES_CDS_RegRec_t *CDSBlockRec
     CDSBlockRecPtr->BlockID = CFE_ES_CDSHANDLE_C(PendingId);
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Set a Memory Pool record table entry free (not used)
  *
@@ -359,6 +368,7 @@ static inline void CFE_ES_CDSBlockRecordSetFree(CFE_ES_CDS_RegRec_t *CDSBlockRec
     CDSBlockRecPtr->BlockID = CFE_ES_CDS_BAD_HANDLE;
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Check if a CDS block record is a match for the given BlockID
  *
@@ -387,6 +397,7 @@ static inline bool CFE_ES_CDSBlockRecordIsMatch(const CFE_ES_CDS_RegRec_t *CDSBl
     return (CDSBlockRecPtr != NULL && CFE_RESOURCEID_TEST_EQUAL(CDSBlockRecPtr->BlockID, BlockID));
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Gets the data size from a given registry record
  *
@@ -410,6 +421,7 @@ static inline size_t CFE_ES_CDSBlockRecordGetUserSize(const CFE_ES_CDS_RegRec_t 
     return (CDSBlockRecPtr->BlockSize - sizeof(CFE_ES_CDS_BlockHeader_t));
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Check if a CDS Block ID table slot is used
  *
@@ -425,7 +437,7 @@ static inline size_t CFE_ES_CDSBlockRecordGetUserSize(const CFE_ES_CDS_RegRec_t 
  */
 bool CFE_ES_CheckCDSHandleSlotUsed(CFE_ResourceId_t CheckId);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Initializes CDS data constructs
 **
@@ -443,7 +455,7 @@ bool CFE_ES_CheckCDSHandleSlotUsed(CFE_ResourceId_t CheckId);
 ******************************************************************************/
 int32 CFE_ES_CDS_EarlyInit(void);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Determines whether a CDS currently exists
 **
@@ -462,7 +474,7 @@ int32 CFE_ES_CDS_EarlyInit(void);
 ******************************************************************************/
 int32 CFE_ES_ValidateCDS(void);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Initializes the CDS Registry
 **
@@ -478,7 +490,7 @@ int32 CFE_ES_ValidateCDS(void);
 ******************************************************************************/
 int32 CFE_ES_InitCDSRegistry(void);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Rebuilds memory pool for CDS and recovers existing registry
 **
@@ -495,7 +507,7 @@ int32 CFE_ES_InitCDSRegistry(void);
 ******************************************************************************/
 int32 CFE_ES_RebuildCDS(void);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Copies the local version of the CDS Registry to the actual CDS
 **
@@ -511,7 +523,7 @@ int32 CFE_ES_RebuildCDS(void);
 ******************************************************************************/
 int32 CFE_ES_UpdateCDSRegistry(void);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Creates a Full CDS name from application name and CDS name
 **
@@ -535,7 +547,7 @@ int32 CFE_ES_UpdateCDSRegistry(void);
 ******************************************************************************/
 void CFE_ES_FormCDSName(char *FullCDSName, const char *CDSName, CFE_ES_AppId_t ThisAppId);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Returns the Registry Record for the specified CDS Name
 **
@@ -554,7 +566,7 @@ void CFE_ES_FormCDSName(char *FullCDSName, const char *CDSName, CFE_ES_AppId_t T
 ******************************************************************************/
 CFE_ES_CDS_RegRec_t *CFE_ES_LocateCDSBlockRecordByName(const char *CDSName);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Locks access to the CDS
 **
@@ -571,7 +583,7 @@ CFE_ES_CDS_RegRec_t *CFE_ES_LocateCDSBlockRecordByName(const char *CDSName);
 ******************************************************************************/
 int32 CFE_ES_LockCDS(void);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Unlocks access to the CDS
 **
@@ -587,7 +599,7 @@ int32 CFE_ES_LockCDS(void);
 ******************************************************************************/
 int32 CFE_ES_UnlockCDS(void);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Rebuilds memory pool for CDS and recovers existing registry
 **
@@ -604,7 +616,7 @@ int32 CFE_ES_UnlockCDS(void);
 ******************************************************************************/
 int32 CFE_ES_RebuildCDS(void);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Initializes the CDS Registry
 **
@@ -620,7 +632,7 @@ int32 CFE_ES_RebuildCDS(void);
 ******************************************************************************/
 int32 CFE_ES_InitCDSRegistry(void);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Determines whether a CDS currently exists
 **
@@ -639,7 +651,7 @@ int32 CFE_ES_InitCDSRegistry(void);
 ******************************************************************************/
 int32 CFE_ES_ValidateCDS(void);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Clears the contents of the CDS
 **
@@ -658,7 +670,7 @@ int32 CFE_ES_ValidateCDS(void);
 ******************************************************************************/
 int32 CFE_ES_ClearCDS(void);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Initializes the signatures of the CDS area
 **

--- a/modules/es/fsw/src/cfe_es_cds_mempool.c
+++ b/modules/es/fsw/src/cfe_es_cds_mempool.c
@@ -106,7 +106,7 @@ int32 CFE_ES_CDS_PoolCommit(CFE_ES_GenPoolRecord_t *GenPoolRecPtr, size_t Offset
  * Function: CFE_ES_CreateCDSPool
  *
  * Application-scope internal function
- * See description in cfe_es_cds_mempool.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_CreateCDSPool(size_t CDSPoolSize, size_t StartOffset)
@@ -141,7 +141,7 @@ int32 CFE_ES_CreateCDSPool(size_t CDSPoolSize, size_t StartOffset)
  * Function: CFE_ES_RebuildCDSPool
  *
  * Application-scope internal function
- * See description in cfe_es_cds_mempool.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_RebuildCDSPool(size_t CDSPoolSize, size_t StartOffset)
@@ -175,7 +175,7 @@ int32 CFE_ES_RebuildCDSPool(size_t CDSPoolSize, size_t StartOffset)
  * Function: CFE_ES_CDSBlockWrite
  *
  * Application-scope internal function
- * See description in cfe_es_cds_mempool.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_CDSBlockWrite(CFE_ES_CDSHandle_t Handle, const void *DataToWrite)
@@ -270,7 +270,7 @@ int32 CFE_ES_CDSBlockWrite(CFE_ES_CDSHandle_t Handle, const void *DataToWrite)
  * Function: CFE_ES_CDSBlockRead
  *
  * Application-scope internal function
- * See description in cfe_es_cds_mempool.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_CDSBlockRead(void *DataRead, CFE_ES_CDSHandle_t Handle)
@@ -354,7 +354,7 @@ int32 CFE_ES_CDSBlockRead(void *DataRead, CFE_ES_CDSHandle_t Handle)
  * Function: CFE_ES_CDSReqdMinSize
  *
  * Application-scope internal function
- * See description in cfe_es_cds_mempool.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 size_t CFE_ES_CDSReqdMinSize(uint32 MaxNumBlocksToSupport)

--- a/modules/es/fsw/src/cfe_es_cds_mempool.c
+++ b/modules/es/fsw/src/cfe_es_cds_mempool.c
@@ -63,11 +63,16 @@ const size_t CFE_ES_CDSMemPoolDefSize[CFE_ES_CDS_NUM_BLOCK_SIZES] = {
 ** Functions
 */
 
-/*
-** CFE_ES_CDS_PoolRetrieve will obtain a block descriptor from CDS storage.
-**
-** This is a bridge between the generic pool implementation and the CDS cache.
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_CDS_PoolRetrieve
+ *
+ * Internal helper routine only, not part of API.
+ *
+ * Obtains a block descriptor from CDS storage.
+ * This is a bridge between the generic pool implementation and the CDS cache.
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_CDS_PoolRetrieve(CFE_ES_GenPoolRecord_t *GenPoolRecPtr, size_t Offset, CFE_ES_GenPoolBD_t **BdPtr)
 {
     CFE_ES_CDS_Instance_t *CDS = (CFE_ES_CDS_Instance_t *)GenPoolRecPtr;
@@ -77,11 +82,16 @@ int32 CFE_ES_CDS_PoolRetrieve(CFE_ES_GenPoolRecord_t *GenPoolRecPtr, size_t Offs
     return CFE_ES_CDS_CacheFetch(&CDS->Cache, Offset, sizeof(CFE_ES_GenPoolBD_t));
 }
 
-/*
-** CFE_ES_CDS_PoolCommit will write a block descriptor to CDS storage.
-**
-** This is a bridge between the generic pool implementation and the CDS cache.
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_CDS_PoolCommit
+ *
+ * Internal helper routine only, not part of API.
+ *
+ * Writes a block descriptor to CDS storage.
+ * This is a bridge between the generic pool implementation and the CDS cache.
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_CDS_PoolCommit(CFE_ES_GenPoolRecord_t *GenPoolRecPtr, size_t Offset, const CFE_ES_GenPoolBD_t *BdPtr)
 {
     CFE_ES_CDS_Instance_t *CDS = (CFE_ES_CDS_Instance_t *)GenPoolRecPtr;
@@ -91,14 +101,14 @@ int32 CFE_ES_CDS_PoolCommit(CFE_ES_GenPoolRecord_t *GenPoolRecPtr, size_t Offset
     return CFE_ES_CDS_CacheFlush(&CDS->Cache);
 }
 
-/*
-** CFE_ES_CreateCDSPool will initialize a pre-allocated memory pool.
-**
-** NOTE:
-**  This function is only ever called during "Early Init" phase,
-**  where it is not possible to have contention writing into the syslog.
-**  Therefore the use of CFE_ES_SysLogWrite_Unsync() is acceptable
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_CreateCDSPool
+ *
+ * Application-scope internal function
+ * See description in cfe_es_cds_mempool.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_CreateCDSPool(size_t CDSPoolSize, size_t StartOffset)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
@@ -126,17 +136,14 @@ int32 CFE_ES_CreateCDSPool(size_t CDSPoolSize, size_t StartOffset)
     return Status;
 }
 
-/*
-** Function:
-**   CFE_ES_RebuildCDSPool
-**
-** Purpose:
-**
-** NOTE:
-**  This function is only ever called during "Early Init" phase,
-**  where it is not possible to have contention writing into the syslog.
-**  Therefore the use of CFE_ES_SysLogWrite_Unsync() is acceptable
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_RebuildCDSPool
+ *
+ * Application-scope internal function
+ * See description in cfe_es_cds_mempool.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_RebuildCDSPool(size_t CDSPoolSize, size_t StartOffset)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
@@ -163,13 +170,14 @@ int32 CFE_ES_RebuildCDSPool(size_t CDSPoolSize, size_t StartOffset)
     return Status;
 }
 
-/*
-** Function:
-**   CFE_ES_CDSBlockWrite
-**
-** Purpose:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_CDSBlockWrite
+ *
+ * Application-scope internal function
+ * See description in cfe_es_cds_mempool.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_CDSBlockWrite(CFE_ES_CDSHandle_t Handle, const void *DataToWrite)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
@@ -257,13 +265,14 @@ int32 CFE_ES_CDSBlockWrite(CFE_ES_CDSHandle_t Handle, const void *DataToWrite)
     return Status;
 }
 
-/*
-** Function:
-**   CFE_ES_CDSBlockRead
-**
-** Purpose:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_CDSBlockRead
+ *
+ * Application-scope internal function
+ * See description in cfe_es_cds_mempool.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_CDSBlockRead(void *DataRead, CFE_ES_CDSHandle_t Handle)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
@@ -340,13 +349,14 @@ int32 CFE_ES_CDSBlockRead(void *DataRead, CFE_ES_CDSHandle_t Handle)
     return Status;
 }
 
-/*
-** Function:
-**   CFE_ES_CDSReqdMinSize
-**
-** Purpose:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_CDSReqdMinSize
+ *
+ * Application-scope internal function
+ * See description in cfe_es_cds_mempool.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 size_t CFE_ES_CDSReqdMinSize(uint32 MaxNumBlocksToSupport)
 {
     size_t ReqSize;

--- a/modules/es/fsw/src/cfe_es_cds_mempool.h
+++ b/modules/es/fsw/src/cfe_es_cds_mempool.h
@@ -51,7 +51,7 @@
 ** Function prototypes
 */
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Creates a CDS memory pool from scratch
 **
@@ -60,19 +60,43 @@
 **        offset into the CDS memory.
 **
 ** \par Assumptions, External Events, and Notes:
-**          None
+**          This function must only be called during "Early Init" phase.
 **
 ** \return #CFE_SUCCESS                     \copydoc CFE_SUCCESS
 **
 ******************************************************************************/
 int32 CFE_ES_CreateCDSPool(size_t CDSPoolSize, size_t StartOffset);
 
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief Rebuilds an existing CDS memory pool from contents
+ *
+ * \par Description
+ *        Reconstructs pool data structures from an existing CDS
+ *
+ * \par Assumptions, External Events, and Notes:
+ *          This function is only ever called during "Early Init" phase.
+ *
+ * \return #CFE_SUCCESS                     \copydoc CFE_SUCCESS
+ */
 int32 CFE_ES_RebuildCDSPool(size_t CDSPoolSize, size_t StartOffset);
 
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Writes a block of data to CDS
+ */
 int32 CFE_ES_CDSBlockWrite(CFE_ES_CDSHandle_t Handle, const void *DataToWrite);
 
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Reads a block of data from CDS
+ */
 int32 CFE_ES_CDSBlockRead(void *DataRead, CFE_ES_CDSHandle_t Handle);
 
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Computes the minimum required size for a CDS pool
+ */
 size_t CFE_ES_CDSReqdMinSize(uint32 MaxNumBlocksToSupport);
 
 #endif /* CFE_ES_CDS_MEMPOOL_H */

--- a/modules/es/fsw/src/cfe_es_erlog.c
+++ b/modules/es/fsw/src/cfe_es_erlog.c
@@ -49,7 +49,7 @@
  * Function: CFE_ES_WriteToERLogWithContext
  *
  * Application-scope internal function
- * See description in cfe_es_log.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_WriteToERLogWithContext(CFE_ES_LogEntryType_Enum_t EntryType, uint32 ResetType, uint32 ResetSubtype,
@@ -152,7 +152,7 @@ int32 CFE_ES_WriteToERLogWithContext(CFE_ES_LogEntryType_Enum_t EntryType, uint3
  * Function: CFE_ES_WriteToERLog
  *
  * Application-scope internal function
- * See description in cfe_es_log.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_WriteToERLog(CFE_ES_LogEntryType_Enum_t EntryType, uint32 ResetType, uint32 ResetSubtype,
@@ -168,7 +168,7 @@ int32 CFE_ES_WriteToERLog(CFE_ES_LogEntryType_Enum_t EntryType, uint32 ResetType
  * Function: CFE_ES_BackgroundERLogFileDataGetter
  *
  * Application-scope internal function
- * See description in cfe_es_apps.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 bool CFE_ES_BackgroundERLogFileDataGetter(void *Meta, uint32 RecordNum, void **Buffer, size_t *BufSize)
@@ -235,7 +235,7 @@ bool CFE_ES_BackgroundERLogFileDataGetter(void *Meta, uint32 RecordNum, void **B
  * Function: CFE_ES_BackgroundERLogFileEventHandler
  *
  * Application-scope internal function
- * See description in cfe_es_apps.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_BackgroundERLogFileEventHandler(void *Meta, CFE_FS_FileWriteEvent_t Event, int32 Status, uint32 RecordNum,
@@ -282,7 +282,7 @@ void CFE_ES_BackgroundERLogFileEventHandler(void *Meta, CFE_FS_FileWriteEvent_t 
  * Function: CFE_ES_RunExceptionScan
  *
  * Application-scope internal function
- * See description in cfe_es_apps.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 bool CFE_ES_RunExceptionScan(uint32 ElapsedTime, void *Arg)

--- a/modules/es/fsw/src/cfe_es_erlog.c
+++ b/modules/es/fsw/src/cfe_es_erlog.c
@@ -44,17 +44,14 @@
 #include <stdio.h>
 #include <stdarg.h>
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*
-** Function: CFE_ES_WriteToERLogWithContext
-**
-** Purpose:  Create an entry in the ES Exception and Reset Log.
-**           This log API accepts extra context information (AppID and ContextID)
-**           and is used when the app/task invoking this API is not the same app
-**           as where the event occurred.
-**
-*/
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_WriteToERLogWithContext
+ *
+ * Application-scope internal function
+ * See description in cfe_es_log.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_WriteToERLogWithContext(CFE_ES_LogEntryType_Enum_t EntryType, uint32 ResetType, uint32 ResetSubtype,
                                      const char *Description, CFE_ES_AppId_t AppId, uint32 PspContextId)
 {
@@ -148,34 +145,32 @@ int32 CFE_ES_WriteToERLogWithContext(CFE_ES_LogEntryType_Enum_t EntryType, uint3
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
     return (CFE_SUCCESS);
+}
 
-} /* End of CFE_ES_WriteToERLogWithContext() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*
-** Function: CFE_ES_WriteToERLog
-**
-** Purpose:  Create an entry in the ES Exception and Reset Log.
-**           This log API is simplified for cases which do not have a separate context
-**
-*/
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_WriteToERLog
+ *
+ * Application-scope internal function
+ * See description in cfe_es_log.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_WriteToERLog(CFE_ES_LogEntryType_Enum_t EntryType, uint32 ResetType, uint32 ResetSubtype,
                           const char *Description)
 {
     /* passing 0xFFFFFFFF as the appid avoids confusion with actual appid 0 */
     return CFE_ES_WriteToERLogWithContext(EntryType, ResetType, ResetSubtype, Description, CFE_ES_APPID_UNDEFINED,
                                           CFE_ES_ERLOG_NO_CONTEXT);
+}
 
-} /* End of CFE_ES_WriteToERLog() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*  Function:  CFE_ES_BackgroundERLogFileDataGetter()                            */
-/*                                                                               */
-/*  Purpose:                                                                     */
-/*    Gets a single record from exception & reset log to write to a file.        */
-/*                                                                               */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_BackgroundERLogFileDataGetter
+ *
+ * Application-scope internal function
+ * See description in cfe_es_apps.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_ES_BackgroundERLogFileDataGetter(void *Meta, uint32 RecordNum, void **Buffer, size_t *BufSize)
 {
     CFE_ES_BackgroundLogDumpGlobal_t *BgFilePtr;
@@ -235,13 +230,14 @@ bool CFE_ES_BackgroundERLogFileDataGetter(void *Meta, uint32 RecordNum, void **B
     return (RecordNum >= (CFE_PLATFORM_ES_ER_LOG_ENTRIES - 1));
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*  Function:  CFE_ER_BackgroundERLogFileEventHandler()                          */
-/*                                                                               */
-/*  Purpose:                                                                     */
-/*    Report events during writing exception & reset log to a file.              */
-/*                                                                               */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_BackgroundERLogFileEventHandler
+ *
+ * Application-scope internal function
+ * See description in cfe_es_apps.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_BackgroundERLogFileEventHandler(void *Meta, CFE_FS_FileWriteEvent_t Event, int32 Status, uint32 RecordNum,
                                             size_t BlockSize, size_t Position)
 {
@@ -281,15 +277,14 @@ void CFE_ES_BackgroundERLogFileEventHandler(void *Meta, CFE_FS_FileWriteEvent_t 
     }
 }
 
-/*
-**---------------------------------------------------------------------------------------
-** Name: CFE_ES_RunExceptionScan
-**
-**   Purpose: This function pools the PSP to check if any exceptions have been logged
-**            since the last background cycle.  If an exception is present, retreive
-**            the details, add it to the ER log, and trigger the action (e.g. app restart).
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_RunExceptionScan
+ *
+ * Application-scope internal function
+ * See description in cfe_es_apps.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_ES_RunExceptionScan(uint32 ElapsedTime, void *Arg)
 {
     int32                      Status;
@@ -437,5 +432,3 @@ bool CFE_ES_RunExceptionScan(uint32 ElapsedTime, void *Arg)
 
     return true; /* returning true because there was an exception to deal with */
 }
-
-/* end of file */

--- a/modules/es/fsw/src/cfe_es_generic_pool.c
+++ b/modules/es/fsw/src/cfe_es_generic_pool.c
@@ -45,13 +45,15 @@
 ** Functions
 */
 
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_GenPoolFindBucket
-**
-**   Local Helper function to find the appropriate bucket given a requested block size
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GenPoolFindBucket
+ *
+ * Internal helper routine only, not part of API.
+ *
+ * Find the appropriate bucket given a requested block size
+ *
+ *-----------------------------------------------------------------*/
 uint16 CFE_ES_GenPoolFindBucket(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t ReqSize)
 {
     uint16 Index;
@@ -72,13 +74,15 @@ uint16 CFE_ES_GenPoolFindBucket(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t ReqSi
     return (PoolRecPtr->NumBuckets - Index);
 }
 
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_GenPoolGetBucketState
-**
-**   Local Helper function to obtain the structure associated with a given bucket ID.
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GenPoolGetBucketState
+ *
+ * Internal helper routine only, not part of API.
+ *
+ * Obtain a pointer to the state structure associated with a given bucket ID
+ *
+ *-----------------------------------------------------------------*/
 CFE_ES_GenPoolBucket_t *CFE_ES_GenPoolGetBucketState(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 BucketId)
 {
     uint16 Index;
@@ -92,13 +96,15 @@ CFE_ES_GenPoolBucket_t *CFE_ES_GenPoolGetBucketState(CFE_ES_GenPoolRecord_t *Poo
     return &PoolRecPtr->Buckets[Index];
 }
 
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_GenPoolRecyclePoolBlock
-**
-**   Local helper function to find and re-allocate a previously returned block
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GenPoolRecyclePoolBlock
+ *
+ * Internal helper routine only, not part of API.
+ *
+ * Find and re-allocate a previously returned block
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GenPoolRecyclePoolBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 BucketId, size_t NewSize,
                                      size_t *BlockOffsetPtr)
 {
@@ -152,13 +158,15 @@ int32 CFE_ES_GenPoolRecyclePoolBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 
     return Status;
 }
 
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_GenPoolCreatePoolBlock
-**
-**   Local helper function to create a new block of the given size
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GenPoolCreatePoolBlock
+ *
+ * Internal helper routine only, not part of API.
+ *
+ * Create a new block of the given size
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GenPoolCreatePoolBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 BucketId, size_t NewSize,
                                     size_t *BlockOffsetPtr)
 {
@@ -227,13 +235,14 @@ int32 CFE_ES_GenPoolCreatePoolBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 B
     return Status;
 }
 
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_GenPoolInitialize
-**
-**   ES Internal API - See Prototype for full API description
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GenPoolInitialize
+ *
+ * Application-scope internal function
+ * See description in cfe_es_generic_pool.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GenPoolInitialize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t StartOffset, size_t PoolSize,
                                size_t AlignSize, uint16 NumBlockSizes, const size_t *BlockSizeList,
                                CFE_ES_PoolRetrieve_Func_t RetrieveFunc, CFE_ES_PoolCommit_Func_t CommitFunc)
@@ -322,13 +331,14 @@ int32 CFE_ES_GenPoolInitialize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t StartO
     return CFE_SUCCESS;
 }
 
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_GenPoolCalcMinSize
-**
-**   ES Internal API - See Prototype for full API description
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GenPoolCalcMinSize
+ *
+ * Application-scope internal function
+ * See description in cfe_es_generic_pool.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 size_t CFE_ES_GenPoolCalcMinSize(uint16 NumBlockSizes, const size_t *BlockSizeList, uint32 NumBlocks)
 {
     uint16 BucketId;
@@ -353,13 +363,14 @@ size_t CFE_ES_GenPoolCalcMinSize(uint16 NumBlockSizes, const size_t *BlockSizeLi
     return (NumBlocks * MinBlockSize);
 }
 
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_GenPoolGetBlock
-**
-**   ES Internal API - See Prototype for full API description
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GenPoolGetBlock
+ *
+ * Application-scope internal function
+ * See description in cfe_es_generic_pool.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GenPoolGetBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockOffsetPtr, size_t ReqSize)
 {
     int32  Status;
@@ -385,13 +396,14 @@ int32 CFE_ES_GenPoolGetBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockOf
     return (Status);
 }
 
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_GenPoolGetBlockSize
-**
-**   ES Internal API - See Prototype for full API description
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GenPoolGetBlockSize
+ *
+ * Application-scope internal function
+ * See description in cfe_es_generic_pool.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GenPoolGetBlockSize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockSizePtr, size_t BlockOffset)
 {
     size_t                  DescOffset;
@@ -429,13 +441,14 @@ int32 CFE_ES_GenPoolGetBlockSize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *Blo
     return Status;
 }
 
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_GenPoolPutBlock
-**
-**   ES Internal API - See Prototype for full API description
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GenPoolPutBlock
+ *
+ * Application-scope internal function
+ * See description in cfe_es_generic_pool.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GenPoolPutBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockSizePtr, size_t BlockOffset)
 {
     size_t                  DescOffset;
@@ -483,13 +496,14 @@ int32 CFE_ES_GenPoolPutBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockSi
     return Status;
 }
 
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_GenPoolRebuild
-**
-**   ES Internal API - See Prototype for full API description
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GenPoolRebuild
+ *
+ * Application-scope internal function
+ * See description in cfe_es_generic_pool.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GenPoolRebuild(CFE_ES_GenPoolRecord_t *PoolRecPtr)
 {
     int32                   Status;
@@ -594,26 +608,28 @@ int32 CFE_ES_GenPoolRebuild(CFE_ES_GenPoolRecord_t *PoolRecPtr)
     return Status;
 }
 
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_GenPoolValidateState
-**
-**   ES Internal API - See Prototype for full API description
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GenPoolValidateState
+ *
+ * Application-scope internal function
+ * See description in cfe_es_generic_pool.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_ES_GenPoolValidateState(const CFE_ES_GenPoolRecord_t *PoolRecPtr)
 {
     return (PoolRecPtr->PoolTotalSize > 0 && PoolRecPtr->TailPosition <= PoolRecPtr->PoolMaxOffset &&
             PoolRecPtr->NumBuckets > 0 && PoolRecPtr->NumBuckets <= CFE_PLATFORM_ES_POOL_MAX_BUCKETS);
 }
 
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_GenPoolGetUsage
-**
-**   ES Internal API - See Prototype for full API description
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GenPoolGetUsage
+ *
+ * Application-scope internal function
+ * See description in cfe_es_generic_pool.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_GenPoolGetUsage(CFE_ES_GenPoolRecord_t *PoolRecPtr, CFE_ES_MemOffset_t *FreeSizeBuf,
                             CFE_ES_MemOffset_t *TotalSizeBuf)
 {
@@ -627,13 +643,14 @@ void CFE_ES_GenPoolGetUsage(CFE_ES_GenPoolRecord_t *PoolRecPtr, CFE_ES_MemOffset
     }
 }
 
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_GenPoolGetCounts
-**
-**   ES Internal API - See Prototype for full API description
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GenPoolGetCounts
+ *
+ * Application-scope internal function
+ * See description in cfe_es_generic_pool.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_GenPoolGetCounts(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 *NumBucketsBuf, uint32 *AllocCountBuf,
                              uint32 *ValidationErrorCountBuf)
 {
@@ -651,13 +668,14 @@ void CFE_ES_GenPoolGetCounts(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 *NumBuck
     }
 }
 
-/*
-**---------------------------------------------------------------------------------------
-**   Name: CFE_ES_GenPoolGetFreeSize
-**
-**   ES Internal API - See Prototype for full API description
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GenPoolGetBucketUsage
+ *
+ * Application-scope internal function
+ * See description in cfe_es_generic_pool.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_GenPoolGetBucketUsage(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 BucketId,
                                   CFE_ES_BlockStats_t *BlockStatsBuf)
 {

--- a/modules/es/fsw/src/cfe_es_generic_pool.c
+++ b/modules/es/fsw/src/cfe_es_generic_pool.c
@@ -240,7 +240,7 @@ int32 CFE_ES_GenPoolCreatePoolBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 B
  * Function: CFE_ES_GenPoolInitialize
  *
  * Application-scope internal function
- * See description in cfe_es_generic_pool.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GenPoolInitialize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t StartOffset, size_t PoolSize,
@@ -336,7 +336,7 @@ int32 CFE_ES_GenPoolInitialize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t StartO
  * Function: CFE_ES_GenPoolCalcMinSize
  *
  * Application-scope internal function
- * See description in cfe_es_generic_pool.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 size_t CFE_ES_GenPoolCalcMinSize(uint16 NumBlockSizes, const size_t *BlockSizeList, uint32 NumBlocks)
@@ -368,7 +368,7 @@ size_t CFE_ES_GenPoolCalcMinSize(uint16 NumBlockSizes, const size_t *BlockSizeLi
  * Function: CFE_ES_GenPoolGetBlock
  *
  * Application-scope internal function
- * See description in cfe_es_generic_pool.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GenPoolGetBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockOffsetPtr, size_t ReqSize)
@@ -401,7 +401,7 @@ int32 CFE_ES_GenPoolGetBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockOf
  * Function: CFE_ES_GenPoolGetBlockSize
  *
  * Application-scope internal function
- * See description in cfe_es_generic_pool.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GenPoolGetBlockSize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockSizePtr, size_t BlockOffset)
@@ -446,7 +446,7 @@ int32 CFE_ES_GenPoolGetBlockSize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *Blo
  * Function: CFE_ES_GenPoolPutBlock
  *
  * Application-scope internal function
- * See description in cfe_es_generic_pool.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GenPoolPutBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockSizePtr, size_t BlockOffset)
@@ -501,7 +501,7 @@ int32 CFE_ES_GenPoolPutBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockSi
  * Function: CFE_ES_GenPoolRebuild
  *
  * Application-scope internal function
- * See description in cfe_es_generic_pool.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GenPoolRebuild(CFE_ES_GenPoolRecord_t *PoolRecPtr)
@@ -613,7 +613,7 @@ int32 CFE_ES_GenPoolRebuild(CFE_ES_GenPoolRecord_t *PoolRecPtr)
  * Function: CFE_ES_GenPoolValidateState
  *
  * Application-scope internal function
- * See description in cfe_es_generic_pool.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 bool CFE_ES_GenPoolValidateState(const CFE_ES_GenPoolRecord_t *PoolRecPtr)
@@ -627,7 +627,7 @@ bool CFE_ES_GenPoolValidateState(const CFE_ES_GenPoolRecord_t *PoolRecPtr)
  * Function: CFE_ES_GenPoolGetUsage
  *
  * Application-scope internal function
- * See description in cfe_es_generic_pool.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_GenPoolGetUsage(CFE_ES_GenPoolRecord_t *PoolRecPtr, CFE_ES_MemOffset_t *FreeSizeBuf,
@@ -648,7 +648,7 @@ void CFE_ES_GenPoolGetUsage(CFE_ES_GenPoolRecord_t *PoolRecPtr, CFE_ES_MemOffset
  * Function: CFE_ES_GenPoolGetCounts
  *
  * Application-scope internal function
- * See description in cfe_es_generic_pool.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_GenPoolGetCounts(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 *NumBucketsBuf, uint32 *AllocCountBuf,
@@ -673,7 +673,7 @@ void CFE_ES_GenPoolGetCounts(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 *NumBuck
  * Function: CFE_ES_GenPoolGetBucketUsage
  *
  * Application-scope internal function
- * See description in cfe_es_generic_pool.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_GenPoolGetBucketUsage(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 BucketId,

--- a/modules/es/fsw/src/cfe_es_generic_pool.h
+++ b/modules/es/fsw/src/cfe_es_generic_pool.h
@@ -123,6 +123,7 @@ struct CFE_ES_GenPoolRecord
 ** Function prototypes
 */
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Initialize a generic pool structure
  *
@@ -144,6 +145,7 @@ int32 CFE_ES_GenPoolInitialize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t StartO
                                size_t AlignSize, uint16 NumBlockSizes, const size_t *BlockSizeList,
                                CFE_ES_PoolRetrieve_Func_t RetrieveFunc, CFE_ES_PoolCommit_Func_t CommitFunc);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Gets a block from the pool
  *
@@ -158,6 +160,7 @@ int32 CFE_ES_GenPoolInitialize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t StartO
  */
 int32 CFE_ES_GenPoolGetBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockOffsetPtr, size_t ReqSize);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Returns a block to the pool
  *
@@ -172,6 +175,7 @@ int32 CFE_ES_GenPoolGetBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockOf
  */
 int32 CFE_ES_GenPoolPutBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockSizePtr, size_t BlockOffset);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Rebuild list of free blocks in pool
  *
@@ -192,6 +196,7 @@ int32 CFE_ES_GenPoolPutBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockSi
  */
 int32 CFE_ES_GenPoolRebuild(CFE_ES_GenPoolRecord_t *PoolRecPtr);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Get size of pool block
  *
@@ -206,6 +211,7 @@ int32 CFE_ES_GenPoolRebuild(CFE_ES_GenPoolRecord_t *PoolRecPtr);
  */
 int32 CFE_ES_GenPoolGetBlockSize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockSizePtr, size_t BlockOffset);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Validate a pool structure
  *
@@ -217,6 +223,7 @@ int32 CFE_ES_GenPoolGetBlockSize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *Blo
  */
 bool CFE_ES_GenPoolValidateState(const CFE_ES_GenPoolRecord_t *PoolRecPtr);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Query basic usage of the pool structure
  *
@@ -234,6 +241,7 @@ bool CFE_ES_GenPoolValidateState(const CFE_ES_GenPoolRecord_t *PoolRecPtr);
 void CFE_ES_GenPoolGetUsage(CFE_ES_GenPoolRecord_t *PoolRecPtr, CFE_ES_MemOffset_t *FreeSizeBuf,
                             CFE_ES_MemOffset_t *TotalSizeBuf);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Query counters associated with the pool structure
  *
@@ -247,6 +255,7 @@ void CFE_ES_GenPoolGetUsage(CFE_ES_GenPoolRecord_t *PoolRecPtr, CFE_ES_MemOffset
 void CFE_ES_GenPoolGetCounts(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 *NumBucketsBuf, uint32 *AllocCountBuf,
                              uint32 *ValidationErrorCountBuf);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Query bucket-specific usage of the pool structure
  *
@@ -261,6 +270,7 @@ void CFE_ES_GenPoolGetCounts(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 *NumBuck
 void CFE_ES_GenPoolGetBucketUsage(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 BucketId,
                                   CFE_ES_BlockStats_t *BlockStatsBuf);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Calculate the pool size required for the specified number of blocks
  *

--- a/modules/es/fsw/src/cfe_es_global.h
+++ b/modules/es/fsw/src/cfe_es_global.h
@@ -230,10 +230,28 @@ typedef struct
 */
 extern CFE_ES_Global_t CFE_ES_Global;
 
-/*
-** Functions used to lock/unlock shared data
-*/
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Obtain exclusive access to the ES global data structures
+ *
+ * ES internal function to take the Shared Data Mutex and handle
+ * error conditions.
+ *
+ * @param FunctionName   the name of the function/caller
+ * @param LineNumber     the line number of the caller
+ */
 extern void CFE_ES_LockSharedData(const char *FunctionName, int32 LineNumber);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Release exclusive access to the ES global data structures
+ *
+ * ES internal function to Release the shared data mutex and handle error
+ * conditions.
+ *
+ * @param FunctionName   the name of the function/caller
+ * @param LineNumber     the line number of the caller
+ */
 extern void CFE_ES_UnlockSharedData(const char *FunctionName, int32 LineNumber);
 
 #endif /* CFE_ES_GLOBAL_H */

--- a/modules/es/fsw/src/cfe_es_log.h
+++ b/modules/es/fsw/src/cfe_es_log.h
@@ -126,6 +126,7 @@ typedef struct
 ** NOTE: CFE_ES_WriteToSysLog() is a public routine in cfe_es.h, it is not prototyped here
 */
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Clear system log
  *
@@ -135,6 +136,7 @@ typedef struct
  */
 void CFE_ES_SysLogClear_Unsync(void);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Begin reading the system log
  *
@@ -156,6 +158,7 @@ void CFE_ES_SysLogClear_Unsync(void);
  */
 void CFE_ES_SysLogReadStart_Unsync(CFE_ES_SysLogReadBuffer_t *Buffer);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Write a printf-style formatted string to the system log
  *
@@ -168,6 +171,7 @@ void CFE_ES_SysLogReadStart_Unsync(CFE_ES_SysLogReadBuffer_t *Buffer);
  */
 int32 CFE_ES_SysLogWrite_Unsync(const char *SpecStringPtr, ...);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Append a complete pre-formatted string to the ES SysLog
  *
@@ -188,6 +192,7 @@ int32 CFE_ES_SysLogWrite_Unsync(const char *SpecStringPtr, ...);
  */
 int32 CFE_ES_SysLogAppend_Unsync(const char *LogString);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Read data from the system log buffer into the local buffer
  *
@@ -213,6 +218,7 @@ int32 CFE_ES_SysLogAppend_Unsync(const char *LogString);
  */
 void CFE_ES_SysLogReadData(CFE_ES_SysLogReadBuffer_t *Buffer);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Sets the operating mode of the system log buffer
  *
@@ -233,6 +239,7 @@ void CFE_ES_SysLogReadData(CFE_ES_SysLogReadBuffer_t *Buffer);
  */
 int32 CFE_ES_SysLogSetMode(CFE_ES_LogMode_Enum_t Mode);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Format a message intended for output to the system log
  *
@@ -256,6 +263,7 @@ int32 CFE_ES_SysLogSetMode(CFE_ES_LogMode_Enum_t Mode);
  */
 void CFE_ES_SysLog_vsnprintf(char *Buffer, size_t BufferSize, const char *SpecStringPtr, va_list ArgPtr);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Format a message intended for output to the system log
  *
@@ -272,6 +280,7 @@ void CFE_ES_SysLog_vsnprintf(char *Buffer, size_t BufferSize, const char *SpecSt
  */
 void CFE_ES_SysLog_snprintf(char *Buffer, size_t BufferSize, const char *SpecStringPtr, ...) OS_PRINTF(3, 4);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Write the contents of the syslog to a disk file
  *
@@ -300,15 +309,10 @@ void CFE_ES_SysLog_snprintf(char *Buffer, size_t BufferSize, const char *SpecStr
 int32 CFE_ES_SysLogDump(const char *Filename);
 
 /*
-** Processor Performance log management
-*/
-int32 CFE_ES_PerfLogClear(void);
-void  CFE_ES_PerfLogDump(void);
-
-/*
 ** Exception and Reset Log API
 */
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Create an entry in the ES Exception and Reset Log.
  *
@@ -325,6 +329,7 @@ void  CFE_ES_PerfLogDump(void);
 int32 CFE_ES_WriteToERLog(CFE_ES_LogEntryType_Enum_t EntryType, uint32 ResetType, uint32 ResetSubtype,
                           const char *Description);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \copydoc CFE_ES_WriteToERLog()
  *

--- a/modules/es/fsw/src/cfe_es_mempool.c
+++ b/modules/es/fsw/src/cfe_es_mempool.c
@@ -108,7 +108,7 @@ int32 CFE_ES_MemPoolDirectCommit(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offs
  * Function: CFE_ES_MemPoolID_ToIndex
  *
  * Application-scope internal function
- * See description in cfe_es_mempool.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_MemPoolID_ToIndex(CFE_ES_MemHandle_t PoolID, uint32 *Idx)
@@ -122,7 +122,7 @@ int32 CFE_ES_MemPoolID_ToIndex(CFE_ES_MemHandle_t PoolID, uint32 *Idx)
  * Function: CFE_ES_CheckMemPoolSlotUsed
  *
  * Application-scope internal function
- * See description in cfe_es_mempool.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 bool CFE_ES_CheckMemPoolSlotUsed(CFE_ResourceId_t CheckId)
@@ -142,7 +142,7 @@ bool CFE_ES_CheckMemPoolSlotUsed(CFE_ResourceId_t CheckId)
  * Function: CFE_ES_LocateMemPoolRecordByID
  *
  * Application-scope internal function
- * See description in cfe_es_mempool.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_ES_MemPoolRecord_t *CFE_ES_LocateMemPoolRecordByID(CFE_ES_MemHandle_t PoolID)
@@ -167,7 +167,7 @@ CFE_ES_MemPoolRecord_t *CFE_ES_LocateMemPoolRecordByID(CFE_ES_MemHandle_t PoolID
  * Function: CFE_ES_PoolCreateNoSem
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_PoolCreateNoSem(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t Size)
@@ -181,7 +181,7 @@ int32 CFE_ES_PoolCreateNoSem(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t Si
  * Function: CFE_ES_PoolCreate
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_PoolCreate(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t Size)
@@ -195,7 +195,7 @@ int32 CFE_ES_PoolCreate(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t Size)
  * Function: CFE_ES_PoolCreateEx
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t Size, uint16 NumBlockSizes,
@@ -369,7 +369,7 @@ int32 CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t Size,
  * Function: CFE_ES_PoolDelete
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_PoolDelete(CFE_ES_MemHandle_t PoolID)
@@ -424,7 +424,7 @@ int32 CFE_ES_PoolDelete(CFE_ES_MemHandle_t PoolID)
  * Function: CFE_ES_GetPoolBuf
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GetPoolBuf(CFE_ES_MemPoolBuf_t *BufPtr, CFE_ES_MemHandle_t Handle, size_t Size)
@@ -493,7 +493,7 @@ int32 CFE_ES_GetPoolBuf(CFE_ES_MemPoolBuf_t *BufPtr, CFE_ES_MemHandle_t Handle, 
  * Function: CFE_ES_GetPoolBufInfo
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GetPoolBufInfo(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_t BufPtr)
@@ -555,7 +555,7 @@ int32 CFE_ES_GetPoolBufInfo(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_t BufPt
  * Function: CFE_ES_PutPoolBuf
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_PutPoolBuf(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_t BufPtr)
@@ -638,7 +638,7 @@ int32 CFE_ES_PutPoolBuf(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_t BufPtr)
  * Function: CFE_ES_GetMemPoolStats
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_GetMemPoolStats(CFE_ES_MemPoolStats_t *BufPtr, CFE_ES_MemHandle_t Handle)
@@ -710,7 +710,7 @@ int32 CFE_ES_GetMemPoolStats(CFE_ES_MemPoolStats_t *BufPtr, CFE_ES_MemHandle_t H
  * Function: CFE_ES_ValidateHandle
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 bool CFE_ES_ValidateHandle(CFE_ES_MemHandle_t Handle)

--- a/modules/es/fsw/src/cfe_es_mempool.c
+++ b/modules/es/fsw/src/cfe_es_mempool.c
@@ -73,6 +73,13 @@ const size_t CFE_ES_MemPoolDefSize[CFE_PLATFORM_ES_POOL_MAX_BUCKETS] = {
 ** Functions
 */
 
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_MemPoolDirectRetrieve
+ *
+ * Internal helper routine only, not part of API.
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_MemPoolDirectRetrieve(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset, CFE_ES_GenPoolBD_t **BdPtr)
 {
     cpuaddr                 DataAddress;
@@ -84,24 +91,40 @@ int32 CFE_ES_MemPoolDirectRetrieve(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Of
     return CFE_SUCCESS;
 }
 
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_MemPoolDirectCommit
+ *
+ * Internal helper routine only, not part of API.
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_MemPoolDirectCommit(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset, const CFE_ES_GenPoolBD_t *BdPtr)
 {
     return CFE_SUCCESS;
 }
 
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_MemPoolID_ToIndex
+ *
+ * Application-scope internal function
+ * See description in cfe_es_mempool.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_MemPoolID_ToIndex(CFE_ES_MemHandle_t PoolID, uint32 *Idx)
 {
     return CFE_ResourceId_ToIndex(CFE_RESOURCEID_UNWRAP(PoolID), CFE_ES_POOLID_BASE, CFE_PLATFORM_ES_MAX_MEMORY_POOLS,
                                   Idx);
 }
 
-/*---------------------------------------------------------------------------------------
+/*----------------------------------------------------------------
+ *
  * Function: CFE_ES_CheckMemPoolSlotUsed
  *
- * Purpose: Helper function, Aids in allocating a new ID by checking if
- * a given table slot is available.  Must be called while locked.
- *---------------------------------------------------------------------------------------
- */
+ * Application-scope internal function
+ * See description in cfe_es_mempool.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_ES_CheckMemPoolSlotUsed(CFE_ResourceId_t CheckId)
 {
     CFE_ES_MemPoolRecord_t *MemPoolRecPtr;
@@ -114,6 +137,14 @@ bool CFE_ES_CheckMemPoolSlotUsed(CFE_ResourceId_t CheckId)
     return (MemPoolRecPtr == NULL || CFE_ES_MemPoolRecordIsUsed(MemPoolRecPtr));
 }
 
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_LocateMemPoolRecordByID
+ *
+ * Application-scope internal function
+ * See description in cfe_es_mempool.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_ES_MemPoolRecord_t *CFE_ES_LocateMemPoolRecordByID(CFE_ES_MemHandle_t PoolID)
 {
     CFE_ES_MemPoolRecord_t *MemPoolRecPtr;
@@ -131,24 +162,42 @@ CFE_ES_MemPoolRecord_t *CFE_ES_LocateMemPoolRecordByID(CFE_ES_MemHandle_t PoolID
     return MemPoolRecPtr;
 }
 
-/*
-** CFE_ES_PoolCreateNoSem will initialize a pre-allocated memory pool without using a mutex.
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_PoolCreateNoSem
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_PoolCreateNoSem(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t Size)
 {
     return CFE_ES_PoolCreateEx(PoolID, MemPtr, Size, CFE_PLATFORM_ES_POOL_MAX_BUCKETS, &CFE_ES_MemPoolDefSize[0],
                                CFE_ES_NO_MUTEX);
 }
 
-/*
-** CFE_ES_PoolCreate will initialize a pre-allocated memory pool while using a mutex.
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_PoolCreate
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_PoolCreate(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t Size)
 {
     return CFE_ES_PoolCreateEx(PoolID, MemPtr, Size, CFE_PLATFORM_ES_POOL_MAX_BUCKETS, &CFE_ES_MemPoolDefSize[0],
                                CFE_ES_USE_MUTEX);
 }
 
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_PoolCreateEx
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t Size, uint16 NumBlockSizes,
                           const size_t *BlockSizes, bool UseMutex)
 {
@@ -315,6 +364,14 @@ int32 CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t Size,
     return (Status);
 }
 
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_PoolDelete
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_PoolDelete(CFE_ES_MemHandle_t PoolID)
 {
     CFE_ES_MemPoolRecord_t *PoolRecPtr;
@@ -362,13 +419,14 @@ int32 CFE_ES_PoolDelete(CFE_ES_MemHandle_t PoolID)
     return Status;
 }
 
-/*
-** Function:
-**   CFE_ES_GetPoolBuf
-**
-** Purpose:
-**   CFE_ES_GetPoolBuf allocates a block from the memory pool.
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GetPoolBuf
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GetPoolBuf(CFE_ES_MemPoolBuf_t *BufPtr, CFE_ES_MemHandle_t Handle, size_t Size)
 {
     int32                   Status;
@@ -430,9 +488,14 @@ int32 CFE_ES_GetPoolBuf(CFE_ES_MemPoolBuf_t *BufPtr, CFE_ES_MemHandle_t Handle, 
     return (int32)Size;
 }
 
-/*
-** CFE_ES_GetPoolBufInfo gets the size of the specified block (if it exists).
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GetPoolBufInfo
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GetPoolBufInfo(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_t BufPtr)
 {
     int32                   Status;
@@ -487,9 +550,14 @@ int32 CFE_ES_GetPoolBufInfo(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_t BufPt
     return Status;
 }
 
-/*
-** CFE_ES_putPoolBuf returns a block back to the memory pool.
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_PutPoolBuf
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_PutPoolBuf(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_t BufPtr)
 {
     CFE_ES_MemPoolRecord_t *PoolRecPtr;
@@ -565,13 +633,14 @@ int32 CFE_ES_PutPoolBuf(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_t BufPtr)
     return Status;
 }
 
-/*
-** Function:
-**   CFE_ES_GetMemPoolStats
-**
-** Purpose:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GetMemPoolStats
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GetMemPoolStats(CFE_ES_MemPoolStats_t *BufPtr, CFE_ES_MemHandle_t Handle)
 {
     CFE_ES_AppId_t          AppId;
@@ -636,13 +705,14 @@ int32 CFE_ES_GetMemPoolStats(CFE_ES_MemPoolStats_t *BufPtr, CFE_ES_MemHandle_t H
     return CFE_SUCCESS;
 }
 
-/*
-** Function:
-**   CFE_ES_ValidateHandle
-**
-** Purpose:
-**   Insures that the handle passed in meets all of the requirements of a valid handle.
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_ValidateHandle
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_ES_ValidateHandle(CFE_ES_MemHandle_t Handle)
 {
     CFE_ES_MemPoolRecord_t *PoolRecPtr;

--- a/modules/es/fsw/src/cfe_es_mempool.h
+++ b/modules/es/fsw/src/cfe_es_mempool.h
@@ -73,6 +73,7 @@ typedef struct
     osal_id_t MutexId;
 } CFE_ES_MemPoolRecord_t;
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Obtain an index value correlating to an ES Memory Pool ID
  *
@@ -97,6 +98,7 @@ typedef struct
  */
 int32 CFE_ES_MemPoolID_ToIndex(CFE_ES_MemHandle_t PoolID, uint32 *Idx);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Locate the Pool table entry correlating with a given Pool ID.
  *
@@ -124,6 +126,7 @@ int32 CFE_ES_MemPoolID_ToIndex(CFE_ES_MemHandle_t PoolID, uint32 *Idx);
  */
 CFE_ES_MemPoolRecord_t *CFE_ES_LocateMemPoolRecordByID(CFE_ES_MemHandle_t PoolID);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Check if a Memory Pool record is in use or free/empty
  *
@@ -143,6 +146,7 @@ static inline bool CFE_ES_MemPoolRecordIsUsed(const CFE_ES_MemPoolRecord_t *Pool
     return CFE_RESOURCEID_TEST_DEFINED(PoolRecPtr->PoolID);
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Get the ID value from a Memory Pool table entry
  *
@@ -159,6 +163,7 @@ static inline CFE_ES_MemHandle_t CFE_ES_MemPoolRecordGetID(const CFE_ES_MemPoolR
     return (PoolRecPtr->PoolID);
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Marks a Memory Pool table entry as used (not free)
  *
@@ -176,6 +181,7 @@ static inline void CFE_ES_MemPoolRecordSetUsed(CFE_ES_MemPoolRecord_t *PoolRecPt
     PoolRecPtr->PoolID = CFE_ES_MEMHANDLE_C(PendingId);
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Set a Memory Pool record table entry free (not used)
  *
@@ -192,6 +198,7 @@ static inline void CFE_ES_MemPoolRecordSetFree(CFE_ES_MemPoolRecord_t *PoolRecPt
     PoolRecPtr->PoolID = CFE_ES_MEMHANDLE_UNDEFINED;
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Check if an Mem Pool record is a match for the given Pool ID
  *
@@ -220,6 +227,7 @@ static inline bool CFE_ES_MemPoolRecordIsMatch(const CFE_ES_MemPoolRecord_t *Poo
     return (PoolRecPtr != NULL && CFE_RESOURCEID_TEST_EQUAL(PoolRecPtr->PoolID, PoolID));
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Check if a Pool ID table slot is used
  *

--- a/modules/es/fsw/src/cfe_es_perf.c
+++ b/modules/es/fsw/src/cfe_es_perf.c
@@ -33,16 +33,14 @@
 
 #include <string.h>
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/* Name: CFE_ES_SetupPerfVariables                                               */
-/*                                                                               */
-/* Purpose:This function initializes filter mask,trigger mask, data & state vals */
-/*                                                                               */
-/* Assumptions and Notes: This gets called from CFE_ES_Main() at startup         */
-/* This code must be called before any other task or code that would use         */
-/* CFE_ES_PerfLogEntry() / CFE_ES_PerfLogExit() functions                        */
-/*                                                                               */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_SetupPerfVariables
+ *
+ * Application-scope internal function
+ * See description in cfe_es_start.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_SetupPerfVariables(uint32 ResetType)
 {
     /* Create a constant union -
@@ -97,13 +95,14 @@ void CFE_ES_SetupPerfVariables(uint32 ResetType)
     }
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                               */
-/* CFE_ES_GetPerfLogDumpRemaining() --                                           */
-/* Estimate the number of perf log entries left to write                         */
-/* This is used for telemetry/progress reporting for the perf log dump request   */
-/*                                                                               */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GetPerfLogDumpRemaining
+ *
+ * Application-scope internal function
+ * See description in cfe_es_perf.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 uint32 CFE_ES_GetPerfLogDumpRemaining(void)
 {
     CFE_ES_PerfDumpGlobal_t *PerfDumpState = &CFE_ES_Global.BackgroundPerfDumpState;
@@ -141,11 +140,14 @@ uint32 CFE_ES_GetPerfLogDumpRemaining(void)
     return Result;
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                               */
-/* CFE_ES_StartPerfDataCmd() --                                                  */
-/*                                                                               */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_StartPerfDataCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfDataCmd_t *data)
 {
     const CFE_ES_StartPerfCmd_Payload_t *CmdPtr        = &data->Payload;
@@ -200,13 +202,16 @@ int32 CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfDataCmd_t *data)
     } /* end if */
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_StartPerfDataCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                               */
-/* CFE_ES_StopPerfDataCmd() --                                                   */
-/*                                                                               */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_StopPerfDataCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_StopPerfDataCmd(const CFE_ES_StopPerfDataCmd_t *data)
 {
     const CFE_ES_StopPerfCmd_Payload_t *CmdPtr        = &data->Payload;
@@ -263,21 +268,16 @@ int32 CFE_ES_StopPerfDataCmd(const CFE_ES_StopPerfDataCmd_t *data)
     } /* end if */
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_StopPerfDataCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*  Function:  CFE_ES_RunPerfLogDump()                                           */
-/*                                                                               */
-/*  Purpose:                                                                     */
-/*    Write performance data to a file                                           */
-/*    This is implemented as a state machine that is invoked in the background   */
-/*    Each iteration should perform a limited amount of work, which will resume  */
-/*    on the next iteration.  State is kept in a global structure.               */
-/*                                                                               */
-/*  Arguments:                                                                   */
-/*    None                                                                       */
-/*                                                                               */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_RunPerfLogDump
+ *
+ * Application-scope internal function
+ * See description in cfe_es_perf.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_ES_RunPerfLogDump(uint32 ElapsedTime, void *Arg)
 {
     CFE_ES_PerfDumpGlobal_t *State = (CFE_ES_PerfDumpGlobal_t *)Arg;
@@ -494,13 +494,16 @@ bool CFE_ES_RunPerfLogDump(uint32 ElapsedTime, void *Arg)
      * Return "true" if activity is ongoing, or "false" if not active
      */
     return (State->CurrentState != CFE_ES_PerfDumpState_IDLE);
-} /* end CFE_ES_PerfLogDump */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                               */
-/* CFE_ES_SetPerfFilterMaskCmd() --                                              */
-/*                                                                               */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_SetPerfFilterMaskCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMaskCmd_t *data)
 {
     const CFE_ES_SetPerfFilterMaskCmd_Payload_t *cmd = &data->Payload;
@@ -532,13 +535,16 @@ int32 CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMaskCmd_t *data)
     }
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_SetPerfFilterMaskCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                               */
-/* CFE_ES_SetPerfTriggerMaskCmd() --                                             */
-/*                                                                               */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_SetPerfTriggerMaskCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_SetPerfTriggerMaskCmd(const CFE_ES_SetPerfTriggerMaskCmd_t *data)
 {
     const CFE_ES_SetPerfTrigMaskCmd_Payload_t *cmd = &data->Payload;
@@ -570,31 +576,16 @@ int32 CFE_ES_SetPerfTriggerMaskCmd(const CFE_ES_SetPerfTriggerMaskCmd_t *data)
     }
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_SetPerfTriggerMaskCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/* Name: CFE_ES_PerfLogAdd                                                       */
-/*                                                                               */
-/* Purpose: This function adds a new entry to the data buffer.                   */
-/*                                                                               */
-/* Assumptions and Notes:                                                        */
-/*                                                                               */
-/*  This function implements a circular buffer using an array.                   */
-/*      DataStart points to first stored entry                                   */
-/*      DataEnd points to next available entry                                   */
-/*      if DataStart == DataEnd then the buffer is either empty or full          */
-/*      depending on the value of the DataCount                                  */
-/*                                                                               */
-/*  Time is stored as 2 32 bit integers, (TimerLower32, TimerUpper32):           */
-/*      TimerLower32 is the curent value of the hardware timer register.         */
-/*      TimerUpper32 is the number of times the timer has rolled over.           */
-/*                                                                               */
-/*  Time is stored as a absolute time instead of a relative time between log     */
-/*  entries. This will yield better accuracy since storing relative time between */
-/*  entries will accumulate (rounding/sampling) errors over time.  It also is    */
-/*  faster since the time does not need to be calculated.                        */
-/*                                                                               */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_PerfLogAdd
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_PerfLogAdd(uint32 Marker, uint32 EntryExit)
 {
     CFE_ES_PerfDataEntry_t EntryData;
@@ -720,5 +711,4 @@ void CFE_ES_PerfLogAdd(uint32 Marker, uint32 EntryExit)
     }
 
     OS_MutSemGive(CFE_ES_Global.PerfDataMutex);
-
-} /* end CFE_ES_PerfLogAdd */
+}

--- a/modules/es/fsw/src/cfe_es_perf.c
+++ b/modules/es/fsw/src/cfe_es_perf.c
@@ -38,7 +38,7 @@
  * Function: CFE_ES_SetupPerfVariables
  *
  * Application-scope internal function
- * See description in cfe_es_start.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_SetupPerfVariables(uint32 ResetType)
@@ -100,7 +100,7 @@ void CFE_ES_SetupPerfVariables(uint32 ResetType)
  * Function: CFE_ES_GetPerfLogDumpRemaining
  *
  * Application-scope internal function
- * See description in cfe_es_perf.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 uint32 CFE_ES_GetPerfLogDumpRemaining(void)
@@ -145,7 +145,7 @@ uint32 CFE_ES_GetPerfLogDumpRemaining(void)
  * Function: CFE_ES_StartPerfDataCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfDataCmd_t *data)
@@ -209,7 +209,7 @@ int32 CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfDataCmd_t *data)
  * Function: CFE_ES_StopPerfDataCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_StopPerfDataCmd(const CFE_ES_StopPerfDataCmd_t *data)
@@ -275,7 +275,7 @@ int32 CFE_ES_StopPerfDataCmd(const CFE_ES_StopPerfDataCmd_t *data)
  * Function: CFE_ES_RunPerfLogDump
  *
  * Application-scope internal function
- * See description in cfe_es_perf.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 bool CFE_ES_RunPerfLogDump(uint32 ElapsedTime, void *Arg)
@@ -501,7 +501,7 @@ bool CFE_ES_RunPerfLogDump(uint32 ElapsedTime, void *Arg)
  * Function: CFE_ES_SetPerfFilterMaskCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMaskCmd_t *data)
@@ -542,7 +542,7 @@ int32 CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMaskCmd_t *data)
  * Function: CFE_ES_SetPerfTriggerMaskCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_SetPerfTriggerMaskCmd(const CFE_ES_SetPerfTriggerMaskCmd_t *data)
@@ -583,7 +583,7 @@ int32 CFE_ES_SetPerfTriggerMaskCmd(const CFE_ES_SetPerfTriggerMaskCmd_t *data)
  * Function: CFE_ES_PerfLogAdd
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_PerfLogAdd(uint32 Marker, uint32 EntryExit)

--- a/modules/es/fsw/src/cfe_es_perf.h
+++ b/modules/es/fsw/src/cfe_es_perf.h
@@ -126,9 +126,16 @@ typedef struct
  */
 uint32 CFE_ES_GetPerfLogDumpRemaining(void);
 
-/*
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Write performance data to a file
+ *
  * Implementation of the background state machine for writing
  * performance log data.
+ *
+ * This is implemented as a state machine that is invoked in the background
+ * Each iteration should perform a limited amount of work, which will resume
+ * on the next iteration.  State is kept in a global structure.
  */
 bool CFE_ES_RunPerfLogDump(uint32 ElapsedTime, void *Arg);
 

--- a/modules/es/fsw/src/cfe_es_resource.c
+++ b/modules/es/fsw/src/cfe_es_resource.c
@@ -39,12 +39,14 @@
 #include <string.h>
 #include <stdlib.h>
 
-/*********************************************************************/
-/*
+/*----------------------------------------------------------------
+ *
  * Function: CFE_ES_TaskId_ToOSAL
  *
- * For complete API information, see prototype in header
- */
+ * Application-scope internal function
+ * See description in cfe_es_resource.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 osal_id_t CFE_ES_TaskId_ToOSAL(CFE_ES_TaskId_t id)
 {
     osal_id_t     Result;
@@ -56,12 +58,14 @@ osal_id_t CFE_ES_TaskId_ToOSAL(CFE_ES_TaskId_t id)
     return Result;
 }
 
-/*********************************************************************/
-/*
- * Function: CFE_TaskId_FromOSAL
+/*----------------------------------------------------------------
  *
- * For complete API information, see prototype in header
- */
+ * Function: CFE_ES_TaskId_FromOSAL
+ *
+ * Application-scope internal function
+ * See description in cfe_es_resource.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_ES_TaskId_t CFE_ES_TaskId_FromOSAL(osal_id_t id)
 {
     CFE_ResourceId_t Result;
@@ -73,12 +77,14 @@ CFE_ES_TaskId_t CFE_ES_TaskId_FromOSAL(osal_id_t id)
     return CFE_ES_TASKID_C(Result);
 }
 
-/*********************************************************************/
-/*
- * CFE_ES_LocateAppRecordByName
+/*----------------------------------------------------------------
  *
- * For complete API information, see prototype in header
- */
+ * Function: CFE_ES_LocateAppRecordByName
+ *
+ * Application-scope internal function
+ * See description in cfe_es_resource.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_ES_AppRecord_t *CFE_ES_LocateAppRecordByName(const char *Name)
 {
     CFE_ES_AppRecord_t *AppRecPtr;
@@ -106,15 +112,16 @@ CFE_ES_AppRecord_t *CFE_ES_LocateAppRecordByName(const char *Name)
     }
 
     return AppRecPtr;
+}
 
-} /* End of CFE_ES_LocateAppRecordByName() */
-
-/*********************************************************************/
-/*
- * CFE_ES_LocateLibRecordByName
+/*----------------------------------------------------------------
  *
- * For complete API information, see prototype in header
- */
+ * Function: CFE_ES_LocateLibRecordByName
+ *
+ * Application-scope internal function
+ * See description in cfe_es_resource.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_ES_LibRecord_t *CFE_ES_LocateLibRecordByName(const char *Name)
 {
     CFE_ES_LibRecord_t *LibRecPtr;
@@ -142,15 +149,16 @@ CFE_ES_LibRecord_t *CFE_ES_LocateLibRecordByName(const char *Name)
     }
 
     return LibRecPtr;
+}
 
-} /* End of CFE_ES_LocateLibRecordByName() */
-
-/*********************************************************************/
-/*
- * CFE_ES_LocateCounterRecordByName
+/*----------------------------------------------------------------
  *
- * For complete API information, see prototype in header
- */
+ * Function: CFE_ES_LocateCounterRecordByName
+ *
+ * Application-scope internal function
+ * See description in cfe_es_resource.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_ES_GenCounterRecord_t *CFE_ES_LocateCounterRecordByName(const char *Name)
 {
     CFE_ES_GenCounterRecord_t *CounterRecPtr;
@@ -180,12 +188,14 @@ CFE_ES_GenCounterRecord_t *CFE_ES_LocateCounterRecordByName(const char *Name)
     return CounterRecPtr;
 }
 
-/*********************************************************************/
-/*
- * CFE_ES_LocateAppRecordByID
+/*----------------------------------------------------------------
  *
- * For complete API information, see prototype in header
- */
+ * Function: CFE_ES_LocateAppRecordByID
+ *
+ * Application-scope internal function
+ * See description in cfe_es_resource.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_ES_AppRecord_t *CFE_ES_LocateAppRecordByID(CFE_ES_AppId_t AppID)
 {
     CFE_ES_AppRecord_t *AppRecPtr;
@@ -203,12 +213,14 @@ CFE_ES_AppRecord_t *CFE_ES_LocateAppRecordByID(CFE_ES_AppId_t AppID)
     return AppRecPtr;
 }
 
-/*********************************************************************/
-/*
- * CFE_ES_LocateLibRecordByID
+/*----------------------------------------------------------------
  *
- * For complete API information, see prototype in header
- */
+ * Function: CFE_ES_LocateLibRecordByID
+ *
+ * Application-scope internal function
+ * See description in cfe_es_resource.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_ES_LibRecord_t *CFE_ES_LocateLibRecordByID(CFE_ES_LibId_t LibID)
 {
     CFE_ES_LibRecord_t *LibRecPtr;
@@ -226,12 +238,14 @@ CFE_ES_LibRecord_t *CFE_ES_LocateLibRecordByID(CFE_ES_LibId_t LibID)
     return LibRecPtr;
 }
 
-/*********************************************************************/
-/*
- * CFE_ES_LocateTaskRecordByID
+/*----------------------------------------------------------------
  *
- * For complete API information, see prototype in header
- */
+ * Function: CFE_ES_LocateTaskRecordByID
+ *
+ * Application-scope internal function
+ * See description in cfe_es_resource.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_ES_TaskRecord_t *CFE_ES_LocateTaskRecordByID(CFE_ES_TaskId_t TaskID)
 {
     CFE_ES_TaskRecord_t *TaskRecPtr;
@@ -249,12 +263,14 @@ CFE_ES_TaskRecord_t *CFE_ES_LocateTaskRecordByID(CFE_ES_TaskId_t TaskID)
     return TaskRecPtr;
 }
 
-/*********************************************************************/
-/*
- * CFE_ES_LocateCounterRecordByID
+/*----------------------------------------------------------------
  *
- * For complete API information, see prototype in header
- */
+ * Function: CFE_ES_LocateCounterRecordByID
+ *
+ * Application-scope internal function
+ * See description in cfe_es_resource.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_ES_GenCounterRecord_t *CFE_ES_LocateCounterRecordByID(CFE_ES_CounterId_t CounterID)
 {
     CFE_ES_GenCounterRecord_t *CounterRecPtr;
@@ -272,15 +288,14 @@ CFE_ES_GenCounterRecord_t *CFE_ES_LocateCounterRecordByID(CFE_ES_CounterId_t Cou
     return CounterRecPtr;
 }
 
-/*********************************************************************/
-/*
- * CFE_ES_GetTaskRecordByContext
+/*----------------------------------------------------------------
  *
- * For complete API information, see prototype in header
+ * Function: CFE_ES_GetTaskRecordByContext
  *
- * This function does additional validation on the task record
- * and should only be called when global data is locked.
- */
+ * Application-scope internal function
+ * See description in cfe_es_resource.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_ES_TaskRecord_t *CFE_ES_GetTaskRecordByContext(void)
 {
     CFE_ES_TaskRecord_t *TaskRecPtr;
@@ -306,12 +321,14 @@ CFE_ES_TaskRecord_t *CFE_ES_GetTaskRecordByContext(void)
     return TaskRecPtr;
 }
 
-/*********************************************************************/
-/*
- * CFE_ES_GetAppRecordByContext
+/*----------------------------------------------------------------
  *
- * For complete API information, see prototype in header
- */
+ * Function: CFE_ES_GetAppRecordByContext
+ *
+ * Application-scope internal function
+ * See description in cfe_es_resource.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_ES_AppRecord_t *CFE_ES_GetAppRecordByContext(void)
 {
     CFE_ES_AppRecord_t * AppRecPtr;
@@ -347,14 +364,14 @@ CFE_ES_AppRecord_t *CFE_ES_GetAppRecordByContext(void)
     return AppRecPtr;
 }
 
-/*
- * ---------------------------------------------------------------------------------------
+/*----------------------------------------------------------------
+ *
  * Function: CFE_ES_CheckCounterIdSlotUsed
  *
- * Purpose: Helper function, Aids in allocating a new ID by checking if
- * a given ID is available.  Must be called while locked.
- * ---------------------------------------------------------------------------------------
- */
+ * Application-scope internal function
+ * See description in cfe_es_resource.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_ES_CheckCounterIdSlotUsed(CFE_ResourceId_t CheckId)
 {
     CFE_ES_GenCounterRecord_t *GenCounterRecPtr;
@@ -367,14 +384,14 @@ bool CFE_ES_CheckCounterIdSlotUsed(CFE_ResourceId_t CheckId)
     return (GenCounterRecPtr == NULL || CFE_ES_CounterRecordIsUsed(GenCounterRecPtr));
 }
 
-/*
- *---------------------------------------------------------------------------------------
+/*----------------------------------------------------------------
+ *
  * Function: CFE_ES_CheckAppIdSlotUsed
  *
- * Purpose: Helper function, Aids in allocating a new ID by checking if
- * a given ID is available.  Must be called while locked.
- *---------------------------------------------------------------------------------------
- */
+ * Application-scope internal function
+ * See description in cfe_es_resource.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_ES_CheckAppIdSlotUsed(CFE_ResourceId_t CheckId)
 {
     CFE_ES_AppRecord_t *AppRecPtr;
@@ -387,14 +404,14 @@ bool CFE_ES_CheckAppIdSlotUsed(CFE_ResourceId_t CheckId)
     return (AppRecPtr == NULL || CFE_ES_AppRecordIsUsed(AppRecPtr));
 }
 
-/*
- * ---------------------------------------------------------------------------------------
+/*----------------------------------------------------------------
+ *
  * Function: CFE_ES_CheckLibIdSlotUsed
  *
- * Purpose: Helper function, Aids in allocating a new ID by checking if
- * a given ID is available.  Must be called while locked.
- * ---------------------------------------------------------------------------------------
- */
+ * Application-scope internal function
+ * See description in cfe_es_resource.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_ES_CheckLibIdSlotUsed(CFE_ResourceId_t CheckId)
 {
     CFE_ES_LibRecord_t *LibRecPtr;

--- a/modules/es/fsw/src/cfe_es_resource.c
+++ b/modules/es/fsw/src/cfe_es_resource.c
@@ -44,7 +44,7 @@
  * Function: CFE_ES_TaskId_ToOSAL
  *
  * Application-scope internal function
- * See description in cfe_es_resource.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 osal_id_t CFE_ES_TaskId_ToOSAL(CFE_ES_TaskId_t id)
@@ -63,7 +63,7 @@ osal_id_t CFE_ES_TaskId_ToOSAL(CFE_ES_TaskId_t id)
  * Function: CFE_ES_TaskId_FromOSAL
  *
  * Application-scope internal function
- * See description in cfe_es_resource.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_ES_TaskId_t CFE_ES_TaskId_FromOSAL(osal_id_t id)
@@ -82,7 +82,7 @@ CFE_ES_TaskId_t CFE_ES_TaskId_FromOSAL(osal_id_t id)
  * Function: CFE_ES_LocateAppRecordByName
  *
  * Application-scope internal function
- * See description in cfe_es_resource.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_ES_AppRecord_t *CFE_ES_LocateAppRecordByName(const char *Name)
@@ -119,7 +119,7 @@ CFE_ES_AppRecord_t *CFE_ES_LocateAppRecordByName(const char *Name)
  * Function: CFE_ES_LocateLibRecordByName
  *
  * Application-scope internal function
- * See description in cfe_es_resource.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_ES_LibRecord_t *CFE_ES_LocateLibRecordByName(const char *Name)
@@ -156,7 +156,7 @@ CFE_ES_LibRecord_t *CFE_ES_LocateLibRecordByName(const char *Name)
  * Function: CFE_ES_LocateCounterRecordByName
  *
  * Application-scope internal function
- * See description in cfe_es_resource.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_ES_GenCounterRecord_t *CFE_ES_LocateCounterRecordByName(const char *Name)
@@ -193,7 +193,7 @@ CFE_ES_GenCounterRecord_t *CFE_ES_LocateCounterRecordByName(const char *Name)
  * Function: CFE_ES_LocateAppRecordByID
  *
  * Application-scope internal function
- * See description in cfe_es_resource.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_ES_AppRecord_t *CFE_ES_LocateAppRecordByID(CFE_ES_AppId_t AppID)
@@ -218,7 +218,7 @@ CFE_ES_AppRecord_t *CFE_ES_LocateAppRecordByID(CFE_ES_AppId_t AppID)
  * Function: CFE_ES_LocateLibRecordByID
  *
  * Application-scope internal function
- * See description in cfe_es_resource.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_ES_LibRecord_t *CFE_ES_LocateLibRecordByID(CFE_ES_LibId_t LibID)
@@ -243,7 +243,7 @@ CFE_ES_LibRecord_t *CFE_ES_LocateLibRecordByID(CFE_ES_LibId_t LibID)
  * Function: CFE_ES_LocateTaskRecordByID
  *
  * Application-scope internal function
- * See description in cfe_es_resource.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_ES_TaskRecord_t *CFE_ES_LocateTaskRecordByID(CFE_ES_TaskId_t TaskID)
@@ -268,7 +268,7 @@ CFE_ES_TaskRecord_t *CFE_ES_LocateTaskRecordByID(CFE_ES_TaskId_t TaskID)
  * Function: CFE_ES_LocateCounterRecordByID
  *
  * Application-scope internal function
- * See description in cfe_es_resource.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_ES_GenCounterRecord_t *CFE_ES_LocateCounterRecordByID(CFE_ES_CounterId_t CounterID)
@@ -293,7 +293,7 @@ CFE_ES_GenCounterRecord_t *CFE_ES_LocateCounterRecordByID(CFE_ES_CounterId_t Cou
  * Function: CFE_ES_GetTaskRecordByContext
  *
  * Application-scope internal function
- * See description in cfe_es_resource.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_ES_TaskRecord_t *CFE_ES_GetTaskRecordByContext(void)
@@ -326,7 +326,7 @@ CFE_ES_TaskRecord_t *CFE_ES_GetTaskRecordByContext(void)
  * Function: CFE_ES_GetAppRecordByContext
  *
  * Application-scope internal function
- * See description in cfe_es_resource.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_ES_AppRecord_t *CFE_ES_GetAppRecordByContext(void)
@@ -369,7 +369,7 @@ CFE_ES_AppRecord_t *CFE_ES_GetAppRecordByContext(void)
  * Function: CFE_ES_CheckCounterIdSlotUsed
  *
  * Application-scope internal function
- * See description in cfe_es_resource.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 bool CFE_ES_CheckCounterIdSlotUsed(CFE_ResourceId_t CheckId)
@@ -389,7 +389,7 @@ bool CFE_ES_CheckCounterIdSlotUsed(CFE_ResourceId_t CheckId)
  * Function: CFE_ES_CheckAppIdSlotUsed
  *
  * Application-scope internal function
- * See description in cfe_es_resource.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 bool CFE_ES_CheckAppIdSlotUsed(CFE_ResourceId_t CheckId)
@@ -409,7 +409,7 @@ bool CFE_ES_CheckAppIdSlotUsed(CFE_ResourceId_t CheckId)
  * Function: CFE_ES_CheckLibIdSlotUsed
  *
  * Application-scope internal function
- * See description in cfe_es_resource.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 bool CFE_ES_CheckLibIdSlotUsed(CFE_ResourceId_t CheckId)

--- a/modules/es/fsw/src/cfe_es_resource.h
+++ b/modules/es/fsw/src/cfe_es_resource.h
@@ -38,6 +38,7 @@
 #include "cfe_core_resourceid_basevalues.h"
 #include "cfe_es_global.h"
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Locate the app table entry correlating with a given app ID.
  *
@@ -65,6 +66,7 @@
  */
 extern CFE_ES_AppRecord_t *CFE_ES_LocateAppRecordByID(CFE_ES_AppId_t AppID);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Locate the Library table entry correlating with a given Lib ID.
  *
@@ -92,6 +94,7 @@ extern CFE_ES_AppRecord_t *CFE_ES_LocateAppRecordByID(CFE_ES_AppId_t AppID);
  */
 extern CFE_ES_LibRecord_t *CFE_ES_LocateLibRecordByID(CFE_ES_LibId_t LibID);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Locate the task table entry correlating with a given task ID.
  *
@@ -119,6 +122,7 @@ extern CFE_ES_LibRecord_t *CFE_ES_LocateLibRecordByID(CFE_ES_LibId_t LibID);
  */
 extern CFE_ES_TaskRecord_t *CFE_ES_LocateTaskRecordByID(CFE_ES_TaskId_t TaskID);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Locate the Counter table entry correlating with a given Counter ID.
  *
@@ -146,6 +150,7 @@ extern CFE_ES_TaskRecord_t *CFE_ES_LocateTaskRecordByID(CFE_ES_TaskId_t TaskID);
  */
 extern CFE_ES_GenCounterRecord_t *CFE_ES_LocateCounterRecordByID(CFE_ES_CounterId_t CounterID);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Check if an app record is in use or free/empty
  *
@@ -165,6 +170,7 @@ static inline bool CFE_ES_AppRecordIsUsed(const CFE_ES_AppRecord_t *AppRecPtr)
     return CFE_RESOURCEID_TEST_DEFINED(AppRecPtr->AppId);
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Get the ID value from an app table entry
  *
@@ -181,6 +187,7 @@ static inline CFE_ES_AppId_t CFE_ES_AppRecordGetID(const CFE_ES_AppRecord_t *App
     return AppRecPtr->AppId;
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Marks an app table entry as used (not free)
  *
@@ -201,6 +208,7 @@ static inline void CFE_ES_AppRecordSetUsed(CFE_ES_AppRecord_t *AppRecPtr, CFE_Re
     AppRecPtr->AppId = CFE_ES_APPID_C(PendingId);
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Set an app record table entry free (not used)
  *
@@ -220,6 +228,7 @@ static inline void CFE_ES_AppRecordSetFree(CFE_ES_AppRecord_t *AppRecPtr)
     AppRecPtr->AppId = CFE_ES_APPID_UNDEFINED;
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Check if an app record is a match for the given AppID
  *
@@ -248,6 +257,7 @@ static inline bool CFE_ES_AppRecordIsMatch(const CFE_ES_AppRecord_t *AppRecPtr, 
     return (AppRecPtr != NULL && CFE_RESOURCEID_TEST_EQUAL(AppRecPtr->AppId, AppID));
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Obtain the name associated with the Application record
  *
@@ -264,6 +274,7 @@ static inline const char *CFE_ES_AppRecordGetName(const CFE_ES_AppRecord_t *AppR
     return AppRecPtr->AppName;
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Check if a Library record is in use or free/empty
  *
@@ -283,6 +294,7 @@ static inline bool CFE_ES_LibRecordIsUsed(const CFE_ES_LibRecord_t *LibRecPtr)
     return CFE_RESOURCEID_TEST_DEFINED(LibRecPtr->LibId);
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Get the ID value from a Library table entry
  *
@@ -303,6 +315,7 @@ static inline CFE_ES_LibId_t CFE_ES_LibRecordGetID(const CFE_ES_LibRecord_t *Lib
     return (LibRecPtr->LibId);
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Marks a Library table entry as used (not free)
  *
@@ -320,6 +333,7 @@ static inline void CFE_ES_LibRecordSetUsed(CFE_ES_LibRecord_t *LibRecPtr, CFE_Re
     LibRecPtr->LibId = CFE_ES_LIBID_C(PendingId);
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Set a Library record table entry free (not used)
  *
@@ -336,6 +350,7 @@ static inline void CFE_ES_LibRecordSetFree(CFE_ES_LibRecord_t *LibRecPtr)
     LibRecPtr->LibId = CFE_ES_LIBID_UNDEFINED;
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Check if a Library record is a match for the given LibID
  *
@@ -364,6 +379,7 @@ static inline bool CFE_ES_LibRecordIsMatch(const CFE_ES_LibRecord_t *LibRecPtr, 
     return (LibRecPtr != NULL && CFE_RESOURCEID_TEST_EQUAL(LibRecPtr->LibId, LibID));
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Obtain the name associated with the Library record
  *
@@ -380,6 +396,7 @@ static inline const char *CFE_ES_LibRecordGetName(const CFE_ES_LibRecord_t *LibR
     return LibRecPtr->LibName;
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Get the ID value from an Task table entry
  *
@@ -399,6 +416,7 @@ static inline CFE_ES_TaskId_t CFE_ES_TaskRecordGetID(const CFE_ES_TaskRecord_t *
     return (TaskRecPtr->TaskId);
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Check if a Task record is in use or free/empty
  *
@@ -418,6 +436,7 @@ static inline bool CFE_ES_TaskRecordIsUsed(const CFE_ES_TaskRecord_t *TaskRecPtr
     return CFE_RESOURCEID_TEST_DEFINED(TaskRecPtr->TaskId);
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Marks an Task table entry as used (not free)
  *
@@ -438,6 +457,7 @@ static inline void CFE_ES_TaskRecordSetUsed(CFE_ES_TaskRecord_t *TaskRecPtr, CFE
     TaskRecPtr->TaskId = CFE_ES_TASKID_C(PendingId);
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Set a Task record table entry free
  *
@@ -457,6 +477,7 @@ static inline void CFE_ES_TaskRecordSetFree(CFE_ES_TaskRecord_t *TaskRecPtr)
     TaskRecPtr->TaskId = CFE_ES_TASKID_UNDEFINED;
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Check if a Task record is a match for the given TaskID
  *
@@ -485,6 +506,7 @@ static inline bool CFE_ES_TaskRecordIsMatch(const CFE_ES_TaskRecord_t *TaskRecPt
     return (TaskRecPtr != NULL && CFE_RESOURCEID_TEST_EQUAL(TaskRecPtr->TaskId, TaskID));
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Obtain the name associated with the Task record
  *
@@ -501,6 +523,7 @@ static inline const char *CFE_ES_TaskRecordGetName(const CFE_ES_TaskRecord_t *Ta
     return TaskRecPtr->TaskName;
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Check if an Counter record is in use or free/empty
  *
@@ -520,6 +543,7 @@ static inline bool CFE_ES_CounterRecordIsUsed(const CFE_ES_GenCounterRecord_t *C
     return CFE_RESOURCEID_TEST_DEFINED(CounterRecPtr->CounterId);
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Get the ID value from an Counter table entry
  *
@@ -536,6 +560,7 @@ static inline CFE_ES_CounterId_t CFE_ES_CounterRecordGetID(const CFE_ES_GenCount
     return CounterRecPtr->CounterId;
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Marks an Counter table entry as used (not free)
  *
@@ -556,6 +581,7 @@ static inline void CFE_ES_CounterRecordSetUsed(CFE_ES_GenCounterRecord_t *Counte
     CounterRecPtr->CounterId = CFE_ES_COUNTERID_C(PendingId);
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Set an Counter record table entry free (not used)
  *
@@ -575,6 +601,7 @@ static inline void CFE_ES_CounterRecordSetFree(CFE_ES_GenCounterRecord_t *Counte
     CounterRecPtr->CounterId = CFE_ES_COUNTERID_UNDEFINED;
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Check if an Counter record is a match for the given CounterID
  *
@@ -604,6 +631,7 @@ static inline bool CFE_ES_CounterRecordIsMatch(const CFE_ES_GenCounterRecord_t *
     return (CounterRecPtr != NULL && CFE_RESOURCEID_TEST_EQUAL(CounterRecPtr->CounterId, CounterID));
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Obtain the name associated with the counter record
  *
@@ -620,6 +648,7 @@ static inline const char *CFE_ES_CounterRecordGetName(const CFE_ES_GenCounterRec
     return CounterRecPtr->CounterName;
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * Locate and validate the app record for the calling context.
  *
@@ -632,6 +661,7 @@ static inline const char *CFE_ES_CounterRecordGetName(const CFE_ES_GenCounterRec
  */
 extern CFE_ES_AppRecord_t *CFE_ES_GetAppRecordByContext(void);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * Locate and validate the task record for the calling context.
  *
@@ -657,6 +687,7 @@ extern CFE_ES_TaskRecord_t *CFE_ES_GetTaskRecordByContext(void);
  * of OSAL task IDs.
  */
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Convert an ES Task ID to an OSAL task ID
  *
@@ -677,6 +708,7 @@ extern CFE_ES_TaskRecord_t *CFE_ES_GetTaskRecordByContext(void);
  */
 extern osal_id_t CFE_ES_TaskId_ToOSAL(CFE_ES_TaskId_t id);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Convert an ES Task ID to an OSAL task ID
  *
@@ -703,14 +735,86 @@ extern CFE_ES_TaskId_t CFE_ES_TaskId_FromOSAL(osal_id_t id);
  * These functions do not lock, they must only be used internally by ES when
  * the lock is already held.
  */
-CFE_ES_AppRecord_t *       CFE_ES_LocateAppRecordByName(const char *Name);
-CFE_ES_LibRecord_t *       CFE_ES_LocateLibRecordByName(const char *Name);
-CFE_ES_TaskRecord_t *      CFE_ES_LocateTaskRecordByName(const char *Name);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Finds an application table record matching the given name
+ *
+ * Helper function, aids in finding an application record from a name string.
+ * Must be called while locked.
+ *
+ * @returns pointer to table entry matching name, or NULL if not found
+ */
+CFE_ES_AppRecord_t *CFE_ES_LocateAppRecordByName(const char *Name);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Finds a library table record matching the given name
+ *
+ * Helper function, aids in finding a library record from a name string.
+ * Must be called while locked.
+ *
+ * @returns pointer to table entry matching name, or NULL if not found
+ */
+CFE_ES_LibRecord_t *CFE_ES_LocateLibRecordByName(const char *Name);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Finds a task table record matching the given name
+ *
+ * Helper function, aids in finding a task record from a name string.
+ * Must be called while locked.
+ *
+ * @returns pointer to table entry matching name, or NULL if not found
+ */
+CFE_ES_TaskRecord_t *CFE_ES_LocateTaskRecordByName(const char *Name);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Finds a counter table record matching the given name
+ *
+ * Helper function, aids in finding a counter record from a name string.
+ * Must be called while locked.
+ *
+ * @returns pointer to table entry matching name, or NULL if not found
+ */
 CFE_ES_GenCounterRecord_t *CFE_ES_LocateCounterRecordByName(const char *Name);
 
-/* Availability check functions used in conjunction with CFE_ResourceId_FindNext() */
+/*
+ * Availability check functions used in conjunction with CFE_ResourceId_FindNext()
+ */
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Checks if Application slot is currently used
+ *
+ * Helper function, Aids in allocating a new ID by checking if
+ * a given ID is available.  Must be called while locked.
+ *
+ * @returns false if slot is unused/available, true if used/unavailable
+ */
 bool CFE_ES_CheckAppIdSlotUsed(CFE_ResourceId_t CheckId);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Checks if Library slot is currently used
+ *
+ * Helper function, Aids in allocating a new ID by checking if
+ * a given ID is available.  Must be called while locked.
+ *
+ * @returns false if slot is unused/available, true if used/unavailable
+ */
 bool CFE_ES_CheckLibIdSlotUsed(CFE_ResourceId_t CheckId);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Checks if Counter slot is currently used
+ *
+ * Helper function, Aids in allocating a new ID by checking if
+ * a given ID is available.  Must be called while locked.
+ *
+ * @returns false if slot is unused/available, true if used/unavailable
+ */
 bool CFE_ES_CheckCounterIdSlotUsed(CFE_ResourceId_t CheckId);
 
 #endif /* CFE_ES_RESOURCE_H */

--- a/modules/es/fsw/src/cfe_es_start.c
+++ b/modules/es/fsw/src/cfe_es_start.c
@@ -70,7 +70,7 @@ CFE_ES_Global_t CFE_ES_Global;
  * Function: CFE_ES_Main
  *
  * Implemented per public API
- * See description in cfe_es.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const char *StartFilePath)
@@ -242,7 +242,7 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const cha
  * Function: CFE_ES_SetupResetVariables
  *
  * Application-scope internal function
- * See description in cfe_es_start.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  * SYSLOGGING NOTE: Any logging in here must use CFE_ES_SysLogWrite_Unsync() as the necessary
  * primitives are not even initialized yet.  There is no chance for log contention here.
@@ -471,7 +471,7 @@ void CFE_ES_SetupResetVariables(uint32 StartType, uint32 StartSubtype, uint32 Bo
  * Function: CFE_ES_InitializeFileSystems
  *
  * Application-scope internal function
- * See description in cfe_es_start.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_InitializeFileSystems(uint32 StartType)
@@ -718,7 +718,7 @@ void CFE_ES_InitializeFileSystems(uint32 StartType)
  * Function: CFE_ES_CreateObjects
  *
  * Application-scope internal function
- * See description in cfe_es_start.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_CreateObjects(void)

--- a/modules/es/fsw/src/cfe_es_start.c
+++ b/modules/es/fsw/src/cfe_es_start.c
@@ -65,9 +65,14 @@ CFE_ES_Global_t CFE_ES_Global;
 ** Code
 */
 
-/*
-** Name: CFE_ES_Main - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_Main
+ *
+ * Implemented per public API
+ * See description in cfe_es.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const char *StartFilePath)
 {
     int32 ReturnCode;
@@ -232,17 +237,16 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const cha
     CFE_ES_Global.SystemState = CFE_ES_SystemState_OPERATIONAL;
 }
 
-/*
-** Name: CFE_ES_SetupResetVariables
-**
-** Purpose: This function initializes the ES reset variables depending on the reset type.
-**          It will also initiate a power on reset when too many processor resets
-**           have happened.
-**
-** SYSLOGGING NOTE: Any logging in here must use CFE_ES_SysLogWrite_Unsync() as the necessary
-** primitives are not even initialized yet.  There is no chance for log contention here.
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_SetupResetVariables
+ *
+ * Application-scope internal function
+ * See description in cfe_es_start.h for argument/return detail
+ *
+ * SYSLOGGING NOTE: Any logging in here must use CFE_ES_SysLogWrite_Unsync() as the necessary
+ * primitives are not even initialized yet.  There is no chance for log contention here.
+ *-----------------------------------------------------------------*/
 void CFE_ES_SetupResetVariables(uint32 StartType, uint32 StartSubtype, uint32 BootSource)
 {
 
@@ -462,12 +466,14 @@ void CFE_ES_SetupResetVariables(uint32 StartType, uint32 StartSubtype, uint32 Bo
     CFE_ES_Global.ResetDataPtr->ResetVars.ES_CausedReset = false;
 }
 
-/*
-** Name: CFE_ES_InitializeFileSystems
-**
-** Purpose: This function initializes the file systems used in the cFE core.
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_InitializeFileSystems
+ *
+ * Application-scope internal function
+ * See description in cfe_es_start.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_InitializeFileSystems(uint32 StartType)
 {
     int32        RetStatus;
@@ -705,19 +711,16 @@ void CFE_ES_InitializeFileSystems(uint32 StartType)
         } /* end if BlocksFree */
 
     } /* end if processor reset */
+}
 
-} /* end function */
-
-/*-------------------------------------------------------------------------
-**
-**                  Functional Prolog
-**
-**   Name: CFE_ES_CreateObjects
-**
-**   Purpose: This function reads the es_object_table and performs all of the
-**            application layer initialization.
-**----------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_CreateObjects
+ *
+ * Application-scope internal function
+ * See description in cfe_es_start.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_CreateObjects(void)
 {
     int32               ReturnCode;
@@ -886,13 +889,16 @@ void CFE_ES_CreateObjects(void)
     CFE_ES_WriteToSysLog("ES Startup: Finished ES CreateObject table entries.\n");
 }
 
-/*
-** Function: CFE_ES_MainTaskSyncDelay
-**
-** Purpose:  Waits for all of the applications that CFE has started thus far to
-**           reach the indicated state, by polling the app counters in a delay loop.
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_MainTaskSyncDelay
+ *
+ * Internal helper routine only, not part of API.
+ *
+ * Waits for all of the applications that CFE has started thus far to
+ * reach the indicated state, by polling the app counters in a delay loop.
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_MainTaskSyncDelay(uint32 AppStateId, uint32 TimeOutMilliseconds)
 {
     int32               Status;

--- a/modules/es/fsw/src/cfe_es_start.h
+++ b/modules/es/fsw/src/cfe_es_start.h
@@ -84,11 +84,40 @@ typedef struct
 extern CFE_ES_ObjectTable_t CFE_ES_ObjectTable[CFE_PLATFORM_ES_OBJECT_TABLE_SIZE]; /* es object table */
 
 /*
-** Function prototypes
-*/
+ * Name: CFE_ES_CreateObjects
+ *
+ * Purpose: This function reads the es_object_table and performs all of the
+ *          application layer initialization.
+ */
 extern void CFE_ES_CreateObjects(void);
+
+/*
+ * Name: CFE_ES_SetupResetVariables
+ *
+ * Purpose: This function initializes the ES reset variables depending on the reset type.
+ *          It will also initiate a power on reset when too many processor resets
+ *          have happened.
+ *
+ */
 extern void CFE_ES_SetupResetVariables(uint32 StartType, uint32 StartSubtype, uint32 BootSource);
+
+/*
+ * Name: CFE_ES_InitializeFileSystems
+ *
+ * Purpose: This function initializes the file systems used in the cFE core.
+ *
+ */
 extern void CFE_ES_InitializeFileSystems(uint32 StartType);
+
+/*
+ * Name: CFE_ES_SetupPerfVariables
+ *
+ * Purpose:This function initializes filter mask,trigger mask, data & state vals
+ *
+ * Assumptions and Notes: This gets called from CFE_ES_Main() at startup
+ * This code must be called before any other task or code that would use
+ * CFE_ES_PerfLogEntry() / CFE_ES_PerfLogExit() functions
+ */
 extern void CFE_ES_SetupPerfVariables(uint32 ResetType);
 
 #endif /* CFE_ES_START_H */

--- a/modules/es/fsw/src/cfe_es_syslog.c
+++ b/modules/es/fsw/src/cfe_es_syslog.c
@@ -76,7 +76,7 @@
  * Function: CFE_ES_SysLogClear_Unsync
  *
  * Application-scope internal function
- * See description in cfe_es_log.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_SysLogClear_Unsync(void)
@@ -96,7 +96,7 @@ void CFE_ES_SysLogClear_Unsync(void)
  * Function: CFE_ES_SysLogReadStart_Unsync
  *
  * Application-scope internal function
- * See description in cfe_es_log.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_SysLogReadStart_Unsync(CFE_ES_SysLogReadBuffer_t *Buffer)
@@ -134,7 +134,7 @@ void CFE_ES_SysLogReadStart_Unsync(CFE_ES_SysLogReadBuffer_t *Buffer)
  * Function: CFE_ES_SysLogAppend_Unsync
  *
  * Application-scope internal function
- * See description in cfe_es_log.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_SysLogAppend_Unsync(const char *LogString)
@@ -258,7 +258,7 @@ int32 CFE_ES_SysLogAppend_Unsync(const char *LogString)
  * Function: CFE_ES_SysLogWrite_Unsync
  *
  * Application-scope internal function
- * See description in cfe_es_log.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_SysLogWrite_Unsync(const char *SpecStringPtr, ...)
@@ -293,7 +293,7 @@ int32 CFE_ES_SysLogWrite_Unsync(const char *SpecStringPtr, ...)
  * Function: CFE_ES_SysLogReadData
  *
  * Application-scope internal function
- * See description in cfe_es_log.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_SysLogReadData(CFE_ES_SysLogReadBuffer_t *Buffer)
@@ -343,7 +343,7 @@ void CFE_ES_SysLogReadData(CFE_ES_SysLogReadBuffer_t *Buffer)
  * Function: CFE_ES_SysLogSetMode
  *
  * Application-scope internal function
- * See description in cfe_es_log.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_SysLogSetMode(CFE_ES_LogMode_Enum_t Mode)
@@ -368,7 +368,7 @@ int32 CFE_ES_SysLogSetMode(CFE_ES_LogMode_Enum_t Mode)
  * Function: CFE_ES_SysLog_vsnprintf
  *
  * Application-scope internal function
- * See description in cfe_es_log.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_SysLog_vsnprintf(char *Buffer, size_t BufferSize, const char *SpecStringPtr, va_list ArgPtr)
@@ -447,7 +447,7 @@ void CFE_ES_SysLog_vsnprintf(char *Buffer, size_t BufferSize, const char *SpecSt
  * Function: CFE_ES_SysLog_snprintf
  *
  * Application-scope internal function
- * See description in cfe_es_log.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_SysLog_snprintf(char *Buffer, size_t BufferSize, const char *SpecStringPtr, ...)
@@ -464,7 +464,7 @@ void CFE_ES_SysLog_snprintf(char *Buffer, size_t BufferSize, const char *SpecStr
  * Function: CFE_ES_SysLogDump
  *
  * Application-scope internal function
- * See description in cfe_es_log.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_SysLogDump(const char *Filename)

--- a/modules/es/fsw/src/cfe_es_syslog.c
+++ b/modules/es/fsw/src/cfe_es_syslog.c
@@ -71,12 +71,14 @@
  *
  *******************************************************************/
 
-/*
- * -----------------------------------------------------------------
- * CFE_ES_SysLogClear --
- * Clear system log & index
- * -----------------------------------------------------------------
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_SysLogClear_Unsync
+ *
+ * Application-scope internal function
+ * See description in cfe_es_log.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_SysLogClear_Unsync(void)
 {
     /*
@@ -87,15 +89,16 @@ void CFE_ES_SysLogClear_Unsync(void)
     CFE_ES_Global.ResetDataPtr->SystemLogWriteIdx = 0;
     CFE_ES_Global.ResetDataPtr->SystemLogEndIdx   = 0;
     CFE_ES_Global.ResetDataPtr->SystemLogEntryNum = 0;
+}
 
-} /* End of CFE_ES_SysLogClear_Unsync() */
-
-/*
- * -----------------------------------------------------------------
- * CFE_ES_SysLogReadStart_Unsync --
- * Locate start (oldest message) of syslog for reading
- * -----------------------------------------------------------------
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_SysLogReadStart_Unsync
+ *
+ * Application-scope internal function
+ * See description in cfe_es_log.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_SysLogReadStart_Unsync(CFE_ES_SysLogReadBuffer_t *Buffer)
 {
     size_t ReadIdx;
@@ -124,14 +127,16 @@ void CFE_ES_SysLogReadStart_Unsync(CFE_ES_SysLogReadBuffer_t *Buffer)
     Buffer->LastOffset = ReadIdx;
     Buffer->EndIdx     = EndIdx;
     Buffer->BlockSize  = 0;
-} /* End of CFE_ES_SysLogReadStart_Unsync() */
+}
 
-/*
- * -----------------------------------------------------------------
- * CFE_ES_SysLogAppend_Unsync() --
- * Append a preformatted string to the syslog
- * -----------------------------------------------------------------
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_SysLogAppend_Unsync
+ *
+ * Application-scope internal function
+ * See description in cfe_es_log.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_SysLogAppend_Unsync(const char *LogString)
 {
     int32  ReturnCode;
@@ -246,16 +251,16 @@ int32 CFE_ES_SysLogAppend_Unsync(const char *LogString)
     }
 
     return (ReturnCode);
-} /* End of CFE_ES_SysLogAppend_Unsync() */
+}
 
-/*
- * -----------------------------------------------------------------
- * CFE_ES_SysLogWrite_Unsync() --
- * Identical to the public CFE_ES_WriteToSysLog() function, except
- * that it operates in an unsynchronized manner.  It can be used in
- * cases where the appropriate lock is already held for other reasons
- * -----------------------------------------------------------------
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_SysLogWrite_Unsync
+ *
+ * Application-scope internal function
+ * See description in cfe_es_log.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_SysLogWrite_Unsync(const char *SpecStringPtr, ...)
 {
     char    TmpString[CFE_ES_MAX_SYSLOG_MSG_SIZE];
@@ -272,7 +277,7 @@ int32 CFE_ES_SysLogWrite_Unsync(const char *SpecStringPtr, ...)
      * Append to the syslog buffer
      */
     return CFE_ES_SysLogAppend_Unsync(TmpString);
-} /* End of CFE_ES_SysLogWrite_Unsync() */
+}
 
 /*******************************************************************
  *
@@ -283,12 +288,14 @@ int32 CFE_ES_SysLogWrite_Unsync(const char *SpecStringPtr, ...)
  *
  *******************************************************************/
 
-/*
- * -----------------------------------------------------------------
- * CFE_ES_SysLogReadData --
- * Copy data out of the syslog buffer into a local buffer
- * -----------------------------------------------------------------
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_SysLogReadData
+ *
+ * Application-scope internal function
+ * See description in cfe_es_log.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_SysLogReadData(CFE_ES_SysLogReadBuffer_t *Buffer)
 {
     size_t BlockSize;
@@ -329,14 +336,16 @@ void CFE_ES_SysLogReadData(CFE_ES_SysLogReadBuffer_t *Buffer)
         Buffer->LastOffset += BlockSize;
         Buffer->SizeLeft -= BlockSize;
     }
-} /* End of CFE_ES_SysLogReadData() */
+}
 
-/*
- * -----------------------------------------------------------------
- * CFE_ES_SysLogOverwrite() --
- * Sets the SysLog Write mode (discard or overwrite)
- * -----------------------------------------------------------------
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_SysLogSetMode
+ *
+ * Application-scope internal function
+ * See description in cfe_es_log.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_SysLogSetMode(CFE_ES_LogMode_Enum_t Mode)
 {
     int32 Status;
@@ -352,15 +361,16 @@ int32 CFE_ES_SysLogSetMode(CFE_ES_LogMode_Enum_t Mode)
     }
 
     return Status;
-} /* End of CFE_ES_SysLogSetMode() */
+}
 
-/*
- * -----------------------------------------------------------------
- * CFE_ES_SysLog_vsnprintf() --
- * Obtain a correctly formatted, time stamped message for output to the syslog,
- * with arguments similar to the "vsnprintf()" C library API call
- * -----------------------------------------------------------------
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_SysLog_vsnprintf
+ *
+ * Application-scope internal function
+ * See description in cfe_es_log.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_SysLog_vsnprintf(char *Buffer, size_t BufferSize, const char *SpecStringPtr, va_list ArgPtr)
 {
     size_t StringLen;
@@ -430,15 +440,16 @@ void CFE_ES_SysLog_vsnprintf(char *Buffer, size_t BufferSize, const char *SpecSt
         /* always output a null terminated string */
         Buffer[StringLen] = 0;
     }
-} /* End of CFE_ES_SysLog_vsnprintf() */
+}
 
-/*
- * -----------------------------------------------------------------
- * CFE_ES_SysLog_snprintf() --
- * Obtain a correctly formatted, time stamped message for output to the syslog,
- * with arguments similar to the "snprintf()" C library API call
- * -----------------------------------------------------------------
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_SysLog_snprintf
+ *
+ * Application-scope internal function
+ * See description in cfe_es_log.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_SysLog_snprintf(char *Buffer, size_t BufferSize, const char *SpecStringPtr, ...)
 {
     va_list ArgPtr;
@@ -446,14 +457,16 @@ void CFE_ES_SysLog_snprintf(char *Buffer, size_t BufferSize, const char *SpecStr
     va_start(ArgPtr, SpecStringPtr);
     CFE_ES_SysLog_vsnprintf(Buffer, BufferSize, SpecStringPtr, ArgPtr);
     va_end(ArgPtr);
-} /* End of CFE_ES_SysLog_snprintf() */
+}
 
-/*
- * -----------------------------------------------------------------
- * CFE_ES_SysLogDump() --
- * Writes the contents of the syslog buffer to disk file
- * -----------------------------------------------------------------
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_SysLogDump
+ *
+ * Application-scope internal function
+ * See description in cfe_es_log.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_SysLogDump(const char *Filename)
 {
     osal_id_t fd;
@@ -550,7 +563,4 @@ int32 CFE_ES_SysLogDump(const char *Filename)
     }
 
     return Status;
-
-} /* End of CFE_ES_SysLogDump() */
-
-/* end of file */
+}

--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -68,7 +68,7 @@ CFE_ES_TaskData_t CFE_ES_TaskData;
  * Function: CFE_ES_TaskMain
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_TaskMain(void)
@@ -348,7 +348,7 @@ void CFE_ES_GenerateBuildInfoEvents(void)
  * Function: CFE_ES_TaskInit
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_TaskInit(void)
@@ -517,7 +517,7 @@ int32 CFE_ES_TaskInit(void)
  * Function: CFE_ES_TaskPipe
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
@@ -734,7 +734,7 @@ void CFE_ES_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
  * Function: CFE_ES_HousekeepingCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
@@ -848,7 +848,7 @@ int32 CFE_ES_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
  * Function: CFE_ES_NoopCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_NoopCmd(const CFE_ES_NoopCmd_t *Cmd)
@@ -877,7 +877,7 @@ int32 CFE_ES_NoopCmd(const CFE_ES_NoopCmd_t *Cmd)
  * Function: CFE_ES_ResetCountersCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_ResetCountersCmd(const CFE_ES_ResetCountersCmd_t *data)
@@ -898,7 +898,7 @@ int32 CFE_ES_ResetCountersCmd(const CFE_ES_ResetCountersCmd_t *data)
  * Function: CFE_ES_RestartCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_RestartCmd(const CFE_ES_RestartCmd_t *data)
@@ -927,7 +927,7 @@ int32 CFE_ES_RestartCmd(const CFE_ES_RestartCmd_t *data)
  * Function: CFE_ES_StartAppCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_StartAppCmd(const CFE_ES_StartAppCmd_t *data)
@@ -1032,7 +1032,7 @@ int32 CFE_ES_StartAppCmd(const CFE_ES_StartAppCmd_t *data)
  * Function: CFE_ES_StopAppCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_StopAppCmd(const CFE_ES_StopAppCmd_t *data)
@@ -1083,7 +1083,7 @@ int32 CFE_ES_StopAppCmd(const CFE_ES_StopAppCmd_t *data)
  * Function: CFE_ES_RestartAppCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_RestartAppCmd(const CFE_ES_RestartAppCmd_t *data)
@@ -1133,7 +1133,7 @@ int32 CFE_ES_RestartAppCmd(const CFE_ES_RestartAppCmd_t *data)
  * Function: CFE_ES_ReloadAppCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_ReloadAppCmd(const CFE_ES_ReloadAppCmd_t *data)
@@ -1192,7 +1192,7 @@ int32 CFE_ES_ReloadAppCmd(const CFE_ES_ReloadAppCmd_t *data)
  * Function: CFE_ES_QueryOneCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_QueryOneCmd(const CFE_ES_QueryOneCmd_t *data)
@@ -1259,7 +1259,7 @@ int32 CFE_ES_QueryOneCmd(const CFE_ES_QueryOneCmd_t *data)
  * Function: CFE_ES_QueryAllCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAllCmd_t *data)
@@ -1420,7 +1420,7 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAllCmd_t *data)
  * Function: CFE_ES_QueryAllTasksCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasksCmd_t *data)
@@ -1572,7 +1572,7 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasksCmd_t *data)
  * Function: CFE_ES_ClearSysLogCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_ClearSysLogCmd(const CFE_ES_ClearSysLogCmd_t *data)
@@ -1599,7 +1599,7 @@ int32 CFE_ES_ClearSysLogCmd(const CFE_ES_ClearSysLogCmd_t *data)
  * Function: CFE_ES_OverWriteSysLogCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_OverWriteSysLogCmd(const CFE_ES_OverWriteSysLogCmd_t *data)
@@ -1632,7 +1632,7 @@ int32 CFE_ES_OverWriteSysLogCmd(const CFE_ES_OverWriteSysLogCmd_t *data)
  * Function: CFE_ES_WriteSysLogCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_WriteSysLogCmd(const CFE_ES_WriteSysLogCmd_t *data)
@@ -1679,7 +1679,7 @@ int32 CFE_ES_WriteSysLogCmd(const CFE_ES_WriteSysLogCmd_t *data)
  * Function: CFE_ES_ClearERLogCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_ClearERLogCmd(const CFE_ES_ClearERLogCmd_t *data)
@@ -1715,7 +1715,7 @@ int32 CFE_ES_ClearERLogCmd(const CFE_ES_ClearERLogCmd_t *data)
  * Function: CFE_ES_WriteERLogCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_WriteERLogCmd(const CFE_ES_WriteERLogCmd_t *data)
@@ -1792,7 +1792,7 @@ int32 CFE_ES_WriteERLogCmd(const CFE_ES_WriteERLogCmd_t *data)
  * Function: CFE_ES_VerifyCmdLength
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 bool CFE_ES_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
@@ -1828,7 +1828,7 @@ bool CFE_ES_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
  * Function: CFE_ES_ResetPRCountCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_ResetPRCountCmd(const CFE_ES_ResetPRCountCmd_t *data)
@@ -1853,7 +1853,7 @@ int32 CFE_ES_ResetPRCountCmd(const CFE_ES_ResetPRCountCmd_t *data)
  * Function: CFE_ES_SetMaxPRCountCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_SetMaxPRCountCmd(const CFE_ES_SetMaxPRCountCmd_t *data)
@@ -1881,7 +1881,7 @@ int32 CFE_ES_SetMaxPRCountCmd(const CFE_ES_SetMaxPRCountCmd_t *data)
  * Function: CFE_ES_DeleteCDSCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_DeleteCDSCmd(const CFE_ES_DeleteCDSCmd_t *data)
@@ -1939,7 +1939,7 @@ int32 CFE_ES_DeleteCDSCmd(const CFE_ES_DeleteCDSCmd_t *data)
  * Function: CFE_ES_SendMemPoolStatsCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_SendMemPoolStatsCmd(const CFE_ES_SendMemPoolStatsCmd_t *data)
@@ -1989,7 +1989,7 @@ int32 CFE_ES_SendMemPoolStatsCmd(const CFE_ES_SendMemPoolStatsCmd_t *data)
  * Function: CFE_ES_DumpCDSRegistryCmd
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistryCmd_t *data)
@@ -2116,7 +2116,7 @@ int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistryCmd_t *data)
  * Function: CFE_ES_FileWriteByteCntErr
  *
  * Application-scope internal function
- * See description in cfe_es_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_FileWriteByteCntErr(const char *Filename, size_t Requested, int32 Status)

--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -63,12 +63,14 @@
 */
 CFE_ES_TaskData_t CFE_ES_TaskData;
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_TaskMain() -- Task entry point and main process loop     */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_TaskMain
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_TaskMain(void)
 {
     int32            Status;
@@ -172,15 +174,17 @@ void CFE_ES_TaskMain(void)
     ** Exit the application, CFE_ES_ExitApp will not return.
     */
     CFE_ES_ExitApp(AppRunStatus);
+}
 
-} /* End of CFE_ES_TaskMain() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_FindConfigKeyValue() -- Find value for given config key  */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_FindConfigKeyValue
+ *
+ * Internal helper routine only, not part of API.
+ *
+ * Find value for given config key
+ *
+ *-----------------------------------------------------------------*/
 const char *CFE_ES_FindConfigKeyValue(const CFE_ConfigKeyValue_t *ConfigList, const char *KeyName)
 {
     const char *ValuePtr;
@@ -203,12 +207,15 @@ const char *CFE_ES_FindConfigKeyValue(const CFE_ConfigKeyValue_t *ConfigList, co
     return ValuePtr;
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                     */
-/* CFE_ES_GenerateSingleVersionEvent() -- Send CFE_ES_VERSION_INF_EID  */
-/*                                                                     */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GenerateSingleVersionEvent
+ *
+ * Internal helper routine only, not part of API.
+ *
+ * Send a single CFE_ES_VERSION_INF_EID event for a component/module
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_GenerateSingleVersionEvent(const char *ModuleType, const char *ModuleName)
 {
     int32       Status;
@@ -232,12 +239,15 @@ int32 CFE_ES_GenerateSingleVersionEvent(const char *ModuleType, const char *Modu
     return Status;
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_GenerateVersionEvents() -- Send CFE_ES_VERSION_INF_EID's */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GenerateVersionEvents
+ *
+ * Internal helper routine only, not part of API.
+ *
+ * Send CFE_ES_VERSION_INF_EID events for all components/modules
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_GenerateVersionEvents(void)
 {
     int32                        Status;
@@ -289,12 +299,15 @@ void CFE_ES_GenerateVersionEvents(void)
     }
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_GenerateBuildInfoEvents() -- Send CFE_ES_BUILD_INF_EID   */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_GenerateBuildInfoEvents
+ *
+ * Internal helper routine only, not part of API.
+ *
+ * Sends the CFE_ES_BUILD_INF_EID event with build information
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_GenerateBuildInfoEvents(void)
 {
     int32       Status;
@@ -330,12 +343,14 @@ void CFE_ES_GenerateBuildInfoEvents(void)
     }
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_TaskInit() -- ES task initialization                     */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_TaskInit
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_TaskInit(void)
 {
     int32   Status;
@@ -495,15 +510,16 @@ int32 CFE_ES_TaskInit(void)
     }
 
     return (CFE_SUCCESS);
+}
 
-} /* End of CFE_ES_TaskInit() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_TaskPipe() -- Process command pipe message               */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_TaskPipe
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
 {
     CFE_SB_MsgId_t    MessageID   = CFE_SB_INVALID_MSG_ID;
@@ -711,15 +727,16 @@ void CFE_ES_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
             CFE_ES_Global.TaskData.CommandErrorCounter++;
             break;
     }
+}
 
-} /* End of CFE_ES_TaskPipe() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_HousekeepingCmd() -- On-board command (HK request)       */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_HousekeepingCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
 {
     OS_heap_prop_t HeapProp;
@@ -824,14 +841,16 @@ int32 CFE_ES_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
     */
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_HousekeepingCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_NoopCmd() -- ES task ground command (NO-OP)              */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_NoopCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_NoopCmd(const CFE_ES_NoopCmd_t *Cmd)
 {
     /*
@@ -851,14 +870,16 @@ int32 CFE_ES_NoopCmd(const CFE_ES_NoopCmd_t *Cmd)
                       CFE_PSP_GetVersionString());
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_NoopCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_ResetCountersCmd() -- ES task ground command (reset counters)    */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_ResetCountersCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_ResetCountersCmd(const CFE_ES_ResetCountersCmd_t *data)
 {
     CFE_ES_Global.TaskData.CommandCounter      = 0;
@@ -870,14 +891,16 @@ int32 CFE_ES_ResetCountersCmd(const CFE_ES_ResetCountersCmd_t *data)
     CFE_EVS_SendEvent(CFE_ES_RESET_INF_EID, CFE_EVS_EventType_INFORMATION, "Reset Counters command");
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_ResetCountersCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_RestartCmd() -- Restart cFE (may reset processor)        */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_RestartCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_RestartCmd(const CFE_ES_RestartCmd_t *data)
 {
     const CFE_ES_RestartCmd_Payload_t *cmd = &data->Payload;
@@ -897,14 +920,16 @@ int32 CFE_ES_RestartCmd(const CFE_ES_RestartCmd_t *data)
     }
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_RestartCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_StartAppCmd() -- Load (and start) single application     */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_StartAppCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_StartAppCmd(const CFE_ES_StartAppCmd_t *data)
 {
     const CFE_ES_StartAppCmd_Payload_t *cmd = &data->Payload;
@@ -1000,14 +1025,16 @@ int32 CFE_ES_StartAppCmd(const CFE_ES_StartAppCmd_t *data)
     } /* End if -- command parameter validation */
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_StartAppCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_StopAppCmd() -- Stop single application                  */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_StopAppCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_StopAppCmd(const CFE_ES_StopAppCmd_t *data)
 {
     const CFE_ES_AppNameCmd_Payload_t *cmd = &data->Payload;
@@ -1049,14 +1076,16 @@ int32 CFE_ES_StopAppCmd(const CFE_ES_StopAppCmd_t *data)
     }
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_StopAppCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_RestartAppCmd() -- Restart a single application            */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_RestartAppCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_RestartAppCmd(const CFE_ES_RestartAppCmd_t *data)
 {
     const CFE_ES_AppNameCmd_Payload_t *cmd = &data->Payload;
@@ -1097,14 +1126,16 @@ int32 CFE_ES_RestartAppCmd(const CFE_ES_RestartAppCmd_t *data)
     }
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_ResetAppCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_ReloadAppCmd() -- Reload a single application            */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_ReloadAppCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_ReloadAppCmd(const CFE_ES_ReloadAppCmd_t *data)
 {
     const CFE_ES_AppReloadCmd_Payload_t *cmd = &data->Payload;
@@ -1154,14 +1185,16 @@ int32 CFE_ES_ReloadAppCmd(const CFE_ES_ReloadAppCmd_t *data)
     }
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_ReloadAppCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_QueryOneCmd() -- Request tlm packet with single app data */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_QueryOneCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_QueryOneCmd(const CFE_ES_QueryOneCmd_t *data)
 {
     const CFE_ES_AppNameCmd_Payload_t *cmd = &data->Payload;
@@ -1219,14 +1252,16 @@ int32 CFE_ES_QueryOneCmd(const CFE_ES_QueryOneCmd_t *data)
     }
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_QueryOneCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_QueryAllCmd() -- Write all app data to file              */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_QueryAllCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAllCmd_t *data)
 {
     CFE_FS_Header_t                     FileHeader;
@@ -1378,14 +1413,16 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAllCmd_t *data)
     }
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_QueryAllCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_QueryAllTasksCmd() -- Write all Task Data to a file      */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_QueryAllTasksCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasksCmd_t *data)
 {
     CFE_FS_Header_t                     FileHeader;
@@ -1528,14 +1565,16 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasksCmd_t *data)
     }
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_QueryAllTasksCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_ClearSysLogCmd() -- Clear executive services system log  */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_ClearSysLogCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_ClearSysLogCmd(const CFE_ES_ClearSysLogCmd_t *data)
 {
     /*
@@ -1553,14 +1592,16 @@ int32 CFE_ES_ClearSysLogCmd(const CFE_ES_ClearSysLogCmd_t *data)
     CFE_EVS_SendEvent(CFE_ES_SYSLOG1_INF_EID, CFE_EVS_EventType_INFORMATION, "Cleared Executive Services log data");
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_ClearSysLogCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_OverWriteSysLogCmd() -- set syslog mode                  */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_OverWriteSysLogCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_OverWriteSysLogCmd(const CFE_ES_OverWriteSysLogCmd_t *data)
 {
     int32                                      Status;
@@ -1584,14 +1625,16 @@ int32 CFE_ES_OverWriteSysLogCmd(const CFE_ES_OverWriteSysLogCmd_t *data)
     }
 
     return CFE_SUCCESS;
-} /* End CFE_ES_OverWriteSysLogCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                       */
-/* CFE_ES_WriteSysLogCmd() -- Process Cmd to write ES System Log to file */
-/*                                                                       */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_WriteSysLogCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_WriteSysLogCmd(const CFE_ES_WriteSysLogCmd_t *data)
 {
     const CFE_ES_FileNameCmd_Payload_t *CmdPtr = &data->Payload;
@@ -1629,14 +1672,16 @@ int32 CFE_ES_WriteSysLogCmd(const CFE_ES_WriteSysLogCmd_t *data)
     } /* end if */
 
     return CFE_SUCCESS;
-} /* end CFE_ES_WriteSysLogCmd */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_ClearERLogCmd() -- Clear The exception and reset log.    */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_ClearERLogCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_ClearERLogCmd(const CFE_ES_ClearERLogCmd_t *data)
 {
     /*
@@ -1663,14 +1708,16 @@ int32 CFE_ES_ClearERLogCmd(const CFE_ES_ClearERLogCmd_t *data)
     CFE_EVS_SendEvent(CFE_ES_ERLOG1_INF_EID, CFE_EVS_EventType_INFORMATION, "Cleared ES Exception and Reset Log data");
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_ClearERLogCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_WriteERLogCmd() -- Process Cmd to write exception & reset*/
-/*                           log to a file.                        */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_WriteERLogCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_WriteERLogCmd(const CFE_ES_WriteERLogCmd_t *data)
 {
     const CFE_ES_FileNameCmd_Payload_t *CmdPtr = &data->Payload;
@@ -1738,14 +1785,16 @@ int32 CFE_ES_WriteERLogCmd(const CFE_ES_WriteERLogCmd_t *data)
     }
 
     return CFE_SUCCESS;
-} /* end CFE_ES_WriteERLogCmd */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_VerifyCmdLength() -- Verify command packet length        */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_VerifyCmdLength
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_ES_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
 {
     bool              result       = true;
@@ -1772,16 +1821,16 @@ bool CFE_ES_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
     }
 
     return (result);
+}
 
-} /* End of CFE_ES_VerifyCmdLength() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_ResetPRCountCmd() -- ES task ground command              */
-/*                              (Processor Reset Count)            */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_ResetPRCountCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_ResetPRCountCmd(const CFE_ES_ResetPRCountCmd_t *data)
 {
     /*
@@ -1797,14 +1846,16 @@ int32 CFE_ES_ResetPRCountCmd(const CFE_ES_ResetPRCountCmd_t *data)
     CFE_ES_Global.TaskData.CommandCounter++;
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_ResetPRCountCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_SetMaxPRCountCmd() -- Set Maximum Processor reset count  */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_SetMaxPRCountCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_SetMaxPRCountCmd(const CFE_ES_SetMaxPRCountCmd_t *data)
 {
     const CFE_ES_SetMaxPRCountCmd_Payload_t *cmd = &data->Payload;
@@ -1823,14 +1874,16 @@ int32 CFE_ES_SetMaxPRCountCmd(const CFE_ES_SetMaxPRCountCmd_t *data)
     CFE_ES_Global.TaskData.CommandCounter++;
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_RestartCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_DeleteCDSCmd() -- Delete Specified Critical Data Store   */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_DeleteCDSCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_DeleteCDSCmd(const CFE_ES_DeleteCDSCmd_t *data)
 {
     int32                                Status;
@@ -1879,17 +1932,16 @@ int32 CFE_ES_DeleteCDSCmd(const CFE_ES_DeleteCDSCmd_t *data)
     }
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_DeleteCDSCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                   */
-/* CFE_ES_SendMemPoolStatsCmd() -- Telemeter Memory Pool Statistics  */
-/*                                                                   */
-/* Note: The "Application" parameter of the                          */
-/*       CFE_ES_TlmPoolStats_t structure is not used.                */
-/*                                                                   */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_SendMemPoolStatsCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_SendMemPoolStatsCmd(const CFE_ES_SendMemPoolStatsCmd_t *data)
 {
     const CFE_ES_SendMemPoolStatsCmd_Payload_t *Cmd;
@@ -1930,14 +1982,16 @@ int32 CFE_ES_SendMemPoolStatsCmd(const CFE_ES_SendMemPoolStatsCmd_t *data)
     }
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_SendMemPoolStatsCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_DumpCDSRegistryCmd() -- Dump CDS Registry to a file           */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_DumpCDSRegistryCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistryCmd_t *data)
 {
     CFE_FS_Header_t                            StdFileHeader;
@@ -2055,23 +2109,20 @@ int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistryCmd_t *data)
     }
 
     return CFE_SUCCESS;
-} /* End of CFE_ES_DumpCDSRegistryCmd() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_ES_FileWriteByteCntErr() -- Send event to inform ground that*/
-/*                                a byte count discrepancy has been*/
-/*                                detected during the file write   */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_ES_FileWriteByteCntErr
+ *
+ * Application-scope internal function
+ * See description in cfe_es_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_ES_FileWriteByteCntErr(const char *Filename, size_t Requested, int32 Status)
 {
 
     CFE_EVS_SendEvent(CFE_ES_FILEWRITE_ERR_EID, CFE_EVS_EventType_ERROR,
                       "File write,byte cnt err,file %s,request=%u,status=0x%08x", Filename, (unsigned int)Requested,
                       (unsigned int)Status);
-
-} /* End of CFE_ES_FileWriteByteCntErr() */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/modules/es/fsw/src/cfe_es_task.h
+++ b/modules/es/fsw/src/cfe_es_task.h
@@ -77,53 +77,226 @@
 /*
 ** ES Task function prototypes
 */
-void  CFE_ES_TaskMain(void);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief Main task function for executive services
+ */
+void CFE_ES_TaskMain(void);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief Initialization of executive services global state
+ */
 int32 CFE_ES_TaskInit(void);
-void  CFE_ES_TaskPipe(CFE_SB_Buffer_t *SBBufPtr);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * Reads and processes messages from the executive services command pipe
+ */
+void CFE_ES_TaskPipe(CFE_SB_Buffer_t *SBBufPtr);
 
 /*
  * Functions related to the ES background helper task for low-priority tasks
  */
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief Initializes the ES background task state
+ */
 int32 CFE_ES_BackgroundInit(void);
-void  CFE_ES_BackgroundTask(void);
-void  CFE_ES_BackgroundCleanup(void);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief ES background task main function
+ *
+ * Purpose: A helper task for low priority routines that may take time to
+ * execute, such as writing log files.
+ *
+ * Assumptions and Notes: This is started from the ES initialization, and
+ * pends on a semaphore until a work request comes in.  This is intended to
+ * avoid the need to create a child task "on demand" when work items arrive,
+ * which is a form of dynamic allocation.
+ */
+void CFE_ES_BackgroundTask(void);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief Exit/Stop the background task
+ */
+void CFE_ES_BackgroundCleanup(void);
 
 /*
 ** ES Task message dispatch functions
 */
 int32 CFE_ES_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief ES task ground command (NO-OP)
+ */
 int32 CFE_ES_NoopCmd(const CFE_ES_NoopCmd_t *Cmd);
+
+/*---------------------------------------------------------------------------------------*/
+/** \brief  ES task ground command (reset counters)
+ */
 int32 CFE_ES_ResetCountersCmd(const CFE_ES_ResetCountersCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  Restart cFE (may reset processor)
+ */
 int32 CFE_ES_RestartCmd(const CFE_ES_RestartCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  Load (and start) single application
+ */
 int32 CFE_ES_StartAppCmd(const CFE_ES_StartAppCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  Stop single application
+ */
 int32 CFE_ES_StopAppCmd(const CFE_ES_StopAppCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  Restart a single application
+ */
 int32 CFE_ES_RestartAppCmd(const CFE_ES_RestartAppCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  Reload a single application
+ */
 int32 CFE_ES_ReloadAppCmd(const CFE_ES_ReloadAppCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  Request tlm packet with single app data
+ */
 int32 CFE_ES_QueryOneCmd(const CFE_ES_QueryOneCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  Write all app data to file
+ */
 int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAllCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  Write all Task Data to a file
+ */
 int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasksCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  Clear executive services system log
+ */
 int32 CFE_ES_ClearSysLogCmd(const CFE_ES_ClearSysLogCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  set syslog mode
+ */
 int32 CFE_ES_OverWriteSysLogCmd(const CFE_ES_OverWriteSysLogCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  Process Cmd to write ES System Log to file
+ */
 int32 CFE_ES_WriteSysLogCmd(const CFE_ES_WriteSysLogCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  Clear The exception and reset log.
+ */
 int32 CFE_ES_ClearERLogCmd(const CFE_ES_ClearERLogCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  Process Cmd to write exception & reset log to a file.
+ */
 int32 CFE_ES_WriteERLogCmd(const CFE_ES_WriteERLogCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  Processor Reset Count
+ */
 int32 CFE_ES_ResetPRCountCmd(const CFE_ES_ResetPRCountCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  Set Maximum Processor reset count
+ */
 int32 CFE_ES_SetMaxPRCountCmd(const CFE_ES_SetMaxPRCountCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  Delete Specified Critical Data Store
+ */
 int32 CFE_ES_DeleteCDSCmd(const CFE_ES_DeleteCDSCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  Command handler to start collecting performance data
+ */
 int32 CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfDataCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  Command handler to stop collecting performance data
+ */
 int32 CFE_ES_StopPerfDataCmd(const CFE_ES_StopPerfDataCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  Command handler to set perf ID filter mask
+ */
 int32 CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMaskCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  Command handler to set perf ID trigger mask
+ */
 int32 CFE_ES_SetPerfTriggerMaskCmd(const CFE_ES_SetPerfTriggerMaskCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  Telemeter Memory Pool Statistics
+ */
 int32 CFE_ES_SendMemPoolStatsCmd(const CFE_ES_SendMemPoolStatsCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  Dump CDS Registry to a file
+ */
 int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistryCmd_t *data);
 
 /*
 ** Message Handler Helper Functions
 */
-bool CFE_ES_ValidateHandle(CFE_ES_MemHandle_t Handle);
-bool CFE_ES_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength);
-void CFE_ES_FileWriteByteCntErr(const char *Filename, size_t Requested, int32 Status);
 
-/*************************************************************************/
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief Insures that the handle passed in meets all of the requirements of a valid handle.
+ */
+bool CFE_ES_ValidateHandle(CFE_ES_MemHandle_t Handle);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief  Verify command packet length
+ */
+bool CFE_ES_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief Notify of file write inconsistency
+ *
+ * Send event to inform ground that a byte count discrepancy has been
+ * detected during the file write
+ */
+void CFE_ES_FileWriteByteCntErr(const char *Filename, size_t Requested, int32 Status);
 
 #endif /* CFE_ES_TASK_H */

--- a/modules/evs/fsw/src/cfe_evs.c
+++ b/modules/evs/fsw/src/cfe_evs.c
@@ -35,15 +35,14 @@
 #include <stdarg.h>
 #include <string.h>
 
-/* External Data */
-
-/* Local Function Prototypes */
-
-/* Function Definitions */
-
-/*
-** Function: CFE_EVS_Register - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_Register
+ *
+ * Implemented per public API
+ * See description in cfe_evs.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_Register(const void *Filters, uint16 NumEventFilters, uint16 FilterScheme)
 {
     uint16               FilterLimit;
@@ -112,12 +111,16 @@ int32 CFE_EVS_Register(const void *Filters, uint16 NumEventFilters, uint16 Filte
     }
 
     return (Status);
+}
 
-} /* End CFE_EVS_Register */
-
-/*
-** Function: CFE_EVS_Unregister - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_Unregister
+ *
+ * Implemented per public API
+ * See description in cfe_evs.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_Unregister(void)
 {
     int32          Status;
@@ -132,12 +135,16 @@ int32 CFE_EVS_Unregister(void)
     }
 
     return (Status);
+}
 
-} /* End CFE_EVS_Unregister */
-
-/*
-** Function: CFE_EVS_SendEvent - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_SendEvent
+ *
+ * Implemented per public API
+ * See description in cfe_evs.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spec, ...)
 {
     int32              Status;
@@ -173,12 +180,16 @@ int32 CFE_EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spec, ...)
     }
 
     return (Status);
+}
 
-} /* End CFE_EVS_SendEvent */
-
-/*
-** Function: CFE_EVS_SendEventWithAppID - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_SendEventWithAppID
+ *
+ * Implemented per public API
+ * See description in cfe_evs.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_SendEventWithAppID(uint16 EventID, uint16 EventType, CFE_ES_AppId_t AppID, const char *Spec, ...)
 {
     int32              Status = CFE_SUCCESS;
@@ -213,12 +224,16 @@ int32 CFE_EVS_SendEventWithAppID(uint16 EventID, uint16 EventType, CFE_ES_AppId_
     }
 
     return Status;
+}
 
-} /* End CFE_EVS_SendEventWithAppID */
-
-/*
-** Function: CFE_EVS_SendTimedEvent - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_SendTimedEvent
+ *
+ * Implemented per public API
+ * See description in cfe_evs.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time, uint16 EventID, uint16 EventType, const char *Spec, ...)
 {
     int32          Status;
@@ -250,12 +265,16 @@ int32 CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time, uint16 EventID, uint16 Eve
     }
 
     return (Status);
+}
 
-} /* End CFE_EVS_SendTimedEvent */
-
-/*
-** Function: CFE_EVS_ResetFilter - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_ResetFilter
+ *
+ * Implemented per public API
+ * See description in cfe_evs.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_ResetFilter(int16 EventID)
 {
     int32            Status;
@@ -287,12 +306,16 @@ int32 CFE_EVS_ResetFilter(int16 EventID)
     }
 
     return (Status);
+}
 
-} /* End CFE_EVS_ResetFilter */
-
-/*
-** Function: CFE_EVS_ResetAllFilters - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_ResetAllFilters
+ *
+ * Implemented per public API
+ * See description in cfe_evs.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_ResetAllFilters(void)
 {
     int32          Status;
@@ -318,7 +341,4 @@ int32 CFE_EVS_ResetAllFilters(void)
     }
 
     return (Status);
-
-} /* End CFE_EVS_ResetAllFilters */
-
-/* End CFE_EVS.C */
+}

--- a/modules/evs/fsw/src/cfe_evs.c
+++ b/modules/evs/fsw/src/cfe_evs.c
@@ -40,7 +40,7 @@
  * Function: CFE_EVS_Register
  *
  * Implemented per public API
- * See description in cfe_evs.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_Register(const void *Filters, uint16 NumEventFilters, uint16 FilterScheme)
@@ -118,7 +118,7 @@ int32 CFE_EVS_Register(const void *Filters, uint16 NumEventFilters, uint16 Filte
  * Function: CFE_EVS_Unregister
  *
  * Implemented per public API
- * See description in cfe_evs.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_Unregister(void)
@@ -142,7 +142,7 @@ int32 CFE_EVS_Unregister(void)
  * Function: CFE_EVS_SendEvent
  *
  * Implemented per public API
- * See description in cfe_evs.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spec, ...)
@@ -187,7 +187,7 @@ int32 CFE_EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spec, ...)
  * Function: CFE_EVS_SendEventWithAppID
  *
  * Implemented per public API
- * See description in cfe_evs.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_SendEventWithAppID(uint16 EventID, uint16 EventType, CFE_ES_AppId_t AppID, const char *Spec, ...)
@@ -231,7 +231,7 @@ int32 CFE_EVS_SendEventWithAppID(uint16 EventID, uint16 EventType, CFE_ES_AppId_
  * Function: CFE_EVS_SendTimedEvent
  *
  * Implemented per public API
- * See description in cfe_evs.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time, uint16 EventID, uint16 EventType, const char *Spec, ...)
@@ -272,7 +272,7 @@ int32 CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time, uint16 EventID, uint16 Eve
  * Function: CFE_EVS_ResetFilter
  *
  * Implemented per public API
- * See description in cfe_evs.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_ResetFilter(int16 EventID)
@@ -313,7 +313,7 @@ int32 CFE_EVS_ResetFilter(int16 EventID)
  * Function: CFE_EVS_ResetAllFilters
  *
  * Implemented per public API
- * See description in cfe_evs.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_ResetAllFilters(void)

--- a/modules/evs/fsw/src/cfe_evs_log.c
+++ b/modules/evs/fsw/src/cfe_evs_log.c
@@ -33,16 +33,14 @@
 
 #include <string.h>
 
-/*
-**             Function Prologue
-**
-** Function Name:      EVS_AddLog
-**
-** Purpose:  This routine adds an event packet to the internal event log.
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: EVS_AddLog
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_log.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void EVS_AddLog(CFE_EVS_LongEventTlm_t *EVS_PktPtr)
 {
 
@@ -90,19 +88,16 @@ void EVS_AddLog(CFE_EVS_LongEventTlm_t *EVS_PktPtr)
     OS_MutSemGive(CFE_EVS_Global.EVS_SharedDataMutexID);
 
     return;
+}
 
-} /* End EVS_AddLog */
-
-/*
-**             Function Prologue
-**
-** Function Name:      EVS_ClearLog
-**
-** Purpose:  This routine clears the contents of the internal event log.
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: EVS_ClearLog
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_log.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void EVS_ClearLog(void)
 {
 
@@ -120,19 +115,16 @@ void EVS_ClearLog(void)
     OS_MutSemGive(CFE_EVS_Global.EVS_SharedDataMutexID);
 
     return;
+}
 
-} /* End EVS_ClearLog */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_WriteLogDataFileCmd
-**
-** Purpose:  This routine writes the contents of the internal event log to a file
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_WriteLogDataFileCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_log.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFileCmd_t *data)
 {
     const CFE_EVS_LogFileCmd_Payload_t *CmdPtr = &data->Payload;
@@ -240,19 +232,16 @@ int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFileCmd_t *data)
     }
 
     return (Result);
+}
 
-} /* End CFE_EVS_WriteLogDataFileCmd */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_SetLogModeCmd
-**
-** Purpose:  This routine sets the internal event log mode.
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_SetLogModeCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_log.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_SetLogModeCmd(const CFE_EVS_SetLogModeCmd_t *data)
 {
     const CFE_EVS_SetLogMode_Payload_t *CmdPtr = &data->Payload;
@@ -278,7 +267,4 @@ int32 CFE_EVS_SetLogModeCmd(const CFE_EVS_SetLogModeCmd_t *data)
     }
 
     return Status;
-
-} /* End CFE_EVS_SetLogModeCmd */
-
-/* END EVSLOG.C */
+}

--- a/modules/evs/fsw/src/cfe_evs_log.c
+++ b/modules/evs/fsw/src/cfe_evs_log.c
@@ -38,7 +38,7 @@
  * Function: EVS_AddLog
  *
  * Application-scope internal function
- * See description in cfe_evs_log.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void EVS_AddLog(CFE_EVS_LongEventTlm_t *EVS_PktPtr)
@@ -95,7 +95,7 @@ void EVS_AddLog(CFE_EVS_LongEventTlm_t *EVS_PktPtr)
  * Function: EVS_ClearLog
  *
  * Application-scope internal function
- * See description in cfe_evs_log.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void EVS_ClearLog(void)
@@ -122,7 +122,7 @@ void EVS_ClearLog(void)
  * Function: CFE_EVS_WriteLogDataFileCmd
  *
  * Application-scope internal function
- * See description in cfe_evs_log.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFileCmd_t *data)
@@ -239,7 +239,7 @@ int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFileCmd_t *data)
  * Function: CFE_EVS_SetLogModeCmd
  *
  * Application-scope internal function
- * See description in cfe_evs_log.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_SetLogModeCmd(const CFE_EVS_SetLogModeCmd_t *data)

--- a/modules/evs/fsw/src/cfe_evs_log.h
+++ b/modules/evs/fsw/src/cfe_evs_log.h
@@ -52,9 +52,32 @@
 
 /* ==============   Section III: Function Prototypes =========== */
 
-void  EVS_AddLog(CFE_EVS_LongEventTlm_t *EVS_PktPtr);
-void  EVS_ClearLog(void);
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief This routine adds an event packet to the internal event log.
+ */
+void EVS_AddLog(CFE_EVS_LongEventTlm_t *EVS_PktPtr);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief This routine clears the contents of the internal event log.
+ */
+void EVS_ClearLog(void);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Message Handler Function
+ *
+ * This routine writes the contents of the internal event log to a file
+ */
 int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFileCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Message Handler Function
+ *
+ * This routine sets the internal event log mode.
+ */
 int32 CFE_EVS_SetLogModeCmd(const CFE_EVS_SetLogModeCmd_t *data);
 
 #endif /* CFE_EVS_LOG_H */

--- a/modules/evs/fsw/src/cfe_evs_task.c
+++ b/modules/evs/fsw/src/cfe_evs_task.c
@@ -56,7 +56,7 @@ bool CFE_EVS_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength);
  * Function: CFE_EVS_EarlyInit
  *
  * Implemented per public API
- * See description in cfe_evs_core_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_EarlyInit(void)
@@ -168,7 +168,7 @@ int32 CFE_EVS_EarlyInit(void)
  * Function: CFE_EVS_CleanUpApp
  *
  * Implemented per public API
- * See description in cfe_evs_core_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_CleanUpApp(CFE_ES_AppId_t AppID)
@@ -196,7 +196,7 @@ int32 CFE_EVS_CleanUpApp(CFE_ES_AppId_t AppID)
  * Function: CFE_EVS_TaskMain
  *
  * Implemented per public API
- * See description in cfe_evs_core_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_EVS_TaskMain(void)
@@ -258,7 +258,7 @@ void CFE_EVS_TaskMain(void)
  * Function: CFE_EVS_TaskInit
  *
  * Application-scope internal function
- * See description in cfe_evs_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_TaskInit(void)
@@ -317,7 +317,7 @@ int32 CFE_EVS_TaskInit(void)
  * Function: CFE_EVS_ProcessCommandPacket
  *
  * Application-scope internal function
- * See description in cfe_evs_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_EVS_ProcessCommandPacket(CFE_SB_Buffer_t *SBBufPtr)
@@ -603,7 +603,7 @@ bool CFE_EVS_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
  * Function: CFE_EVS_NoopCmd
  *
  * Application-scope internal function
- * See description in cfe_evs_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_NoopCmd(const CFE_EVS_NoopCmd_t *data)
@@ -617,7 +617,7 @@ int32 CFE_EVS_NoopCmd(const CFE_EVS_NoopCmd_t *data)
  * Function: CFE_EVS_ClearLogCmd
  *
  * Application-scope internal function
- * See description in cfe_evs_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_ClearLogCmd(const CFE_EVS_ClearLogCmd_t *data)
@@ -631,7 +631,7 @@ int32 CFE_EVS_ClearLogCmd(const CFE_EVS_ClearLogCmd_t *data)
  * Function: CFE_EVS_ReportHousekeepingCmd
  *
  * Application-scope internal function
- * See description in cfe_evs_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_ReportHousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
@@ -681,7 +681,7 @@ int32 CFE_EVS_ReportHousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
  * Function: CFE_EVS_ResetCountersCmd
  *
  * Application-scope internal function
- * See description in cfe_evs_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_ResetCountersCmd(const CFE_EVS_ResetCountersCmd_t *data)
@@ -707,7 +707,7 @@ int32 CFE_EVS_ResetCountersCmd(const CFE_EVS_ResetCountersCmd_t *data)
  * Function: CFE_EVS_SetFilterCmd
  *
  * Application-scope internal function
- * See description in cfe_evs_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_SetFilterCmd(const CFE_EVS_SetFilterCmd_t *data)
@@ -775,7 +775,7 @@ int32 CFE_EVS_SetFilterCmd(const CFE_EVS_SetFilterCmd_t *data)
  * Function: CFE_EVS_EnablePortsCmd
  *
  * Application-scope internal function
- * See description in cfe_evs_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_EnablePortsCmd(const CFE_EVS_EnablePortsCmd_t *data)
@@ -825,7 +825,7 @@ int32 CFE_EVS_EnablePortsCmd(const CFE_EVS_EnablePortsCmd_t *data)
  * Function: CFE_EVS_DisablePortsCmd
  *
  * Application-scope internal function
- * See description in cfe_evs_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_DisablePortsCmd(const CFE_EVS_DisablePortsCmd_t *data)
@@ -876,7 +876,7 @@ int32 CFE_EVS_DisablePortsCmd(const CFE_EVS_DisablePortsCmd_t *data)
  * Function: CFE_EVS_EnableEventTypeCmd
  *
  * Application-scope internal function
- * See description in cfe_evs_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_EnableEventTypeCmd(const CFE_EVS_EnableEventTypeCmd_t *data)
@@ -922,7 +922,7 @@ int32 CFE_EVS_EnableEventTypeCmd(const CFE_EVS_EnableEventTypeCmd_t *data)
  * Function: CFE_EVS_DisableEventTypeCmd
  *
  * Application-scope internal function
- * See description in cfe_evs_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_DisableEventTypeCmd(const CFE_EVS_DisableEventTypeCmd_t *data)
@@ -969,7 +969,7 @@ int32 CFE_EVS_DisableEventTypeCmd(const CFE_EVS_DisableEventTypeCmd_t *data)
  * Function: CFE_EVS_SetEventFormatModeCmd
  *
  * Application-scope internal function
- * See description in cfe_evs_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_SetEventFormatModeCmd(const CFE_EVS_SetEventFormatModeCmd_t *data)
@@ -1001,7 +1001,7 @@ int32 CFE_EVS_SetEventFormatModeCmd(const CFE_EVS_SetEventFormatModeCmd_t *data)
  * Function: CFE_EVS_EnableAppEventTypeCmd
  *
  * Application-scope internal function
- * See description in cfe_evs_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_EnableAppEventTypeCmd(const CFE_EVS_EnableAppEventTypeCmd_t *data)
@@ -1069,7 +1069,7 @@ int32 CFE_EVS_EnableAppEventTypeCmd(const CFE_EVS_EnableAppEventTypeCmd_t *data)
  * Function: CFE_EVS_DisableAppEventTypeCmd
  *
  * Application-scope internal function
- * See description in cfe_evs_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_DisableAppEventTypeCmd(const CFE_EVS_DisableAppEventTypeCmd_t *data)
@@ -1137,7 +1137,7 @@ int32 CFE_EVS_DisableAppEventTypeCmd(const CFE_EVS_DisableAppEventTypeCmd_t *dat
  * Function: CFE_EVS_EnableAppEventsCmd
  *
  * Application-scope internal function
- * See description in cfe_evs_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_EnableAppEventsCmd(const CFE_EVS_EnableAppEventsCmd_t *data)
@@ -1189,7 +1189,7 @@ int32 CFE_EVS_EnableAppEventsCmd(const CFE_EVS_EnableAppEventsCmd_t *data)
  * Function: CFE_EVS_DisableAppEventsCmd
  *
  * Application-scope internal function
- * See description in cfe_evs_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_DisableAppEventsCmd(const CFE_EVS_DisableAppEventsCmd_t *data)
@@ -1241,7 +1241,7 @@ int32 CFE_EVS_DisableAppEventsCmd(const CFE_EVS_DisableAppEventsCmd_t *data)
  * Function: CFE_EVS_ResetAppCounterCmd
  *
  * Application-scope internal function
- * See description in cfe_evs_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_ResetAppCounterCmd(const CFE_EVS_ResetAppCounterCmd_t *data)
@@ -1293,7 +1293,7 @@ int32 CFE_EVS_ResetAppCounterCmd(const CFE_EVS_ResetAppCounterCmd_t *data)
  * Function: CFE_EVS_ResetFilterCmd
  *
  * Application-scope internal function
- * See description in cfe_evs_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_ResetFilterCmd(const CFE_EVS_ResetFilterCmd_t *data)
@@ -1360,7 +1360,7 @@ int32 CFE_EVS_ResetFilterCmd(const CFE_EVS_ResetFilterCmd_t *data)
  * Function: CFE_EVS_ResetAllFiltersCmd
  *
  * Application-scope internal function
- * See description in cfe_evs_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_ResetAllFiltersCmd(const CFE_EVS_ResetAllFiltersCmd_t *data)
@@ -1416,7 +1416,7 @@ int32 CFE_EVS_ResetAllFiltersCmd(const CFE_EVS_ResetAllFiltersCmd_t *data)
  * Function: CFE_EVS_AddEventFilterCmd
  *
  * Application-scope internal function
- * See description in cfe_evs_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_AddEventFilterCmd(const CFE_EVS_AddEventFilterCmd_t *data)
@@ -1503,7 +1503,7 @@ int32 CFE_EVS_AddEventFilterCmd(const CFE_EVS_AddEventFilterCmd_t *data)
  * Function: CFE_EVS_DeleteEventFilterCmd
  *
  * Application-scope internal function
- * See description in cfe_evs_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_DeleteEventFilterCmd(const CFE_EVS_DeleteEventFilterCmd_t *data)
@@ -1572,7 +1572,7 @@ int32 CFE_EVS_DeleteEventFilterCmd(const CFE_EVS_DeleteEventFilterCmd_t *data)
  * Function: CFE_EVS_WriteAppDataFileCmd
  *
  * Application-scope internal function
- * See description in cfe_evs_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFileCmd_t *data)

--- a/modules/evs/fsw/src/cfe_evs_task.c
+++ b/modules/evs/fsw/src/cfe_evs_task.c
@@ -51,18 +51,14 @@ bool CFE_EVS_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength);
 
 /* Function Definitions */
 
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_EarlyInit
-**
-** Purpose:  This routine provides initialization for the EVS API.
-**
-** Assumptions and Notes: This routine must be called before the EVS
-**      application is started.  CFE_EVS_EarlyInit performs initialization
-**      necessary to support EVS API calls that might occur before
-**      the EVS application has completed its startup initialization.
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_EarlyInit
+ *
+ * Implemented per public API
+ * See description in cfe_evs_core_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_EarlyInit(void)
 {
 
@@ -165,18 +161,16 @@ int32 CFE_EVS_EarlyInit(void)
     }
 
     return (Status);
+}
 
-} /* End CFE_EVS_EarlyInit */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_CleanUpApp
-**
-** Purpose:  ES calls this routine when an app is being terminated.
-**
-** Assumptions and Notes:
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_CleanUpApp
+ *
+ * Implemented per public API
+ * See description in cfe_evs_core_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_CleanUpApp(CFE_ES_AppId_t AppID)
 {
     int32          Status = CFE_SUCCESS;
@@ -197,16 +191,14 @@ int32 CFE_EVS_CleanUpApp(CFE_ES_AppId_t AppID)
     return (Status);
 }
 
-/*
-**             Function Prologue
-**
-** Function Name:      EVS_TaskMain
-**
-** Purpose:  This is the main EVS task process loop.
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_TaskMain
+ *
+ * Implemented per public API
+ * See description in cfe_evs_core_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_EVS_TaskMain(void)
 {
     int32            Status;
@@ -259,19 +251,16 @@ void CFE_EVS_TaskMain(void)
 
     /* while loop exits only if CFE_SB_ReceiveBuffer returns error */
     CFE_ES_ExitApp(CFE_ES_RunStatus_CORE_APP_RUNTIME_ERROR);
+}
 
-} /* end CFE_EVS_TaskMain */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_TaskInit
-**
-** Purpose:  This function performs any necessary EVS task initialization.
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_TaskInit
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_TaskInit(void)
 {
     int32          Status;
@@ -321,19 +310,16 @@ int32 CFE_EVS_TaskInit(void)
     EVS_SendEvent(CFE_EVS_STARTUP_EID, CFE_EVS_EventType_INFORMATION, "cFE EVS Initialized.%s", CFE_VERSION_STRING);
 
     return CFE_SUCCESS;
+}
 
-} /* End CFE_EVS_TaskInit */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_ProcessCommandPacket
-**
-** Purpose:  This function processes packets received on the EVS command pipe.
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_ProcessCommandPacket
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_EVS_ProcessCommandPacket(CFE_SB_Buffer_t *SBBufPtr)
 {
     CFE_SB_MsgId_t MessageID = CFE_SB_INVALID_MSG_ID;
@@ -362,20 +348,18 @@ void CFE_EVS_ProcessCommandPacket(CFE_SB_Buffer_t *SBBufPtr)
     }
 
     return;
+}
 
-} /* End CFE_EVS_ProcessCommandPacket */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_ProcessGroundCommand
-**
-** Purpose:  This function processes a command, verifying that it is valid and of
-**           proper length.
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_ProcessGroundCommand
+ *
+ * Internal helper routine only, not part of API.
+ *
+ * This function processes a command, verifying that it is valid and of
+ *  proper length.
+ *
+ *-----------------------------------------------------------------*/
 void CFE_EVS_ProcessGroundCommand(CFE_SB_Buffer_t *SBBufPtr, CFE_SB_MsgId_t MsgId)
 {
     /* status will get reset if it passes length check */
@@ -575,19 +559,18 @@ void CFE_EVS_ProcessGroundCommand(CFE_SB_Buffer_t *SBBufPtr, CFE_SB_MsgId_t MsgI
     }
 
     return;
+}
 
-} /* End of EVS_ProcessGroundCommand() */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_VerifyCmdLength
-**
-** Purpose:  This function validates the length of incoming commands.
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_VerifyCmdLength
+ *
+ * Internal helper routine only, not part of API.
+ *
+ * This function validates the length of a command structure, and
+ * generates an error event if is not the expected length.
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_EVS_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
 {
     bool              result       = true;
@@ -613,51 +596,44 @@ bool CFE_EVS_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
     }
 
     return (result);
+}
 
-} /* End of CFE_EVS_VerifyCmdLength() */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_NoopCmd
-**
-** Purpose:  This function processes "no-op" commands received on the EVS command pipe.
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_NoopCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_NoopCmd(const CFE_EVS_NoopCmd_t *data)
 {
     EVS_SendEvent(CFE_EVS_NOOP_EID, CFE_EVS_EventType_INFORMATION, "No-op command. %s", CFE_VERSION_STRING);
     return CFE_SUCCESS;
 }
 
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_ClearLogCmd
-**
-** Purpose:  This function processes "clear log" commands received on the EVS command pipe.
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_ClearLogCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_ClearLogCmd(const CFE_EVS_ClearLogCmd_t *data)
 {
     EVS_ClearLog();
     return CFE_SUCCESS;
 }
 
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_ReportHousekeepingCmd
-**
-** Purpose:  Request for housekeeping status telemetry packet.
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_ReportHousekeepingCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_ReportHousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
 {
     uint32                i, j;
@@ -698,19 +674,16 @@ int32 CFE_EVS_ReportHousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
     CFE_SB_TransmitMsg(&CFE_EVS_Global.EVS_TlmPkt.TlmHeader.Msg, true);
 
     return CFE_STATUS_NO_COUNTER_INCREMENT;
-} /* End of CFE_EVS_ReportHousekeepingCmd() */
+}
 
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_ResetCountersCmd
-**
-** Purpose:  This function resets all the global counter variables that are
-**           part of the task telemetry.
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_ResetCountersCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_ResetCountersCmd(const CFE_EVS_ResetCountersCmd_t *data)
 {
     /* Status of commands processed by EVS task */
@@ -727,19 +700,16 @@ int32 CFE_EVS_ResetCountersCmd(const CFE_EVS_ResetCountersCmd_t *data)
     /* NOTE: Historically the reset counters command does _NOT_ increment the command counter */
 
     return CFE_STATUS_NO_COUNTER_INCREMENT;
-} /* End of CFE_EVS_ResetCountersCmd() */
+}
 
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_SetEventFilterMaskCmd
-**
-** Purpose:  This routine sets the filter mask for the given event_id in the
-**           calling task's filter array
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_SetFilterCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_SetFilterCmd(const CFE_EVS_SetFilterCmd_t *data)
 {
     const CFE_EVS_AppNameEventIDMaskCmd_Payload_t *CmdPtr = &data->Payload;
@@ -798,20 +768,16 @@ int32 CFE_EVS_SetFilterCmd(const CFE_EVS_SetFilterCmd_t *data)
     }
 
     return Status;
+}
 
-} /* End CFE_EVS_SetFilterMaskCmd */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_EnablePortsCmd
-**
-** Purpose:  This routine sets the command given ports to an enabled state
-**
-** Assumptions and Notes:
-** Shifting is done so the value not masked off is placed in the ones spot:
-** necessary for comparing with true.
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_EnablePortsCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_EnablePortsCmd(const CFE_EVS_EnablePortsCmd_t *data)
 {
     const CFE_EVS_BitMaskCmd_Payload_t *CmdPtr = &data->Payload;
@@ -852,20 +818,16 @@ int32 CFE_EVS_EnablePortsCmd(const CFE_EVS_EnablePortsCmd_t *data)
     }
 
     return ReturnCode;
+}
 
-} /* End CFE_EVS_EnablePortsCmd */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_DisablePortsCmd
-**
-** Purpose:  This routine sets the command given ports to a disabled state
-**
-** Assumptions and Notes:
-** Shifting is done so the value not masked off is placed in the ones spot:
-** necessary for comparing with true.
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_DisablePortsCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_DisablePortsCmd(const CFE_EVS_DisablePortsCmd_t *data)
 {
     const CFE_EVS_BitMaskCmd_Payload_t *CmdPtr = &data->Payload;
@@ -907,20 +869,16 @@ int32 CFE_EVS_DisablePortsCmd(const CFE_EVS_DisablePortsCmd_t *data)
     }
 
     return ReturnCode;
+}
 
-} /* End CFE_EVS_DisablePortsCmd */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_EnableEventTypesCmd
-**
-** Purpose:  This routine sets the given event types to an enabled state across all
-**           registered applications
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_EnableEventTypeCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_EnableEventTypeCmd(const CFE_EVS_EnableEventTypeCmd_t *data)
 {
     uint32                              i;
@@ -957,20 +915,16 @@ int32 CFE_EVS_EnableEventTypeCmd(const CFE_EVS_EnableEventTypeCmd_t *data)
     }
 
     return ReturnCode;
+}
 
-} /* End CFE_EVS_EnableEventTypesCmd */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_DisableEventTypesCmd
-**
-** Purpose:  This routine sets the given event types to a disabled state across all
-**           registered applications
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_DisableEventTypeCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_DisableEventTypeCmd(const CFE_EVS_DisableEventTypeCmd_t *data)
 {
     uint32                              i;
@@ -1008,19 +962,16 @@ int32 CFE_EVS_DisableEventTypeCmd(const CFE_EVS_DisableEventTypeCmd_t *data)
     }
 
     return ReturnCode;
+}
 
-} /* End CFE_EVS_DisableEventTypesCmd */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_SetEventFormatModeCmd
-**
-** Purpose:  This routine sets the Event Format Mode
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_SetEventFormatModeCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_SetEventFormatModeCmd(const CFE_EVS_SetEventFormatModeCmd_t *data)
 {
     const CFE_EVS_SetEventFormatMode_Payload_t *CmdPtr = &data->Payload;
@@ -1043,20 +994,16 @@ int32 CFE_EVS_SetEventFormatModeCmd(const CFE_EVS_SetEventFormatModeCmd_t *data)
     }
 
     return Status;
+}
 
-} /* End CFE_EVS_SetEventFormatModeCmd */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_EnableAppEventTypesCmd
-**
-** Purpose:  This routine sets the given event type for the given application identifier to an
-**           enabled state
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_EnableAppEventTypeCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_EnableAppEventTypeCmd(const CFE_EVS_EnableAppEventTypeCmd_t *data)
 {
     const CFE_EVS_AppNameBitMaskCmd_Payload_t *CmdPtr = &data->Payload;
@@ -1115,20 +1062,16 @@ int32 CFE_EVS_EnableAppEventTypeCmd(const CFE_EVS_EnableAppEventTypeCmd_t *data)
     }
 
     return Status;
+}
 
-} /* End CFE_EVS_EnableAppEventTypesCmd */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_DisableAppEventTypesCmd
-**
-** Purpose:  This routine sets the given event type for the given application identifier to a
-**           disabled state
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_DisableAppEventTypeCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_DisableAppEventTypeCmd(const CFE_EVS_DisableAppEventTypeCmd_t *data)
 {
     EVS_AppData_t *                            AppDataPtr;
@@ -1187,19 +1130,16 @@ int32 CFE_EVS_DisableAppEventTypeCmd(const CFE_EVS_DisableAppEventTypeCmd_t *dat
     }
 
     return Status;
+}
 
-} /* End CFE_EVS_DisableAppEventTypes */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_EnableAppEventsCmd
-**
-** Purpose:  This routine enables application events for the given application identifier
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_EnableAppEventsCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_EnableAppEventsCmd(const CFE_EVS_EnableAppEventsCmd_t *data)
 {
     EVS_AppData_t *                     AppDataPtr;
@@ -1242,19 +1182,16 @@ int32 CFE_EVS_EnableAppEventsCmd(const CFE_EVS_EnableAppEventsCmd_t *data)
     }
 
     return Status;
+}
 
-} /* End EVS_EnableAppEventsCmd */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_DisableAppEventsCmd
-**
-** Purpose:  This routine disables application events for the given application identifier
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_DisableAppEventsCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_DisableAppEventsCmd(const CFE_EVS_DisableAppEventsCmd_t *data)
 {
     EVS_AppData_t *                     AppDataPtr;
@@ -1297,20 +1234,16 @@ int32 CFE_EVS_DisableAppEventsCmd(const CFE_EVS_DisableAppEventsCmd_t *data)
     }
 
     return Status;
+}
 
-} /* End CFE_EVS_DisableAppEventsCmd */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_ResetAppEventCounterCmd
-**
-** Purpose:  This routine sets the application event counter to zero for the given
-**           application identifier
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_ResetAppCounterCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_ResetAppCounterCmd(const CFE_EVS_ResetAppCounterCmd_t *data)
 {
     EVS_AppData_t *                     AppDataPtr;
@@ -1353,20 +1286,16 @@ int32 CFE_EVS_ResetAppCounterCmd(const CFE_EVS_ResetAppCounterCmd_t *data)
     }
 
     return Status;
+}
 
-} /* End CFE_EVS_ResetAppEventCounterCmd */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_ResetFilterCmd
-**
-** Purpose:  This routine sets the application event filter counter to zero for the given
-**           application identifier and event identifier
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_ResetFilterCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_ResetFilterCmd(const CFE_EVS_ResetFilterCmd_t *data)
 {
     const CFE_EVS_AppNameEventIDCmd_Payload_t *CmdPtr = &data->Payload;
@@ -1424,20 +1353,16 @@ int32 CFE_EVS_ResetFilterCmd(const CFE_EVS_ResetFilterCmd_t *data)
     }
 
     return Status;
+}
 
-} /* End CFE_EVS_ResetFilterCmd */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_ResetAllFiltersCmd
-**
-** Purpose:  This routine sets all application event filter counters to zero for the given
-**           application identifier
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_ResetAllFiltersCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_ResetAllFiltersCmd(const CFE_EVS_ResetAllFiltersCmd_t *data)
 {
     EVS_AppData_t *                     AppDataPtr;
@@ -1484,20 +1409,16 @@ int32 CFE_EVS_ResetAllFiltersCmd(const CFE_EVS_ResetAllFiltersCmd_t *data)
     }
 
     return Status;
+}
 
-} /* End CFE_EVS_ResetAllFiltersCmd */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_AddEventFilterCmd
-**
-** Purpose:  This routine adds the given event filter for the given application
-**           identifier and event identifier.
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_AddEventFilterCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_AddEventFilterCmd(const CFE_EVS_AddEventFilterCmd_t *data)
 {
     const CFE_EVS_AppNameEventIDMaskCmd_Payload_t *CmdPtr = &data->Payload;
@@ -1575,20 +1496,16 @@ int32 CFE_EVS_AddEventFilterCmd(const CFE_EVS_AddEventFilterCmd_t *data)
     }
 
     return Status;
+}
 
-} /* CFE_End EVS_AddEventFilterCmd */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_DeleteEventFilterCmd
-**
-** Purpose:  This routine deletes the event filter for the given application
-**           identifer and event identifier
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_DeleteEventFilterCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_DeleteEventFilterCmd(const CFE_EVS_DeleteEventFilterCmd_t *data)
 {
     const CFE_EVS_AppNameEventIDCmd_Payload_t *CmdPtr = &data->Payload;
@@ -1648,21 +1565,16 @@ int32 CFE_EVS_DeleteEventFilterCmd(const CFE_EVS_DeleteEventFilterCmd_t *data)
     }
 
     return Status;
+}
 
-} /* End EVS_DeleteEventFilterCmd */
-
-/*
-**             Function Prologue
-**
-** Function Name:      CFE_EVS_WriteAppDataFileCmd
-**
-** Purpose:  This routine writes all application data to a file for all applications that
-**           have registered with the EVS.  The application data includes the Application ID,
-**           Active Flag, Event Count, Event Types Active Flag, and Filter Data.
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_EVS_WriteAppDataFileCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFileCmd_t *data)
 {
     int32                               Result;
@@ -1766,7 +1678,4 @@ int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFileCmd_t *data)
     }
 
     return (Result);
-
-} /* End CFE_EVS_WriteAppDataFileCmd */
-
-/* End cfe_evs_task */
+}

--- a/modules/evs/fsw/src/cfe_evs_task.h
+++ b/modules/evs/fsw/src/cfe_evs_task.h
@@ -132,31 +132,201 @@ extern CFE_EVS_Global_t CFE_EVS_Global;
 /*
  * Functions used within this module and by the unit test
  */
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Task Initialization
+ *
+ * This function performs any necessary EVS task initialization.
+ */
 extern int32 CFE_EVS_TaskInit(void);
-extern void  CFE_EVS_ProcessCommandPacket(CFE_SB_Buffer_t *SBBufPtr);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Command Pipe Processing
+ *
+ * This function processes packets received on the EVS command pipe.
+ */
+extern void CFE_EVS_ProcessCommandPacket(CFE_SB_Buffer_t *SBBufPtr);
 
 /*
  * EVS Message Handler Functions
  */
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Message Handler Function
+ *
+ * Request for housekeeping status telemetry packet.
+ */
 int32 CFE_EVS_ReportHousekeepingCmd(const CFE_MSG_CommandHeader_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Message Handler Function
+ *
+ * This function processes "noop" commands received on the EVS command pipe.
+ */
 int32 CFE_EVS_NoopCmd(const CFE_EVS_NoopCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Message Handler Function
+ *
+ * This function processes "clear log" commands received on the EVS command pipe.
+ */
 int32 CFE_EVS_ClearLogCmd(const CFE_EVS_ClearLogCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Message Handler Function
+ *
+ * This function resets all the global counter variables that are part of the task telemetry.
+ */
 int32 CFE_EVS_ResetCountersCmd(const CFE_EVS_ResetCountersCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Message Handler Function
+ *
+ * This routine sets the filter mask for the given event_id in the
+ * calling task's filter array
+ */
 int32 CFE_EVS_SetFilterCmd(const CFE_EVS_SetFilterCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Message Handler Function
+ *
+ * This routine sets the command given ports to an enabled state
+ * @note Shifting is done so the value not masked off is placed in the ones spot:
+ * necessary for comparing with true.
+ */
 int32 CFE_EVS_EnablePortsCmd(const CFE_EVS_EnablePortsCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Message Handler Function
+ *
+ * This routine sets the command given ports to a disabled state
+ * @note Shifting is done so the value not masked off is placed in the ones spot:
+ * necessary for comparing with true.
+ */
 int32 CFE_EVS_DisablePortsCmd(const CFE_EVS_DisablePortsCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Message Handler Function
+ *
+ * This routine sets the given event types to an enabled state across all
+ * registered applications
+ */
 int32 CFE_EVS_EnableEventTypeCmd(const CFE_EVS_EnableEventTypeCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Message Handler Function
+ *
+ * This routine sets the given event types to a disabled state across all
+ * registered applications
+ */
 int32 CFE_EVS_DisableEventTypeCmd(const CFE_EVS_DisableEventTypeCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Message Handler Function
+ *
+ * This routine sets the Event Format Mode
+ */
 int32 CFE_EVS_SetEventFormatModeCmd(const CFE_EVS_SetEventFormatModeCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Message Handler Function
+ *
+ * This routine sets the given event type for the given application identifier to an
+ * enabled state
+ */
 int32 CFE_EVS_EnableAppEventTypeCmd(const CFE_EVS_EnableAppEventTypeCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Message Handler Function
+ *
+ * This routine sets the given event type for the given application identifier to a
+ * disabled state
+ */
 int32 CFE_EVS_DisableAppEventTypeCmd(const CFE_EVS_DisableAppEventTypeCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Message Handler Function
+ *
+ * This routine enables application events for the given application identifier
+ */
 int32 CFE_EVS_EnableAppEventsCmd(const CFE_EVS_EnableAppEventsCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Message Handler Function
+ *
+ * This routine disables application events for the given application identifier
+ */
 int32 CFE_EVS_DisableAppEventsCmd(const CFE_EVS_DisableAppEventsCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Message Handler Function
+ *
+ * This routine sets the application event counter to zero for the given
+ * application identifier
+ */
 int32 CFE_EVS_ResetAppCounterCmd(const CFE_EVS_ResetAppCounterCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Message Handler Function
+ *
+ * This routine sets the application event filter counter to zero for the given
+ * application identifier and event identifier
+ */
 int32 CFE_EVS_ResetFilterCmd(const CFE_EVS_ResetFilterCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Message Handler Function
+ *
+ * This routine adds the given event filter for the given application
+ * identifier and event identifier.
+ */
 int32 CFE_EVS_AddEventFilterCmd(const CFE_EVS_AddEventFilterCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Message Handler Function
+ *
+ * This routine deletes the event filter for the given application
+ * identifer and event identifier
+ */
 int32 CFE_EVS_DeleteEventFilterCmd(const CFE_EVS_DeleteEventFilterCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Message Handler Function
+ *
+ * This routine writes all application data to a file for all applications that
+ * have registered with the EVS.  The application data includes the Application ID,
+ * Active Flag, Event Count, Event Types Active Flag, and Filter Data.
+ */
 int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFileCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Message Handler Function
+ *
+ * This routine sets all application event filter counters to zero for the given
+ * application identifier
+ */
 int32 CFE_EVS_ResetAllFiltersCmd(const CFE_EVS_ResetAllFiltersCmd_t *data);
 
 #endif /* CFE_EVS_TASK_H */

--- a/modules/evs/fsw/src/cfe_evs_utils.c
+++ b/modules/evs/fsw/src/cfe_evs_utils.c
@@ -43,16 +43,14 @@ void EVS_OutputPort4(char *Message);
 
 /* Function Definitions */
 
-/*
-**             Function Prologue
-**
-** Function Name:      EVS_GetAppID
-**
-** Purpose:  This routine gets and validates the caller's AppID
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: EVS_GetAppDataByID
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 EVS_AppData_t *EVS_GetAppDataByID(CFE_ES_AppId_t AppID)
 {
     uint32         AppIndex;
@@ -68,9 +66,16 @@ EVS_AppData_t *EVS_GetAppDataByID(CFE_ES_AppId_t AppID)
     }
 
     return (AppDataPtr);
+}
 
-} /* End EVS_GetAppDataByID */
-
+/*----------------------------------------------------------------
+ *
+ * Function: EVS_GetCurrentContext
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 EVS_GetCurrentContext(EVS_AppData_t **AppDataOut, CFE_ES_AppId_t *AppIDOut)
 {
     CFE_ES_AppId_t AppID;
@@ -104,20 +109,16 @@ int32 EVS_GetCurrentContext(EVS_AppData_t **AppDataOut, CFE_ES_AppId_t *AppIDOut
     }
 
     return Status;
+}
 
-} /* End EVS_GetCurrentContext */
-
-/*
-**             Function Prologue
-**
-** Function Name:      EVS_GetApplicationInfo
-**
-** Purpose:  This routine returns the application ID and
-**           status specifying the validity of the ID
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: EVS_GetApplicationInfo
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 EVS_GetApplicationInfo(EVS_AppData_t **AppDataOut, const char *pAppName)
 {
     int32          Status;
@@ -151,19 +152,16 @@ int32 EVS_GetApplicationInfo(EVS_AppData_t **AppDataOut, const char *pAppName)
 
     *AppDataOut = AppDataPtr;
     return Status;
+}
 
-} /* End EVS_GetApplicationInfo */
-
-/*
-**             Function Prologue
-**
-** Function Name:      EVS_NotRegistered
-**
-** Purpose:  This routine sends one "not registered" event per application
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: EVS_NotRegistered
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 EVS_NotRegistered(EVS_AppData_t *AppDataPtr, CFE_ES_AppId_t CallerID)
 {
     char AppName[OS_MAX_API_NAME];
@@ -189,21 +187,16 @@ int32 EVS_NotRegistered(EVS_AppData_t *AppDataPtr, CFE_ES_AppId_t CallerID)
     }
 
     return (CFE_EVS_APP_NOT_REGISTERED);
+}
 
-} /* End EVS_NotRegistered */
-
-/*
-**             Function Prologue
-**
-** Function Name:      EVS_IsFiltered
-**
-** Purpose:  This routine returns true if the given event identifier and event type
-**           is filtered for the given application identifier.  Otherwise a value of
-**           false is returned.
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: EVS_IsFiltered
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 bool EVS_IsFiltered(EVS_AppData_t *AppDataPtr, uint16 EventID, uint16 EventType)
 {
     EVS_BinFilter_t *FilterPtr;
@@ -294,20 +287,16 @@ bool EVS_IsFiltered(EVS_AppData_t *AppDataPtr, uint16 EventID, uint16 EventType)
     }
 
     return (Filtered);
+}
 
-} /* End EVS_IsFiltered */
-
-/*
-**             Function Prologue
-**
-** Function Name:      EVS_FindEventID
-**
-** Purpose:  This routine searches and returns an index to the given Event ID with the
-**           given application filter array.
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: EVS_FindEventID
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 EVS_BinFilter_t *EVS_FindEventID(int16 EventID, EVS_BinFilter_t *FilterArray)
 {
     uint32 i;
@@ -321,61 +310,48 @@ EVS_BinFilter_t *EVS_FindEventID(int16 EventID, EVS_BinFilter_t *FilterArray)
     }
 
     return ((EVS_BinFilter_t *)NULL);
+}
 
-} /* End EVS_FindEventID */
-
-/*
-**             Function Prologue
-**
-** Function Name:      EVS_EnableTypes
-**
-** Purpose:  This routine enables event types selected in BitMask
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: EVS_EnableTypes
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void EVS_EnableTypes(EVS_AppData_t *AppDataPtr, uint8 BitMask)
 {
     uint8 EventTypeBits = (CFE_EVS_DEBUG_BIT | CFE_EVS_INFORMATION_BIT | CFE_EVS_ERROR_BIT | CFE_EVS_CRITICAL_BIT);
 
     /* Enable selected event type bits from bitmask */
     AppDataPtr->EventTypesActiveFlag |= (BitMask & EventTypeBits);
+}
 
-} /* End EVS_EnableTypes */
-
-/*
-**             Function Prologue
-**
-** Function Name:      EVS_DisableTypes
-**
-** Purpose:  This routine disables event types selected in BitMask
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: EVS_DisableTypes
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void EVS_DisableTypes(EVS_AppData_t *AppDataPtr, uint8 BitMask)
 {
     uint8 EventTypeBits = (CFE_EVS_DEBUG_BIT | CFE_EVS_INFORMATION_BIT | CFE_EVS_ERROR_BIT | CFE_EVS_CRITICAL_BIT);
 
     /* Disable selected event type bits from bitmask */
     AppDataPtr->EventTypesActiveFlag &= ~(BitMask & EventTypeBits);
+}
 
-} /* End EVS_DisableTypes */
-
-/*
-**             Function Prologue
-**
-** Function Name:      EVS_GenerateEventTelemetry
-**
-** Purpose:  This routine sends an EVS event message out the software bus and all
-**           enabled output ports
-**
-** Assumptions and Notes:
-**           This always generates a "long" style message for logging purposes.
-**           If configured for long events the same message is sent on the software bus as well.
-**           If configured for short events, a separate short message is generated using a subset
-**           of the information from the long message.
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: EVS_GenerateEventTelemetry
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint16 EventType,
                                 const CFE_TIME_SysTime_t *TimeStamp, const char *MsgSpec, va_list ArgPtr)
 {
@@ -449,19 +425,18 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint1
     {
         AppDataPtr->EventCount++;
     }
+}
 
-} /* End EVS_GenerateEventTelemetry */
-
-/*
-**             Function Prologue
-**
-** Function Name:      EVS_SendViaPorts
-**
-** Purpose:  This routine sends a string event message out all enabled
-**           output ports
-**
-** Assumptions and Notes:
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: EVS_SendViaPorts
+ *
+ * Internal helper routine only, not part of API.
+ *
+ * This routine sends a string event message out all enabled
+ * output ports
+ *
+ *-----------------------------------------------------------------*/
 void EVS_SendViaPorts(CFE_EVS_LongEventTlm_t *EVS_PktPtr)
 {
     char PortMessage[CFE_EVS_MAX_PORT_MSG_LENGTH];
@@ -509,89 +484,64 @@ void EVS_SendViaPorts(CFE_EVS_LongEventTlm_t *EVS_PktPtr)
         /* Send string event out port #4 */
         EVS_OutputPort4(PortMessage);
     }
+}
 
-} /* End SendViaPorts */
-
-/*
-**             Function Prologue
-**
-** Function Name:      EVS_OutputPort1
-**
-** Purpose:  This routine sends the input message string out
-**           EVS port 1
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: EVS_OutputPort1
+ *
+ * Internal helper routine only, not part of API.
+ *
+ *-----------------------------------------------------------------*/
 void EVS_OutputPort1(char *Message)
 {
     OS_printf("%s\n", Message);
+}
 
-} /* End ES_OutputPort1 */
-
-/*
-**             Function Prologue
-**
-** Function Name:      EVS_OutputPort2
-**
-** Purpose:  This routine sends the input message string out
-**           EVS port 2
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: EVS_OutputPort2
+ *
+ * Internal helper routine only, not part of API.
+ *
+ *-----------------------------------------------------------------*/
 void EVS_OutputPort2(char *Message)
 {
     OS_printf("%s\n", Message);
+}
 
-} /* End ES_OutputPort2 */
-
-/*
-**             Function Prologue
-**
-** Function Name:      EVS_OutputPort3
-**
-** Purpose:  This routine sends the input message string out
-**           EVS port 3
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: EVS_OutputPort3
+ *
+ * Internal helper routine only, not part of API.
+ *
+ *-----------------------------------------------------------------*/
 void EVS_OutputPort3(char *Message)
 {
     OS_printf("%s\n", Message);
+}
 
-} /* End ES_OutputPort3 */
-
-/*
-**             Function Prologue
-**
-** Function Name:      EVS_OutputPort4
-**
-** Purpose:  This routine sends the input message string out
-**           EVS port 4
-**
-** Assumptions and Notes:
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: EVS_OutputPort4
+ *
+ * Internal helper routine only, not part of API.
+ *
+ *-----------------------------------------------------------------*/
 void EVS_OutputPort4(char *Message)
 {
     OS_printf("%s\n", Message);
+}
 
-} /* End ES_OutputPort4 */
-
-/*
-**             Function Prologue
-**
-** Function Name:      EVS_SendEvent
-**
-** Purpose:  This routine allows EVS to send events without having to verify
-**           that the caller has a valid AppID and has registered with EVS.
-**           This routine also does not need to acquire the mutex semaphore,
-**           which can be time consuming on some platforms.
-**
-** Assumptions and Notes:
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: EVS_SendEvent
+ *
+ * Application-scope internal function
+ * See description in cfe_evs_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spec, ...)
 {
     CFE_TIME_SysTime_t Time;
@@ -618,7 +568,4 @@ int32 EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spec, ...)
     }
 
     return (CFE_SUCCESS);
-
-} /* End EVS_SendEvent */
-
-/* End cfe_evs_utils */
+}

--- a/modules/evs/fsw/src/cfe_evs_utils.c
+++ b/modules/evs/fsw/src/cfe_evs_utils.c
@@ -48,7 +48,7 @@ void EVS_OutputPort4(char *Message);
  * Function: EVS_GetAppDataByID
  *
  * Application-scope internal function
- * See description in cfe_evs_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 EVS_AppData_t *EVS_GetAppDataByID(CFE_ES_AppId_t AppID)
@@ -73,7 +73,7 @@ EVS_AppData_t *EVS_GetAppDataByID(CFE_ES_AppId_t AppID)
  * Function: EVS_GetCurrentContext
  *
  * Application-scope internal function
- * See description in cfe_evs_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 EVS_GetCurrentContext(EVS_AppData_t **AppDataOut, CFE_ES_AppId_t *AppIDOut)
@@ -116,7 +116,7 @@ int32 EVS_GetCurrentContext(EVS_AppData_t **AppDataOut, CFE_ES_AppId_t *AppIDOut
  * Function: EVS_GetApplicationInfo
  *
  * Application-scope internal function
- * See description in cfe_evs_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 EVS_GetApplicationInfo(EVS_AppData_t **AppDataOut, const char *pAppName)
@@ -159,7 +159,7 @@ int32 EVS_GetApplicationInfo(EVS_AppData_t **AppDataOut, const char *pAppName)
  * Function: EVS_NotRegistered
  *
  * Application-scope internal function
- * See description in cfe_evs_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 EVS_NotRegistered(EVS_AppData_t *AppDataPtr, CFE_ES_AppId_t CallerID)
@@ -194,7 +194,7 @@ int32 EVS_NotRegistered(EVS_AppData_t *AppDataPtr, CFE_ES_AppId_t CallerID)
  * Function: EVS_IsFiltered
  *
  * Application-scope internal function
- * See description in cfe_evs_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 bool EVS_IsFiltered(EVS_AppData_t *AppDataPtr, uint16 EventID, uint16 EventType)
@@ -294,7 +294,7 @@ bool EVS_IsFiltered(EVS_AppData_t *AppDataPtr, uint16 EventID, uint16 EventType)
  * Function: EVS_FindEventID
  *
  * Application-scope internal function
- * See description in cfe_evs_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 EVS_BinFilter_t *EVS_FindEventID(int16 EventID, EVS_BinFilter_t *FilterArray)
@@ -317,7 +317,7 @@ EVS_BinFilter_t *EVS_FindEventID(int16 EventID, EVS_BinFilter_t *FilterArray)
  * Function: EVS_EnableTypes
  *
  * Application-scope internal function
- * See description in cfe_evs_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void EVS_EnableTypes(EVS_AppData_t *AppDataPtr, uint8 BitMask)
@@ -333,7 +333,7 @@ void EVS_EnableTypes(EVS_AppData_t *AppDataPtr, uint8 BitMask)
  * Function: EVS_DisableTypes
  *
  * Application-scope internal function
- * See description in cfe_evs_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void EVS_DisableTypes(EVS_AppData_t *AppDataPtr, uint8 BitMask)
@@ -349,7 +349,7 @@ void EVS_DisableTypes(EVS_AppData_t *AppDataPtr, uint8 BitMask)
  * Function: EVS_GenerateEventTelemetry
  *
  * Application-scope internal function
- * See description in cfe_evs_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint16 EventType,
@@ -539,7 +539,7 @@ void EVS_OutputPort4(char *Message)
  * Function: EVS_SendEvent
  *
  * Application-scope internal function
- * See description in cfe_evs_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spec, ...)

--- a/modules/evs/fsw/src/cfe_evs_utils.h
+++ b/modules/evs/fsw/src/cfe_evs_utils.h
@@ -54,6 +54,7 @@
 
 /* ==============   Section III: Function Prototypes =========== */
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Obtain the EVS app record for the given ID
  *
@@ -68,6 +69,7 @@
  */
 EVS_AppData_t *EVS_GetAppDataByID(CFE_ES_AppId_t AppID);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Obtain the context information for the currently running app
  *
@@ -79,6 +81,7 @@ EVS_AppData_t *EVS_GetAppDataByID(CFE_ES_AppId_t AppID);
  */
 int32 EVS_GetCurrentContext(EVS_AppData_t **AppDataOut, CFE_ES_AppId_t *AppIDOut);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Check if an EVS app record is in use or free/empty
  *
@@ -95,6 +98,7 @@ static inline bool EVS_AppDataIsUsed(EVS_AppData_t *AppDataPtr)
     return CFE_RESOURCEID_TEST_DEFINED(AppDataPtr->AppID);
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Get the ID value from an EVS table entry
  *
@@ -112,6 +116,7 @@ static inline CFE_ES_AppId_t EVS_AppDataGetID(EVS_AppData_t *AppDataPtr)
     return (AppDataPtr->AppID);
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Marks an EVS table entry as used (not free)
  *
@@ -129,6 +134,7 @@ static inline void EVS_AppDataSetUsed(EVS_AppData_t *AppDataPtr, CFE_ES_AppId_t 
     AppDataPtr->AppID = AppID;
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Set an EVS table entry free (not used)
  *
@@ -142,6 +148,7 @@ static inline void EVS_AppDataSetFree(EVS_AppData_t *AppDataPtr)
     AppDataPtr->AppID = CFE_ES_APPID_UNDEFINED;
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Check if an EVS record is a match for the given AppID
  *
@@ -157,20 +164,82 @@ static inline bool EVS_AppDataIsMatch(EVS_AppData_t *AppDataPtr, CFE_ES_AppId_t 
     return (AppDataPtr != NULL && CFE_RESOURCEID_TEST_EQUAL(AppDataPtr->AppID, AppID));
 }
 
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Retrieve app details by app name
+ *
+ * This routine returns the application ID and
+ * status specifying the validity of the ID
+ */
 int32 EVS_GetApplicationInfo(EVS_AppData_t **AppDataOut, const char *pAppName);
 
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Generate "not registered" error event
+ *
+ * This routine sends one "not registered" event per application
+ * Assumptions and Notes:
+ */
 int32 EVS_NotRegistered(EVS_AppData_t *AppDataPtr, CFE_ES_AppId_t CallerID);
 
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Check if event is filtered
+ *
+ * This routine returns true if the given event identifier and event type
+ * is filtered for the given application identifier.  Otherwise a value of
+ * false is returned.
+ */
 bool EVS_IsFiltered(EVS_AppData_t *AppDataPtr, uint16 EventID, uint16 EventType);
 
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Find the filter record corresponding to the given event ID
+ *
+ * This routine searches and returns an index to the given Event ID with the
+ * given application filter array.
+ */
 EVS_BinFilter_t *EVS_FindEventID(int16 EventID, EVS_BinFilter_t *FilterArray);
 
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Enable event types
+ *
+ * This routine enables event types selected in BitMask
+ */
 void EVS_EnableTypes(EVS_AppData_t *AppDataPtr, uint8 BitMask);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Disable event types
+ *
+ * This routine disables event types selected in BitMask
+ */
 void EVS_DisableTypes(EVS_AppData_t *AppDataPtr, uint8 BitMask);
 
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Send all configured telemetry for an event
+ *
+ * This routine sends an EVS event message out the software bus and all
+ * enabled output ports
+ * @note This always generates a "long" style message for logging purposes.
+ * If configured for long events the same message is sent on the software bus as well.
+ * If configured for short events, a separate short message is generated using a subset
+ * of the information from the long message.
+ */
 void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint16 EventType,
                                 const CFE_TIME_SysTime_t *Time, const char *MsgSpec, va_list ArgPtr);
 
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Internal function to send an event
+ *
+ * This routine allows EVS to send events without having to verify
+ * that the caller has a valid AppID and has registered with EVS.
+ * This routine also does not need to acquire the mutex semaphore,
+ * which can be time consuming on some platforms.
+ */
 int32 EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spec, ...);
 
 #endif /* CFE_EVS_UTILS_H */

--- a/modules/fs/fsw/src/cfe_fs_api.c
+++ b/modules/fs/fsw/src/cfe_fs_api.c
@@ -52,7 +52,7 @@ const char CFE_FS_DEFAULT_LOG_FILE_EXTENSION[]  = ".log";
  * Function: CFE_FS_GetDefaultMountPoint
  *
  * Implemented per public API
- * See description in cfe_fs.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 const char *CFE_FS_GetDefaultMountPoint(CFE_FS_FileCategory_t FileCategory)
@@ -85,7 +85,7 @@ const char *CFE_FS_GetDefaultMountPoint(CFE_FS_FileCategory_t FileCategory)
  * Function: CFE_FS_GetDefaultExtension
  *
  * Implemented per public API
- * See description in cfe_fs.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 const char *CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_t FileCategory)
@@ -124,7 +124,7 @@ const char *CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_t FileCategory)
  * Function: CFE_FS_ReadHeader
  *
  * Implemented per public API
- * See description in cfe_fs.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, osal_id_t FileDes)
@@ -166,7 +166,7 @@ int32 CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, osal_id_t FileDes)
  * Function: CFE_FS_InitHeader
  *
  * Implemented per public API
- * See description in cfe_fs.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_FS_InitHeader(CFE_FS_Header_t *Hdr, const char *Description, uint32 SubType)
@@ -188,7 +188,7 @@ void CFE_FS_InitHeader(CFE_FS_Header_t *Hdr, const char *Description, uint32 Sub
  * Function: CFE_FS_WriteHeader
  *
  * Implemented per public API
- * See description in cfe_fs.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr)
@@ -266,7 +266,7 @@ int32 CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr)
  * Function: CFE_FS_SetTimestamp
  *
  * Implemented per public API
- * See description in cfe_fs.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_FS_SetTimestamp(osal_id_t FileDes, CFE_TIME_SysTime_t NewTimestamp)
@@ -327,7 +327,7 @@ int32 CFE_FS_SetTimestamp(osal_id_t FileDes, CFE_TIME_SysTime_t NewTimestamp)
  * Function: CFE_FS_ByteSwapCFEHeader
  *
  * Application-scope internal function
- * See description in cfe_fs_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_FS_ByteSwapCFEHeader(CFE_FS_Header_t *Hdr)
@@ -347,7 +347,7 @@ void CFE_FS_ByteSwapCFEHeader(CFE_FS_Header_t *Hdr)
  * Function: CFE_FS_ByteSwapUint32
  *
  * Application-scope internal function
- * See description in cfe_fs_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_FS_ByteSwapUint32(uint32 *Uint32ToSwapPtr)
@@ -367,7 +367,7 @@ void CFE_FS_ByteSwapUint32(uint32 *Uint32ToSwapPtr)
  * Function: CFE_FS_ParseInputFileNameEx
  *
  * Implemented per public API
- * See description in cfe_fs.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_FS_ParseInputFileNameEx(char *OutputBuffer, const char *InputBuffer, size_t OutputBufSize,
@@ -582,7 +582,7 @@ int32 CFE_FS_ParseInputFileNameEx(char *OutputBuffer, const char *InputBuffer, s
  * Function: CFE_FS_ParseInputFileName
  *
  * Implemented per public API
- * See description in cfe_fs.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_FS_ParseInputFileName(char *OutputBuffer, const char *InputName, size_t OutputBufSize,
@@ -598,7 +598,7 @@ int32 CFE_FS_ParseInputFileName(char *OutputBuffer, const char *InputName, size_
  * Function: CFE_FS_ExtractFilenameFromPath
  *
  * Implemented per public API
- * See description in cfe_fs.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_FS_ExtractFilenameFromPath(const char *OriginalPath, char *FileNameOnly)
@@ -678,7 +678,7 @@ int32 CFE_FS_ExtractFilenameFromPath(const char *OriginalPath, char *FileNameOnl
  * Function: CFE_FS_RunBackgroundFileDump
  *
  * Implemented per public API
- * See description in cfe_fs.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 bool CFE_FS_RunBackgroundFileDump(uint32 ElapsedTime, void *Arg)
@@ -836,7 +836,7 @@ bool CFE_FS_RunBackgroundFileDump(uint32 ElapsedTime, void *Arg)
  * Function: CFE_FS_BackgroundFileDumpRequest
  *
  * Implemented per public API
- * See description in cfe_fs.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_FS_BackgroundFileDumpRequest(CFE_FS_FileWriteMetaData_t *Meta)
@@ -924,7 +924,7 @@ int32 CFE_FS_BackgroundFileDumpRequest(CFE_FS_FileWriteMetaData_t *Meta)
  * Function: CFE_FS_BackgroundFileDumpIsPending
  *
  * Implemented per public API
- * See description in cfe_fs.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 bool CFE_FS_BackgroundFileDumpIsPending(const CFE_FS_FileWriteMetaData_t *Meta)

--- a/modules/fs/fsw/src/cfe_fs_api.c
+++ b/modules/fs/fsw/src/cfe_fs_api.c
@@ -47,6 +47,14 @@ const char CFE_FS_DEFAULT_DUMP_FILE_EXTENSION[] = ".dat";
 const char CFE_FS_DEFAULT_TEMP_FILE_EXTENSION[] = ".tmp";
 const char CFE_FS_DEFAULT_LOG_FILE_EXTENSION[]  = ".log";
 
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_FS_GetDefaultMountPoint
+ *
+ * Implemented per public API
+ * See description in cfe_fs.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 const char *CFE_FS_GetDefaultMountPoint(CFE_FS_FileCategory_t FileCategory)
 {
     const char *Result;
@@ -72,6 +80,14 @@ const char *CFE_FS_GetDefaultMountPoint(CFE_FS_FileCategory_t FileCategory)
     return Result;
 }
 
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_FS_GetDefaultExtension
+ *
+ * Implemented per public API
+ * See description in cfe_fs.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 const char *CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_t FileCategory)
 {
     const char *Result;
@@ -103,9 +119,14 @@ const char *CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_t FileCategory)
     return Result;
 }
 
-/*
-** CFE_FS_ReadHeader() - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_FS_ReadHeader
+ *
+ * Implemented per public API
+ * See description in cfe_fs.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, osal_id_t FileDes)
 {
     int32 Result;
@@ -138,12 +159,16 @@ int32 CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, osal_id_t FileDes)
     }
 
     return (Result);
+}
 
-} /* End of CFE_FS_ReadHeader() */
-
-/*
-** CFE_FS_InitHeader() - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_FS_InitHeader
+ *
+ * Implemented per public API
+ * See description in cfe_fs.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_FS_InitHeader(CFE_FS_Header_t *Hdr, const char *Description, uint32 SubType)
 {
     if (Hdr == NULL || Description == NULL)
@@ -158,9 +183,14 @@ void CFE_FS_InitHeader(CFE_FS_Header_t *Hdr, const char *Description, uint32 Sub
     }
 }
 
-/*
-** CFE_FS_WriteHeader() - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_FS_WriteHeader
+ *
+ * Implemented per public API
+ * See description in cfe_fs.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr)
 {
     CFE_TIME_SysTime_t Time;
@@ -229,12 +259,16 @@ int32 CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr)
     }
 
     return (Result);
+}
 
-} /* End of CFE_FS_WriteHeader() */
-
-/*
-** CFE_FS_SetTimestamp - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_FS_SetTimestamp
+ *
+ * Implemented per public API
+ * See description in cfe_fs.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_FS_SetTimestamp(osal_id_t FileDes, CFE_TIME_SysTime_t NewTimestamp)
 {
     int32              Result;
@@ -286,14 +320,16 @@ int32 CFE_FS_SetTimestamp(osal_id_t FileDes, CFE_TIME_SysTime_t NewTimestamp)
     }
 
     return (Result);
-} /* End of CFE_FS_SetTimestamp() */
+}
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                         */
-/* CFE_FS_ByteSwapCFEHeader() -- byte swap cFE file header structure       */
-/*                                                                         */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_FS_ByteSwapCFEHeader
+ *
+ * Application-scope internal function
+ * See description in cfe_fs_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_FS_ByteSwapCFEHeader(CFE_FS_Header_t *Hdr)
 {
     CFE_FS_ByteSwapUint32(&Hdr->ContentType);
@@ -304,15 +340,16 @@ void CFE_FS_ByteSwapCFEHeader(CFE_FS_Header_t *Hdr)
     CFE_FS_ByteSwapUint32(&Hdr->ApplicationID);
     CFE_FS_ByteSwapUint32(&Hdr->TimeSeconds);
     CFE_FS_ByteSwapUint32(&Hdr->TimeSubSeconds);
+}
 
-} /* End of CFE_FS_ByteSwapCFEHeader() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                         */
-/* CFE_FS_ByteSwapUint32() -- byte swap an uint32                          */
-/*                                                                         */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_FS_ByteSwapUint32
+ *
+ * Application-scope internal function
+ * See description in cfe_fs_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_FS_ByteSwapUint32(uint32 *Uint32ToSwapPtr)
 {
     int32 Temp   = *Uint32ToSwapPtr;
@@ -323,17 +360,16 @@ void CFE_FS_ByteSwapUint32(uint32 *Uint32ToSwapPtr)
     OutPtr[1] = InPtr[2];
     OutPtr[2] = InPtr[1];
     OutPtr[3] = InPtr[0];
-} /* End of CFE_FS_ByteSwapUint32() */
+}
 
-/*
-**---------------------------------------------------------------------------------------
-** Name: CFE_FS_ParseInputFileNameEx
-**
-**   Purpose: This reads a file name from user input with extra logic to make more user friendly
-**            - absolute path is optional; assume default dir if missing
-**            - module extension is optional; append default for OS/platform if missing
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_FS_ParseInputFileNameEx
+ *
+ * Implemented per public API
+ * See description in cfe_fs.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_FS_ParseInputFileNameEx(char *OutputBuffer, const char *InputBuffer, size_t OutputBufSize,
                                   size_t InputBufSize, const char *DefaultInput, const char *DefaultPath,
                                   const char *DefaultExtension)
@@ -541,14 +577,14 @@ int32 CFE_FS_ParseInputFileNameEx(char *OutputBuffer, const char *InputBuffer, s
     return Status;
 }
 
-/*
-**---------------------------------------------------------------------------------------
-** Name: CFE_FS_ParseInputFileName
-**
-**   Purpose: Simplified API for CFE_FS_ParseInputFileNameEx where input is always known to be
-**            a non-empty, null terminated string and the fixed-length input buffer not needed.
-**---------------------------------------------------------------------------------------
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_FS_ParseInputFileName
+ *
+ * Implemented per public API
+ * See description in cfe_fs.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_FS_ParseInputFileName(char *OutputBuffer, const char *InputName, size_t OutputBufSize,
                                 CFE_FS_FileCategory_t FileCategory)
 {
@@ -557,9 +593,14 @@ int32 CFE_FS_ParseInputFileName(char *OutputBuffer, const char *InputName, size_
                                        CFE_FS_GetDefaultExtension(FileCategory));
 }
 
-/*
-** CFE_FS_ExtractFilenameFromPath - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_FS_ExtractFilenameFromPath
+ *
+ * Implemented per public API
+ * See description in cfe_fs.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_FS_ExtractFilenameFromPath(const char *OriginalPath, char *FileNameOnly)
 {
     uint32 i, j;
@@ -632,9 +673,14 @@ int32 CFE_FS_ExtractFilenameFromPath(const char *OriginalPath, char *FileNameOnl
     return (ReturnCode);
 }
 
-/*
-** CFE_FS_RunBackgroundFileDump - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_FS_RunBackgroundFileDump
+ *
+ * Implemented per public API
+ * See description in cfe_fs.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_FS_RunBackgroundFileDump(uint32 ElapsedTime, void *Arg)
 {
     CFE_FS_CurrentFileState_t *       State;
@@ -785,9 +831,14 @@ bool CFE_FS_RunBackgroundFileDump(uint32 ElapsedTime, void *Arg)
     return !IsEOF;
 }
 
-/*
-** CFE_FS_BackgroundFileDumpRequest - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_FS_BackgroundFileDumpRequest
+ *
+ * Implemented per public API
+ * See description in cfe_fs.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_FS_BackgroundFileDumpRequest(CFE_FS_FileWriteMetaData_t *Meta)
 {
     CFE_FS_BackgroundFileDumpEntry_t *Curr;
@@ -868,9 +919,14 @@ int32 CFE_FS_BackgroundFileDumpRequest(CFE_FS_FileWriteMetaData_t *Meta)
     return Status;
 }
 
-/*
-** CFE_FS_ExtractFilenameFromPath - See API and header file for details
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_FS_BackgroundFileDumpIsPending
+ *
+ * Implemented per public API
+ * See description in cfe_fs.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_FS_BackgroundFileDumpIsPending(const CFE_FS_FileWriteMetaData_t *Meta)
 {
     if (Meta == NULL)
@@ -880,7 +936,3 @@ bool CFE_FS_BackgroundFileDumpIsPending(const CFE_FS_FileWriteMetaData_t *Meta)
 
     return Meta->IsPending;
 }
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/modules/fs/fsw/src/cfe_fs_priv.c
+++ b/modules/fs/fsw/src/cfe_fs_priv.c
@@ -42,20 +42,14 @@
 */
 CFE_FS_Global_t CFE_FS_Global;
 
-/******************************************************************************
-**  Function:  CFE_FS_EarlyInit()
-**
-**  Purpose:
-**    Initialize the FS data structures before the cFE runs.
-**
-**  Arguments:
-**
-**  Notes:
-**    This function MUST be called before any FS API's are called.
-**
-**  Return:
-**    CFE_SUCCESS
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_FS_EarlyInit
+ *
+ * Implemented per public API
+ * See description in cfe_fs_core_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_FS_EarlyInit(void)
 {
     int32 Stat;
@@ -70,22 +64,16 @@ int32 CFE_FS_EarlyInit(void)
     } /* end if */
 
     return Stat;
+}
 
-} /* end CFE_FS_EarlyInit */
-
-/******************************************************************************
-**  Function:  CFE_FS_LockSharedData()
-**
-**  Purpose:
-**    FS internal function to handle a semaphore take failure for the FS
-**    Data Mutex
-**
-**  Arguments:
-**    FunctionName   - the Function Name of the code that generated the error.
-**
-**  Return:
-**    None
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_FS_LockSharedData
+ *
+ * Application-scope internal function
+ * See description in cfe_fs_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_FS_LockSharedData(const char *FunctionName)
 {
     int32          Status;
@@ -102,22 +90,16 @@ void CFE_FS_LockSharedData(const char *FunctionName)
     } /* end if */
 
     return;
+}
 
-} /* end CFE_FS_LockSharedData */
-
-/******************************************************************************
-**  Function:  CFE_FS_UnlockSharedData()
-**
-**  Purpose:
-**    FS internal function to handle a semaphore give failure for the Shared
-**    Data Mutex
-**
-**  Arguments:
-**    FunctionName - the Function containing the code that generated the error.
-**
-**  Return:
-**    None
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_FS_UnlockSharedData
+ *
+ * Application-scope internal function
+ * See description in cfe_fs_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_FS_UnlockSharedData(const char *FunctionName)
 {
     int32          Status;
@@ -132,9 +114,4 @@ void CFE_FS_UnlockSharedData(const char *FunctionName)
 
     } /* end if */
     return;
-
-} /* end CFE_FS_UnlockSharedData */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/modules/fs/fsw/src/cfe_fs_priv.c
+++ b/modules/fs/fsw/src/cfe_fs_priv.c
@@ -47,7 +47,7 @@ CFE_FS_Global_t CFE_FS_Global;
  * Function: CFE_FS_EarlyInit
  *
  * Implemented per public API
- * See description in cfe_fs_core_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_FS_EarlyInit(void)
@@ -71,7 +71,7 @@ int32 CFE_FS_EarlyInit(void)
  * Function: CFE_FS_LockSharedData
  *
  * Application-scope internal function
- * See description in cfe_fs_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_FS_LockSharedData(const char *FunctionName)
@@ -97,7 +97,7 @@ void CFE_FS_LockSharedData(const char *FunctionName)
  * Function: CFE_FS_UnlockSharedData
  *
  * Application-scope internal function
- * See description in cfe_fs_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_FS_UnlockSharedData(const char *FunctionName)

--- a/modules/fs/fsw/src/cfe_fs_priv.h
+++ b/modules/fs/fsw/src/cfe_fs_priv.h
@@ -98,6 +98,7 @@ typedef struct
     size_t    FileSize;
 } CFE_FS_CurrentFileState_t;
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Background file dump queue structure
  *
@@ -147,9 +148,36 @@ extern CFE_FS_Global_t CFE_FS_Global;
 ** FS Function Prototypes
 */
 
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Obtains exclusive access to the FS global data structures
+ *
+ * @param FunctionName The name of the calling function
+ */
 extern void CFE_FS_LockSharedData(const char *FunctionName);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Releases exclusive access to the FS global data structures
+ *
+ * @param FunctionName The name of the calling function
+ */
 extern void CFE_FS_UnlockSharedData(const char *FunctionName);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief byte swap cFE file header structure
+ *
+ * @param Hdr The object to byte swap
+ */
 extern void CFE_FS_ByteSwapCFEHeader(CFE_FS_Header_t *Hdr);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief byte swap uint32 value
+ *
+ * @param Uint32ToSwapPtr The buffer to byte swap
+ */
 extern void CFE_FS_ByteSwapUint32(uint32 *Uint32ToSwapPtr);
 
 #endif /* CFE_FS_PRIV_H */

--- a/modules/msg/fsw/src/cfe_msg_ccsdsext.c
+++ b/modules/msg/fsw/src/cfe_msg_ccsdsext.c
@@ -39,7 +39,7 @@
  * Function: CFE_MSG_SetDefaultCCSDSExt
  *
  * Application-scope internal function
- * See description in cfe_msg_defaults.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_MSG_SetDefaultCCSDSExt(CFE_MSG_Message_t *MsgPtr)
@@ -63,7 +63,7 @@ void CFE_MSG_SetDefaultCCSDSExt(CFE_MSG_Message_t *MsgPtr)
  * Function: CFE_MSG_GetEDSVersion
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetEDSVersion(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_EDSVersion_t *Version)
@@ -85,7 +85,7 @@ int32 CFE_MSG_GetEDSVersion(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_EDSVersion_
  * Function: CFE_MSG_SetEDSVersion
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetEDSVersion(CFE_MSG_Message_t *MsgPtr, CFE_MSG_EDSVersion_t Version)
@@ -105,7 +105,7 @@ int32 CFE_MSG_SetEDSVersion(CFE_MSG_Message_t *MsgPtr, CFE_MSG_EDSVersion_t Vers
  * Function: CFE_MSG_GetEndian
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetEndian(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Endian_t *Endian)
@@ -133,7 +133,7 @@ int32 CFE_MSG_GetEndian(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Endian_t *Endia
  * Function: CFE_MSG_SetEndian
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetEndian(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Endian_t Endian)
@@ -166,7 +166,7 @@ int32 CFE_MSG_SetEndian(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Endian_t Endian)
  * Function: CFE_MSG_GetPlaybackFlag
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetPlaybackFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_PlaybackFlag_t *PlayFlag)
@@ -194,7 +194,7 @@ int32 CFE_MSG_GetPlaybackFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_PlaybackF
  * Function: CFE_MSG_SetPlaybackFlag
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetPlaybackFlag(CFE_MSG_Message_t *MsgPtr, CFE_MSG_PlaybackFlag_t PlayFlag)
@@ -227,7 +227,7 @@ int32 CFE_MSG_SetPlaybackFlag(CFE_MSG_Message_t *MsgPtr, CFE_MSG_PlaybackFlag_t 
  * Function: CFE_MSG_GetSubsystem
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetSubsystem(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Subsystem_t *Subsystem)
@@ -248,7 +248,7 @@ int32 CFE_MSG_GetSubsystem(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Subsystem_t 
  * Function: CFE_MSG_SetSubsystem
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetSubsystem(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Subsystem_t Subsystem)
@@ -268,7 +268,7 @@ int32 CFE_MSG_SetSubsystem(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Subsystem_t Subsys
  * Function: CFE_MSG_GetSystem
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetSystem(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_System_t *System)
@@ -289,7 +289,7 @@ int32 CFE_MSG_GetSystem(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_System_t *Syste
  * Function: CFE_MSG_SetSystem
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetSystem(CFE_MSG_Message_t *MsgPtr, CFE_MSG_System_t System)

--- a/modules/msg/fsw/src/cfe_msg_ccsdsext.c
+++ b/modules/msg/fsw/src/cfe_msg_ccsdsext.c
@@ -34,9 +34,14 @@
 #define CFE_MSG_PLAYBACK_MASK 0x0200 /**< \brief CCSDS playback flag, playback when set */
 #define CFE_MSG_SUBSYS_MASK   0x01FF /**< \brief CCSDS Subsystem mask */
 
-/******************************************************************************
- * CCSDS extended header initialization - See header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_SetDefaultCCSDSExt
+ *
+ * Application-scope internal function
+ * See description in cfe_msg_defaults.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_MSG_SetDefaultCCSDSExt(CFE_MSG_Message_t *MsgPtr)
 {
 
@@ -53,9 +58,14 @@ void CFE_MSG_SetDefaultCCSDSExt(CFE_MSG_Message_t *MsgPtr)
     CFE_MSG_SetSystem(MsgPtr, (CFE_MSG_System_t)CFE_PSP_GetSpacecraftId());
 }
 
-/******************************************************************************
- * Get message EDS version - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_GetEDSVersion
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetEDSVersion(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_EDSVersion_t *Version)
 {
 
@@ -70,9 +80,14 @@ int32 CFE_MSG_GetEDSVersion(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_EDSVersion_
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Set message EDS version - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_SetEDSVersion
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetEDSVersion(CFE_MSG_Message_t *MsgPtr, CFE_MSG_EDSVersion_t Version)
 {
     if (MsgPtr == NULL || (Version > (CFE_MSG_EDSVER_MASK >> CFE_MSG_EDSVER_SHIFT)))
@@ -85,9 +100,14 @@ int32 CFE_MSG_SetEDSVersion(CFE_MSG_Message_t *MsgPtr, CFE_MSG_EDSVersion_t Vers
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Get message endian - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_GetEndian
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetEndian(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Endian_t *Endian)
 {
 
@@ -108,9 +128,14 @@ int32 CFE_MSG_GetEndian(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Endian_t *Endia
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Set message endian - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_SetEndian
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetEndian(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Endian_t Endian)
 {
     int32 status = CFE_SUCCESS;
@@ -136,9 +161,14 @@ int32 CFE_MSG_SetEndian(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Endian_t Endian)
     return status;
 }
 
-/******************************************************************************
- * Get message playback flag - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_GetPlaybackFlag
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetPlaybackFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_PlaybackFlag_t *PlayFlag)
 {
 
@@ -159,9 +189,14 @@ int32 CFE_MSG_GetPlaybackFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_PlaybackF
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Set message playback flag - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_SetPlaybackFlag
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetPlaybackFlag(CFE_MSG_Message_t *MsgPtr, CFE_MSG_PlaybackFlag_t PlayFlag)
 {
     int32 status = CFE_SUCCESS;
@@ -187,9 +222,14 @@ int32 CFE_MSG_SetPlaybackFlag(CFE_MSG_Message_t *MsgPtr, CFE_MSG_PlaybackFlag_t 
     return status;
 }
 
-/******************************************************************************
- * Get message subsystem - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_GetSubsystem
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetSubsystem(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Subsystem_t *Subsystem)
 {
 
@@ -203,9 +243,14 @@ int32 CFE_MSG_GetSubsystem(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Subsystem_t 
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Set message subsystem - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_SetSubsystem
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetSubsystem(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Subsystem_t Subsystem)
 {
     if (MsgPtr == NULL || ((Subsystem & ~CFE_MSG_SUBSYS_MASK) != 0))
@@ -218,9 +263,14 @@ int32 CFE_MSG_SetSubsystem(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Subsystem_t Subsys
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Get message system - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_GetSystem
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetSystem(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_System_t *System)
 {
 
@@ -234,9 +284,14 @@ int32 CFE_MSG_GetSystem(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_System_t *Syste
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Set message system - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_SetSystem
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetSystem(CFE_MSG_Message_t *MsgPtr, CFE_MSG_System_t System)
 {
     if (MsgPtr == NULL)

--- a/modules/msg/fsw/src/cfe_msg_ccsdspri.c
+++ b/modules/msg/fsw/src/cfe_msg_ccsdspri.c
@@ -40,9 +40,14 @@
 #define CFE_MSG_SEGFLG_UNSEG   0xC000 /**< \brief CCSDS Unsegmented flag */
 #define CFE_MSG_SEQCNT_MASK    0x3FFF /**< \brief CCSDS Sequence count mask */
 
-/******************************************************************************
- * CCSDS Primary header initialization - See header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_SetDefaultCCSDSPri
+ *
+ * Application-scope internal function
+ * See description in cfe_msg_defaults.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_MSG_SetDefaultCCSDSPri(CFE_MSG_Message_t *MsgPtr)
 {
 
@@ -59,9 +64,14 @@ void CFE_MSG_SetDefaultCCSDSPri(CFE_MSG_Message_t *MsgPtr)
     CFE_MSG_SetSegmentationFlag(MsgPtr, CFE_MSG_SegFlag_Unsegmented);
 }
 
-/******************************************************************************
- * Get message header version - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_GetHeaderVersion
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetHeaderVersion(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_HeaderVersion_t *Version)
 {
 
@@ -76,9 +86,14 @@ int32 CFE_MSG_GetHeaderVersion(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_HeaderVe
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Set message header version - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_SetHeaderVersion
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetHeaderVersion(CFE_MSG_Message_t *MsgPtr, CFE_MSG_HeaderVersion_t Version)
 {
     if (MsgPtr == NULL || (Version > (CFE_MSG_CCSDSVER_MASK >> CFE_MSG_CCSDSVER_SHIFT)))
@@ -91,9 +106,14 @@ int32 CFE_MSG_SetHeaderVersion(CFE_MSG_Message_t *MsgPtr, CFE_MSG_HeaderVersion_
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Get message type - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_GetType
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetType(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t *Type)
 {
 
@@ -114,9 +134,14 @@ int32 CFE_MSG_GetType(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t *Type)
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Set message type - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_SetType
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetType(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t Type)
 {
     int32 status = CFE_SUCCESS;
@@ -142,9 +167,14 @@ int32 CFE_MSG_SetType(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t Type)
     return status;
 }
 
-/******************************************************************************
- * Get message has secondary header flag - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_GetHasSecondaryHeader
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetHasSecondaryHeader(const CFE_MSG_Message_t *MsgPtr, bool *HasSecondary)
 {
 
@@ -158,9 +188,14 @@ int32 CFE_MSG_GetHasSecondaryHeader(const CFE_MSG_Message_t *MsgPtr, bool *HasSe
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Set message has secondary header flag - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_SetHasSecondaryHeader
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetHasSecondaryHeader(CFE_MSG_Message_t *MsgPtr, bool HasSecondary)
 {
     if (MsgPtr == NULL)
@@ -180,9 +215,14 @@ int32 CFE_MSG_SetHasSecondaryHeader(CFE_MSG_Message_t *MsgPtr, bool HasSecondary
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Get message application ID - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_GetApId
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetApId(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t *ApId)
 {
 
@@ -196,9 +236,14 @@ int32 CFE_MSG_GetApId(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t *ApId)
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Set message application ID - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_SetApId
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetApId(CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t ApId)
 {
     if (MsgPtr == NULL || ((ApId & ~CFE_MSG_APID_MASK) != 0))
@@ -211,9 +256,14 @@ int32 CFE_MSG_SetApId(CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t ApId)
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Get message segmentation flag - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_GetSegmentationFlag
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetSegmentationFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_SegmentationFlag_t *SegFlag)
 {
 
@@ -245,9 +295,14 @@ int32 CFE_MSG_GetSegmentationFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Segme
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Set message segmentation flag - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_SetSegmentationFlag
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetSegmentationFlag(CFE_MSG_Message_t *MsgPtr, CFE_MSG_SegmentationFlag_t SegFlag)
 {
     uint16 rawval = 0;
@@ -285,9 +340,14 @@ int32 CFE_MSG_SetSegmentationFlag(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Segmentatio
     return status;
 }
 
-/******************************************************************************
- * Get message sequence count - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_GetSequenceCount
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetSequenceCount(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_SequenceCount_t *SeqCnt)
 {
 
@@ -301,9 +361,14 @@ int32 CFE_MSG_GetSequenceCount(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Sequence
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Set message sequence count - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_SetSequenceCount
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetSequenceCount(CFE_MSG_Message_t *MsgPtr, CFE_MSG_SequenceCount_t SeqCnt)
 {
     if (MsgPtr == NULL || ((SeqCnt & ~CFE_MSG_SEQCNT_MASK) != 0))
@@ -316,9 +381,14 @@ int32 CFE_MSG_SetSequenceCount(CFE_MSG_Message_t *MsgPtr, CFE_MSG_SequenceCount_
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Get message size - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_GetSize
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetSize(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t *Size)
 {
 
@@ -332,9 +402,14 @@ int32 CFE_MSG_GetSize(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t *Size)
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Set message size - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_SetSize
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetSize(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t Size)
 {
     if (MsgPtr == NULL || Size < CFE_MSG_SIZE_OFFSET || Size > (0xFFFF + CFE_MSG_SIZE_OFFSET))

--- a/modules/msg/fsw/src/cfe_msg_ccsdspri.c
+++ b/modules/msg/fsw/src/cfe_msg_ccsdspri.c
@@ -45,7 +45,7 @@
  * Function: CFE_MSG_SetDefaultCCSDSPri
  *
  * Application-scope internal function
- * See description in cfe_msg_defaults.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_MSG_SetDefaultCCSDSPri(CFE_MSG_Message_t *MsgPtr)
@@ -69,7 +69,7 @@ void CFE_MSG_SetDefaultCCSDSPri(CFE_MSG_Message_t *MsgPtr)
  * Function: CFE_MSG_GetHeaderVersion
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetHeaderVersion(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_HeaderVersion_t *Version)
@@ -91,7 +91,7 @@ int32 CFE_MSG_GetHeaderVersion(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_HeaderVe
  * Function: CFE_MSG_SetHeaderVersion
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetHeaderVersion(CFE_MSG_Message_t *MsgPtr, CFE_MSG_HeaderVersion_t Version)
@@ -111,7 +111,7 @@ int32 CFE_MSG_SetHeaderVersion(CFE_MSG_Message_t *MsgPtr, CFE_MSG_HeaderVersion_
  * Function: CFE_MSG_GetType
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetType(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t *Type)
@@ -139,7 +139,7 @@ int32 CFE_MSG_GetType(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t *Type)
  * Function: CFE_MSG_SetType
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetType(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t Type)
@@ -172,7 +172,7 @@ int32 CFE_MSG_SetType(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t Type)
  * Function: CFE_MSG_GetHasSecondaryHeader
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetHasSecondaryHeader(const CFE_MSG_Message_t *MsgPtr, bool *HasSecondary)
@@ -193,7 +193,7 @@ int32 CFE_MSG_GetHasSecondaryHeader(const CFE_MSG_Message_t *MsgPtr, bool *HasSe
  * Function: CFE_MSG_SetHasSecondaryHeader
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetHasSecondaryHeader(CFE_MSG_Message_t *MsgPtr, bool HasSecondary)
@@ -220,7 +220,7 @@ int32 CFE_MSG_SetHasSecondaryHeader(CFE_MSG_Message_t *MsgPtr, bool HasSecondary
  * Function: CFE_MSG_GetApId
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetApId(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t *ApId)
@@ -241,7 +241,7 @@ int32 CFE_MSG_GetApId(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t *ApId)
  * Function: CFE_MSG_SetApId
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetApId(CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t ApId)
@@ -261,7 +261,7 @@ int32 CFE_MSG_SetApId(CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t ApId)
  * Function: CFE_MSG_GetSegmentationFlag
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetSegmentationFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_SegmentationFlag_t *SegFlag)
@@ -300,7 +300,7 @@ int32 CFE_MSG_GetSegmentationFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Segme
  * Function: CFE_MSG_SetSegmentationFlag
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetSegmentationFlag(CFE_MSG_Message_t *MsgPtr, CFE_MSG_SegmentationFlag_t SegFlag)
@@ -345,7 +345,7 @@ int32 CFE_MSG_SetSegmentationFlag(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Segmentatio
  * Function: CFE_MSG_GetSequenceCount
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetSequenceCount(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_SequenceCount_t *SeqCnt)
@@ -366,7 +366,7 @@ int32 CFE_MSG_GetSequenceCount(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Sequence
  * Function: CFE_MSG_SetSequenceCount
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetSequenceCount(CFE_MSG_Message_t *MsgPtr, CFE_MSG_SequenceCount_t SeqCnt)
@@ -386,7 +386,7 @@ int32 CFE_MSG_SetSequenceCount(CFE_MSG_Message_t *MsgPtr, CFE_MSG_SequenceCount_
  * Function: CFE_MSG_GetSize
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetSize(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t *Size)
@@ -407,7 +407,7 @@ int32 CFE_MSG_GetSize(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t *Size)
  * Function: CFE_MSG_SetSize
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetSize(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t Size)

--- a/modules/msg/fsw/src/cfe_msg_defaults.h
+++ b/modules/msg/fsw/src/cfe_msg_defaults.h
@@ -56,7 +56,7 @@
 #define CFE_PLATFORM_EDSVER 1 /**< \brief Default EDS version, cFS historically = 1 */
 #endif
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Set CCSDS Primary header defaults
  *
@@ -68,7 +68,7 @@
  */
 void CFE_MSG_SetDefaultCCSDSPri(CFE_MSG_Message_t *MsgPtr);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Set CCSDS Extended header defaults
  *

--- a/modules/msg/fsw/src/cfe_msg_init.c
+++ b/modules/msg/fsw/src/cfe_msg_init.c
@@ -26,9 +26,14 @@
 #include "cfe_msg_defaults.h"
 #include "string.h"
 
-/******************************************************************************
- * Top level message initialization - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_Init
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_MSG_Size_t Size)
 {
 

--- a/modules/msg/fsw/src/cfe_msg_init.c
+++ b/modules/msg/fsw/src/cfe_msg_init.c
@@ -31,7 +31,7 @@
  * Function: CFE_MSG_Init
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_MSG_Size_t Size)

--- a/modules/msg/fsw/src/cfe_msg_initdefaulthdr_pri.c
+++ b/modules/msg/fsw/src/cfe_msg_initdefaulthdr_pri.c
@@ -30,7 +30,7 @@
  * Function: CFE_MSG_InitDefaultHdr
  *
  * Application-scope internal function
- * See description in cfe_msg_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_MSG_InitDefaultHdr(CFE_MSG_Message_t *MsgPtr)

--- a/modules/msg/fsw/src/cfe_msg_initdefaulthdr_pri.c
+++ b/modules/msg/fsw/src/cfe_msg_initdefaulthdr_pri.c
@@ -25,9 +25,14 @@
 #include "cfe_msg_hdr.h"
 #include "cfe_msg_defaults.h"
 
-/******************************************************************************
- * Top level message initialization - See header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_InitDefaultHdr
+ *
+ * Application-scope internal function
+ * See description in cfe_msg_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_MSG_InitDefaultHdr(CFE_MSG_Message_t *MsgPtr)
 {
     CFE_MSG_SetDefaultCCSDSPri(MsgPtr);

--- a/modules/msg/fsw/src/cfe_msg_initdefaulthdr_priext.c
+++ b/modules/msg/fsw/src/cfe_msg_initdefaulthdr_priext.c
@@ -30,7 +30,7 @@
  * Function: CFE_MSG_InitDefaultHdr
  *
  * Application-scope internal function
- * See description in cfe_msg_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_MSG_InitDefaultHdr(CFE_MSG_Message_t *MsgPtr)

--- a/modules/msg/fsw/src/cfe_msg_initdefaulthdr_priext.c
+++ b/modules/msg/fsw/src/cfe_msg_initdefaulthdr_priext.c
@@ -25,9 +25,14 @@
 #include "cfe_msg_hdr.h"
 #include "cfe_msg_defaults.h"
 
-/******************************************************************************
- * Top level message initialization - See header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_InitDefaultHdr
+ *
+ * Application-scope internal function
+ * See description in cfe_msg_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_MSG_InitDefaultHdr(CFE_MSG_Message_t *MsgPtr)
 {
     CFE_MSG_SetDefaultCCSDSPri(MsgPtr);

--- a/modules/msg/fsw/src/cfe_msg_msgid_shared.c
+++ b/modules/msg/fsw/src/cfe_msg_msgid_shared.c
@@ -30,7 +30,7 @@
  * Function: CFE_MSG_GetTypeFromMsgId
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetTypeFromMsgId(CFE_SB_MsgId_t MsgId, CFE_MSG_Type_t *Type)

--- a/modules/msg/fsw/src/cfe_msg_msgid_shared.c
+++ b/modules/msg/fsw/src/cfe_msg_msgid_shared.c
@@ -25,10 +25,14 @@
 #include "cfe_msg_priv.h"
 #include "cfe_error.h"
 
-/******************************************************************************
- * Get type from message id - See API and header file for details
- * cFS default implementation
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_GetTypeFromMsgId
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetTypeFromMsgId(CFE_SB_MsgId_t MsgId, CFE_MSG_Type_t *Type)
 {
 

--- a/modules/msg/fsw/src/cfe_msg_msgid_v1.c
+++ b/modules/msg/fsw/src/cfe_msg_msgid_v1.c
@@ -27,12 +27,14 @@
 #include "cfe_platform_cfg.h"
 #include "cfe_sb.h"
 
-/******************************************************************************
- * Get message id - See API and header file for details
- * cFS default version 1 implementation using CCSDS headers
+/*----------------------------------------------------------------
  *
- * Message Id = CCSDS Stream ID (in local endian)
- */
+ * Function: CFE_MSG_GetMsgId
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetMsgId(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgId)
 {
 
@@ -49,12 +51,14 @@ int32 CFE_MSG_GetMsgId(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgId)
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Set message id - See API and header file for details
- * cFS default version 1 implementations using CCSDS headers
+/*----------------------------------------------------------------
  *
- * CCSDS Stream ID = Message Id converted to big endian
- */
+ * Function: CFE_MSG_SetMsgId
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetMsgId(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId)
 {
 

--- a/modules/msg/fsw/src/cfe_msg_msgid_v1.c
+++ b/modules/msg/fsw/src/cfe_msg_msgid_v1.c
@@ -32,7 +32,7 @@
  * Function: CFE_MSG_GetMsgId
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetMsgId(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgId)
@@ -56,7 +56,7 @@ int32 CFE_MSG_GetMsgId(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgId)
  * Function: CFE_MSG_SetMsgId
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetMsgId(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId)

--- a/modules/msg/fsw/src/cfe_msg_msgid_v2.c
+++ b/modules/msg/fsw/src/cfe_msg_msgid_v2.c
@@ -52,7 +52,7 @@
  * Function: CFE_MSG_GetMsgId
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetMsgId(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgId)
@@ -87,7 +87,7 @@ int32 CFE_MSG_GetMsgId(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgId)
  * Function: CFE_MSG_SetMsgId
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetMsgId(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId)

--- a/modules/msg/fsw/src/cfe_msg_msgid_v2.c
+++ b/modules/msg/fsw/src/cfe_msg_msgid_v2.c
@@ -47,9 +47,14 @@
 #define CFE_MSG_MSGID_TYPE_MASK   0x0080 /**< \brief Message type mask for MsgId, set = cmd */
 #define CFE_MSG_MSGID_SUBSYS_MASK 0xFF00 /**< \brief Subsystem mask for MsgId */
 
-/******************************************************************************
- * Get message id - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_GetMsgId
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetMsgId(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgId)
 {
 
@@ -77,9 +82,14 @@ int32 CFE_MSG_GetMsgId(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgId)
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Set message id - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_SetMsgId
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetMsgId(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId)
 {
 

--- a/modules/msg/fsw/src/cfe_msg_priv.h
+++ b/modules/msg/fsw/src/cfe_msg_priv.h
@@ -34,7 +34,7 @@
 #include "common_types.h"
 #include "cfe_msg_hdr.h"
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief get generic header field (uint8 array[2])
  *
@@ -51,7 +51,7 @@ static inline void CFE_MSG_GetHeaderField(const uint8 *Word, uint16 *Val, uint16
     *Val = (Word[0] << 8 | Word[1]) & Mask;
 }
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Set generic header field (uint8 array[2])
  *
@@ -69,7 +69,7 @@ static inline void CFE_MSG_SetHeaderField(uint8 *Word, uint16 Val, uint16 Mask)
     Word[1] = ((Word[1] & ~Mask) | (Val & Mask)) & 0xFF;
 }
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Initialize default header - implemented based on selected header format
  *

--- a/modules/msg/fsw/src/cfe_msg_sechdr_checksum.c
+++ b/modules/msg/fsw/src/cfe_msg_sechdr_checksum.c
@@ -24,14 +24,17 @@
 #include "cfe_msg.h"
 #include "cfe_msg_priv.h"
 
-/******************************************************************************/
-/**
- * \brief Compute checksum - internal utility
+/*----------------------------------------------------------------
  *
- * \param[in]  MsgPtr  Message pointer to checksum
+ * Function: CFE_MSG_ComputeCheckSum
  *
- * \return Calculated checksum
- */
+ * Internal helper routine only, not part of API.
+ *
+ * Computes checksum -
+ * MsgPtr is Message pointer to checksum
+ * Return Value is Calculated checksum
+ *
+ *-----------------------------------------------------------------*/
 CFE_MSG_Checksum_t CFE_MSG_ComputeCheckSum(const CFE_MSG_Message_t *MsgPtr)
 {
 
@@ -50,10 +53,14 @@ CFE_MSG_Checksum_t CFE_MSG_ComputeCheckSum(const CFE_MSG_Message_t *MsgPtr)
     return chksum;
 }
 
-/******************************************************************************
- * Calculate and set checksum field - See API and header file for details
- * Implementation supports cFS secondary definition or no secodary header
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_GenerateChecksum
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_GenerateChecksum(CFE_MSG_Message_t *MsgPtr)
 {
     uint32                   status;
@@ -85,10 +92,14 @@ int32 CFE_MSG_GenerateChecksum(CFE_MSG_Message_t *MsgPtr)
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Validate checksum - See API and header file for details
- * Implementation supports cFS secondary definition or no secondary header
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_ValidateChecksum
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_ValidateChecksum(const CFE_MSG_Message_t *MsgPtr, bool *IsValid)
 {
 

--- a/modules/msg/fsw/src/cfe_msg_sechdr_checksum.c
+++ b/modules/msg/fsw/src/cfe_msg_sechdr_checksum.c
@@ -58,7 +58,7 @@ CFE_MSG_Checksum_t CFE_MSG_ComputeCheckSum(const CFE_MSG_Message_t *MsgPtr)
  * Function: CFE_MSG_GenerateChecksum
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_GenerateChecksum(CFE_MSG_Message_t *MsgPtr)
@@ -97,7 +97,7 @@ int32 CFE_MSG_GenerateChecksum(CFE_MSG_Message_t *MsgPtr)
  * Function: CFE_MSG_ValidateChecksum
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_ValidateChecksum(const CFE_MSG_Message_t *MsgPtr, bool *IsValid)

--- a/modules/msg/fsw/src/cfe_msg_sechdr_fc.c
+++ b/modules/msg/fsw/src/cfe_msg_sechdr_fc.c
@@ -26,10 +26,14 @@
 
 #define CFE_MSG_FC_MASK 0x7F /**< \brief Function code mask */
 
-/******************************************************************************
- * Get function code - See API and header file for details
- * cFS default secondary header implementation
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_GetFcnCode
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetFcnCode(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_FcnCode_t *FcnCode)
 {
     uint32                   status;
@@ -57,10 +61,14 @@ int32 CFE_MSG_GetFcnCode(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_FcnCode_t *Fcn
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Set function code - See API and header file for details
- * cFS default secondary header implementation
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_SetFcnCode
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetFcnCode(CFE_MSG_Message_t *MsgPtr, CFE_MSG_FcnCode_t FcnCode)
 {
     uint32                   status;

--- a/modules/msg/fsw/src/cfe_msg_sechdr_fc.c
+++ b/modules/msg/fsw/src/cfe_msg_sechdr_fc.c
@@ -31,7 +31,7 @@
  * Function: CFE_MSG_GetFcnCode
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetFcnCode(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_FcnCode_t *FcnCode)
@@ -66,7 +66,7 @@ int32 CFE_MSG_GetFcnCode(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_FcnCode_t *Fcn
  * Function: CFE_MSG_SetFcnCode
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetFcnCode(CFE_MSG_Message_t *MsgPtr, CFE_MSG_FcnCode_t FcnCode)

--- a/modules/msg/fsw/src/cfe_msg_sechdr_time.c
+++ b/modules/msg/fsw/src/cfe_msg_sechdr_time.c
@@ -32,7 +32,7 @@
  * Function: CFE_MSG_SetMsgTime
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetMsgTime(CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t NewTime)
@@ -73,7 +73,7 @@ int32 CFE_MSG_SetMsgTime(CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t NewTime)
  * Function: CFE_MSG_GetMsgTime
  *
  * Implemented per public API
- * See description in cfe_msg.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetMsgTime(const CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t *Time)

--- a/modules/msg/fsw/src/cfe_msg_sechdr_time.c
+++ b/modules/msg/fsw/src/cfe_msg_sechdr_time.c
@@ -27,9 +27,14 @@
 #include "cfe_error.h"
 #include <string.h>
 
-/******************************************************************************
- * Set message time - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_SetMsgTime
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_SetMsgTime(CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t NewTime)
 {
 
@@ -63,9 +68,14 @@ int32 CFE_MSG_SetMsgTime(CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t NewTime)
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Get message time -  See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_MSG_GetMsgTime
+ *
+ * Implemented per public API
+ * See description in cfe_msg.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_MSG_GetMsgTime(const CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t *Time)
 {
 

--- a/modules/resourceid/fsw/src/cfe_resourceid_api.c
+++ b/modules/resourceid/fsw/src/cfe_resourceid_api.c
@@ -55,7 +55,7 @@ CompileTimeAssert(((CFE_RESOURCEID_MAX + 1) & CFE_RESOURCEID_MAX) == 0, CFE_RESO
  * Function: CFE_ResourceId_GetBase
  *
  * Implemented per public API
- * See description in cfe_resourceid.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 uint32 CFE_ResourceId_GetBase(CFE_ResourceId_t ResourceId)
@@ -68,7 +68,7 @@ uint32 CFE_ResourceId_GetBase(CFE_ResourceId_t ResourceId)
  * Function: CFE_ResourceId_GetSerial
  *
  * Implemented per public API
- * See description in cfe_resourceid.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 uint32 CFE_ResourceId_GetSerial(CFE_ResourceId_t ResourceId)
@@ -81,7 +81,7 @@ uint32 CFE_ResourceId_GetSerial(CFE_ResourceId_t ResourceId)
  * Function: CFE_ResourceId_ToIndex
  *
  * Implemented per public API
- * See description in cfe_resourceid.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_ResourceId_ToIndex(CFE_ResourceId_t Id, uint32 BaseValue, uint32 TableSize, uint32 *Idx)
@@ -109,7 +109,7 @@ int32 CFE_ResourceId_ToIndex(CFE_ResourceId_t Id, uint32 BaseValue, uint32 Table
  * Function: CFE_ResourceId_FindNext
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_ResourceId_t CFE_ResourceId_FindNext(CFE_ResourceId_t StartId, uint32 TableSize,

--- a/modules/resourceid/fsw/src/cfe_resourceid_api.c
+++ b/modules/resourceid/fsw/src/cfe_resourceid_api.c
@@ -50,34 +50,40 @@
  */
 CompileTimeAssert(((CFE_RESOURCEID_MAX + 1) & CFE_RESOURCEID_MAX) == 0, CFE_RESOURCEID_MAX_BITMASK);
 
-/*********************************************************************/
-/*
- * CFE_ResourceId_GetBase
+/*----------------------------------------------------------------
  *
- * For complete API information, see prototype in header
- */
+ * Function: CFE_ResourceId_GetBase
+ *
+ * Implemented per public API
+ * See description in cfe_resourceid.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 uint32 CFE_ResourceId_GetBase(CFE_ResourceId_t ResourceId)
 {
     return (CFE_ResourceId_ToInteger(ResourceId) & ~((uint32)CFE_RESOURCEID_MAX));
 }
 
-/*********************************************************************/
-/*
- * CFE_ResourceId_GetSerial
+/*----------------------------------------------------------------
  *
- * For complete API information, see prototype in header
- */
+ * Function: CFE_ResourceId_GetSerial
+ *
+ * Implemented per public API
+ * See description in cfe_resourceid.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 uint32 CFE_ResourceId_GetSerial(CFE_ResourceId_t ResourceId)
 {
     return (CFE_ResourceId_ToInteger(ResourceId) & ((uint32)CFE_RESOURCEID_MAX));
 }
 
-/*********************************************************************/
-/*
- * CFE_ResourceId_ToIndex
+/*----------------------------------------------------------------
  *
- * For complete API information, see prototype in header
- */
+ * Function: CFE_ResourceId_ToIndex
+ *
+ * Implemented per public API
+ * See description in cfe_resourceid.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_ResourceId_ToIndex(CFE_ResourceId_t Id, uint32 BaseValue, uint32 TableSize, uint32 *Idx)
 {
     uint32 Serial;
@@ -98,12 +104,14 @@ int32 CFE_ResourceId_ToIndex(CFE_ResourceId_t Id, uint32 BaseValue, uint32 Table
     return CFE_SUCCESS;
 }
 
-/*********************************************************************/
-/*
- * CFE_ResourceId_FindNext
+/*----------------------------------------------------------------
  *
- * For complete API information, see prototype in header
- */
+ * Function: CFE_ResourceId_FindNext
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_ResourceId_t CFE_ResourceId_FindNext(CFE_ResourceId_t StartId, uint32 TableSize,
                                          bool (*CheckFunc)(CFE_ResourceId_t))
 {

--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -82,7 +82,7 @@ typedef struct
  * Function: CFE_SB_PipeId_ToIndex
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_SB_PipeId_ToIndex(CFE_SB_PipeId_t PipeID, uint32 *Idx)
@@ -95,7 +95,7 @@ CFE_Status_t CFE_SB_PipeId_ToIndex(CFE_SB_PipeId_t PipeID, uint32 *Idx)
  * Function: CFE_SB_CreatePipe
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16 Depth, const char *PipeName)
@@ -280,7 +280,7 @@ int32 CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16 Depth, const char *Pi
  * Function: CFE_SB_DeletePipe
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_DeletePipe(CFE_SB_PipeId_t PipeId)
@@ -301,7 +301,7 @@ int32 CFE_SB_DeletePipe(CFE_SB_PipeId_t PipeId)
  * Function: CFE_SB_DeletePipeWithAppId
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_DeletePipeWithAppId(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId)
@@ -342,7 +342,7 @@ void CFE_SB_RemovePipeFromRoute(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
  * Function: CFE_SB_DeletePipeFull
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId)
@@ -491,7 +491,7 @@ int32 CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId)
  * Function: CFE_SB_SetPipeOpts
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_SetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 Opts)
@@ -580,7 +580,7 @@ int32 CFE_SB_SetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 Opts)
  * Function: CFE_SB_GetPipeOpts
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_GetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 *OptsPtr)
@@ -657,7 +657,7 @@ int32 CFE_SB_GetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 *OptsPtr)
  * Function: CFE_SB_GetPipeName
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_GetPipeName(char *PipeNameBuf, size_t PipeNameSize, CFE_SB_PipeId_t PipeId)
@@ -751,7 +751,7 @@ int32 CFE_SB_GetPipeName(char *PipeNameBuf, size_t PipeNameSize, CFE_SB_PipeId_t
  * Function: CFE_SB_GetPipeIdByName
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *PipeName)
@@ -856,7 +856,7 @@ int32 CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *PipeName)
  * Function: CFE_SB_SubscribeEx
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_SubscribeEx(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_Qos_t Quality, uint16 MsgLim)
@@ -869,7 +869,7 @@ int32 CFE_SB_SubscribeEx(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_Qo
  * Function: CFE_SB_SubscribeLocal
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_SubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint16 MsgLim)
@@ -882,7 +882,7 @@ int32 CFE_SB_SubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint16
  * Function: CFE_SB_Subscribe
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_Subscribe(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId)
@@ -896,7 +896,7 @@ int32 CFE_SB_Subscribe(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId)
  * Function: CFE_SB_SubscribeFull
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_Qos_t Quality, uint16 MsgLim,
@@ -1137,7 +1137,7 @@ int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_
  * Function: CFE_SB_Unsubscribe
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_Unsubscribe(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId)
@@ -1158,7 +1158,7 @@ int32 CFE_SB_Unsubscribe(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId)
  * Function: CFE_SB_UnsubscribeLocal
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_UnsubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId)
@@ -1179,7 +1179,7 @@ int32 CFE_SB_UnsubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId)
  * Function: CFE_SB_UnsubscribeWithAppId
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_UnsubscribeWithAppId(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId)
@@ -1196,7 +1196,7 @@ int32 CFE_SB_UnsubscribeWithAppId(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, 
  * Function: CFE_SB_UnsubscribeFull
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint8 Scope, CFE_ES_AppId_t AppId)
@@ -1320,7 +1320,7 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint8
  * Function: CFE_SB_TransmitMsg
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_TransmitMsg(CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount)
@@ -1427,7 +1427,7 @@ int32 CFE_SB_TransmitMsg(CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount)
  * Function: CFE_SB_TransmitMsgValidate
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_TransmitMsgValidate(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgIdPtr, CFE_MSG_Size_t *SizePtr,
@@ -1544,7 +1544,7 @@ int32 CFE_SB_TransmitMsgValidate(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgI
  * Function: CFE_SB_BroadcastBufferToRoute
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_t RouteId)
@@ -1769,7 +1769,7 @@ void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_
  * Function: CFE_SB_ReceiveBuffer
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_ReceiveBuffer(CFE_SB_Buffer_t **BufPtr, CFE_SB_PipeId_t PipeId, int32 TimeOut)
@@ -2026,7 +2026,7 @@ int32 CFE_SB_ReceiveBuffer(CFE_SB_Buffer_t **BufPtr, CFE_SB_PipeId_t PipeId, int
  * Function: CFE_SB_AllocateMessageBuffer
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_SB_Buffer_t *CFE_SB_AllocateMessageBuffer(size_t MsgSize)
@@ -2086,7 +2086,7 @@ CFE_SB_Buffer_t *CFE_SB_AllocateMessageBuffer(size_t MsgSize)
  * Function: CFE_SB_ZeroCopyBufferValidate
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_ZeroCopyBufferValidate(CFE_SB_Buffer_t *BufPtr, CFE_SB_BufferD_t **BufDscPtr)
@@ -2125,7 +2125,7 @@ int32 CFE_SB_ZeroCopyBufferValidate(CFE_SB_Buffer_t *BufPtr, CFE_SB_BufferD_t **
  * Function: CFE_SB_ReleaseMessageBuffer
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_SB_ReleaseMessageBuffer(CFE_SB_Buffer_t *BufPtr)
@@ -2154,7 +2154,7 @@ CFE_Status_t CFE_SB_ReleaseMessageBuffer(CFE_SB_Buffer_t *BufPtr)
  * Function: CFE_SB_TransmitBuffer
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_TransmitBuffer(CFE_SB_Buffer_t *BufPtr, bool IncrementSequenceCount)

--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -77,17 +77,27 @@ typedef struct
     CFE_SB_PipeId_t PipeId;   /* Pipe id to remove */
 } CFE_SB_RemovePipeCallback_t;
 
-/*
- *  Function: CFE_SB_PipeId_ToIndex - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_PipeId_ToIndex
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_Status_t CFE_SB_PipeId_ToIndex(CFE_SB_PipeId_t PipeID, uint32 *Idx)
 {
     return CFE_ResourceId_ToIndex(CFE_RESOURCEID_UNWRAP(PipeID), CFE_SB_PIPEID_BASE, CFE_PLATFORM_SB_MAX_PIPES, Idx);
 }
 
-/*
- * Function: CFE_SB_CreatePipe - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_CreatePipe
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16 Depth, const char *PipeName)
 {
     CFE_ES_AppId_t   AppId;
@@ -263,12 +273,16 @@ int32 CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16 Depth, const char *Pi
     }
 
     return Status;
+}
 
-} /* end CFE_SB_CreatePipe */
-
-/*
- *  Function: CFE_SB_DeletePipe - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_DeletePipe
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_DeletePipe(CFE_SB_PipeId_t PipeId)
 {
     CFE_ES_AppId_t CallerId;
@@ -280,21 +294,16 @@ int32 CFE_SB_DeletePipe(CFE_SB_PipeId_t PipeId)
     Status = CFE_SB_DeletePipeFull(PipeId, CallerId);
 
     return Status;
+}
 
-} /* end CFE_SB_DeletePipe */
-
-/******************************************************************************
-**  Function:  CFE_SB_DeletePipeWithAppId()
-**
-**  Purpose:
-**
-**
-**  Arguments:
-**    PipeId - The ID of the pipe to delete.
-**
-**  Return:
-**    CFE_SUCCESS or cFE Error Code
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_DeletePipeWithAppId
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_DeletePipeWithAppId(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId)
 {
     int32 Status = 0;
@@ -302,12 +311,17 @@ int32 CFE_SB_DeletePipeWithAppId(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId)
     Status = CFE_SB_DeletePipeFull(PipeId, AppId);
 
     return Status;
+}
 
-} /* end CFE_SB_DeletePipeWithAppId */
-
-/******************************************************************************
- * Local callback helper for deleting a pipe from a route
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_RemovePipeFromRoute
+ *
+ * Internal helper routine only, not part of API.
+ *
+ * Callback for deleting a pipe from a route
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_RemovePipeFromRoute(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
 {
     CFE_SB_DestinationD_t *      destptr;
@@ -323,21 +337,14 @@ void CFE_SB_RemovePipeFromRoute(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
     }
 }
 
-/******************************************************************************
-**  Function:  CFE_SB_DeletePipeFull()
-**
-**  Purpose:
-**    Will unsubscribe to all routes associated with the given pipe id, then remove
-**    pipe from the pipe table.
-**
-**  NOTE:This function cannot be called directly, it would not be semaphore protected
-**
-**  Arguments:
-**    PipeId - The ID of the pipe to delete.
-**
-**  Return:
-**    CFE_SUCCESS or cFE Error Code
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_DeletePipeFull
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId)
 {
     CFE_SB_PipeD_t *            PipeDscPtr;
@@ -477,12 +484,16 @@ int32 CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId)
     }
 
     return Status;
+}
 
-} /* end CFE_SB_DeletePipeFull */
-
-/*
- *  Function: CFE_SB_SetPipeOpts - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_SetPipeOpts
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_SetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 Opts)
 {
     CFE_SB_PipeD_t *PipeDscPtr;
@@ -562,11 +573,16 @@ int32 CFE_SB_SetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 Opts)
     }
 
     return Status;
-} /* end CFE_SB_SetPipeOpts */
+}
 
-/*
- *  Function:  CFE_SB_GetPipeOpts - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_GetPipeOpts
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_GetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 *OptsPtr)
 {
     int32           Status;
@@ -634,11 +650,16 @@ int32 CFE_SB_GetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 *OptsPtr)
     }
 
     return Status;
-} /* end CFE_SB_GetPipeOpts */
+}
 
-/*
- *  Function:  CFE_SB_GetPipeName - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_GetPipeName
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_GetPipeName(char *PipeNameBuf, size_t PipeNameSize, CFE_SB_PipeId_t PipeId)
 {
     int32           Status;
@@ -723,12 +744,16 @@ int32 CFE_SB_GetPipeName(char *PipeNameBuf, size_t PipeNameSize, CFE_SB_PipeId_t
     }
 
     return Status;
+}
 
-} /* end CFE_SB_GetPipeName */
-
-/*
- *  Function:  CFE_SB_GetPipeIdByName - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_GetPipeIdByName
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *PipeName)
 {
     int32           Status;
@@ -824,66 +849,56 @@ int32 CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *PipeName)
     }
 
     return Status;
+}
 
-} /* end CFE_SB_GetPipeIdByName */
-
-/*
- * Function: CFE_SB_SubscribeEx - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_SubscribeEx
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_SubscribeEx(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_Qos_t Quality, uint16 MsgLim)
 {
     return CFE_SB_SubscribeFull(MsgId, PipeId, Quality, MsgLim, (uint8)CFE_SB_MSG_GLOBAL);
+}
 
-} /* end CFE_SB_SubscribeEx */
-
-/*
- * Function: CFE_SB_SubscribeLocal - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_SubscribeLocal
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_SubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint16 MsgLim)
 {
     return CFE_SB_SubscribeFull(MsgId, PipeId, CFE_SB_DEFAULT_QOS, MsgLim, (uint8)CFE_SB_MSG_LOCAL);
+}
 
-} /* end CFE_SB_SubscribeLocal */
-
-/*
- * Function: CFE_SB_Subscribe - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_Subscribe
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_Subscribe(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId)
 {
     return CFE_SB_SubscribeFull(MsgId, PipeId, CFE_SB_DEFAULT_QOS, (uint16)CFE_PLATFORM_SB_DEFAULT_MSG_LIMIT,
                                 (uint8)CFE_SB_MSG_GLOBAL);
+}
 
-} /* end CFE_SB_Subscribe */
-
-/******************************************************************************
-** Name:    CFE_SB_SubscribeFull
-**
-** Purpose: CFE Internal API used to subscribe to a message. Contains an input
-**          parameter for all possible subscription choices. This function is
-**          called by CFE_SB_SubscribeEx, CFE_SB_Subscribe and
-**          CFE_SB_SubscribeLocal.
-**
-** Assumptions, External Events, and Notes:
-**          Has the same typedef as the message Id
-**
-** Date Written:
-**          04/25/2005
-**
-** Input Arguments:
-**          MsgId - Mission unique identifier for the message being requested
-**          PipeId  - The Pipe ID to send the message to
-**          Quality - Quality of Service (Qos) - priority and reliability
-**          MsgLim  - Max number of messages, with this MsgId, allowed on the
-**                    pipe at any time.
-**          Scope   - Local subscription or broadcasted to peers
-**
-** Output Arguments:
-**          None
-**
-** Return Values:
-**          Status
-**
-******************************************************************************/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_SubscribeFull
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_Qos_t Quality, uint16 MsgLim,
                            uint8 Scope)
 {
@@ -1115,12 +1130,16 @@ int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_
     }
 
     return Status;
+}
 
-} /* end CFE_SB_SubscribeFull */
-
-/*
- * Function: CFE_SB_Unsubscribe - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_Unsubscribe
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_Unsubscribe(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId)
 {
     CFE_ES_AppId_t CallerId;
@@ -1132,12 +1151,16 @@ int32 CFE_SB_Unsubscribe(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId)
     Status = CFE_SB_UnsubscribeFull(MsgId, PipeId, (uint8)CFE_SB_MSG_GLOBAL, CallerId);
 
     return Status;
+}
 
-} /* end CFE_SB_Unsubscribe */
-
-/*
- * Function: CFE_SB_UnsubscribeLocal - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_UnsubscribeLocal
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_UnsubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId)
 {
     CFE_ES_AppId_t CallerId;
@@ -1149,31 +1172,16 @@ int32 CFE_SB_UnsubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId)
     Status = CFE_SB_UnsubscribeFull(MsgId, PipeId, (uint8)CFE_SB_MSG_LOCAL, CallerId);
 
     return Status;
+}
 
-} /* end CFE_SB_UnsubscribeLocal */
-
-/******************************************************************************
-** Name:    CFE_SB_UnsubscribeAppId
-**
-** Purpose: CFE Internal API intented to be called by CFE_ES when an applications
-**          SB resources need to be freed. The regular unsibscribe api won't work
-**          because it does a check to ensure the caller is the owner of the pipe.
-**
-** Date Written:
-**          03/15/2007
-**
-** Input Arguments:
-**          MsgId
-**          PipeId
-**          AppId
-**
-** Output Arguments:
-**          None
-**
-** Return Values:
-**          Status
-**
-******************************************************************************/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_UnsubscribeWithAppId
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_UnsubscribeWithAppId(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId)
 {
     int32 Status = 0;
@@ -1181,37 +1189,16 @@ int32 CFE_SB_UnsubscribeWithAppId(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, 
     Status = CFE_SB_UnsubscribeFull(MsgId, PipeId, (uint8)CFE_SB_MSG_LOCAL, AppId);
 
     return Status;
+}
 
-} /* end CFE_SB_UnsubscribeWithAppId */
-
-/******************************************************************************
-** Name:    CFE_SB_UnsubscribeFull
-**
-** Purpose: CFE Internal API used to unsubscribe to a message.
-**
-** Assumptions, External Events, and Notes:
-**
-**
-** Notes:This function cannot be called directly,it would not be semaphore protected.
-**       Also,if more than one subscription is found, this function will remove all
-**       entries that match.
-**
-** Date Written:
-**          04/25/2005
-**
-** Input Arguments:
-**          MsgId
-**          PipeId
-**          Scope
-**          AppId
-**
-** Output Arguments:
-**          None
-**
-** Return Values:
-**          Status
-**
-******************************************************************************/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_UnsubscribeFull
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint8 Scope, CFE_ES_AppId_t AppId)
 {
     int32                  Status;
@@ -1326,11 +1313,16 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint8
     }
 
     return Status;
-} /* end CFE_SB_UnsubscribeFull */
+}
 
-/*
- * Function CFE_SB_TransmitMsg - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_TransmitMsg
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_TransmitMsg(CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount)
 {
     int32             Status;
@@ -1430,15 +1422,14 @@ int32 CFE_SB_TransmitMsg(CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount)
     return Status;
 }
 
-/*****************************************************************************/
-/**
- * \brief Internal routine to validate a transmit message before sending
+/*----------------------------------------------------------------
  *
- * \param[in]  MsgPtr     Pointer to the message to validate
- * \param[out] MsgIdPtr   Message Id of message
- * \param[out] SizePtr    Size of message
- * \param[out] RouteIdPtr Route ID of the message (invalid if none)
- */
+ * Function: CFE_SB_TransmitMsgValidate
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_TransmitMsgValidate(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgIdPtr, CFE_MSG_Size_t *SizePtr,
                                  CFE_SBR_RouteId_t *RouteIdPtr)
 {
@@ -1548,14 +1539,14 @@ int32 CFE_SB_TransmitMsgValidate(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgI
     return Status;
 }
 
-/*****************************************************************************/
-/**
- * \brief Internal routine implements full send logic
+/*----------------------------------------------------------------
  *
- * \param[in] BufDscPtr Pointer to the buffer description from the memory pool,
- *                      released prior to return
- * \param[in] RouteId   Route to send to
- */
+ * Function: CFE_SB_BroadcastBufferToRoute
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_t RouteId)
 {
     CFE_ES_AppId_t         AppId;
@@ -1773,9 +1764,14 @@ void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_
     }
 }
 
-/*
- * Function: CFE_SB_ReceiveBuffer - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_ReceiveBuffer
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_ReceiveBuffer(CFE_SB_Buffer_t **BufPtr, CFE_SB_PipeId_t PipeId, int32 TimeOut)
 {
     int32                  Status;
@@ -2025,9 +2021,14 @@ int32 CFE_SB_ReceiveBuffer(CFE_SB_Buffer_t **BufPtr, CFE_SB_PipeId_t PipeId, int
     return Status;
 }
 
-/*
- * Function: CFE_SB_AllocateMessageBuffer - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_AllocateMessageBuffer
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_SB_Buffer_t *CFE_SB_AllocateMessageBuffer(size_t MsgSize)
 {
     CFE_ES_AppId_t    AppId;
@@ -2078,13 +2079,16 @@ CFE_SB_Buffer_t *CFE_SB_AllocateMessageBuffer(size_t MsgSize)
     }
 
     return BufPtr;
+}
 
-} /* CFE_SB_AllocateMessageBuffer */
-
-/*
- * Helper function to do sanity checks on the Zero Copy Buffer and
- * outputs the encapsulating descriptor if successful
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_ZeroCopyBufferValidate
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_ZeroCopyBufferValidate(CFE_SB_Buffer_t *BufPtr, CFE_SB_BufferD_t **BufDscPtr)
 {
     cpuaddr BufDscAddr;
@@ -2116,9 +2120,14 @@ int32 CFE_SB_ZeroCopyBufferValidate(CFE_SB_Buffer_t *BufPtr, CFE_SB_BufferD_t **
     return CFE_SUCCESS;
 }
 
-/*
- * Function: CFE_SB_ReleaseMessageBuffer - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_ReleaseMessageBuffer
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_Status_t CFE_SB_ReleaseMessageBuffer(CFE_SB_Buffer_t *BufPtr)
 {
     CFE_SB_BufferD_t *BufDscPtr;
@@ -2138,12 +2147,16 @@ CFE_Status_t CFE_SB_ReleaseMessageBuffer(CFE_SB_Buffer_t *BufPtr)
     CFE_SB_UnlockSharedData(__func__, __LINE__);
 
     return Status;
+}
 
-} /* end CFE_SB_ReleaseMessageBuffer */
-
-/*
- * Function CFE_SB_TransmitBuffer - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_TransmitBuffer
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_TransmitBuffer(CFE_SB_Buffer_t *BufPtr, bool IncrementSequenceCount)
 {
     int32             Status;

--- a/modules/sb/fsw/src/cfe_sb_buf.c
+++ b/modules/sb/fsw/src/cfe_sb_buf.c
@@ -42,10 +42,14 @@
  */
 #define CFE_SB_BUFFERD_CONTENT_OFFSET (offsetof(CFE_SB_BufferD_t, Content))
 
-/******************************************************************************
+/*----------------------------------------------------------------
  *
- * Helper function to reset/clear the links on a list node (make empty)
- */
+ * Function: CFE_SB_TrackingListReset
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_TrackingListReset(CFE_SB_BufferLink_t *Link)
 {
     /* A singleton node/empty list points to itself */
@@ -53,10 +57,14 @@ void CFE_SB_TrackingListReset(CFE_SB_BufferLink_t *Link)
     Link->Next = Link;
 }
 
-/******************************************************************************
+/*----------------------------------------------------------------
  *
- * Helper function to remove a node from a tracking list
- */
+ * Function: CFE_SB_TrackingListRemove
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_TrackingListRemove(CFE_SB_BufferLink_t *Node)
 {
     /* Remove from list */
@@ -67,10 +75,14 @@ void CFE_SB_TrackingListRemove(CFE_SB_BufferLink_t *Node)
     CFE_SB_TrackingListReset(Node);
 }
 
-/******************************************************************************
+/*----------------------------------------------------------------
  *
- * Helper function to add a node to a tracking list
- */
+ * Function: CFE_SB_TrackingListAdd
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_TrackingListAdd(CFE_SB_BufferLink_t *List, CFE_SB_BufferLink_t *Node)
 {
     /* Connect this node to the list at "prev" position (tail) */
@@ -82,26 +94,14 @@ void CFE_SB_TrackingListAdd(CFE_SB_BufferLink_t *List, CFE_SB_BufferLink_t *Node
     Node->Next->Prev = Node;
 }
 
-/******************************************************************************
-**  Function:   CFE_SB_GetBufferFromPool()
-**
-**  Purpose:
-**    Request a buffer from the SB buffer pool. The SB buffer pool is a
-**    pre-allocated block of memory of size CFE_PLATFORM_SB_BUF_MEMORY_BYTES. It is used
-**    by the SB to dynamically allocate memory to hold the message and a buffer
-**    descriptor associated with the message during the sending of a message.
-**
-**  Note:
-**    This must only be invoked while holding the SB global lock
-**
-**  Arguments:
-**    MaxMsgSize         : Size of the buffer content area in bytes.
-**
-**  Return:
-**    Pointer to the buffer descriptor for the new buffer, or NULL if the buffer
-**    could not be allocated.
-*/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_GetBufferFromPool
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_SB_BufferD_t *CFE_SB_GetBufferFromPool(size_t MaxMsgSize)
 {
     int32             stat1;
@@ -143,26 +143,16 @@ CFE_SB_BufferD_t *CFE_SB_GetBufferFromPool(size_t MaxMsgSize)
     CFE_SB_TrackingListReset(&bd->Link);
 
     return bd;
+}
 
-} /* CFE_SB_GetBufferFromPool */
-
-/******************************************************************************
-**  Function:   CFE_SB_ReturnBufferToPool()
-**
-**  Purpose:
-**    This function will return two blocks of memory back to the memory pool.
-**    One block is the memory used to store the actual message, the other block
-**    was used to store the buffer descriptor for the message.
-**
-**  Note:
-**    This must only be invoked while holding the SB global lock
-**
-**  Arguments:
-**    bd     : Pointer to the buffer descriptor.
-**
-**  Return:
-**    None
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_ReturnBufferToPool
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_ReturnBufferToPool(CFE_SB_BufferD_t *bd)
 {
     /* Remove from any tracking list (no effect if not in a list) */
@@ -173,27 +163,16 @@ void CFE_SB_ReturnBufferToPool(CFE_SB_BufferD_t *bd)
 
     /* finally give the buf descriptor back to the buf descriptor pool */
     CFE_ES_PutPoolBuf(CFE_SB_Global.Mem.PoolHdl, bd);
+}
 
-} /* end CFE_SB_ReturnBufferToPool */
-
-/******************************************************************************
-**  Function:   CFE_SB_IncrBufUseCnt()
-**
-**  Purpose:
-**    This function will increment the UseCount of a particular buffer.
-**
-**  Note:
-**    UseCount is a variable in the CFE_SB_BufferD_t and is used only to
-**    determine when a buffer may be returned to the memory pool.
-**
-**    This must only be invoked while holding the SB global lock
-**
-**  Arguments:
-**    bd : Pointer to the buffer descriptor.
-**
-**  Return:
-**    CFE_SUCCESS for normal operation.
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_IncrBufUseCnt
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_IncrBufUseCnt(CFE_SB_BufferD_t *bd)
 {
     /* range check the UseCount variable */
@@ -201,29 +180,16 @@ void CFE_SB_IncrBufUseCnt(CFE_SB_BufferD_t *bd)
     {
         ++bd->UseCount;
     }
+}
 
-} /* end CFE_SB_DecrBufUseCnt */
-
-/******************************************************************************
-**  Function:   CFE_SB_DecrBufUseCnt()
-**
-**  Purpose:
-**    This function will decrement the UseCount of a particular buffer. If the
-**    the UseCount is decremented to zero, it will return the buffer to the
-**    memory pool.
-**
-**  Note:
-**    UseCount is a variable in the CFE_SB_BufferD_t and is used only to
-**    determine when a buffer may be returned to the memory pool.
-**
-**    This must only be invoked while holding the SB global lock
-**
-**  Arguments:
-**    bd : Pointer to the buffer descriptor.
-**
-**  Return:
-**    CFE_SUCCESS for normal operation.
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_DecrBufUseCnt
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_DecrBufUseCnt(CFE_SB_BufferD_t *bd)
 {
     /* range check the UseCount variable */
@@ -236,24 +202,16 @@ void CFE_SB_DecrBufUseCnt(CFE_SB_BufferD_t *bd)
             CFE_SB_ReturnBufferToPool(bd);
         }
     }
+}
 
-} /* end CFE_SB_DecrBufUseCnt */
-
-/******************************************************************************
-**  Function:   CFE_SB_GetDestinationBlk()
-**
-**  Purpose:
-**    This function gets a destination descriptor from the SB memory pool.
-**
-**  Note:
-**    This must only be invoked while holding the SB global lock
-**
-**  Arguments:
-**    None
-**
-**  Return:
-**    Pointer to the destination descriptor
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_GetDestinationBlk
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_SB_DestinationD_t *CFE_SB_GetDestinationBlk(void)
 {
     int32                  Stat;
@@ -275,24 +233,16 @@ CFE_SB_DestinationD_t *CFE_SB_GetDestinationBlk(void)
     } /* end if */
 
     return Dest;
+}
 
-} /* end CFE_SB_GetDestinationBlk */
-
-/******************************************************************************
-**  Function:   CFE_SB_PutDestinationBlk()
-**
-**  Purpose:
-**    This function returns a destination descriptor to the SB memory pool.
-**
-**  Note:
-**    This must only be invoked while holding the SB global lock
-**
-**  Arguments:
-**    None
-**
-**  Return:
-**    Pointer to the destination descriptor
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_PutDestinationBlk
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_PutDestinationBlk(CFE_SB_DestinationD_t *Dest)
 {
     int32 Stat;
@@ -311,7 +261,4 @@ int32 CFE_SB_PutDestinationBlk(CFE_SB_DestinationD_t *Dest)
     } /* end if */
 
     return CFE_SUCCESS;
-
-} /* end CFE_SB_PutDestinationBlk */
-
-/*****************************************************************************/
+}

--- a/modules/sb/fsw/src/cfe_sb_buf.c
+++ b/modules/sb/fsw/src/cfe_sb_buf.c
@@ -47,7 +47,7 @@
  * Function: CFE_SB_TrackingListReset
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_TrackingListReset(CFE_SB_BufferLink_t *Link)
@@ -62,7 +62,7 @@ void CFE_SB_TrackingListReset(CFE_SB_BufferLink_t *Link)
  * Function: CFE_SB_TrackingListRemove
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_TrackingListRemove(CFE_SB_BufferLink_t *Node)
@@ -80,7 +80,7 @@ void CFE_SB_TrackingListRemove(CFE_SB_BufferLink_t *Node)
  * Function: CFE_SB_TrackingListAdd
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_TrackingListAdd(CFE_SB_BufferLink_t *List, CFE_SB_BufferLink_t *Node)
@@ -99,7 +99,7 @@ void CFE_SB_TrackingListAdd(CFE_SB_BufferLink_t *List, CFE_SB_BufferLink_t *Node
  * Function: CFE_SB_GetBufferFromPool
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_SB_BufferD_t *CFE_SB_GetBufferFromPool(size_t MaxMsgSize)
@@ -150,7 +150,7 @@ CFE_SB_BufferD_t *CFE_SB_GetBufferFromPool(size_t MaxMsgSize)
  * Function: CFE_SB_ReturnBufferToPool
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_ReturnBufferToPool(CFE_SB_BufferD_t *bd)
@@ -170,7 +170,7 @@ void CFE_SB_ReturnBufferToPool(CFE_SB_BufferD_t *bd)
  * Function: CFE_SB_IncrBufUseCnt
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_IncrBufUseCnt(CFE_SB_BufferD_t *bd)
@@ -187,7 +187,7 @@ void CFE_SB_IncrBufUseCnt(CFE_SB_BufferD_t *bd)
  * Function: CFE_SB_DecrBufUseCnt
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_DecrBufUseCnt(CFE_SB_BufferD_t *bd)
@@ -209,7 +209,7 @@ void CFE_SB_DecrBufUseCnt(CFE_SB_BufferD_t *bd)
  * Function: CFE_SB_GetDestinationBlk
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_SB_DestinationD_t *CFE_SB_GetDestinationBlk(void)
@@ -240,7 +240,7 @@ CFE_SB_DestinationD_t *CFE_SB_GetDestinationBlk(void)
  * Function: CFE_SB_PutDestinationBlk
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_PutDestinationBlk(CFE_SB_DestinationD_t *Dest)

--- a/modules/sb/fsw/src/cfe_sb_init.c
+++ b/modules/sb/fsw/src/cfe_sb_init.c
@@ -53,7 +53,7 @@ const size_t CFE_SB_MemPoolDefSize[CFE_PLATFORM_ES_POOL_MAX_BUCKETS] = {
  * Function: CFE_SB_EarlyInit
  *
  * Implemented per public API
- * See description in cfe_sb_core_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_EarlyInit(void)
@@ -100,7 +100,7 @@ int32 CFE_SB_EarlyInit(void)
  * Function: CFE_SB_InitBuffers
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_InitBuffers(void)
@@ -134,7 +134,7 @@ int32 CFE_SB_InitBuffers(void)
  * Function: CFE_SB_InitPipeTbl
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_InitPipeTbl(void)

--- a/modules/sb/fsw/src/cfe_sb_init.c
+++ b/modules/sb/fsw/src/cfe_sb_init.c
@@ -48,20 +48,14 @@ const size_t CFE_SB_MemPoolDefSize[CFE_PLATFORM_ES_POOL_MAX_BUCKETS] = {
     CFE_PLATFORM_SB_MEM_BLOCK_SIZE_05, CFE_PLATFORM_SB_MEM_BLOCK_SIZE_04, CFE_PLATFORM_SB_MEM_BLOCK_SIZE_03,
     CFE_PLATFORM_SB_MEM_BLOCK_SIZE_02, CFE_PLATFORM_SB_MEM_BLOCK_SIZE_01};
 
-/******************************************************************************
-**  Function:  CFE_SB_EarlyInit()
-**
-**  Purpose:
-**    Initialize the Software Bus routing tables.
-**
-**  Arguments:
-**
-**  Notes:
-**    This function MUST be called before any SB API's are called.
-**
-**  Return:
-**    CFE_SUCCESS
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_EarlyInit
+ *
+ * Implemented per public API
+ * See description in cfe_sb_core_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_EarlyInit(void)
 {
 
@@ -99,23 +93,16 @@ int32 CFE_SB_EarlyInit(void)
                  sizeof(CFE_SB_Global.StatTlmMsg));
 
     return Stat;
+}
 
-} /* end CFE_SB_EarlyInit */
-
-/******************************************************************************
-**  Function:  CFE_SB_InitBuffers()
-**
-**  Purpose:
-**    Initialize the Software Bus Buffer Pool.
-**
-**  Arguments:
-**
-**  Notes:
-**    This function MUST be called before any SB API's are called.
-**
-**  Return:
-**    none
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_InitBuffers
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_InitBuffers(void)
 {
 
@@ -140,27 +127,17 @@ int32 CFE_SB_InitBuffers(void)
     CFE_SB_TrackingListReset(&CFE_SB_Global.ZeroCopyList);
 
     return CFE_SUCCESS;
+}
 
-} /* end CFE_SB_InitBuffers */
-
-/******************************************************************************
-**  Function:  CFE_SB_InitPipeTbl()
-**
-**  Purpose:
-**    Initialize the Software Bus Pipe Table.
-**
-**  Arguments:
-**
-**  Notes:
-**    This function MUST be called before any SB API's are called.
-**
-**  Return:
-**    none
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_InitPipeTbl
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_InitPipeTbl(void)
 {
     CFE_SB_Global.LastPipeId = CFE_ResourceId_FromInteger(CFE_SB_PIPEID_BASE);
-
-} /* end CFE_SB_InitPipeTbl */
-
-/*****************************************************************************/
+}

--- a/modules/sb/fsw/src/cfe_sb_msg_id_util.c
+++ b/modules/sb/fsw/src/cfe_sb_msg_id_util.c
@@ -33,7 +33,7 @@
  * Function: CFE_SB_IsValidMsgId
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 bool CFE_SB_IsValidMsgId(CFE_SB_MsgId_t MsgId)

--- a/modules/sb/fsw/src/cfe_sb_msg_id_util.c
+++ b/modules/sb/fsw/src/cfe_sb_msg_id_util.c
@@ -28,11 +28,16 @@
 */
 #include "cfe_sb_module_all.h"
 
-/*
- * Function: CFE_SB_IsValidMsgId - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_IsValidMsgId
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_SB_IsValidMsgId(CFE_SB_MsgId_t MsgId)
 {
     return (!CFE_SB_MsgId_Equal(MsgId, CFE_SB_INVALID_MSG_ID) &&
             CFE_SB_MsgIdToValue(MsgId) <= CFE_PLATFORM_SB_HIGHEST_VALID_MSGID);
-} /* end CFE_SB_IsValidMsgId */
+}

--- a/modules/sb/fsw/src/cfe_sb_priv.c
+++ b/modules/sb/fsw/src/cfe_sb_priv.c
@@ -85,7 +85,7 @@
  * Function: CFE_SB_CleanUpApp
  *
  * Implemented per public API
- * See description in cfe_sb_core_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_CleanUpApp(CFE_ES_AppId_t AppId)
@@ -129,7 +129,7 @@ int32 CFE_SB_CleanUpApp(CFE_ES_AppId_t AppId)
  * Function: CFE_SB_LockSharedData
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_LockSharedData(const char *FuncName, int32 LineNumber)
@@ -157,7 +157,7 @@ void CFE_SB_LockSharedData(const char *FuncName, int32 LineNumber)
  * Function: CFE_SB_UnlockSharedData
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_UnlockSharedData(const char *FuncName, int32 LineNumber)
@@ -185,7 +185,7 @@ void CFE_SB_UnlockSharedData(const char *FuncName, int32 LineNumber)
  * Function: CFE_SB_GetDestPtr
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_SB_DestinationD_t *CFE_SB_GetDestPtr(CFE_SBR_RouteId_t RouteId, CFE_SB_PipeId_t PipeId)
@@ -212,7 +212,7 @@ CFE_SB_DestinationD_t *CFE_SB_GetDestPtr(CFE_SBR_RouteId_t RouteId, CFE_SB_PipeI
  * Function: CFE_SB_ValidateMsgId
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_ValidateMsgId(CFE_SB_MsgId_t MsgId)
@@ -235,7 +235,7 @@ int32 CFE_SB_ValidateMsgId(CFE_SB_MsgId_t MsgId)
  * Function: CFE_SB_LocatePipeDescByID
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_SB_PipeD_t *CFE_SB_LocatePipeDescByID(CFE_SB_PipeId_t PipeId)
@@ -260,7 +260,7 @@ CFE_SB_PipeD_t *CFE_SB_LocatePipeDescByID(CFE_SB_PipeId_t PipeId)
  * Function: CFE_SB_CheckPipeDescSlotUsed
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 bool CFE_SB_CheckPipeDescSlotUsed(CFE_ResourceId_t CheckId)
@@ -280,7 +280,7 @@ bool CFE_SB_CheckPipeDescSlotUsed(CFE_ResourceId_t CheckId)
  * Function: CFE_SB_GetAppTskName
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 char *CFE_SB_GetAppTskName(CFE_ES_TaskId_t TaskId, char *FullName)
@@ -326,7 +326,7 @@ char *CFE_SB_GetAppTskName(CFE_ES_TaskId_t TaskId, char *FullName)
  * Function: CFE_SB_RequestToSendEvent
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 uint32 CFE_SB_RequestToSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit)
@@ -359,7 +359,7 @@ uint32 CFE_SB_RequestToSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit)
  * Function: CFE_SB_FinishSendEvent
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_FinishSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit)
@@ -381,7 +381,7 @@ void CFE_SB_FinishSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit)
  * Function: CFE_SB_AddDestNode
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_AddDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *NewNode)
@@ -422,7 +422,7 @@ int32 CFE_SB_AddDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *NewNo
  * Function: CFE_SB_RemoveDest
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_RemoveDest(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *DestPtr)
@@ -437,7 +437,7 @@ void CFE_SB_RemoveDest(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *DestPtr
  * Function: CFE_SB_RemoveDestNode
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_RemoveDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *NodeToRemove)
@@ -483,7 +483,7 @@ void CFE_SB_RemoveDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *Nod
  * Function: CFE_SB_ZeroCopyReleaseAppId
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_ZeroCopyReleaseAppId(CFE_ES_AppId_t AppId)

--- a/modules/sb/fsw/src/cfe_sb_priv.c
+++ b/modules/sb/fsw/src/cfe_sb_priv.c
@@ -80,16 +80,14 @@
 
 #include <string.h>
 
-/******************************************************************************
-**  Function:  CFE_SB_CleanUpApp()
-**
-**  Purpose:
-**
-**  Arguments:
-**
-**  Return:
-**    None
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_CleanUpApp
+ *
+ * Implemented per public API
+ * See description in cfe_sb_core_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_CleanUpApp(CFE_ES_AppId_t AppId)
 {
     uint32          i;
@@ -124,23 +122,16 @@ int32 CFE_SB_CleanUpApp(CFE_ES_AppId_t AppId)
     CFE_SB_ZeroCopyReleaseAppId(AppId);
 
     return CFE_SUCCESS;
+}
 
-} /* end CFE_SB_CleanUpApp */
-
-/******************************************************************************
-**  Function:  CFE_SB_LockSharedData()
-**
-**  Purpose:
-**    SB internal function to handle a semaphore take failure for the Shared
-**    Data Mutex
-**
-**  Arguments:
-**    FuncName   - the function name containing the code that generated the error.
-**    LineNumber - the line number in the file of the code that generated the error.
-**
-**  Return:
-**    None
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_LockSharedData
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_LockSharedData(const char *FuncName, int32 LineNumber)
 {
 
@@ -159,23 +150,16 @@ void CFE_SB_LockSharedData(const char *FuncName, int32 LineNumber)
     } /* end if */
 
     return;
+}
 
-} /* end CFE_SB_LockSharedData */
-
-/******************************************************************************
-**  Function:  CFE_SB_UnlockSharedData()
-**
-**  Purpose:
-**    SB internal function to handle a semaphore give failure  for the Shared
-**    Data Mutex
-**
-**  Arguments:
-**    FuncName   - the function name containing the code that generated the error.
-**    LineNumber - the line number in the file of the code that generated the error.
-**
-**  Return:
-**    None
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_UnlockSharedData
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_UnlockSharedData(const char *FuncName, int32 LineNumber)
 {
 
@@ -194,12 +178,16 @@ void CFE_SB_UnlockSharedData(const char *FuncName, int32 LineNumber)
     } /* end if */
 
     return;
+}
 
-} /* end CFE_SB_UnlockSharedData */
-
-/******************************************************************************
- * SB private function to get destination pointer - see description in header
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_GetDestPtr
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_SB_DestinationD_t *CFE_SB_GetDestPtr(CFE_SBR_RouteId_t RouteId, CFE_SB_PipeId_t PipeId)
 {
     CFE_SB_DestinationD_t *destptr;
@@ -219,17 +207,14 @@ CFE_SB_DestinationD_t *CFE_SB_GetDestPtr(CFE_SBR_RouteId_t RouteId, CFE_SB_PipeI
     return destptr;
 }
 
-/******************************************************************************
-**  Function:  CFE_SB_ValidateMsgId()
-**
-**  Purpose:
-**    SB internal function to validate a given MsgId.
-**
-**  Arguments:
-**
-**  Return:
-**    None
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_ValidateMsgId
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_ValidateMsgId(CFE_SB_MsgId_t MsgId)
 {
 
@@ -241,15 +226,18 @@ int32 CFE_SB_ValidateMsgId(CFE_SB_MsgId_t MsgId)
     {
         return CFE_SUCCESS;
     } /* end if */
-
-} /* end CFE_SB_ValidateMsgId */
+}
 
 /*********************************************************************/
-/*
- * CFE_SB_LocatePipeDescByID
+
+/*----------------------------------------------------------------
  *
- * For complete API information, see prototype in header
- */
+ * Function: CFE_SB_LocatePipeDescByID
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_SB_PipeD_t *CFE_SB_LocatePipeDescByID(CFE_SB_PipeId_t PipeId)
 {
     CFE_SB_PipeD_t *PipeDscPtr;
@@ -267,12 +255,14 @@ CFE_SB_PipeD_t *CFE_SB_LocatePipeDescByID(CFE_SB_PipeId_t PipeId)
     return PipeDscPtr;
 }
 
-/*********************************************************************/
-/*
- * CFE_SB_CheckPipeDescSlotUsed
+/*----------------------------------------------------------------
  *
- * Checks if a table slot is used or not (helper for allocating IDs)
- */
+ * Function: CFE_SB_CheckPipeDescSlotUsed
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_SB_CheckPipeDescSlotUsed(CFE_ResourceId_t CheckId)
 {
     CFE_SB_PipeD_t *PipeDscPtr;
@@ -285,22 +275,14 @@ bool CFE_SB_CheckPipeDescSlotUsed(CFE_ResourceId_t CheckId)
     return (PipeDscPtr == NULL || CFE_SB_PipeDescIsUsed(PipeDscPtr));
 }
 
-/******************************************************************************
-**  Function:  CFE_SB_GetAppTskName()
-**
-**  Purpose:
-**    This function returns a pointer to the app.tsk name string
-**
-**  Arguments:
-**    TaskId - the task id of the app.task name desired
-**    FullName - string buffer to store name
-**
-**  Return:
-**    Pointer to App.Tsk Name
-**
-**  Note: With taskId, Parent App name and Child Task name can be queried from ES
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_GetAppTskName
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 char *CFE_SB_GetAppTskName(CFE_ES_TaskId_t TaskId, char *FullName)
 {
 
@@ -337,24 +319,16 @@ char *CFE_SB_GetAppTskName(CFE_ES_TaskId_t TaskId, char *FullName)
     } /* end if */
 
     return FullName;
+}
 
-} /* end CFE_SB_GetAppTskName */
-
-/******************************************************************************
-**  Function:  CFE_SB_RequestToSendEvent()
-**
-**  Purpose:
-**    This function will test the given bit for the given task. If the bit is set
-**    this function will return CFE_SB_DENIED. If bit is not set, this function set
-**    the bit and return CFE_SB_GRANTED. This will prevent recursive events from
-**    occurring.
-**
-**  Arguments:
-**
-**  Return:
-**    If the bit is set this function will return CFE_SB_DENIED.
-**    If bit is not set, this function set the bit and return CFE_SB_GRANTED.
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_RequestToSendEvent
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 uint32 CFE_SB_RequestToSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit)
 {
 
@@ -378,22 +352,16 @@ uint32 CFE_SB_RequestToSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit)
         return CFE_SB_GRANTED;
 
     } /* end if */
+}
 
-} /* end CFE_SB_RequestToSendEvent */
-
-/******************************************************************************
-**  Function:  CFE_SB_FinishSendEvent()
-**
-**  Purpose:
-**    This function will clear the given bit for the given task. Called after
-**    a successful CFE_SB_RequestToSendEvent()
-**
-**  Arguments:
-**
-**  Return:
-**    If the bit is set this function will return CFE_SB_DENIED.
-**    If bit is not set, this function set the bit and return CFE_SB_GRANTED.
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_FinishSendEvent
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_FinishSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit)
 {
 
@@ -406,11 +374,16 @@ void CFE_SB_FinishSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit)
 
     /* clear the bit so the task may send this event again */
     CFE_CLR(CFE_SB_Global.StopRecurseFlags[Indx], Bit);
-} /* end CFE_SB_RequestToSendEvent */
+}
 
-/******************************************************************************
- * SB private function to add a destination node - see description in header
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_AddDestNode
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_AddDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *NewNode)
 {
 
@@ -444,9 +417,14 @@ int32 CFE_SB_AddDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *NewNo
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * SB private function to remove a destination - see description in header
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_RemoveDest
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_RemoveDest(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *DestPtr)
 {
     CFE_SB_RemoveDestNode(RouteId, DestPtr);
@@ -454,9 +432,14 @@ void CFE_SB_RemoveDest(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *DestPtr
     CFE_SB_Global.StatTlmMsg.Payload.SubscriptionsInUse--;
 }
 
-/******************************************************************************
- * SB private function to remove a destination node - see description in header
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_RemoveDestNode
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_RemoveDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *NodeToRemove)
 {
     CFE_SB_DestinationD_t *PrevNode;
@@ -495,29 +478,14 @@ void CFE_SB_RemoveDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *Nod
     NodeToRemove->Prev = NULL;
 }
 
-/******************************************************************************
-** Name:    CFE_SB_ZeroCopyReleaseAppId
-**
-** Purpose: API used for releasing all pointers to a buffers (for zero copy mode
-**          only) for a specific Application. This function is used for cleaning
-**          up when an application crashes.
-**
-** Assumptions, External Events, and Notes:
-**          None
-**
-** Date Written:
-**          07/23/2009
-**
-** Input Arguments:
-**          AppId
-**
-** Output Arguments:
-**          None
-**
-** Return Values:
-**          Status
-**
-******************************************************************************/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_ZeroCopyReleaseAppId
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_ZeroCopyReleaseAppId(CFE_ES_AppId_t AppId)
 {
     CFE_SB_BufferLink_t *NextLink;
@@ -556,7 +524,4 @@ int32 CFE_SB_ZeroCopyReleaseAppId(CFE_ES_AppId_t AppId)
     }
 
     return CFE_SUCCESS;
-
-} /* end CFE_SB_ZeroCopyReleaseAppId */
-
-/*****************************************************************************/
+}

--- a/modules/sb/fsw/src/cfe_sb_priv.h
+++ b/modules/sb/fsw/src/cfe_sb_priv.h
@@ -292,42 +292,275 @@ typedef struct
 ** Software Bus Function Prototypes
 */
 
+/*---------------------------------------------------------------------------------------*/
+/**
+ * Initialization routine for SB application.
+ *
+ * This routine is executed when  * the SB application is started by Executive Services.
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ */
 int32 CFE_SB_AppInit(void);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * Initialize the Software Bus Buffer Pool.
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ */
 int32 CFE_SB_InitBuffers(void);
-void  CFE_SB_InitPipeTbl(void);
-void  CFE_SB_InitIdxStack(void);
-void  CFE_SB_ResetCounts(void);
-void  CFE_SB_LockSharedData(const char *FuncName, int32 LineNumber);
-void  CFE_SB_UnlockSharedData(const char *FuncName, int32 LineNumber);
-void  CFE_SB_ReleaseBuffer(CFE_SB_BufferD_t *bd, CFE_SB_DestinationD_t *dest);
-int32 CFE_SB_WriteQueue(CFE_SB_PipeD_t *pd, uint32 TskId, const CFE_SB_BufferD_t *bd, CFE_SB_MsgId_t MsgId);
-void  CFE_SB_ProcessCmdPipePkt(CFE_SB_Buffer_t *SBBufPtr);
-void  CFE_SB_ResetCounters(void);
-void  CFE_SB_SetMsgSeqCnt(CFE_MSG_Message_t *MsgPtr, uint32 Count);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * Initialize the Software Bus Pipe Table.
+ *
+ * @note This function MUST be called before any SB API's are called.
+ */
+void CFE_SB_InitPipeTbl(void);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * SB internal function to obtain exclusive access to SB global data structures
+ *
+ * @param FuncName    the function name containing the code
+ * @param LineNumber  the line number of the calling code
+ */
+void CFE_SB_LockSharedData(const char *FuncName, int32 LineNumber);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * SB internal function to release exclusive access to SB global data structures
+ *
+ * @param FuncName    the function name containing the code
+ * @param LineNumber  the line number of the calling code
+ */
+void CFE_SB_UnlockSharedData(const char *FuncName, int32 LineNumber);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * Processes a single message buffer that has been received from the command pipe
+ *
+ * @param SBBufPtr Software bus buffer pointer
+ */
+void CFE_SB_ProcessCmdPipePkt(CFE_SB_Buffer_t *SBBufPtr);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * Function to reset the SB housekeeping counters.
+ * @note Command counter not incremented for this command
+ */
+void CFE_SB_ResetCounters(void);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * This function returns a pointer to the app.tsk name string
+ *
+ * @note With taskId, Parent App name and Child Task name can be queried from ES
+ *
+ * @param TaskId  the task id of the app.task name desired
+ * @param FullName  string buffer to store name
+ * @return Pointer to App.Tsk Name
+ */
 char *CFE_SB_GetAppTskName(CFE_ES_TaskId_t TaskId, char *FullName);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * Deletes a pipe from SB owned by a specific app
+ *
+ * @param PipeId  The ID of the pipe to delete.
+ * @param AppId   The application that owns the pipe
+ * \return Execution status, see \ref CFEReturnCodes
+ */
 int32 CFE_SB_DeletePipeWithAppId(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @copydoc CFE_SB_DeletePipeWithAppId
+ *
+ * Internal implementation of the pipe delete operation
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ */
 int32 CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * CFE Internal API used to subscribe to a message
+ *
+ * This internal API exposes all subscription choices/parameters.  This function is
+ * called by CFE_SB_SubscribeEx, CFE_SB_Subscribe and CFE_SB_SubscribeLocal.
+ *
+ * @param MsgId    Mission unique identifier for the message being requested
+ * @param PipeId   The Pipe ID to send the message to
+ * @param Quality  Quality of Service (Qos)  priority and reliability
+ * @param MsgLim   Max number of messages, with this MsgId, allowed on the
+ *                 pipe at any time.
+ * @param Scope    Local subscription or broadcasted to peers
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ */
 int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_Qos_t Quality, uint16 MsgLim,
                            uint8 Scope);
 
+/*---------------------------------------------------------------------------------------*/
+/**
+ * Unsubscribe a Message ID from a pipe
+ *
+ * This internal API can be used to force unsubscribe when the calling context
+ * is not the owner of the pipe.
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ */
 int32 CFE_SB_UnsubscribeWithAppId(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId);
 
-int32  CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint8 Scope, CFE_ES_AppId_t AppId);
-int32  CFE_SB_TransmitMsgValidate(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgIdPtr, CFE_MSG_Size_t *SizePtr,
-                                  CFE_SBR_RouteId_t *RouteIdPtr);
-int32  CFE_SB_ZeroCopyReleaseAppId(CFE_ES_AppId_t AppId);
-void   CFE_SB_IncrBufUseCnt(CFE_SB_BufferD_t *bd);
-void   CFE_SB_DecrBufUseCnt(CFE_SB_BufferD_t *bd);
-int32  CFE_SB_ValidateMsgId(CFE_SB_MsgId_t MsgId);
-int32  CFE_SB_ValidatePipeId(CFE_SB_PipeId_t PipeId);
-void   CFE_SB_IncrCmdCtr(int32 status);
-void   CFE_SB_SetSubscriptionReporting(uint32 state);
-int32  CFE_SB_SendSubscriptionReport(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_Qos_t Quality);
-uint32 CFE_SB_RequestToSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit);
-void   CFE_SB_FinishSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit);
-CFE_SB_DestinationD_t *CFE_SB_GetDestinationBlk(void);
-int32                  CFE_SB_PutDestinationBlk(CFE_SB_DestinationD_t *Dest);
+/*---------------------------------------------------------------------------------------*/
+/**
+ * CFE Internal API used to unsubscribe to a message.
+ *
+ * This internal API exposes all available unsubscribe choices/parameters.
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ */
+int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint8 Scope, CFE_ES_AppId_t AppId);
 
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief Internal routine to validate a transmit message before sending
+ *
+ * \param[in]  MsgPtr     Pointer to the message to validate
+ * \param[out] MsgIdPtr   Message Id of message
+ * \param[out] SizePtr    Size of message
+ * \param[out] RouteIdPtr Route ID of the message (invalid if none)
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ */
+int32 CFE_SB_TransmitMsgValidate(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgIdPtr, CFE_MSG_Size_t *SizePtr,
+                                 CFE_SBR_RouteId_t *RouteIdPtr);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * Release all zero-copy buffers associated with the given app ID.
+ *
+ * API used for releasing all pointers to a buffers (for zero copy mode
+ * only) for a specific Application. This function is used for cleaning
+ * up when an application crashes.
+ *
+ * @param AppId  Application ID to clean up
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ */
+int32 CFE_SB_ZeroCopyReleaseAppId(CFE_ES_AppId_t AppId);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Increment the UseCount of a buffer
+ *
+ * UseCount is a variable in the CFE_SB_BufferD_t and is used to
+ * determine when a buffer may be returned to the memory pool.
+ *
+ * @note This must only be invoked while holding the SB global lock
+ *
+ * @param bd  Pointer to the buffer descriptor.
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ */
+void CFE_SB_IncrBufUseCnt(CFE_SB_BufferD_t *bd);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Decrement the UseCount of a buffer
+ *
+ * UseCount is a variable in the CFE_SB_BufferD_t and is used to
+ * determine when a buffer may be returned to the memory pool.
+ *
+ * If the the UseCount is decremented to zero, it will return the buffer to
+ * the memory pool.
+ *
+ * @note This must only be invoked while holding the SB global lock
+ *
+ * @param bd  Pointer to the buffer descriptor.
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ */
+void CFE_SB_DecrBufUseCnt(CFE_SB_BufferD_t *bd);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * SB internal function to validate a given MsgId.
+ * \return Execution status, see \ref CFEReturnCodes
+ */
+int32 CFE_SB_ValidateMsgId(CFE_SB_MsgId_t MsgId);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * Increment the command counter based on the status input.
+ *
+ * This small utility was written to eliminate duplicate code.
+ *
+ * @param status  typically #CFE_SUCCESS or an SB error code
+ */
+void CFE_SB_IncrCmdCtr(int32 status);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * SB internal function to enable and disable subscription reporting.
+ */
+void CFE_SB_SetSubscriptionReporting(uint32 state);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * SB internal function to generate the "ONESUB_TLM" message after a subscription.
+ *
+ * Arguments reflect the Payload of notification message - MsgId, PipeId, QOS
+ *
+ * @note this is a no-op when subscription reporting is disabled.
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ */
+int32 CFE_SB_SendSubscriptionReport(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_Qos_t Quality);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * This function will test the given bit for the given task.
+ *
+ * This prevents recursive events from occurring.
+ *
+ * If the bit is set this function will return #CFE_SB_DENIED. If bit is not set, this
+ * function will set  the bit and return #CFE_SB_GRANTED.
+ *
+ * @returns grant/deny status
+ */
+uint32 CFE_SB_RequestToSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * This function will clear the given bit for the given task.
+ *
+ * This should be called after a successful CFE_SB_RequestToSendEvent()
+ */
+void CFE_SB_FinishSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * This function gets a destination descriptor from the SB memory pool.
+ *
+ * @note This must only be invoked while holding the SB global lock
+ * @return Pointer to the destination descriptor
+ */
+CFE_SB_DestinationD_t *CFE_SB_GetDestinationBlk(void);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * This function returns a destination descriptor to the SB memory pool.
+ * @note This must only be invoked while holding the SB global lock
+ *
+ * @param Dest Pointer to the destination descriptor
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ */
+int32 CFE_SB_PutDestinationBlk(CFE_SB_DestinationD_t *Dest);
+
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief For SB buffer tracking, get first/next position in a list
  */
@@ -336,6 +569,7 @@ static inline CFE_SB_BufferLink_t *CFE_SB_TrackingListGetNext(CFE_SB_BufferLink_
     return Node->Next;
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief For SB buffer tracking, checks if this current position represents the end of the list
  */
@@ -345,6 +579,7 @@ static inline bool CFE_SB_TrackingListIsEnd(CFE_SB_BufferLink_t *List, CFE_SB_Bu
     return (Node == NULL || Node == List);
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief For SB buffer tracking, reset link state to default
  *
@@ -353,6 +588,7 @@ static inline bool CFE_SB_TrackingListIsEnd(CFE_SB_BufferLink_t *List, CFE_SB_Bu
  */
 void CFE_SB_TrackingListReset(CFE_SB_BufferLink_t *Link);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief For SB buffer tracking, removes a node from a tracking list
  *
@@ -362,6 +598,7 @@ void CFE_SB_TrackingListReset(CFE_SB_BufferLink_t *Link);
  */
 void CFE_SB_TrackingListRemove(CFE_SB_BufferLink_t *Node);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief For SB buffer tracking, adds a node to a tracking list
  *
@@ -371,21 +608,35 @@ void CFE_SB_TrackingListRemove(CFE_SB_BufferLink_t *Node);
  */
 void CFE_SB_TrackingListAdd(CFE_SB_BufferLink_t *List, CFE_SB_BufferLink_t *Node);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Allocates a new buffer descriptor from the SB memory pool.
+ *
+ * Requests a buffer from the SB buffer pool. The SB buffer pool is a
+ * preallocated block of memory of size #CFE_PLATFORM_SB_BUF_MEMORY_BYTES. It is used
+ * by the SB to dynamically allocate memory to hold the message and a buffer
+ * descriptor associated with the message during the sending of a message.
+ *
+ * @note This must only be invoked while holding the SB global lock
  *
  * \param[in] MaxMsgSize Maximum message content size that the buffer must be capable of holding
  * \returns Pointer to buffer descriptor, or NULL on failure.
  */
 CFE_SB_BufferD_t *CFE_SB_GetBufferFromPool(size_t MaxMsgSize);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Returns a buffer to SB memory pool
  *
- * \param[in] Pointer to descriptor to return
+ * This function will return a block of memory back to the SB memory pool,
+ * so it can be re-used for a future message
+ *
+ * @note This must only be invoked while holding the SB global lock
+ * \param[in] bd Pointer to descriptor to return
  */
 void CFE_SB_ReturnBufferToPool(CFE_SB_BufferD_t *bd);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Broadcast a SB buffer descriptor to all destinations in route
  *
@@ -420,6 +671,7 @@ void CFE_SB_ReturnBufferToPool(CFE_SB_BufferD_t *bd);
  */
 void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_t RouteId);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Perform basic sanity check on the Zero Copy handle
  *
@@ -430,6 +682,7 @@ void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_
  */
 int32 CFE_SB_ZeroCopyBufferValidate(CFE_SB_Buffer_t *BufPtr, CFE_SB_BufferD_t **BufDscPtr);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Add a destination node
  *
@@ -442,6 +695,7 @@ int32 CFE_SB_ZeroCopyBufferValidate(CFE_SB_Buffer_t *BufPtr, CFE_SB_BufferD_t **
  */
 int32 CFE_SB_AddDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *NewNode);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Remove a destination node
  *
@@ -454,6 +708,7 @@ int32 CFE_SB_AddDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *NewNo
  */
 void CFE_SB_RemoveDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *NodeToRemove);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Remove a destination
  *
@@ -467,6 +722,7 @@ void CFE_SB_RemoveDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *Nod
  */
 void CFE_SB_RemoveDest(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *DestPtr);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Get destination pointer for PipeId from RouteId
  *
@@ -480,7 +736,7 @@ void CFE_SB_RemoveDest(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *DestPtr
  */
 CFE_SB_DestinationD_t *CFE_SB_GetDestPtr(CFE_SBR_RouteId_t RouteId, CFE_SB_PipeId_t PipeId);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Get the size of a message header.
 **
@@ -508,19 +764,136 @@ size_t CFE_SB_MsgHdrSize(const CFE_MSG_Message_t *MsgPtr);
 /*
  * Software Bus Message Handler Function prototypes
  */
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief Command Message Handler function
+ *
+ * \param[in] data Pointer to command structure
+ * \return Execution status, see \ref CFEReturnCodes
+ */
 int32 CFE_SB_NoopCmd(const CFE_SB_NoopCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief Command Message Handler function
+ *
+ * \param[in] data Pointer to command structure
+ * \return Execution status, see \ref CFEReturnCodes
+ */
 int32 CFE_SB_ResetCountersCmd(const CFE_SB_ResetCountersCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief Command Message Handler function
+ *
+ * \param[in] data Pointer to command structure
+ * \return Execution status, see \ref CFEReturnCodes
+ */
 int32 CFE_SB_EnableSubReportingCmd(const CFE_SB_EnableSubReportingCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief Command Message Handler function
+ *
+ * \param[in] data Pointer to command structure
+ * \return Execution status, see \ref CFEReturnCodes
+ */
 int32 CFE_SB_DisableSubReportingCmd(const CFE_SB_DisableSubReportingCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief Function to send the SB housekeeping packet.
+ *
+ * @note Command counter not incremented for this command
+ *
+ * \param[in] data Pointer to command structure
+ * \return Execution status, see \ref CFEReturnCodes
+ */
 int32 CFE_SB_SendHKTlmCmd(const CFE_MSG_CommandHeader_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief Command Message Handler function
+ *
+ * SB internal function to enable a specific route.
+ * A route is defined as a MsgId/PipeId combination.
+ *
+ * \param[in] data Pointer to command structure
+ * \return Execution status, see \ref CFEReturnCodes
+ */
 int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief Command Message Handler function
+ *
+ * SB internal function to disable a specific route.
+ * A route is defined as a MsgId/PipeId combination.
+ *
+ * \param[in] data Pointer to command structure
+ * \return Execution status, see \ref CFEReturnCodes
+ */
 int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief Command Message Handler function
+ *
+ * SB internal function to send a Software Bus statistics packet
+ *
+ * \param[in] data Pointer to command structure
+ * \return Execution status, see \ref CFEReturnCodes
+ */
 int32 CFE_SB_SendStatsCmd(const CFE_SB_SendSbStatsCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief Command Message Handler function
+ *
+ * SB internal function to handle processing of 'Write Routing Info' Cmd
+ *
+ * \param[in] data Pointer to command structure
+ * \return Execution status, see \ref CFEReturnCodes
+ */
 int32 CFE_SB_WriteRoutingInfoCmd(const CFE_SB_WriteRoutingInfoCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief Command Message Handler function
+ *
+ * SB internal function to handle processing of 'Write Pipe Info' Cmd
+ *
+ * \param[in] data Pointer to command structure
+ * \return Execution status, see \ref CFEReturnCodes
+ */
 int32 CFE_SB_WritePipeInfoCmd(const CFE_SB_WritePipeInfoCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief Command Message Handler function
+ *
+ * SB internal function to handle processing of 'Write Map Info' Cmd
+ *
+ * \param[in] data Pointer to command structure
+ * \return Execution status, see \ref CFEReturnCodes
+ */
 int32 CFE_SB_WriteMapInfoCmd(const CFE_SB_WriteMapInfoCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief Command Message Handler function
+ *
+ * SB function to build and send an SB packet containing a complete list of
+ * current subscriptions.Intended to be used primarily for the Software Bus
+ * Networking Application (SBN).
+ *
+ * \param[in] data Pointer to command structure
+ * \return Execution status, see \ref CFEReturnCodes
+ */
 int32 CFE_SB_SendPrevSubsCmd(const CFE_SB_SendPrevSubsCmd_t *data);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Locate the Pipe table entry correlating with a given Pipe ID.
  *
@@ -548,6 +921,7 @@ int32 CFE_SB_SendPrevSubsCmd(const CFE_SB_SendPrevSubsCmd_t *data);
  */
 extern CFE_SB_PipeD_t *CFE_SB_LocatePipeDescByID(CFE_SB_PipeId_t PipeId);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Check if an Pipe descriptor is in use or free/empty
  *
@@ -567,6 +941,7 @@ static inline bool CFE_SB_PipeDescIsUsed(const CFE_SB_PipeD_t *PipeDscPtr)
     return CFE_RESOURCEID_TEST_DEFINED(PipeDscPtr->PipeId);
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Get the ID value from an Pipe table entry
  *
@@ -583,6 +958,7 @@ static inline CFE_SB_PipeId_t CFE_SB_PipeDescGetID(const CFE_SB_PipeD_t *PipeDsc
     return PipeDscPtr->PipeId;
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Marks an Pipe table entry as used (not free)
  *
@@ -603,6 +979,7 @@ static inline void CFE_SB_PipeDescSetUsed(CFE_SB_PipeD_t *PipeDscPtr, CFE_Resour
     PipeDscPtr->PipeId = CFE_SB_PIPEID_C(PendingID);
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Set an Pipe descriptor table entry free (not used)
  *
@@ -622,6 +999,7 @@ static inline void CFE_SB_PipeDescSetFree(CFE_SB_PipeD_t *PipeDscPtr)
     PipeDscPtr->PipeId = CFE_SB_INVALID_PIPE;
 }
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * @brief Check if an Pipe descriptor is a match for the given PipeID
  *
@@ -650,14 +1028,35 @@ static inline bool CFE_SB_PipeDescIsMatch(const CFE_SB_PipeD_t *PipeDscPtr, CFE_
     return (PipeDscPtr != NULL && CFE_RESOURCEID_TEST_EQUAL(PipeDscPtr->PipeId, PipeID));
 }
 
-/* Availability check functions used in conjunction with CFE_ResourceId_FindNext() */
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Checks if a table slot is used or not
+ *
+ * Helper for allocating IDs,
+ * Used in conjunction with CFE_ResourceId_FindNext().
+ *
+ * @param CheckId generic slot ID to test
+ * @returns true if slot is currently in use/unavailable
+ */
 bool CFE_SB_CheckPipeDescSlotUsed(CFE_ResourceId_t CheckId);
 
 /*
  * Helper functions for background file write requests (callbacks)
  */
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Local callback helper for writing map info to a file
+ * This retrieves a single record of information from the SB global state object(s)
+ */
 void CFE_SB_CollectMsgMapInfo(CFE_SBR_RouteId_t RouteId, void *ArgPtr);
 bool CFE_SB_WriteMsgMapInfoDataGetter(void *Meta, uint32 RecordNum, void **Buffer, size_t *BufSize);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Local callback helper for writing routing info to a file
+ * This retrieves a single record of information from the SB global state object(s)
+ */
 void CFE_SB_CollectRouteInfo(CFE_SBR_RouteId_t RouteId, void *ArgPtr);
 bool CFE_SB_WriteRouteInfoDataGetter(void *Meta, uint32 RecordNum, void **Buffer, size_t *BufSize);
 bool CFE_SB_WritePipeInfoDataGetter(void *Meta, uint32 RecordNum, void **Buffer, size_t *BufSize);

--- a/modules/sb/fsw/src/cfe_sb_task.c
+++ b/modules/sb/fsw/src/cfe_sb_task.c
@@ -54,7 +54,7 @@ typedef struct
  * Function: CFE_SB_TaskMain
  *
  * Implemented per public API
- * See description in cfe_sb_core_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_TaskMain(void)
@@ -116,7 +116,7 @@ void CFE_SB_TaskMain(void)
  * Function: CFE_SB_AppInit
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_AppInit(void)
@@ -323,7 +323,7 @@ bool CFE_SB_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
  * Function: CFE_SB_ProcessCmdPipePkt
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_ProcessCmdPipePkt(CFE_SB_Buffer_t *SBBufPtr)
@@ -458,7 +458,7 @@ void CFE_SB_ProcessCmdPipePkt(CFE_SB_Buffer_t *SBBufPtr)
  * Function: CFE_SB_NoopCmd
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_NoopCmd(const CFE_SB_NoopCmd_t *data)
@@ -474,7 +474,7 @@ int32 CFE_SB_NoopCmd(const CFE_SB_NoopCmd_t *data)
  * Function: CFE_SB_ResetCountersCmd
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_ResetCountersCmd(const CFE_SB_ResetCountersCmd_t *data)
@@ -491,7 +491,7 @@ int32 CFE_SB_ResetCountersCmd(const CFE_SB_ResetCountersCmd_t *data)
  * Function: CFE_SB_EnableSubReportingCmd
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_EnableSubReportingCmd(const CFE_SB_EnableSubReportingCmd_t *data)
@@ -505,7 +505,7 @@ int32 CFE_SB_EnableSubReportingCmd(const CFE_SB_EnableSubReportingCmd_t *data)
  * Function: CFE_SB_DisableSubReportingCmd
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_DisableSubReportingCmd(const CFE_SB_DisableSubReportingCmd_t *data)
@@ -519,7 +519,7 @@ int32 CFE_SB_DisableSubReportingCmd(const CFE_SB_DisableSubReportingCmd_t *data)
  * Function: CFE_SB_SendHKTlmCmd
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_SendHKTlmCmd(const CFE_MSG_CommandHeader_t *data)
@@ -543,7 +543,7 @@ int32 CFE_SB_SendHKTlmCmd(const CFE_MSG_CommandHeader_t *data)
  * Function: CFE_SB_ResetCounters
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_ResetCounters(void)
@@ -567,7 +567,7 @@ void CFE_SB_ResetCounters(void)
  * Function: CFE_SB_EnableRouteCmd
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data)
@@ -637,7 +637,7 @@ int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data)
  * Function: CFE_SB_DisableRouteCmd
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data)
@@ -707,7 +707,7 @@ int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data)
  * Function: CFE_SB_SendStatsCmd
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_SendStatsCmd(const CFE_SB_SendSbStatsCmd_t *data)
@@ -769,7 +769,7 @@ int32 CFE_SB_SendStatsCmd(const CFE_SB_SendSbStatsCmd_t *data)
  * Function: CFE_SB_CollectRouteInfo
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_CollectRouteInfo(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
@@ -850,7 +850,7 @@ void CFE_SB_CollectRouteInfo(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
  * Function: CFE_SB_SendSubscriptionReport
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_SendSubscriptionReport(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_Qos_t Quality)
@@ -884,7 +884,7 @@ int32 CFE_SB_SendSubscriptionReport(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId
  * Function: CFE_SB_WriteRouteInfoDataGetter
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 bool CFE_SB_WriteRouteInfoDataGetter(void *Meta, uint32 RecordNum, void **Buffer, size_t *BufSize)
@@ -918,7 +918,7 @@ bool CFE_SB_WriteRouteInfoDataGetter(void *Meta, uint32 RecordNum, void **Buffer
  * Function: CFE_SB_BackgroundFileEventHandler
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_BackgroundFileEventHandler(void *Meta, CFE_FS_FileWriteEvent_t Event, int32 Status, uint32 RecordNum,
@@ -966,7 +966,7 @@ void CFE_SB_BackgroundFileEventHandler(void *Meta, CFE_FS_FileWriteEvent_t Event
  * Function: CFE_SB_WriteRoutingInfoCmd
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_WriteRoutingInfoCmd(const CFE_SB_WriteRoutingInfoCmd_t *data)
@@ -1029,7 +1029,7 @@ int32 CFE_SB_WriteRoutingInfoCmd(const CFE_SB_WriteRoutingInfoCmd_t *data)
  * Function: CFE_SB_WritePipeInfoDataGetter
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 bool CFE_SB_WritePipeInfoDataGetter(void *Meta, uint32 RecordNum, void **Buffer, size_t *BufSize)
@@ -1109,7 +1109,7 @@ bool CFE_SB_WritePipeInfoDataGetter(void *Meta, uint32 RecordNum, void **Buffer,
  * Function: CFE_SB_WritePipeInfoCmd
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_WritePipeInfoCmd(const CFE_SB_WritePipeInfoCmd_t *data)
@@ -1172,7 +1172,7 @@ int32 CFE_SB_WritePipeInfoCmd(const CFE_SB_WritePipeInfoCmd_t *data)
  * Function: CFE_SB_CollectMsgMapInfo
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_CollectMsgMapInfo(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
@@ -1197,7 +1197,7 @@ void CFE_SB_CollectMsgMapInfo(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
  * Function: CFE_SB_WriteMsgMapInfoDataGetter
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 bool CFE_SB_WriteMsgMapInfoDataGetter(void *Meta, uint32 RecordNum, void **Buffer, size_t *BufSize)
@@ -1239,7 +1239,7 @@ bool CFE_SB_WriteMsgMapInfoDataGetter(void *Meta, uint32 RecordNum, void **Buffe
  * Function: CFE_SB_WriteMapInfoCmd
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_WriteMapInfoCmd(const CFE_SB_WriteMapInfoCmd_t *data)
@@ -1360,7 +1360,7 @@ void CFE_SB_SendRouteSub(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
  * Function: CFE_SB_SendPrevSubsCmd
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_SendPrevSubsCmd(const CFE_SB_SendPrevSubsCmd_t *data)
@@ -1397,7 +1397,7 @@ int32 CFE_SB_SendPrevSubsCmd(const CFE_SB_SendPrevSubsCmd_t *data)
  * Function: CFE_SB_IncrCmdCtr
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_IncrCmdCtr(int32 status)
@@ -1418,7 +1418,7 @@ void CFE_SB_IncrCmdCtr(int32 status)
  * Function: CFE_SB_SetSubscriptionReporting
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_SetSubscriptionReporting(uint32 state)

--- a/modules/sb/fsw/src/cfe_sb_task.c
+++ b/modules/sb/fsw/src/cfe_sb_task.c
@@ -49,18 +49,14 @@ typedef struct
     int32       Status;     /* File write status */
 } CFE_SB_FileWriteCallback_t;
 
-/******************************************************************************
-**  Function:  CFE_SB_TaskMain()
-**
-**  Purpose:
-**    Main loop for Software Bus task, used to process SB commands.
-**
-**  Arguments:
-**    none
-**
-**  Return:
-**    none
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_TaskMain
+ *
+ * Implemented per public API
+ * See description in cfe_sb_core_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_TaskMain(void)
 {
     int32            Status;
@@ -113,24 +109,16 @@ void CFE_SB_TaskMain(void)
 
     /* while loop exits only if CFE_SB_ReceiveBuffer returns error */
     CFE_ES_ExitApp(CFE_ES_RunStatus_CORE_APP_RUNTIME_ERROR);
+}
 
-} /* end CFE_SB_TaskMain */
-
-/******************************************************************************
-**  Function:  CFE_SB_AppInit()
-**
-**  Purpose:
-**    Initialization routine for SB application. This routine is executed when
-**    the SB application is started by Executive Services.
-**
-**  Arguments:
-**    none
-**
-**  Return:
-**    CFE_SUCCESS if no errors, otherwise this function returns the error code
-**    that was received from the function that detected the error.
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_AppInit
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_AppInit(void)
 {
 
@@ -291,21 +279,17 @@ int32 CFE_SB_AppInit(void)
     } /* end if */
 
     return CFE_SUCCESS;
+}
 
-} /* end CFE_SB_AppInit */
-
-/******************************************************************************
-**  Function:  CFE_SB_VerifyCmdLength()
-**
-**  Purpose:
-**    Function to verify the length of incoming SB command packets
-**
-**  Arguments:
-**    Message pointer and expected length
-**
-**  Return:
-**    true if length is acceptable
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_VerifyCmdLength
+ *
+ * Internal helper routine only, not part of API.
+ *
+ * Verifies the length of incoming SB command packets, returns true if acceptable
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_SB_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
 {
     bool              result       = true;
@@ -332,21 +316,16 @@ bool CFE_SB_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
     }
 
     return (result);
+}
 
-} /* End of CFE_SB_VerifyCmdLength() */
-
-/******************************************************************************
-**  Function:  CFE_SB_ProcessCmdPipePkt()
-**
-**  Purpose:
-**    Function to control actions when an SB command is received.
-**
-**  Arguments:
-**    Software bus buffer pointer
-**
-**  Return:
-**    none
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_ProcessCmdPipePkt
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_ProcessCmdPipePkt(CFE_SB_Buffer_t *SBBufPtr)
 {
     CFE_SB_MsgId_t    MessageID = CFE_SB_INVALID_MSG_ID;
@@ -472,16 +451,16 @@ void CFE_SB_ProcessCmdPipePkt(CFE_SB_Buffer_t *SBBufPtr)
             break;
 
     } /* end switch on MsgId */
+}
 
-} /* end CFE_SB_ProcessCmdPipePkt */
-
-/******************************************************************************
-**  Function:  CFE_SB_NoopCmd()
-**
-**  Purpose:
-**    Handler function the SB command
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_NoopCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_NoopCmd(const CFE_SB_NoopCmd_t *data)
 {
     CFE_EVS_SendEvent(CFE_SB_CMD0_RCVD_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd. %s", CFE_VERSION_STRING);
@@ -490,13 +469,14 @@ int32 CFE_SB_NoopCmd(const CFE_SB_NoopCmd_t *data)
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
-**  Function:  CFE_SB_ResetCountersCmd()
-**
-**  Purpose:
-**    Handler function the SB command
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_ResetCountersCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_ResetCountersCmd(const CFE_SB_ResetCountersCmd_t *data)
 {
     CFE_EVS_SendEvent(CFE_SB_CMD1_RCVD_EID, CFE_EVS_EventType_DEBUG, "Reset Counters Cmd Rcvd");
@@ -506,47 +486,42 @@ int32 CFE_SB_ResetCountersCmd(const CFE_SB_ResetCountersCmd_t *data)
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
-**  Function:  CFE_SB_EnableSubReportingCmd()
-**
-**  Purpose:
-**    Handler function the SB command
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_EnableSubReportingCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_EnableSubReportingCmd(const CFE_SB_EnableSubReportingCmd_t *data)
 {
     CFE_SB_SetSubscriptionReporting(CFE_SB_ENABLE);
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
-**  Function:  CFE_SB_DisableSubReportingCmd()
-**
-**  Purpose:
-**    Handler function the SB command
-**
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_DisableSubReportingCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_DisableSubReportingCmd(const CFE_SB_DisableSubReportingCmd_t *data)
 {
     CFE_SB_SetSubscriptionReporting(CFE_SB_DISABLE);
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
-**  Function:  CFE_SB_SendHKTlmCmd()
-**
-**  Purpose:
-**    Function to send the SB housekeeping packet.
-**
-**  Arguments:
-**    none
-**
-**  Notes:
-**    Command counter not incremented for this command
-**
-**  Return:
-**    none
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_SendHKTlmCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_SendHKTlmCmd(const CFE_MSG_CommandHeader_t *data)
 {
     CFE_SB_LockSharedData(__FILE__, __LINE__);
@@ -561,23 +536,16 @@ int32 CFE_SB_SendHKTlmCmd(const CFE_MSG_CommandHeader_t *data)
     CFE_SB_TransmitMsg(&CFE_SB_Global.HKTlmMsg.Hdr.Msg, true);
 
     return CFE_SUCCESS;
-} /* end CFE_SB_SendHKTlmCmd */
+}
 
-/******************************************************************************
-**  Function:  CFE_SB_ResetCounters()
-**
-**  Purpose:
-**    Function to reset the SB housekeeping counters.
-**
-**  Arguments:
-**    none
-**
-**  Notes:
-**    Command counter not incremented for this command
-**
-**  Return:
-**    none
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_ResetCounters
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_ResetCounters(void)
 {
 
@@ -592,22 +560,16 @@ void CFE_SB_ResetCounters(void)
     CFE_SB_Global.HKTlmMsg.Payload.SubscribeErrorCounter         = 0;
     CFE_SB_Global.HKTlmMsg.Payload.PipeOverflowErrorCounter      = 0;
     CFE_SB_Global.HKTlmMsg.Payload.MsgLimitErrorCounter          = 0;
+}
 
-} /* end CFE_SB_ResetCounters */
-
-/******************************************************************************
-**  Function:  CFE_SB_EnableRouteCmd()
-**
-**  Purpose:
-**    SB internal function to enable a specific route. A route is defined as a
-**    MsgId/PipeId combination.
-**
-**  Arguments:
-**    MsgPtr  : pointer to the message
-**
-**  Return:
-**    None
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_EnableRouteCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data)
 {
     CFE_SB_MsgId_t                   MsgId;
@@ -668,21 +630,16 @@ int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data)
     }
 
     return CFE_SUCCESS;
-} /* end CFE_SB_EnableRouteCmd */
+}
 
-/******************************************************************************
-**  Function:  CFE_SB_DisableRouteCmd()
-**
-**  Purpose:
-**    SB internal function to disable a specific route. A route is defined as a
-**    MsgId/PipeId combination.
-**
-**  Arguments:
-**    MsgPtr  : pointer to the message
-**
-**  Return:
-**    None
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_DisableRouteCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data)
 {
     CFE_SB_MsgId_t                   MsgId;
@@ -743,20 +700,16 @@ int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data)
     }
 
     return CFE_SUCCESS;
-} /* end CFE_SB_DisableRouteCmd */
+}
 
-/******************************************************************************
-**  Function:  CFE_SB_SendStatsCmd()
-**
-**  Purpose:
-**    SB internal function to send a Software Bus statistics packet
-**
-**  Arguments:
-**    None
-**
-**  Return:
-**    None
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_SendStatsCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_SendStatsCmd(const CFE_SB_SendSbStatsCmd_t *data)
 {
     uint32                   PipeDscCount;
@@ -809,11 +762,16 @@ int32 CFE_SB_SendStatsCmd(const CFE_SB_SendSbStatsCmd_t *data)
     CFE_SB_Global.HKTlmMsg.Payload.CommandCounter++;
 
     return CFE_SUCCESS;
-} /* CFE_SB_SendStatsCmd */
+}
 
-/******************************************************************************
- * Local callback helper for writing routing info to a file
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_CollectRouteInfo
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_CollectRouteInfo(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
 {
     CFE_SB_DestinationD_t *             DestPtr;
@@ -887,19 +845,14 @@ void CFE_SB_CollectRouteInfo(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
     }
 }
 
-/******************************************************************************
-**  Function:  CFE_SB_SendSubscriptionReport()
-**
-**  Purpose:
-**    SB internal function to generate the "ONESUB_TLM" message after a subscription.
-**    No-op when subscription reporting is disabled.
-**
-**  Arguments:
-**    Payload of notification message - MsgId, PipeId, QOS
-**
-**  Return:
-**    CFE_SUCCESS or error code
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_SendSubscriptionReport
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_SendSubscriptionReport(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_Qos_t Quality)
 {
     CFE_SB_SingleSubscriptionTlm_t SubRptMsg;
@@ -926,6 +879,14 @@ int32 CFE_SB_SendSubscriptionReport(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId
     return Status;
 }
 
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_WriteRouteInfoDataGetter
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_SB_WriteRouteInfoDataGetter(void *Meta, uint32 RecordNum, void **Buffer, size_t *BufSize)
 {
     CFE_SB_BackgroundFileStateInfo_t *BgFilePtr;
@@ -952,6 +913,14 @@ bool CFE_SB_WriteRouteInfoDataGetter(void *Meta, uint32 RecordNum, void **Buffer
     return (Throttle.NextIndex == 0);
 }
 
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_BackgroundFileEventHandler
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_BackgroundFileEventHandler(void *Meta, CFE_FS_FileWriteEvent_t Event, int32 Status, uint32 RecordNum,
                                        size_t BlockSize, size_t Position)
 {
@@ -992,13 +961,14 @@ void CFE_SB_BackgroundFileEventHandler(void *Meta, CFE_FS_FileWriteEvent_t Event
     }
 }
 
-/******************************************************************************
- * \brief SB internal function to handle processing of 'Write Routing Info' Cmd
+/*----------------------------------------------------------------
  *
- * \param[in] data Pointer to command structure
+ * Function: CFE_SB_WriteRoutingInfoCmd
  *
- * \return Execution status, see \ref CFEReturnCodes
- */
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_WriteRoutingInfoCmd(const CFE_SB_WriteRoutingInfoCmd_t *data)
 {
     const CFE_SB_WriteFileInfoCmd_Payload_t *CmdPtr;
@@ -1052,8 +1022,16 @@ int32 CFE_SB_WriteRoutingInfoCmd(const CFE_SB_WriteRoutingInfoCmd_t *data)
     CFE_SB_IncrCmdCtr(Status);
 
     return CFE_SUCCESS;
-} /* end CFE_SB_WriteRoutingInfoCmd */
+}
 
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_WritePipeInfoDataGetter
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_SB_WritePipeInfoDataGetter(void *Meta, uint32 RecordNum, void **Buffer, size_t *BufSize)
 {
     CFE_SB_BackgroundFileStateInfo_t *BgFilePtr;
@@ -1126,13 +1104,14 @@ bool CFE_SB_WritePipeInfoDataGetter(void *Meta, uint32 RecordNum, void **Buffer,
     return (RecordNum >= (CFE_PLATFORM_SB_MAX_PIPES - 1));
 }
 
-/******************************************************************************
- * \brief SB internal function to handle processing of 'Write Pipe Info' Cmd
+/*----------------------------------------------------------------
  *
- * \param[in] data Pointer to command structure
+ * Function: CFE_SB_WritePipeInfoCmd
  *
- * \return Execution status, see \ref CFEReturnCodes
- */
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_WritePipeInfoCmd(const CFE_SB_WritePipeInfoCmd_t *data)
 {
     const CFE_SB_WriteFileInfoCmd_Payload_t *CmdPtr;
@@ -1188,9 +1167,14 @@ int32 CFE_SB_WritePipeInfoCmd(const CFE_SB_WritePipeInfoCmd_t *data)
     return CFE_SUCCESS;
 }
 
-/******************************************************************************
- * Local callback helper for writing map info to a file
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_CollectMsgMapInfo
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_CollectMsgMapInfo(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
 {
     CFE_SB_MsgMapFileEntry_t *BufferPtr;
@@ -1208,6 +1192,14 @@ void CFE_SB_CollectMsgMapInfo(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
     CFE_SB_UnlockSharedData(__FILE__, __LINE__);
 }
 
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_WriteMsgMapInfoDataGetter
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_SB_WriteMsgMapInfoDataGetter(void *Meta, uint32 RecordNum, void **Buffer, size_t *BufSize)
 {
     CFE_SB_BackgroundFileStateInfo_t *BgFilePtr;
@@ -1242,13 +1234,14 @@ bool CFE_SB_WriteMsgMapInfoDataGetter(void *Meta, uint32 RecordNum, void **Buffe
     return (Throttle.NextIndex == 0);
 }
 
-/******************************************************************************
- * \brief SB internal function to handle processing of 'Write Map Info' Cmd
+/*----------------------------------------------------------------
  *
- * \param[in] data Pointer to command structure
+ * Function: CFE_SB_WriteMapInfoCmd
  *
- * \return Execution status, see \ref CFEReturnCodes
- */
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_WriteMapInfoCmd(const CFE_SB_WriteMapInfoCmd_t *data)
 {
     const CFE_SB_WriteFileInfoCmd_Payload_t *CmdPtr;
@@ -1302,11 +1295,17 @@ int32 CFE_SB_WriteMapInfoCmd(const CFE_SB_WriteMapInfoCmd_t *data)
     CFE_SB_IncrCmdCtr(Status);
 
     return CFE_SUCCESS;
-} /* end CFE_SB_WriteMapInfoCmd */
+}
 
-/******************************************************************************
- * Local callback helper for sending route subscriptions
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_SendRouteSub
+ *
+ * Internal helper routine only, not part of API.
+ *
+ * Callback for sending route subscriptions
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_SendRouteSub(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
 {
     CFE_SB_DestinationD_t *destptr;
@@ -1356,20 +1355,14 @@ void CFE_SB_SendRouteSub(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
     }
 }
 
-/******************************************************************************
-**  Function:  CFE_SB_SendPrevSubsCmd()
-**
-**  Purpose:
-**    SB function to build and send an SB packet containing a complete list of
-**    current subscriptions.Intended to be used primarily for the Software Bus
-**    Networking Application (SBN).
-**
-**  Arguments:
-**    None
-**
-**  Return:
-**    None
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_SendPrevSubsCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_SendPrevSubsCmd(const CFE_SB_SendPrevSubsCmd_t *data)
 {
     int32 status;
@@ -1397,21 +1390,16 @@ int32 CFE_SB_SendPrevSubsCmd(const CFE_SB_SendPrevSubsCmd_t *data)
     }
 
     return CFE_SUCCESS;
-} /* end CFE_SB_SendPrevSubsCmd */
+}
 
-/******************************************************************************
-**  Function:  CFE_SB_IncrCmdCtr()
-**
-**  Purpose:
-**    SB internal function to increment the proper cmd counter based on the
-**    status input. This small utility was written to eliminate duplicate code.
-**
-**  Arguments:
-**    status - typically CFE_SUCCESS or an SB error code
-**
-**  Return:
-**    None
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_IncrCmdCtr
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_IncrCmdCtr(int32 status)
 {
 
@@ -1423,24 +1411,18 @@ void CFE_SB_IncrCmdCtr(int32 status)
     {
         CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter++;
     } /* end if */
+}
 
-} /* end CFE_SB_IncrCmdCtr */
-
-/******************************************************************************
-**  Function:  CFE_SB_SetSubscriptionReporting()
-**
-**  Purpose:
-**    SB internal function to enable and disable subscription reporting.
-**
-**  Arguments:
-**
-**
-**  Return:
-**    None
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_SetSubscriptionReporting
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_SetSubscriptionReporting(uint32 state)
 {
 
     CFE_SB_Global.SubscriptionReporting = state;
-
-} /* end CFE_SB_SetSubscriptionReporting */
+}

--- a/modules/sb/fsw/src/cfe_sb_util.c
+++ b/modules/sb/fsw/src/cfe_sb_util.c
@@ -42,7 +42,7 @@
  * Function: CFE_SB_MsgHdrSize
  *
  * Application-scope internal function
- * See description in cfe_sb_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 size_t CFE_SB_MsgHdrSize(const CFE_MSG_Message_t *MsgPtr)
@@ -82,7 +82,7 @@ size_t CFE_SB_MsgHdrSize(const CFE_MSG_Message_t *MsgPtr)
  * Function: CFE_SB_GetUserData
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void *CFE_SB_GetUserData(CFE_MSG_Message_t *MsgPtr)
@@ -107,7 +107,7 @@ void *CFE_SB_GetUserData(CFE_MSG_Message_t *MsgPtr)
  * Function: CFE_SB_GetUserDataLength
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 size_t CFE_SB_GetUserDataLength(const CFE_MSG_Message_t *MsgPtr)
@@ -131,7 +131,7 @@ size_t CFE_SB_GetUserDataLength(const CFE_MSG_Message_t *MsgPtr)
  * Function: CFE_SB_SetUserDataLength
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_SetUserDataLength(CFE_MSG_Message_t *MsgPtr, size_t DataLength)
@@ -164,7 +164,7 @@ void CFE_SB_SetUserDataLength(CFE_MSG_Message_t *MsgPtr, size_t DataLength)
  * Function: CFE_SB_TimeStampMsg
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_TimeStampMsg(CFE_MSG_Message_t *MsgPtr)
@@ -177,7 +177,7 @@ void CFE_SB_TimeStampMsg(CFE_MSG_Message_t *MsgPtr)
  * Function: CFE_SB_MessageStringGet
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_MessageStringGet(char *DestStringPtr, const char *SourceStringPtr, const char *DefaultString,
@@ -234,7 +234,7 @@ int32 CFE_SB_MessageStringGet(char *DestStringPtr, const char *SourceStringPtr, 
  * Function: CFE_SB_MessageStringSet
  *
  * Implemented per public API
- * See description in cfe_sb.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_MessageStringSet(char *DestStringPtr, const char *SourceStringPtr, size_t DestMaxSize,

--- a/modules/sb/fsw/src/cfe_sb_util.c
+++ b/modules/sb/fsw/src/cfe_sb_util.c
@@ -37,18 +37,14 @@
 
 #include <string.h>
 
-/******************************************************************************
-**  Function:  CFE_SB_MsgHdrSize()
-**
-**  Purpose:
-**    Get the size of a message header.
-**
-**  Arguments:
-**    *MsgPtr - Pointer to a SB message
-**
-**  Return:
-**     Size of Message Header.
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_MsgHdrSize
+ *
+ * Application-scope internal function
+ * See description in cfe_sb_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 size_t CFE_SB_MsgHdrSize(const CFE_MSG_Message_t *MsgPtr)
 {
     size_t         size      = 0;
@@ -79,12 +75,16 @@ size_t CFE_SB_MsgHdrSize(const CFE_MSG_Message_t *MsgPtr)
     }
 
     return size;
+}
 
-} /* end CFE_SB_MsgHdrSize */
-
-/*
- * Function: CFE_SB_GetUserData - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_GetUserData
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void *CFE_SB_GetUserData(CFE_MSG_Message_t *MsgPtr)
 {
     uint8 *BytePtr;
@@ -100,11 +100,16 @@ void *CFE_SB_GetUserData(CFE_MSG_Message_t *MsgPtr)
     HdrSize = CFE_SB_MsgHdrSize(MsgPtr);
 
     return (BytePtr + HdrSize);
-} /* end CFE_SB_GetUserData */
+}
 
-/*
- * Function: CFE_SB_GetUserDataLength - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_GetUserDataLength
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 size_t CFE_SB_GetUserDataLength(const CFE_MSG_Message_t *MsgPtr)
 {
     CFE_MSG_Size_t TotalMsgSize = 0;
@@ -119,11 +124,16 @@ size_t CFE_SB_GetUserDataLength(const CFE_MSG_Message_t *MsgPtr)
     HdrSize = CFE_SB_MsgHdrSize(MsgPtr);
 
     return TotalMsgSize - HdrSize;
-} /* end CFE_SB_GetUserDataLength */
+}
 
-/*
- * Function: CFE_SB_SetUserDataLength - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_SetUserDataLength
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_SetUserDataLength(CFE_MSG_Message_t *MsgPtr, size_t DataLength)
 {
     CFE_MSG_Size_t TotalMsgSize;
@@ -147,20 +157,29 @@ void CFE_SB_SetUserDataLength(CFE_MSG_Message_t *MsgPtr, size_t DataLength)
             CFE_ES_WriteToSysLog("CFE_SB:SetUserDataLength-Failed TotalMsgSize too large\n");
         }
     }
-} /* end CFE_SB_SetUserDataLength */
+}
 
-/*
- * Function: CFE_SB_TimeStampMsg - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_TimeStampMsg
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SB_TimeStampMsg(CFE_MSG_Message_t *MsgPtr)
 {
     CFE_MSG_SetMsgTime(MsgPtr, CFE_TIME_GetTime());
+}
 
-} /* end CFE_SB_TimeStampMsg */
-
-/*
- * Function: CFE_SB_MessageStringGet - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_MessageStringGet
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_MessageStringGet(char *DestStringPtr, const char *SourceStringPtr, const char *DefaultString,
                               size_t DestMaxSize, size_t SourceMaxSize)
 {
@@ -210,9 +229,14 @@ int32 CFE_SB_MessageStringGet(char *DestStringPtr, const char *SourceStringPtr, 
     return Result;
 }
 
-/*
- * Function: CFE_SB_MessageStringSet - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SB_MessageStringSet
+ *
+ * Implemented per public API
+ * See description in cfe_sb.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_SB_MessageStringSet(char *DestStringPtr, const char *SourceStringPtr, size_t DestMaxSize,
                               size_t SourceMaxSize)
 {

--- a/modules/sbr/fsw/src/cfe_sbr_map_direct.c
+++ b/modules/sbr/fsw/src/cfe_sbr_map_direct.c
@@ -61,7 +61,7 @@ CFE_SBR_RouteId_t CFE_SBR_MSGMAP[CFE_SBR_MSG_MAP_SIZE];
  * Function: CFE_SBR_Init_Map
  *
  * Application-scope internal function
- * See description in cfe_sbr_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SBR_Init_Map(void)
@@ -75,7 +75,7 @@ void CFE_SBR_Init_Map(void)
  * Function: CFE_SBR_SetRouteId
  *
  * Application-scope internal function
- * See description in cfe_sbr_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 uint32 CFE_SBR_SetRouteId(CFE_SB_MsgId_t MsgId, CFE_SBR_RouteId_t RouteId)

--- a/modules/sbr/fsw/src/cfe_sbr_map_direct.c
+++ b/modules/sbr/fsw/src/cfe_sbr_map_direct.c
@@ -56,18 +56,28 @@
 /** \brief Message map shared data */
 CFE_SBR_RouteId_t CFE_SBR_MSGMAP[CFE_SBR_MSG_MAP_SIZE];
 
-/******************************************************************************
- *  Interface function - see header for description
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SBR_Init_Map
+ *
+ * Application-scope internal function
+ * See description in cfe_sbr_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SBR_Init_Map(void)
 {
     /* Clear the shared data */
     memset(&CFE_SBR_MSGMAP, 0, sizeof(CFE_SBR_MSGMAP));
 }
 
-/******************************************************************************
- *  Interface function - see header for description
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SBR_SetRouteId
+ *
+ * Application-scope internal function
+ * See description in cfe_sbr_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 uint32 CFE_SBR_SetRouteId(CFE_SB_MsgId_t MsgId, CFE_SBR_RouteId_t RouteId)
 {
     if (CFE_SB_IsValidMsgId(MsgId))
@@ -79,9 +89,13 @@ uint32 CFE_SBR_SetRouteId(CFE_SB_MsgId_t MsgId, CFE_SBR_RouteId_t RouteId)
     return 0;
 }
 
-/******************************************************************************
- *  Interface function - see API for description
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SBR_GetRouteId
+ *
+ * Internal helper routine only, not part of API.
+ *
+ *-----------------------------------------------------------------*/
 CFE_SBR_RouteId_t CFE_SBR_GetRouteId(CFE_SB_MsgId_t MsgId)
 {
     CFE_SBR_RouteId_t routeid = CFE_SBR_INVALID_ROUTE_ID;

--- a/modules/sbr/fsw/src/cfe_sbr_map_hash.c
+++ b/modules/sbr/fsw/src/cfe_sbr_map_hash.c
@@ -107,7 +107,7 @@ CFE_SB_MsgId_Atom_t CFE_SBR_MsgIdHash(CFE_SB_MsgId_t MsgId)
  * Function: CFE_SBR_Init_Map
  *
  * Application-scope internal function
- * See description in cfe_sbr_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SBR_Init_Map(void)
@@ -121,7 +121,7 @@ void CFE_SBR_Init_Map(void)
  * Function: CFE_SBR_SetRouteId
  *
  * Application-scope internal function
- * See description in cfe_sbr_priv.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 uint32 CFE_SBR_SetRouteId(CFE_SB_MsgId_t MsgId, CFE_SBR_RouteId_t RouteId)

--- a/modules/sbr/fsw/src/cfe_sbr_map_hash.c
+++ b/modules/sbr/fsw/src/cfe_sbr_map_hash.c
@@ -74,12 +74,18 @@
 /** \brief Message map shared data */
 CFE_SBR_RouteId_t CFE_SBR_MSGMAP[CFE_SBR_MSG_MAP_SIZE];
 
-/******************************************************************************
- * Internal helper function to hash the message id
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SBR_MsgIdHash
+ *
+ * Internal helper routine only, not part of API.
+ *
+ * Hashes the message id
  *
  * Note: algorithm designed for a 32 bit int, changing the size of
  * CFE_SB_MsgId_Atom_t may require an update to this impelementation
- */
+ *
+ *-----------------------------------------------------------------*/
 CFE_SB_MsgId_Atom_t CFE_SBR_MsgIdHash(CFE_SB_MsgId_t MsgId)
 {
     CFE_SB_MsgId_Atom_t hash;
@@ -96,18 +102,28 @@ CFE_SB_MsgId_Atom_t CFE_SBR_MsgIdHash(CFE_SB_MsgId_t MsgId)
     return hash;
 }
 
-/******************************************************************************
- *  Interface function - see header for description
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SBR_Init_Map
+ *
+ * Application-scope internal function
+ * See description in cfe_sbr_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SBR_Init_Map(void)
 {
     /* Clear the shared data */
     memset(&CFE_SBR_MSGMAP, 0, sizeof(CFE_SBR_MSGMAP));
 }
 
-/******************************************************************************
- *  Interface function - see header for description
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SBR_SetRouteId
+ *
+ * Application-scope internal function
+ * See description in cfe_sbr_priv.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 uint32 CFE_SBR_SetRouteId(CFE_SB_MsgId_t MsgId, CFE_SBR_RouteId_t RouteId)
 {
     CFE_SB_MsgId_Atom_t hash;
@@ -135,9 +151,13 @@ uint32 CFE_SBR_SetRouteId(CFE_SB_MsgId_t MsgId, CFE_SBR_RouteId_t RouteId)
     return collisions;
 }
 
-/******************************************************************************
- *  Interface function - see API for description
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SBR_GetRouteId
+ *
+ * Internal helper routine only, not part of API.
+ *
+ *-----------------------------------------------------------------*/
 CFE_SBR_RouteId_t CFE_SBR_GetRouteId(CFE_SB_MsgId_t MsgId)
 {
     CFE_SB_MsgId_Atom_t hash;

--- a/modules/sbr/fsw/src/cfe_sbr_priv.h
+++ b/modules/sbr/fsw/src/cfe_sbr_priv.h
@@ -37,11 +37,13 @@
  * Function prototypes
  */
 
+/*---------------------------------------------------------------------------------------*/
 /**
  *  \brief Routing map initialization
  */
 void CFE_SBR_Init_Map(void);
 
+/*---------------------------------------------------------------------------------------*/
 /**
  * \brief Associates the given route ID with the given message ID
  *

--- a/modules/sbr/fsw/src/cfe_sbr_route_unsorted.c
+++ b/modules/sbr/fsw/src/cfe_sbr_route_unsorted.c
@@ -65,9 +65,13 @@ typedef struct
 /** \brief Routing module shared data */
 cfe_sbr_route_data_t CFE_SBR_RDATA;
 
-/******************************************************************************
- *  Interface function - see API for description
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SBR_Init
+ *
+ * Internal helper routine only, not part of API.
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SBR_Init(void)
 {
     CFE_SB_RouteId_Atom_t routeidx;
@@ -85,9 +89,13 @@ void CFE_SBR_Init(void)
     CFE_SBR_Init_Map();
 }
 
-/******************************************************************************
- *  Interface function - see API for description
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SBR_AddRoute
+ *
+ * Internal helper routine only, not part of API.
+ *
+ *-----------------------------------------------------------------*/
 CFE_SBR_RouteId_t CFE_SBR_AddRoute(CFE_SB_MsgId_t MsgId, uint32 *CollisionsPtr)
 {
     CFE_SBR_RouteId_t routeid    = CFE_SBR_INVALID_ROUTE_ID;
@@ -110,9 +118,13 @@ CFE_SBR_RouteId_t CFE_SBR_AddRoute(CFE_SB_MsgId_t MsgId, uint32 *CollisionsPtr)
     return routeid;
 }
 
-/******************************************************************************
- *  Interface function - see API for description
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SBR_GetMsgId
+ *
+ * Internal helper routine only, not part of API.
+ *
+ *-----------------------------------------------------------------*/
 CFE_SB_MsgId_t CFE_SBR_GetMsgId(CFE_SBR_RouteId_t RouteId)
 {
     CFE_SB_MsgId_t msgid = CFE_SB_INVALID_MSG_ID;
@@ -125,9 +137,13 @@ CFE_SB_MsgId_t CFE_SBR_GetMsgId(CFE_SBR_RouteId_t RouteId)
     return msgid;
 }
 
-/******************************************************************************
- *  Interface function - see API for description
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SBR_GetDestListHeadPtr
+ *
+ * Internal helper routine only, not part of API.
+ *
+ *-----------------------------------------------------------------*/
 CFE_SB_DestinationD_t *CFE_SBR_GetDestListHeadPtr(CFE_SBR_RouteId_t RouteId)
 {
 
@@ -141,9 +157,13 @@ CFE_SB_DestinationD_t *CFE_SBR_GetDestListHeadPtr(CFE_SBR_RouteId_t RouteId)
     return destptr;
 }
 
-/******************************************************************************
- *  Interface function - see API for description
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SBR_SetDestListHeadPtr
+ *
+ * Internal helper routine only, not part of API.
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SBR_SetDestListHeadPtr(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *DestPtr)
 {
 
@@ -153,9 +173,13 @@ void CFE_SBR_SetDestListHeadPtr(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t
     }
 }
 
-/******************************************************************************
- *  Interface function - see API for description
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SBR_IncrementSequenceCounter
+ *
+ * Internal helper routine only, not part of API.
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SBR_IncrementSequenceCounter(CFE_SBR_RouteId_t RouteId)
 {
     if (CFE_SBR_IsValidRouteId(RouteId))
@@ -164,9 +188,13 @@ void CFE_SBR_IncrementSequenceCounter(CFE_SBR_RouteId_t RouteId)
     }
 }
 
-/******************************************************************************
- *  Interface function - see API for description
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SBR_GetSequenceCounter
+ *
+ * Internal helper routine only, not part of API.
+ *
+ *-----------------------------------------------------------------*/
 CFE_MSG_SequenceCount_t CFE_SBR_GetSequenceCounter(CFE_SBR_RouteId_t RouteId)
 {
     uint32 seqcnt = 0;
@@ -179,9 +207,13 @@ CFE_MSG_SequenceCount_t CFE_SBR_GetSequenceCounter(CFE_SBR_RouteId_t RouteId)
     return seqcnt;
 }
 
-/******************************************************************************
- *  Interface function - see API for description
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_SBR_ForEachRouteId
+ *
+ * Internal helper routine only, not part of API.
+ *
+ *-----------------------------------------------------------------*/
 void CFE_SBR_ForEachRouteId(CFE_SBR_CallbackPtr_t CallbackPtr, void *ArgPtr, CFE_SBR_Throttle_t *ThrottlePtr)
 {
     CFE_SB_RouteId_Atom_t routeidx;

--- a/modules/tbl/fsw/src/cfe_tbl_api.c
+++ b/modules/tbl/fsw/src/cfe_tbl_api.c
@@ -40,9 +40,14 @@
 ** Local Macros
 */
 
-/*
- * Function: CFE_TBL_Register - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_Register
+ *
+ * Implemented per public API
+ * See description in cfe_tbl.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, size_t Size, uint16 TblOptionFlags,
                        CFE_TBL_CallbackFuncPtr_t TblValidationFuncPtr)
 {
@@ -501,11 +506,16 @@ int32 CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, size_t 
     }
 
     return Status;
-} /* End of CFE_TBL_Register() */
+}
 
-/*
- * Function: CFE_TBL_Share - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_Share
+ *
+ * Implemented per public API
+ * See description in cfe_tbl.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_Share(CFE_TBL_Handle_t *TblHandlePtr, const char *TblName)
 {
     int32                       Status;
@@ -599,11 +609,16 @@ int32 CFE_TBL_Share(CFE_TBL_Handle_t *TblHandlePtr, const char *TblName)
     }
 
     return Status;
-} /* End of CFE_TBL_Share() */
+}
 
-/*
- * Function: CFE_TBL_Unregister - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_Unregister
+ *
+ * Implemented per public API
+ * See description in cfe_tbl.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_Unregister(CFE_TBL_Handle_t TblHandle)
 {
     int32                       Status;
@@ -659,16 +674,16 @@ int32 CFE_TBL_Unregister(CFE_TBL_Handle_t TblHandle)
     }
 
     return Status;
-} /* End of CFE_TBL_Unregister() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_Load() -- Load a specified table with data from the
-**                   specified source
-**
-** NOTE: For complete prolog information, see 'cfe_tbl.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_Load
+ *
+ * Implemented per public API
+ * See description in cfe_tbl.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_Load(CFE_TBL_Handle_t TblHandle, CFE_TBL_SrcEnum_t SrcType, const void *SrcDataPtr)
 {
     int32                       Status;
@@ -890,11 +905,16 @@ int32 CFE_TBL_Load(CFE_TBL_Handle_t TblHandle, CFE_TBL_SrcEnum_t SrcType, const 
     }
 
     return Status;
-} /* End of CFE_TBL_Load() */
+}
 
-/*
- * Function: CFE_TBL_Update - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_Update
+ *
+ * Implemented per public API
+ * See description in cfe_tbl_events.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_Update(CFE_TBL_Handle_t TblHandle)
 {
     int32                       Status;
@@ -962,11 +982,16 @@ int32 CFE_TBL_Update(CFE_TBL_Handle_t TblHandle)
     }
 
     return Status;
-} /* End of CFE_TBL_Update() */
+}
 
-/*
- * Function: CFE_TBL_GetAddress - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_GetAddress
+ *
+ * Implemented per public API
+ * See description in cfe_tbl.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_GetAddress(void **TblPtr, CFE_TBL_Handle_t TblHandle)
 {
     int32          Status;
@@ -997,11 +1022,16 @@ int32 CFE_TBL_GetAddress(void **TblPtr, CFE_TBL_Handle_t TblHandle)
     }
 
     return Status;
-} /* End of CFE_TBL_GetAddress() */
+}
 
-/*
- * Function: CFE_TBL_ReleaseAddress - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_ReleaseAddress
+ *
+ * Implemented per public API
+ * See description in cfe_tbl.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_ReleaseAddress(CFE_TBL_Handle_t TblHandle)
 {
     int32          Status;
@@ -1029,11 +1059,16 @@ int32 CFE_TBL_ReleaseAddress(CFE_TBL_Handle_t TblHandle)
     }
 
     return Status;
-} /* End of CFE_TBL_ReleaseAddress() */
+}
 
-/*
- * Function: CFE_TBL_GetAddresses() - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_GetAddresses
+ *
+ * Implemented per public API
+ * See description in cfe_tbl.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_GetAddresses(void **TblPtrs[], uint16 NumTables, const CFE_TBL_Handle_t TblHandles[])
 {
     uint16         i;
@@ -1077,11 +1112,16 @@ int32 CFE_TBL_GetAddresses(void **TblPtrs[], uint16 NumTables, const CFE_TBL_Han
     }
 
     return Status;
-} /* End of CFE_TBL_GetAddresses() */
+}
 
-/*
- * Function: CFE_TBL_ReleaseAddresses - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_ReleaseAddresses
+ *
+ * Implemented per public API
+ * See description in cfe_tbl.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_ReleaseAddresses(uint16 NumTables, const CFE_TBL_Handle_t TblHandles[])
 {
     int32  Status = CFE_SUCCESS;
@@ -1103,11 +1143,16 @@ int32 CFE_TBL_ReleaseAddresses(uint16 NumTables, const CFE_TBL_Handle_t TblHandl
     }
 
     return Status;
-} /* End of CFE_TBL_ReleaseAddresses() */
+}
 
-/*
- * Function: CFE_TBL_Validate - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_Validate
+ *
+ * Implemented per public API
+ * See description in cfe_tbl_events.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_Validate(CFE_TBL_Handle_t TblHandle)
 {
     int32                       Status;
@@ -1246,11 +1291,16 @@ int32 CFE_TBL_Validate(CFE_TBL_Handle_t TblHandle)
     }
 
     return Status;
-} /* End of CFE_TBL_Validate() */
+}
 
-/*
- * Function: CFE_TBL_Manage - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_Manage
+ *
+ * Implemented per public API
+ * See description in cfe_tbl.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_Manage(CFE_TBL_Handle_t TblHandle)
 {
     int32 Status           = CFE_SUCCESS;
@@ -1301,11 +1351,16 @@ int32 CFE_TBL_Manage(CFE_TBL_Handle_t TblHandle)
     }
 
     return Status;
-} /* End of CFE_TBL_Manage() */
+}
 
-/*
- * Function: CFE_TBL_GetStatus - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_GetStatus
+ *
+ * Implemented per public API
+ * See description in cfe_tbl.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_GetStatus(CFE_TBL_Handle_t TblHandle)
 {
     int32                       Status;
@@ -1344,11 +1399,16 @@ int32 CFE_TBL_GetStatus(CFE_TBL_Handle_t TblHandle)
     }
 
     return Status;
-} /* End of CFE_TBL_GetStatus() */
+}
 
-/*
- * Function: CFE_TBL_GetInfo - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_GetInfo
+ *
+ * Implemented per public API
+ * See description in cfe_tbl.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_GetInfo(CFE_TBL_Info_t *TblInfoPtr, const char *TblName)
 {
     int32                  Status = CFE_SUCCESS;
@@ -1403,11 +1463,16 @@ int32 CFE_TBL_GetInfo(CFE_TBL_Info_t *TblInfoPtr, const char *TblName)
     }
 
     return Status;
-} /* End of CFE_TBL_GetInfo() */
+}
 
-/*
- * Function: CFE_TBL_DumpToBuffer - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_DumpToBuffer
+ *
+ * Implemented per public API
+ * See description in cfe_tbl.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_DumpToBuffer(CFE_TBL_Handle_t TblHandle)
 {
     int32                       Status;
@@ -1442,11 +1507,16 @@ int32 CFE_TBL_DumpToBuffer(CFE_TBL_Handle_t TblHandle)
     }
 
     return Status;
-} /* End of CFE_TBL_DumpToBuffer() */
+}
 
-/*
- * Function: CFE_TBL_Modified - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_Modified
+ *
+ * Implemented per public API
+ * See description in cfe_tbl.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_Modified(CFE_TBL_Handle_t TblHandle)
 {
     int32                       Status;
@@ -1508,11 +1578,16 @@ int32 CFE_TBL_Modified(CFE_TBL_Handle_t TblHandle)
     }
 
     return Status;
-} /* End of CFE_TBL_Modified() */
+}
 
-/*
- * Function: CFE_TBL_NotifyByMessage - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_NotifyByMessage
+ *
+ * Implemented per public API
+ * See description in cfe_tbl.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_NotifyByMessage(CFE_TBL_Handle_t TblHandle, CFE_SB_MsgId_t MsgId, CFE_MSG_FcnCode_t CommandCode,
                               uint32 Parameter)
 {
@@ -1547,8 +1622,4 @@ int32 CFE_TBL_NotifyByMessage(CFE_TBL_Handle_t TblHandle, CFE_SB_MsgId_t MsgId, 
     }
 
     return Status;
-} /* End of CFE_TBL_NotifyByMessage() */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/modules/tbl/fsw/src/cfe_tbl_api.c
+++ b/modules/tbl/fsw/src/cfe_tbl_api.c
@@ -45,7 +45,7 @@
  * Function: CFE_TBL_Register
  *
  * Implemented per public API
- * See description in cfe_tbl.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, size_t Size, uint16 TblOptionFlags,
@@ -513,7 +513,7 @@ int32 CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, size_t 
  * Function: CFE_TBL_Share
  *
  * Implemented per public API
- * See description in cfe_tbl.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_Share(CFE_TBL_Handle_t *TblHandlePtr, const char *TblName)
@@ -616,7 +616,7 @@ int32 CFE_TBL_Share(CFE_TBL_Handle_t *TblHandlePtr, const char *TblName)
  * Function: CFE_TBL_Unregister
  *
  * Implemented per public API
- * See description in cfe_tbl.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_Unregister(CFE_TBL_Handle_t TblHandle)
@@ -681,7 +681,7 @@ int32 CFE_TBL_Unregister(CFE_TBL_Handle_t TblHandle)
  * Function: CFE_TBL_Load
  *
  * Implemented per public API
- * See description in cfe_tbl.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_Load(CFE_TBL_Handle_t TblHandle, CFE_TBL_SrcEnum_t SrcType, const void *SrcDataPtr)
@@ -912,7 +912,7 @@ int32 CFE_TBL_Load(CFE_TBL_Handle_t TblHandle, CFE_TBL_SrcEnum_t SrcType, const 
  * Function: CFE_TBL_Update
  *
  * Implemented per public API
- * See description in cfe_tbl_events.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_Update(CFE_TBL_Handle_t TblHandle)
@@ -989,7 +989,7 @@ int32 CFE_TBL_Update(CFE_TBL_Handle_t TblHandle)
  * Function: CFE_TBL_GetAddress
  *
  * Implemented per public API
- * See description in cfe_tbl.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_GetAddress(void **TblPtr, CFE_TBL_Handle_t TblHandle)
@@ -1029,7 +1029,7 @@ int32 CFE_TBL_GetAddress(void **TblPtr, CFE_TBL_Handle_t TblHandle)
  * Function: CFE_TBL_ReleaseAddress
  *
  * Implemented per public API
- * See description in cfe_tbl.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_ReleaseAddress(CFE_TBL_Handle_t TblHandle)
@@ -1066,7 +1066,7 @@ int32 CFE_TBL_ReleaseAddress(CFE_TBL_Handle_t TblHandle)
  * Function: CFE_TBL_GetAddresses
  *
  * Implemented per public API
- * See description in cfe_tbl.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_GetAddresses(void **TblPtrs[], uint16 NumTables, const CFE_TBL_Handle_t TblHandles[])
@@ -1119,7 +1119,7 @@ int32 CFE_TBL_GetAddresses(void **TblPtrs[], uint16 NumTables, const CFE_TBL_Han
  * Function: CFE_TBL_ReleaseAddresses
  *
  * Implemented per public API
- * See description in cfe_tbl.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_ReleaseAddresses(uint16 NumTables, const CFE_TBL_Handle_t TblHandles[])
@@ -1150,7 +1150,7 @@ int32 CFE_TBL_ReleaseAddresses(uint16 NumTables, const CFE_TBL_Handle_t TblHandl
  * Function: CFE_TBL_Validate
  *
  * Implemented per public API
- * See description in cfe_tbl_events.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_Validate(CFE_TBL_Handle_t TblHandle)
@@ -1298,7 +1298,7 @@ int32 CFE_TBL_Validate(CFE_TBL_Handle_t TblHandle)
  * Function: CFE_TBL_Manage
  *
  * Implemented per public API
- * See description in cfe_tbl.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_Manage(CFE_TBL_Handle_t TblHandle)
@@ -1358,7 +1358,7 @@ int32 CFE_TBL_Manage(CFE_TBL_Handle_t TblHandle)
  * Function: CFE_TBL_GetStatus
  *
  * Implemented per public API
- * See description in cfe_tbl.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_GetStatus(CFE_TBL_Handle_t TblHandle)
@@ -1406,7 +1406,7 @@ int32 CFE_TBL_GetStatus(CFE_TBL_Handle_t TblHandle)
  * Function: CFE_TBL_GetInfo
  *
  * Implemented per public API
- * See description in cfe_tbl.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_GetInfo(CFE_TBL_Info_t *TblInfoPtr, const char *TblName)
@@ -1470,7 +1470,7 @@ int32 CFE_TBL_GetInfo(CFE_TBL_Info_t *TblInfoPtr, const char *TblName)
  * Function: CFE_TBL_DumpToBuffer
  *
  * Implemented per public API
- * See description in cfe_tbl.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_DumpToBuffer(CFE_TBL_Handle_t TblHandle)
@@ -1514,7 +1514,7 @@ int32 CFE_TBL_DumpToBuffer(CFE_TBL_Handle_t TblHandle)
  * Function: CFE_TBL_Modified
  *
  * Implemented per public API
- * See description in cfe_tbl.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_Modified(CFE_TBL_Handle_t TblHandle)
@@ -1585,7 +1585,7 @@ int32 CFE_TBL_Modified(CFE_TBL_Handle_t TblHandle)
  * Function: CFE_TBL_NotifyByMessage
  *
  * Implemented per public API
- * See description in cfe_tbl.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_NotifyByMessage(CFE_TBL_Handle_t TblHandle, CFE_SB_MsgId_t MsgId, CFE_MSG_FcnCode_t CommandCode,

--- a/modules/tbl/fsw/src/cfe_tbl_internal.c
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.c
@@ -42,7 +42,7 @@
  * Function: CFE_TBL_EarlyInit
  *
  * Implemented per public API
- * See description in cfe_tbl_core_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_EarlyInit(void)
@@ -197,7 +197,7 @@ int32 CFE_TBL_EarlyInit(void)
  * Function: CFE_TBL_InitRegistryRecord
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TBL_InitRegistryRecord(CFE_TBL_RegistryRec_t *RegRecPtr)
@@ -219,7 +219,7 @@ void CFE_TBL_InitRegistryRecord(CFE_TBL_RegistryRec_t *RegRecPtr)
  * Function: CFE_TBL_ValidateHandle
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_ValidateHandle(CFE_TBL_Handle_t TblHandle)
@@ -245,7 +245,7 @@ int32 CFE_TBL_ValidateHandle(CFE_TBL_Handle_t TblHandle)
  * Function: CFE_TBL_ValidateAccess
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_ValidateAccess(CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t *AppIdPtr)
@@ -278,7 +278,7 @@ int32 CFE_TBL_ValidateAccess(CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t *AppIdPt
  * Function: CFE_TBL_CheckAccessRights
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_CheckAccessRights(CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t ThisAppId)
@@ -303,7 +303,7 @@ int32 CFE_TBL_CheckAccessRights(CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t ThisA
  * Function: CFE_TBL_RemoveAccessLink
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_RemoveAccessLink(CFE_TBL_Handle_t TblHandle)
@@ -399,7 +399,7 @@ int32 CFE_TBL_RemoveAccessLink(CFE_TBL_Handle_t TblHandle)
  * Function: CFE_TBL_GetAddressInternal
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_GetAddressInternal(void **TblPtr, CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t ThisAppId)
@@ -471,7 +471,7 @@ int32 CFE_TBL_GetAddressInternal(void **TblPtr, CFE_TBL_Handle_t TblHandle, CFE_
  * Function: CFE_TBL_GetNextNotification
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_GetNextNotification(CFE_TBL_Handle_t TblHandle)
@@ -499,7 +499,7 @@ int32 CFE_TBL_GetNextNotification(CFE_TBL_Handle_t TblHandle)
  * Function: CFE_TBL_FindTableInRegistry
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int16 CFE_TBL_FindTableInRegistry(const char *TblName)
@@ -532,7 +532,7 @@ int16 CFE_TBL_FindTableInRegistry(const char *TblName)
  * Function: CFE_TBL_FindFreeRegistryEntry
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int16 CFE_TBL_FindFreeRegistryEntry(void)
@@ -563,7 +563,7 @@ int16 CFE_TBL_FindFreeRegistryEntry(void)
  * Function: CFE_TBL_FindFreeHandle
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_TBL_Handle_t CFE_TBL_FindFreeHandle(void)
@@ -591,7 +591,7 @@ CFE_TBL_Handle_t CFE_TBL_FindFreeHandle(void)
  * Function: CFE_TBL_FormTableName
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TBL_FormTableName(char *FullTblName, const char *TblName, CFE_ES_AppId_t ThisAppId)
@@ -614,7 +614,7 @@ void CFE_TBL_FormTableName(char *FullTblName, const char *TblName, CFE_ES_AppId_
  * Function: CFE_TBL_LockRegistry
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_LockRegistry(void)
@@ -636,7 +636,7 @@ int32 CFE_TBL_LockRegistry(void)
  * Function: CFE_TBL_UnlockRegistry
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_UnlockRegistry(void)
@@ -658,7 +658,7 @@ int32 CFE_TBL_UnlockRegistry(void)
  * Function: CFE_TBL_GetWorkingBuffer
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr, CFE_TBL_RegistryRec_t *RegRecPtr,
@@ -794,7 +794,7 @@ int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr, CFE_TBL_Re
  * Function: CFE_TBL_LoadFromFile
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBufferPtr, CFE_TBL_RegistryRec_t *RegRecPtr,
@@ -921,7 +921,7 @@ int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBuffe
  * Function: CFE_TBL_UpdateInternal
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_UpdateInternal(CFE_TBL_Handle_t TblHandle, CFE_TBL_RegistryRec_t *RegRecPtr,
@@ -1025,7 +1025,7 @@ int32 CFE_TBL_UpdateInternal(CFE_TBL_Handle_t TblHandle, CFE_TBL_RegistryRec_t *
  * Function: CFE_TBL_NotifyTblUsersOfUpdate
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TBL_NotifyTblUsersOfUpdate(CFE_TBL_RegistryRec_t *RegRecPtr)
@@ -1053,7 +1053,7 @@ void CFE_TBL_NotifyTblUsersOfUpdate(CFE_TBL_RegistryRec_t *RegRecPtr)
  * Function: CFE_TBL_ReadHeaders
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_ReadHeaders(osal_id_t FileDescriptor, CFE_FS_Header_t *StdFileHeaderPtr,
@@ -1201,7 +1201,7 @@ int32 CFE_TBL_ReadHeaders(osal_id_t FileDescriptor, CFE_FS_Header_t *StdFileHead
  * Function: CFE_TBL_ByteSwapTblHeader
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TBL_ByteSwapTblHeader(CFE_TBL_File_Hdr_t *HdrPtr)
@@ -1216,7 +1216,7 @@ void CFE_TBL_ByteSwapTblHeader(CFE_TBL_File_Hdr_t *HdrPtr)
  * Function: CFE_TBL_ByteSwapUint32
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TBL_ByteSwapUint32(uint32 *Uint32ToSwapPtr)
@@ -1236,7 +1236,7 @@ void CFE_TBL_ByteSwapUint32(uint32 *Uint32ToSwapPtr)
  * Function: CFE_TBL_CleanUpApp
  *
  * Implemented per public API
- * See description in cfe_tbl_core_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_CleanUpApp(CFE_ES_AppId_t AppId)
@@ -1303,7 +1303,7 @@ int32 CFE_TBL_CleanUpApp(CFE_ES_AppId_t AppId)
  * Function: CFE_TBL_FindCriticalTblInfo
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TBL_FindCriticalTblInfo(CFE_TBL_CritRegRec_t **CritRegRecPtr, CFE_ES_CDSHandle_t CDSHandleToFind)
@@ -1328,7 +1328,7 @@ void CFE_TBL_FindCriticalTblInfo(CFE_TBL_CritRegRec_t **CritRegRecPtr, CFE_ES_CD
  * Function: CFE_TBL_UpdateCriticalTblCDS
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TBL_UpdateCriticalTblCDS(CFE_TBL_RegistryRec_t *RegRecPtr)
@@ -1386,7 +1386,7 @@ void CFE_TBL_UpdateCriticalTblCDS(CFE_TBL_RegistryRec_t *RegRecPtr)
  * Function: CFE_TBL_SendNotificationMsg
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_SendNotificationMsg(CFE_TBL_RegistryRec_t *RegRecPtr)

--- a/modules/tbl/fsw/src/cfe_tbl_internal.c
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.c
@@ -37,26 +37,14 @@
 #include <stdio.h>
 #include <string.h>
 
-/*******************************************************************
-**
-** CFE_TBL_EarlyInit
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
-/******************************************************************************
-**  Function:  CFE_TBL_EarlyInit()
-**
-**  Purpose:
-**    Initialize the Table Services
-**
-**  Arguments:
-**
-**  Notes:
-**    This function MUST be called before any TBL API's are called.
-**
-**  Return:
-**    none
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_EarlyInit
+ *
+ * Implemented per public API
+ * See description in cfe_tbl_core_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_EarlyInit(void)
 {
     uint16 i;
@@ -202,15 +190,16 @@ int32 CFE_TBL_EarlyInit(void)
     }
 
     return Status;
+}
 
-} /* End CFE_TBL_EarlyInit */
-
-/*******************************************************************
-**
-** CFE_TBL_InitRegistryRecord
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_InitRegistryRecord
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TBL_InitRegistryRecord(CFE_TBL_RegistryRec_t *RegRecPtr)
 {
     memset(RegRecPtr, 0, sizeof(*RegRecPtr));
@@ -223,15 +212,16 @@ void CFE_TBL_InitRegistryRecord(CFE_TBL_RegistryRec_t *RegRecPtr)
     RegRecPtr->ValidateInactiveIndex = CFE_TBL_NO_VALIDATION_PENDING;
     RegRecPtr->CDSHandle             = CFE_ES_CDS_BAD_HANDLE;
     RegRecPtr->DumpControlIndex      = CFE_TBL_NO_DUMP_PENDING;
-} /* End CFE_TBL_InitRegistryRecord */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_ValidateHandle
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_ValidateHandle
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_ValidateHandle(CFE_TBL_Handle_t TblHandle)
 {
     /* Is the handle out of range? */
@@ -248,15 +238,16 @@ int32 CFE_TBL_ValidateHandle(CFE_TBL_Handle_t TblHandle)
         }
     }
     return CFE_SUCCESS;
-} /* End of CFE_TBL_ValidateHandle() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_ValidateAccess
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_ValidateAccess
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_ValidateAccess(CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t *AppIdPtr)
 {
     int32 Status;
@@ -280,15 +271,16 @@ int32 CFE_TBL_ValidateAccess(CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t *AppIdPt
     Status = CFE_TBL_CheckAccessRights(TblHandle, *AppIdPtr);
 
     return Status;
-} /* End of CFE_TBL_ValidateAccess() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_CheckAccessRights
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_CheckAccessRights
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_CheckAccessRights(CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t ThisAppId)
 {
     int32 Status = CFE_SUCCESS;
@@ -304,15 +296,16 @@ int32 CFE_TBL_CheckAccessRights(CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t ThisA
     }
 
     return Status;
-} /* End of CFE_TBL_CheckAccessRights() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_RemoveAccessLink
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_RemoveAccessLink
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_RemoveAccessLink(CFE_TBL_Handle_t TblHandle)
 {
     int32                       Status        = CFE_SUCCESS;
@@ -399,15 +392,16 @@ int32 CFE_TBL_RemoveAccessLink(CFE_TBL_Handle_t TblHandle)
     CFE_TBL_UnlockRegistry();
 
     return Status;
-} /* End of CFE_TBL_RemoveAccessLink() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_GetAddressInternal
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_GetAddressInternal
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_GetAddressInternal(void **TblPtr, CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t ThisAppId)
 {
     int32                       Status;
@@ -470,15 +464,16 @@ int32 CFE_TBL_GetAddressInternal(void **TblPtr, CFE_TBL_Handle_t TblHandle, CFE_
     }
 
     return Status;
-} /* End of CFE_TBL_GetAddressInternal() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_GetNextNotification
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_GetNextNotification
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_GetNextNotification(CFE_TBL_Handle_t TblHandle)
 {
     int32                       Status        = CFE_SUCCESS;
@@ -497,15 +492,16 @@ int32 CFE_TBL_GetNextNotification(CFE_TBL_Handle_t TblHandle)
     }
 
     return Status;
-} /* End of CFE_TBL_GetNextNotification() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_FindTableInRegistry
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_FindTableInRegistry
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int16 CFE_TBL_FindTableInRegistry(const char *TblName)
 {
     int16 RegIndx = CFE_TBL_NOT_FOUND;
@@ -529,15 +525,16 @@ int16 CFE_TBL_FindTableInRegistry(const char *TblName)
     } while ((RegIndx == CFE_TBL_NOT_FOUND) && (i < (CFE_PLATFORM_TBL_MAX_NUM_TABLES - 1)));
 
     return RegIndx;
-} /* End of CFE_TBL_FindTableInRegistry() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_FindFreeRegistryEntry
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_FindFreeRegistryEntry
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int16 CFE_TBL_FindFreeRegistryEntry(void)
 {
     int16 RegIndx = CFE_TBL_NOT_FOUND;
@@ -559,15 +556,16 @@ int16 CFE_TBL_FindFreeRegistryEntry(void)
     }
 
     return RegIndx;
-} /* End of CFE_TBL_FindFreeRegistryEntry() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_FindFreeHandle
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_FindFreeHandle
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_TBL_Handle_t CFE_TBL_FindFreeHandle(void)
 {
     CFE_TBL_Handle_t HandleIndx = CFE_TBL_END_OF_LIST;
@@ -586,15 +584,16 @@ CFE_TBL_Handle_t CFE_TBL_FindFreeHandle(void)
     }
 
     return HandleIndx;
-} /* End of CFE_TBL_FindFreeHandle() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_FormTableName
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_FormTableName
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TBL_FormTableName(char *FullTblName, const char *TblName, CFE_ES_AppId_t ThisAppId)
 {
     char AppName[OS_MAX_API_NAME];
@@ -608,15 +607,16 @@ void CFE_TBL_FormTableName(char *FullTblName, const char *TblName, CFE_ES_AppId_
     sprintf(FullTblName, "%s.%s", AppName, TblName);
 
     return;
-} /* End of CFE_TBL_FormTableName() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_LockRegistry
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_LockRegistry
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_LockRegistry(void)
 {
     int32 Status;
@@ -629,16 +629,16 @@ int32 CFE_TBL_LockRegistry(void)
     }
 
     return Status;
+}
 
-} /* End of CFE_TBL_LockRegistry() */
-
-/*******************************************************************
-**
-** CFE_TBL_UnlockRegistry
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_UnlockRegistry
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_UnlockRegistry(void)
 {
     int32 Status;
@@ -651,16 +651,16 @@ int32 CFE_TBL_UnlockRegistry(void)
     }
 
     return Status;
+}
 
-} /* End of CFE_TBL_UnlockRegistry() */
-
-/*******************************************************************
-**
-** CFE_TBL_GetWorkingBuffer
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_GetWorkingBuffer
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr, CFE_TBL_RegistryRec_t *RegRecPtr,
                                bool CalledByApp)
 {
@@ -787,16 +787,16 @@ int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr, CFE_TBL_Re
     }
 
     return Status;
+}
 
-} /* End of CFE_TBL_GetWorkingBuffer() */
-
-/*******************************************************************
-**
-** CFE_TBL_LoadFromFile
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_LoadFromFile
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBufferPtr, CFE_TBL_RegistryRec_t *RegRecPtr,
                            const char *Filename)
 {
@@ -914,15 +914,16 @@ int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBuffe
     OS_close(FileDescriptor);
 
     return Status;
-} /* End of CFE_TBL_LoadFromFile() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_UpdateInternal
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_UpdateInternal
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_UpdateInternal(CFE_TBL_Handle_t TblHandle, CFE_TBL_RegistryRec_t *RegRecPtr,
                              CFE_TBL_AccessDescriptor_t *AccessDescPtr)
 {
@@ -1017,15 +1018,16 @@ int32 CFE_TBL_UpdateInternal(CFE_TBL_Handle_t TblHandle, CFE_TBL_RegistryRec_t *
     }
 
     return Status;
-} /* End of CFE_TBL_UpdateInternal() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_NotifyTblUsersOfUpdate
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_NotifyTblUsersOfUpdate
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TBL_NotifyTblUsersOfUpdate(CFE_TBL_RegistryRec_t *RegRecPtr)
 {
     CFE_TBL_Handle_t AccessIterator;
@@ -1044,15 +1046,16 @@ void CFE_TBL_NotifyTblUsersOfUpdate(CFE_TBL_RegistryRec_t *RegRecPtr)
 
         AccessIterator = CFE_TBL_Global.Handles[AccessIterator].NextLink;
     }
-} /* End of CFE_TBL_NotifyTblUsersOfUpdate() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_ReadHeaders
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_ReadHeaders
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_ReadHeaders(osal_id_t FileDescriptor, CFE_FS_Header_t *StdFileHeaderPtr,
                           CFE_TBL_File_Hdr_t *TblFileHeaderPtr, const char *LoadFilename)
 {
@@ -1191,29 +1194,31 @@ int32 CFE_TBL_ReadHeaders(osal_id_t FileDescriptor, CFE_FS_Header_t *StdFileHead
     }
 
     return Status;
-} /* End of CFE_TBL_ReadHeaders() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_ByteSwapTblHeader
-**
-** NOTE: For complete prolog information, see above
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_ByteSwapTblHeader
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TBL_ByteSwapTblHeader(CFE_TBL_File_Hdr_t *HdrPtr)
 {
     CFE_TBL_ByteSwapUint32(&HdrPtr->Reserved);
     CFE_TBL_ByteSwapUint32(&HdrPtr->Offset);
     CFE_TBL_ByteSwapUint32(&HdrPtr->NumBytes);
-} /* End of CFE_TBL_ByteSwapTblHeader() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_ByteSwapUint32
-**
-** NOTE: For complete prolog information, see above
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_ByteSwapUint32
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TBL_ByteSwapUint32(uint32 *Uint32ToSwapPtr)
 {
     int32 Temp   = *Uint32ToSwapPtr;
@@ -1224,15 +1229,16 @@ void CFE_TBL_ByteSwapUint32(uint32 *Uint32ToSwapPtr)
     OutPtr[1] = InPtr[2];
     OutPtr[2] = InPtr[1];
     OutPtr[3] = InPtr[0];
-} /* End of CFE_TBL_ByteSwapUint32() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_CleanUpApp
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_CleanUpApp
+ *
+ * Implemented per public API
+ * See description in cfe_tbl_core_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_CleanUpApp(CFE_ES_AppId_t AppId)
 {
     uint32                      i;
@@ -1290,15 +1296,16 @@ int32 CFE_TBL_CleanUpApp(CFE_ES_AppId_t AppId)
     }
 
     return CFE_SUCCESS;
-} /* End of CFE_TBL_CleanUpApp() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_FindCriticalTblInfo
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_FindCriticalTblInfo
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TBL_FindCriticalTblInfo(CFE_TBL_CritRegRec_t **CritRegRecPtr, CFE_ES_CDSHandle_t CDSHandleToFind)
 {
     uint32 i;
@@ -1314,15 +1321,16 @@ void CFE_TBL_FindCriticalTblInfo(CFE_TBL_CritRegRec_t **CritRegRecPtr, CFE_ES_CD
             break;
         }
     }
-} /* End of CFE_TBL_FindCriticalTblInfo() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_UpdateCriticalTblCDS
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_UpdateCriticalTblCDS
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TBL_UpdateCriticalTblCDS(CFE_TBL_RegistryRec_t *RegRecPtr)
 {
     CFE_TBL_CritRegRec_t *CritRegRecPtr = NULL;
@@ -1371,15 +1379,16 @@ void CFE_TBL_UpdateCriticalTblCDS(CFE_TBL_RegistryRec_t *RegRecPtr)
     }
 
     /* Don't bother notifying the caller of the problem since the active table is still legitimate */
-} /* End of CFE_TBL_UpdateCriticalTblCDS() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_SendNotificationMsg
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_internal.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_SendNotificationMsg
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_SendNotificationMsg(CFE_TBL_RegistryRec_t *RegRecPtr)
 {
     int32 Status = CFE_SUCCESS;
@@ -1407,8 +1416,4 @@ int32 CFE_TBL_SendNotificationMsg(CFE_TBL_RegistryRec_t *RegRecPtr)
     }
 
     return Status;
-} /* End of CFE_TBL_SendNotificationMsg() */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/modules/tbl/fsw/src/cfe_tbl_internal.h
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.h
@@ -52,7 +52,7 @@
 
 /*****************************  Function Prototypes   **********************************/
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Validates specified handle to ensure legality
 **
@@ -69,10 +69,10 @@
 ** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
 ** \retval #CFE_TBL_ERR_INVALID_HANDLE      \copydoc CFE_TBL_ERR_INVALID_HANDLE
 **
-******************************************************************************/
+*/
 int32 CFE_TBL_ValidateHandle(CFE_TBL_Handle_t TblHandle);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Determines whether handle is associated with calling Application
 **
@@ -97,10 +97,10 @@ int32 CFE_TBL_ValidateHandle(CFE_TBL_Handle_t TblHandle);
 ** \retval #CFE_TBL_ERR_INVALID_HANDLE      \copydoc CFE_TBL_ERR_INVALID_HANDLE
 ** \retval #CFE_TBL_ERR_NO_ACCESS           \copydoc CFE_TBL_ERR_NO_ACCESS
 **
-******************************************************************************/
+*/
 int32 CFE_TBL_ValidateAccess(CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t *AppIdPtr);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Determines if calling application has the right to access specified table
 **
@@ -120,10 +120,10 @@ int32 CFE_TBL_ValidateAccess(CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t *AppIdPt
 ** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
 ** \retval #CFE_TBL_ERR_NO_ACCESS           \copydoc CFE_TBL_ERR_NO_ACCESS
 **
-******************************************************************************/
+*/
 int32 CFE_TBL_CheckAccessRights(CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t ThisAppId);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Removes Access Descriptor from Table's linked list of Access Descriptors
 **
@@ -141,10 +141,10 @@ int32 CFE_TBL_CheckAccessRights(CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t ThisA
 **
 ** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
 **
-******************************************************************************/
+*/
 int32 CFE_TBL_RemoveAccessLink(CFE_TBL_Handle_t TblHandle);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Obtains the data address for the specified table
 **
@@ -169,10 +169,10 @@ int32 CFE_TBL_RemoveAccessLink(CFE_TBL_Handle_t TblHandle);
 ** \retval #CFE_TBL_ERR_NO_ACCESS           \copydoc CFE_TBL_ERR_NO_ACCESS
 ** \retval #CFE_TBL_ERR_UNREGISTERED        \copydoc CFE_TBL_ERR_UNREGISTERED
 **
-******************************************************************************/
+*/
 int32 CFE_TBL_GetAddressInternal(void **TblPtr, CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t ThisAppId);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Returns any pending non-error status code for the specified table.
 **
@@ -189,10 +189,10 @@ int32 CFE_TBL_GetAddressInternal(void **TblPtr, CFE_TBL_Handle_t TblHandle, CFE_
 ** \retval #CFE_TBL_INFO_UPDATE_PENDING     \copydoc CFE_TBL_INFO_UPDATE_PENDING
 ** \retval #CFE_TBL_INFO_UPDATED            \copydoc CFE_TBL_INFO_UPDATED
 **
-******************************************************************************/
+*/
 int32 CFE_TBL_GetNextNotification(CFE_TBL_Handle_t TblHandle);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Returns the Registry Index for the specified Table Name
 **
@@ -208,10 +208,10 @@ int32 CFE_TBL_GetNextNotification(CFE_TBL_Handle_t TblHandle);
 **
 ** \retval #CFE_TBL_NOT_FOUND or the Index into Registry for Table with specified name
 **
-******************************************************************************/
+*/
 int16 CFE_TBL_FindTableInRegistry(const char *TblName);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Locates a free slot in the Table Registry.
 **
@@ -222,10 +222,10 @@ int16 CFE_TBL_FindTableInRegistry(const char *TblName);
 **        Note: This function assumes the registry has been locked.
 **
 ** \retval #CFE_TBL_NOT_FOUND or Index into Table Registry of unused entry
-******************************************************************************/
+*/
 int16 CFE_TBL_FindFreeRegistryEntry(void);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Locates a free Access Descriptor in the Table Handles Array.
 **
@@ -236,10 +236,10 @@ int16 CFE_TBL_FindFreeRegistryEntry(void);
 **        Note: This function assumes the registry has been locked.
 **
 ** \retval #CFE_TBL_END_OF_LIST or Table Handle of unused Access Descriptor
-******************************************************************************/
+*/
 CFE_TBL_Handle_t CFE_TBL_FindFreeHandle(void);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Creates a Full Table name from application name and table name
 **
@@ -260,10 +260,10 @@ CFE_TBL_Handle_t CFE_TBL_FindFreeHandle(void);
 **
 ** \param[in]  ThisAppId the Application ID of the Application making the call.
 **
-******************************************************************************/
+*/
 void CFE_TBL_FormTableName(char *FullTblName, const char *TblName, CFE_ES_AppId_t ThisAppId);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Locks access to the Table Registry
 **
@@ -275,10 +275,10 @@ void CFE_TBL_FormTableName(char *FullTblName, const char *TblName, CFE_ES_AppId_
 **          None
 **
 ** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
-******************************************************************************/
+*/
 int32 CFE_TBL_LockRegistry(void);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Unlocks access to the Table Registry
 **
@@ -291,10 +291,10 @@ int32 CFE_TBL_LockRegistry(void);
 **
 ** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
 **
-******************************************************************************/
+*/
 int32 CFE_TBL_UnlockRegistry(void);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Finds the address of a buffer compatible with the specified table
 **
@@ -324,11 +324,11 @@ int32 CFE_TBL_UnlockRegistry(void);
 ** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
 ** \retval #CFE_TBL_ERR_NO_BUFFER_AVAIL     \copydoc CFE_TBL_ERR_NO_BUFFER_AVAIL
 **
-******************************************************************************/
+*/
 int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr, CFE_TBL_RegistryRec_t *RegRecPtr,
                                bool CalledByApp);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Loads a table buffer with data from a specified file
 **
@@ -367,11 +367,11 @@ int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr, CFE_TBL_Re
 ** \retval #CFE_TBL_ERR_BAD_CONTENT_ID       \copydoc CFE_TBL_ERR_BAD_CONTENT_ID
 ** \retval #CFE_TBL_ERR_BAD_SUBTYPE_ID       \copydoc CFE_TBL_ERR_BAD_SUBTYPE_ID
 **
-******************************************************************************/
+*/
 int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBufferPtr, CFE_TBL_RegistryRec_t *RegRecPtr,
                            const char *Filename);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Updates the active table buffer with contents of inactive buffer
 **
@@ -392,11 +392,11 @@ int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBuffe
 ** \param[in]  AccessDescPtr  Pointer to appropriate access descriptor for table-application interface
 **
 ** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
-******************************************************************************/
+*/
 int32 CFE_TBL_UpdateInternal(CFE_TBL_Handle_t TblHandle, CFE_TBL_RegistryRec_t *RegRecPtr,
                              CFE_TBL_AccessDescriptor_t *AccessDescPtr);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Sets flags in access descriptors associated with specified table
 **
@@ -409,10 +409,10 @@ int32 CFE_TBL_UpdateInternal(CFE_TBL_Handle_t TblHandle, CFE_TBL_RegistryRec_t *
 **           is called.
 **
 ** \param[in]  RegRecPtr      Pointer to Table Registry Entry for table to be updated
-******************************************************************************/
+*/
 void CFE_TBL_NotifyTblUsersOfUpdate(CFE_TBL_RegistryRec_t *RegRecPtr);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Reads Table File Headers
 **
@@ -445,11 +445,11 @@ void CFE_TBL_NotifyTblUsersOfUpdate(CFE_TBL_RegistryRec_t *RegRecPtr);
 ** \retval #CFE_TBL_ERR_BAD_SPACECRAFT_ID   \copydoc CFE_TBL_ERR_BAD_SPACECRAFT_ID
 ** \retval #CFE_TBL_ERR_BAD_PROCESSOR_ID    \copydoc CFE_TBL_ERR_BAD_PROCESSOR_ID
 **
-******************************************************************************/
+*/
 int32 CFE_TBL_ReadHeaders(osal_id_t FileDescriptor, CFE_FS_Header_t *StdFileHeaderPtr,
                           CFE_TBL_File_Hdr_t *TblFileHeaderPtr, const char *LoadFilename);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Initializes the entries of a single Table Registry Record
 **
@@ -459,10 +459,10 @@ int32 CFE_TBL_ReadHeaders(osal_id_t FileDescriptor, CFE_FS_Header_t *StdFileHead
 ** \par Assumptions, External Events, and Notes:
 **        -# This function is intended to be called before populating a table registry record
 **
-******************************************************************************/
+*/
 void CFE_TBL_InitRegistryRecord(CFE_TBL_RegistryRec_t *RegRecPtr);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Byte swaps a CFE_TBL_File_Hdr_t structure
 **
@@ -475,10 +475,10 @@ void CFE_TBL_InitRegistryRecord(CFE_TBL_RegistryRec_t *RegRecPtr);
 **
 ** \param[in, out]  HdrPtr   Pointer to table header that needs to be swapped. *HdrPtr provides the swapped header
 **
-******************************************************************************/
+*/
 void CFE_TBL_ByteSwapTblHeader(CFE_TBL_File_Hdr_t *HdrPtr);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Searches the Critical Table Registry for the given handle
 **
@@ -500,10 +500,10 @@ void CFE_TBL_ByteSwapTblHeader(CFE_TBL_File_Hdr_t *HdrPtr);
 **
 ** \param[in]  CDSHandleToFind   CDS Handle to be located in Critical Table Registry.
 **
-******************************************************************************/
+*/
 void CFE_TBL_FindCriticalTblInfo(CFE_TBL_CritRegRec_t **CritRegRecPtr, CFE_ES_CDSHandle_t CDSHandleToFind);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Updates a CDS associated with a Critical Table
 **
@@ -519,10 +519,10 @@ void CFE_TBL_FindCriticalTblInfo(CFE_TBL_CritRegRec_t **CritRegRecPtr, CFE_ES_CD
 ** \param[in]  RegRecPtr Pointer to Registry Record of Critical Table whose CDS
 **                       needs to be updated.
 **
-******************************************************************************/
+*/
 void CFE_TBL_UpdateCriticalTblCDS(CFE_TBL_RegistryRec_t *RegRecPtr);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief When enabled, will send a manage notification command message
 **
@@ -537,10 +537,10 @@ void CFE_TBL_UpdateCriticalTblCDS(CFE_TBL_RegistryRec_t *RegRecPtr);
 **
 ** \param[in]  RegRecPtr Pointer to Registry Record of Table whose owner needs notifying.
 **
-******************************************************************************/
+*/
 int32 CFE_TBL_SendNotificationMsg(CFE_TBL_RegistryRec_t *RegRecPtr);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Performs a byte swap on a uint32 integer
 **
@@ -553,7 +553,7 @@ int32 CFE_TBL_SendNotificationMsg(CFE_TBL_RegistryRec_t *RegRecPtr);
 **
 ** \param[in, out]  Uint32ToSwapPtr Pointer to uint32 value to be swapped. *Uint32ToSwapPtr is the swapped uint32 value
 **
-******************************************************************************/
+*/
 extern void CFE_TBL_ByteSwapUint32(uint32 *Uint32ToSwapPtr);
 
 /*

--- a/modules/tbl/fsw/src/cfe_tbl_task.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task.c
@@ -85,6 +85,14 @@ const CFE_TBL_CmdHandlerTblRec_t CFE_TBL_CmdHandlerTbl[] = {
 
 /******************************************************************************/
 
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_TaskMain
+ *
+ * Implemented per public API
+ * See description in cfe_tbl_core_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TBL_TaskMain(void)
 {
     int32            Status;
@@ -137,11 +145,16 @@ void CFE_TBL_TaskMain(void)
 
     /* while loop exits only if CFE_SB_ReceiveBuffer returns error */
     CFE_ES_ExitApp(CFE_ES_RunStatus_CORE_APP_RUNTIME_ERROR);
+}
 
-} /* end CFE_TBL_TaskMain() */
-
-/******************************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_TaskInit
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_TaskInit(void)
 {
     int32 Status;
@@ -207,11 +220,16 @@ int32 CFE_TBL_TaskInit(void)
     } /* end if */
 
     return CFE_SUCCESS;
+}
 
-} /* End of CFE_TBL_TaskInit() */
-
-/******************************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_InitData
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TBL_InitData(void)
 {
 
@@ -227,11 +245,16 @@ void CFE_TBL_InitData(void)
 
     /* Message ID is set when sent, so OK as 0 here */
     CFE_MSG_Init(&CFE_TBL_Global.NotifyMsg.CmdHeader.Msg, CFE_SB_ValueToMsgId(0), sizeof(CFE_TBL_Global.NotifyMsg));
+}
 
-} /* End of CFE_TBL_InitData() */
-
-/******************************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_TaskPipe
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TBL_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
 {
     CFE_SB_MsgId_t       MessageID   = CFE_SB_INVALID_MSG_ID;
@@ -302,11 +325,16 @@ void CFE_TBL_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
     }
 
     return;
+}
 
-} /* End of CFE_TBL_TaskPipe() */
-
-/******************************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_SearchCmdHndlrTbl
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_task.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int16 CFE_TBL_SearchCmdHndlrTbl(CFE_SB_MsgId_t MessageID, uint16 CommandCode)
 {
     int16 TblIndx    = CFE_TBL_BAD_CMD_CODE;
@@ -361,8 +389,4 @@ int16 CFE_TBL_SearchCmdHndlrTbl(CFE_SB_MsgId_t MessageID, uint16 CommandCode)
     }
 
     return TblIndx;
-} /* End of CFE_TBL_SearchCmdHndlrTbl() */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/modules/tbl/fsw/src/cfe_tbl_task.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task.c
@@ -90,7 +90,7 @@ const CFE_TBL_CmdHandlerTblRec_t CFE_TBL_CmdHandlerTbl[] = {
  * Function: CFE_TBL_TaskMain
  *
  * Implemented per public API
- * See description in cfe_tbl_core_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TBL_TaskMain(void)
@@ -152,7 +152,7 @@ void CFE_TBL_TaskMain(void)
  * Function: CFE_TBL_TaskInit
  *
  * Application-scope internal function
- * See description in cfe_tbl_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_TaskInit(void)
@@ -227,7 +227,7 @@ int32 CFE_TBL_TaskInit(void)
  * Function: CFE_TBL_InitData
  *
  * Application-scope internal function
- * See description in cfe_tbl_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TBL_InitData(void)
@@ -252,7 +252,7 @@ void CFE_TBL_InitData(void)
  * Function: CFE_TBL_TaskPipe
  *
  * Application-scope internal function
- * See description in cfe_tbl_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TBL_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
@@ -332,7 +332,7 @@ void CFE_TBL_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
  * Function: CFE_TBL_SearchCmdHndlrTbl
  *
  * Application-scope internal function
- * See description in cfe_tbl_task.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int16 CFE_TBL_SearchCmdHndlrTbl(CFE_SB_MsgId_t MessageID, uint16 CommandCode)

--- a/modules/tbl/fsw/src/cfe_tbl_task.h
+++ b/modules/tbl/fsw/src/cfe_tbl_task.h
@@ -349,7 +349,7 @@ typedef struct
  * Functions
  */
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Compares message with #CFE_TBL_CmdHandlerTbl to identify the message
 **
@@ -369,10 +369,10 @@ typedef struct
 ** \retval #CFE_TBL_BAD_CMD_CODE \copydoc CFE_TBL_BAD_CMD_CODE
 ** \retval #CFE_TBL_BAD_MSG_ID   \copydoc CFE_TBL_BAD_MSG_ID
 **
-******************************************************************************/
+*/
 extern int16 CFE_TBL_SearchCmdHndlrTbl(CFE_SB_MsgId_t MessageID, uint16 CommandCode);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief cFE Table Services Core Application Initialization
 **
@@ -389,10 +389,10 @@ extern int16 CFE_TBL_SearchCmdHndlrTbl(CFE_SB_MsgId_t MessageID, uint16 CommandC
 ** \return Any of the return values from #CFE_SB_CreatePipe
 ** \return Any of the return values from #CFE_SB_Subscribe
 ** \return Any of the return values from #CFE_EVS_SendEvent
-******************************************************************************/
+*/
 int32 CFE_TBL_TaskInit(void);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Processes command pipe messages
 **
@@ -404,10 +404,10 @@ int32 CFE_TBL_TaskInit(void);
 **
 ** \param[in] MessagePtr a pointer to the message received from the command pipe
 **
-******************************************************************************/
+*/
 void CFE_TBL_TaskPipe(CFE_SB_Buffer_t *SBBufPtr);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Table Service Application Data Initialization
 **
@@ -417,7 +417,7 @@ void CFE_TBL_TaskPipe(CFE_SB_Buffer_t *SBBufPtr);
 ** \par Assumptions, External Events, and Notes:
 **          None
 **
-******************************************************************************/
+*/
 void CFE_TBL_InitData(void);
 
 #endif /* CFE_TBL_TASK_H */

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
@@ -37,13 +37,14 @@
 
 #include <string.h>
 
-/*******************************************************************
-**
-** CFE_TBL_HousekeepingCmd() -- Process Housekeeping Request Message
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_HousekeepingCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_task_cmds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
 {
     int32                  Status;
@@ -132,16 +133,16 @@ int32 CFE_TBL_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
     }
 
     return CFE_TBL_DONT_INC_CTR;
+}
 
-} /* End of CFE_TBL_HousekeepingCmd() */
-
-/*******************************************************************
-**
-** CFE_TBL_GetHkData() -- Collect data and store it into the Housekeeping Message
-**
-** NOTE: For complete prolog information, see prototype above
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_GetHkData
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_task_cmds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TBL_GetHkData(void)
 {
     uint32                      i;
@@ -246,15 +247,16 @@ void CFE_TBL_GetHkData(void)
                                     sizeof(CFE_TBL_Global.Registry[CFE_TBL_Global.LastTblUpdated].Name));
         }
     }
-} /* End of CFE_TBL_GetHkData() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_GetTblRegData() -- Convert Table Registry Entry for a Table into a Message
-**
-** NOTE: For complete prolog information, see prototype above
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_GetTblRegData
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_task_cmds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TBL_GetTblRegData(void)
 {
     CFE_TBL_RegistryRec_t *RegRecPtr;
@@ -305,31 +307,32 @@ void CFE_TBL_GetTblRegData(void)
                             sizeof(RegRecPtr->LastFileLoaded));
     CFE_ES_GetAppName(CFE_TBL_Global.TblRegPacket.Payload.OwnerAppName, RegRecPtr->OwnerAppId,
                       sizeof(CFE_TBL_Global.TblRegPacket.Payload.OwnerAppName));
-} /* End of CFE_TBL_GetTblRegData() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_NoopCmd() -- Process NO-Op Command Message
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_NoopCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_task_cmds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_NoopCmd(const CFE_TBL_NoopCmd_t *data)
 {
     /* Acknowledge receipt of NOOP with Event Message */
     CFE_EVS_SendEvent(CFE_TBL_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op command. %s", CFE_VERSION_STRING);
 
     return CFE_TBL_INC_CMD_CTR;
+}
 
-} /* End of CFE_TBL_NoopCmd() */
-
-/*******************************************************************
-**
-** CFE_TBL_ResetCountersCmd() -- Process Reset Counters Command Message
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_ResetCountersCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_task_cmds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCountersCmd_t *data)
 {
     CFE_TBL_Global.CommandCounter      = 0;
@@ -342,16 +345,16 @@ int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCountersCmd_t *data)
     CFE_EVS_SendEvent(CFE_TBL_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "Reset Counters command");
 
     return CFE_TBL_DONT_INC_CTR;
+}
 
-} /* End of CFE_TBL_ResetCountersCmd() */
-
-/*******************************************************************
-**
-** CFE_TBL_LoadCmd() -- Process Load Table File to Buffer Command Message
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_LoadCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_task_cmds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t             ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
@@ -533,16 +536,16 @@ int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
     }
 
     return ReturnCode;
+}
 
-} /* End of CFE_TBL_LoadCmd() */
-
-/*******************************************************************
-**
-** CFE_TBL_DumpCmd() -- Process Dump Table to File Command Message
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_DumpCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_task_cmds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t             ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
@@ -679,16 +682,16 @@ int32 CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data)
     }
 
     return ReturnCode;
+}
 
-} /* End of CFE_TBL_DumpCmd() */
-
-/*******************************************************************
-**
-** CFE_TBL_DumpToFile() -- Write table data to a file
-**
-** NOTE: For complete prolog information, see prototype above
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_DumpToFile
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_task_cmds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_TBL_CmdProcRet_t CFE_TBL_DumpToFile(const char *DumpFilename, const char *TableName, const void *DumpDataAddr,
                                         size_t TblSizeInBytes)
 {
@@ -805,15 +808,16 @@ CFE_TBL_CmdProcRet_t CFE_TBL_DumpToFile(const char *DumpFilename, const char *Ta
     }
 
     return ReturnCode;
-} /* End of CFE_TBL_DumpToFile() */
+}
 
-/*******************************************************************
-**
-** CFE_TBL_ValidateCmd() -- Process Validate Table Command Message
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_ValidateCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_task_cmds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t                 ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
@@ -947,16 +951,16 @@ int32 CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data)
     }
 
     return ReturnCode;
+}
 
-} /* End of CFE_TBL_ValidateCmd() */
-
-/*******************************************************************
-**
-** CFE_TBL_ActivateCmd() -- Process Activate Table Command Message
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_ActivateCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_task_cmds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_ActivateCmd(const CFE_TBL_ActivateCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t                 ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
@@ -1027,15 +1031,16 @@ int32 CFE_TBL_ActivateCmd(const CFE_TBL_ActivateCmd_t *data)
     }
 
     return ReturnCode;
+}
 
-} /* End of CFE_TBL_ActivateCmd() */
-
-/*******************************************************************
-**
-** CFE_TBL_DumpRegistryGetter() -- Helper function for dumping table registry
-**
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_DumpRegistryGetter
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_TBL_DumpRegistryGetter(void *Meta, uint32 RecordNum, void **Buffer, size_t *BufSize)
 {
     CFE_TBL_RegDumpStateInfo_t *StatePtr = (CFE_TBL_RegDumpStateInfo_t *)Meta;
@@ -1148,12 +1153,14 @@ bool CFE_TBL_DumpRegistryGetter(void *Meta, uint32 RecordNum, void **Buffer, siz
     return (RecordNum >= (CFE_PLATFORM_TBL_MAX_NUM_TABLES - 1));
 }
 
-/*******************************************************************
-**
-** CFE_TBL_DumpRegistryEventHandler() -- Helper function for dumping table registry
-**
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_DumpRegistryEventHandler
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TBL_DumpRegistryEventHandler(void *Meta, CFE_FS_FileWriteEvent_t Event, int32 Status, uint32 RecordNum,
                                       size_t BlockSize, size_t Position)
 {
@@ -1210,13 +1217,14 @@ void CFE_TBL_DumpRegistryEventHandler(void *Meta, CFE_FS_FileWriteEvent_t Event,
     }
 }
 
-/*******************************************************************
-**
-** CFE_TBL_DumpRegistryCmd() -- Process Dump Table Registry to file Command Message
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_DumpRegistryCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_task_cmds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t                     ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
@@ -1270,16 +1278,16 @@ int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data)
     }
 
     return ReturnCode;
+}
 
-} /* End of CFE_TBL_DumpRegistryCmd() */
-
-/*******************************************************************
-**
-** CFE_TBL_SendRegistryCmd() -- Process Telemeter Table Registry Entry Command Message
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_SendRegistryCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_task_cmds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t                     ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
@@ -1311,16 +1319,16 @@ int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data)
     }
 
     return ReturnCode;
+}
 
-} /* End of CFE_TBL_SendRegistryCmd() */
-
-/*******************************************************************
-**
-** CFE_TBL_DeleteCDSCmd() -- Process Delete Critical Table's CDS Command Message
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_DeleteCDSCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_task_cmds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t               ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
@@ -1401,16 +1409,16 @@ int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data)
                           "'%s' found in Table Registry. CDS cannot be deleted until table is unregistered", TableName);
     }
     return ReturnCode;
+}
 
-} /* End of CFE_TBL_DeleteCDSCmd() */
-
-/*******************************************************************
-**
-** CFE_TBL_AbortLoadCmd() -- Process Abort Load Command Message
-**
-** NOTE: For complete prolog information, see 'cfe_tbl_task_cmds.h'
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_AbortLoadCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_task_cmds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TBL_AbortLoadCmd(const CFE_TBL_AbortLoadCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t                  ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
@@ -1453,16 +1461,16 @@ int32 CFE_TBL_AbortLoadCmd(const CFE_TBL_AbortLoadCmd_t *data)
     }
 
     return ReturnCode;
+}
 
-} /* End of CFE_TBL_AbortLoadCmd() */
-
-/*******************************************************************
-**
-** CFE_TBL_AbortLoad() -- Abort load, free buffers, issue event message
-**
-** NOTE: For complete prolog information, see above
-********************************************************************/
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TBL_AbortLoad
+ *
+ * Application-scope internal function
+ * See description in cfe_tbl_task_cmds.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TBL_AbortLoad(CFE_TBL_RegistryRec_t *RegRecPtr)
 {
     /* The ground has aborted the load, free the working buffer for another attempt */
@@ -1480,8 +1488,4 @@ void CFE_TBL_AbortLoad(CFE_TBL_RegistryRec_t *RegRecPtr)
 
     CFE_EVS_SendEvent(CFE_TBL_LOAD_ABORT_INF_EID, CFE_EVS_EventType_INFORMATION, "Table Load Aborted for '%s'",
                       RegRecPtr->Name);
-} /* End of CFE_TBL_AbortLoad() */
-
-/************************/
-/*  End of File Comment */
-/************************/
+}

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
@@ -42,7 +42,7 @@
  * Function: CFE_TBL_HousekeepingCmd
  *
  * Application-scope internal function
- * See description in cfe_tbl_task_cmds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
@@ -140,7 +140,7 @@ int32 CFE_TBL_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
  * Function: CFE_TBL_GetHkData
  *
  * Application-scope internal function
- * See description in cfe_tbl_task_cmds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TBL_GetHkData(void)
@@ -254,7 +254,7 @@ void CFE_TBL_GetHkData(void)
  * Function: CFE_TBL_GetTblRegData
  *
  * Application-scope internal function
- * See description in cfe_tbl_task_cmds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TBL_GetTblRegData(void)
@@ -314,7 +314,7 @@ void CFE_TBL_GetTblRegData(void)
  * Function: CFE_TBL_NoopCmd
  *
  * Application-scope internal function
- * See description in cfe_tbl_task_cmds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_NoopCmd(const CFE_TBL_NoopCmd_t *data)
@@ -330,7 +330,7 @@ int32 CFE_TBL_NoopCmd(const CFE_TBL_NoopCmd_t *data)
  * Function: CFE_TBL_ResetCountersCmd
  *
  * Application-scope internal function
- * See description in cfe_tbl_task_cmds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCountersCmd_t *data)
@@ -352,7 +352,7 @@ int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCountersCmd_t *data)
  * Function: CFE_TBL_LoadCmd
  *
  * Application-scope internal function
- * See description in cfe_tbl_task_cmds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
@@ -543,7 +543,7 @@ int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
  * Function: CFE_TBL_DumpCmd
  *
  * Application-scope internal function
- * See description in cfe_tbl_task_cmds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data)
@@ -689,7 +689,7 @@ int32 CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data)
  * Function: CFE_TBL_DumpToFile
  *
  * Application-scope internal function
- * See description in cfe_tbl_task_cmds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_TBL_CmdProcRet_t CFE_TBL_DumpToFile(const char *DumpFilename, const char *TableName, const void *DumpDataAddr,
@@ -815,7 +815,7 @@ CFE_TBL_CmdProcRet_t CFE_TBL_DumpToFile(const char *DumpFilename, const char *Ta
  * Function: CFE_TBL_ValidateCmd
  *
  * Application-scope internal function
- * See description in cfe_tbl_task_cmds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data)
@@ -958,7 +958,7 @@ int32 CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data)
  * Function: CFE_TBL_ActivateCmd
  *
  * Application-scope internal function
- * See description in cfe_tbl_task_cmds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_ActivateCmd(const CFE_TBL_ActivateCmd_t *data)
@@ -1038,7 +1038,7 @@ int32 CFE_TBL_ActivateCmd(const CFE_TBL_ActivateCmd_t *data)
  * Function: CFE_TBL_DumpRegistryGetter
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 bool CFE_TBL_DumpRegistryGetter(void *Meta, uint32 RecordNum, void **Buffer, size_t *BufSize)
@@ -1158,7 +1158,7 @@ bool CFE_TBL_DumpRegistryGetter(void *Meta, uint32 RecordNum, void **Buffer, siz
  * Function: CFE_TBL_DumpRegistryEventHandler
  *
  * Application-scope internal function
- * See description in cfe_tbl_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TBL_DumpRegistryEventHandler(void *Meta, CFE_FS_FileWriteEvent_t Event, int32 Status, uint32 RecordNum,
@@ -1222,7 +1222,7 @@ void CFE_TBL_DumpRegistryEventHandler(void *Meta, CFE_FS_FileWriteEvent_t Event,
  * Function: CFE_TBL_DumpRegistryCmd
  *
  * Application-scope internal function
- * See description in cfe_tbl_task_cmds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data)
@@ -1285,7 +1285,7 @@ int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data)
  * Function: CFE_TBL_SendRegistryCmd
  *
  * Application-scope internal function
- * See description in cfe_tbl_task_cmds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data)
@@ -1326,7 +1326,7 @@ int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data)
  * Function: CFE_TBL_DeleteCDSCmd
  *
  * Application-scope internal function
- * See description in cfe_tbl_task_cmds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data)
@@ -1416,7 +1416,7 @@ int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data)
  * Function: CFE_TBL_AbortLoadCmd
  *
  * Application-scope internal function
- * See description in cfe_tbl_task_cmds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_AbortLoadCmd(const CFE_TBL_AbortLoadCmd_t *data)
@@ -1468,7 +1468,7 @@ int32 CFE_TBL_AbortLoadCmd(const CFE_TBL_AbortLoadCmd_t *data)
  * Function: CFE_TBL_AbortLoad
  *
  * Application-scope internal function
- * See description in cfe_tbl_task_cmds.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TBL_AbortLoad(CFE_TBL_RegistryRec_t *RegRecPtr)

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.h
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.h
@@ -88,6 +88,8 @@ typedef struct
 
 /* Command Message Processing Functions */
 /*****************************************************************************/
+
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Gathers data and puts it into the Housekeeping Message format
 **
@@ -98,10 +100,10 @@ typedef struct
 ** \par Assumptions, External Events, and Notes:
 **          None
 **
-******************************************************************************/
+*/
 extern void CFE_TBL_GetHkData(void);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Convert Table Registry Entry for a Table into a Message
 **
@@ -114,10 +116,10 @@ extern void CFE_TBL_GetHkData(void);
 **        #CFE_TBL_Global_t::HkTlmTblRegIndex is assumed to be a valid index into
 **           the Table Registry.
 **
-******************************************************************************/
+*/
 extern void CFE_TBL_GetTblRegData(void);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Process Housekeeping Request Message
 **
@@ -130,10 +132,10 @@ extern void CFE_TBL_GetTblRegData(void);
 ** \param[in] data points to the message received via command pipe that needs processing
 **
 ** \retval #CFE_TBL_DONT_INC_CTR \copydoc CFE_TBL_DONT_INC_CTR
-******************************************************************************/
+*/
 int32 CFE_TBL_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Process NO OP Command Message
 **
@@ -147,10 +149,10 @@ int32 CFE_TBL_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data);
 **
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
-******************************************************************************/
+*/
 int32 CFE_TBL_NoopCmd(const CFE_TBL_NoopCmd_t *data);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Process Reset Counters Command Message
 **
@@ -163,10 +165,10 @@ int32 CFE_TBL_NoopCmd(const CFE_TBL_NoopCmd_t *data);
 ** \param[in] data points to the message received via command pipe that needs processing
 **
 ** \retval #CFE_TBL_DONT_INC_CTR \copydoc CFE_TBL_DONT_INC_CTR
-******************************************************************************/
+*/
 int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCountersCmd_t *data);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Process Load Table Command Message
 **
@@ -181,10 +183,10 @@ int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCountersCmd_t *data);
 **
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
-******************************************************************************/
+*/
 int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Process Dump Table Command Message
 **
@@ -199,10 +201,10 @@ int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data);
 **
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
-******************************************************************************/
+*/
 int32 CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Process Validate Table Command Message
 **
@@ -218,10 +220,10 @@ int32 CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data);
 **
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
-******************************************************************************/
+*/
 int32 CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Process Activate Table Command Message
 **
@@ -236,10 +238,10 @@ int32 CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data);
 **
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
-******************************************************************************/
+*/
 int32 CFE_TBL_ActivateCmd(const CFE_TBL_ActivateCmd_t *data);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Process Dump Table Registry Command Message
 **
@@ -253,10 +255,10 @@ int32 CFE_TBL_ActivateCmd(const CFE_TBL_ActivateCmd_t *data);
 **
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
-******************************************************************************/
+*/
 int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Process Telemeter Table Registry Entry Command Message
 **
@@ -271,10 +273,10 @@ int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data);
 **
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
-******************************************************************************/
+*/
 int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Delete Critical Table's CDS Command message
 **
@@ -288,10 +290,10 @@ int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data);
 **
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
-******************************************************************************/
+*/
 int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Process Abort Load Command message
 **
@@ -305,10 +307,10 @@ int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data);
 **
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
-******************************************************************************/
+*/
 int32 CFE_TBL_AbortLoadCmd(const CFE_TBL_AbortLoadCmd_t *data);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Output block of data to file with standard cFE Table Image Headers
 **
@@ -331,11 +333,11 @@ int32 CFE_TBL_AbortLoadCmd(const CFE_TBL_AbortLoadCmd_t *data);
 **
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
-******************************************************************************/
+*/
 extern CFE_TBL_CmdProcRet_t CFE_TBL_DumpToFile(const char *DumpFilename, const char *TableName,
                                                const void *DumpDataAddr, size_t TblSizeInBytes);
 
-/*****************************************************************************/
+/*---------------------------------------------------------------------------------------*/
 /**
 ** \brief Aborts load by freeing associated inactive buffers and sending event message
 **
@@ -349,7 +351,7 @@ extern CFE_TBL_CmdProcRet_t CFE_TBL_DumpToFile(const char *DumpFilename, const c
 **
 ** \param[in] RegRecPtr   Pointer to registry record entry for the table whose load is to be aborted
 **
-******************************************************************************/
+*/
 void CFE_TBL_AbortLoad(CFE_TBL_RegistryRec_t *RegRecPtr);
 
 #endif /* CFE_TBL_TASK_CMDS_H */

--- a/modules/time/fsw/src/cfe_time_api.c
+++ b/modules/time/fsw/src/cfe_time_api.c
@@ -41,7 +41,7 @@
  * Function: CFE_TIME_GetTime
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_GetTime(void)
@@ -66,7 +66,7 @@ CFE_TIME_SysTime_t CFE_TIME_GetTime(void)
  * Function: CFE_TIME_GetTAI
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_GetTAI(void)
@@ -97,7 +97,7 @@ CFE_TIME_SysTime_t CFE_TIME_GetTAI(void)
  * Function: CFE_TIME_GetUTC
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_GetUTC(void)
@@ -127,7 +127,7 @@ CFE_TIME_SysTime_t CFE_TIME_GetUTC(void)
  * Function: CFE_TIME_MET2SCTime
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_MET2SCTime(CFE_TIME_SysTime_t METTime)
@@ -168,7 +168,7 @@ CFE_TIME_SysTime_t CFE_TIME_MET2SCTime(CFE_TIME_SysTime_t METTime)
  * Function: CFE_TIME_GetClockState
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_TIME_ClockState_Enum_t CFE_TIME_GetClockState(void)
@@ -198,7 +198,7 @@ CFE_TIME_ClockState_Enum_t CFE_TIME_GetClockState(void)
  * Function: CFE_TIME_GetClockInfo
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 uint16 CFE_TIME_GetClockInfo(void)
@@ -292,7 +292,7 @@ uint16 CFE_TIME_GetClockInfo(void)
  * Function: CFE_TIME_GetLeapSeconds
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int16 CFE_TIME_GetLeapSeconds(void)
@@ -317,7 +317,7 @@ int16 CFE_TIME_GetLeapSeconds(void)
  * Function: CFE_TIME_GetSTCF
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_GetSTCF(void)
@@ -342,7 +342,7 @@ CFE_TIME_SysTime_t CFE_TIME_GetSTCF(void)
  * Function: CFE_TIME_GetMET
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_GetMET(void)
@@ -367,7 +367,7 @@ CFE_TIME_SysTime_t CFE_TIME_GetMET(void)
  * Function: CFE_TIME_GetMETseconds
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 uint32 CFE_TIME_GetMETseconds(void)
@@ -392,7 +392,7 @@ uint32 CFE_TIME_GetMETseconds(void)
  * Function: CFE_TIME_GetMETsubsecs
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 uint32 CFE_TIME_GetMETsubsecs(void)
@@ -417,7 +417,7 @@ uint32 CFE_TIME_GetMETsubsecs(void)
  * Function: CFE_TIME_Add
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_Add(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2)
@@ -446,7 +446,7 @@ CFE_TIME_SysTime_t CFE_TIME_Add(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Tim
  * Function: CFE_TIME_Subtract
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_Subtract(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2)
@@ -472,7 +472,7 @@ CFE_TIME_SysTime_t CFE_TIME_Subtract(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_
  * Function: CFE_TIME_Compare
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_TIME_Compare_t CFE_TIME_Compare(CFE_TIME_SysTime_t TimeA, CFE_TIME_SysTime_t TimeB)
@@ -534,7 +534,7 @@ CFE_TIME_Compare_t CFE_TIME_Compare(CFE_TIME_SysTime_t TimeA, CFE_TIME_SysTime_t
  * Function: CFE_TIME_Sub2MicroSecs
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 uint32 CFE_TIME_Sub2MicroSecs(uint32 SubSeconds)
@@ -556,7 +556,7 @@ uint32 CFE_TIME_Sub2MicroSecs(uint32 SubSeconds)
  * Function: CFE_TIME_Micro2SubSecs
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 uint32 CFE_TIME_Micro2SubSecs(uint32 MicroSeconds)
@@ -589,7 +589,7 @@ uint32 CFE_TIME_Micro2SubSecs(uint32 MicroSeconds)
  * Function: CFE_TIME_Print
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_Print(char *PrintBuffer, CFE_TIME_SysTime_t TimeToPrint)
@@ -741,7 +741,7 @@ void CFE_TIME_Print(char *PrintBuffer, CFE_TIME_SysTime_t TimeToPrint)
  * Function: CFE_TIME_ExternalTone
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_ExternalTone(void)
@@ -759,7 +759,7 @@ void CFE_TIME_ExternalTone(void)
  * Function: CFE_TIME_RegisterSynchCallback
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_RegisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPtr)
@@ -801,7 +801,7 @@ int32 CFE_TIME_RegisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPtr
  * Function: CFE_TIME_UnregisterSynchCallback
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_UnregisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPtr)
@@ -843,7 +843,7 @@ int32 CFE_TIME_UnregisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncP
  * Function: CFE_TIME_ExternalMET
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SRC_MET == true)
@@ -863,7 +863,7 @@ void CFE_TIME_ExternalMET(CFE_TIME_SysTime_t NewMET)
  * Function: CFE_TIME_ExternalGPS
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SRC_GPS == true)
@@ -883,7 +883,7 @@ void CFE_TIME_ExternalGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps)
  * Function: CFE_TIME_ExternalTime
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SRC_TIME == true)

--- a/modules/time/fsw/src/cfe_time_api.c
+++ b/modules/time/fsw/src/cfe_time_api.c
@@ -36,9 +36,14 @@
 
 #include <string.h>
 
-/*
- * Function: CFE_TIME_GetTime - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_GetTime
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_GetTime(void)
 {
     CFE_TIME_SysTime_t CurrentTime;
@@ -54,12 +59,16 @@ CFE_TIME_SysTime_t CFE_TIME_GetTime(void)
 #endif
 
     return (CurrentTime);
+}
 
-} /* End of CFE_TIME_GetTime() */
-
-/*
- * Function: CFE_TIME_GetTAI - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_GetTAI
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_GetTAI(void)
 {
     CFE_TIME_Reference_t Reference;
@@ -81,12 +90,16 @@ CFE_TIME_SysTime_t CFE_TIME_GetTAI(void)
     tai = CFE_TIME_CalculateTAI(&Reference);
 
     return (tai);
+}
 
-} /* End of CFE_TIME_GetTAI() */
-
-/*
- * Function: CFE_TIME_GetUTC - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_GetUTC
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_GetUTC(void)
 {
     CFE_TIME_Reference_t Reference;
@@ -107,12 +120,16 @@ CFE_TIME_SysTime_t CFE_TIME_GetUTC(void)
     utc = CFE_TIME_CalculateUTC(&Reference);
 
     return (utc);
+}
 
-} /* End of CFE_TIME_GetUTC() */
-
-/*
- * Function: CFE_TIME_MET2SCTime - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_MET2SCTime
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_MET2SCTime(CFE_TIME_SysTime_t METTime)
 {
 
@@ -144,11 +161,16 @@ CFE_TIME_SysTime_t CFE_TIME_MET2SCTime(CFE_TIME_SysTime_t METTime)
 #endif
 
     return (ReturnTime);
-} /* end CFE_TIME_MET2SCTime() */
+}
 
-/*
- * Function: CFE_TIME_GetClockState - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_GetClockState
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_TIME_ClockState_Enum_t CFE_TIME_GetClockState(void)
 {
     CFE_TIME_Reference_t       Reference;
@@ -169,12 +191,16 @@ CFE_TIME_ClockState_Enum_t CFE_TIME_GetClockState(void)
     state = (CFE_TIME_ClockState_Enum_t)CFE_TIME_CalculateState(&Reference);
 
     return (state);
+}
 
-} /* End of CFE_TIME_GetClockState() */
-
-/*
- * Function: CFE_TIME_GetClockInfo - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_GetClockInfo
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 uint16 CFE_TIME_GetClockInfo(void)
 {
     uint16                              StateFlags = 0;
@@ -259,12 +285,16 @@ uint16 CFE_TIME_GetClockInfo(void)
     }
 
     return (StateFlags);
+}
 
-} /* End of CFE_TIME_GetClockInfo() */
-
-/*
- * Function: CFE_TIME_GetLeapSeconds - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_GetLeapSeconds
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int16 CFE_TIME_GetLeapSeconds(void)
 {
     CFE_TIME_Reference_t Reference;
@@ -280,12 +310,16 @@ int16 CFE_TIME_GetLeapSeconds(void)
     CFE_TIME_GetReference(&Reference);
 
     return (Reference.AtToneLeapSeconds);
+}
 
-} /* End of CFE_TIME_GetLeapSeconds() */
-
-/*
- * Function: CFE_TIME_GetSTCF - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_GetSTCF
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_GetSTCF(void)
 {
     CFE_TIME_Reference_t Reference;
@@ -301,12 +335,16 @@ CFE_TIME_SysTime_t CFE_TIME_GetSTCF(void)
     CFE_TIME_GetReference(&Reference);
 
     return (Reference.AtToneSTCF);
+}
 
-} /* End of CFE_TIME_GetSTCF() */
-
-/*
- * Function: CFE_TIME_GetMET - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_GetMET
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_GetMET(void)
 {
     CFE_TIME_Reference_t Reference;
@@ -322,12 +360,16 @@ CFE_TIME_SysTime_t CFE_TIME_GetMET(void)
     CFE_TIME_GetReference(&Reference);
 
     return (Reference.CurrentMET);
+}
 
-} /* End of CFE_TIME_GetMET() */
-
-/*
- * Function: CFE_TIME_GetMETseconds - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_GetMETseconds
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 uint32 CFE_TIME_GetMETseconds(void)
 {
     CFE_TIME_Reference_t Reference;
@@ -343,12 +385,16 @@ uint32 CFE_TIME_GetMETseconds(void)
     CFE_TIME_GetReference(&Reference);
 
     return (Reference.CurrentMET.Seconds);
+}
 
-} /* End of CFE_TIME_GetMETseconds() */
-
-/*
- * Function: CFE_TIME_GetMETsubsecs - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_GetMETsubsecs
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 uint32 CFE_TIME_GetMETsubsecs(void)
 {
     CFE_TIME_Reference_t Reference;
@@ -364,12 +410,16 @@ uint32 CFE_TIME_GetMETsubsecs(void)
     CFE_TIME_GetReference(&Reference);
 
     return (Reference.CurrentMET.Subseconds);
+}
 
-} /* End of CFE_TIME_GetMETsubsecs() */
-
-/*
- * Function: CFE_TIME_Add - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_Add
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_Add(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2)
 {
     CFE_TIME_SysTime_t Result;
@@ -389,12 +439,16 @@ CFE_TIME_SysTime_t CFE_TIME_Add(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Tim
     }
 
     return (Result);
+}
 
-} /* End of CFE_TIME_Add() */
-
-/*
- * Function: CFE_TIME_Subtract - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_Subtract
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_Subtract(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2)
 {
     CFE_TIME_SysTime_t Result;
@@ -411,12 +465,16 @@ CFE_TIME_SysTime_t CFE_TIME_Subtract(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_
     }
 
     return (Result);
+}
 
-} /* End of CFE_TIME_Subtract() */
-
-/*
- * Function: CFE_TIME_Compare - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_Compare
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_TIME_Compare_t CFE_TIME_Compare(CFE_TIME_SysTime_t TimeA, CFE_TIME_SysTime_t TimeB)
 {
     CFE_TIME_Compare_t Result;
@@ -469,12 +527,16 @@ CFE_TIME_Compare_t CFE_TIME_Compare(CFE_TIME_SysTime_t TimeA, CFE_TIME_SysTime_t
     }
 
     return (Result);
+}
 
-} /* End of CFE_TIME_Compare() */
-
-/*
- * Function: CFE_TIME_Sub2MicroSecs - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_Sub2MicroSecs
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 uint32 CFE_TIME_Sub2MicroSecs(uint32 SubSeconds)
 {
     OS_time_t tm;
@@ -487,12 +549,16 @@ uint32 CFE_TIME_Sub2MicroSecs(uint32 SubSeconds)
     tm = OS_TimeAssembleFromSubseconds(0, SubSeconds);
 
     return OS_TimeGetMicrosecondsPart(tm);
+}
 
-} /* End of CFE_TIME_Sub2MicroSecs() */
-
-/*
- * Function: CFE_TIME_Micro2SubSecs - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_Micro2SubSecs
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 uint32 CFE_TIME_Micro2SubSecs(uint32 MicroSeconds)
 {
     OS_time_t tm;
@@ -516,12 +582,16 @@ uint32 CFE_TIME_Micro2SubSecs(uint32 MicroSeconds)
     }
 
     return (SubSeconds);
+}
 
-} /* End of CFE_TIME_Micro2SubSecs() */
-
-/*
- * Function: CFE_TIME_Print - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_Print
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_Print(char *PrintBuffer, CFE_TIME_SysTime_t TimeToPrint)
 {
     uint32 NumberOfYears;
@@ -664,12 +734,16 @@ void CFE_TIME_Print(char *PrintBuffer, CFE_TIME_SysTime_t TimeToPrint)
     *PrintBuffer++ = '\0';
 
     return;
+}
 
-} /* End of CFE_TIME_Print() */
-
-/*
- * Function: CFE_TIME_ExternalTone - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_ExternalTone
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_ExternalTone(void)
 {
     /*
@@ -678,12 +752,16 @@ void CFE_TIME_ExternalTone(void)
     CFE_TIME_Tone1HzISR();
 
     return;
+}
 
-} /* End of CFE_TIME_ExternalTone() */
-
-/*
- * Function: CFE_TIME_RegisterSynchCallback - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_RegisterSynchCallback
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_RegisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPtr)
 {
     int32          Status;
@@ -716,11 +794,16 @@ int32 CFE_TIME_RegisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPtr
     }
 
     return Status;
-} /* End of CFE_TIME_RegisterSynchCallback() */
+}
 
-/*
- * Function: CFE_TIME_UnregisterSynchCallback - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_UnregisterSynchCallback
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_UnregisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPtr)
 {
     int32          Status;
@@ -753,11 +836,16 @@ int32 CFE_TIME_UnregisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncP
     }
 
     return Status;
-} /* End of CFE_TIME_UnregisterSynchCallback() */
+}
 
-/*
- * Function: CFE_TIME_ExternalMET - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_ExternalMET
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SRC_MET == true)
 void CFE_TIME_ExternalMET(CFE_TIME_SysTime_t NewMET)
 {
@@ -767,13 +855,17 @@ void CFE_TIME_ExternalMET(CFE_TIME_SysTime_t NewMET)
     CFE_TIME_ToneSendMET(NewMET);
 
     return;
-
-} /* End of CFE_TIME_ExternalMET() */
+}
 #endif /* CFE_PLATFORM_TIME_CFG_SRC_MET  */
 
-/*
- * Function: CFE_TIME_ExternalGPS - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_ExternalGPS
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SRC_GPS == true)
 void CFE_TIME_ExternalGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps)
 {
@@ -783,13 +875,17 @@ void CFE_TIME_ExternalGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps)
     CFE_TIME_ToneSendGPS(NewTime, NewLeaps);
 
     return;
-
-} /* End of CFE_TIME_ExternalGPS() */
+}
 #endif /* CFE_PLATFORM_TIME_CFG_SRC_GPS */
 
-/*
- * Function: CFE_TIME_ExternalTime - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_ExternalTime
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SRC_TIME == true)
 void CFE_TIME_ExternalTime(CFE_TIME_SysTime_t NewTime)
 {
@@ -799,10 +895,5 @@ void CFE_TIME_ExternalTime(CFE_TIME_SysTime_t NewTime)
     CFE_TIME_ToneSendTime(NewTime);
 
     return;
-
-} /* End of CFE_TIME_ExternalTime() */
+}
 #endif /* CFE_PLATFORM_TIME_CFG_SRC_TIME */
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/modules/time/fsw/src/cfe_time_task.c
+++ b/modules/time/fsw/src/cfe_time_task.c
@@ -45,7 +45,7 @@ CFE_TIME_Global_t CFE_TIME_Global;
  * Function: CFE_TIME_EarlyInit
  *
  * Implemented per public API
- * See description in cfe_time_core_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_EarlyInit(void)
@@ -63,7 +63,7 @@ int32 CFE_TIME_EarlyInit(void)
  * Function: CFE_TIME_TaskMain
  *
  * Implemented per public API
- * See description in cfe_time_core_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_TaskMain(void)
@@ -126,7 +126,7 @@ void CFE_TIME_TaskMain(void)
  * Function: CFE_TIME_TaskInit
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_TaskInit(void)
@@ -349,7 +349,7 @@ bool CFE_TIME_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
  * Function: CFE_TIME_TaskPipe
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
@@ -554,7 +554,7 @@ void CFE_TIME_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
  * Function: CFE_TIME_HousekeepingCmd
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
@@ -594,7 +594,7 @@ int32 CFE_TIME_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
  * Function: CFE_TIME_ToneSignalCmd
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_ToneSignalCmd(const CFE_TIME_ToneSignalCmd_t *data)
@@ -616,7 +616,7 @@ int32 CFE_TIME_ToneSignalCmd(const CFE_TIME_ToneSignalCmd_t *data)
  * Function: CFE_TIME_ToneDataCmd
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_ToneDataCmd(const CFE_TIME_ToneDataCmd_t *data)
@@ -638,7 +638,7 @@ int32 CFE_TIME_ToneDataCmd(const CFE_TIME_ToneDataCmd_t *data)
  * Function: CFE_TIME_OneHzCmd
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_OneHzCmd(const CFE_TIME_1HzCmd_t *data)
@@ -670,7 +670,7 @@ int32 CFE_TIME_OneHzCmd(const CFE_TIME_1HzCmd_t *data)
  * Function: CFE_TIME_ToneSendCmd
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
@@ -694,7 +694,7 @@ int32 CFE_TIME_ToneSendCmd(const CFE_TIME_FakeToneCmd_t *data)
  * Function: CFE_TIME_NoopCmd
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_NoopCmd(const CFE_TIME_NoopCmd_t *data)
@@ -712,7 +712,7 @@ int32 CFE_TIME_NoopCmd(const CFE_TIME_NoopCmd_t *data)
  * Function: CFE_TIME_ResetCountersCmd
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_ResetCountersCmd(const CFE_TIME_ResetCountersCmd_t *data)
@@ -753,7 +753,7 @@ int32 CFE_TIME_ResetCountersCmd(const CFE_TIME_ResetCountersCmd_t *data)
  * Function: CFE_TIME_SendDiagnosticTlm
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_SendDiagnosticTlm(const CFE_TIME_SendDiagnosticCmd_t *data)
@@ -781,7 +781,7 @@ int32 CFE_TIME_SendDiagnosticTlm(const CFE_TIME_SendDiagnosticCmd_t *data)
  * Function: CFE_TIME_SetStateCmd
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_SetStateCmd(const CFE_TIME_SetStateCmd_t *data)
@@ -832,7 +832,7 @@ int32 CFE_TIME_SetStateCmd(const CFE_TIME_SetStateCmd_t *data)
  * Function: CFE_TIME_SetSourceCmd
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_SetSourceCmd(const CFE_TIME_SetSourceCmd_t *data)
@@ -901,7 +901,7 @@ int32 CFE_TIME_SetSourceCmd(const CFE_TIME_SetSourceCmd_t *data)
  * Function: CFE_TIME_SetSignalCmd
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_SetSignalCmd(const CFE_TIME_SetSignalCmd_t *data)
@@ -970,7 +970,7 @@ int32 CFE_TIME_SetSignalCmd(const CFE_TIME_SetSignalCmd_t *data)
  * Function: CFE_TIME_SetDelayImpl
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_SetDelayImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_AdjustDirection_Enum_t Direction)
@@ -1020,7 +1020,7 @@ void CFE_TIME_SetDelayImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIM
  * Function: CFE_TIME_AddDelayCmd
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_AddDelayCmd(const CFE_TIME_AddDelayCmd_t *data)
@@ -1034,7 +1034,7 @@ int32 CFE_TIME_AddDelayCmd(const CFE_TIME_AddDelayCmd_t *data)
  * Function: CFE_TIME_SubDelayCmd
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_SubDelayCmd(const CFE_TIME_SubDelayCmd_t *data)
@@ -1048,7 +1048,7 @@ int32 CFE_TIME_SubDelayCmd(const CFE_TIME_SubDelayCmd_t *data)
  * Function: CFE_TIME_SetTimeCmd
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data)
@@ -1101,7 +1101,7 @@ int32 CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data)
  * Function: CFE_TIME_SetMETCmd
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_SetMETCmd(const CFE_TIME_SetMETCmd_t *data)
@@ -1154,7 +1154,7 @@ int32 CFE_TIME_SetMETCmd(const CFE_TIME_SetMETCmd_t *data)
  * Function: CFE_TIME_SetSTCFCmd
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_SetSTCFCmd(const CFE_TIME_SetSTCFCmd_t *data)
@@ -1207,7 +1207,7 @@ int32 CFE_TIME_SetSTCFCmd(const CFE_TIME_SetSTCFCmd_t *data)
  * Function: CFE_TIME_SetLeapSecondsCmd
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_SetLeapSecondsCmd(const CFE_TIME_SetLeapSecondsCmd_t *data)
@@ -1245,7 +1245,7 @@ int32 CFE_TIME_SetLeapSecondsCmd(const CFE_TIME_SetLeapSecondsCmd_t *data)
  * Function: CFE_TIME_AdjustImpl
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_AdjustImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_AdjustDirection_Enum_t Direction)
@@ -1295,7 +1295,7 @@ void CFE_TIME_AdjustImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_
  * Function: CFE_TIME_AddAdjustCmd
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_AddAdjustCmd(const CFE_TIME_AddAdjustCmd_t *data)
@@ -1309,7 +1309,7 @@ int32 CFE_TIME_AddAdjustCmd(const CFE_TIME_AddAdjustCmd_t *data)
  * Function: CFE_TIME_SubAdjustCmd
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_SubAdjustCmd(const CFE_TIME_SubAdjustCmd_t *data)
@@ -1323,7 +1323,7 @@ int32 CFE_TIME_SubAdjustCmd(const CFE_TIME_SubAdjustCmd_t *data)
  * Function: CFE_TIME_1HzAdjImpl
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_1HzAdjImpl(const CFE_TIME_OneHzAdjustmentCmd_Payload_t *CommandPtr,
@@ -1362,7 +1362,7 @@ void CFE_TIME_1HzAdjImpl(const CFE_TIME_OneHzAdjustmentCmd_Payload_t *CommandPtr
  * Function: CFE_TIME_Add1HZAdjustmentCmd
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_Add1HZAdjustmentCmd(const CFE_TIME_Add1HZAdjustmentCmd_t *data)
@@ -1376,7 +1376,7 @@ int32 CFE_TIME_Add1HZAdjustmentCmd(const CFE_TIME_Add1HZAdjustmentCmd_t *data)
  * Function: CFE_TIME_Sub1HZAdjustmentCmd
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_Sub1HZAdjustmentCmd(const CFE_TIME_Sub1HZAdjustmentCmd_t *data)

--- a/modules/time/fsw/src/cfe_time_task.c
+++ b/modules/time/fsw/src/cfe_time_task.c
@@ -40,79 +40,14 @@
 */
 CFE_TIME_Global_t CFE_TIME_Global;
 
-/*
-** Command handler for "HK request"...
-*/
-int32 CFE_TIME_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data);
-
-/*
-** Command handler for "tone signal detected"...
-*/
-int32 CFE_TIME_ToneSignalCmd(const CFE_TIME_ToneSignalCmd_t *data);
-
-/*
-** Command handler for "time at the tone"...
-*/
-int32 CFE_TIME_ToneDataCmd(const CFE_TIME_ToneDataCmd_t *data);
-
-/*
-** Command handler for 1Hz signal...
-*/
-int32 CFE_TIME_OneHzCmd(const CFE_TIME_1HzCmd_t *data);
-
-/*
-** Command handler for "request time at the tone"...
-**
-** Note: This command (sent by the scheduler) is used to
-**       signal that now is the right time (in relation
-**       to the "real" tone signal) for a Time Server to
-**       send the "time at the tone" data packet.  We do
-**       not need (or want) this command if we are not a
-**       Time Server.
-**
-**       In "fake tone" mode this command is locally generated
-**       however it is still sent via the software bus, thereby
-**       utilizing (mostly) the same code path as the
-**       non-fake tone mode.
-*/
-#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
-int32 CFE_TIME_ToneSendCmd(const CFE_TIME_FakeToneCmd_t *data);
-#endif
-
-/*
- * Ground command helper functions
- */
-void CFE_TIME_SetDelayImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_AdjustDirection_Enum_t Direction);
-void CFE_TIME_1HzAdjImpl(const CFE_TIME_OneHzAdjustmentCmd_Payload_t *CommandPtr,
-                         CFE_TIME_AdjustDirection_Enum_t              Direction);
-void CFE_TIME_AdjustImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_AdjustDirection_Enum_t Direction);
-
-/*
-** Ground command handlers...
-*/
-int32 CFE_TIME_Add1HZAdjustmentCmd(const CFE_TIME_Add1HZAdjustmentCmd_t *data);
-int32 CFE_TIME_AddAdjustCmd(const CFE_TIME_AddAdjustCmd_t *data);
-int32 CFE_TIME_AddDelayCmd(const CFE_TIME_AddDelayCmd_t *data);
-int32 CFE_TIME_SendDiagnosticTlm(const CFE_TIME_SendDiagnosticCmd_t *data);
-int32 CFE_TIME_NoopCmd(const CFE_TIME_NoopCmd_t *data);
-int32 CFE_TIME_ResetCountersCmd(const CFE_TIME_ResetCountersCmd_t *data);
-int32 CFE_TIME_SetLeapSecondsCmd(const CFE_TIME_SetLeapSecondsCmd_t *data);
-int32 CFE_TIME_SetMETCmd(const CFE_TIME_SetMETCmd_t *data);
-int32 CFE_TIME_SetSignalCmd(const CFE_TIME_SetSignalCmd_t *data);
-int32 CFE_TIME_SetSourceCmd(const CFE_TIME_SetSourceCmd_t *data);
-int32 CFE_TIME_SetStateCmd(const CFE_TIME_SetStateCmd_t *data);
-int32 CFE_TIME_SetSTCFCmd(const CFE_TIME_SetSTCFCmd_t *data);
-int32 CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data);
-int32 CFE_TIME_Sub1HZAdjustmentCmd(const CFE_TIME_Sub1HZAdjustmentCmd_t *data);
-int32 CFE_TIME_SubAdjustCmd(const CFE_TIME_SubAdjustCmd_t *data);
-int32 CFE_TIME_SubDelayCmd(const CFE_TIME_SubDelayCmd_t *data);
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_EarlyInit() -- API initialization before any tasks     */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_EarlyInit
+ *
+ * Implemented per public API
+ * See description in cfe_time_core_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_EarlyInit(void)
 {
     /*
@@ -121,15 +56,16 @@ int32 CFE_TIME_EarlyInit(void)
     CFE_TIME_InitData();
 
     return (CFE_SUCCESS);
+}
 
-} /* End of CFE_TIME_EarlyInit() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_TaskMain() -- Task entry point and main process loop   */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_TaskMain
+ *
+ * Implemented per public API
+ * See description in cfe_time_core_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_TaskMain(void)
 {
     int32            Status;
@@ -183,15 +119,16 @@ void CFE_TIME_TaskMain(void)
 
     /* while loop exits only if CFE_SB_ReceiveBuffer returns error */
     CFE_ES_ExitApp(CFE_ES_RunStatus_CORE_APP_RUNTIME_ERROR);
+}
 
-} /* end CFE_TIME_TaskMain */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_TaskInit() -- Time task initialization                 */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_TaskInit
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_TaskInit(void)
 {
     int32     Status;
@@ -368,21 +305,17 @@ int32 CFE_TIME_TaskInit(void)
     }
 
     return CFE_SUCCESS;
+}
 
-} /* End of CFE_TIME_TaskInit() */
-
-/******************************************************************************
-**  Function:  CFE_TIME_VerifyCmdLength()
-**
-**  Purpose:
-**    Function to verify the length of incoming TIME command packets
-**
-**  Arguments:
-**    Message pointer and expected length
-**
-**  Return:
-**    true if length is acceptable
-*/
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_VerifyCmdLength
+ *
+ * Internal helper routine only, not part of API.
+ *
+ * Function to verify the length of incoming TIME command packets
+ *
+ *-----------------------------------------------------------------*/
 bool CFE_TIME_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
 {
     bool              result       = true;
@@ -409,15 +342,16 @@ bool CFE_TIME_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
     }
 
     return (result);
+}
 
-} /* End of CFE_TIME_VerifyCmdLength() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_TaskPipe() -- Process command pipe message             */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_TaskPipe
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
 {
     CFE_SB_MsgId_t    MessageID   = CFE_SB_INVALID_MSG_ID;
@@ -613,15 +547,16 @@ void CFE_TIME_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
     } /* switch (message ID) */
 
     return;
+}
 
-} /* End of CFE_TIME_TaskPipe() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_HousekeepingCmd() -- On-board command (HK request)     */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_HousekeepingCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
 {
     CFE_TIME_Reference_t Reference;
@@ -652,15 +587,16 @@ int32 CFE_TIME_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
     **   processing CFE_TIME_CMD_MID commands...
     */
     return CFE_SUCCESS;
+}
 
-} /* End of CFE_TIME_HousekeepingCmd() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_ToneSignalCmd() -- Time at tone command (signal)       */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_ToneSignalCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_ToneSignalCmd(const CFE_TIME_ToneSignalCmd_t *data)
 {
     /*
@@ -673,15 +609,16 @@ int32 CFE_TIME_ToneSignalCmd(const CFE_TIME_ToneSignalCmd_t *data)
     **   processing CFE_TIME_CMD_MID commands...
     */
     return CFE_SUCCESS;
+}
 
-} /* End of CFE_TIME_ToneSignalCmd() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_ToneDataCmd() -- Time at tone command (data)           */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_ToneDataCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_ToneDataCmd(const CFE_TIME_ToneDataCmd_t *data)
 {
     /*
@@ -694,20 +631,16 @@ int32 CFE_TIME_ToneDataCmd(const CFE_TIME_ToneDataCmd_t *data)
     **   processing CFE_TIME_CMD_MID commands...
     */
     return CFE_SUCCESS;
+}
 
-} /* End of CFE_TIME_ToneDataCmd() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
+/*----------------------------------------------------------------
  *
- * CFE_TIME_OneHzCmd() -- Execute state machine tasks required at 1Hz
+ * Function: CFE_TIME_OneHzCmd
  *
- * Service the "1Hz" notification message, and perform any state machine
- * tasks that are intended to be executed at local 1Hz intervals.
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
  *
- * This also implements the "fake tone" functionality when that is enabled,
- * as we do not need a separate MID for this job.
- *
- * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_OneHzCmd(const CFE_TIME_1HzCmd_t *data)
 {
     /*
@@ -730,15 +663,16 @@ int32 CFE_TIME_OneHzCmd(const CFE_TIME_1HzCmd_t *data)
     **   processing CFE_TIME_CMD_MID commands...
     */
     return CFE_SUCCESS;
+}
 
-} /* End of CFE_TIME_OneHzCmd() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_ToneSendCmd() -- Time at tone command (send data)      */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_ToneSendCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
 int32 CFE_TIME_ToneSendCmd(const CFE_TIME_FakeToneCmd_t *data)
 {
@@ -752,16 +686,17 @@ int32 CFE_TIME_ToneSendCmd(const CFE_TIME_FakeToneCmd_t *data)
     **   processing CFE_TIME_CMD_MID commands...
     */
     return CFE_SUCCESS;
-
-} /* End of CFE_TIME_SendCmd() */
+}
 #endif /* CFE_PLATFORM_TIME_CFG_SERVER */
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_NoopCmd() -- Time task ground command (NO-OP)          */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_NoopCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_NoopCmd(const CFE_TIME_NoopCmd_t *data)
 {
 
@@ -770,15 +705,16 @@ int32 CFE_TIME_NoopCmd(const CFE_TIME_NoopCmd_t *data)
     CFE_EVS_SendEvent(CFE_TIME_NOOP_EID, CFE_EVS_EventType_INFORMATION, "No-op command.%s", CFE_VERSION_STRING);
 
     return CFE_SUCCESS;
+}
 
-} /* End of CFE_TIME_NoopCmd() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                         */
-/* CFE_TIME_ResetCountersCmd() -- Time task ground command (reset counters)*/
-/*                                                                         */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_ResetCountersCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_ResetCountersCmd(const CFE_TIME_ResetCountersCmd_t *data)
 {
 
@@ -810,15 +746,16 @@ int32 CFE_TIME_ResetCountersCmd(const CFE_TIME_ResetCountersCmd_t *data)
     CFE_EVS_SendEvent(CFE_TIME_RESET_EID, CFE_EVS_EventType_DEBUG, "Reset Counters command");
 
     return CFE_SUCCESS;
+}
 
-} /* End of CFE_TIME_ResetCountersCmd() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_DiagCmd() -- Time task ground command (diagnostics)    */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_SendDiagnosticTlm
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_SendDiagnosticTlm(const CFE_TIME_SendDiagnosticCmd_t *data)
 {
     CFE_TIME_Global.CommandCounter++;
@@ -837,15 +774,16 @@ int32 CFE_TIME_SendDiagnosticTlm(const CFE_TIME_SendDiagnosticCmd_t *data)
     CFE_EVS_SendEvent(CFE_TIME_DIAG_EID, CFE_EVS_EventType_DEBUG, "Request diagnostics command");
 
     return CFE_SUCCESS;
+}
 
-} /* End of CFE_TIME_DiagCmd() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_SetStateCmd() -- Time task command (set clock state)   */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_SetStateCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_SetStateCmd(const CFE_TIME_SetStateCmd_t *data)
 {
     const CFE_TIME_StateCmd_Payload_t *CommandPtr = &data->Payload;
@@ -887,15 +825,16 @@ int32 CFE_TIME_SetStateCmd(const CFE_TIME_SetStateCmd_t *data)
     }
 
     return CFE_SUCCESS;
+}
 
-} /* End of CFE_TIME_SetStateCmd() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_SetSourceCmd() -- Time task command (set time source)  */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_SetSourceCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_SetSourceCmd(const CFE_TIME_SetSourceCmd_t *data)
 {
     const CFE_TIME_SourceCmd_Payload_t *CommandPtr = &data->Payload;
@@ -955,14 +894,16 @@ int32 CFE_TIME_SetSourceCmd(const CFE_TIME_SetSourceCmd_t *data)
     }
 
     return CFE_SUCCESS;
+}
 
-} /* End of CFE_TIME_SetSourceCmd() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_SetSignalCmd() -- Time task command (set tone source)  */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_SetSignalCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_SetSignalCmd(const CFE_TIME_SetSignalCmd_t *data)
 {
     const CFE_TIME_SignalCmd_Payload_t *CommandPtr = &data->Payload;
@@ -1022,15 +963,16 @@ int32 CFE_TIME_SetSignalCmd(const CFE_TIME_SetSignalCmd_t *data)
     }
 
     return CFE_SUCCESS;
+}
 
-} /* End of CFE_TIME_SetSignalCmd() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_SetDelayImpl() -- Time task ground command (tone delay)*/
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_SetDelayImpl
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_SetDelayImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_AdjustDirection_Enum_t Direction)
 {
     /*
@@ -1071,33 +1013,44 @@ void CFE_TIME_SetDelayImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIM
                           "Invalid Tone Delay -- secs = %u, usecs = %u", (unsigned int)CommandPtr->Seconds,
                           (unsigned int)CommandPtr->MicroSeconds);
     }
+}
 
-} /* End of CFE_TIME_SetDelayImpl() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                     */
-/* CFE_TIME_AddSubDelayCmd() -- Time task ground command (tone delay)  */
-/*                                                                     */
-/* Wrapper around CFE_TIME_SetDelayImpl() for add/subtract operations  */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_AddDelayCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_AddDelayCmd(const CFE_TIME_AddDelayCmd_t *data)
 {
     CFE_TIME_SetDelayImpl(&data->Payload, CFE_TIME_AdjustDirection_ADD);
     return CFE_SUCCESS;
 }
+
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_SubDelayCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_SubDelayCmd(const CFE_TIME_SubDelayCmd_t *data)
 {
     CFE_TIME_SetDelayImpl(&data->Payload, CFE_TIME_AdjustDirection_SUBTRACT);
     return CFE_SUCCESS;
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_SetTimeCmd() -- Time task ground command (calc STCF)   */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_SetTimeCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data)
 {
     const CFE_TIME_TimeCmd_Payload_t *CommandPtr = &data->Payload;
@@ -1141,20 +1094,16 @@ int32 CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data)
     }
 
     return CFE_SUCCESS;
+}
 
-} /* End of CFE_TIME_SetTimeCmd() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_SetMETCmd() -- Time task ground command (set MET)      */
-/*                                                                 */
-/* Note: This command will not have lasting effect if configured   */
-/*       to get external time of type MET.  Also, there cannot     */
-/*       be a local h/w MET and an external MET since both would   */
-/*       need to be synchronized to the same tone signal.          */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_SetMETCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_SetMETCmd(const CFE_TIME_SetMETCmd_t *data)
 {
     const CFE_TIME_TimeCmd_Payload_t *CommandPtr = &data->Payload;
@@ -1198,15 +1147,16 @@ int32 CFE_TIME_SetMETCmd(const CFE_TIME_SetMETCmd_t *data)
     }
 
     return CFE_SUCCESS;
+}
 
-} /* End of CFE_TIME_SetMETCmd() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_SetSTCFCmd() -- Time task ground command (set STCF)    */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_SetSTCFCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_SetSTCFCmd(const CFE_TIME_SetSTCFCmd_t *data)
 {
     const CFE_TIME_TimeCmd_Payload_t *CommandPtr = &data->Payload;
@@ -1250,15 +1200,16 @@ int32 CFE_TIME_SetSTCFCmd(const CFE_TIME_SetSTCFCmd_t *data)
     }
 
     return CFE_SUCCESS;
+}
 
-} /* End of CFE_TIME_SetSTCFCmd() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                       */
-/* CFE_TIME_SetLeapSecondsCmd() -- Time task ground command (set leaps)  */
-/*                                                                       */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_SetLeapSecondsCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_SetLeapSecondsCmd(const CFE_TIME_SetLeapSecondsCmd_t *data)
 {
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
@@ -1287,15 +1238,16 @@ int32 CFE_TIME_SetLeapSecondsCmd(const CFE_TIME_SetLeapSecondsCmd_t *data)
 #endif /* CFE_PLATFORM_TIME_CFG_SERVER */
 
     return CFE_SUCCESS;
+}
 
-} /* End of CFE_TIME_SetLeapSecondsCmd() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_AdjustImpl() -- Time task ground command (adjust STCF) */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_AdjustImpl
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_AdjustImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_AdjustDirection_Enum_t Direction)
 {
     /*
@@ -1336,43 +1288,44 @@ void CFE_TIME_AdjustImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_
                           "Invalid STCF Adjust -- secs = %u, usecs = %u, dir[1=Pos, 2=Neg] = %d",
                           (unsigned int)CommandPtr->Seconds, (unsigned int)CommandPtr->MicroSeconds, (int)Direction);
     }
+}
 
-} /* End of CFE_TIME_AdjustImpl() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                     */
-/* CFE_TIME_AddAdjustCmd() -- Time task ground command (1Hz adjust)    */
-/*                                                                     */
-/* This is a wrapper around CFE_TIME_AdjustImpl()                      */
-/*                                                                     */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_AddAdjustCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_AddAdjustCmd(const CFE_TIME_AddAdjustCmd_t *data)
 {
     CFE_TIME_AdjustImpl(&data->Payload, CFE_TIME_AdjustDirection_ADD);
     return CFE_SUCCESS;
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                     */
-/* CFE_TIME_SubAdjustCmd() -- Time task ground command (1Hz adjust)    */
-/*                                                                     */
-/* This is a wrapper around CFE_TIME_AdjustImpl()                      */
-/*                                                                     */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_SubAdjustCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_SubAdjustCmd(const CFE_TIME_SubAdjustCmd_t *data)
 {
     CFE_TIME_AdjustImpl(&data->Payload, CFE_TIME_AdjustDirection_SUBTRACT);
     return CFE_SUCCESS;
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_1HzAdjImpl() -- Time task ground command (1Hz adjust)  */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_1HzAdjImpl
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_1HzAdjImpl(const CFE_TIME_OneHzAdjustmentCmd_Payload_t *CommandPtr,
                          CFE_TIME_AdjustDirection_Enum_t              Direction)
 {
@@ -1402,37 +1355,32 @@ void CFE_TIME_1HzAdjImpl(const CFE_TIME_OneHzAdjustmentCmd_Payload_t *CommandPtr
                       "1Hz Adjust commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to TRUE");
 
 #endif /* CFE_PLATFORM_TIME_CFG_SERVER */
+}
 
-} /* End of CFE_TIME_1HzAdjImpl() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                         */
-/* CFE_TIME_Add1HZAdjustmentCmd() -- Time task ground command (1Hz adjust) */
-/*                                                                         */
-/* This is a wrapper around CFE_TIME_1HzAdjImpl()                          */
-/*                                                                         */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_Add1HZAdjustmentCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_Add1HZAdjustmentCmd(const CFE_TIME_Add1HZAdjustmentCmd_t *data)
 {
     CFE_TIME_1HzAdjImpl(&data->Payload, CFE_TIME_AdjustDirection_ADD);
     return CFE_SUCCESS;
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                         */
-/* CFE_TIME_Sub1HZAdjustmentCmd() -- Time task ground command (1Hz adjust) */
-/*                                                                         */
-/* This is a wrapper around CFE_TIME_1HzAdjImpl()                          */
-/*                                                                         */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_Sub1HZAdjustmentCmd
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_Sub1HZAdjustmentCmd(const CFE_TIME_Sub1HZAdjustmentCmd_t *data)
 {
     CFE_TIME_1HzAdjImpl(&data->Payload, CFE_TIME_AdjustDirection_SUBTRACT);
     return CFE_SUCCESS;
 }
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/modules/time/fsw/src/cfe_time_tone.c
+++ b/modules/time/fsw/src/cfe_time_tone.c
@@ -43,17 +43,14 @@
 
 #include <string.h>
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_ToneSend() -- Send "time at the tone" (local time)     */
-/*                                                                 */
-/* There is a presumption that this function will be called at     */
-/*    the appropriate time (relative to the tone) such that the    */
-/*    "time at the tone" data command will arrive within the       */
-/*    specified window for tone and data packet verification.      */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_ToneSend
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
 void CFE_TIME_ToneSend(void)
 {
@@ -165,21 +162,17 @@ void CFE_TIME_ToneSend(void)
     CFE_TIME_Global.InternalCount++;
 
     return;
-
-} /* End of CFE_TIME_ToneSend() */
+}
 #endif /* CFE_PLATFORM_TIME_CFG_SERVER */
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_ToneSendMET() -- Send "time at tone" (external MET)    */
-/*                                                                 */
-/* There is a presumption that this function will be called at     */
-/*    the appropriate time (relative to the tone) such that the    */
-/*    "time at the tone" data command will arrive within the       */
-/*    specified window for tone and data packet verification.      */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_ToneSendMET
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SRC_MET == true)
 int32 CFE_TIME_ToneSendMET(CFE_TIME_SysTime_t NewMET)
 {
@@ -302,21 +295,17 @@ int32 CFE_TIME_ToneSendMET(CFE_TIME_SysTime_t NewMET)
     /* Exit performance monitoring */
     CFE_ES_PerfLogExit(CFE_MISSION_TIME_SENDMET_PERF_ID);
     return (Result);
-
-} /* End of CFE_TIME_ToneSendMET() */
+}
 #endif /* CFE_PLATFORM_TIME_CFG_SRC_MET */
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_ToneSendGPS() -- Send "time at tone" (external GPS)    */
-/*                                                                 */
-/* There is a presumption that this function will be called at     */
-/*    the appropriate time (relative to the tone) such that the    */
-/*    "time at the tone" data command will arrive within the       */
-/*    specified window for tone and data packet verification.      */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_ToneSendGPS
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SRC_GPS == true)
 int32 CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps)
 {
@@ -446,21 +435,17 @@ int32 CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps)
     }
 
     return (Result);
-
-} /* End of CFE_TIME_ToneSendGPS() */
+}
 #endif /* CFE_PLATFORM_TIME_CFG_SRC_GPS */
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_ToneSendTime() -- Send "time at tone" (external time)  */
-/*                                                                 */
-/* There is a presumption that this function will be called at     */
-/*    the appropriate time (relative to the tone) such that the    */
-/*    "time at the tone" data command will arrive within the       */
-/*    specified window for tone and data packet verification.      */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_ToneSendTime
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SRC_TIME == true)
 int32 CFE_TIME_ToneSendTime(CFE_TIME_SysTime_t NewTime)
 {
@@ -592,16 +577,17 @@ int32 CFE_TIME_ToneSendTime(CFE_TIME_SysTime_t NewTime)
     }
 
     return (Result);
-
-} /* End of CFE_TIME_ToneSendTime() */
+}
 #endif /* CFE_PLATFORM_TIME_CFG_SRC_TIME */
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_ToneData() -- process "time at tone" data packet       */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_ToneData
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_ToneData(const CFE_TIME_ToneDataCmd_Payload_t *ToneDataCmd)
 {
     /*
@@ -664,30 +650,16 @@ void CFE_TIME_ToneData(const CFE_TIME_ToneDataCmd_Payload_t *ToneDataCmd)
     CFE_TIME_Global.ToneDataCounter++;
 
     return;
+}
 
-} /* End of CFE_TIME_ToneData() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_ToneSignal() -- "tone signal" occurred recently        */
-/*                                                                 */
-/* This function is called upon receipt of a command indicating    */
-/*    that a time at the tone signal was detected.  The mission    */
-/*    dependent h/w or s/w that detected the tone signal latched   */
-/*    the local clock and generated this command.  The use of a    */
-/*    command announcing the tone signal ensures that this code    */
-/*    is not called from within an interrupt handler.              */
-/*                                                                 */
-/* It is not a concern that some amount of time has elapsed since  */
-/*    the tone actually occurred.  We are currently computing      */
-/*    time as a delta (as measured on our local clock) from a      */
-/*    previously latched tone.  It just doesn't matter if the      */
-/*    size of the delta slightly exceeds a second.  The quality    */
-/*    of our local clock will always be sufficient to measure      */
-/*    time for a couple of seconds.                                */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_ToneSignal
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_ToneSignal(void)
 {
 /*
@@ -721,30 +693,16 @@ void CFE_TIME_ToneSignal(void)
     CFE_TIME_Global.ToneSignalCounter++;
 
     return;
+}
 
-} /* End of CFE_TIME_ToneSignal() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_ToneVerify() -- validate tone and data packet          */
-/*                                                                 */
-/*                                                                 */
-/* If the data packet is designed to arrive after the tone, then   */
-/*                                                                 */
-/*    Time1 = local clock latched at the detection of the tone     */
-/*    Time2 = local clock latched at the arrival of the packet     */
-/*                                                                 */
-/*                                                                 */
-/* If the data packet is designed to arrive before the tone, then  */
-/*                                                                 */
-/*    Time1 = local clock latched at the arrival of the packet     */
-/*    Time2 = local clock latched at the detection of the tone     */
-/*                                                                 */
-/*                                                                 */
-/* In either case, Time1 occurred before Time2                     */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_ToneVerify
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_ToneVerify(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2)
 {
     CFE_TIME_Compare_t result;
@@ -823,15 +781,16 @@ void CFE_TIME_ToneVerify(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2)
     PrevTime2 = Time2;
 
     return;
+}
 
-} /* End of CFE_TIME_ToneVerify() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_ToneUpdate() -- process "matching" tone & data packet  */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_ToneUpdate
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_ToneUpdate(void)
 {
     CFE_TIME_Reference_t                Reference;
@@ -1013,29 +972,29 @@ void CFE_TIME_ToneUpdate(void)
     }
 
     return;
+}
 
-} /* End of CFE_TIME_ToneUpdate() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_Local1HzTimerCallback() -- 1Hz callback routine        */
-/*                                                                 */
-/* This is a wrapper around CFE_TIME_Local1HzISR that conforms to  */
-/* the prototype of an OSAL Timer callback routine.                */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_Local1HzTimerCallback
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_Local1HzTimerCallback(osal_id_t TimerId, void *Arg)
 {
     CFE_TIME_Local1HzISR();
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_Tone1HzISR() -- Tone signal ISR                        */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_Tone1HzISR
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_Tone1HzISR(void)
 {
 
@@ -1135,17 +1094,16 @@ void CFE_TIME_Tone1HzISR(void)
     CFE_ES_PerfLogExit(CFE_MISSION_TIME_TONE1HZISR_PERF_ID);
 
     return;
+}
 
-} /* End of CFE_TIME_Tone1HzISR() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_Tone1HzTask() -- Tone 1Hz task                         */
-/*                                                                 */
-/* This task exists solely to generate the tone signal command.    */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_Tone1HzTask
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_Tone1HzTask(void)
 {
     int32 Result;
@@ -1195,16 +1153,16 @@ void CFE_TIME_Tone1HzTask(void)
     **    had an error in the creation of the semaphore.
     */
     return;
+}
 
-} /* End of CFE_TIME_Tone1HzTask() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_Local1HzStateMachine() --                              */
-/*    Update the TIME state, should be called at 1Hz               */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_Local1HzStateMachine
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_Local1HzStateMachine(void)
 {
 
@@ -1315,9 +1273,14 @@ void CFE_TIME_Local1HzStateMachine(void)
     CFE_ES_PerfLogExit(CFE_MISSION_TIME_LOCAL1HZISR_PERF_ID);
 }
 
-/*
- * Function: CFE_TIME_Local1HzISR - See API and header file for details
- */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_Local1HzISR
+ *
+ * Implemented per public API
+ * See description in cfe_time.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_Local1HzISR(void)
 {
 
@@ -1329,19 +1292,16 @@ void CFE_TIME_Local1HzISR(void)
     OS_BinSemGive(CFE_TIME_Global.LocalSemaphore);
 
     return;
+}
 
-} /* End of CFE_TIME_Local1HzISR() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_Local1HzTask() -- Local 1Hz task (not the tone)        */
-/*                                                                 */
-/* This task exists solely to generate the 1Hz wake-up command.    */
-/*                                                                 */
-/* This is a temporary solution until a scheduler is implemented.  */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_Local1HzTask
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_Local1HzTask(void)
 {
     int32 Result;
@@ -1392,15 +1352,16 @@ void CFE_TIME_Local1HzTask(void)
     **    error in the creation of the semaphore.
     */
     return;
+}
 
-} /* End of CFE_TIME_Local1HzTask() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_NotifyTimeSynchApps() -- Call App Synch Callback Funcs */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_NotifyTimeSynchApps
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_NotifyTimeSynchApps(void)
 {
     uint32                      i;
@@ -1427,7 +1388,3 @@ void CFE_TIME_NotifyTimeSynchApps(void)
 
     return;
 }
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/modules/time/fsw/src/cfe_time_tone.c
+++ b/modules/time/fsw/src/cfe_time_tone.c
@@ -48,7 +48,7 @@
  * Function: CFE_TIME_ToneSend
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
@@ -170,7 +170,7 @@ void CFE_TIME_ToneSend(void)
  * Function: CFE_TIME_ToneSendMET
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SRC_MET == true)
@@ -303,7 +303,7 @@ int32 CFE_TIME_ToneSendMET(CFE_TIME_SysTime_t NewMET)
  * Function: CFE_TIME_ToneSendGPS
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SRC_GPS == true)
@@ -443,7 +443,7 @@ int32 CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps)
  * Function: CFE_TIME_ToneSendTime
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SRC_TIME == true)
@@ -585,7 +585,7 @@ int32 CFE_TIME_ToneSendTime(CFE_TIME_SysTime_t NewTime)
  * Function: CFE_TIME_ToneData
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_ToneData(const CFE_TIME_ToneDataCmd_Payload_t *ToneDataCmd)
@@ -657,7 +657,7 @@ void CFE_TIME_ToneData(const CFE_TIME_ToneDataCmd_Payload_t *ToneDataCmd)
  * Function: CFE_TIME_ToneSignal
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_ToneSignal(void)
@@ -700,7 +700,7 @@ void CFE_TIME_ToneSignal(void)
  * Function: CFE_TIME_ToneVerify
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_ToneVerify(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2)
@@ -788,7 +788,7 @@ void CFE_TIME_ToneVerify(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2)
  * Function: CFE_TIME_ToneUpdate
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_ToneUpdate(void)
@@ -979,7 +979,7 @@ void CFE_TIME_ToneUpdate(void)
  * Function: CFE_TIME_Local1HzTimerCallback
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_Local1HzTimerCallback(osal_id_t TimerId, void *Arg)
@@ -992,7 +992,7 @@ void CFE_TIME_Local1HzTimerCallback(osal_id_t TimerId, void *Arg)
  * Function: CFE_TIME_Tone1HzISR
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_Tone1HzISR(void)
@@ -1101,7 +1101,7 @@ void CFE_TIME_Tone1HzISR(void)
  * Function: CFE_TIME_Tone1HzTask
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_Tone1HzTask(void)
@@ -1160,7 +1160,7 @@ void CFE_TIME_Tone1HzTask(void)
  * Function: CFE_TIME_Local1HzStateMachine
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_Local1HzStateMachine(void)
@@ -1278,7 +1278,7 @@ void CFE_TIME_Local1HzStateMachine(void)
  * Function: CFE_TIME_Local1HzISR
  *
  * Implemented per public API
- * See description in cfe_time.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_Local1HzISR(void)
@@ -1299,7 +1299,7 @@ void CFE_TIME_Local1HzISR(void)
  * Function: CFE_TIME_Local1HzTask
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_Local1HzTask(void)
@@ -1359,7 +1359,7 @@ void CFE_TIME_Local1HzTask(void)
  * Function: CFE_TIME_NotifyTimeSynchApps
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_NotifyTimeSynchApps(void)

--- a/modules/time/fsw/src/cfe_time_utils.c
+++ b/modules/time/fsw/src/cfe_time_utils.c
@@ -47,7 +47,7 @@
  * Function: CFE_TIME_StartReferenceUpdate
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 volatile CFE_TIME_ReferenceState_t *CFE_TIME_StartReferenceUpdate(void)
@@ -80,7 +80,7 @@ volatile CFE_TIME_ReferenceState_t *CFE_TIME_StartReferenceUpdate(void)
  * Function: CFE_TIME_LatchClock
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_LatchClock(void)
@@ -107,7 +107,7 @@ CFE_TIME_SysTime_t CFE_TIME_LatchClock(void)
  * Function: CFE_TIME_QueryResetVars
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_QueryResetVars(void)
@@ -197,7 +197,7 @@ void CFE_TIME_QueryResetVars(void)
  * Function: CFE_TIME_UpdateResetVars
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_UpdateResetVars(const CFE_TIME_Reference_t *Reference)
@@ -241,7 +241,7 @@ void CFE_TIME_UpdateResetVars(const CFE_TIME_Reference_t *Reference)
  * Function: CFE_TIME_InitData
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_InitData(void)
@@ -378,7 +378,7 @@ void CFE_TIME_InitData(void)
  * Function: CFE_TIME_GetHkData
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_GetHkData(const CFE_TIME_Reference_t *Reference)
@@ -438,7 +438,7 @@ void CFE_TIME_GetHkData(const CFE_TIME_Reference_t *Reference)
  * Function: CFE_TIME_GetDiagData
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_GetDiagData(void)
@@ -560,7 +560,7 @@ void CFE_TIME_GetDiagData(void)
  * Function: CFE_TIME_GetReference
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_GetReference(CFE_TIME_Reference_t *Reference)
@@ -669,7 +669,7 @@ void CFE_TIME_GetReference(CFE_TIME_Reference_t *Reference)
  * Function: CFE_TIME_CalculateTAI
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_CalculateTAI(const CFE_TIME_Reference_t *Reference)
@@ -686,7 +686,7 @@ CFE_TIME_SysTime_t CFE_TIME_CalculateTAI(const CFE_TIME_Reference_t *Reference)
  * Function: CFE_TIME_CalculateUTC
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_CalculateUTC(const CFE_TIME_Reference_t *Reference)
@@ -704,7 +704,7 @@ CFE_TIME_SysTime_t CFE_TIME_CalculateUTC(const CFE_TIME_Reference_t *Reference)
  * Function: CFE_TIME_CalculateState
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int16 CFE_TIME_CalculateState(const CFE_TIME_Reference_t *Reference)
@@ -758,7 +758,7 @@ int16 CFE_TIME_CalculateState(const CFE_TIME_Reference_t *Reference)
  * Function: CFE_TIME_SetState
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_SetState(int16 NewState)
@@ -804,7 +804,7 @@ void CFE_TIME_SetState(int16 NewState)
  * Function: CFE_TIME_SetSource
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SOURCE == true)
@@ -819,7 +819,7 @@ void CFE_TIME_SetSource(int16 NewSource)
  * Function: CFE_TIME_SetSignal
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SIGNAL == true)
@@ -837,7 +837,7 @@ void CFE_TIME_SetSignal(int16 NewSignal)
  * Function: CFE_TIME_SetDelay
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
@@ -864,7 +864,7 @@ void CFE_TIME_SetDelay(CFE_TIME_SysTime_t NewDelay, int16 Direction)
  * Function: CFE_TIME_SetTime
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
@@ -915,7 +915,7 @@ void CFE_TIME_SetTime(CFE_TIME_SysTime_t NewTime)
  * Function: CFE_TIME_SetMET
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
@@ -953,7 +953,7 @@ void CFE_TIME_SetMET(CFE_TIME_SysTime_t NewMET)
  * Function: CFE_TIME_SetSTCF
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
@@ -979,7 +979,7 @@ void CFE_TIME_SetSTCF(CFE_TIME_SysTime_t NewSTCF)
  * Function: CFE_TIME_SetLeapSeconds
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
@@ -1005,7 +1005,7 @@ void CFE_TIME_SetLeapSeconds(int16 NewLeaps)
  * Function: CFE_TIME_SetAdjust
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
@@ -1044,7 +1044,7 @@ void CFE_TIME_SetAdjust(CFE_TIME_SysTime_t NewAdjust, int16 Direction)
  * Function: CFE_TIME_Set1HzAdj
  *
  * Application-scope internal function
- * See description in cfe_time_utils.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
@@ -1063,7 +1063,7 @@ void CFE_TIME_Set1HzAdj(CFE_TIME_SysTime_t NewAdjust, int16 Direction)
  * Function: CFE_TIME_CleanUpApp
  *
  * Implemented per public API
- * See description in cfe_time_core_internal.h for argument/return detail
+ * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_CleanUpApp(CFE_ES_AppId_t AppId)

--- a/modules/time/fsw/src/cfe_time_utils.c
+++ b/modules/time/fsw/src/cfe_time_utils.c
@@ -42,12 +42,14 @@
 
 #include <string.h>
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_StartReferenceUpdate()                                 */
-/* Initiate an update to the global time reference data            */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_StartReferenceUpdate
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 volatile CFE_TIME_ReferenceState_t *CFE_TIME_StartReferenceUpdate(void)
 {
     uint32                              Version = CFE_TIME_Global.LastVersionCounter;
@@ -73,12 +75,14 @@ volatile CFE_TIME_ReferenceState_t *CFE_TIME_StartReferenceUpdate(void)
     return NextState;
 }
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_LatchClock() -- query local clock                      */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_LatchClock
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_LatchClock(void)
 {
     CFE_TIME_SysTime_t LatchTime;
@@ -96,15 +100,16 @@ CFE_TIME_SysTime_t CFE_TIME_LatchClock(void)
     LatchTime.Subseconds = OS_TimeGetSubsecondsPart(LocalTime);
 
     return (LatchTime);
+}
 
-} /* End of CFE_TIME_LatchClock() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_QueryResetVars() -- query contents of Reset Variables  */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_QueryResetVars
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_QueryResetVars(void)
 {
 
@@ -185,15 +190,16 @@ void CFE_TIME_QueryResetVars(void)
     CFE_TIME_FinishReferenceUpdate(RefState);
 
     return;
+}
 
-} /* End of CFE_TIME_QueryResetVars() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_UpdateResetVars() -- update contents of Reset Variables*/
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_UpdateResetVars
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_UpdateResetVars(const CFE_TIME_Reference_t *Reference)
 {
     CFE_TIME_ResetVars_t LocalResetVars;
@@ -228,15 +234,16 @@ void CFE_TIME_UpdateResetVars(const CFE_TIME_Reference_t *Reference)
     }
 
     return;
+}
 
-} /* End of CFE_TIME_UpdateResetVars() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_InitData() -- initialize global time task nonzero data */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_InitData
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_InitData(void)
 {
     uint32                              i;
@@ -364,15 +371,16 @@ void CFE_TIME_InitData(void)
                  sizeof(CFE_TIME_Global.Local1HzCmd));
 
     return;
+}
 
-} /* End of CFE_TIME_InitData() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_GetHkData() -- Report local housekeeping data          */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_GetHkData
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_GetHkData(const CFE_TIME_Reference_t *Reference)
 {
 
@@ -423,15 +431,16 @@ void CFE_TIME_GetHkData(const CFE_TIME_Reference_t *Reference)
 #endif
 
     return;
+}
 
-} /* End of CFE_TIME_GetHkData() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_GetDiagData() -- Report diagnostics data               */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_GetDiagData
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_GetDiagData(void)
 {
     CFE_TIME_Reference_t Reference;
@@ -544,15 +553,16 @@ void CFE_TIME_GetDiagData(void)
     CFE_TIME_Global.DiagPacket.Payload.DataStoreStatus = CFE_TIME_Global.DataStoreStatus;
 
     return;
+}
 
-} /* End of CFE_TIME_GetDiagData() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_GetReference() -- get reference data (time at "tone")  */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_GetReference
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_GetReference(CFE_TIME_Reference_t *Reference)
 {
     CFE_TIME_SysTime_t                  TimeSinceTone;
@@ -652,15 +662,16 @@ void CFE_TIME_GetReference(CFE_TIME_Reference_t *Reference)
     Reference->CurrentMET = CurrentMET;
 
     return;
+}
 
-} /* End of CFE_TIME_GetReference() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_CalculateTAI() -- calculate TAI from reference data    */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_CalculateTAI
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_CalculateTAI(const CFE_TIME_Reference_t *Reference)
 {
     CFE_TIME_SysTime_t TimeAsTAI;
@@ -668,15 +679,16 @@ CFE_TIME_SysTime_t CFE_TIME_CalculateTAI(const CFE_TIME_Reference_t *Reference)
     TimeAsTAI = CFE_TIME_Add(Reference->CurrentMET, Reference->AtToneSTCF);
 
     return (TimeAsTAI);
+}
 
-} /* End of CFE_TIME_CalculateTAI() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_CalculateUTC() -- calculate UTC from reference data    */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_CalculateUTC
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_CalculateUTC(const CFE_TIME_Reference_t *Reference)
 {
     CFE_TIME_SysTime_t TimeAsUTC;
@@ -685,15 +697,16 @@ CFE_TIME_SysTime_t CFE_TIME_CalculateUTC(const CFE_TIME_Reference_t *Reference)
     TimeAsUTC.Seconds -= Reference->AtToneLeapSeconds;
 
     return (TimeAsUTC);
+}
 
-} /* End of CFE_TIME_CalculateUTC() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                         */
-/* CFE_TIME_CalculateState() -- determine current time state (per API)     */
-/*                                                                         */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_CalculateState
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int16 CFE_TIME_CalculateState(const CFE_TIME_Reference_t *Reference)
 {
     int16 ClockState;
@@ -738,15 +751,16 @@ int16 CFE_TIME_CalculateState(const CFE_TIME_Reference_t *Reference)
     }
 
     return (ClockState);
+}
 
-} /* End of CFE_TIME_CalculateState() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_SetState() -- set clock state                          */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_SetState
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 void CFE_TIME_SetState(int16 NewState)
 {
     volatile CFE_TIME_ReferenceState_t *RefState;
@@ -783,29 +797,31 @@ void CFE_TIME_SetState(int16 NewState)
     CFE_TIME_FinishReferenceUpdate(RefState);
 
     return;
+}
 
-} /* End of CFE_TIME_SetState() */
-
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_SetSource() -- set clock source                        */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_SetSource
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SOURCE == true)
 void CFE_TIME_SetSource(int16 NewSource)
 {
     CFE_TIME_Global.ClockSource = NewSource;
-
-} /* End of CFE_TIME_SetSource() */
+}
 #endif /* CFE_PLATFORM_TIME_CFG_SOURCE */
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_SetSignal() -- set tone signal (pri vs red)            */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_SetSignal
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SIGNAL == true)
 void CFE_TIME_SetSignal(int16 NewSignal)
 {
@@ -813,16 +829,17 @@ void CFE_TIME_SetSignal(int16 NewSignal)
     ** Maintain current tone signal selection for telemetry...
     */
     CFE_TIME_Global.ClockSignal = NewSignal;
-
-} /* End of CFE_TIME_SetSignal() */
+}
 #endif /* CFE_PLATFORM_TIME_CFG_SIGNAL */
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_SetDelay() -- set tone delay (time client only)        */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_SetDelay
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
 void CFE_TIME_SetDelay(CFE_TIME_SysTime_t NewDelay, int16 Direction)
 {
@@ -839,16 +856,17 @@ void CFE_TIME_SetDelay(CFE_TIME_SysTime_t NewDelay, int16 Direction)
     CFE_TIME_FinishReferenceUpdate(RefState);
 
     return;
-
-} /* End of CFE_TIME_SetDelay() */
+}
 #endif /* CFE_PLATFORM_TIME_CFG_CLIENT */
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_SetTime() -- set time (time server only)               */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_SetTime
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
 void CFE_TIME_SetTime(CFE_TIME_SysTime_t NewTime)
 {
@@ -889,21 +907,17 @@ void CFE_TIME_SetTime(CFE_TIME_SysTime_t NewTime)
     CFE_TIME_FinishReferenceUpdate(RefState);
 
     return;
-
-} /* End of CFE_TIME_SetTime() */
+}
 #endif /* CFE_PLATFORM_TIME_CFG_SERVER */
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_SetMET() -- set MET (time server only)                 */
-/*                                                                 */
-/* Note: This command will not have lasting effect if configured   */
-/*       to get external time of type MET.  Also, there cannot     */
-/*       be a local h/w MET and an external MET since both would   */
-/*       need to be synchronized to the same tone signal.          */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_SetMET
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
 void CFE_TIME_SetMET(CFE_TIME_SysTime_t NewMET)
 {
@@ -931,16 +945,17 @@ void CFE_TIME_SetMET(CFE_TIME_SysTime_t NewMET)
     CFE_TIME_FinishReferenceUpdate(RefState);
 
     return;
-
-} /* End of CFE_TIME_SetMET() */
+}
 #endif /* CFE_PLATFORM_TIME_CFG_SERVER */
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_SetSTCF() -- set STCF (time server only)               */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_SetSTCF
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
 void CFE_TIME_SetSTCF(CFE_TIME_SysTime_t NewSTCF)
 {
@@ -956,16 +971,17 @@ void CFE_TIME_SetSTCF(CFE_TIME_SysTime_t NewSTCF)
     CFE_TIME_FinishReferenceUpdate(RefState);
 
     return;
-
-} /* End of CFE_TIME_SetSTCF() */
+}
 #endif /* CFE_PLATFORM_TIME_CFG_SERVER */
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_SetLeapSeconds() -- set leap seconds (time server only)      */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_SetLeapSeconds
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
 void CFE_TIME_SetLeapSeconds(int16 NewLeaps)
 {
@@ -981,16 +997,17 @@ void CFE_TIME_SetLeapSeconds(int16 NewLeaps)
     CFE_TIME_FinishReferenceUpdate(RefState);
 
     return;
-
-} /* End of CFE_TIME_SetLeapSeconds() */
+}
 #endif /* CFE_PLATFORM_TIME_CFG_SERVER */
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_SetAdjust() -- one time STCF adjustment (server only)  */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_SetAdjust
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
 void CFE_TIME_SetAdjust(CFE_TIME_SysTime_t NewAdjust, int16 Direction)
 {
@@ -1019,16 +1036,17 @@ void CFE_TIME_SetAdjust(CFE_TIME_SysTime_t NewAdjust, int16 Direction)
     CFE_TIME_FinishReferenceUpdate(RefState);
 
     return;
-
-} /* End of CFE_TIME_SetAdjust() */
+}
 #endif /* CFE_PLATFORM_TIME_CFG_SERVER */
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_Set1HzAdj() -- 1Hz STCF adjustment (time server only)  */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_Set1HzAdj
+ *
+ * Application-scope internal function
+ * See description in cfe_time_utils.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
 void CFE_TIME_Set1HzAdj(CFE_TIME_SysTime_t NewAdjust, int16 Direction)
 {
@@ -1037,16 +1055,17 @@ void CFE_TIME_Set1HzAdj(CFE_TIME_SysTime_t NewAdjust, int16 Direction)
     */
     CFE_TIME_Global.OneHzAdjust    = NewAdjust;
     CFE_TIME_Global.OneHzDirection = Direction;
-
-} /* End of CFE_TIME_Set1HzAdj() */
+}
 #endif /* CFE_PLATFORM_TIME_CFG_SERVER */
 
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-/*                                                                 */
-/* CFE_TIME_CleanUpApp() -- Free resources associated with App     */
-/*                                                                 */
-/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-
+/*----------------------------------------------------------------
+ *
+ * Function: CFE_TIME_CleanUpApp
+ *
+ * Implemented per public API
+ * See description in cfe_time_core_internal.h for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 int32 CFE_TIME_CleanUpApp(CFE_ES_AppId_t AppId)
 {
     int32  Status;
@@ -1068,7 +1087,3 @@ int32 CFE_TIME_CleanUpApp(CFE_ES_AppId_t AppId)
 
     return Status;
 }
-
-/************************/
-/*  End of File Comment */
-/************************/

--- a/modules/time/fsw/src/cfe_time_utils.h
+++ b/modules/time/fsw/src/cfe_time_utils.h
@@ -325,57 +325,147 @@ typedef struct
 */
 extern CFE_TIME_Global_t CFE_TIME_Global;
 
-/*************************************************************************/
-/*
-** Function prototypes (get local clock)...
-*/
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief query local clock
+ */
 CFE_TIME_SysTime_t CFE_TIME_LatchClock(void);
 
-/*
-** Function prototypes (Time Services utilities data)...
-*/
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Time task initialization
+ */
 int32 CFE_TIME_TaskInit(void);
-void  CFE_TIME_TaskPipe(CFE_SB_Buffer_t *SBBufPtr);
-void  CFE_TIME_InitData(void);
-void  CFE_TIME_QueryResetVars(void);
-void  CFE_TIME_UpdateResetVars(const CFE_TIME_Reference_t *Reference);
-void  CFE_TIME_GetDiagData(void);
-void  CFE_TIME_GetHkData(const CFE_TIME_Reference_t *Reference);
 
-/*
-** Function prototypes (reference)...
-*/
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Process command pipe message
+ */
+void CFE_TIME_TaskPipe(CFE_SB_Buffer_t *SBBufPtr);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Initialize global time task data
+ */
+void CFE_TIME_InitData(void);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief query contents of Reset Variables
+ */
+void CFE_TIME_QueryResetVars(void);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief update contents of Reset Variables
+ */
+void CFE_TIME_UpdateResetVars(const CFE_TIME_Reference_t *Reference);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Report diagnostics data
+ */
+void CFE_TIME_GetDiagData(void);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Report local housekeeping data
+ */
+void CFE_TIME_GetHkData(const CFE_TIME_Reference_t *Reference);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief get reference data (time at "tone")
+ */
 void CFE_TIME_GetReference(CFE_TIME_Reference_t *Reference);
 
-/*
-** Function prototypes (calculate TAI/UTC)...
-*/
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief calculate TAI from reference data
+ */
 CFE_TIME_SysTime_t CFE_TIME_CalculateTAI(const CFE_TIME_Reference_t *Reference);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief calculate UTC from reference data
+ */
 CFE_TIME_SysTime_t CFE_TIME_CalculateUTC(const CFE_TIME_Reference_t *Reference);
 
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief determine current time state (per API)
+ */
 int16 CFE_TIME_CalculateState(const CFE_TIME_Reference_t *Reference);
 
-/*
-** Function prototypes (set time globals)...
-*/
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief set clock state
+ */
 void CFE_TIME_SetState(int16 NewState);
+
 #if (CFE_PLATFORM_TIME_CFG_SOURCE == true)
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  set clock source
+ */
 void CFE_TIME_SetSource(int16 NewSource);
 #endif
 
 #if (CFE_PLATFORM_TIME_CFG_SIGNAL == true)
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief set tone signal (pri vs red)
+ */
 void CFE_TIME_SetSignal(int16 NewSignal);
 #endif
 
 #if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief set tone delay (time client only)
+ */
 void CFE_TIME_SetDelay(CFE_TIME_SysTime_t NewDelay, int16 Direction);
 #endif
+
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief set time (time server only)
+ */
 void CFE_TIME_SetTime(CFE_TIME_SysTime_t NewTime);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief set MET (time server only)
+ */
 void CFE_TIME_SetMET(CFE_TIME_SysTime_t NewMET);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief set STCF (time server only)
+ */
 void CFE_TIME_SetSTCF(CFE_TIME_SysTime_t NewSTCF);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief set leap seconds (time server only)
+ */
 void CFE_TIME_SetLeapSeconds(int16 NewLeaps);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief one time STCF adjustment (server only)
+ */
 void CFE_TIME_SetAdjust(CFE_TIME_SysTime_t NewAdjust, int16 Direction);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief 1Hz STCF adjustment (time server only)
+ */
 void CFE_TIME_Set1HzAdj(CFE_TIME_SysTime_t NewAdjust, int16 Direction);
 #endif
 
@@ -383,6 +473,15 @@ void CFE_TIME_Set1HzAdj(CFE_TIME_SysTime_t NewAdjust, int16 Direction);
 ** Function prototypes (send time at tone data packet -- local MET)...
 */
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Send "time at the tone" (local time)
+ *
+ * the appropriate time (relative to the tone) such that the
+ * "time at the tone" data command will arrive within the
+ * specified window for tone and data packet verification.
+ */
 void CFE_TIME_ToneSend(void); /* signal to send time at tone packet */
 #endif
 
@@ -390,24 +489,57 @@ void CFE_TIME_ToneSend(void); /* signal to send time at tone packet */
 ** Function prototypes (send time at tone data packet -- external time)...
 */
 #if (CFE_PLATFORM_TIME_CFG_SRC_MET == true)
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Send "time at tone" (external MET)
+ *
+ * the appropriate time (relative to the tone) such that the
+ * "time at the tone" data command will arrive within the
+ * specified window for tone and data packet verification.
+ */
 int32 CFE_TIME_ToneSendMET(CFE_TIME_SysTime_t NewMET);
 #endif
 
 #if (CFE_PLATFORM_TIME_CFG_SRC_GPS == true)
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Send "time at tone" (external GPS)
+ *
+ * the appropriate time (relative to the tone) such that the
+ * "time at the tone" data command will arrive within the
+ * specified window for tone and data packet verification.
+ */
 int32 CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps);
 #endif
 
 #if (CFE_PLATFORM_TIME_CFG_SRC_TIME == true)
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Send "time at tone" (external time)
+ *
+ * the appropriate time (relative to the tone) such that the
+ * "time at the tone" data command will arrive within the
+ * specified window for tone and data packet verification.
+ */
 int32 CFE_TIME_ToneSendTime(CFE_TIME_SysTime_t NewTime);
 #endif
 
-/*
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Initiate an update to the global time reference data
+ *
  * Helper function for updating the "Reference" value
  * This is the local replacement for "OS_IntLock()"
  */
 volatile CFE_TIME_ReferenceState_t *CFE_TIME_StartReferenceUpdate(void);
 
-/*
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Complete an update to the global time reference data
+ *
  * Helper function for updating the "Reference" value
  * This is the local replacement for "OS_IntUnlock()"
  */
@@ -416,7 +548,10 @@ static inline void CFE_TIME_FinishReferenceUpdate(volatile CFE_TIME_ReferenceSta
     CFE_TIME_Global.LastVersionCounter = NextState->StateVersion;
 }
 
-/*
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Get a pointer to the global time reference data
+ *
  * Helper function for getting the "Reference" value
  * This is the replacement for direct memory reads of
  * the state info from the global data structure.
@@ -429,23 +564,319 @@ static inline volatile CFE_TIME_ReferenceState_t *CFE_TIME_GetReferenceState(voi
 /*
 ** Function prototypes (process time at the tone signal and data packet)...
 */
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief "tone signal" occurred recently
+ *
+ * This function is called upon receipt of a command indicating
+ * that a time at the tone signal was detected.  The mission
+ * dependent h/w or s/w that detected the tone signal latched
+ * the local clock and generated this command.  The use of a
+ * command announcing the tone signal ensures that this code
+ * is not called from within an interrupt handler.
+ *
+ * It is not a concern that some amount of time has elapsed since
+ * the tone actually occurred.  We are currently computing
+ * time as a delta (as measured on our local clock) from a
+ * previously latched tone.  It just doesn't matter if the
+ * size of the delta slightly exceeds a second.  The quality
+ * of our local clock will always be sufficient to measure
+ * time for a couple of seconds.
+ */
 void CFE_TIME_ToneSignal(void);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief process "time at tone" data packet
+ */
 void CFE_TIME_ToneData(const CFE_TIME_ToneDataCmd_Payload_t *ToneDataCmd);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief validate tone and data packet
+ *
+ * If the data packet is designed to arrive after the tone, then
+ *
+ *    Time1 = local clock latched at the detection of the tone
+ *    Time2 = local clock latched at the arrival of the packet
+ *
+ *
+ * If the data packet is designed to arrive before the tone, then
+ *
+ *    Time1 = local clock latched at the arrival of the packet
+ *    Time2 = local clock latched at the detection of the tone
+ *
+ * In either case, Time1 occurred before Time2
+ */
 void CFE_TIME_ToneVerify(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief process "matching" tone & data packet
+ */
 void CFE_TIME_ToneUpdate(void);
 
 /*
 ** Function prototypes (tone 1Hz interrupt)...
 */
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Tone signal ISR
+ */
 void CFE_TIME_Tone1HzISR(void);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Tone 1Hz task
+ *
+ * This task exists solely to generate the tone signal command.
+ */
 void CFE_TIME_Tone1HzTask(void);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Call App Synch Callback Funcs
+ */
 void CFE_TIME_NotifyTimeSynchApps(void);
 
 /*
 ** Function prototypes (local 1Hz interrupt)...
 */
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Local 1Hz task (not the tone)
+ *
+ * This task exists solely to generate the 1Hz wakeup command.
+ *
+ * This is a temporary solution until a scheduler is implemented.
+ */
 void CFE_TIME_Local1HzTask(void);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Update the TIME state, should be called at 1Hz
+ */
 void CFE_TIME_Local1HzStateMachine(void);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  1Hz callback routine
+ *
+ * This is a wrapper around CFE_TIME_Local1HzISR that conforms to
+ * the prototype of an OSAL Timer callback routine.
+ */
 void CFE_TIME_Local1HzTimerCallback(osal_id_t TimerId, void *Arg);
+
+/*
+** Command handler for "HK request"...
+*/
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Onboard command (HK request)
+ */
+int32 CFE_TIME_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data);
+
+/*
+** Command handler for "tone signal detected"...
+*/
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time at tone command (signal)
+ */
+int32 CFE_TIME_ToneSignalCmd(const CFE_TIME_ToneSignalCmd_t *data);
+
+/*
+** Command handler for "time at the tone"...
+*/
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time at tone command (data)
+ */
+int32 CFE_TIME_ToneDataCmd(const CFE_TIME_ToneDataCmd_t *data);
+
+/*
+** Command handler for 1Hz signal...
+*/
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Execute state machine tasks required at 1Hz
+ *
+ * Service the "1Hz" notification message, and perform any state machine
+ * tasks that are intended to be executed at local 1Hz intervals.
+ *
+ * This also implements the "fake tone" functionality when that is enabled,
+ * as we do not need a separate MID for this job.
+ */
+int32 CFE_TIME_OneHzCmd(const CFE_TIME_1HzCmd_t *data);
+
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time at tone command (send data)
+ *
+ * Command handler for "request time at the tone"...
+ *
+ * @note This command (sent by the scheduler) is used to
+ *       signal that now is the right time (in relation
+ *       to the "real" tone signal) for a Time Server to
+ *       send the "time at the tone" data packet.  We do
+ *       not need (or want) this command if we are not a
+ *       Time Server.
+ *
+ *       In "fake tone" mode this command is locally generated
+ *       however it is still sent via the software bus, thereby
+ *       utilizing (mostly) the same code path as the
+ *       non-fake tone mode.
+ */
+int32 CFE_TIME_ToneSendCmd(const CFE_TIME_FakeToneCmd_t *data);
+#endif
+
+/*
+ * Ground command helper functions
+ */
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time task ground command (tone delay)
+ */
+void CFE_TIME_SetDelayImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_AdjustDirection_Enum_t Direction);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time task ground command (1Hz adjust)
+ */
+void CFE_TIME_1HzAdjImpl(const CFE_TIME_OneHzAdjustmentCmd_Payload_t *CommandPtr,
+                         CFE_TIME_AdjustDirection_Enum_t              Direction);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time task ground command (adjust STCF)
+ */
+void CFE_TIME_AdjustImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_AdjustDirection_Enum_t Direction);
+
+/*
+** Ground command handlers...
+*/
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time task ground command (1Hz adjust)
+ *
+ * This is a wrapper around CFE_TIME_1HzAdjImpl()
+ */
+int32 CFE_TIME_Add1HZAdjustmentCmd(const CFE_TIME_Add1HZAdjustmentCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time task ground command (1Hz adjust)
+ *
+ * This is a wrapper around CFE_TIME_AdjustImpl()
+ */
+int32 CFE_TIME_AddAdjustCmd(const CFE_TIME_AddAdjustCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time task ground command (tone delay)
+ *
+ * Wrapper around CFE_TIME_SetDelayImpl() for add/subtract operations
+ */
+int32 CFE_TIME_AddDelayCmd(const CFE_TIME_AddDelayCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time task ground command (tone delay)
+ *
+ * Wrapper around CFE_TIME_SetDelayImpl() for add/subtract operations
+ */
+int32 CFE_TIME_SubDelayCmd(const CFE_TIME_SubDelayCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time task ground command (diagnostics)
+ */
+int32 CFE_TIME_SendDiagnosticTlm(const CFE_TIME_SendDiagnosticCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time task ground command (NOOP)
+ */
+int32 CFE_TIME_NoopCmd(const CFE_TIME_NoopCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time task ground command (reset counters)
+ */
+int32 CFE_TIME_ResetCountersCmd(const CFE_TIME_ResetCountersCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time task ground command (set leaps)
+ */
+int32 CFE_TIME_SetLeapSecondsCmd(const CFE_TIME_SetLeapSecondsCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time task ground command (set MET)
+ *
+ * @note This command will not have lasting effect if configured
+ * to get external time of type MET.  Also, there cannot
+ * be a local h/w MET and an external MET since both would
+ * need to be synchronized to the same tone signal.
+ */
+int32 CFE_TIME_SetMETCmd(const CFE_TIME_SetMETCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time task command (set tone source)
+ */
+int32 CFE_TIME_SetSignalCmd(const CFE_TIME_SetSignalCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time task command (set time source)
+ */
+int32 CFE_TIME_SetSourceCmd(const CFE_TIME_SetSourceCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time task command (set clock state)
+ */
+int32 CFE_TIME_SetStateCmd(const CFE_TIME_SetStateCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time task ground command (set STCF)
+ */
+int32 CFE_TIME_SetSTCFCmd(const CFE_TIME_SetSTCFCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time task ground command (calc STCF)
+ */
+int32 CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time task ground command (1Hz adjust)
+ *
+ * This is a wrapper around CFE_TIME_1HzAdjImpl()
+ */
+int32 CFE_TIME_Sub1HZAdjustmentCmd(const CFE_TIME_Sub1HZAdjustmentCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time task ground command (1Hz adjust)
+ *
+ * This is a wrapper around CFE_TIME_AdjustImpl()
+ */
+int32 CFE_TIME_SubAdjustCmd(const CFE_TIME_SubAdjustCmd_t *data);
 
 #endif /* CFE_TIME_UTILS_H */


### PR DESCRIPTION
**Describe the contribution**
Fixes #1336 

Scrub all internal APIs within CFE core to make comment blocks in sources and headers more consistent. 

Whenever a function is prototyped in a header, this moves the information about the function behavior to that prototype and puts it into doxygen format.  The comment block on the function implementation refers the reader to the prototype - it does not duplicate the info.  Exception for local helper functions which are not separately prototyped, these may have pre/post condition info in the block itself.

All functions definitions are noted whether they intend to conform to the public API (i.e. from a header in core_api) and therefore have global scope, or if they have application-internal scope, or if they have file/local scope.

**Testing performed**
Build and sanity check CFE, run all unit tests

**Expected behavior changes**
None - documentation updates only

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Changes to each subsystem are put in a separate commit.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

EDIT - also fixes #1350 (deletes instead of moves, they are not implemented)