### PR TITLE
Fix #1436, table object file name

### DIFF
--- a/cmake/arch_build.cmake
+++ b/cmake/arch_build.cmake
@@ -197,9 +197,6 @@ function(add_cfe_tables APP_NAME TBL_SRC_FILES)
       add_library(${TGT}_${TBLWE}-obj STATIC ${TBL_SRC})
       target_link_libraries(${TGT}_${TBLWE}-obj PRIVATE core_api)
 
-      get_filename_component(TBLOBJ ${TBL} NAME)
-      string(APPEND TBLOBJ ${CMAKE_C_OUTPUT_EXTENSION})
-
       # IMPORTANT: This rule assumes that the output filename of elf2cfetbl matches
       # the input file name but with a different extension (.o -> .tbl)
       # The actual output filename is embedded in the source file (.c), however
@@ -208,8 +205,11 @@ function(add_cfe_tables APP_NAME TBL_SRC_FILES)
       # current content of a dependency (rightfully so).
       add_custom_command(
         OUTPUT "${TABLE_DESTDIR}/${TBLWE}.tbl"
-        COMMAND ${CMAKE_AR} x $<TARGET_FILE:${TGT}_${TBLWE}-obj>
-        COMMAND ${MISSION_BINARY_DIR}/tools/elf2cfetbl/elf2cfetbl "${TBLOBJ}"
+        COMMAND ${CMAKE_COMMAND}
+            -DCMAKE_AR=${CMAKE_AR}
+            -DTBLTOOL=${MISSION_BINARY_DIR}/tools/elf2cfetbl/elf2cfetbl
+            -DLIB=$<TARGET_FILE:${TGT}_${TBLWE}-obj>
+            -P ${CFE_SOURCE_DIR}/cmake/generate_table.cmake
         DEPENDS ${MISSION_BINARY_DIR}/tools/elf2cfetbl/elf2cfetbl ${TGT}_${TBLWE}-obj
         WORKING_DIRECTORY ${TABLE_DESTDIR}
       )

--- a/cmake/generate_table.cmake
+++ b/cmake/generate_table.cmake
@@ -1,0 +1,48 @@
+##################################################################
+#
+# Sub-script to generate a table file via elf2cfetbl
+#
+# This small script runs at build time (as opposed to prep time)
+# which converts a static library (.a) with a single object into a
+# table (.tbl) file
+#
+##################################################################
+
+#
+# Required passed in values:
+#  CMAKE_AR => path to "ar" utility for working with static lib files
+#  TBLTOOL => path to "elf2cfetbl" utility
+#  LIB => name of library file to convert
+#
+# This assumes/requires that the static library has a single object in it.
+# Note, In newer versions of CMake an object library can be used. This workaround
+# is intended to also be compatible with older CMake versions.
+#
+
+# First run "ar t" to get the object file name, there should be only 1 file.
+execute_process(COMMAND ${CMAKE_AR} t "${LIB}"
+    OUTPUT_VARIABLE OBJNAME
+    RESULT_VARIABLE RESULT
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+if (NOT RESULT EQUAL 0)
+    message(FATAL_ERROR "Failure running ${CMAKE_AR} t ${LIB}")
+endif()
+
+# Next run "ar x" to extract that file.
+execute_process(COMMAND ${CMAKE_AR} x "${LIB}" "${OBJNAME}"
+    RESULT_VARIABLE RESULT
+)
+if (NOT RESULT EQUAL 0)
+    message(FATAL_ERROR "Failure running ${CMAKE_AR} x ${LIB} ${OBJNAME}")
+endif()
+
+# Finally invoke the table tool (elf2cfetbl) on the object
+execute_process(COMMAND ${TBLTOOL} "${OBJNAME}"
+    RESULT_VARIABLE RESULT
+)
+if (NOT RESULT EQUAL 0)
+    message(FATAL_ERROR "Failure running ${TBLTOOL}")
+endif()
+
+message("Successfully converted ${LIB} to a CFE table")


### PR DESCRIPTION
**Describe the contribution**
Use a shell glob instead of assuming a specific file name, this should pick up the object file no matter how it was named, as
long as it ends in ${CMAKE_C_OUTPUT_EXTENSION}.

It does rely on/assume there is only one such file, so this might break if one changes the name of a table without a clean rebuild.

A proper fix would still be to use TARGET_OBJECTS generator expression, but that can't happen until Ubuntu 18.04 (w/ ver 3.10) is EOL.

Fixes #1436

**Testing performed**
Build and sanity check CFE, confirm tables are built successfully

**Expected behavior changes**
Tables should build even if the file name pattern is not as expected.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
