### PR TITLE
Fix #1343, OSAL config file simplification

### DIFF
--- a/cmake/sample_defs/default_osconfig.cmake
+++ b/cmake/sample_defs/default_osconfig.cmake
@@ -1,210 +1,54 @@
 ##########################################################################
 #
-# CFE configuration options for OSAL
+# CFE-specific configuration options for OSAL
 #
-# This file specifies the default values for various compile-time options
-# supported by OSAL.  These options can be further tuned by the specific
-# OSAL and BSP selection, as well as the user application.
+# This file specifies the CFE-specific values for various compile options
+# supported by OSAL.
+#
+# OSAL has many configuration options, which may vary depending on the
+# specific version of OSAL in use.  The complete list of OSAL options,
+# along with a description of each, can be found OSAL source in the file:
+#
+#    osal/default_config.cmake
+#
+# A CFE framework build utilizes mostly the OSAL default configuration.
+# This file only contains a few specific overrides that tune for a debug
+# environment, rather than a deployment environment.
+#
+# ALSO NOTE: There is also an arch-specific addendum to this file
+# to allow further tuning on a per-arch basis, in the form of:
+#
+#    ${TOOLCHAIN_NAME}_osconfig.cmake
+#
+# See "native_osconfig.cmake" for options which apply only to "native" builds.
 #
 ##########################################################################
 
-
-##############################################################
-# Code/Feature Selection Options for the OSAL implementation
-##############################################################
-
-
-# OSAL_CONFIG_INCLUDE_NETWORK
-# ----------------------------------
-#
-# Whether to include the Network API
-#
-# If set TRUE, the the socket abstraction (if applicable on the platform)
-# will be included.  If set FALSE, then all calls to the network API will
-# return OS_ERR_NOT_IMPLEMENTED.
-#
-# This can be set FALSE for platforms which do not have a network or
-# IP stack available, or to save code space if the application does
-# not use network resources.
-#
-set(OSAL_CONFIG_INCLUDE_NETWORK                 TRUE)
-
-
-#
-# OSAL_CONFIG_INCLUDE_DYNAMIC_LOADER
-# ----------------------------------
-#
-# Whether to include the capability of loading dynamic code objects
-#
-# This is normally set TRUE to support modularized applications on
-# platforms which have this capability.
-#
-# For deployments which are always statically linked, this may be set
-# FALSE for a smaller library size and reduced linking requirements.
-#
-set(OSAL_CONFIG_INCLUDE_DYNAMIC_LOADER          TRUE)
-
-
-#
-# OSAL_CONFIG_INCLUDE_STATIC_LOADER
-# ----------------------------------
-#
-# Whether to include a compatibility "loader" for statically-linked objects
-#
-# This feature allows applications normally written for dynamic module loading
-# operate transparently in a static link environment.  If this is set TRUE,
-# then the application must supply an object named "OS_STATIC_SYMBOL_TABLE" that
-# contains the names and addresses of statically-linked symbols that should
-# be known to the lookup/load functions.
-#
-# Note that modules "loaded" using this abstraction are still assigned a
-# module ID and still require a slot in the module table even though
-# no actual runtime loading is performed (see OSAL_CONFIG_MAX_MODULES).
-#
-set(OSAL_CONFIG_INCLUDE_STATIC_LOADER           TRUE)
-
-#
-# OSAL_CONFIG_INCLUDE_SHELL
-# ----------------------------------
-#
-# Whether to include features which utilize the operating system shell.
-#
-# Remote Shell commands can be very powerful tool for remotely diagnosing
-# and mitigating runtime issues in the field, but also have significant
-# security implications.  If this is set to "false" then shell functionality
-# is disabled and OSAL functions which invoke the shell will return
-# OS_ERR_NOT_IMPLEMENTED.
-#
-set(OSAL_CONFIG_INCLUDE_SHELL                   FALSE)
-
-
-#
-# OSAL_CONFIG_DEBUG_PERMISSIVE_MODE
-# ----------------------------------
-#
-# The OSAL_CONFIG_DEBUG_PERMISSIVE_MODE option controls how privileged operations
-# are handled by the OSAL in the event that the user does not have sufficient permission.
-# In particular this applies to task priorities and message queues.
-#
-# If set FALSE, then all permissions are enforced, and a failure due to lack of permission
-# will cause a failure of the overall operation, which is passed back to the application.
-#
-# If set to TRUE, this will treat some errors non-fatal and enable a graceful fallback,
-# allowing the overall operation to complete in a reduced form.  This makes the
-# OSAL library compatible with a non-root (normal user mode) environment.
-#
-# In the PC-Linux/Posix build, this means:
-#  - A message queue deeper than the maximum system limit will be silently truncated
-#    to the maximum system limit (no error).
-#  - If the user does not have permission to create elevated priority tasks, then the tasks will
-#    be created at the default priority (no error).
-#
-set(OSAL_CONFIG_DEBUG_PERMISSIVE_MODE           FALSE)
-
 #
 # OSAL_CONFIG_DEBUG_PRINTF
-# ----------------------------------
+# ------------------------
 #
-# Controls inclusion of OS_DEBUG statements in the code
+# For CFE builds this can be helpful during debugging as it will display more
+# specific error messages for various OSAL error/warning events, such as if a
+# module cannot be loaded or a file cannot be opened for some reason.
 #
-# If set FALSE, all OS_DEBUG statements are compiled out.
+set(OSAL_CONFIG_DEBUG_PRINTF TRUE)
+
+
 #
-# If set TRUE, all the "OS_DEBUG" statements will be compiled in and displayed
-# on the debug console.  The statements may still be suppressed at runtime.
+# OSAL_CONFIG_UTILITYTASK_PRIORITY
+# --------------------------------
 #
-set(OSAL_CONFIG_DEBUG_PRINTF                    TRUE)
-
-
-#############################################
-# Resource Limits for the OS API
-#############################################
-
-# The maximum number of concurrently-running tasks to support
-set(OSAL_CONFIG_MAX_TASKS               64)
-
-# The maximum number of queues to support
-set(OSAL_CONFIG_MAX_QUEUES              64)
-
-# The maximum number of counting semaphores to support
-set(OSAL_CONFIG_MAX_COUNT_SEMAPHORES    20)
-
-# The maximum number of binary semaphores to support
-set(OSAL_CONFIG_MAX_BIN_SEMAPHORES      20)
-
-# The maximum number of mutexes to support
-set(OSAL_CONFIG_MAX_MUTEXES             20)
-
-# The maximum number of loadable modules to support
-# Note that emulating module loading for statically-linked objects also
-# requires a slot in this table, as it still assigns an OSAL ID.
-set(OSAL_CONFIG_MAX_MODULES             20)
-
-# The maximum number of time base objects (reference for timers)
-set(OSAL_CONFIG_MAX_TIMEBASES           5)
-
-# The maximum number of user timers / app callbacks that can be registered
-set(OSAL_CONFIG_MAX_TIMERS              10)
-
-# The maximum number of concurrently open file descriptors to support
-set(OSAL_CONFIG_MAX_NUM_OPEN_FILES      50)
-
-# The maximum number of concurrently open directory descriptors to support
-set(OSAL_CONFIG_MAX_NUM_OPEN_DIRS       4)
-
-# The maximum number of file systems that can be managed by OSAL
-set(OSAL_CONFIG_MAX_FILE_SYSTEMS        14)
-
-# The maximum length for a file name, including any extension
-# (This does not include the directory part)
-# This length must include an extra character for NULL termination.
-set(OSAL_CONFIG_MAX_FILE_NAME           20)
-
-# Maximum length for an virtual path name (virtual directory + file)
-# This length must include an extra character for NULL termination.
-set(OSAL_CONFIG_MAX_PATH_LEN            64)
-
-# Maximum length allowed for a object (task,queue....) name
-# This length must include an extra character for NULL termination.
-set(OSAL_CONFIG_MAX_API_NAME            20)
-
-# Maximum length of a symbol name for OS_SymbolLookup()
-# This length must include an extra character for NULL termination.
-set(OSAL_CONFIG_MAX_SYM_LEN             64)
-
-# Maximum length of a network socket address
-# This is only relevant if network support is included, and the
-# required length depends on the address families in use
-set(OSAL_CONFIG_SOCKADDR_MAX_LEN        28)
-
-# Maximum length of a single message produced by OS_printf()
-set(OSAL_CONFIG_PRINTF_BUFFER_SIZE      172)
-
-# Maximum number of OS_printf() messages that will be buffered
-set(OSAL_CONFIG_PRINTF_BUFFER_DEPTH     100)
-
-# Priority level of a console output helper task
+# Elevate the priority level of the console output helper task
 #
-# Set logically low (high number) to maximize performance.
-#   - Messages from OS_printf() may show on the console with some delay
-#     but should have minimal impact to real time tasks.
+# By default OSAL uses a low-priority utility task to write
+# "OS_printf" messages in a deferred manner. However this deferred
+# write can potentially cause the messages to appear on the console
+# out of sync with the events they are related to.
 #
-# Set logically high (low number) for debugging
-#   - Messages from OS_printf() will have more timely output, but may
-#     adversely impact real time tasks.
-set(OSAL_CONFIG_UTILITYTASK_PRIORITY    245)
-
-# Stack size of console output task.
+# Raising the priority of this task from its default to be _higher_
+# than the CFE core tasks means that OS_printf() messages should
+# appear on the console in a timely manner, which helps during debug.
+# However for a flight deployment this may cause undesired delays.
 #
-# This applies to RTOS layers with precise stack control,
-# normally not necessary to change this unless the task implementation
-# changes.
-set(OSAL_CONFIG_UTILITYTASK_STACK_SIZE  2048)
-
-# The size of a command that can be passed to the underlying OS
-# This length must include an extra character for NULL termination.
-set(OSAL_CONFIG_MAX_CMD_LEN             1000)
-
-# The maximum depth of an OSAL message queue.
-# On some implementations this may affect the overall OSAL memory footprint
-# so it may be beneficial to set this limit accordingly.
-set(OSAL_CONFIG_QUEUE_MAX_DEPTH         50)
+set(OSAL_CONFIG_UTILITYTASK_PRIORITY 10)

--- a/cmake/sample_defs/native_osconfig.cmake
+++ b/cmake/sample_defs/native_osconfig.cmake
@@ -1,5 +1,39 @@
+##########################################################################
 #
-# OSAL configuration addendum when building with SIMULATION=native
-# In this mode, enable the PERMISSIVE option, which allows for easier testing.
+# CPU/Arch-specific configuration options for OSAL
+#
+# This file specifies the CFE-specific values for various compile options
+# that are used only when compiling using a specific toolchain.
+#
+# OSAL has many configuration options, which may vary depending on the
+# specific version of OSAL in use.  The complete list of OSAL options,
+# along with a description of each, can be found OSAL source in the file:
+#
+#    osal/default_config.cmake
+#
+# This file is an addendum to the CFE-specific overrides that will be
+# used/enabled when building with the "SIMULATION=native" mode.
+#
+# See "default_osconfig.cmake" for options which apply only to all builds,
+# regardless of toolchain in use.
+#
+##########################################################################
+
+#
+# OSAL_CONFIG_DEBUG_PERMISSIVE_MODE
+# ---------------------------------
+#
+# When building with SIMULATION=native, enable the PERMISSIVE option,
+# which allows for easier testing.  This option causes the OSAL to
+# continue through certain privleged operations (ignores errors) when
+# running as a standard/non-root user.
+#
+# Typically a regular user on a default Linux workstation configuration
+# would not have permission to create realtime priority threads or FIFO
+# queues deeper than the soft limit in /proc/sys/fs/mqueue/msg_max.
+#
+# Note that even with this enabled, OSAL will still _attempt_ to create
+# resources as requested, this only makes it so the overall request will
+# continue, regardless of whether the privileged operation succeeded or not.
 #
 set(OSAL_CONFIG_DEBUG_PERMISSIVE_MODE TRUE)


### PR DESCRIPTION
**Describe the contribution**
The CFE framework build uses mostly default values for OSAL compile time configuration.  There are just a few exceptions where the CFE build is tuned for a more debug-friendly result.

This updates the configuration files in "sample_defs" to reflect only those values which are set to a non-default value, along with
information about why the configurable item is changed. Currently, these are only items related to debugging.

This change also includes more documentation/comments about how this configuration facility works and where to find information on the complete set of options available (which is OSAL version dependent).

Fixes #1343 

**Testing performed**
Build and sanity check CFE, run all tests

**Expected behavior changes**
None, this is just documentation/sample config cleanup, but does not change the effective OSAL configuration, since most of the values in this sample file were the same as the default value.

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
