### PR TITLE
Fix #1488, Report files checked in cppcheck action

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run bundle cppcheck
         if: ${{matrix.cppcheck =='all'}}
-        run: cppcheck --force --inline-suppr --quiet . 2> ${{matrix.cppcheck}}_cppcheck_err.txt
+        run: cppcheck --force --inline-suppr . 2> ${{matrix.cppcheck}}_cppcheck_err.txt
 
         # Run strict static analysis for embedded portions of cfe
       - name: cfe strict cppcheck


### PR DESCRIPTION
**Describe the contribution**
Fix #1488, removes `--quite` option so files checked go to stdout

**Testing performed**
CI

**Expected behavior changes**
Reports files checked in CI

**System(s) tested on**
CI

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC