### PR TITLE
cFE Integration candidate: 2021-05-18

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ The detailed cFE user's guide can be viewed at <https://github.com/nasa/cFS/blob
 
 ## Version History
 
+### Development Build: v6.8.0-rc1+dev580
+
+- Adds `CFE_MSG_GetNextSequenceCount` so the auto-increment of the local sequence counter works when sending tlm (and increment is enabled). Updates unit tests and adds the old-style stub. The unit tests check for the correct rollover behavior.Sequence count will roll over based on the mask. Before the fix the sequence counter would "stick" in telemetry until the passed in value rolled over.
+- [docs] Correctly format code block section terminator so Markdown renders correctly
+- [docs] Fix typos in developer guide
+- See <https://github.com/nasa/cFE/pull/1508> and <https://github.com/nasa/cFS/pull/259>
+
 ### Development Build: v6.8.0-rc1+dev575
 
 - Removes broken travis-ci script
@@ -21,7 +28,7 @@ a default handler routine.
 - [docs] Adds documentation and comments about how the configuration facility works and where to find information on the complete set of options available
 - Updates the configuration files in "sample_defs" to reflect only those parameters that are set to a non-default value along with information about why the configurable item is changed.
 - Removes --quiet option so files checked go to stdout
-
+- See <https://github.com/nasa/cFE/pull/1492> and <https://github.com/nasa/cFS/pull/256>
 
 ### Development Build: v6.8.0-rc1+dev559
 

--- a/docs/cFE Application Developers Guide.md
+++ b/docs/cFE Application Developers Guide.md
@@ -1795,7 +1795,7 @@ one deployment to the next. By using these functions, Applications are
 guaranteed to work regardless of the structure of the Message Header.
 
 Although CFE_SB_SetUserDataLength APIs is available,
-it is based on assumptions about the defintion of "User Data" and is
+it is based on assumptions about the definition of "User Data" and is
 really just a best guess since the packet structure is dependent on implementation.
 The preference is to use CFE_MSG_SetSize and actual packet structure
 information when available.
@@ -1842,7 +1842,7 @@ CFE_MSG_ValidateChecksum() and it simply returns a success or failure
 indication.
 
 Although CFE_SB_GetUserDataLength and CFE_SB_GetUserData APIs are available,
-they are based on assumptions about the defintion of "User Data" and are
+they are based on assumptions about the definition of "User Data" and are
 really just a best guess since the packet structure is dependent on implementation.
 The preference is to use the actual packet structure when available.
 
@@ -3210,7 +3210,7 @@ paradigm that allows the Time Services on the processor that has access
 to the primary onboard time base to broadcast the current time to Time
 Clients. As long as the Time Server has a working communication path to
 all Time Clients, the time available to every Application is essentially
-the same with neglible errors. When a Time Server and Time Client become
+the same with negligible errors. When a Time Server and Time Client become
 disconnected from one another, they each do their best to maintain the
 current time with what information they have available.
 

--- a/docs/cFE Application Developers Guide.md
+++ b/docs/cFE Application Developers Guide.md
@@ -2033,7 +2033,7 @@ SAMPLE_AppData_t  SAMPLE_AppData;  /* Instantiate Task Data */
    /* SAMPLE_AppData.BigPktBuf is no longer a valid pointer */
    ...
 }
-```c  
+```
 
 ## 6.9 Best Practices for using Software Bus
 

--- a/modules/core_api/fsw/inc/cfe_msg.h
+++ b/modules/core_api/fsw/inc/cfe_msg.h
@@ -292,6 +292,22 @@ CFE_Status_t CFE_MSG_SetSequenceCount(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Sequenc
 
 /*****************************************************************************/
 /**
+ * \brief Gets the next sequence count value (rolls over if appropriate)
+ *
+ * \par Description
+ *          Abstract method to get the next valid sequence count value.
+ *          Will roll over to zero for any input value greater than or
+ *          equal to the maximum possible sequence count value given
+ *          the field in the header.
+ *
+ * \param[in]       SeqCnt      Sequence count
+ *
+ * \return The next valid sequence count value
+ */
+CFE_MSG_SequenceCount_t CFE_MSG_GetNextSequenceCount(CFE_MSG_SequenceCount_t SeqCnt);
+
+/*****************************************************************************/
+/**
  * \brief Gets the message EDS version
  *
  * \par Description

--- a/modules/core_api/fsw/inc/cfe_version.h
+++ b/modules/core_api/fsw/inc/cfe_version.h
@@ -28,7 +28,7 @@
 #define CFE_VERSION_H
 
 /* Development Build Macro Definitions */
-#define CFE_BUILD_NUMBER 575 /*!< Development Build: Number of commits since baseline */
+#define CFE_BUILD_NUMBER 580 /*!< Development Build: Number of commits since baseline */
 #define CFE_BUILD_BASELINE                                                                    \
     "v6.8.0-rc1" /*!< Development Build: git tag that is the base for the current development \
                   */

--- a/modules/core_api/ut-stubs/src/cfe_msg_handlers.c
+++ b/modules/core_api/ut-stubs/src/cfe_msg_handlers.c
@@ -360,3 +360,21 @@ void UT_DefaultHandler_CFE_MSG_ValidateChecksum(void *UserObj, UT_EntryKey_t Fun
                          sizeof(*IsValid));
     }
 }
+
+/*------------------------------------------------------------
+ *
+ * Default handler for CFE_MSG_GetNextSequenceCount coverage stub function
+ *
+ *------------------------------------------------------------*/
+void UT_DefaultHandler_CFE_MSG_GetNextSequenceCount(void *UserObj, UT_EntryKey_t FuncKey,
+                                                    const UT_StubContext_t *Context)
+{
+    int32                   status;
+    CFE_MSG_SequenceCount_t return_value;
+
+    UT_Stub_GetInt32StatusCode(Context, &status);
+
+    return_value = status;
+
+    UT_Stub_SetReturnValue(FuncKey, return_value);
+}

--- a/modules/core_api/ut-stubs/src/cfe_msg_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_msg_stubs.c
@@ -35,6 +35,7 @@ extern void UT_DefaultHandler_CFE_MSG_GetHasSecondaryHeader(void *, UT_EntryKey_
 extern void UT_DefaultHandler_CFE_MSG_GetHeaderVersion(void *, UT_EntryKey_t, const UT_StubContext_t *);
 extern void UT_DefaultHandler_CFE_MSG_GetMsgId(void *, UT_EntryKey_t, const UT_StubContext_t *);
 extern void UT_DefaultHandler_CFE_MSG_GetMsgTime(void *, UT_EntryKey_t, const UT_StubContext_t *);
+extern void UT_DefaultHandler_CFE_MSG_GetNextSequenceCount(void *, UT_EntryKey_t, const UT_StubContext_t *);
 extern void UT_DefaultHandler_CFE_MSG_GetPlaybackFlag(void *, UT_EntryKey_t, const UT_StubContext_t *);
 extern void UT_DefaultHandler_CFE_MSG_GetSegmentationFlag(void *, UT_EntryKey_t, const UT_StubContext_t *);
 extern void UT_DefaultHandler_CFE_MSG_GetSequenceCount(void *, UT_EntryKey_t, const UT_StubContext_t *);
@@ -195,6 +196,22 @@ CFE_Status_t CFE_MSG_GetMsgTime(const CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTim
     UT_GenStub_Execute(CFE_MSG_GetMsgTime, Basic, UT_DefaultHandler_CFE_MSG_GetMsgTime);
 
     return UT_GenStub_GetReturnValue(CFE_MSG_GetMsgTime, CFE_Status_t);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CFE_MSG_GetNextSequenceCount()
+ * ----------------------------------------------------
+ */
+CFE_MSG_SequenceCount_t CFE_MSG_GetNextSequenceCount(CFE_MSG_SequenceCount_t SeqCnt)
+{
+    UT_GenStub_SetupReturnBuffer(CFE_MSG_GetNextSequenceCount, CFE_MSG_SequenceCount_t);
+
+    UT_GenStub_AddParam(CFE_MSG_GetNextSequenceCount, CFE_MSG_SequenceCount_t, SeqCnt);
+
+    UT_GenStub_Execute(CFE_MSG_GetNextSequenceCount, Basic, UT_DefaultHandler_CFE_MSG_GetNextSequenceCount);
+
+    return UT_GenStub_GetReturnValue(CFE_MSG_GetNextSequenceCount, CFE_MSG_SequenceCount_t);
 }
 
 /*

--- a/modules/msg/fsw/src/cfe_msg_ccsdspri.c
+++ b/modules/msg/fsw/src/cfe_msg_ccsdspri.c
@@ -383,6 +383,26 @@ int32 CFE_MSG_SetSequenceCount(CFE_MSG_Message_t *MsgPtr, CFE_MSG_SequenceCount_
 
 /*----------------------------------------------------------------
  *
+ * Function: CFE_MSG_GetNextSequenceCount
+ *
+ * Implemented per public API
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+CFE_MSG_SequenceCount_t CFE_MSG_GetNextSequenceCount(CFE_MSG_SequenceCount_t SeqCnt)
+{
+    SeqCnt++;
+
+    if (SeqCnt > CFE_MSG_SEQCNT_MASK)
+    {
+        SeqCnt = 0;
+    }
+
+    return SeqCnt;
+}
+
+/*----------------------------------------------------------------
+ *
  * Function: CFE_MSG_GetSize
  *
  * Implemented per public API

--- a/modules/msg/ut-coverage/test_cfe_msg_ccsdspri.c
+++ b/modules/msg/ut-coverage/test_cfe_msg_ccsdspri.c
@@ -396,10 +396,13 @@ void Test_MSG_SegmentationFlag(void)
 
 void Test_MSG_SequenceCount(void)
 {
-    CFE_MSG_Message_t msg;
-    CFE_MSG_ApId_t    input[] = {0, TEST_SEQUENCE_MAX / 2, TEST_SEQUENCE_MAX};
-    CFE_MSG_ApId_t    actual  = TEST_SEQUENCE_MAX;
-    int               i;
+    CFE_MSG_Message_t             msg;
+    const CFE_MSG_SequenceCount_t input[] = {0, TEST_SEQUENCE_MAX / 2, TEST_SEQUENCE_MAX};
+    CFE_MSG_SequenceCount_t       actual  = TEST_SEQUENCE_MAX;
+    CFE_MSG_SequenceCount_t       maxsc;
+    int                           i;
+
+    memset(&maxsc, 0xFF, sizeof(maxsc));
 
     UtPrintf("Bad parameter tests, Null pointers and invalid (max valid + 1, max)");
     memset(&msg, 0, sizeof(msg));
@@ -410,7 +413,7 @@ void Test_MSG_SequenceCount(void)
     ASSERT_EQ(CFE_MSG_SetSequenceCount(NULL, input[0]), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(CFE_MSG_SetSequenceCount(&msg, TEST_SEQUENCE_MAX + 1), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(Test_MSG_NotZero(&msg), 0);
-    ASSERT_EQ(CFE_MSG_SetSequenceCount(&msg, 0xFFFF), CFE_MSG_BAD_ARGUMENT);
+    ASSERT_EQ(CFE_MSG_SetSequenceCount(&msg, maxsc), CFE_MSG_BAD_ARGUMENT);
     ASSERT_EQ(Test_MSG_NotZero(&msg), 0);
 
     UtPrintf("Set to all F's, various valid inputs");
@@ -452,6 +455,12 @@ void Test_MSG_SequenceCount(void)
             ASSERT_EQ(Test_MSG_NotZero(&msg), MSG_SEQUENCE_FLAG);
         }
     }
+
+    UtPrintf("Fully exercise getting next sequence count");
+    ASSERT_EQ(CFE_MSG_GetNextSequenceCount(0), 1);
+    ASSERT_EQ(CFE_MSG_GetNextSequenceCount(TEST_SEQUENCE_MAX / 2), (TEST_SEQUENCE_MAX / 2) + 1);
+    ASSERT_EQ(CFE_MSG_GetNextSequenceCount(TEST_SEQUENCE_MAX), 0);
+    ASSERT_EQ(CFE_MSG_GetNextSequenceCount(maxsc), 0);
 }
 
 /*

--- a/modules/sbr/fsw/src/cfe_sbr_route_unsorted.c
+++ b/modules/sbr/fsw/src/cfe_sbr_route_unsorted.c
@@ -38,6 +38,7 @@
 #include <string.h>
 
 #include "cfe_sb.h"
+#include "cfe_msg.h"
 
 /******************************************************************************
  * Type Definitions
@@ -182,9 +183,12 @@ void CFE_SBR_SetDestListHeadPtr(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t
  *-----------------------------------------------------------------*/
 void CFE_SBR_IncrementSequenceCounter(CFE_SBR_RouteId_t RouteId)
 {
+    CFE_MSG_SequenceCount_t *cnt;
+
     if (CFE_SBR_IsValidRouteId(RouteId))
     {
-        CFE_SBR_RDATA.RoutingTbl[CFE_SBR_RouteIdToValue(RouteId)].SeqCnt++;
+        cnt  = &CFE_SBR_RDATA.RoutingTbl[CFE_SBR_RouteIdToValue(RouteId)].SeqCnt;
+        *cnt = CFE_MSG_GetNextSequenceCount(*cnt);
     }
 }
 

--- a/modules/sbr/ut-coverage/test_cfe_sbr_route_unsorted.c
+++ b/modules/sbr/ut-coverage/test_cfe_sbr_route_unsorted.c
@@ -115,12 +115,13 @@ void Test_SBR_Route_Unsort_General(void)
 void Test_SBR_Route_Unsort_GetSet(void)
 {
 
-    CFE_SB_RouteId_Atom_t routeidx;
-    CFE_SB_MsgId_t        msgid[3];
-    CFE_SBR_RouteId_t     routeid[3];
-    CFE_SB_DestinationD_t dest[2];
-    uint32                count;
-    uint32                i;
+    CFE_SB_RouteId_Atom_t   routeidx;
+    CFE_SB_MsgId_t          msgid[3];
+    CFE_SBR_RouteId_t       routeid[3];
+    CFE_SB_DestinationD_t   dest[2];
+    CFE_MSG_SequenceCount_t seqcntexpected[] = {1, 2};
+    uint32                  count;
+    uint32                  i;
 
     UtPrintf("Invalid route ID checks");
     routeid[0] = CFE_SBR_INVALID_ROUTE_ID;
@@ -167,20 +168,24 @@ void Test_SBR_Route_Unsort_GetSet(void)
     }
 
     /* Check the msgid matches and increment a sequence counter */
+    UT_SetDefaultReturnValue(UT_KEY(CFE_MSG_GetNextSequenceCount), seqcntexpected[0]);
     for (i = 0; i < 3; i++)
     {
         ASSERT_TRUE(CFE_SB_MsgId_Equal(msgid[i], CFE_SBR_GetMsgId(routeid[i])));
         CFE_SBR_IncrementSequenceCounter(routeid[0]);
     }
+    ASSERT_EQ(UT_GetStubCount(UT_KEY(CFE_MSG_GetNextSequenceCount)), 3);
 
     /* Increment route 1 once and set dest pointers */
+    UT_SetDefaultReturnValue(UT_KEY(CFE_MSG_GetNextSequenceCount), seqcntexpected[1]);
     CFE_SBR_IncrementSequenceCounter(routeid[1]);
+    ASSERT_EQ(UT_GetStubCount(UT_KEY(CFE_MSG_GetNextSequenceCount)), 4);
     CFE_SBR_SetDestListHeadPtr(routeid[1], &dest[1]);
     CFE_SBR_SetDestListHeadPtr(routeid[2], &dest[0]);
 
     UtPrintf("Verify remaining set values");
-    ASSERT_EQ(CFE_SBR_GetSequenceCounter(routeid[0]), 3);
-    ASSERT_EQ(CFE_SBR_GetSequenceCounter(routeid[1]), 1);
+    ASSERT_EQ(CFE_SBR_GetSequenceCounter(routeid[0]), seqcntexpected[0]);
+    ASSERT_EQ(CFE_SBR_GetSequenceCounter(routeid[1]), seqcntexpected[1]);
     ASSERT_EQ(CFE_SBR_GetSequenceCounter(routeid[2]), 0);
     UtAssert_ADDRESS_EQ(CFE_SBR_GetDestListHeadPtr(routeid[0]), NULL);
     UtAssert_ADDRESS_EQ(CFE_SBR_GetDestListHeadPtr(routeid[1]), &dest[1]);


### PR DESCRIPTION
## Context

Part of <https://github.com/nasa/cFS/pull/259>

## Testing

cFE Checks <https://github.com/nasa/cFE/pull/1508/checks>
cFS Bundle Checks <https://github.com/nasa/cFS/pull/259/checks>

## Description

### PR #1482

Fix #1419, Resolve sequence count auto-increment rollover bug

Adds `CFE_MSG_GetNextSequenceCount` so the auto-increment of the local sequence counter works when sending tlm (and increment is enabled).  Updates unit tests and adds the old-style stub.  The unit tests check for the correct rollover behavior.Sequence count will roll over based on the mask.  Before the fix the sequence counter would "stick" in telemetry until the passed in value rolled over.

### PR #1491, *Community Contribution!*

Fix #1421, Correctly format code block section terminator

Markdown renders correctly after fixing fixing code block termination. 

### PR #1530, *Community Contribution!* 

Fix #1550, typos in developer guide 

## Authors

@skliper 
@jbohren-hbr 
@tniessen 
