### PR TITLE
Fix #1505, accept "NULL" as entry point

### DIFF
--- a/modules/es/fsw/src/cfe_es_apps.c
+++ b/modules/es/fsw/src/cfe_es_apps.c
@@ -450,7 +450,8 @@ int32 CFE_ES_LoadModule(CFE_ResourceId_t ParentResourceId, const char *ModuleNam
     /*
      * If the Load was OK, then lookup the address of the entry point
      */
-    if (ReturnCode == CFE_SUCCESS && LoadParams->InitSymbolName[0] != 0)
+    if (ReturnCode == CFE_SUCCESS && LoadParams->InitSymbolName[0] != 0 &&
+        strcmp(LoadParams->InitSymbolName, "NULL") != 0)
     {
         StatusCode = OS_ModuleSymbolLookup(ModuleId, &InitSymbolAddress, LoadParams->InitSymbolName);
         if (StatusCode != OS_SUCCESS)

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -1848,6 +1848,23 @@ void TestLibs(void)
     Return = CFE_ES_LoadLibrary(&Id, "TST_LIB", &LoadParams);
     UtAssert_INT32_EQ(Return, CFE_STATUS_EXTERNAL_RESOURCE_FAIL);
 
+    /*
+     * Test shared library loading and initialization where the library
+     * entry point symbol is the special string "NULL".  This should skip
+     * symbol lookup.
+     */
+    ES_ResetUnitTest();
+    ES_UT_SetupModuleLoadParams(&LoadParams, "nullep", "NULL");
+    Return = CFE_ES_LoadLibrary(&Id, "TST_LIB1", &LoadParams);
+    UtAssert_INT32_EQ(Return, CFE_SUCCESS);
+    UtAssert_STUB_COUNT(OS_ModuleSymbolLookup, 0); /* should NOT have been called */
+
+    /* Likewise for a entry point where the string is empty */
+    LoadParams.InitSymbolName[0] = 0;
+    Return                       = CFE_ES_LoadLibrary(&Id, "TST_LIB2", &LoadParams);
+    UtAssert_INT32_EQ(Return, CFE_SUCCESS);
+    UtAssert_STUB_COUNT(OS_ModuleSymbolLookup, 0); /* should NOT have been called */
+
     /* Test shared library loading and initialization where the library
      * initialization function fails and then must be cleaned up
      */


### PR DESCRIPTION
**Describe the contribution**
Recognize the special string "NULL" to indicate no entry point should be called for the library.  Equivalent to leaving the
field empty. 

Fixes #1505 

**Testing performed**
Build and sanity check CFE, and use a startup script that loads a CFE_LIB with a NULL entry point
Run all unit tests.

**Expected behavior changes**
Specifying the special string `NULL` as the entry point in a startup script should work as it did in previous versions - skips the entry point.

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
