### PR TITLE
Fix #1446, Remove unused EVS LogMode defines

### DIFF
--- a/modules/evs/fsw/inc/cfe_evs_events.h
+++ b/modules/evs/fsw/inc/cfe_evs_events.h
@@ -561,7 +561,7 @@
 **  This event message is generated when a "Set Log Mode" command is completed successfully.
 **
 **  The event text identifies the Log Mode command argument.  Valid Log Mode command
-**  arguments are: #CFE_EVS_LOG_OVERWRITE or #CFE_EVS_LOG_DISCARD.
+**  arguments are: #CFE_EVS_LogMode_OVERWRITE or #CFE_EVS_LogMode_DISCARD.
 **/
 #define CFE_EVS_LOGMODE_EID 38
 
@@ -576,7 +576,7 @@
 **  an invalid Log Mode command argument.
 **
 **  The event text identifies the invalid Log Mode command argument.  Valid Log Mode command
-**  arguments are: #CFE_EVS_LOG_OVERWRITE or #CFE_EVS_LOG_DISCARD.
+**  arguments are: #CFE_EVS_LogMode_OVERWRITE or #CFE_EVS_LogMode_DISCARD.
 **/
 #define CFE_EVS_ERR_LOGMODE_EID 39
 

--- a/modules/evs/fsw/inc/cfe_evs_msg.h
+++ b/modules/evs/fsw/inc/cfe_evs_msg.h
@@ -907,10 +907,6 @@
 #define CFE_EVS_PORT3_BIT 0x0004
 #define CFE_EVS_PORT4_BIT 0x0008
 
-/* EVS Log Modes */
-#define CFE_EVS_LOG_OVERWRITE 0
-#define CFE_EVS_LOG_DISCARD   1
-
 /******************  Structure Definitions *********************/
 
 /**


### PR DESCRIPTION
**Describe the contribution**
Removed unused EVS LogMode defines and references to these defines.

Fixes #1446 

**Testing performed**
Steps taken to test the contribution:
1. Build and run unit tests

**Expected behavior changes**
There are no behavior changes. Everything continues to run the same.

**System(s) tested on**
 - OS: Ubuntu 18.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Jose F. Martinez Pedraza, NASA GSFC code 582
