### PR TITLE
Fix #1554, add doxygen aliases for OSAL parameter/retvals

### DIFF
--- a/cmake/osal-common.doxyfile.in
+++ b/cmake/osal-common.doxyfile.in
@@ -16,6 +16,10 @@ ABBREVIATE_BRIEF       = "The $name class " \
                          the
 TAB_SIZE               = 8
 OPTIMIZE_OUTPUT_FOR_C  = YES
+ALIASES               +=  nonnull="(must not be null)"
+ALIASES               +=  nonzero="(must not be zero)"
+ALIASES               +=  covtest="(return value only verified in coverage test)"
+
 #---------------------------------------------------------------------------
 # Build related configuration options
 #---------------------------------------------------------------------------


### PR DESCRIPTION
**Describe the contribution**

Adds "nonnull", "nonzero", and "covtest" tags to mark parameters and return values in documentation.  This info is helpful when
auditing the test cases.

Fixes #1554

**Testing performed**
Build osalguide documentation, confirm output in the generated HTML

**Expected behavior changes**
Documentation only, no FSW.
Doxygen parameters and retvals can now be marked accordingly

**System(s) tested on**
Ubuntu

**Additional context**
This markup will be required for some of the OSAL return value verifications

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
