### PR TITLE
Fix #1441, Replace Header Content Type magic number.

### DIFF
--- a/modules/fs/fsw/src/cfe_fs_api.c
+++ b/modules/fs/fsw/src/cfe_fs_api.c
@@ -223,7 +223,7 @@ int32 CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr)
         Hdr->Length = sizeof(CFE_FS_Header_t);
 
         /* put the header, 'cfe1' in hex, in to the content type */
-        Hdr->ContentType = 0x63464531;
+        Hdr->ContentType = CFE_FS_FILE_CONTENT_ID;
 
         /*
         ** Fill in the timestamp fields...


### PR DESCRIPTION
**Describe the contribution**
Fixes #1441
Changes the magic number to the defined value. 

**Testing performed**
Build and run unit test

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC