### PR TITLE
Fix #1548, Include verify headers to validate config

### DIFF
--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -39,6 +39,7 @@
 
 #include "cfe_version.h"
 #include "target_config.h"
+#include "cfe_es_verify.h"
 
 #include <string.h>
 

--- a/modules/evs/fsw/src/cfe_evs_task.c
+++ b/modules/evs/fsw/src/cfe_evs_task.c
@@ -32,6 +32,7 @@
 /* Include Files */
 #include "cfe_evs_module_all.h" /* All EVS internal definitions and API */
 #include "cfe_version.h"        /* cFE version definitions */
+#include "cfe_evs_verify.h"
 
 #include <string.h>
 

--- a/modules/sb/fsw/src/cfe_sb_task.c
+++ b/modules/sb/fsw/src/cfe_sb_task.c
@@ -33,6 +33,7 @@
 #include "cfe_sb_module_all.h"
 #include "cfe_version.h"
 #include "cfe_es_msg.h" /* needed for local use of CFE_ES_RestartCmd_t */
+#include "cfe_sb_verify.h"
 
 #include <string.h>
 

--- a/modules/tbl/fsw/src/cfe_tbl_task.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task.c
@@ -34,6 +34,7 @@
 */
 #include "cfe_tbl_module_all.h"
 #include "cfe_version.h"
+#include "cfe_tbl_verify.h"
 
 #include <string.h>
 

--- a/modules/time/fsw/src/cfe_time_task.c
+++ b/modules/time/fsw/src/cfe_time_task.c
@@ -34,6 +34,7 @@
 */
 #include "cfe_time_module_all.h"
 #include "cfe_version.h"
+#include "cfe_time_verify.h"
 
 /*
 ** Time task global data...


### PR DESCRIPTION
**Describe the contribution**
Fix #1548 - includes the verify.h headers in service *_task.c file to verify config settings

**Testing performed**
Build and ran unit tests w/ default config (passed)
Made an ES config invalid and confirmed it errored on build

**Expected behavior changes**
Actually runs the config verification macros

**System(s) tested on**
 - Hardware: Docker on laptop
 - OS: Ubuntu 18.04
 - Versions: bundle main + this commit

**Additional context**
Eventually the compile time checks could move closer to use, but for now at least this performs the checks as part of service compilation.  Debated running as a separate check in cmake, but preference is to move closer to where it matters vs further away.  We dropped them once, hopefully we'll be less likely to drop them in the future when it's actually in the code.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC