### PR TITLE
Fix #1507, Document TblName as app specific

### DIFF
--- a/modules/core_api/fsw/inc/cfe_tbl.h
+++ b/modules/core_api/fsw/inc/cfe_tbl.h
@@ -70,9 +70,9 @@
 **                                 when performing Table operations. This value is returned at  ddress specified by
 **                                 TblHandlePtr.
 **
-** \param[in] Name                 The application-specific name.  This name will be combined with the name of the
-**                                 application to produce a processor specific name of the form
-**                                 "ApplicationName.TableName".  The processor specific name will be used in commands
+** \param[in] Name                 The raw table name.  This name will be combined with the name of the
+**                                 application to produce a name of the form "AppName.RawTableName".
+**                                 This application specific name will be used in commands
 **                                 for modifying or viewing the contents of the table.
 **
 ** \param[in] Size                 The size, in bytes, of the table to be created.  This is the size that will be
@@ -209,12 +209,9 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *        TblHandlePtr,          /
 **                           identify table to cFE when performing Table operations.
 **                           This value is returned at the address specified by TblHandlePtr.
 **
-** \param[in]  TblName       The processor specific name of the table.  It is important to note
-**                           that the processor specific table name is different from the table
-**                           name specified in the #CFE_TBL_Register API call.  The processor
-**                           specific table name includes the name of the application that created
-**                           the table.  The name would be of the form "ApplicationName.TableName".
-**                           An example of this would be "ACS.TamParams" for a table called "TamParams"
+** \param[in]  TblName       The application specific name of the table of the form "AppName.RawTableName",
+**                           where RawTableName is the name specified in the #CFE_TBL_Register API call.
+**                           Example: "ACS.TamParams" for a table called "TamParams"
 **                           that was registered by the application called "ACS".
 **
 ** \return Execution status, see \ref CFEReturnCodes
@@ -678,13 +675,9 @@ CFE_Status_t CFE_TBL_GetStatus(CFE_TBL_Handle_t TblHandle);
 **                           with table characteristics and information. *TblInfoPtr is the description of the tables
 **                           characteristics and registry information stored in the #CFE_TBL_Info_t data structure
 **                           format.
-**
-** \param[in]  TblName       The processor specific name of the table.  It is important to note
-**                           that the processor specific table name is different from the table
-**                           name specified in the #CFE_TBL_Register API call.  The processor
-**                           specific table name includes the name of the application that created
-**                           the table.  The name would be of the form "ApplicationName.TableName".
-**                           An example of this would be "ACS.TamParams" for a table called "TamParams"
+** \param[in]  TblName       The application specific name of the table of the form "AppName.RawTableName",
+**                           where RawTableName is the name specified in the #CFE_TBL_Register API call.
+**                           Example: "ACS.TamParams" for a table called "TamParams"
 **                           that was registered by the application called "ACS".
 **
 ** \return Execution status, see \ref CFEReturnCodes

--- a/modules/tbl/fsw/src/cfe_tbl_api.c
+++ b/modules/tbl/fsw/src/cfe_tbl_api.c
@@ -89,8 +89,7 @@ int32 CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, size_t 
         }
         else
         {
-            /* Modify specified name to be processor specific name */
-            /* of the form "AppName.TableName"                     */
+            /* Generate application specific table name */
             CFE_TBL_FormTableName(TblName, Name, ThisAppId);
 
             /* Make sure the specified size is acceptable */

--- a/modules/tbl/fsw/src/cfe_tbl_internal.c
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.c
@@ -603,7 +603,7 @@ void CFE_TBL_FormTableName(char *FullTblName, const char *TblName, CFE_ES_AppId_
     /* Ensure that AppName is null terminated */
     AppName[OS_MAX_API_NAME - 1] = '\0';
 
-    /* Complete formation of processor specific table name */
+    /* Complete formation of application specific table name */
     sprintf(FullTblName, "%s.%s", AppName, TblName);
 
     return;

--- a/modules/tbl/fsw/src/cfe_tbl_internal.h
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.h
@@ -244,22 +244,18 @@ CFE_TBL_Handle_t CFE_TBL_FindFreeHandle(void);
 ** \brief Creates a Full Table name from application name and table name
 **
 ** \par Description
-**        Takes a given Table Name and combines it with the calling
-**        Application's name to make a processor specific name of the
-**        form: "AppName.TblName"
+**        Takes a given raw table name and combines it with the calling
+**        Application's name to make the application specific name of the
+**        form: "AppName.RawTableName"
 **
 ** \par Assumptions, External Events, and Notes:
-**        Note: AppName portion will be truncated to OS_MAX_API_NAME.
+**        AppName portion will be truncated to OS_MAX_API_NAME.
 **
-** \param[in, out]  FullTblName pointer to character buffer of #CFE_TBL_MAX_FULL_NAME_LEN size that will be filled with
-**                  the processor specific Table Name. *FullTblName is the processor specific Table Name of the form
-**                  "AppName.TblName".
-**
-** \param[in]  TblName pointer to character string containing the Application's local name for
-**                     the Table.
-**
-** \param[in]  ThisAppId the Application ID of the Application making the call.
-**
+** \param[in, out] FullTblName  Pointer to character buffer of #CFE_TBL_MAX_FULL_NAME_LEN
+**                              size that will be filled with the application specific name
+**                              of the form "AppName.RawTableName"
+** \param[in] TblName           Pointer to character string containing the raw table name.
+** \param[in] ThisAppId         Application ID of the Application making the call.
 */
 void CFE_TBL_FormTableName(char *FullTblName, const char *TblName, CFE_ES_AppId_t ThisAppId);
 


### PR DESCRIPTION
**Describe the contribution**
Fix #1507 - replaces "processor specific" comments with app specific in relation to table name and also refers to the "raw table name" instead of overloading "table name"

**Testing performed**
CI - documentation only

**Expected behavior changes**
None

**System(s) tested on**
CI

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC