### PR TITLE
Fix #1476, Use CFE_MSG_SequenceCount_t for seqcnt type

### DIFF
--- a/modules/sbr/fsw/src/cfe_sbr_route_unsorted.c
+++ b/modules/sbr/fsw/src/cfe_sbr_route_unsorted.c
@@ -201,7 +201,7 @@ void CFE_SBR_IncrementSequenceCounter(CFE_SBR_RouteId_t RouteId)
  *-----------------------------------------------------------------*/
 CFE_MSG_SequenceCount_t CFE_SBR_GetSequenceCounter(CFE_SBR_RouteId_t RouteId)
 {
-    uint32 seqcnt = 0;
+    CFE_MSG_SequenceCount_t seqcnt = 0;
 
     if (CFE_SBR_IsValidRouteId(RouteId))
     {


### PR DESCRIPTION
**Describe the contribution**
Fix #1476 - fixed type for seqcnt

**Testing performed**
Built all unit tests, ran sbr tests and passed

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: Docker on laptop
 - OS: Ubuntu 18.04
 - Versions: bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC