### PR TITLE
Fix #1442, Simplify CFE_FS_SetTimestamp and fix syslog typo

### DIFF
--- a/modules/cfe_testcase/src/fs_header_test.c
+++ b/modules/cfe_testcase/src/fs_header_test.c
@@ -93,7 +93,7 @@ void TestTimeStamp(void)
 
     CFE_FS_InitHeader(&Header, TestDescription, CFE_FS_SubType_ES_ERLOG);
     UtAssert_INT32_EQ(CFE_FS_WriteHeader(fd, &Header), sizeof(CFE_FS_Header_t));
-    UtAssert_INT32_EQ(CFE_FS_SetTimestamp(fd, NewTimestamp), OS_SUCCESS);
+    UtAssert_INT32_EQ(CFE_FS_SetTimestamp(fd, NewTimestamp), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_FS_ReadHeader(&ReadHeader, fd), sizeof(CFE_FS_Header_t));
 
     UtAssert_INT32_EQ(10, ReadHeader.TimeSeconds);

--- a/modules/fs/fsw/src/cfe_fs_api.c
+++ b/modules/fs/fsw/src/cfe_fs_api.c
@@ -293,25 +293,17 @@ CFE_Status_t CFE_FS_SetTimestamp(osal_id_t FileDes, CFE_TIME_SysTime_t NewTimest
             CFE_FS_ByteSwapUint32(&OutTimestamp.Subseconds);
         }
 
-        Result = OS_write(FileDes, &OutTimestamp.Seconds, sizeof(OutTimestamp.Seconds));
+        Result = OS_write(FileDes, &OutTimestamp, sizeof(OutTimestamp));
 
         /* On a good write, the value returned will equal the number of bytes written */
-        if (Result == sizeof(OutTimestamp.Seconds))
+        if (Result == sizeof(OutTimestamp))
         {
-            Result = OS_write(FileDes, &OutTimestamp.Subseconds, sizeof(OutTimestamp.Subseconds));
-
-            if (Result == sizeof(OutTimestamp.Subseconds))
-            {
-                Result = OS_SUCCESS;
-            }
-            else
-            {
-                CFE_ES_WriteToSysLog("CFE_FS:SetTime-Failed to write Seconds (Status=0x%08X)\n", (unsigned int)Result);
-            }
+            Result = CFE_SUCCESS;
         }
         else
         {
-            CFE_ES_WriteToSysLog("CFE_FS:SetTime-Failed to write Seconds (Status=0x%08X)\n", (unsigned int)Result);
+            CFE_ES_WriteToSysLog("%s(): Failed to write timestamp (Status=0x%08X)\n", __func__, (unsigned int)Result);
+            Result = CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
         }
     }
     else

--- a/modules/fs/ut-coverage/fs_UT.c
+++ b/modules/fs/ut-coverage/fs_UT.c
@@ -167,18 +167,18 @@ void Test_CFE_FS_SetTimestamp(void)
     /* Test setting the time stamp with a seconds write failure */
     UT_InitData();
     UT_SetDefaultReturnValue(UT_KEY(OS_write), OS_ERROR);
-    UT_Report(__FILE__, __LINE__, CFE_FS_SetTimestamp(FileDes, NewTimestamp) != OS_SUCCESS, "CFE_FS_SetTimestamp",
+    UT_Report(__FILE__, __LINE__, CFE_FS_SetTimestamp(FileDes, NewTimestamp) != CFE_SUCCESS, "CFE_FS_SetTimestamp",
               "Failed to write seconds");
 
     /* Test setting the time stamp with a subeconds write failure */
     UT_InitData();
-    UT_SetDeferredRetcode(UT_KEY(OS_write), 2, 0);
-    UT_Report(__FILE__, __LINE__, CFE_FS_SetTimestamp(FileDes, NewTimestamp) == OS_SUCCESS, "CFE_FS_SetTimestamp",
+    UT_SetDeferredRetcode(UT_KEY(OS_write), 1, 0);
+    UT_Report(__FILE__, __LINE__, CFE_FS_SetTimestamp(FileDes, NewTimestamp) != CFE_SUCCESS, "CFE_FS_SetTimestamp",
               "Failed to write subseconds");
 
     /* Test successfully setting the time stamp */
     UT_InitData();
-    UT_Report(__FILE__, __LINE__, CFE_FS_SetTimestamp(FileDes, NewTimestamp) == OS_SUCCESS, "CFE_FS_SetTimestamp",
+    UT_Report(__FILE__, __LINE__, CFE_FS_SetTimestamp(FileDes, NewTimestamp) == CFE_SUCCESS, "CFE_FS_SetTimestamp",
               "Write time stamp - successful");
 }
 

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
@@ -108,7 +108,7 @@ int32 CFE_TBL_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
                 {
                     Status = CFE_FS_SetTimestamp(FileDescriptor, DumpTime);
 
-                    if (Status != OS_SUCCESS)
+                    if (Status != CFE_SUCCESS)
                     {
                         CFE_ES_WriteToSysLog("CFE_TBL:HkCmd-Unable to update timestamp in dump file '%s'\n",
                                              DumpCtrlPtr->DumpBufferPtr->DataSource);


### PR DESCRIPTION
**Describe the contribution**
Fix #1442 - writes the timestamp with one call and updates/fixes the syslog message

 - Now setting success as `CFE_SUCCESS`
 - `CFE_FS_SetTimestamp` now returns `CFE_STATUS_EXTERNAL_RESOURCE_FAIL` if the write doesn't return the correct bytes written
 - Update coverage test checks
 - Updated the functional test to check for `CFE_SUCCESS` vs `OS_SUCCESS`
 - Updated check of status in `cfe_tbl_task_cmds.c` to `CFE_SUCCESS`

**Testing performed**
Built and ran unit tests, passed.

**Expected behavior changes**
Updated syslog, returns an actual error code if there is an error.

**System(s) tested on**
 - Hardware: Docker on laptop
 - OS: Ubuntu 18.04
 - Versions: bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC