### PR TITLE
Fix #1435, Consistent use of uint16 for EventID

### DIFF
--- a/modules/core_api/fsw/inc/cfe_evs.h
+++ b/modules/core_api/fsw/inc/cfe_evs.h
@@ -305,7 +305,7 @@ CFE_Status_t CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time, uint16 EventID, uin
 ** \sa #CFE_EVS_ResetAllFilters
 **
 **/
-CFE_Status_t CFE_EVS_ResetFilter(int16 EventID);
+CFE_Status_t CFE_EVS_ResetFilter(uint16 EventID);
 
 /**
 ** \brief Resets all of the calling application's event filters.

--- a/modules/core_api/ut-stubs/src/cfe_evs_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_evs_stubs.c
@@ -70,11 +70,11 @@ CFE_Status_t CFE_EVS_ResetAllFilters(void)
  * Generated stub function for CFE_EVS_ResetFilter()
  * ----------------------------------------------------
  */
-CFE_Status_t CFE_EVS_ResetFilter(int16 EventID)
+CFE_Status_t CFE_EVS_ResetFilter(uint16 EventID)
 {
     UT_GenStub_SetupReturnBuffer(CFE_EVS_ResetFilter, CFE_Status_t);
 
-    UT_GenStub_AddParam(CFE_EVS_ResetFilter, int16, EventID);
+    UT_GenStub_AddParam(CFE_EVS_ResetFilter, uint16, EventID);
 
     UT_GenStub_Execute(CFE_EVS_ResetFilter, Basic, NULL);
 

--- a/modules/evs/fsw/src/cfe_evs.c
+++ b/modules/evs/fsw/src/cfe_evs.c
@@ -275,7 +275,7 @@ int32 CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time, uint16 EventID, uint16 Eve
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_ResetFilter(int16 EventID)
+int32 CFE_EVS_ResetFilter(uint16 EventID)
 {
     int32            Status;
     EVS_BinFilter_t *FilterPtr = NULL;

--- a/modules/evs/fsw/src/cfe_evs_task.h
+++ b/modules/evs/fsw/src/cfe_evs_task.h
@@ -74,7 +74,7 @@
 
 typedef struct
 {
-    int16  EventID; /* Numerical event identifier */
+    uint16 EventID; /* Numerical event identifier */
     uint16 Mask;    /* Binary filter mask */
     uint16 Count;   /* Binary filter counter */
     uint16 Padding; /* Structure padding */

--- a/modules/evs/fsw/src/cfe_evs_utils.c
+++ b/modules/evs/fsw/src/cfe_evs_utils.c
@@ -297,7 +297,7 @@ bool EVS_IsFiltered(EVS_AppData_t *AppDataPtr, uint16 EventID, uint16 EventType)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-EVS_BinFilter_t *EVS_FindEventID(int16 EventID, EVS_BinFilter_t *FilterArray)
+EVS_BinFilter_t *EVS_FindEventID(uint16 EventID, EVS_BinFilter_t *FilterArray)
 {
     uint32 i;
 

--- a/modules/evs/fsw/src/cfe_evs_utils.h
+++ b/modules/evs/fsw/src/cfe_evs_utils.h
@@ -199,7 +199,7 @@ bool EVS_IsFiltered(EVS_AppData_t *AppDataPtr, uint16 EventID, uint16 EventType)
  * This routine searches and returns an index to the given Event ID with the
  * given application filter array.
  */
-EVS_BinFilter_t *EVS_FindEventID(int16 EventID, EVS_BinFilter_t *FilterArray);
+EVS_BinFilter_t *EVS_FindEventID(uint16 EventID, EVS_BinFilter_t *FilterArray);
 
 /*---------------------------------------------------------------------------------------*/
 /**

--- a/modules/evs/ut-coverage/evs_UT.c
+++ b/modules/evs/ut-coverage/evs_UT.c
@@ -666,9 +666,9 @@ void Test_FilterReset(void)
 */
 void Test_Format(void)
 {
-    int   i;
-    char  long_msg[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH + 2];
-    int16 EventID[2];
+    int    i;
+    char   long_msg[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH + 2];
+    uint16 EventID[2];
 
     CFE_TIME_SysTime_t              time = {0, 0};
     CFE_EVS_SetEventFormatModeCmd_t modecmd;


### PR DESCRIPTION
**Describe the contribution**
Fix #1435 - use `uint16` everywhere for `EventID`

**Testing performed**
Built/ran unit tests, passed

**Expected behavior changes**
None, just makes types consistent

**System(s) tested on**
 - Hardware: Intel i5, Docker
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
Doesn't fix the fact CFE_EVS_FREE_SLOT is not documented or handled well.  See #1574.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC