### PR TITLE
Fix #1394, Remove shell file subtype and clarify scope

### DIFF
--- a/modules/core_api/fsw/inc/cfe_fs_extern_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_fs_extern_typedefs.h
@@ -53,7 +53,12 @@
 #define CFE_FS_FILE_CONTENT_ID 0x63464531 /**< \brief Magic Number for cFE compliant files (= 'cFE1') */
 
 /**
- * @brief Label definitions associated with CFE_FS_SubType_Enum_t
+ * @brief File subtypes used within cFE
+ *
+ * This defines all the file subtypes used by cFE.
+ * Note apps can extend as needed but need to
+ * avoid conflicts (app context not currently included
+ * in the file header).
  */
 enum CFE_FS_SubType
 {
@@ -97,15 +102,6 @@ enum CFE_FS_SubType
      *
      */
     CFE_FS_SubType_ES_PERFDATA = 4,
-
-    /**
-     * @brief Executive Services Shell Response File
-     *
-     * Executive Services Shell Response Data File which is generated in response to a
-     * shell command.
-     *
-     */
-    CFE_FS_SubType_ES_SHELL = 5,
 
     /**
      * @brief Executive Services Critical Data Store Registry Dump File


### PR DESCRIPTION
**Describe the contribution**
Fix #1394 - removes `CFE_FS_SubType_ES_SHELL` and clarifies the scope of `CFE_FS_SubType_Enum_t` to just include the cFE defined file types

**Testing performed**
Build and run unit tests, passed

**Expected behavior changes**
None, wasn't used since shell command was removed from CFE/ES.

**System(s) tested on**
 - Hardware: Intel I5/Docker
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC