### PR TITLE
Fix #1386, Remove CFE_EVS_Unregister API

### DIFF
--- a/docs/cFE Application Developers Guide.md
+++ b/docs/cFE Application Developers Guide.md
@@ -2365,19 +2365,7 @@ consistent style of writing in all messages. One should consult, if
 possible, with members of the Flight Operations team and scientists to
 find what kind of messages are required and how they should be worded.
 
-## 7.6 Event Service Un-registration
-
-Applications that have registered with the EVS can un-register
-themselves. The cFE, however, will automatically un-register an
-Application when the Application is terminated. An example of the
-function call to perform un-registration from within an Application is
-shown below:
-
-```
-CFE_EVS_Unregister ();
-```
-
-## 7.7 Best Practices for using Event Services
+## 7.6 Best Practices for using Event Services
 
 The following are recommended "best practices" for applications using EVS.
 1. Event Message IDs should be unique across an application so that an

--- a/docs/cFE_FunctionalRequirements.csv
+++ b/docs/cFE_FunctionalRequirements.csv
@@ -259,14 +259,6 @@ EVS: Register App,cEVS3100,"Upon receipt of Request, the cFE shall register an A
 EVS: Register App - Create Filter Counter,cEVS3100.1,"Upon receipt of Request to register an Application for event service, the cFE shall create one Application Binary Filter Counter per registered Event ID.",Supports the cFE's Binary Filtering Algorithm.
 EVS: Register App - Create Sent Message Counter,cEVS3100.2,"Upon receipt of Request to register an Application for event service, the cFE shall create an Application Event Message Sent Counter.",Supports the cFE's dynamic Application model.
 EVS: Register App - Default Event Enable Status,cEVS3100.3,"Upon receipt of Request to register an Application for event service, the cFE shall use the `<PLATFORM_DEFINED>` Application Event Type Enable Statuses for each event.","By default each platform should have a standard configuration for each event message type (eg. DEBUGs disable.  INFO, ERROR and CRITICAL events DISABLED) that should be applied to all events.  Commands are available to modify the settings."
-EVS: Unregister App,cEVS3101,"Upon receipt of Request, the cFE shall un-register an Application from using event services, deleting the following Application data:
-
-- Application Event Message Sent Counter
-- Application Event Service Enable Status
-- Application Event Type Enable Statuses (one for each Event Type)
-- Application Filtered Event IDs
-- Application Binary Filter Masks (one per registered Event ID)
-- Application Binary Filter Counters (one per registered Event ID)",Supports the cFE's dynamic Application model allowing applications to clean up after themselves.
 EVS: Message Types,cEVS3102,The cFE shall support the following Event Message Types: Debug Informational Error Critical.,Supports cFE event services.
 EVS: Create Message,cEVS3103,"Upon receipt of a Request to send an Event Message, the cFE shall create a Short or Long Event Message, as specified by the SB Event Format Mode, ONLY if the following cFE conditions are met:
 

--- a/docs/src/cfe_api.dox
+++ b/docs/src/cfe_api.dox
@@ -80,7 +80,6 @@
     <LI> \ref CFEAPIEVSReg
     <UL>
       <LI> #CFE_EVS_Register - \copybrief CFE_EVS_Register
-      <LI> #CFE_EVS_Unregister - \copybrief CFE_EVS_Unregister
     </UL>
     <LI> \ref CFEAPIEVSSend
     <UL>

--- a/modules/core_api/fsw/inc/cfe_evs.h
+++ b/modules/core_api/fsw/inc/cfe_evs.h
@@ -102,35 +102,10 @@
 ** \retval #CFE_EVS_APP_FILTER_OVERLOAD \copybrief CFE_EVS_APP_FILTER_OVERLOAD
 ** \retval #CFE_EVS_UNKNOWN_FILTER      \copybrief CFE_EVS_UNKNOWN_FILTER
 ** \retval #CFE_EVS_APP_ILLEGAL_APP_ID  \copybrief CFE_EVS_APP_ILLEGAL_APP_ID
-**
-** \sa #CFE_EVS_Unregister
-**
 **/
 CFE_Status_t CFE_EVS_Register(const void *Filters,           /* Pointer to an array of filters */
                               uint16      NumFilteredEvents, /* How many elements in the array? */
                               uint16      FilterScheme);          /* Filtering Algorithm to be implemented */
-
-/**
-** \brief Cleanup internal structures used by the event manager for the calling Application.
-**
-** \par Description
-**          This routine un-registers the calling application from receiving event services
-**          and removes and deletes the calling applications filters and counters from the
-**          internal event service filter and counter tables if registered.  Applications
-**          must call this routine as part of their orderly shutdown process.
-**
-** \par Assumptions, External Events, and Notes:
-**          None
-**
-** \return Execution status below or from #CFE_ES_GetAppID/#CFE_ES_PutPoolBuf, see \ref CFEReturnCodes
-** \retval #CFE_SUCCESS                \copybrief CFE_SUCCESS
-** \retval #CFE_EVS_APP_NOT_REGISTERED \copybrief CFE_EVS_APP_NOT_REGISTERED
-** \retval #CFE_EVS_APP_ILLEGAL_APP_ID \copybrief CFE_EVS_APP_ILLEGAL_APP_ID
-**
-** \sa #CFE_EVS_Register
-**
-**/
-CFE_Status_t CFE_EVS_Unregister(void);
 /**@}*/
 
 /** @defgroup CFEAPIEVSSend cFE Send Event APIs

--- a/modules/core_api/ut-stubs/src/cfe_evs_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_evs_stubs.c
@@ -148,17 +148,3 @@ CFE_Status_t CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time, uint16 EventID, uin
 
     return UT_GenStub_GetReturnValue(CFE_EVS_SendTimedEvent, CFE_Status_t);
 }
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CFE_EVS_Unregister()
- * ----------------------------------------------------
- */
-CFE_Status_t CFE_EVS_Unregister(void)
-{
-    UT_GenStub_SetupReturnBuffer(CFE_EVS_Unregister, CFE_Status_t);
-
-    UT_GenStub_Execute(CFE_EVS_Unregister, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(CFE_EVS_Unregister, CFE_Status_t);
-}

--- a/modules/evs/fsw/src/cfe_evs.c
+++ b/modules/evs/fsw/src/cfe_evs.c
@@ -115,30 +115,6 @@ int32 CFE_EVS_Register(const void *Filters, uint16 NumEventFilters, uint16 Filte
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_EVS_Unregister
- *
- * Implemented per public API
- * See description in header file for argument/return detail
- *
- *-----------------------------------------------------------------*/
-int32 CFE_EVS_Unregister(void)
-{
-    int32          Status;
-    CFE_ES_AppId_t AppID;
-    EVS_AppData_t *AppDataPtr;
-
-    /* Query and verify the caller's AppID */
-    Status = EVS_GetCurrentContext(&AppDataPtr, &AppID);
-    if (Status == CFE_SUCCESS && EVS_AppDataIsMatch(AppDataPtr, AppID))
-    {
-        EVS_AppDataSetFree(AppDataPtr);
-    }
-
-    return (Status);
-}
-
-/*----------------------------------------------------------------
- *
  * Function: CFE_EVS_SendEvent
  *
  * Implemented per public API

--- a/modules/evs/fsw/src/cfe_evs_task.c
+++ b/modules/evs/fsw/src/cfe_evs_task.c
@@ -184,7 +184,6 @@ int32 CFE_EVS_CleanUpApp(CFE_ES_AppId_t AppID)
     }
     else if (EVS_AppDataIsMatch(AppDataPtr, AppID))
     {
-        /* Same cleanup as CFE_EVS_Unregister() */
         EVS_AppDataSetFree(AppDataPtr);
     }
 

--- a/modules/evs/ut-coverage/evs_UT.c
+++ b/modules/evs/ut-coverage/evs_UT.c
@@ -392,12 +392,6 @@ void Test_IllegalAppID(void)
     UT_Report(__FILE__, __LINE__, CFE_EVS_Register(NULL, 0, 0) == CFE_EVS_APP_ILLEGAL_APP_ID, "CFE_EVS_Register",
               "Illegal app ID");
 
-    /* Test unregistering an event using an illegal application ID */
-    UT_InitData();
-    UT_SetDefaultReturnValue(UT_KEY(CFE_ES_AppID_ToIndex), CFE_ES_ERR_RESOURCEID_NOT_VALID);
-    UT_Report(__FILE__, __LINE__, CFE_EVS_Unregister() == CFE_EVS_APP_ILLEGAL_APP_ID, "CFE_EVS_Unregister",
-              "Illegal app ID");
-
     /* Test sending an event using an illegal application ID */
     UT_InitData();
     UT_SetDefaultReturnValue(UT_KEY(CFE_ES_AppID_ToIndex), CFE_ES_ERR_RESOURCEID_NOT_VALID);
@@ -458,10 +452,7 @@ void Test_UnregisteredApp(void)
     UT_InitData();
 
     /* Unregister the application (it was registered in CFE_EVS_TaskInit) */
-    CFE_EVS_Unregister();
-
-    /* Test unregistering an already unregistered application */
-    UT_Report(__FILE__, __LINE__, CFE_EVS_Unregister() == CFE_SUCCESS, "CFE_EVS_Unregister", "App not registered");
+    CFE_EVS_CleanUpApp(AppID);
 
     /* Test sending an event to an unregistered application */
     UT_InitData();
@@ -531,21 +522,14 @@ void Test_FilterRegistration(void)
     UT_Report(__FILE__, __LINE__, CFE_EVS_Register(NULL, 0, CFE_EVS_EventFilter_BINARY) == CFE_SUCCESS,
               "CFE_EVS_Register", "Valid w/ no filters");
 
-    /* Test filter unregistration with failed ES_putPool */
-    UT_InitData();
-    UT_SetDefaultReturnValue(UT_KEY(CFE_ES_PutPoolBuf), -1);
-    UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppID), 1, -1);
-    UT_Report(__FILE__, __LINE__, CFE_EVS_Unregister() < 0, "CFE_EVS_Unregister",
-              "Unregistration with failed ES_putPool");
-
     /* Re-register to test valid unregistration */
     UT_InitData();
     UT_Report(__FILE__, __LINE__, CFE_EVS_Register(NULL, 0, CFE_EVS_EventFilter_BINARY) == CFE_SUCCESS,
               "CFE_EVS_Register", "Valid with no filters (re-registration)");
 
-    /* Test successful filter unregistration */
+    /* Test successful app cleanup */
     UT_InitData();
-    UT_Report(__FILE__, __LINE__, CFE_EVS_Unregister() == CFE_SUCCESS, "CFE_EVS_Unregister", "Valid unregistration");
+    UT_Report(__FILE__, __LINE__, CFE_EVS_CleanUpApp(AppID) == CFE_SUCCESS, "CFE_EVS_CleanUpApp", "Valid cleanup");
 
     /* Test successful filter registration with a valid filter */
     UT_InitData();


### PR DESCRIPTION
**Describe the contribution**
Fix #1386, Remove CFE_EVS_Unregister API
- Removed requirement cEVS3101
- Removed documentation references
- Removed from API header
- Removed stub
- Removed implementation
- Removed coverage test

**Testing performed**
Built and ran unit tests, passed

**Expected behavior changes**
Removed API.

**System(s) tested on**
 - Hardware: Intel I5/Docker
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC