### PR TITLE
Fix #1362, Simplify CFE_ES_QueryAllCmd file open logic

### DIFF
--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -1317,17 +1317,7 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAllCmd_t *data)
     if (Result == CFE_SUCCESS)
     {
         /*
-        ** Check to see if the file already exists
-        */
-        Result = OS_OpenCreate(&FileDescriptor, QueryAllFilename, OS_FILE_FLAG_NONE, OS_READ_ONLY);
-        if (Result >= 0)
-        {
-            OS_close(FileDescriptor);
-            OS_remove(QueryAllFilename);
-        }
-
-        /*
-        ** Create ES task log data file
+        ** Create (or truncate) ES task log data file
         */
         Result = OS_OpenCreate(&FileDescriptor, QueryAllFilename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE,
                                OS_WRITE_ONLY);
@@ -1469,17 +1459,7 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasksCmd_t *data)
     if (Result == CFE_SUCCESS)
     {
         /*
-        ** Check to see if the file already exists
-        */
-        Result = OS_OpenCreate(&FileDescriptor, QueryAllFilename, OS_FILE_FLAG_NONE, OS_READ_ONLY);
-        if (Result >= 0)
-        {
-            OS_close(FileDescriptor);
-            OS_remove(QueryAllFilename);
-        }
-
-        /*
-        ** Create ES task log data file
+        ** Create (or truncate) ES task log data file
         */
         Result = OS_OpenCreate(&FileDescriptor, QueryAllFilename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE,
                                OS_WRITE_ONLY);

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -3151,14 +3151,6 @@ void TestTask(void)
     UT_Report(__FILE__, __LINE__, UT_EventIsInHistory(CFE_ES_LEN_ERR_EID), "CFE_ES_QueryAllAppCmd",
               "Query all applications command; invalid command length");
 
-    /* Test write of all app data to file with a file open failure */
-    ES_ResetUnitTest();
-    memset(&CmdBuf, 0, sizeof(CmdBuf));
-    UT_SetDeferredRetcode(UT_KEY(OS_OpenCreate), 1, OS_ERROR);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryAllCmd), UT_TPID_CFE_ES_CMD_QUERY_ALL_CC);
-    UT_Report(__FILE__, __LINE__, UT_EventIsInHistory(CFE_ES_ALL_APPS_EID), "CFE_ES_QueryAllCmd",
-              "Write application information file fail; file open");
-
     /* Test sending a write request for all tasks with an
      * invalid command length
      */
@@ -3166,15 +3158,6 @@ void TestTask(void)
     UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, 0, UT_TPID_CFE_ES_CMD_QUERY_ALL_TASKS_CC);
     UT_Report(__FILE__, __LINE__, UT_EventIsInHistory(CFE_ES_LEN_ERR_EID), "CFE_ES_QueryAllAppCmd",
               "Query all tasks command; invalid command length");
-
-    /* Test write of all task data to file with a file open failure */
-    ES_ResetUnitTest();
-    memset(&CmdBuf, 0, sizeof(CmdBuf));
-    UT_SetDeferredRetcode(UT_KEY(OS_OpenCreate), 1, OS_ERROR);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.QueryAllTasksCmd),
-                    UT_TPID_CFE_ES_CMD_QUERY_ALL_TASKS_CC);
-    UT_Report(__FILE__, __LINE__, UT_EventIsInHistory(CFE_ES_TASKINFO_EID), "CFE_ES_QueryAllCmd",
-              "Write task information file fail; file open");
 
     /* Test sending a request to clear the system log with an
      * invalid command length


### PR DESCRIPTION
**Describe the contribution**
Fix #1362 - removes the first OS_OpenCreate (and file remove on success) since the following OS_OpenCreate with truncate makes it obsolete

**Testing performed**
Build/run unit tests, passed (once updated)

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: Intel I5/Docker
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC