### PR TITLE
Fix #1308, Removed redundant check/set of CFE_CPU_ID_VALUE

### DIFF
--- a/cmake/target/src/target_config.c
+++ b/cmake/target/src/target_config.c
@@ -45,10 +45,6 @@
 #define CFE_CPU_NAME_VALUE "unknown"
 #endif
 
-#ifndef CFE_CPU_ID_VALUE
-#define CFE_CPU_ID_VALUE 0
-#endif
-
 #ifndef CFE_SPACECRAFT_ID_VALUE
 #define CFE_SPACECRAFT_ID_VALUE 0x42
 #endif


### PR DESCRIPTION
**Describe the contribution**
Fix #1308 - removed redundant set of CFE_CPU_ID_VALUE if not set.

And checked as well as assigned to CFE_CPU_ID_VALUE here:
https://github.com/nasa/cFE/blob/176e3df03f54f7753cb34beb3e986202604d6cef/cmake/target/CMakeLists.txt#L20-L22
https://github.com/nasa/cFE/blob/176e3df03f54f7753cb34beb3e986202604d6cef/cmake/target/CMakeLists.txt#L127-L133

and used here:
https://github.com/nasa/cFE/blob/176e3df03f54f7753cb34beb3e986202604d6cef/cmake/target/src/target_config.c#L172

**Testing performed**
Removed assignment of cpu1_PROCESSORID and confirmed error was generated by target/CMakeLists.txt:
`cpu1_PROCESSORID must be defined to link a final exe`

**Expected behavior changes**
None as long as required elements are defined.

**System(s) tested on**
 - Hardware: Intel I5/Docker
 - OS:  Ubuntu 18.04
 - Versions: Bundle Main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC