### PR TITLE
Fix #1544, add time get reference error bit

### DIFF
--- a/modules/time/fsw/inc/cfe_time_msg.h
+++ b/modules/time/fsw/inc/cfe_time_msg.h
@@ -717,7 +717,9 @@
 #define CFE_TIME_FLAG_ADDTCL 0x0080 /**< \brief Time Client Latency is applied in a positive direction */
 #define CFE_TIME_FLAG_SERVER 0x0040 /**< \brief This instance of Time Services is a Time Server */
 #define CFE_TIME_FLAG_GDTONE 0x0020 /**< \brief The tone received is good compared to the last tone received */
-#define CFE_TIME_FLAG_UNUSED 0x001F /**< \brief Reserved flags - should be zero */
+#define CFE_TIME_FLAG_REFERR \
+    0x0010 /**< \brief GetReference read error, will be set if unable to get a consistent ref value */
+#define CFE_TIME_FLAG_UNUSED 0x000F /**< \brief Reserved flags - should be zero */
 /** \} */
 
 /*************************************************************************/

--- a/modules/time/fsw/src/cfe_time_api.c
+++ b/modules/time/fsw/src/cfe_time_api.c
@@ -284,6 +284,14 @@ uint16 CFE_TIME_GetClockInfo(void)
         StateFlags |= CFE_TIME_FLAG_GDTONE;
     }
 
+    /*
+    ** Check if CFE_TIME_GetReference ever failed to get a good value
+    */
+    if (CFE_TIME_Global.GetReferenceFail)
+    {
+        StateFlags |= CFE_TIME_FLAG_REFERR;
+    }
+
     return (StateFlags);
 }
 

--- a/modules/time/fsw/src/cfe_time_utils.h
+++ b/modules/time/fsw/src/cfe_time_utils.h
@@ -257,9 +257,9 @@ typedef struct
     bool IsToneGood;
 
     /*
-    ** Spare byte for alignment
+    ** Flag that indicates if "CFE_TIME_GetReference()" ever failed to get a valid time
     */
-    bool Spare;
+    bool GetReferenceFail;
 
     /*
     ** Local 1Hz wake-up command packet (not related to time at tone)...


### PR DESCRIPTION
**Describe the contribution**
Use one of the unused time state bits to indicate if an error has occurred where CFE_TIME_GetReference was not able to get a consistent copy of the reference state data.

In a functional system this should never occur - there should be at most one retry, which only happens in the event there was a burst of updates (more than 4) concurrently with reading the structure.

The previous implementation did not report or handle the condition at all, this at least sets a TLM status bit and returns a reference struct filled with all zeros.

Fixes #1544 

**Testing performed**
Build and sanity check CFE, run all unit tests
Check coverage report to ensure the new tests are being executed and confirm that the read error flag gets set, and the output state is all 0 in that case.
Force the error to occur during a syslog call and confirm the timestamp gets set, e.g.

    1980-001-00:00:00.00000 ES Startup: Opened ES App Startup file: /cf/cfe_es_startup.scr


**Expected behavior changes**
If CFE_TIME_GetReference was ever not able to get a valid reference structure, it outputs all zeros and the "REFERR" bit (0x0010) will be set in the output TLM structure until the system is rebooted.

**System(s) tested on**
Ubuntu

**Additional context**
This solution was chosen over an event/syslog because both of those will also get the time, thereby introducing a recursive loop if the error happens again.  

By zero-filling the structure the output is also identifiable; i.e. if the date "1980-001-00:00:00.00000" ever appears in a log file, failure of CFE_TIME_GetReference is really the only way a timestamp like that is possible.  Without this change the time data would be variable/unpredicatable.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.