### PR TITLE
Fix #1595, provide CFE assert lock/unlock

### DIFF
--- a/modules/cfe_assert/src/cfe_assert_io.c
+++ b/modules/cfe_assert/src/cfe_assert_io.c
@@ -38,6 +38,28 @@
 
 CFE_Assert_Global_t CFE_Assert_Global;
 
+void UT_BSP_Lock(void)
+{
+    int32 rc;
+
+    rc = OS_MutSemTake(CFE_Assert_Global.AccessMutex);
+    if (rc != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("%s(): Error from OS_MutSemTake(): %d\n", __func__, (int)rc);
+    }
+}
+
+void UT_BSP_Unlock(void)
+{
+    int32 rc;
+
+    rc = OS_MutSemGive(CFE_Assert_Global.AccessMutex);
+    if (rc != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("%s(): Error from OS_MutSemTake(): %d\n", __func__, (int)rc);
+    }
+}
+
 void UT_BSP_Setup(void)
 {
     CFE_Assert_Global.CurrVerbosity = (2 << UTASSERT_CASETYPE_PASS) - 1;


### PR DESCRIPTION
**Describe the contribution**
Provide the UT_BSP_Lock/Unlock function to be compatible with nasa/osal#1065.  The library no longer needs to be locked the
entire time a test runs. This also allows test programs to be multi threaded.

Fixes #1595

**Testing performed**
Build and run CFE functional tests in cfe_testcase app that use cfe_assert library

**Expected behavior changes**
More fine-grained locking, and tests may use child tasks safely.

**System(s) tested on**
Ubuntu

**Additional context**
Required for compatibility with nasa/osal#1065

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
