### PR TITLE
Fix #1299, Updated FS Read/WriteHeader API return documentation

### DIFF
--- a/modules/core_api/fsw/inc/cfe_fs.h
+++ b/modules/core_api/fsw/inc/cfe_fs.h
@@ -65,7 +65,7 @@
 **                         filled with the contents of the Standard cFE File Header. *Hdr is the contents of the
 **                         Standard cFE File Header for the specified file.
 **
-** \return Execution status, see \ref CFEReturnCodes
+** \return Bytes read or error status, see \ref CFEReturnCodes
 **
 ** \sa #CFE_FS_WriteHeader
 **
@@ -125,7 +125,7 @@ void CFE_FS_InitHeader(CFE_FS_Header_t *Hdr, const char *Description, uint32 Sub
 **                         filled with the contents of the Standard cFE File Header. *Hdr is the contents of the
 **                         Standard cFE File Header for the specified file.
 **
-** \return Execution status, see \ref CFEReturnCodes
+** \return Bytes written or error status, see \ref CFEReturnCodes
 **
 ** \sa #CFE_FS_ReadHeader
 **


### PR DESCRIPTION
**Describe the contribution**
Fix #1299 - updated return documentation for CFE_FS_ReadHeader and CFE_FS_WriteHeader to state they return bytes read/written or error code.  Left as CFE_Status_t since they do return error codes, although overloaded.  It is confusing since 0 actually indicates the data wasn't read or written, but that would require an API change.  Related issue is #483.

**Testing performed**
CI - documentation only 

**Expected behavior changes**
None, documentation only

**System(s) tested on**
CI

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC