### PR TITLE
Fix #1604, Clean/simplify version header and reporting

### DIFF
--- a/modules/core_api/fsw/inc/cfe_version.h
+++ b/modules/core_api/fsw/inc/cfe_version.h
@@ -21,41 +21,40 @@
 /**
  * @file
  *
- * Provide version identifiers for the cFE core.
+ * Provide version identifiers for the cFE core. See @ref cfsversions for further details.
  */
 
 #ifndef CFE_VERSION_H
 #define CFE_VERSION_H
 
 /* Development Build Macro Definitions */
-#define CFE_BUILD_NUMBER 642 /*!< Development Build: Number of commits since baseline */
-#define CFE_BUILD_BASELINE                                                                    \
-    "v6.8.0-rc1" /*!< Development Build: git tag that is the base for the current development \
-                  */
+#define CFE_BUILD_NUMBER   642          /**< @brief Development: Number of development commits since baseline */
+#define CFE_BUILD_BASELINE "v6.8.0-rc1" /**< @brief Development: Reference git tag for build number */
 
-/* Version Macro Definitions */
-#define CFE_MAJOR_VERSION 6 /*!< @brief ONLY APPLY for OFFICIAL releases. Major version number. */
-#define CFE_MINOR_VERSION 7 /*!< @brief ONLY APPLY for OFFICIAL releases. Minor version number. */
-#define CFE_REVISION                                                                                                  \
-    99 /*!< @brief ONLY APPLY for OFFICIAL releases. Revision version number. A value of "99" indicates a development \
-          version.  */
-#define CFE_MISSION_REV 0 /*!< @brief ONLY USED by MISSION Implementations. Mission revision */
+/* Version Macro Definitions updated for official releases only */
+#define CFE_MAJOR_VERSION 6  /**< @brief Major release version (Former for Revision == 99) */
+#define CFE_MINOR_VERSION 7  /**< @brief Minor release version (Former for Revision == 99) */
+#define CFE_REVISION      99 /**< @brief Revision, 99 indicates development */
+#define CFE_MISSION_REV   0  /**< @brief Mission revision, reserved for mission use */
 
-#define CFE_STR_HELPER(x) #x                /*!< @brief Helper function to concatenate strings from integer macros */
-#define CFE_STR(x)        CFE_STR_HELPER(x) /*!< @brief Helper function to concatenate strings from integer macros */
+#define CFE_STR_HELPER(x) #x                /**< @brief Convert agrument to string */
+#define CFE_STR(x)        CFE_STR_HELPER(x) /**< @brief Expand macro before conversion */
 
-/*! @brief Development Build Version Number.
- * @details Baseline git tag + Number of commits since baseline. @n
- * See @ref cfsversions for format differences between development and release versions.
+/**
+ * @brief Short Build Version String
+ *
+ * Short string identifying the build, see @ref cfsversions for suggested format for development
+ * and official releases.
  */
 #define CFE_SRC_VERSION CFE_BUILD_BASELINE "+dev" CFE_STR(CFE_BUILD_NUMBER)
 
-/*! @brief Development Build Version String.
- * @details Reports the current development build's baseline, number, and name. Also includes a note about the latest
- * official version. @n See @ref cfsversions for format differences between development and release versions.
+/**
+ * @brief Long Build Version String
+ *
+ * Long freeform string identifying the build, see @ref cfsversions for suggested format for development
+ * and official releases.
  */
-#define CFE_VERSION_STRING                                                                                 \
-    " cFE DEVELOPMENT BUILD " CFE_SRC_VERSION " (Codename: Bootes)" /* Codename for current development */ \
-    ", Last Official Release: cfe v6.7.0"                           /* For full support please use this version */
+#define CFE_VERSION_STRING \
+    " cFE DEVELOPMENT BUILD " CFE_SRC_VERSION " (Codename: Bootes), Last Official Release: cfe v6.7.0"
 
 #endif /* CFE_VERSION_H */

--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -474,7 +474,8 @@ int32 CFE_ES_TaskInit(void)
     /*
     ** Task startup event message.
     */
-    Status = CFE_EVS_SendEvent(CFE_ES_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "cFE ES Initialized");
+    Status = CFE_EVS_SendEvent(CFE_ES_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "cFE ES Initialized: %s",
+                               CFE_VERSION_STRING);
     if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("ES:Error sending init event:RC=0x%08X\n", (unsigned int)Status);

--- a/modules/evs/fsw/src/cfe_evs_task.c
+++ b/modules/evs/fsw/src/cfe_evs_task.c
@@ -307,7 +307,7 @@ int32 CFE_EVS_TaskInit(void)
 
     /* Write the AppID to the global location, now that the rest of initialization is done */
     CFE_EVS_Global.EVS_AppID = AppID;
-    EVS_SendEvent(CFE_EVS_STARTUP_EID, CFE_EVS_EventType_INFORMATION, "cFE EVS Initialized.%s", CFE_VERSION_STRING);
+    EVS_SendEvent(CFE_EVS_STARTUP_EID, CFE_EVS_EventType_INFORMATION, "cFE EVS Initialized: %s", CFE_VERSION_STRING);
 
     return CFE_SUCCESS;
 }
@@ -608,7 +608,7 @@ bool CFE_EVS_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_NoopCmd(const CFE_EVS_NoopCmd_t *data)
 {
-    EVS_SendEvent(CFE_EVS_NOOP_EID, CFE_EVS_EventType_INFORMATION, "No-op command. %s", CFE_VERSION_STRING);
+    EVS_SendEvent(CFE_EVS_NOOP_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", CFE_VERSION_STRING);
     return CFE_SUCCESS;
 }
 

--- a/modules/sb/fsw/src/cfe_sb_task.c
+++ b/modules/sb/fsw/src/cfe_sb_task.c
@@ -272,7 +272,8 @@ int32 CFE_SB_AppInit(void)
         return Status;
     } /* end if */
 
-    Status = CFE_EVS_SendEvent(CFE_SB_INIT_EID, CFE_EVS_EventType_INFORMATION, "cFE SB Initialized");
+    Status =
+        CFE_EVS_SendEvent(CFE_SB_INIT_EID, CFE_EVS_EventType_INFORMATION, "cFE SB Initialized: %s", CFE_VERSION_STRING);
     if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("SB:Error sending init event:RC=0x%08X\n", (unsigned int)Status);
@@ -464,7 +465,7 @@ void CFE_SB_ProcessCmdPipePkt(CFE_SB_Buffer_t *SBBufPtr)
  *-----------------------------------------------------------------*/
 int32 CFE_SB_NoopCmd(const CFE_SB_NoopCmd_t *data)
 {
-    CFE_EVS_SendEvent(CFE_SB_CMD0_RCVD_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd. %s", CFE_VERSION_STRING);
+    CFE_EVS_SendEvent(CFE_SB_CMD0_RCVD_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", CFE_VERSION_STRING);
     CFE_SB_Global.HKTlmMsg.Payload.CommandCounter++;
 
     return CFE_SUCCESS;

--- a/modules/tbl/fsw/src/cfe_tbl_task.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task.c
@@ -211,7 +211,7 @@ int32 CFE_TBL_TaskInit(void)
     /*
     ** Task startup event message
     */
-    Status = CFE_EVS_SendEvent(CFE_TBL_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "cFE TBL Initialized.%s",
+    Status = CFE_EVS_SendEvent(CFE_TBL_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "cFE TBL Initialized: %s",
                                CFE_VERSION_STRING);
 
     if (Status != CFE_SUCCESS)

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
@@ -320,7 +320,7 @@ void CFE_TBL_GetTblRegData(void)
 int32 CFE_TBL_NoopCmd(const CFE_TBL_NoopCmd_t *data)
 {
     /* Acknowledge receipt of NOOP with Event Message */
-    CFE_EVS_SendEvent(CFE_TBL_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op command. %s", CFE_VERSION_STRING);
+    CFE_EVS_SendEvent(CFE_TBL_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", CFE_VERSION_STRING);
 
     return CFE_TBL_INC_CMD_CTR;
 }

--- a/modules/time/fsw/src/cfe_time_task.c
+++ b/modules/time/fsw/src/cfe_time_task.c
@@ -263,7 +263,8 @@ int32 CFE_TIME_TaskInit(void)
         return Status;
     } /* end if */
 
-    Status = CFE_EVS_SendEvent(CFE_TIME_INIT_EID, CFE_EVS_EventType_INFORMATION, "cFE TIME Initialized");
+    Status = CFE_EVS_SendEvent(CFE_TIME_INIT_EID, CFE_EVS_EventType_INFORMATION, "cFE TIME Initialized: %s",
+                               CFE_VERSION_STRING);
     if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("TIME:Error sending init event:RC=0x%08X\n", (unsigned int)Status);
@@ -703,7 +704,7 @@ int32 CFE_TIME_NoopCmd(const CFE_TIME_NoopCmd_t *data)
 
     CFE_TIME_Global.CommandCounter++;
 
-    CFE_EVS_SendEvent(CFE_TIME_NOOP_EID, CFE_EVS_EventType_INFORMATION, "No-op command.%s", CFE_VERSION_STRING);
+    CFE_EVS_SendEvent(CFE_TIME_NOOP_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", CFE_VERSION_STRING);
 
     return CFE_SUCCESS;
 }


### PR DESCRIPTION
**Describe the contribution**
Fix #1604 - cleans up the version header and how it's reported (standardized event text).  Note just ES uses/reports the short version.

**Testing performed**
Built and ran unit tests, executed cfe to confirm output.

**Expected behavior changes**
Minor event message output format changes

**System(s) tested on**
 - Hardware: Intel I5/Docker
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
#1603

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC