### PR TITLE
Fix #1325, Prepend system log messages with function name

### DIFF
--- a/modules/cfe_assert/src/cfe_assert_init.c
+++ b/modules/cfe_assert/src/cfe_assert_init.c
@@ -59,7 +59,7 @@ int32 CFE_Assert_LibInit(CFE_ES_LibId_t LibId)
     status = OS_MutSemCreate(&CFE_Assert_Global.AccessMutex, "CFE_Assert", 0);
     if (status != OS_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("%s(): OS_MutSemCreate failed, rc=%d\n", __func__, (int)status);
+        CFE_ES_WriteToSysLog("%s: OS_MutSemCreate failed, rc=%d\n", __func__, (int)status);
         return CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
     }
 

--- a/modules/cfe_assert/src/cfe_assert_runner.c
+++ b/modules/cfe_assert/src/cfe_assert_runner.c
@@ -110,7 +110,7 @@ int32 CFE_Assert_RegisterTest(const char *TestName)
                           CFE_EVS_EventFilter_BINARY);
     if (rc != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("Error from CFE_EVS_Register: %08lx\n", (unsigned long)rc);
+        CFE_ES_WriteToSysLog("%s: Error from CFE_EVS_Register: %08lx\n", __func__, (unsigned long)rc);
         return rc;
     }
 
@@ -124,7 +124,7 @@ int32 CFE_Assert_RegisterTest(const char *TestName)
     rc = CFE_ES_WaitForSystemState(CFE_ES_SystemState_OPERATIONAL, CFE_TESTRUNNER_MAX_STARTUP_WAIT);
     if (rc != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("Error while waiting for OPERATIONAL state: %08lx\n", (unsigned long)rc);
+        CFE_ES_WriteToSysLog("%s: Error while waiting for OPERATIONAL state: %08lx\n", __func__, (unsigned long)rc);
         return rc;
     }
 
@@ -206,7 +206,7 @@ void CFE_Assert_ExecuteTest(void)
     rc = CFE_ES_GetAppID(&AppId);
     if (rc != CFE_SUCCESS || !CFE_RESOURCEID_TEST_EQUAL(AppId, CFE_Assert_Global.OwnerAppId))
     {
-        CFE_ES_WriteToSysLog("%s(): Invalid calling context, CFE_ES_GetAppId() rc=%08x AppId=%lx, OwnerAppId=%lx\n",
+        CFE_ES_WriteToSysLog("%s: Invalid calling context, CFE_ES_GetAppId() rc=%08x AppId=%lx, OwnerAppId=%lx\n",
                              __func__, (unsigned int)rc, CFE_RESOURCEID_TO_ULONG(AppId),
                              CFE_RESOURCEID_TO_ULONG(CFE_Assert_Global.OwnerAppId));
         return;
@@ -222,6 +222,16 @@ void CFE_Assert_ExecuteTest(void)
     /* unregister the callback and unset the appid */
     UT_BSP_Lock();
     CFE_Assert_RegisterCallback(NULL);
+<<<<<<< HEAD
     CFE_Assert_Global.OwnerAppId = CFE_ES_APPID_UNDEFINED;
     UT_BSP_Unlock();
+=======
+
+    /* Release the access mutex so the next test program can run */
+    rc = OS_MutSemGive(CFE_Assert_Global.AccessMutex);
+    if (rc != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("%s: Error from OS_MutSemGive(): %d\n", __func__, (int)rc);
+    }
+>>>>>>> Fix #1325, Prepend system log writes with function name
 }

--- a/modules/cfe_assert/src/cfe_assert_runner.c
+++ b/modules/cfe_assert/src/cfe_assert_runner.c
@@ -222,16 +222,6 @@ void CFE_Assert_ExecuteTest(void)
     /* unregister the callback and unset the appid */
     UT_BSP_Lock();
     CFE_Assert_RegisterCallback(NULL);
-<<<<<<< HEAD
     CFE_Assert_Global.OwnerAppId = CFE_ES_APPID_UNDEFINED;
     UT_BSP_Unlock();
-=======
-
-    /* Release the access mutex so the next test program can run */
-    rc = OS_MutSemGive(CFE_Assert_Global.AccessMutex);
-    if (rc != CFE_SUCCESS)
-    {
-        CFE_ES_WriteToSysLog("%s: Error from OS_MutSemGive(): %d\n", __func__, (int)rc);
-    }
->>>>>>> Fix #1325, Prepend system log writes with function name
 }

--- a/modules/core_private/ut-stubs/src/ut_osprintf_stubs.c
+++ b/modules/core_private/ut-stubs/src/ut_osprintf_stubs.c
@@ -41,123 +41,64 @@
 */
 
 const char *UT_OSP_MESSAGES[] = {
-    [0] = NULL, /* Message 0 is reserved */
-    /* ES Startup: Error Mounting Volatile(RAM) Volume. EC = 0x~ */
-    [UT_OSP_MOUNT_VOLATILE] = "ES Startup: Error Mounting Volatile(RAM) Volume. EC = 0x%08X\n",
-    /* CFE_ES_ExitApp: CORE Application CFE_ES Had a Runtime Error. */
-    [UT_OSP_CORE_RUNTIME] = "CFE_ES_ExitApp: CORE Application %s Had a Runtime Error.\n",
-    /* ES Startup: OS_TaskCreate error creating core App: CFE_TBL: EC = 0x~ */
-    [UT_OSP_CORE_APP_CREATE] = "ES Startup: OS_TaskCreate error creating core App: %s: EC = 0x%08X\n",
-    /* ES Startup: Error returned when calling function: CFE_TBL_EarlyInit: EC = 0x~ */
-    [UT_OSP_EARLYINIT] = "ES Startup: Error returned when calling function: %s: EC = 0x%08X\n",
-    /* ES Startup: Could not find Library Init symbol:TST_LIB_Init. EC = 0x~ */
-    [UT_OSP_FIND_LIBRARY] = "ES Startup: Could not find Library Init symbol:%s. EC = %d\n",
-    /* POWER ON RESET due to max proc resets (HW Spec Cmd). */
-    [UT_OSP_POR_MAX_HW_SPECIAL] = "POWER ON RESET due to max proc resets (HW Spec Cmd).\n",
-    /* CFE_ES_ExitChildTask Error: Cannot Call from a cFE App Main Task. ID = ~ */
-    [UT_OSP_CANNOT_CALL_APP_MAIN] = "CFE_ES_ExitChildTask Error: Cannot Call from a cFE App Main Task. ID = %d\n",
-    /* ES Startup: bad function pointer ( table entry = 1). */
-    [UT_OSP_FUNCTION_POINTER] = "ES Startup: bad function pointer ( table entry = %d).\n",
-    /* ES Startup: Error Reading Startup file. EC = 0x~ */
-    [UT_OSP_STARTUP_READ] = "ES Startup: Error Reading Startup file. EC = 0x%08X\n",
-    /* PROCESSOR RESET called from CFE_ES_ResetCFE (Commanded). */
-    [UT_OSP_PROC_RESET_COMMANDED] = "PROCESSOR RESET called from CFE_ES_ResetCFE (Commanded).\n",
-    /* ES SharedData Mutex Take Err Stat=0x~,App=1,Func=TestAPI,Line=12345 */
-    [UT_OSP_MUTEX_TAKE] = "ES SharedData Mutex Take Err Stat=0x%x,Func=%s,Line=%d\n",
-    /* ES Startup: Startup Sync failed - Applications may not have all started */
-    [UT_OSP_STARTUP_SYNC_FAIL_1] = "ES Startup: Startup Sync failed - Applications may not have all started\n",
-    /* Warning: System Log full, log entry discarded. */
-    [UT_OSP_SYSTEM_LOG_FULL] = "Warning: System Log full, log entry discarded.\n",
-    /* ES Startup: ES Startup File Line is too long: 137 bytes. */
-    [UT_OSP_FILE_LINE_TOO_LONG] = "ES Startup: **WARNING** File Line %u is malformed: %u bytes, %u tokens.\n",
-    /* ES Startup: Load Shared Library Init Error. */
-    [UT_OSP_SHARED_LIBRARY_INIT] = "ES Startup: Load Shared Library Init Error = 0x%08x\n",
-    /* ES Startup: Error Removing Volatile(RAM) Volume. EC = 0x~ */
-    [UT_OSP_REMOVE_VOLATILE] = "ES Startup: Error Removing Volatile(RAM) Volume. EC = 0x%08X\n",
-    /* POWER ON RESET due to other cause (See Subtype). */
-    [UT_OSP_POR_OTHER] = "POWER ON RESET due to other cause (See Subtype).\n",
-    /* ES Startup: Error Determining Blocks Free on Volume. EC = 0x~ */
-    [UT_OSP_DETERMINE_BLOCKS] = "ES Startup: Error Determining Blocks Free on Volume. EC = 0x%08X\n",
-    /* ES Startup: Startup Sync failed - Applications may not have all initialized */
-    [UT_OSP_STARTUP_SYNC_FAIL_2] = "ES Startup: Startup Sync failed - Applications may not have all initialized\n",
-    /* ES Startup: No free library slots available */
-    [UT_OSP_LIBRARY_SLOTS] = "ES Startup: No free library slots available\n",
-    /* ES Startup: Unable to extract filename from path: ut/filename.gz. */
-    [UT_OSP_EXTRACT_FILENAME_UT] = "ES Startup: Unable to extract filename from path: %s.\n",
-    /* ES Startup: Application path plus file name length (~) exceeds max allowed (~) */
-    [UT_OSP_APP_PATH_FILE_TOO_LONG] =
-        "ES Startup: Application path plus file name length (%d) exceeds max allowed (%d)\n",
-    /* ES Startup: Error Re-Formating Volatile(RAM) Volume. EC = 0x~ */
-    [UT_OSP_REFORMAT_VOLATILE] = "ES Startup: Error Re-Formating Volatile(RAM) Volume. EC = 0x%08X\n",
-    /* ES Startup: Could not load cFE application file:ut/filename.x. EC = 0x~ */
-    [UT_OSP_EXTRACT_FILENAME_UT55] = "ES Startup: Could not load file:%s. EC = 0x%08X\n",
-    /* ES Startup: Unable to extract filename from path: ut46/ */
-    [UT_OSP_EXTRACT_FILENAME_UT46] = "ES Startup: Unable to extract filename from path: %s.\n",
-    /* ES Startup: No free application slots available */
-    [UT_OSP_NO_FREE_APP_SLOTS] = "ES Startup: No free application slots available\n",
-    /* ES Startup: Unable to extract filename from path: ut57/ */
-    [UT_OSP_EXTRACT_FILENAME_UT57] = "ES Startup: Unable to extract filename from path: %s.\n",
-    /* ES SharedData Mutex Give Err Stat=0x~,App=1,Func=TestAPI,Line=98765 */
-    [UT_OSP_MUTEX_GIVE] = "ES SharedData Mutex Give Err Stat=0x%x,Func=%s,Line=%d\n",
-    /* ES Startup: Could not find symbol:EntryPoint. EC = 0x~ */
-    [UT_OSP_CANNOT_FIND_SYMBOL] = "ES Startup: Could not find symbol:%s. EC = 0x%08X\n",
-    /* ES Startup: Error Initializing Volatile(RAM) Volume. EC = 0x~ */
-    [UT_OSP_INIT_VOLATILE] = "ES Startup: Error Initializing Volatile(RAM) Volume. EC = 0x%08X\n",
-    /* ES:Application Init Failed,RC=0x~ */
-    [UT_OSP_APP_INIT] = "ES:Application Init Failed,RC=0x%08X\n",
-    /* POWER ON RESET due to max proc resets (Commanded). */
-    [UT_OSP_POR_MAX_PROC_RESETS] = "POWER ON RESET due to max proc resets (Commanded).\n",
-    /* CFE_ES_RestartApp: Cannot Restart Application appName, It is not running. */
-    [UT_OSP_CANNOT_RESTART_APP] = "CFE_ES_RestartApp: Cannot Restart Application %s, It is not running.\n",
-    /* ES Startup: Insufficent Free Space on Volatile Disk, Reformatting. */
-    [UT_OSP_INSUFF_FREE_SPACE] = "ES Startup: Insufficent Free Space on Volatile Disk, Reformatting.\n",
-    /* ES Startup: Could not load cFE Shared Library */
-    [UT_OSP_LOAD_SHARED_LIBRARY] = "ES Startup: Could not load cFE Shared Library\n",
-    /* POWER ON RESET due to HW Special Cmd (Hw Spec Cmd). */
-    [UT_OSP_POR_HW_SPECIAL] = "POWER ON RESET due to HW Special Cmd (Hw Spec Cmd).\n",
-    /* ES Startup: AppCreate Error: TaskCreate AppName Failed. EC = 0x~! */
-    [UT_OSP_APP_CREATE] = "ES Startup: AppCreate Error: TaskCreate %s Failed. EC = 0x%08X!\n",
-    /* ES Startup: Error Creating Volatile(RAM) Volume. EC = 0x~ */
-    [UT_OSP_CREATE_VOLATILE] = "ES Startup: Error Creating Volatile(RAM) Volume. EC = 0x%08X\n",
-    /* ES Startup: Failed to unload APP: AppName. EC = 0x~ */
-    [UT_OSP_MODULE_UNLOAD_FAILED] = "ES Startup: Failed to unload: %s. EC = 0x%08X\n",
-    /* POWERON RESET called from CFE_ES_ResetCFE (Commanded). */
-    [UT_OSP_POR_COMMANDED] = "POWERON RESET called from CFE_ES_ResetCFE (Commanded).\n",
-    /* ES Startup: Error Re-Mounting Volatile(RAM) Volume. EC = 0x~ */
-    [UT_OSP_REMOUNT_VOLATILE] = "ES Startup: Error Re-Mounting Volatile(RAM) Volume. EC = 0x%08X\n",
-    /* CFE_ES_ExitApp, Cannot Exit CORE Application CFE_ES */
-    [UT_OSP_CORE_APP_EXIT] = "CFE_ES_ExitApp, Cannot Exit CORE Application %s\n",
-    /* ES Startup: Opened ES App Startup file:  */
-    [UT_OSP_ES_APP_STARTUP_OPEN] = "ES Startup: Opened ES App Startup file: %s\n",
-    /* CFE_ES_ExitApp: CORE Application CFE_ES Had an Init Error. */
-    [UT_OSP_CORE_INIT] = "CFE_ES_ExitApp: CORE Application %s Had an Init Error.\n",
-    /* PROCESSOR RESET due to Hardware Special Command (HW Spec Cmd). */
-    [UT_OSP_PROC_RESET_MAX_HW_SPECIAL] = "PROCESSOR RESET due to Hardware Special Command (HW Spec Cmd).\n",
-    /* ES:Error reading cmd pipe,RC=0x~ */
-    [UT_OSP_COMMAND_PIPE] = "ES:Error reading cmd pipe,RC=0x%08X\n",
-    /* ES Startup: Error Un-Mounting Volatile(RAM) Volume. EC = 0x~ */
-    [UT_OSP_UNMOUNT_VOLATILE] = "ES Startup: Error Un-Mounting Volatile(RAM) Volume. EC = 0x%08X\n",
-    /* ES Startup: Error: ES_TaskTable slot in use at task creation! */
-    [UT_OSP_TABLE_SLOT_IN_USE] = "ES Startup: Error: ES_TaskTable slot in use at task creation!\n",
-    /* ES Startup: Error, Can't Open ES App Startup file:  */
-    [UT_OSP_CANNOT_OPEN_ES_APP_STARTUP] = "ES Startup: Error, Can't Open ES App Startup file: %s EC = 0x%08X\n",
-    /* ES Startup: Unable to extract filename from path: /cf/apps/tst_lib.bundle.gz. */
-    [UT_OSP_EXTRACT_FILENAME_CF] = "ES Startup: Unable to extract filename from path: %s.\n",
-    /* Warning: Invalid System Log mode, log entry discarded. */
-    [UT_OSP_INVALID_LOG_MODE] = "Warning: Invalid System Log mode, log entry discarded.\n",
-    /* ES Startup: Library path plus file name length (~) exceeds max allowed (~) */
-    [UT_OSP_LIB_PATH_FILE_TOO_LONG] = "ES Startup: Library path plus file name length (%d) exceeds max allowed (%d)\n",
-    /* ES Startup: Unable to decompress Application File: ut/filename.gz */
-    [UT_OSP_DECOMPRESS_APP] = "ES Startup: Unable to decompress Application File: %s\n",
-    /* ES Startup: Unable to decompress library file: /cf/apps/tst_lib.bundle.gz */
-    [UT_OSP_DECOMPRESS_LIBRARY] = "ES Startup: Unable to decompress library file: %s\n",
-    /* CFE_ES_ExitChildTask Error Calling CFE_ES_GetAppID. Task ID = ~, RC = 0x~ */
-    [UT_OSP_GET_APP_ID] = "CFE_ES_ExitChildTask Error Calling CFE_ES_GetAppID. Task ID = %d, RC = 0x%08X\n",
-    /* ES Startup: Error, No free application slots available for CORE App! */
-    [UT_OSP_NO_FREE_CORE_APP_SLOTS] = "ES Startup: Error, No free application slots available for CORE App!\n",
-    /* ES Startup: CFE_ES_Global.TaskTable record used error for App: CFE_EVS, continuing. */
-    [UT_OSP_RECORD_USED] = "ES Startup: Error: ES_TaskTable slot for ID %lx in use at task creation!\n",
-    /* CFE_ES_ExitChildTask called from invalid task context */
-    [UT_OSP_TASKEXIT_BAD_CONTEXT] = "CFE_ES_ExitChildTask called from invalid task context\n",
-    [UT_OSP_BACKGROUND_TAKE]      = "CFE_ES: Failed to take background sem: %08lx\n",
+    [0]                                 = NULL, /* Message 0 is reserved */
+    [UT_OSP_MOUNT_VOLATILE]             = "%s: Error Mounting Volatile(RAM) Volume. EC = 0x%08X\n",
+    [UT_OSP_CORE_RUNTIME]               = "%s: CORE Application %s Had a Runtime Error.\n",
+    [UT_OSP_CORE_APP_CREATE]            = "%s: OS_TaskCreate error creating core App: %s: EC = 0x%08X\n",
+    [UT_OSP_EARLYINIT]                  = "%s: Error returned when calling function: %s: EC = 0x%08X\n",
+    [UT_OSP_FIND_LIBRARY]               = "%s: Could not find Library Init symbol:%s. EC = %d\n",
+    [UT_OSP_POR_MAX_HW_SPECIAL]         = "%s: POWER ON RESET due to max proc resets (HW Spec Cmd).\n",
+    [UT_OSP_CANNOT_CALL_APP_MAIN]       = "%s: Error: Cannot Call from a cFE App Main Task. ID = %d\n",
+    [UT_OSP_FUNCTION_POINTER]           = "%s: bad function pointer ( table entry = %d).\n",
+    [UT_OSP_STARTUP_READ]               = "%s: Error Reading Startup file. EC = 0x%08X\n",
+    [UT_OSP_PROC_RESET_COMMANDED]       = "%s: PROCESSOR RESET called from CFE_ES_ResetCFE (Commanded).\n",
+    [UT_OSP_MUTEX_TAKE]                 = "%s: SharedData Mutex Take Err Stat=0x%x,Func=%s,Line=%d\n",
+    [UT_OSP_STARTUP_SYNC_FAIL_1]        = "%s: Startup Sync failed - Applications may not have all started\n",
+    [UT_OSP_SYSTEM_LOG_FULL]            = "Warning: System Log full, log entry discarded.\n",
+    [UT_OSP_FILE_LINE_TOO_LONG]         = "%s: **WARNING** File Line %u is malformed: %u bytes, %u tokens.\n",
+    [UT_OSP_SHARED_LIBRARY_INIT]        = "%s: Load Shared Library Init Error = 0x%08x\n",
+    [UT_OSP_REMOVE_VOLATILE]            = "%s: Error Removing Volatile(RAM) Volume. EC = 0x%08X\n",
+    [UT_OSP_POR_OTHER]                  = "%s: POWER ON RESET due to other cause (See Subtype).\n",
+    [UT_OSP_DETERMINE_BLOCKS]           = "%s: Error Determining Blocks Free on Volume. EC = 0x%08X\n",
+    [UT_OSP_STARTUP_SYNC_FAIL_2]        = "%s: Startup Sync failed - Applications may not have all initialized\n",
+    [UT_OSP_LIBRARY_SLOTS]              = "%s: No free library slots available\n",
+    [UT_OSP_EXTRACT_FILENAME_UT]        = "%s: Unable to extract filename from path: %s.\n",
+    [UT_OSP_APP_PATH_FILE_TOO_LONG]     = "%s: Application path plus file name length (%d) exceeds max allowed (%d)\n",
+    [UT_OSP_REFORMAT_VOLATILE]          = "%s: Error Re-Formating Volatile(RAM) Volume. EC = 0x%08X\n",
+    [UT_OSP_EXTRACT_FILENAME_UT55]      = "%s: Could not load file:%s. EC = 0x%08X\n",
+    [UT_OSP_EXTRACT_FILENAME_UT46]      = "%s: Unable to extract filename from path: %s.\n",
+    [UT_OSP_NO_FREE_APP_SLOTS]          = "%s: No free application slots available\n",
+    [UT_OSP_EXTRACT_FILENAME_UT57]      = "%s: Unable to extract filename from path: %s.\n",
+    [UT_OSP_MUTEX_GIVE]                 = "%s: SharedData Mutex Give Err Stat=0x%x,Func=%s,Line=%d\n",
+    [UT_OSP_CANNOT_FIND_SYMBOL]         = "%s: Could not find symbol:%s. EC = 0x%08X\n",
+    [UT_OSP_INIT_VOLATILE]              = "%s: Error Initializing Volatile(RAM) Volume. EC = 0x%08X\n",
+    [UT_OSP_APP_INIT]                   = "%s: Application Init Failed,RC=0x%08X\n",
+    [UT_OSP_POR_MAX_PROC_RESETS]        = "%s: POWER ON RESET due to max proc resets (Commanded).\n",
+    [UT_OSP_CANNOT_RESTART_APP]         = "%s: Cannot Restart Application %s, It is not running.\n",
+    [UT_OSP_INSUFF_FREE_SPACE]          = "%s: Insufficent Free Space on Volatile Disk, Reformatting.\n",
+    [UT_OSP_LOAD_SHARED_LIBRARY]        = "%s: Could not load cFE Shared Library\n",
+    [UT_OSP_POR_HW_SPECIAL]             = "%s: POWER ON RESET due to HW Special Cmd (Hw Spec Cmd).\n",
+    [UT_OSP_APP_CREATE]                 = "%s: AppCreate Error: TaskCreate %s Failed. EC = 0x%08X!\n",
+    [UT_OSP_CREATE_VOLATILE]            = "%s: Error Creating Volatile(RAM) Volume. EC = 0x%08X\n",
+    [UT_OSP_MODULE_UNLOAD_FAILED]       = "%s: Failed to unload: %s. EC = 0x%08X\n",
+    [UT_OSP_POR_COMMANDED]              = "%s: POWERON RESET called from CFE_ES_ResetCFE (Commanded).\n",
+    [UT_OSP_REMOUNT_VOLATILE]           = "%s: Error Re-Mounting Volatile(RAM) Volume. EC = 0x%08X\n",
+    [UT_OSP_CORE_APP_EXIT]              = "%s: Cannot Exit CORE Application %s\n",
+    [UT_OSP_ES_APP_STARTUP_OPEN]        = "%s: Opened ES App Startup file: %s\n",
+    [UT_OSP_CORE_INIT]                  = "%s: CORE Application %s Had an Init Error.\n",
+    [UT_OSP_PROC_RESET_MAX_HW_SPECIAL]  = "%s: PROCESSOR RESET due to Hardware Special Command (HW Spec Cmd).\n",
+    [UT_OSP_COMMAND_PIPE]               = "%s: Error reading cmd pipe,RC=0x%08X\n",
+    [UT_OSP_UNMOUNT_VOLATILE]           = "%s: Error Un-Mounting Volatile(RAM) Volume. EC = 0x%08X\n",
+    [UT_OSP_TABLE_SLOT_IN_USE]          = "%s: Error: ES_TaskTable slot in use at task creation!\n",
+    [UT_OSP_CANNOT_OPEN_ES_APP_STARTUP] = "%s: Error, Can't Open ES App Startup file: %s EC = 0x%08X\n",
+    [UT_OSP_EXTRACT_FILENAME_CF]        = "%s: Unable to extract filename from path: %s.\n",
+    [UT_OSP_INVALID_LOG_MODE]           = "Warning: Invalid System Log mode, log entry discarded.\n",
+    [UT_OSP_LIB_PATH_FILE_TOO_LONG]     = "%s: Library path plus file name length (%d) exceeds max allowed (%d)\n",
+    [UT_OSP_DECOMPRESS_APP]             = "%s: Unable to decompress Application File: %s\n",
+    [UT_OSP_DECOMPRESS_LIBRARY]         = "%s: Unable to decompress library file: %s\n",
+    [UT_OSP_GET_APP_ID]                 = "%s: Error Calling CFE_ES_GetAppID. Task ID = %d, RC = 0x%08X\n",
+    [UT_OSP_NO_FREE_CORE_APP_SLOTS]     = "%s: Error, No free application slots available for CORE App!\n",
+    [UT_OSP_RECORD_USED]                = "%s: Error: ES_TaskTable slot for ID %lx in use at task creation!\n",
+    [UT_OSP_TASKEXIT_BAD_CONTEXT]       = "%s: Called from invalid task context\n",
+    [UT_OSP_BACKGROUND_TAKE]            = "%s: Failed to take background sem: %08lx\n",
 };

--- a/modules/es/fsw/src/cfe_es_api.c
+++ b/modules/es/fsw/src/cfe_es_api.c
@@ -86,7 +86,7 @@ CFE_Status_t CFE_ES_ResetCFE(uint32 ResetType)
         if (CFE_ES_Global.ResetDataPtr->ResetVars.ProcessorResetCount >
             CFE_ES_Global.ResetDataPtr->ResetVars.MaxProcessorResetCount)
         {
-            CFE_ES_WriteToSysLog("POWER ON RESET due to max proc resets (Commanded).\n");
+            CFE_ES_WriteToSysLog("%s: POWER ON RESET due to max proc resets (Commanded).\n", __func__);
 
             /*
             ** Log the reset in the ER Log. The log will be wiped out, but it's good to have
@@ -101,7 +101,7 @@ CFE_Status_t CFE_ES_ResetCFE(uint32 ResetType)
         }
         else
         {
-            CFE_ES_WriteToSysLog("PROCESSOR RESET called from CFE_ES_ResetCFE (Commanded).\n");
+            CFE_ES_WriteToSysLog("%s: PROCESSOR RESET called from CFE_ES_ResetCFE (Commanded).\n", __func__);
 
             /*
             ** Update the reset variables
@@ -128,7 +128,7 @@ CFE_Status_t CFE_ES_ResetCFE(uint32 ResetType)
     }
     else if (ResetType == CFE_PSP_RST_TYPE_POWERON)
     {
-        CFE_ES_WriteToSysLog("POWERON RESET called from CFE_ES_ResetCFE (Commanded).\n");
+        CFE_ES_WriteToSysLog("%s: POWERON RESET called from CFE_ES_ResetCFE (Commanded).\n", __func__);
 
         /*
         ** Log the reset in the ER Log. The log will be wiped out, but it's good to have
@@ -150,7 +150,7 @@ CFE_Status_t CFE_ES_ResetCFE(uint32 ResetType)
     }
     else
     {
-        CFE_ES_WriteToSysLog("ES ResetCFE: Invalid Reset Type: %d.\n", (int)ResetType);
+        CFE_ES_WriteToSysLog("%s: Invalid Reset Type: %d.\n", __func__, (int)ResetType);
         ReturnCode = CFE_ES_BAD_ARGUMENT;
     }
 
@@ -182,13 +182,13 @@ CFE_Status_t CFE_ES_RestartApp(CFE_ES_AppId_t AppID)
         */
         if (AppRecPtr->Type == CFE_ES_AppType_CORE)
         {
-            CFE_ES_SysLogWrite_Unsync("CFE_ES_RestartApp: Cannot Restart a CORE Application: %s.\n",
+            CFE_ES_SysLogWrite_Unsync("%s: Cannot Restart a CORE Application: %s.\n", __func__,
                                       CFE_ES_AppRecordGetName(AppRecPtr));
             ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
         }
         else if (AppRecPtr->AppState != CFE_ES_AppState_RUNNING)
         {
-            CFE_ES_SysLogWrite_Unsync("CFE_ES_RestartApp: Cannot Restart Application %s, It is not running.\n",
+            CFE_ES_SysLogWrite_Unsync("%s: Cannot Restart Application %s, It is not running.\n", __func__,
                                       CFE_ES_AppRecordGetName(AppRecPtr));
             ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
         }
@@ -199,13 +199,13 @@ CFE_Status_t CFE_ES_RestartApp(CFE_ES_AppId_t AppID)
             */
             if (OS_stat(AppRecPtr->StartParams.BasicInfo.FileName, &FileStatus) == OS_SUCCESS)
             {
-                CFE_ES_SysLogWrite_Unsync("CFE_ES_RestartApp: Restart Application %s Initiated\n",
+                CFE_ES_SysLogWrite_Unsync("%s: Restart Application %s Initiated\n", __func__,
                                           CFE_ES_AppRecordGetName(AppRecPtr));
                 AppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_SYS_RESTART;
             }
             else
             {
-                CFE_ES_SysLogWrite_Unsync("CFE_ES_RestartApp: Cannot Restart Application %s, File %s does not exist.\n",
+                CFE_ES_SysLogWrite_Unsync("%s: Cannot Restart Application %s, File %s does not exist.\n", __func__,
                                           CFE_ES_AppRecordGetName(AppRecPtr),
                                           AppRecPtr->StartParams.BasicInfo.FileName);
                 ReturnCode = CFE_ES_FILE_IO_ERR;
@@ -218,7 +218,7 @@ CFE_Status_t CFE_ES_RestartApp(CFE_ES_AppId_t AppID)
     {
         ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
 
-        CFE_ES_WriteToSysLog("CFE_ES_RestartApp: Invalid Application ID received, AppID = %lu\n",
+        CFE_ES_WriteToSysLog("%s: Invalid Application ID received, AppID = %lu\n", __func__,
                              CFE_RESOURCEID_TO_ULONG(AppID));
 
     } /* end if */
@@ -252,13 +252,13 @@ CFE_Status_t CFE_ES_ReloadApp(CFE_ES_AppId_t AppID, const char *AppFileName)
     */
     if (AppRecPtr->Type == CFE_ES_AppType_CORE)
     {
-        CFE_ES_SysLogWrite_Unsync("CFE_ES_DeleteApp: Cannot Reload a CORE Application: %s.\n",
+        CFE_ES_SysLogWrite_Unsync("%s: Cannot Reload a CORE Application: %s.\n", __func__,
                                   CFE_ES_AppRecordGetName(AppRecPtr));
         ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
     }
     else if (AppRecPtr->AppState != CFE_ES_AppState_RUNNING)
     {
-        CFE_ES_SysLogWrite_Unsync("CFE_ES_ReloadApp: Cannot Reload Application %s, It is not running.\n",
+        CFE_ES_SysLogWrite_Unsync("%s: Cannot Reload Application %s, It is not running.\n", __func__,
                                   CFE_ES_AppRecordGetName(AppRecPtr));
         ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
     }
@@ -269,7 +269,7 @@ CFE_Status_t CFE_ES_ReloadApp(CFE_ES_AppId_t AppID, const char *AppFileName)
         */
         if (OS_stat(AppFileName, &FileStatus) == OS_SUCCESS)
         {
-            CFE_ES_SysLogWrite_Unsync("CFE_ES_ReloadApp: Reload Application %s Initiated. New filename = %s\n",
+            CFE_ES_SysLogWrite_Unsync("%s: Reload Application %s Initiated. New filename = %s\n", __func__,
                                       CFE_ES_AppRecordGetName(AppRecPtr), AppFileName);
             strncpy(AppRecPtr->StartParams.BasicInfo.FileName, AppFileName,
                     sizeof(AppRecPtr->StartParams.BasicInfo.FileName) - 1);
@@ -278,7 +278,7 @@ CFE_Status_t CFE_ES_ReloadApp(CFE_ES_AppId_t AppID, const char *AppFileName)
         }
         else
         {
-            CFE_ES_SysLogWrite_Unsync("CFE_ES_ReloadApp: Cannot Reload Application %s, File %s does not exist.\n",
+            CFE_ES_SysLogWrite_Unsync("%s: Cannot Reload Application %s, File %s does not exist.\n", __func__,
                                       CFE_ES_AppRecordGetName(AppRecPtr), AppFileName);
             ReturnCode = CFE_ES_FILE_IO_ERR;
         }
@@ -314,19 +314,19 @@ CFE_Status_t CFE_ES_DeleteApp(CFE_ES_AppId_t AppID)
     */
     if (AppRecPtr->Type == CFE_ES_AppType_CORE)
     {
-        CFE_ES_SysLogWrite_Unsync("CFE_ES_DeleteApp: Cannot Delete a CORE Application: %s.\n",
+        CFE_ES_SysLogWrite_Unsync("%s: Cannot Delete a CORE Application: %s.\n", __func__,
                                   CFE_ES_AppRecordGetName(AppRecPtr));
         ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
     }
     else if (AppRecPtr->AppState != CFE_ES_AppState_RUNNING)
     {
-        CFE_ES_SysLogWrite_Unsync("CFE_ES_DeleteApp: Cannot Delete Application %s, It is not running.\n",
+        CFE_ES_SysLogWrite_Unsync("%s: Cannot Delete Application %s, It is not running.\n", __func__,
                                   CFE_ES_AppRecordGetName(AppRecPtr));
         ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
     }
     else
     {
-        CFE_ES_SysLogWrite_Unsync("CFE_ES_DeleteApp: Delete Application %s Initiated\n",
+        CFE_ES_SysLogWrite_Unsync("%s: Delete Application %s Initiated\n", __func__,
                                   CFE_ES_AppRecordGetName(AppRecPtr));
         AppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_SYS_DELETE;
     }
@@ -358,7 +358,7 @@ void CFE_ES_ExitApp(uint32 ExitStatus)
 
     if (ExitStatus == CFE_ES_RunStatus_UNDEFINED || ExitStatus >= CFE_ES_RunStatus_MAX)
     {
-        CFE_ES_SysLogWrite_Unsync("CFE_ES_ExitApp: Called with invalid status (%u).\n", (unsigned int)ExitStatus);
+        CFE_ES_SysLogWrite_Unsync("%s: Called with invalid status (%u).\n", __func__, (unsigned int)ExitStatus);
 
         /* revert to the ERROR status */
         ExitStatus = CFE_ES_RunStatus_APP_ERROR;
@@ -392,7 +392,7 @@ void CFE_ES_ExitApp(uint32 ExitStatus)
             */
             if (ExitStatus == CFE_ES_RunStatus_CORE_APP_INIT_ERROR)
             {
-                CFE_ES_SysLogWrite_Unsync("CFE_ES_ExitApp: CORE Application %s Had an Init Error.\n",
+                CFE_ES_SysLogWrite_Unsync("%s: CORE Application %s Had an Init Error.\n", __func__,
                                           CFE_ES_AppRecordGetName(AppRecPtr));
 
                 /*
@@ -410,14 +410,14 @@ void CFE_ES_ExitApp(uint32 ExitStatus)
                 ** but it may return during unit testing. If it does,
                 ** log the return code (even if it claims CFE_SUCCESS).
                 */
-                CFE_ES_WriteToSysLog("CFE_ES_ExitApp: CORE Application Init Error Processor Reset, RC = 0x%08X\n",
+                CFE_ES_WriteToSysLog("%s: CORE Application Init Error Processor Reset, RC = 0x%08X\n", __func__,
                                      (unsigned int)ReturnCode);
 
                 return;
             }
             else if (ExitStatus == CFE_ES_RunStatus_CORE_APP_RUNTIME_ERROR)
             {
-                CFE_ES_SysLogWrite_Unsync("CFE_ES_ExitApp: CORE Application %s Had a Runtime Error.\n",
+                CFE_ES_SysLogWrite_Unsync("%s: CORE Application %s Had a Runtime Error.\n", __func__,
                                           CFE_ES_AppRecordGetName(AppRecPtr));
 
                 /*
@@ -437,14 +437,15 @@ void CFE_ES_ExitApp(uint32 ExitStatus)
             }
             else
             {
-                CFE_ES_SysLogWrite_Unsync("CFE_ES_ExitApp, Cannot Exit CORE Application %s\n",
+                CFE_ES_SysLogWrite_Unsync("%s: Cannot Exit CORE Application %s\n", __func__,
                                           CFE_ES_AppRecordGetName(AppRecPtr));
             }
         }
         else /* It is an external App */
         {
 
-            CFE_ES_SysLogWrite_Unsync("Application %s called CFE_ES_ExitApp\n", CFE_ES_AppRecordGetName(AppRecPtr));
+            CFE_ES_SysLogWrite_Unsync("%s: Application %s called CFE_ES_ExitApp\n", __func__,
+                                      CFE_ES_AppRecordGetName(AppRecPtr));
 
             AppRecPtr->AppState = CFE_ES_AppState_STOPPED;
 
@@ -550,7 +551,7 @@ bool CFE_ES_RunLoop(uint32 *RunStatus)
         /*
          * Cannot do anything without the AppID
          */
-        CFE_ES_SysLogWrite_Unsync("CFE_ES_RunLoop Error: Cannot get AppID for the caller\n");
+        CFE_ES_SysLogWrite_Unsync("%s: Error getting AppID for the caller\n", __func__);
         ReturnCode = false;
 
     } /* end if Status == CFE_SUCCESS */
@@ -1013,7 +1014,7 @@ CFE_Status_t CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, CFE_ES_AppId_t AppId)
 
     if (AppInfo == NULL)
     {
-        CFE_ES_WriteToSysLog("CFE_ES_GetAppInfo: Invalid Parameter ( Null Pointer )\n");
+        CFE_ES_WriteToSysLog("%s: Invalid Parameter ( Null Pointer )\n", __func__);
         return CFE_ES_BAD_ARGUMENT;
     }
 
@@ -1029,7 +1030,7 @@ CFE_Status_t CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, CFE_ES_AppId_t AppId)
         /*
          * Log a message if called with an invalid ID.
          */
-        CFE_ES_WriteToSysLog("CFE_ES_GetAppInfo: App ID not active: %lu\n", CFE_RESOURCEID_TO_ULONG(AppId));
+        CFE_ES_WriteToSysLog("%s: App ID not active: %lu\n", __func__, CFE_RESOURCEID_TO_ULONG(AppId));
 
         Status = CFE_ES_ERR_RESOURCEID_NOT_VALID;
     }
@@ -1108,7 +1109,7 @@ int32 CFE_ES_GetLibInfo(CFE_ES_AppInfo_t *LibInfo, CFE_ES_LibId_t LibId)
 
     if (LibInfo == NULL)
     {
-        CFE_ES_WriteToSysLog("CFE_ES_GetLibInfo: Invalid Parameter ( Null Pointer )\n");
+        CFE_ES_WriteToSysLog("%s: Invalid Parameter ( Null Pointer )\n", __func__);
         return CFE_ES_BAD_ARGUMENT;
     }
 
@@ -1124,7 +1125,7 @@ int32 CFE_ES_GetLibInfo(CFE_ES_AppInfo_t *LibInfo, CFE_ES_LibId_t LibId)
         /*
          * Log a message if called with an invalid ID.
          */
-        CFE_ES_SysLogWrite_Unsync("CFE_ES_GetLibInfo: Lib ID not active: %lu\n", CFE_RESOURCEID_TO_ULONG(LibId));
+        CFE_ES_SysLogWrite_Unsync("%s: Lib ID not active: %lu\n", __func__, CFE_RESOURCEID_TO_ULONG(LibId));
 
         Status = CFE_ES_ERR_RESOURCEID_NOT_VALID;
     }
@@ -1181,8 +1182,7 @@ int32 CFE_ES_GetModuleInfo(CFE_ES_AppInfo_t *ModuleInfo, CFE_ResourceId_t Resour
             /*
              * Log a message if called with an invalid ID.
              */
-            CFE_ES_WriteToSysLog("CFE_ES_GetModuleInfo: Resource ID not valid: %lu\n",
-                                 CFE_ResourceId_ToInteger(ResourceId));
+            CFE_ES_WriteToSysLog("%s: Resource ID not valid: %lu\n", __func__, CFE_ResourceId_ToInteger(ResourceId));
             Status = CFE_ES_ERR_RESOURCEID_NOT_VALID;
             break;
     }
@@ -1206,7 +1206,7 @@ CFE_Status_t CFE_ES_GetTaskInfo(CFE_ES_TaskInfo_t *TaskInfo, CFE_ES_TaskId_t Tas
 
     if (TaskInfo == NULL)
     {
-        CFE_ES_WriteToSysLog("CFE_ES_GetTaskInfo: Invalid Parameter ( Null Pointer )\n");
+        CFE_ES_WriteToSysLog("%s: Invalid Parameter ( Null Pointer )\n", __func__);
         return CFE_ES_BAD_ARGUMENT;
     }
 
@@ -1220,7 +1220,7 @@ CFE_Status_t CFE_ES_GetTaskInfo(CFE_ES_TaskInfo_t *TaskInfo, CFE_ES_TaskId_t Tas
     {
         /* task ID is bad */
         Status = CFE_ES_ERR_RESOURCEID_NOT_VALID;
-        CFE_ES_SysLogWrite_Unsync("CFE_ES_GetTaskInfo: Task ID Not Active: %lu\n", CFE_RESOURCEID_TO_ULONG(TaskId));
+        CFE_ES_SysLogWrite_Unsync("%s: Task ID Not Active: %lu\n", __func__, CFE_RESOURCEID_TO_ULONG(TaskId));
     }
     else
     {
@@ -1297,24 +1297,23 @@ CFE_Status_t CFE_ES_CreateChildTask(CFE_ES_TaskId_t *TaskIdPtr, const char *Task
     {
         if (TaskName == NULL)
         {
-            CFE_ES_WriteToSysLog("CFE_ES_CreateChildTask: Task Id and Name Pointer Parameters are NULL.\n");
+            CFE_ES_WriteToSysLog("%s: Task Id and Name Pointer Parameters are NULL.\n", __func__);
             ReturnCode = CFE_ES_BAD_ARGUMENT;
         }
         else
         {
-            CFE_ES_WriteToSysLog("CFE_ES_CreateChildTask: Task Id Pointer Parameter is NULL for Task '%s'.\n",
-                                 TaskName);
+            CFE_ES_WriteToSysLog("%s: Task Id Pointer Parameter is NULL for Task '%s'.\n", __func__, TaskName);
             ReturnCode = CFE_ES_BAD_ARGUMENT;
         }
     }
     else if (TaskName == NULL)
     {
-        CFE_ES_WriteToSysLog("CFE_ES_CreateChildTask: TaskName Parameter is NULL\n");
+        CFE_ES_WriteToSysLog("%s: TaskName Parameter is NULL\n", __func__);
         ReturnCode = CFE_ES_BAD_ARGUMENT;
     }
     else if (FunctionPtr == NULL)
     {
-        CFE_ES_WriteToSysLog("CFE_ES_CreateChildTask: Function Pointer Parameter is NULL for Task '%s'\n", TaskName);
+        CFE_ES_WriteToSysLog("%s: Function Pointer Parameter is NULL for Task '%s'\n", __func__, TaskName);
         ReturnCode = CFE_ES_BAD_ARGUMENT;
     }
     else
@@ -1333,13 +1332,12 @@ CFE_Status_t CFE_ES_CreateChildTask(CFE_ES_TaskId_t *TaskIdPtr, const char *Task
         AppRecPtr = CFE_ES_GetAppRecordByContext();
         if (AppRecPtr == NULL)
         {
-            CFE_ES_SysLogWrite_Unsync("CFE_ES_CreateChildTask: Invalid calling context when creating Task '%s'\n",
-                                      TaskName);
+            CFE_ES_SysLogWrite_Unsync("%s: Invalid calling context when creating Task '%s'\n", __func__, TaskName);
             ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
         }
         else if (!CFE_RESOURCEID_TEST_EQUAL(SelfTaskId, AppRecPtr->MainTaskId))
         {
-            CFE_ES_SysLogWrite_Unsync("CFE_ES_CreateChildTask: Error: Cannot call from a Child Task (for Task '%s').\n",
+            CFE_ES_SysLogWrite_Unsync("%s: Error: Cannot call from a Child Task (for Task '%s').\n", __func__,
                                       TaskName);
             ReturnCode = CFE_ES_ERR_CHILD_TASK_CREATE;
         }
@@ -1467,15 +1465,13 @@ CFE_Status_t CFE_ES_DeleteChildTask(CFE_ES_TaskId_t TaskId)
                     /*
                     ** Report the task delete
                     */
-                    CFE_ES_SysLogWrite_Unsync("CFE_ES_DeleteChildTask Task %lu Deleted\n",
-                                              CFE_RESOURCEID_TO_ULONG(TaskId));
+                    CFE_ES_SysLogWrite_Unsync("%s: Task %lu Deleted\n", __func__, CFE_RESOURCEID_TO_ULONG(TaskId));
                     ReturnCode = CFE_SUCCESS;
                 }
                 else
                 {
-                    CFE_ES_SysLogWrite_Unsync(
-                        "CFE_ES_DeleteChildTask Error: Error Calling OS_TaskDelete: Task %lu, RC = 0x%08X\n",
-                        CFE_RESOURCEID_TO_ULONG(TaskId), (unsigned int)OSReturnCode);
+                    CFE_ES_SysLogWrite_Unsync("%s: Error Calling OS_TaskDelete: Task %lu, RC = 0x%08X\n", __func__,
+                                              CFE_RESOURCEID_TO_ULONG(TaskId), (unsigned int)OSReturnCode);
                     ReturnCode = CFE_ES_ERR_CHILD_TASK_DELETE;
                 }
             }
@@ -1484,7 +1480,7 @@ CFE_Status_t CFE_ES_DeleteChildTask(CFE_ES_TaskId_t TaskId)
                 /*
                 ** Error: The task is a cFE Application Main task
                 */
-                CFE_ES_SysLogWrite_Unsync("CFE_ES_DeleteChildTask Error: Task %lu is a cFE Main Task.\n",
+                CFE_ES_SysLogWrite_Unsync("%s: Error: Task %lu is a cFE Main Task.\n", __func__,
                                           CFE_RESOURCEID_TO_ULONG(TaskId));
                 ReturnCode = CFE_ES_ERR_CHILD_TASK_DELETE_MAIN_TASK;
             } /* end if TaskMain == false */
@@ -1494,7 +1490,7 @@ CFE_Status_t CFE_ES_DeleteChildTask(CFE_ES_TaskId_t TaskId)
             /*
             ** Task ID is not in use, so it is invalid
             */
-            CFE_ES_SysLogWrite_Unsync("CFE_ES_DeleteChildTask Error: Task ID is not active: %lu\n",
+            CFE_ES_SysLogWrite_Unsync("%s: Error: Task ID is not active: %lu\n", __func__,
                                       CFE_RESOURCEID_TO_ULONG(TaskId));
             ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
 
@@ -1507,7 +1503,7 @@ CFE_Status_t CFE_ES_DeleteChildTask(CFE_ES_TaskId_t TaskId)
         /*
         ** Task ID is invalid ( too large )
         */
-        CFE_ES_WriteToSysLog("CFE_ES_DeleteChildTask Error: Invalid Task ID: %lu\n", CFE_RESOURCEID_TO_ULONG(TaskId));
+        CFE_ES_WriteToSysLog("%s: Error: Invalid Task ID: %lu\n", __func__, CFE_RESOURCEID_TO_ULONG(TaskId));
         ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
     }
     return (ReturnCode);
@@ -1559,13 +1555,13 @@ void CFE_ES_ExitChildTask(void)
         }
         else
         {
-            CFE_ES_SysLogWrite_Unsync("CFE_ES_ExitChildTask Error: Cannot Call from a cFE App Main Task. ID = %lu\n",
+            CFE_ES_SysLogWrite_Unsync("%s: Error: Cannot Call from a cFE App Main Task. ID = %lu\n", __func__,
                                       CFE_RESOURCEID_TO_ULONG(CFE_ES_TaskRecordGetID(TaskRecPtr)));
         }
     }
     else
     {
-        CFE_ES_SysLogWrite_Unsync("CFE_ES_ExitChildTask called from invalid task context\n");
+        CFE_ES_SysLogWrite_Unsync("%s: Called from invalid task context\n", __func__);
     } /* end if GetAppId */
 
     CFE_ES_UnlockSharedData(__func__, __LINE__);
@@ -1656,7 +1652,7 @@ uint32 CFE_ES_CalculateCRC(const void *DataPtr, size_t DataLength, uint32 InputC
     switch (TypeCRC)
     {
         case CFE_MISSION_ES_CRC_32:
-            CFE_ES_WriteToSysLog("CFE ES Calculate CRC32 not Implemented\n");
+            CFE_ES_WriteToSysLog("%s: Calculate CRC32 not Implemented\n", __func__);
             break;
 
         case CFE_MISSION_ES_CRC_16:
@@ -1677,7 +1673,7 @@ uint32 CFE_ES_CalculateCRC(const void *DataPtr, size_t DataLength, uint32 InputC
             break;
 
         case CFE_MISSION_ES_CRC_8:
-            CFE_ES_WriteToSysLog("CFE ES Calculate CRC8 not Implemented\n");
+            CFE_ES_WriteToSysLog("%s: Calculate CRC8 not Implemented\n", __func__);
             break;
 
         default:
@@ -1708,7 +1704,7 @@ CFE_Status_t CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *CDSHandlePtr, size_t BlockSi
 
     if (CDSHandlePtr == NULL || Name == NULL)
     {
-        CFE_ES_WriteToSysLog("CFE_ES_RegisterCDS:-Failed invalid arguments\n");
+        CFE_ES_WriteToSysLog("%s: Failed invalid arguments\n", __func__);
         return CFE_ES_BAD_ARGUMENT;
     }
 
@@ -1717,11 +1713,11 @@ CFE_Status_t CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *CDSHandlePtr, size_t BlockSi
 
     if (Status != CFE_SUCCESS) /* Application ID was invalid */
     {
-        CFE_ES_WriteToSysLog("CFE_CDS:Register-Bad AppId context\n");
+        CFE_ES_WriteToSysLog("%s: Bad AppId context\n", __func__);
     }
     else if (!CFE_ES_Global.CDSIsAvailable)
     {
-        CFE_ES_WriteToSysLog("CFE_CDS:Register-CDS not available\n");
+        CFE_ES_WriteToSysLog("%s: CDS not available\n", __func__);
         Status = CFE_ES_NOT_IMPLEMENTED;
     }
     else
@@ -1736,7 +1732,7 @@ CFE_Status_t CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *CDSHandlePtr, size_t BlockSi
 
             strncpy(CDSName, Name, sizeof(CDSName) - 1);
             CDSName[sizeof(CDSName) - 1] = '\0';
-            CFE_ES_WriteToSysLog("CFE_CDS:Register-CDS Name (%s) is too long\n", CDSName);
+            CFE_ES_WriteToSysLog("%s: CDS Name (%s) is too long\n", __func__, CDSName);
         }
         else
         {
@@ -1750,8 +1746,7 @@ CFE_Status_t CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *CDSHandlePtr, size_t BlockSi
             /* If size is unacceptable, log it */
             if (Status == CFE_ES_CDS_INVALID_SIZE)
             {
-                CFE_ES_WriteToSysLog("CFE_CDS:Register-CDS %s has invalid size (%lu)\n", Name,
-                                     (unsigned long)BlockSize);
+                CFE_ES_WriteToSysLog("%s: CDS %s has invalid size (%lu)\n", __func__, Name, (unsigned long)BlockSize);
             }
         }
     }
@@ -1923,7 +1918,7 @@ CFE_Status_t CFE_ES_RegisterGenCounter(CFE_ES_CounterId_t *CounterIdPtr, const c
     CountRecPtr = CFE_ES_LocateCounterRecordByName(CounterName);
     if (CountRecPtr != NULL)
     {
-        CFE_ES_SysLogWrite_Unsync("ES Startup: Duplicate Counter name '%s'\n", CounterName);
+        CFE_ES_SysLogWrite_Unsync("%s: Duplicate Counter name '%s'\n", __func__, CounterName);
         Status            = CFE_ES_ERR_DUPLICATE_NAME;
         PendingResourceId = CFE_RESOURCEID_UNDEFINED;
     }
@@ -1936,7 +1931,7 @@ CFE_Status_t CFE_ES_RegisterGenCounter(CFE_ES_CounterId_t *CounterIdPtr, const c
 
         if (CountRecPtr == NULL)
         {
-            CFE_ES_SysLogWrite_Unsync("ES Startup: No free Counter slots available\n");
+            CFE_ES_SysLogWrite_Unsync("%s: No free Counter slots available\n", __func__);
             Status = CFE_ES_NO_RESOURCE_IDS_AVAILABLE;
         }
         else
@@ -2227,8 +2222,8 @@ void CFE_ES_LockSharedData(const char *FunctionName, int32 LineNumber)
          * NOTE: this is going to write into a buffer that itself
          * is _supposed_ to be protected by this same mutex.
          */
-        CFE_ES_SysLogWrite_Unsync("ES SharedData Mutex Take Err Stat=0x%x,Func=%s,Line=%d\n", (unsigned int)Status,
-                                  FunctionName, (int)LineNumber);
+        CFE_ES_SysLogWrite_Unsync("%s: SharedData Mutex Take Err Stat=0x%x,Func=%s,Line=%d\n", __func__,
+                                  (unsigned int)Status, FunctionName, (int)LineNumber);
 
     } /* end if */
 
@@ -2254,8 +2249,8 @@ void CFE_ES_UnlockSharedData(const char *FunctionName, int32 LineNumber)
          * NOTE: this is going to write into a buffer that itself
          * is _supposed_ to be protected by this same mutex.
          */
-        CFE_ES_SysLogWrite_Unsync("ES SharedData Mutex Give Err Stat=0x%x,Func=%s,Line=%d\n", (unsigned int)Status,
-                                  FunctionName, (int)LineNumber);
+        CFE_ES_SysLogWrite_Unsync("%s: SharedData Mutex Give Err Stat=0x%x,Func=%s,Line=%d\n", __func__,
+                                  (unsigned int)Status, FunctionName, (int)LineNumber);
 
     } /* end if */
 

--- a/modules/es/fsw/src/cfe_es_apps.c
+++ b/modules/es/fsw/src/cfe_es_apps.c
@@ -105,12 +105,12 @@ void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath)
 
         if (Status >= 0)
         {
-            CFE_ES_WriteToSysLog("ES Startup: Opened ES App Startup file: %s\n", ScriptFileName);
+            CFE_ES_WriteToSysLog("%s: Opened ES App Startup file: %s\n", __func__, ScriptFileName);
             FileOpened = true;
         }
         else
         {
-            CFE_ES_WriteToSysLog("ES Startup: Cannot Open Volatile Startup file, Trying Nonvolatile.\n");
+            CFE_ES_WriteToSysLog("%s: Cannot Open Volatile Startup file, Trying Nonvolatile.\n", __func__);
         }
 
     } /* end if */
@@ -134,12 +134,12 @@ void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath)
 
         if (Status >= 0)
         {
-            CFE_ES_WriteToSysLog("ES Startup: Opened ES App Startup file: %s\n", ScriptFileName);
+            CFE_ES_WriteToSysLog("%s: Opened ES App Startup file: %s\n", __func__, ScriptFileName);
             FileOpened = true;
         }
         else
         {
-            CFE_ES_WriteToSysLog("ES Startup: Error, Can't Open ES App Startup file: %s EC = 0x%08X\n", StartFilePath,
+            CFE_ES_WriteToSysLog("%s: Error, Can't Open ES App Startup file: %s EC = 0x%08X\n", __func__, StartFilePath,
                                  (unsigned int)Status);
         }
     }
@@ -164,7 +164,7 @@ void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath)
             Status = OS_read(AppFile, &c, 1);
             if (Status < 0)
             {
-                CFE_ES_WriteToSysLog("ES Startup: Error Reading Startup file. EC = 0x%08X\n", (unsigned int)Status);
+                CFE_ES_WriteToSysLog("%s: Error Reading Startup file. EC = 0x%08X\n", __func__, (unsigned int)Status);
                 break;
             }
             else if (Status == 0)
@@ -236,9 +236,9 @@ void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath)
                         /*
                         ** The line was not formed correctly
                         */
-                        CFE_ES_WriteToSysLog(
-                            "ES Startup: **WARNING** File Line %u is malformed: %u bytes, %u tokens.\n",
-                            (unsigned int)NumLines, (unsigned int)BuffLen, (unsigned int)NumTokens);
+                        CFE_ES_WriteToSysLog("%s: **WARNING** File Line %u is malformed: %u bytes, %u tokens.\n",
+                                             __func__, (unsigned int)NumLines, (unsigned int)BuffLen,
+                                             (unsigned int)NumTokens);
                         LineTooLong = false;
                     }
                     else
@@ -295,7 +295,7 @@ int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens)
     */
     if (NumTokens < 8)
     {
-        CFE_ES_WriteToSysLog("ES Startup: Invalid ES Startup file entry: %u\n", (unsigned int)NumTokens);
+        CFE_ES_WriteToSysLog("%s: Invalid ES Startup file entry: %u\n", __func__, (unsigned int)NumTokens);
         return CFE_ES_BAD_ARGUMENT;
     }
 
@@ -312,7 +312,7 @@ int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens)
                                        CFE_FS_FileCategory_DYNAMIC_MODULE);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("ES Startup: Invalid ES Startup script file name: %s\n", TokenList[1]);
+        CFE_ES_WriteToSysLog("%s: Invalid ES Startup script file name: %s\n", __func__, TokenList[1]);
         return Status;
     }
 
@@ -320,7 +320,7 @@ int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens)
 
     if (strcmp(EntryType, "CFE_APP") == 0)
     {
-        CFE_ES_WriteToSysLog("ES Startup: Loading file: %s, APP: %s\n", ParamBuf.BasicInfo.FileName, ModuleName);
+        CFE_ES_WriteToSysLog("%s: Loading file: %s, APP: %s\n", __func__, ParamBuf.BasicInfo.FileName, ModuleName);
 
         /*
          * Priority and Exception action have limited ranges, which is checked here
@@ -364,7 +364,7 @@ int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens)
     }
     else if (strcmp(EntryType, "CFE_LIB") == 0)
     {
-        CFE_ES_WriteToSysLog("ES Startup: Loading shared library: %s\n", ParamBuf.BasicInfo.FileName);
+        CFE_ES_WriteToSysLog("%s: Loading shared library: %s\n", __func__, ParamBuf.BasicInfo.FileName);
 
         /*
         ** Now load the library
@@ -373,7 +373,7 @@ int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens)
     }
     else
     {
-        CFE_ES_WriteToSysLog("ES Startup: Unexpected EntryType %s in startup file.\n", EntryType);
+        CFE_ES_WriteToSysLog("%s: Unexpected EntryType %s in startup file.\n", __func__, EntryType);
         Status = CFE_ES_ERR_APP_CREATE;
     }
 
@@ -436,7 +436,7 @@ int32 CFE_ES_LoadModule(CFE_ResourceId_t ParentResourceId, const char *ModuleNam
 
         if (StatusCode != OS_SUCCESS)
         {
-            CFE_ES_WriteToSysLog("ES Startup: Could not load file:%s. EC = 0x%08X\n", LoadParams->FileName,
+            CFE_ES_WriteToSysLog("%s: Could not load file:%s. EC = 0x%08X\n", __func__, LoadParams->FileName,
                                  (unsigned int)StatusCode);
             ModuleId   = OS_OBJECT_ID_UNDEFINED;
             ReturnCode = CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
@@ -456,7 +456,7 @@ int32 CFE_ES_LoadModule(CFE_ResourceId_t ParentResourceId, const char *ModuleNam
         StatusCode = OS_ModuleSymbolLookup(ModuleId, &InitSymbolAddress, LoadParams->InitSymbolName);
         if (StatusCode != OS_SUCCESS)
         {
-            CFE_ES_WriteToSysLog("ES Startup: Could not find symbol:%s. EC = 0x%08X\n", LoadParams->InitSymbolName,
+            CFE_ES_WriteToSysLog("%s: Could not find symbol:%s. EC = 0x%08X\n", __func__, LoadParams->InitSymbolName,
                                  (unsigned int)StatusCode);
             ReturnCode = CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
         }
@@ -475,7 +475,7 @@ int32 CFE_ES_LoadModule(CFE_ResourceId_t ParentResourceId, const char *ModuleNam
         StatusCode = OS_ModuleUnload(ModuleId);
         if (StatusCode != OS_SUCCESS) /* There's not much we can do except notify */
         {
-            CFE_ES_WriteToSysLog("ES Startup: Failed to unload: %s. EC = 0x%08X\n", ModuleName,
+            CFE_ES_WriteToSysLog("%s: Failed to unload: %s. EC = 0x%08X\n", __func__, ModuleName,
                                  (unsigned int)StatusCode);
         }
     }
@@ -610,7 +610,7 @@ int32 CFE_ES_StartAppTask(CFE_ES_TaskId_t *TaskIdPtr, const char *TaskName, CFE_
         TaskRecPtr  = CFE_ES_LocateTaskRecordByID(LocalTaskId);
         if (CFE_ES_TaskRecordIsUsed(TaskRecPtr))
         {
-            CFE_ES_SysLogWrite_Unsync("ES Startup: Error: ES_TaskTable slot for ID %lx in use at task creation!\n",
+            CFE_ES_SysLogWrite_Unsync("%s: Error: ES_TaskTable slot for ID %lx in use at task creation!\n", __func__,
                                       OS_ObjectIdToInteger(OsalTaskId));
         }
 
@@ -638,7 +638,7 @@ int32 CFE_ES_StartAppTask(CFE_ES_TaskId_t *TaskIdPtr, const char *TaskName, CFE_
     }
     else
     {
-        CFE_ES_SysLogWrite_Unsync("ES Startup: AppCreate Error: TaskCreate %s Failed. EC = 0x%08X!\n", TaskName,
+        CFE_ES_SysLogWrite_Unsync("%s: AppCreate Error: TaskCreate %s Failed. EC = 0x%08X!\n", __func__, TaskName,
                                   (unsigned int)StatusCode);
         ReturnCode = CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
         *TaskIdPtr = CFE_ES_TASKID_UNDEFINED;
@@ -703,7 +703,7 @@ int32 CFE_ES_AppCreate(CFE_ES_AppId_t *ApplicationIdPtr, const char *AppName, co
     AppRecPtr = CFE_ES_LocateAppRecordByName(AppName);
     if (AppRecPtr != NULL)
     {
-        CFE_ES_SysLogWrite_Unsync("ES Startup: Duplicate app name '%s'\n", AppName);
+        CFE_ES_SysLogWrite_Unsync("%s: Duplicate app name '%s'\n", __func__, AppName);
         Status = CFE_ES_ERR_DUPLICATE_NAME;
     }
     else
@@ -715,7 +715,7 @@ int32 CFE_ES_AppCreate(CFE_ES_AppId_t *ApplicationIdPtr, const char *AppName, co
 
         if (AppRecPtr == NULL)
         {
-            CFE_ES_SysLogWrite_Unsync("ES Startup: No free application slots available\n");
+            CFE_ES_SysLogWrite_Unsync("%s: No free application slots available\n", __func__);
             Status = CFE_ES_NO_RESOURCE_IDS_AVAILABLE;
         }
         else
@@ -871,7 +871,7 @@ int32 CFE_ES_LoadLibrary(CFE_ES_LibId_t *LibraryIdPtr, const char *LibName, cons
     LibSlotPtr = CFE_ES_LocateLibRecordByName(LibName);
     if (LibSlotPtr != NULL || CFE_ES_LocateAppRecordByName(LibName) != NULL)
     {
-        CFE_ES_SysLogWrite_Unsync("ES Startup: Duplicate Lib name '%s'\n", LibName);
+        CFE_ES_SysLogWrite_Unsync("%s: Duplicate Lib name '%s'\n", __func__, LibName);
         if (LibSlotPtr != NULL)
         {
             PendingResourceId = CFE_RESOURCEID_UNWRAP(CFE_ES_LibRecordGetID(LibSlotPtr));
@@ -887,7 +887,7 @@ int32 CFE_ES_LoadLibrary(CFE_ES_LibId_t *LibraryIdPtr, const char *LibName, cons
 
         if (LibSlotPtr == NULL)
         {
-            CFE_ES_SysLogWrite_Unsync("ES Startup: No free library slots available\n");
+            CFE_ES_SysLogWrite_Unsync("%s: No free library slots available\n", __func__);
             Status = CFE_ES_NO_RESOURCE_IDS_AVAILABLE;
         }
         else
@@ -932,7 +932,7 @@ int32 CFE_ES_LoadLibrary(CFE_ES_LibId_t *LibraryIdPtr, const char *LibName, cons
             Status = (*FunctionPointer)(CFE_ES_LIBID_C(PendingResourceId));
             if (Status != CFE_SUCCESS)
             {
-                CFE_ES_WriteToSysLog("ES Startup: Load Shared Library Init Error = 0x%08x\n", (unsigned int)Status);
+                CFE_ES_WriteToSysLog("%s: Load Shared Library Init Error = 0x%08x\n", __func__, (unsigned int)Status);
             }
         }
     }
@@ -1421,7 +1421,7 @@ int32 CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId)
     }
     else
     {
-        CFE_ES_SysLogWrite_Unsync("CFE_ES_CleanUpApp: AppID %lu is not valid for deletion\n",
+        CFE_ES_SysLogWrite_Unsync("%s: AppID %lu is not valid for deletion\n", __func__,
                                   CFE_RESOURCEID_TO_ULONG(AppId));
         ReturnCode = CFE_ES_APP_CLEANUP_ERR;
     }
@@ -1462,8 +1462,7 @@ int32 CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId)
     Status = CFE_EVS_CleanUpApp(AppId);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("CFE_ES_CleanUpApp: Call to CFE_EVS_CleanUpApp returned Error: 0x%08X\n",
-                             (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Call to CFE_EVS_CleanUpApp returned Error: 0x%08X\n", __func__, (unsigned int)Status);
         ReturnCode = CFE_ES_APP_CLEANUP_ERR;
     }
 
@@ -1482,7 +1481,7 @@ int32 CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId)
         Status = CFE_ES_CleanupTaskResources(TaskList[i]);
         if (Status != CFE_SUCCESS)
         {
-            CFE_ES_WriteToSysLog("CFE_ES_CleanUpApp: CleanUpTaskResources for Task ID:%lu returned Error: 0x%08X\n",
+            CFE_ES_WriteToSysLog("%s: CleanUpTaskResources for Task ID:%lu returned Error: 0x%08X\n", __func__,
                                  CFE_RESOURCEID_TO_ULONG(TaskList[i]), (unsigned int)Status);
             ReturnCode = CFE_ES_APP_CLEANUP_ERR;
         }
@@ -1496,7 +1495,7 @@ int32 CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId)
         Status = CFE_ES_PoolDelete(PoolList[i]);
         if (Status != CFE_SUCCESS)
         {
-            CFE_ES_WriteToSysLog("CFE_ES_MemPoolCleanupApp: delete pool %lu returned Error: 0x%08X\n",
+            CFE_ES_WriteToSysLog("%s: delete pool %lu returned Error: 0x%08X\n", __func__,
                                  CFE_RESOURCEID_TO_ULONG(PoolList[i]), (unsigned int)Status);
             ReturnCode = CFE_ES_APP_CLEANUP_ERR;
         }
@@ -1513,7 +1512,7 @@ int32 CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId)
         Status = OS_ModuleUnload(ModuleId);
         if (Status != OS_SUCCESS)
         {
-            CFE_ES_WriteToSysLog("CFE_ES_CleanUpApp: Module (ID:0x%08lX) Unload failed. RC=0x%08X\n",
+            CFE_ES_WriteToSysLog("%s: Module (ID:0x%08lX) Unload failed. RC=0x%08X\n", __func__,
                                  OS_ObjectIdToInteger(ModuleId), (unsigned int)Status);
             ReturnCode = CFE_ES_APP_CLEANUP_ERR;
         }
@@ -1626,7 +1625,7 @@ void CFE_ES_CleanupObjectCallback(osal_id_t ObjectId, void *arg)
         }
         else
         {
-            CFE_ES_SysLogWrite_Unsync("Call to OSAL Delete Object (ID:%lu) failed. RC=0x%08X\n",
+            CFE_ES_SysLogWrite_Unsync("%s: Call to OSAL Delete Object (ID:%lu) failed. RC=0x%08X\n", __func__,
                                       OS_ObjectIdToInteger(ObjectId), (unsigned int)Status);
             if (CleanState->OverallStatus == CFE_SUCCESS)
             {

--- a/modules/es/fsw/src/cfe_es_backgroundtask.c
+++ b/modules/es/fsw/src/cfe_es_backgroundtask.c
@@ -157,7 +157,7 @@ void CFE_ES_BackgroundTask(void)
         if (status != OS_SUCCESS && status != OS_SEM_TIMEOUT)
         {
             /* should never occur */
-            CFE_ES_WriteToSysLog("CFE_ES: Failed to take background sem: %08lx\n", (unsigned long)status);
+            CFE_ES_WriteToSysLog("%s: Failed to take background sem: %08lx\n", __func__, (unsigned long)status);
             break;
         }
     }
@@ -178,7 +178,7 @@ int32 CFE_ES_BackgroundInit(void)
     status = OS_BinSemCreate(&CFE_ES_Global.BackgroundTask.WorkSem, CFE_ES_BACKGROUND_SEM_NAME, 0, 0);
     if (status != OS_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("CFE_ES: Failed to create background sem: %08lx\n", (unsigned long)status);
+        CFE_ES_WriteToSysLog("%s: Failed to create background sem: %08lx\n", __func__, (unsigned long)status);
         return status;
     }
 
@@ -190,7 +190,7 @@ int32 CFE_ES_BackgroundInit(void)
 
     if (status != OS_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("CFE_ES: Failed to create background task: %08lx\n", (unsigned long)status);
+        CFE_ES_WriteToSysLog("%s: Failed to create background task: %08lx\n", __func__, (unsigned long)status);
         return status;
     }
 

--- a/modules/es/fsw/src/cfe_es_cds.c
+++ b/modules/es/fsw/src/cfe_es_cds.c
@@ -65,7 +65,7 @@ int32 CFE_ES_CDS_EarlyInit(void)
     Status = OS_MutSemCreate(&CDS->GenMutex, CFE_ES_CDS_MUT_REG_NAME, CFE_ES_CDS_MUT_REG_VALUE);
     if (Status != OS_SUCCESS)
     {
-        CFE_ES_SysLogWrite_Unsync("CFE_ES_CDS_EarlyInit: Failed to create mutex with error %d\n", (int)Status);
+        CFE_ES_SysLogWrite_Unsync("%s: Failed to create mutex with error %d\n", __func__, (int)Status);
         return CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
     }
 
@@ -77,8 +77,7 @@ int32 CFE_ES_CDS_EarlyInit(void)
     if (Status != CFE_PSP_SUCCESS)
     {
         /* Error getting the size of the CDS from the BSP */
-        CFE_ES_WriteToSysLog("CFE_CDS:EarlyInit-Unable to obtain CDS Size from BSP (Err=0x%08X)\n",
-                             (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Unable to obtain CDS Size from BSP (Err=0x%08X)\n", __func__, (unsigned int)Status);
         return Status;
     }
 
@@ -91,8 +90,8 @@ int32 CFE_ES_CDS_EarlyInit(void)
 
     if (CDS->TotalSize < MinRequiredSize)
     {
-        CFE_ES_WriteToSysLog("CFE_CDS:EarlyInit-CDS Size (%lu) less than required (%lu)\n",
-                             (unsigned long)CDS->TotalSize, (unsigned long)MinRequiredSize);
+        CFE_ES_WriteToSysLog("%s: CDS Size (%lu) less than required (%lu)\n", __func__, (unsigned long)CDS->TotalSize,
+                             (unsigned long)MinRequiredSize);
         Status = CFE_SUCCESS;
     }
     else
@@ -135,8 +134,7 @@ int32 CFE_ES_CDS_EarlyInit(void)
         if (Status != CFE_SUCCESS)
         {
             /* Unrecoverable error while reading the CDS */
-            CFE_ES_WriteToSysLog("CFE_CDS:EarlyInit-error validating/initializing CDS (0x%08lX)\n",
-                                 (unsigned long)Status);
+            CFE_ES_WriteToSysLog("%s: Error validating/initializing CDS (0x%08lX)\n", __func__, (unsigned long)Status);
         }
         else
         {
@@ -441,7 +439,7 @@ int32 CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr, size_t UserBlockSize, 
     /* Log any failures AFTER releasing the lock */
     if (RegUpdateStatus != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("CFE_CDS:RegCDS-Failed to update CDS Registry (Stat=0x%08X)\n",
+        CFE_ES_WriteToSysLog("%s: Failed to update CDS Registry (Stat=0x%08X)\n", __func__,
                              (unsigned int)RegUpdateStatus);
 
         /*
@@ -492,7 +490,7 @@ int32 CFE_ES_ValidateCDS(void)
     Status = CFE_ES_CDS_CacheFetch(&CDS->Cache, CDS_SIG_BEGIN_OFFSET, SIG_CDS_SIZE);
     if (Status != CFE_PSP_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("CFE_CDS:Validate-1st ReadFromCDS Failed. Status=0x%X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: 1st ReadFromCDS Failed. Status=0x%X\n", __func__, (unsigned int)Status);
         return Status;
     }
 
@@ -509,7 +507,7 @@ int32 CFE_ES_ValidateCDS(void)
     if (Status != CFE_PSP_SUCCESS)
     {
         /* BSP reported an error reading from CDS */
-        CFE_ES_WriteToSysLog("CFE_CDS:Validate-2nd ReadFromCDS Failed. Status=0x%X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: 2nd ReadFromCDS Failed. Status=0x%X\n", __func__, (unsigned int)Status);
         return Status;
     }
 
@@ -563,7 +561,7 @@ int32 CFE_ES_ClearCDS(void)
 
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("CFE_CDS:Init-Clear CDS failed @ Offset=%lu Status=0x%08X\n",
+        CFE_ES_WriteToSysLog("%s: Clear CDS failed @ Offset=%lu Status=0x%08X\n", __func__,
                              (unsigned long)CDS->Cache.Offset, (unsigned int)CDS->Cache.AccessStatus);
     }
 
@@ -591,7 +589,7 @@ int32 CFE_ES_InitCDSSignatures(void)
     if (Status != CFE_SUCCESS)
     {
         /* BSP reported an error writing to CDS */
-        CFE_ES_WriteToSysLog("CFE_CDS:Init-'_CDSBeg_' write failed. Status=0x%08X\n",
+        CFE_ES_WriteToSysLog("%s: '_CDSBeg_' write failed. Status=0x%08X\n", __func__,
                              (unsigned int)CDS->Cache.AccessStatus);
         return Status;
     }
@@ -603,7 +601,7 @@ int32 CFE_ES_InitCDSSignatures(void)
     Status = CFE_ES_CDS_CacheFlush(&CDS->Cache);
     if (Status != CFE_PSP_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("CFE_CDS:Init-'_CDSEnd_' write failed. Status=0x%08X\n",
+        CFE_ES_WriteToSysLog("%s: '_CDSEnd_' write failed. Status=0x%08X\n", __func__,
                              (unsigned int)CDS->Cache.AccessStatus);
         return Status;
     }
@@ -638,7 +636,7 @@ int32 CFE_ES_InitCDSRegistry(void)
     }
     else
     {
-        CFE_ES_WriteToSysLog("CFE_CDS:InitReg-Failed to write Reg Size. Status=0x%08X\n",
+        CFE_ES_WriteToSysLog("%s: Failed to write Reg Size. Status=0x%08X\n", __func__,
                              (unsigned int)CDS->Cache.AccessStatus);
     }
 
@@ -663,7 +661,7 @@ int32 CFE_ES_UpdateCDSRegistry(void)
 
     if (Status != CFE_PSP_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("CFE_CDS:UpdateReg-Failed to write CDS Registry. Status=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Failed to write CDS Registry. Status=0x%08X\n", __func__, (unsigned int)Status);
         Status = CFE_ES_CDS_ACCESS_ERROR;
     }
 
@@ -809,7 +807,7 @@ int32 CFE_ES_RebuildCDS(void)
     Status = CFE_ES_CDS_CacheFetch(&CDS->Cache, CDS_REG_SIZE_OFFSET, sizeof(CDS->Cache.Data.RegistrySize));
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("CFE_CDS:Rebuild-PSP Error reading Registry size (%lx)\n",
+        CFE_ES_WriteToSysLog("%s: PSP Error reading Registry size (%lx)\n", __func__,
                              (unsigned long)CDS->Cache.AccessStatus);
         return CFE_ES_CDS_INVALID;
     }
@@ -817,7 +815,7 @@ int32 CFE_ES_RebuildCDS(void)
     if (CDS->Cache.Data.RegistrySize != CFE_PLATFORM_ES_CDS_MAX_NUM_ENTRIES)
     {
         /* Registry in CDS is incompatible size to recover */
-        CFE_ES_WriteToSysLog("CFE_CDS:Rebuild-Registry in CDS incorrect size (%lu)\n",
+        CFE_ES_WriteToSysLog("%s: Registry in CDS incorrect size (%lu)\n", __func__,
                              (unsigned long)CDS->Cache.Data.RegistrySize);
         return CFE_ES_CDS_INVALID;
     }
@@ -832,7 +830,7 @@ int32 CFE_ES_RebuildCDS(void)
     else
     {
         /* Registry in CDS is unreadable */
-        CFE_ES_WriteToSysLog("CFE_CDS:Rebuild-Registry in CDS is unreadable, PSP error %lx\n", (unsigned long)Status);
+        CFE_ES_WriteToSysLog("%s: Registry in CDS is unreadable, PSP error %lx\n", __func__, (unsigned long)Status);
         Status = CFE_ES_CDS_INVALID;
     }
 
@@ -937,7 +935,7 @@ int32 CFE_ES_DeleteCDS(const char *CDSName, bool CalledByTblServices)
     /* Output the message to syslog once the CDS registry resource is unlocked */
     if (LogMessage[0] != 0)
     {
-        CFE_ES_WriteToSysLog("%s(): %s", __func__, LogMessage);
+        CFE_ES_WriteToSysLog("%s: %s", __func__, LogMessage);
     }
 
     return Status;

--- a/modules/es/fsw/src/cfe_es_cds_mempool.c
+++ b/modules/es/fsw/src/cfe_es_cds_mempool.c
@@ -122,7 +122,7 @@ int32 CFE_ES_CreateCDSPool(size_t CDSPoolSize, size_t StartOffset)
     if (ActualSize < SizeCheck)
     {
         /* Must be able make Pool verification, block descriptor and at least one of the smallest blocks  */
-        CFE_ES_SysLogWrite_Unsync("CFE_ES:CreateCDSPool-Pool size(%lu) too small for one CDS Block, need >=%lu\n",
+        CFE_ES_SysLogWrite_Unsync("%s: Pool size(%lu) too small for one CDS Block, need >=%lu\n", __func__,
                                   (unsigned long)ActualSize, (unsigned long)SizeCheck);
         return CFE_ES_CDS_INVALID_SIZE;
     }
@@ -163,7 +163,7 @@ int32 CFE_ES_RebuildCDSPool(size_t CDSPoolSize, size_t StartOffset)
 
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_SysLogWrite_Unsync("CFE_ES:RebuildCDS-Err rebuilding CDS (Stat=0x%08x)\n", (unsigned int)Status);
+        CFE_ES_SysLogWrite_Unsync("%s: Err rebuilding CDS (Stat=0x%08x)\n", __func__, (unsigned int)Status);
         Status = CFE_ES_CDS_ACCESS_ERROR;
     }
 
@@ -259,7 +259,7 @@ int32 CFE_ES_CDSBlockWrite(CFE_ES_CDSHandle_t Handle, const void *DataToWrite)
     /* Do the actual syslog if something went wrong */
     if (LogMessage[0] != 0)
     {
-        CFE_ES_WriteToSysLog("%s(): %s", __func__, LogMessage);
+        CFE_ES_WriteToSysLog("%s: %s", __func__, LogMessage);
     }
 
     return Status;

--- a/modules/es/fsw/src/cfe_es_erlog.c
+++ b/modules/es/fsw/src/cfe_es_erlog.c
@@ -315,7 +315,7 @@ bool CFE_ES_RunExceptionScan(uint32 ElapsedTime, void *Arg)
      * Note that writes to the ES ER log actually do not get propagated to the debug console.
      * so by writing to SysLog here it becomes visible in both places.
      */
-    CFE_ES_WriteToSysLog("ExceptionID 0x%lx in TaskID %lu: %s\n", (unsigned long)PspContextId,
+    CFE_ES_WriteToSysLog("%s: ExceptionID 0x%lx in TaskID %lu: %s\n", __func__, (unsigned long)PspContextId,
                          OS_ObjectIdToInteger(ExceptionTaskID), ReasonString);
 
     /*
@@ -370,14 +370,14 @@ bool CFE_ES_RunExceptionScan(uint32 ElapsedTime, void *Arg)
             if (CFE_ES_Global.ResetDataPtr->ResetVars.ProcessorResetCount >=
                 CFE_ES_Global.ResetDataPtr->ResetVars.MaxProcessorResetCount)
             {
-                CFE_ES_WriteToSysLog("Maximum Processor Reset count reached (%u)",
+                CFE_ES_WriteToSysLog("%s: Maximum Processor Reset count reached (%u)", __func__,
                                      (unsigned int)CFE_ES_Global.ResetDataPtr->ResetVars.MaxProcessorResetCount);
 
                 ResetType = CFE_PSP_RST_TYPE_POWERON;
             }
             else
             {
-                CFE_ES_WriteToSysLog("Processor Reset count not reached (%u/%u)",
+                CFE_ES_WriteToSysLog("%s: Processor Reset count not reached (%u/%u)", __func__,
                                      (unsigned int)CFE_ES_Global.ResetDataPtr->ResetVars.ProcessorResetCount,
                                      (unsigned int)CFE_ES_Global.ResetDataPtr->ResetVars.MaxProcessorResetCount);
 

--- a/modules/es/fsw/src/cfe_es_generic_pool.c
+++ b/modules/es/fsw/src/cfe_es_generic_pool.c
@@ -277,7 +277,7 @@ int32 CFE_ES_GenPoolInitialize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t StartO
      */
     if ((AlignMask & AlignSize) != 0)
     {
-        CFE_ES_WriteToSysLog("%s(): invalid alignment for pool: %lu\n", __func__, (unsigned long)AlignSize);
+        CFE_ES_WriteToSysLog("%s: invalid alignment for pool: %lu\n", __func__, (unsigned long)AlignSize);
         return CFE_ES_BAD_ARGUMENT;
     }
 
@@ -380,7 +380,7 @@ int32 CFE_ES_GenPoolGetBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockOf
     BucketId = CFE_ES_GenPoolFindBucket(PoolRecPtr, ReqSize);
     if (BucketId == 0)
     {
-        CFE_ES_WriteToSysLog("CFE_ES:getPoolBlock err:size(%lu) > max(%lu).\n", (unsigned long)ReqSize,
+        CFE_ES_WriteToSysLog("%s: Err:size(%lu) > max(%lu)\n", __func__, (unsigned long)ReqSize,
                              (unsigned long)PoolRecPtr->Buckets[PoolRecPtr->NumBuckets - 1].BlockSize);
         return (CFE_ES_ERR_MEM_BLOCK_SIZE);
     }

--- a/modules/es/fsw/src/cfe_es_mempool.c
+++ b/modules/es/fsw/src/cfe_es_mempool.c
@@ -217,7 +217,7 @@ CFE_Status_t CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_
     /* If too many sizes are specified, return an error */
     if (NumBlockSizes > CFE_PLATFORM_ES_POOL_MAX_BUCKETS)
     {
-        CFE_ES_WriteToSysLog("CFE_ES:poolCreate Num Block Sizes (%d) greater than max (%d)\n", (int)NumBlockSizes,
+        CFE_ES_WriteToSysLog("%s: Num Block Sizes (%d) greater than max (%d)\n", __func__, (int)NumBlockSizes,
                              CFE_PLATFORM_ES_POOL_MAX_BUCKETS);
         return (CFE_ES_BAD_ARGUMENT);
     }
@@ -240,7 +240,7 @@ CFE_Status_t CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_
     MinimumSize = CFE_ES_GenPoolCalcMinSize(NumBlockSizes, BlockSizes, 1);
     if (Size < MinimumSize)
     {
-        CFE_ES_WriteToSysLog("CFE_ES:poolCreate Pool size(%lu) too small, need >=%lu bytes\n", (unsigned long)Size,
+        CFE_ES_WriteToSysLog("%s: Pool size(%lu) too small, need >=%lu bytes\n", __func__, (unsigned long)Size,
                              (unsigned long)MinimumSize);
         return CFE_ES_BAD_ARGUMENT;
     }
@@ -254,7 +254,7 @@ CFE_Status_t CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_
 
     if (PoolRecPtr == NULL)
     {
-        CFE_ES_SysLogWrite_Unsync("ES Startup: No free MemPoolrary slots available\n");
+        CFE_ES_SysLogWrite_Unsync("%s: No free MemPoolrary slots available\n", __func__);
         Status = CFE_ES_NO_RESOURCE_IDS_AVAILABLE;
     }
     else
@@ -315,7 +315,7 @@ CFE_Status_t CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_
         if (Status != OS_SUCCESS)
         {
             /* log error and rewrite to CFE status code */
-            CFE_ES_WriteToSysLog("CFE_ES:poolCreate OSAL error %d while creating mutex\n", (int)Status);
+            CFE_ES_WriteToSysLog("%s: OSAL error %d while creating mutex\n", __func__, (int)Status);
 
             Status = CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
         }
@@ -352,7 +352,7 @@ CFE_Status_t CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_
 
         if (Status == CFE_ES_POOL_BOUNDS_ERROR)
         {
-            CFE_ES_WriteToSysLog("CFE_ES:poolCreate Pool size(%lu) too small\n", (unsigned long)Size);
+            CFE_ES_WriteToSysLog("%s: Pool size(%lu) too small\n", __func__, (unsigned long)Size);
         }
     }
 
@@ -412,7 +412,7 @@ int32 CFE_ES_PoolDelete(CFE_ES_MemHandle_t PoolID)
              * The MemPool entry has already been deleted, so this
              * function should not return an error at this point.
              */
-            CFE_ES_WriteToSysLog("CFE_ES:poolDelete error %d deleting mutex\n", (int)MutDeleteStatus);
+            CFE_ES_WriteToSysLog("%s: Error %d deleting mutex\n", __func__, (int)MutDeleteStatus);
         }
     }
 
@@ -445,7 +445,7 @@ int32 CFE_ES_GetPoolBuf(CFE_ES_MemPoolBuf_t *BufPtr, CFE_ES_MemHandle_t Handle, 
     if (!CFE_ES_MemPoolRecordIsMatch(PoolRecPtr, Handle))
     {
         CFE_ES_GetAppID(&AppId);
-        CFE_ES_WriteToSysLog("CFE_ES:getPoolBuf err:Bad handle(0x%08lX) AppId=%lu\n", CFE_RESOURCEID_TO_ULONG(Handle),
+        CFE_ES_WriteToSysLog("%s: Err:Bad handle(0x%08lX) AppId=%lu\n", __func__, CFE_RESOURCEID_TO_ULONG(Handle),
                              CFE_RESOURCEID_TO_ULONG(AppId));
         return (CFE_ES_ERR_RESOURCEID_NOT_VALID);
     }
@@ -575,8 +575,7 @@ int32 CFE_ES_PutPoolBuf(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_t BufPtr)
     /* basic sanity check */
     if (!CFE_ES_MemPoolRecordIsMatch(PoolRecPtr, Handle))
     {
-        CFE_ES_WriteToSysLog("CFE_ES:putPoolBuf err:Invalid Memory Handle (0x%08lX).\n",
-                             CFE_RESOURCEID_TO_ULONG(Handle));
+        CFE_ES_WriteToSysLog("%s: Err:Invalid Memory Handle (0x%08lX).\n", __func__, CFE_RESOURCEID_TO_ULONG(Handle));
 
         return (CFE_ES_ERR_RESOURCEID_NOT_VALID);
     }
@@ -621,13 +620,12 @@ int32 CFE_ES_PutPoolBuf(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_t BufPtr)
     }
     else if (Status == CFE_ES_POOL_BLOCK_INVALID)
     {
-        CFE_ES_WriteToSysLog("CFE_ES:putPoolBuf err:Deallocating invalid or corrupt memory block @ 0x%08lX\n",
+        CFE_ES_WriteToSysLog("%s: Err:Deallocating invalid or corrupt memory block @ 0x%08lX\n", __func__,
                              (unsigned long)BufPtr);
     }
     else if (Status == CFE_ES_BUFFER_NOT_IN_POOL)
     {
-        CFE_ES_WriteToSysLog("CFE_ES_GenPoolPutBlock err:Bad offset(%lu) outside pool boundary\n",
-                             (unsigned long)DataOffset);
+        CFE_ES_WriteToSysLog("%s: Err:Bad offset(%lu) outside pool boundary\n", __func__, (unsigned long)DataOffset);
     }
 
     return Status;
@@ -659,8 +657,8 @@ CFE_Status_t CFE_ES_GetMemPoolStats(CFE_ES_MemPoolStats_t *BufPtr, CFE_ES_MemHan
     if (!CFE_ES_MemPoolRecordIsMatch(PoolRecPtr, Handle))
     {
         CFE_ES_GetAppID(&AppId);
-        CFE_ES_WriteToSysLog("CFE_ES:getMemPoolStats err:Bad handle(0x%08lX) AppId=%lu\n",
-                             CFE_RESOURCEID_TO_ULONG(Handle), CFE_RESOURCEID_TO_ULONG(AppId));
+        CFE_ES_WriteToSysLog("%s: Err:Bad handle(0x%08lX) AppId=%lu\n", __func__, CFE_RESOURCEID_TO_ULONG(Handle),
+                             CFE_RESOURCEID_TO_ULONG(AppId));
         return (CFE_ES_ERR_RESOURCEID_NOT_VALID);
     }
 

--- a/modules/es/fsw/src/cfe_es_perf.c
+++ b/modules/es/fsw/src/cfe_es_perf.c
@@ -611,7 +611,7 @@ void CFE_ES_PerfLogAdd(uint32 Marker, uint32 EntryExit)
         /* if marker has not been reported previously ... */
         if (Perf->MetaData.InvalidMarkerReported == false)
         {
-            CFE_ES_WriteToSysLog("ES PERF:Invalid performance marker %d,max is %d\n", (unsigned int)Marker,
+            CFE_ES_WriteToSysLog("%s: Invalid performance marker %d,max is %d\n", __func__, (unsigned int)Marker,
                                  (CFE_MISSION_ES_PERF_MAX_IDS - 1));
             Perf->MetaData.InvalidMarkerReported = true;
         } /* end if */

--- a/modules/es/fsw/src/cfe_es_start.c
+++ b/modules/es/fsw/src/cfe_es_start.c
@@ -137,7 +137,7 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const cha
     ReturnCode = OS_MutSemCreate(&CFE_ES_Global.PerfDataMutex, "ES_PERF_MUTEX", 0);
     if (ReturnCode != OS_SUCCESS)
     {
-        CFE_ES_SysLogWrite_Unsync("ES Startup: Error: ES Performance Data Mutex could not be created. RC=0x%08X\n",
+        CFE_ES_SysLogWrite_Unsync("%s: Error: ES Performance Data Mutex could not be created. RC=0x%08X\n", __func__,
                                   (unsigned int)ReturnCode);
 
         /*
@@ -159,7 +159,7 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const cha
     /*
     ** Announce the startup
     */
-    CFE_ES_WriteToSysLog("ES Startup: CFE_ES_Main in EARLY_INIT state\n");
+    CFE_ES_WriteToSysLog("%s: CFE_ES_Main in EARLY_INIT state\n", __func__);
 
     /*
     ** Create and Mount the filesystems needed
@@ -182,7 +182,7 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const cha
     /*
     ** Indicate that the CFE core is now starting up / going multi-threaded
     */
-    CFE_ES_WriteToSysLog("ES Startup: CFE_ES_Main entering CORE_STARTUP state\n");
+    CFE_ES_WriteToSysLog("%s: CFE_ES_Main entering CORE_STARTUP state\n", __func__);
     CFE_ES_Global.SystemState = CFE_ES_SystemState_CORE_STARTUP;
 
     /*
@@ -193,7 +193,7 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const cha
     /*
     ** Indicate that the CFE core is ready
     */
-    CFE_ES_WriteToSysLog("ES Startup: CFE_ES_Main entering CORE_READY state\n");
+    CFE_ES_WriteToSysLog("%s: CFE_ES_Main entering CORE_READY state\n", __func__);
     CFE_ES_Global.SystemState = CFE_ES_SystemState_CORE_READY;
 
     /*
@@ -212,10 +212,10 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const cha
      */
     if (CFE_ES_MainTaskSyncDelay(CFE_ES_AppState_LATE_INIT, CFE_PLATFORM_ES_STARTUP_SCRIPT_TIMEOUT_MSEC) != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("ES Startup: Startup Sync failed - Applications may not have all initialized\n");
+        CFE_ES_WriteToSysLog("%s: Startup Sync failed - Applications may not have all initialized\n", __func__);
     }
 
-    CFE_ES_WriteToSysLog("ES Startup: CFE_ES_Main entering APPS_INIT state\n");
+    CFE_ES_WriteToSysLog("%s: CFE_ES_Main entering APPS_INIT state\n", __func__);
     CFE_ES_Global.SystemState = CFE_ES_SystemState_APPS_INIT;
 
     /*
@@ -227,13 +227,13 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const cha
      */
     if (CFE_ES_MainTaskSyncDelay(CFE_ES_AppState_RUNNING, CFE_PLATFORM_ES_STARTUP_SCRIPT_TIMEOUT_MSEC) != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("ES Startup: Startup Sync failed - Applications may not have all started\n");
+        CFE_ES_WriteToSysLog("%s: Startup Sync failed - Applications may not have all started\n", __func__);
     }
 
     /*
     ** Startup is fully complete
     */
-    CFE_ES_WriteToSysLog("ES Startup: CFE_ES_Main entering OPERATIONAL state\n");
+    CFE_ES_WriteToSysLog("%s: CFE_ES_Main entering OPERATIONAL state\n", __func__);
     CFE_ES_Global.SystemState = CFE_ES_SystemState_OPERATIONAL;
 }
 
@@ -339,19 +339,19 @@ void CFE_ES_SetupResetVariables(uint32 StartType, uint32 StartSubtype, uint32 Bo
         */
         if (StartSubtype == CFE_PSP_RST_SUBTYPE_POWER_CYCLE)
         {
-            CFE_ES_SysLogWrite_Unsync("POWER ON RESET due to Power Cycle (Power Cycle).\n");
+            CFE_ES_SysLogWrite_Unsync("%s: POWER ON RESET due to Power Cycle (Power Cycle).\n", __func__);
             CFE_ES_WriteToERLog(CFE_ES_LogEntryType_CORE, CFE_PSP_RST_TYPE_POWERON, StartSubtype,
                                 "POWER ON RESET due to Power Cycle (Power Cycle)");
         }
         else if (StartSubtype == CFE_PSP_RST_SUBTYPE_HW_SPECIAL_COMMAND)
         {
-            CFE_ES_SysLogWrite_Unsync("POWER ON RESET due to HW Special Cmd (Hw Spec Cmd).\n");
+            CFE_ES_SysLogWrite_Unsync("%s: POWER ON RESET due to HW Special Cmd (Hw Spec Cmd).\n", __func__);
             CFE_ES_WriteToERLog(CFE_ES_LogEntryType_CORE, CFE_PSP_RST_TYPE_POWERON, StartSubtype,
                                 "POWER ON RESET due to HW Special Cmd (Hw Spec Cmd)");
         }
         else
         {
-            CFE_ES_SysLogWrite_Unsync("POWER ON RESET due to other cause (See Subtype).\n");
+            CFE_ES_SysLogWrite_Unsync("%s: POWER ON RESET due to other cause (See Subtype).\n", __func__);
             CFE_ES_WriteToERLog(CFE_ES_LogEntryType_CORE, CFE_PSP_RST_TYPE_POWERON, StartSubtype,
                                 "POWER ON RESET due to other cause (See Subtype)");
         }
@@ -384,7 +384,7 @@ void CFE_ES_SetupResetVariables(uint32 StartType, uint32 StartSubtype, uint32 Bo
                 if (StartSubtype == CFE_PSP_RST_SUBTYPE_HW_SPECIAL_COMMAND)
                 {
                     CFE_ES_Global.ResetDataPtr->ResetVars.ResetSubtype = CFE_PSP_RST_SUBTYPE_HW_SPECIAL_COMMAND;
-                    CFE_ES_SysLogWrite_Unsync("POWER ON RESET due to max proc resets (HW Spec Cmd).\n");
+                    CFE_ES_SysLogWrite_Unsync("%s: POWER ON RESET due to max proc resets (HW Spec Cmd).\n", __func__);
 
                     /*
                     ** Log the reset in the ER Log. The log will be wiped out, but it's good to have
@@ -396,7 +396,7 @@ void CFE_ES_SetupResetVariables(uint32 StartType, uint32 StartSubtype, uint32 Bo
                 else
                 {
                     CFE_ES_Global.ResetDataPtr->ResetVars.ResetSubtype = CFE_PSP_RST_SUBTYPE_HW_WATCHDOG;
-                    CFE_ES_SysLogWrite_Unsync("POWER ON RESET due to max proc resets (Watchdog).\n");
+                    CFE_ES_SysLogWrite_Unsync("%s: POWER ON RESET due to max proc resets (Watchdog).\n", __func__);
 
                     /*
                     ** Log the reset in the ER Log. The log will be wiped out, but it's good to have
@@ -413,14 +413,15 @@ void CFE_ES_SetupResetVariables(uint32 StartType, uint32 StartSubtype, uint32 Bo
                 /*
                 ** Should not return here.
                 */
-                CFE_ES_SysLogWrite_Unsync("ES Startup: Error: CFE_PSP_Restart returned.\n");
+                CFE_ES_SysLogWrite_Unsync("%s: Error: CFE_PSP_Restart returned.\n", __func__);
             }
             else /* Maximum processor reset not exceeded */
             {
                 if (StartSubtype == CFE_PSP_RST_SUBTYPE_HW_SPECIAL_COMMAND)
                 {
                     CFE_ES_Global.ResetDataPtr->ResetVars.ResetSubtype = CFE_PSP_RST_SUBTYPE_HW_SPECIAL_COMMAND;
-                    CFE_ES_SysLogWrite_Unsync("PROCESSOR RESET due to Hardware Special Command (HW Spec Cmd).\n");
+                    CFE_ES_SysLogWrite_Unsync("%s: PROCESSOR RESET due to Hardware Special Command (HW Spec Cmd).\n",
+                                              __func__);
 
                     /*
                     ** Log the watchdog reset
@@ -431,7 +432,7 @@ void CFE_ES_SetupResetVariables(uint32 StartType, uint32 StartSubtype, uint32 Bo
                 else
                 {
                     CFE_ES_Global.ResetDataPtr->ResetVars.ResetSubtype = CFE_PSP_RST_SUBTYPE_HW_WATCHDOG;
-                    CFE_ES_SysLogWrite_Unsync("PROCESSOR RESET due to Watchdog (Watchdog).\n");
+                    CFE_ES_SysLogWrite_Unsync("%s: PROCESSOR RESET due to Watchdog (Watchdog).\n", __func__);
 
                     /*
                     ** Log the watchdog reset
@@ -489,7 +490,8 @@ void CFE_ES_InitializeFileSystems(uint32 StartType)
 
     if (RetStatus != CFE_PSP_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("ES Startup: Cannot Get Memory for Volatile Disk. EC = 0x%08X\n", (unsigned int)RetStatus);
+        CFE_ES_WriteToSysLog("%s: Cannot Get Memory for Volatile Disk. EC = 0x%08X\n", __func__,
+                             (unsigned int)RetStatus);
 
         /*
         ** Delay to allow the message to be read
@@ -512,7 +514,7 @@ void CFE_ES_InitializeFileSystems(uint32 StartType)
                             CFE_PLATFORM_ES_RAM_DISK_NUM_SECTORS);
         if (RetStatus != OS_SUCCESS)
         {
-            CFE_ES_WriteToSysLog("ES Startup: Error Creating Volatile(RAM) Volume. EC = 0x%08X\n",
+            CFE_ES_WriteToSysLog("%s: Error Creating Volatile(RAM) Volume. EC = 0x%08X\n", __func__,
                                  (unsigned int)RetStatus);
 
             /*
@@ -532,15 +534,15 @@ void CFE_ES_InitializeFileSystems(uint32 StartType)
                               CFE_PLATFORM_ES_RAM_DISK_NUM_SECTORS);
         if (RetStatus != OS_SUCCESS)
         {
-            CFE_ES_WriteToSysLog("ES Startup: Error Initializing Volatile(RAM) Volume. EC = 0x%08X\n",
+            CFE_ES_WriteToSysLog("%s: Error Initializing Volatile(RAM) Volume. EC = 0x%08X\n", __func__,
                                  (unsigned int)RetStatus);
-            CFE_ES_WriteToSysLog("ES Startup: Formatting Volatile(RAM) Volume.\n");
+            CFE_ES_WriteToSysLog("%s: Formatting Volatile(RAM) Volume.\n", __func__);
 
             RetStatus = OS_mkfs((void *)RamDiskMemoryAddress, "/ramdev0", "RAM", CFE_PLATFORM_ES_RAM_DISK_SECTOR_SIZE,
                                 CFE_PLATFORM_ES_RAM_DISK_NUM_SECTORS);
             if (RetStatus != OS_SUCCESS)
             {
-                CFE_ES_WriteToSysLog("ES Startup: Error Creating Volatile(RAM) Volume. EC = 0x%08X\n",
+                CFE_ES_WriteToSysLog("%s: Error Creating Volatile(RAM) Volume. EC = 0x%08X\n", __func__,
                                      (unsigned int)RetStatus);
 
                 /*
@@ -562,7 +564,8 @@ void CFE_ES_InitializeFileSystems(uint32 StartType)
     RetStatus = OS_mount("/ramdev0", CFE_PLATFORM_ES_RAM_DISK_MOUNT_STRING);
     if (RetStatus != OS_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("ES Startup: Error Mounting Volatile(RAM) Volume. EC = 0x%08X\n", (unsigned int)RetStatus);
+        CFE_ES_WriteToSysLog("%s: Error Mounting Volatile(RAM) Volume. EC = 0x%08X\n", __func__,
+                             (unsigned int)RetStatus);
         /*
         ** Delay to allow the message to be read
         */
@@ -593,11 +596,11 @@ void CFE_ES_InitializeFileSystems(uint32 StartType)
             ** Determine if the disk is too full
             */
             PercentFree = (StatBuf.blocks_free * 100) / StatBuf.total_blocks;
-            CFE_ES_WriteToSysLog("Volatile Disk has %d Percent free space.\n", (int)PercentFree);
+            CFE_ES_WriteToSysLog("%s: Volatile Disk has %d Percent free space.\n", __func__, (int)PercentFree);
 
             if (PercentFree < CFE_PLATFORM_ES_RAM_DISK_PERCENT_RESERVED)
             {
-                CFE_ES_WriteToSysLog("ES Startup: Insufficent Free Space on Volatile Disk, Reformatting.\n");
+                CFE_ES_WriteToSysLog("%s: Insufficent Free Space on Volatile Disk, Reformatting.\n", __func__);
 
                 /*
                 ** First, unmount the disk
@@ -626,9 +629,8 @@ void CFE_ES_InitializeFileSystems(uint32 StartType)
                             RetStatus = OS_mount("/ramdev0", CFE_PLATFORM_ES_RAM_DISK_MOUNT_STRING);
                             if (RetStatus != OS_SUCCESS)
                             {
-                                CFE_ES_WriteToSysLog(
-                                    "ES Startup: Error Re-Mounting Volatile(RAM) Volume. EC = 0x%08X\n",
-                                    (unsigned int)RetStatus);
+                                CFE_ES_WriteToSysLog("%s: Error Re-Mounting Volatile(RAM) Volume. EC = 0x%08X\n",
+                                                     __func__, (unsigned int)RetStatus);
                                 /*
                                 ** Delay to allow the message to be read
                                 */
@@ -644,7 +646,7 @@ void CFE_ES_InitializeFileSystems(uint32 StartType)
                         else
                         {
 
-                            CFE_ES_WriteToSysLog("ES Startup: Error Re-Formating Volatile(RAM) Volume. EC = 0x%08X\n",
+                            CFE_ES_WriteToSysLog("%s: Error Re-Formating Volatile(RAM) Volume. EC = 0x%08X\n", __func__,
                                                  (unsigned int)RetStatus);
                             /*
                             ** Delay to allow the message to be read
@@ -661,7 +663,7 @@ void CFE_ES_InitializeFileSystems(uint32 StartType)
                     else /* could not Remove File system */
                     {
 
-                        CFE_ES_WriteToSysLog("ES Startup: Error Removing Volatile(RAM) Volume. EC = 0x%08X\n",
+                        CFE_ES_WriteToSysLog("%s: Error Removing Volatile(RAM) Volume. EC = 0x%08X\n", __func__,
                                              (unsigned int)RetStatus);
                         /*
                         ** Delay to allow the message to be read
@@ -677,7 +679,7 @@ void CFE_ES_InitializeFileSystems(uint32 StartType)
                 }
                 else /* could not un-mount disk */
                 {
-                    CFE_ES_WriteToSysLog("ES Startup: Error Un-Mounting Volatile(RAM) Volume. EC = 0x%08X\n",
+                    CFE_ES_WriteToSysLog("%s: Error Un-Mounting Volatile(RAM) Volume. EC = 0x%08X\n", __func__,
                                          (unsigned int)RetStatus);
                     /*
                     ** Delay to allow the message to be read
@@ -695,7 +697,7 @@ void CFE_ES_InitializeFileSystems(uint32 StartType)
         else /* could not determine free blocks */
         {
             /* Log error message -- note that BlocksFree returns the error code in this case */
-            CFE_ES_WriteToSysLog("ES Startup: Error Determining Blocks Free on Volume. EC = 0x%08X\n",
+            CFE_ES_WriteToSysLog("%s: Error Determining Blocks Free on Volume. EC = 0x%08X\n", __func__,
                                  (unsigned int)RetStatus);
 
             /*
@@ -728,7 +730,7 @@ void CFE_ES_CreateObjects(void)
     CFE_ES_AppRecord_t *AppRecPtr;
     CFE_ResourceId_t    PendingAppId;
 
-    CFE_ES_WriteToSysLog("ES Startup: Starting Object Creation calls.\n");
+    CFE_ES_WriteToSysLog("%s: Starting Object Creation calls.\n", __func__);
 
     for (i = 0; i < CFE_PLATFORM_ES_OBJECT_TABLE_SIZE; i++)
     {
@@ -815,7 +817,7 @@ void CFE_ES_CreateObjects(void)
                 else
                 {
                     /* appSlot not found -- This should never happen!*/
-                    CFE_ES_WriteToSysLog("ES Startup: Error, No free application slots available for CORE App!\n");
+                    CFE_ES_WriteToSysLog("%s: Error, No free application slots available for CORE App!\n", __func__);
                     ReturnCode = CFE_ES_ERR_APP_CREATE;
                 }
 
@@ -831,7 +833,7 @@ void CFE_ES_CreateObjects(void)
 
                 if (ReturnCode != CFE_SUCCESS)
                 {
-                    CFE_ES_WriteToSysLog("ES Startup: OS_TaskCreate error creating core App: %s: EC = 0x%08X\n",
+                    CFE_ES_WriteToSysLog("%s: OS_TaskCreate error creating core App: %s: EC = 0x%08X\n", __func__,
                                          CFE_ES_ObjectTable[i].ObjectName, (unsigned int)ReturnCode);
 
                     /*
@@ -850,14 +852,14 @@ void CFE_ES_CreateObjects(void)
 
                 if (CFE_ES_ObjectTable[i].FuncPtrUnion.FunctionPtr != NULL)
                 {
-                    CFE_ES_WriteToSysLog("ES Startup: Calling %s\n", CFE_ES_ObjectTable[i].ObjectName);
+                    CFE_ES_WriteToSysLog("%s: Calling %s\n", __func__, CFE_ES_ObjectTable[i].ObjectName);
                     /*
                     ** Call the function
                     */
                     ReturnCode = (*CFE_ES_ObjectTable[i].FuncPtrUnion.FunctionPtr)();
                     if (ReturnCode != CFE_SUCCESS)
                     {
-                        CFE_ES_WriteToSysLog("ES Startup: Error returned when calling function: %s: EC = 0x%08X\n",
+                        CFE_ES_WriteToSysLog("%s: Error returned when calling function: %s: EC = 0x%08X\n", __func__,
                                              CFE_ES_ObjectTable[i].ObjectName, (unsigned int)ReturnCode);
 
                         /*
@@ -874,7 +876,7 @@ void CFE_ES_CreateObjects(void)
                 }
                 else
                 {
-                    CFE_ES_WriteToSysLog("ES Startup: bad function pointer ( table entry = %d).\n", i);
+                    CFE_ES_WriteToSysLog("%s: bad function pointer ( table entry = %d).\n", __func__, i);
                 }
                 break;
 
@@ -886,7 +888,7 @@ void CFE_ES_CreateObjects(void)
 
     } /* end for */
 
-    CFE_ES_WriteToSysLog("ES Startup: Finished ES CreateObject table entries.\n");
+    CFE_ES_WriteToSysLog("%s: Finished ES CreateObject table entries.\n", __func__);
 }
 
 /*----------------------------------------------------------------

--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -92,7 +92,7 @@ void CFE_ES_TaskMain(void)
         /*
         ** Create a syslog entry
         */
-        CFE_ES_WriteToSysLog("ES:Application Init Failed,RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Application Init Failed,RC=0x%08X\n", __func__, (unsigned int)Status);
 
         /*
         ** Allow Core App to Exit
@@ -155,7 +155,7 @@ void CFE_ES_TaskMain(void)
             /*
             ** SB Error: Write a SysLog Message
             */
-            CFE_ES_WriteToSysLog("ES:Error reading cmd pipe,RC=0x%08X\n", (unsigned int)Status);
+            CFE_ES_WriteToSysLog("%s: Error reading cmd pipe,RC=0x%08X\n", __func__, (unsigned int)Status);
 
             /*
             ** Allow Core App to Exit
@@ -261,7 +261,7 @@ void CFE_ES_GenerateVersionEvents(void)
     Status = CFE_ES_GenerateSingleVersionEvent("Mission", GLOBAL_CONFIGDATA.MissionName);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("ES:Error sending mission version event:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Error sending mission version event:RC=0x%08X\n", __func__, (unsigned int)Status);
     }
 
     /*
@@ -276,7 +276,8 @@ void CFE_ES_GenerateVersionEvents(void)
             Status = CFE_ES_GenerateSingleVersionEvent("Core Module", ModuleNamePtr->Name);
             if (Status != CFE_SUCCESS)
             {
-                CFE_ES_WriteToSysLog("ES:Error sending core module version event:RC=0x%08X\n", (unsigned int)Status);
+                CFE_ES_WriteToSysLog("%s: Error sending core module version event:RC=0x%08X\n", __func__,
+                                     (unsigned int)Status);
             }
             ++ModuleNamePtr;
         }
@@ -293,7 +294,8 @@ void CFE_ES_GenerateVersionEvents(void)
             Status = CFE_ES_GenerateSingleVersionEvent("PSP Module", StaticModulePtr->Name);
             if (Status != CFE_SUCCESS)
             {
-                CFE_ES_WriteToSysLog("ES:Error sending PSP module version event:RC=0x%08X\n", (unsigned int)Status);
+                CFE_ES_WriteToSysLog("%s: Error sending PSP module version event:RC=0x%08X\n", __func__,
+                                     (unsigned int)Status);
             }
             ++StaticModulePtr;
         }
@@ -340,7 +342,7 @@ void CFE_ES_GenerateBuildInfoEvents(void)
                                BuildDate, BuildUser, BuildHost, GLOBAL_CONFIGDATA.Config);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("ES:Error sending build info event:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Error sending build info event:RC=0x%08X\n", __func__, (unsigned int)Status);
     }
 }
 
@@ -383,7 +385,7 @@ int32 CFE_ES_TaskInit(void)
     Status = CFE_EVS_Register(NULL, 0, CFE_EVS_EventFilter_BINARY);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("ES:Call to CFE_EVS_Register Failed, RC = 0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Call to CFE_EVS_Register Failed, RC = 0x%08X\n", __func__, (unsigned int)Status);
         return (Status);
     }
 
@@ -411,7 +413,7 @@ int32 CFE_ES_TaskInit(void)
     Status = CFE_SB_CreatePipe(&CFE_ES_Global.TaskData.CmdPipe, CFE_ES_PIPE_DEPTH, CFE_ES_PIPE_NAME);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("ES:Cannot Create SB Pipe, RC = 0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Cannot Create SB Pipe, RC = 0x%08X\n", __func__, (unsigned int)Status);
         return (Status);
     }
 
@@ -421,7 +423,7 @@ int32 CFE_ES_TaskInit(void)
     Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_ES_SEND_HK_MID), CFE_ES_Global.TaskData.CmdPipe);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("ES:Cannot Subscribe to HK packet, RC = 0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Cannot Subscribe to HK packet, RC = 0x%08X\n", __func__, (unsigned int)Status);
         return (Status);
     }
 
@@ -431,7 +433,8 @@ int32 CFE_ES_TaskInit(void)
     Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_ES_CMD_MID), CFE_ES_Global.TaskData.CmdPipe);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("ES:Cannot Subscribe to ES ground commands, RC = 0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Cannot Subscribe to ES ground commands, RC = 0x%08X\n", __func__,
+                             (unsigned int)Status);
         return (Status);
     }
 
@@ -477,7 +480,7 @@ int32 CFE_ES_TaskInit(void)
     Status = CFE_EVS_SendEvent(CFE_ES_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "cFE ES Initialized");
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("ES:Error sending init event:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Error sending init event:RC=0x%08X\n", __func__, (unsigned int)Status);
         return (Status);
     }
 
@@ -488,7 +491,7 @@ int32 CFE_ES_TaskInit(void)
 
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("ES:Error sending init stats event:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Error sending init stats event:RC=0x%08X\n", __func__, (unsigned int)Status);
         return (Status);
     }
 
@@ -506,7 +509,7 @@ int32 CFE_ES_TaskInit(void)
     Status = CFE_ES_BackgroundInit();
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("ES:Error initializing background task:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Error initializing background task:RC=0x%08X\n", __func__, (unsigned int)Status);
         return (Status);
     }
 

--- a/modules/evs/fsw/src/cfe_evs.c
+++ b/modules/evs/fsw/src/cfe_evs.c
@@ -82,7 +82,7 @@ CFE_Status_t CFE_EVS_Register(const void *Filters, uint16 NumEventFilters, uint1
             else
             {
                 FilterLimit = CFE_PLATFORM_EVS_MAX_EVENT_FILTERS;
-                CFE_ES_WriteToSysLog("CFE_EVS_Register: Filter limit truncated to %d\n", (int)FilterLimit);
+                CFE_ES_WriteToSysLog("%s: Filter limit truncated to %d\n", __func__, (int)FilterLimit);
             }
 
             if (Filters != NULL)

--- a/modules/evs/fsw/src/cfe_evs_task.c
+++ b/modules/evs/fsw/src/cfe_evs_task.c
@@ -86,7 +86,7 @@ int32 CFE_EVS_EarlyInit(void)
     if (Status != CFE_PSP_SUCCESS)
     {
         /* Can't log evs messages without the reset area */
-        CFE_ES_WriteToSysLog("EVS call to CFE_PSP_GetResetArea failed, RC=0x%08x\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Call to CFE_PSP_GetResetArea failed, RC=0x%08x\n", __func__, (unsigned int)Status);
 
         /* Delay to allow message to be read */
         OS_TaskDelay(CFE_EVS_PANIC_DELAY);
@@ -97,8 +97,8 @@ int32 CFE_EVS_EarlyInit(void)
     {
         /* Got the pointer but the size is wrong */
         Status = CFE_EVS_RESET_AREA_POINTER;
-        CFE_ES_WriteToSysLog("Unexpected size from CFE_PSP_GetResetArea: expected = 0x%08lX, actual = 0x%08lX\n",
-                             (unsigned long)sizeof(CFE_ES_ResetData_t), (unsigned long)resetAreaSize);
+        CFE_ES_WriteToSysLog("%s: Unexpected size from CFE_PSP_GetResetArea: expected = 0x%08lX, actual = 0x%08lX\n",
+                             __func__, (unsigned long)sizeof(CFE_ES_ResetData_t), (unsigned long)resetAreaSize);
 
         /* Delay to allow message to be read */
         OS_TaskDelay(CFE_EVS_PANIC_DELAY);
@@ -116,7 +116,7 @@ int32 CFE_EVS_EarlyInit(void)
 
         if (Status != OS_SUCCESS)
         {
-            CFE_ES_WriteToSysLog("EVS call to OS_MutSemCreate failed, RC=0x%08x\n", (unsigned int)Status);
+            CFE_ES_WriteToSysLog("%s: OS_MutSemCreate failed, RC=0x%08x\n", __func__, (unsigned int)Status);
 
             /* Delay to allow message to be read */
             OS_TaskDelay(CFE_EVS_PANIC_DELAY);
@@ -135,7 +135,7 @@ int32 CFE_EVS_EarlyInit(void)
         /* Clear event log if power-on reset or bad contents */
         if (CFE_ES_GetResetType(NULL) == CFE_PSP_RST_TYPE_POWERON)
         {
-            CFE_ES_WriteToSysLog("Event Log cleared following power-on reset\n");
+            CFE_ES_WriteToSysLog("%s: Event Log cleared following power-on reset\n", __func__);
             EVS_ClearLog();
             CFE_EVS_Global.EVS_LogPtr->LogMode = CFE_PLATFORM_EVS_DEFAULT_LOG_MODE;
         }
@@ -145,7 +145,7 @@ int32 CFE_EVS_EarlyInit(void)
                   (CFE_EVS_Global.EVS_LogPtr->LogFullFlag != true)) ||
                  (CFE_EVS_Global.EVS_LogPtr->Next >= CFE_PLATFORM_EVS_LOG_MAX))
         {
-            CFE_ES_WriteToSysLog("Event Log cleared, n=%d, c=%d, f=%d, m=%d, o=%d\n",
+            CFE_ES_WriteToSysLog("%s: Event Log cleared, n=%d, c=%d, f=%d, m=%d, o=%d\n", __func__,
                                  (int)CFE_EVS_Global.EVS_LogPtr->Next, (int)CFE_EVS_Global.EVS_LogPtr->LogCount,
                                  (int)CFE_EVS_Global.EVS_LogPtr->LogFullFlag, (int)CFE_EVS_Global.EVS_LogPtr->LogMode,
                                  (int)CFE_EVS_Global.EVS_LogPtr->LogOverflowCounter);
@@ -154,7 +154,7 @@ int32 CFE_EVS_EarlyInit(void)
         }
         else
         {
-            CFE_ES_WriteToSysLog("Event Log restored, n=%d, c=%d, f=%d, m=%d, o=%d\n",
+            CFE_ES_WriteToSysLog("%s: Event Log restored, n=%d, c=%d, f=%d, m=%d, o=%d\n", __func__,
                                  (int)CFE_EVS_Global.EVS_LogPtr->Next, (int)CFE_EVS_Global.EVS_LogPtr->LogCount,
                                  (int)CFE_EVS_Global.EVS_LogPtr->LogFullFlag, (int)CFE_EVS_Global.EVS_LogPtr->LogMode,
                                  (int)CFE_EVS_Global.EVS_LogPtr->LogOverflowCounter);
@@ -210,7 +210,7 @@ void CFE_EVS_TaskMain(void)
 
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("EVS:Application Init Failed,RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Application Init Failed,RC=0x%08X\n", __func__, (unsigned int)Status);
         CFE_ES_PerfLogExit(CFE_MISSION_EVS_MAIN_PERF_ID);
         /* Note: CFE_ES_ExitApp will not return */
         CFE_ES_ExitApp(CFE_ES_RunStatus_CORE_APP_INIT_ERROR);
@@ -244,7 +244,7 @@ void CFE_EVS_TaskMain(void)
         }
         else
         {
-            CFE_ES_WriteToSysLog("EVS:Error reading cmd pipe,RC=0x%08X\n", (unsigned int)Status);
+            CFE_ES_WriteToSysLog("%s: Error reading cmd pipe,RC=0x%08X\n", __func__, (unsigned int)Status);
         } /* end if */
 
     } /* end while */
@@ -270,7 +270,7 @@ int32 CFE_EVS_TaskInit(void)
     Status = CFE_ES_GetAppID(&AppID);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("EVS:Call to CFE_ES_GetAppID Failed:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Call to CFE_ES_GetAppID Failed:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     }
 
@@ -278,7 +278,7 @@ int32 CFE_EVS_TaskInit(void)
     Status = CFE_EVS_Register(NULL, 0, CFE_EVS_EventFilter_BINARY);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("EVS:Call to CFE_EVS_Register Failed:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Call to CFE_EVS_Register Failed:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     }
 
@@ -286,7 +286,7 @@ int32 CFE_EVS_TaskInit(void)
     Status = CFE_SB_CreatePipe(&CFE_EVS_Global.EVS_CommandPipe, CFE_EVS_PIPE_DEPTH, CFE_EVS_PIPE_NAME);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("EVS:Call to CFE_SB_CreatePipe Failed:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Call to CFE_SB_CreatePipe Failed:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     }
 
@@ -294,14 +294,14 @@ int32 CFE_EVS_TaskInit(void)
     Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_EVS_CMD_MID), CFE_EVS_Global.EVS_CommandPipe);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("EVS:Subscribing to Cmds Failed:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Subscribing to Cmds Failed:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     }
 
     Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_EVS_SEND_HK_MID), CFE_EVS_Global.EVS_CommandPipe);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("EVS:Subscribing to HK Request Failed:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Subscribing to HK Request Failed:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     }
 

--- a/modules/evs/fsw/src/cfe_evs_utils.c
+++ b/modules/evs/fsw/src/cfe_evs_utils.c
@@ -183,7 +183,8 @@ int32 EVS_NotRegistered(EVS_AppData_t *AppDataPtr, CFE_ES_AppId_t CallerID)
                       "App %s not registered with Event Services. Unable to send event.", AppName);
 
         /* Write the "not registered" info to the system log */
-        CFE_ES_WriteToSysLog("App %s not registered with Event Services. Unable to send event.\n", AppName);
+        CFE_ES_WriteToSysLog("%s: App %s not registered with Event Services. Unable to send event.\n", __func__,
+                             AppName);
     }
 
     return (CFE_EVS_APP_NOT_REGISTERED);

--- a/modules/evs/ut-coverage/evs_UT.c
+++ b/modules/evs/ut-coverage/evs_UT.c
@@ -42,20 +42,20 @@
 
 static const char *EVS_SYSLOG_MSGS[] = {
     NULL,
-    "EVS call to CFE_PSP_GetResetArea failed, RC=0x%08x\n",
-    "Unexpected size from CFE_PSP_GetResetArea: expected = 0x%08lX, actual = 0x%08lX\n",
-    "EVS call to OS_MutSemCreate failed, RC=0x%08x\n",
-    "Event Log cleared following power-on reset\n",
-    "Event Log cleared, n=%d, c=%d, f=%d, m=%d, o=%d\n",
-    "Event Log restored, n=%d, c=%d, f=%d, m=%d, o=%d\n",
-    "EVS:Application Init Failed,RC=0x%08X\n",
-    "EVS:Error reading cmd pipe,RC=0x%08X\n",
+    "%s: Call to CFE_PSP_GetResetArea failed, RC=0x%08x\n",
+    "%s: Unexpected size from CFE_PSP_GetResetArea: expected = 0x%08lX, actual = 0x%08lX\n",
+    "%s: OS_MutSemCreate failed, RC=0x%08x\n",
+    "%s: Event Log cleared following power-on reset\n",
+    "%s: Event Log cleared, n=%d, c=%d, f=%d, m=%d, o=%d\n",
+    "%s: Event Log restored, n=%d, c=%d, f=%d, m=%d, o=%d\n",
+    "%s: Application Init Failed,RC=0x%08X\n",
+    "%s: Error reading cmd pipe,RC=0x%08X\n",
     NULL, /* old message removed - placeholder to maintain indices */
-    "EVS:Call to CFE_ES_GetAppID Failed:RC=0x%08X\n",
-    "EVS:Call to CFE_EVS_Register Failed:RC=0x%08X\n",
-    "EVS:Call to CFE_SB_CreatePipe Failed:RC=0x%08X\n",
-    "EVS:Subscribing to Cmds Failed:RC=0x%08X\n",
-    "EVS:Subscribing to HK Request Failed:RC=0x%08X\n"};
+    "%s: Call to CFE_ES_GetAppID Failed:RC=0x%08X\n",
+    "%s: Call to CFE_EVS_Register Failed:RC=0x%08X\n",
+    "%s: Call to CFE_SB_CreatePipe Failed:RC=0x%08X\n",
+    "%s: Subscribing to Cmds Failed:RC=0x%08X\n",
+    "%s: Subscribing to HK Request Failed:RC=0x%08X\n"};
 
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_NOOP_CC = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
                                                                     .CommandCode = CFE_EVS_NOOP_CC};

--- a/modules/fs/fsw/src/cfe_fs_api.c
+++ b/modules/fs/fsw/src/cfe_fs_api.c
@@ -173,7 +173,7 @@ void CFE_FS_InitHeader(CFE_FS_Header_t *Hdr, const char *Description, uint32 Sub
 {
     if (Hdr == NULL || Description == NULL)
     {
-        CFE_ES_WriteToSysLog("CFE_FS:InitHeader-Failed invalid arguments\n");
+        CFE_ES_WriteToSysLog("%s: Failed invalid arguments\n", __func__);
     }
     else
     {
@@ -302,13 +302,14 @@ CFE_Status_t CFE_FS_SetTimestamp(osal_id_t FileDes, CFE_TIME_SysTime_t NewTimest
         }
         else
         {
-            CFE_ES_WriteToSysLog("%s(): Failed to write timestamp (Status=0x%08X)\n", __func__, (unsigned int)Result);
+            CFE_ES_WriteToSysLog("%s: Failed to write timestamp (Status=0x%08X)\n", __func__, (unsigned int)Result);
             Result = CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
         }
     }
     else
     {
-        CFE_ES_WriteToSysLog("CFE_FS:SetTime-Failed to lseek time fields (Status=0x%08X)\n", (unsigned int)Result);
+        CFE_ES_WriteToSysLog("%s: Failed to lseek time fields (Status=0x%08X)\n", __func__,
+                             (unsigned int)Result);
     }
 
     return (Result);

--- a/modules/fs/fsw/src/cfe_fs_api.c
+++ b/modules/fs/fsw/src/cfe_fs_api.c
@@ -308,8 +308,7 @@ CFE_Status_t CFE_FS_SetTimestamp(osal_id_t FileDes, CFE_TIME_SysTime_t NewTimest
     }
     else
     {
-        CFE_ES_WriteToSysLog("%s: Failed to lseek time fields (Status=0x%08X)\n", __func__,
-                             (unsigned int)Result);
+        CFE_ES_WriteToSysLog("%s: Failed to lseek time fields (Status=0x%08X)\n", __func__, (unsigned int)Result);
     }
 
     return (Result);

--- a/modules/fs/fsw/src/cfe_fs_priv.c
+++ b/modules/fs/fsw/src/cfe_fs_priv.c
@@ -59,7 +59,7 @@ int32 CFE_FS_EarlyInit(void)
     Stat = OS_MutSemCreate(&CFE_FS_Global.SharedDataMutexId, "CFE_FS_SharedMutex", 0);
     if (Stat != OS_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("FS Shared Data Mutex creation failed! RC=0x%08x\n", (unsigned int)Stat);
+        CFE_ES_WriteToSysLog("%s: Shared Data Mutex creation failed! RC=0x%08x\n", __func__, (unsigned int)Stat);
         return Stat;
     } /* end if */
 
@@ -84,8 +84,8 @@ void CFE_FS_LockSharedData(const char *FunctionName)
     {
         CFE_ES_GetAppID(&AppId);
 
-        CFE_ES_WriteToSysLog("FS SharedData Mutex Take Err Stat=0x%x,App=%lu,Function=%s\n", (unsigned int)Status,
-                             CFE_RESOURCEID_TO_ULONG(AppId), FunctionName);
+        CFE_ES_WriteToSysLog("%s: SharedData Mutex Take Err Stat=0x%x,App=%lu,Function=%s\n", __func__,
+                             (unsigned int)Status, CFE_RESOURCEID_TO_ULONG(AppId), FunctionName);
 
     } /* end if */
 
@@ -109,8 +109,8 @@ void CFE_FS_UnlockSharedData(const char *FunctionName)
     if (Status != OS_SUCCESS)
     {
         CFE_ES_GetAppID(&AppId);
-        CFE_ES_WriteToSysLog("FS SharedData Mutex Give Err Stat=0x%x,App=%lu,Function=%s\n", (unsigned int)Status,
-                             CFE_RESOURCEID_TO_ULONG(AppId), FunctionName);
+        CFE_ES_WriteToSysLog("%s: SharedData Mutex Give Err Stat=0x%x,App=%lu,Function=%s\n", __func__,
+                             (unsigned int)Status, CFE_RESOURCEID_TO_ULONG(AppId), FunctionName);
 
     } /* end if */
     return;

--- a/modules/fs/ut-coverage/fs_UT.c
+++ b/modules/fs/ut-coverage/fs_UT.c
@@ -42,8 +42,8 @@
 
 #include "target_config.h"
 
-const char *FS_SYSLOG_MSGS[] = {NULL, "FS SharedData Mutex Take Err Stat=0x%x,App=%lu,Function=%s\n",
-                                "FS SharedData Mutex Give Err Stat=0x%x,App=%lu,Function=%s\n"};
+const char *FS_SYSLOG_MSGS[] = {NULL, "%s: SharedData Mutex Take Err Stat=0x%x,App=%lu,Function=%s\n",
+                                "%s: SharedData Mutex Give Err Stat=0x%x,App=%lu,Function=%s\n"};
 
 /* counts the number of times UT_FS_OnEvent() was invoked (below) */
 uint32 UT_FS_FileWriteEventCount[CFE_FS_FileWriteEvent_MAX];

--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -2041,7 +2041,7 @@ CFE_SB_Buffer_t *CFE_SB_AllocateMessageBuffer(size_t MsgSize)
 
     if (MsgSize > CFE_MISSION_SB_MAX_SB_MSG_SIZE)
     {
-        CFE_ES_WriteToSysLog(" CFE_SB:ZeroCopyGetPtr-Failed, MsgSize is too large\n");
+        CFE_ES_WriteToSysLog("%s: ZeroCopyGetPtr-Failed, MsgSize is too large\n", __func__);
         return NULL;
     }
 

--- a/modules/sb/fsw/src/cfe_sb_init.c
+++ b/modules/sb/fsw/src/cfe_sb_init.c
@@ -67,7 +67,7 @@ int32 CFE_SB_EarlyInit(void)
     Stat = OS_MutSemCreate(&CFE_SB_Global.SharedDataMutexId, "CFE_SB_DataMutex", 0);
     if (Stat != OS_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("SB shared data mutex creation failed! RC=0x%08x\n", (unsigned int)Stat);
+        CFE_ES_WriteToSysLog("%s: Shared data mutex creation failed! RC=0x%08x\n", __func__, (unsigned int)Stat);
         return Stat;
     } /* end if */
 
@@ -114,7 +114,7 @@ int32 CFE_SB_InitBuffers(void)
 
     if (Stat != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("PoolCreate failed for SB Buffers, gave adr 0x%lx,size %d,stat=0x%x\n",
+        CFE_ES_WriteToSysLog("%s: PoolCreate failed for SB Buffers, gave adr 0x%lx,size %d,stat=0x%x\n", __func__,
                              (unsigned long)CFE_SB_Global.Mem.Partition.Data, CFE_PLATFORM_SB_BUF_MEMORY_BYTES,
                              (unsigned int)Stat);
         return Stat;

--- a/modules/sb/fsw/src/cfe_sb_priv.c
+++ b/modules/sb/fsw/src/cfe_sb_priv.c
@@ -144,8 +144,8 @@ void CFE_SB_LockSharedData(const char *FuncName, int32 LineNumber)
 
         CFE_ES_GetAppID(&AppId);
 
-        CFE_ES_WriteToSysLog("SB SharedData Mutex Take Err Stat=0x%x,App=%lu,Func=%s,Line=%d\n", (unsigned int)Status,
-                             CFE_RESOURCEID_TO_ULONG(AppId), FuncName, (int)LineNumber);
+        CFE_ES_WriteToSysLog("%s: SharedData Mutex Take Err Stat=0x%x,App=%lu,Func=%s,Line=%d\n", __func__,
+                             (unsigned int)Status, CFE_RESOURCEID_TO_ULONG(AppId), FuncName, (int)LineNumber);
 
     } /* end if */
 
@@ -172,8 +172,8 @@ void CFE_SB_UnlockSharedData(const char *FuncName, int32 LineNumber)
 
         CFE_ES_GetAppID(&AppId);
 
-        CFE_ES_WriteToSysLog("SB SharedData Mutex Give Err Stat=0x%x,App=%lu,Func=%s,Line=%d\n", (unsigned int)Status,
-                             CFE_RESOURCEID_TO_ULONG(AppId), FuncName, (int)LineNumber);
+        CFE_ES_WriteToSysLog("%s: SharedData Mutex Give Err Stat=0x%x,App=%lu,Func=%s,Line=%d\n", __func__,
+                             (unsigned int)Status, CFE_RESOURCEID_TO_ULONG(AppId), FuncName, (int)LineNumber);
 
     } /* end if */
 

--- a/modules/sb/fsw/src/cfe_sb_task.c
+++ b/modules/sb/fsw/src/cfe_sb_task.c
@@ -69,7 +69,7 @@ void CFE_SB_TaskMain(void)
 
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("SB:Application Init Failed,RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Application Init Failed,RC=0x%08X\n", __func__, (unsigned int)Status);
         CFE_ES_PerfLogExit(CFE_MISSION_SB_MAIN_PERF_ID);
         /* Note: CFE_ES_ExitApp will not return */
         CFE_ES_ExitApp(CFE_ES_RunStatus_CORE_APP_INIT_ERROR);
@@ -103,7 +103,7 @@ void CFE_SB_TaskMain(void)
         }
         else
         {
-            CFE_ES_WriteToSysLog("SB:Error reading cmd pipe,RC=0x%08X\n", (unsigned int)Status);
+            CFE_ES_WriteToSysLog("%s: Error reading cmd pipe,RC=0x%08X\n", __func__, (unsigned int)Status);
         } /* end if */
 
     } /* end while */
@@ -198,11 +198,11 @@ int32 CFE_SB_AppInit(void)
     Status = CFE_EVS_Register(CFE_SB_Global.EventFilters, CfgFileEventsToFilter, CFE_EVS_EventFilter_BINARY);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("SB:Call to CFE_EVS_Register Failed:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Call to CFE_EVS_Register Failed:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 
-    CFE_ES_WriteToSysLog("SB:Registered %d events for filtering\n", (int)CfgFileEventsToFilter);
+    CFE_ES_WriteToSysLog("%s: Registered %d events for filtering\n", __func__, (int)CfgFileEventsToFilter);
 
     CFE_MSG_Init(&CFE_SB_Global.HKTlmMsg.Hdr.Msg, CFE_SB_ValueToMsgId(CFE_SB_HK_TLM_MID),
                  sizeof(CFE_SB_Global.HKTlmMsg));
@@ -224,7 +224,7 @@ int32 CFE_SB_AppInit(void)
     Status = CFE_SB_CreatePipe(&CFE_SB_Global.CmdPipe, CFE_SB_CMD_PIPE_DEPTH, CFE_SB_CMD_PIPE_NAME);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("SB:Call to CFE_SB_CreatePipe Failed:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Call to CFE_SB_CreatePipe Failed:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 
@@ -232,7 +232,7 @@ int32 CFE_SB_AppInit(void)
 
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("SB:Subscribe to Cmds Failed:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Subscribe to Cmds Failed:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 
@@ -240,7 +240,7 @@ int32 CFE_SB_AppInit(void)
 
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("SB:Subscribe to HK Request Failed:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Subscribe to HK Request Failed:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 
@@ -248,7 +248,8 @@ int32 CFE_SB_AppInit(void)
 
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("SB:Subscribe to Subscription Report Request Failed:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Subscribe to Subscription Report Request Failed:RC=0x%08X\n", __func__,
+                             (unsigned int)Status);
         return Status;
     } /* end if */
 
@@ -258,7 +259,7 @@ int32 CFE_SB_AppInit(void)
 
     if (Status < 0)
     {
-        CFE_ES_WriteToSysLog("SB:Init error, GetPool Failed:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Init error, GetPool Failed:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 
@@ -268,14 +269,14 @@ int32 CFE_SB_AppInit(void)
 
     if (Status < 0)
     {
-        CFE_ES_WriteToSysLog("SB:Init error, PutPool Failed:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Init error, PutPool Failed:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 
     Status = CFE_EVS_SendEvent(CFE_SB_INIT_EID, CFE_EVS_EventType_INFORMATION, "cFE SB Initialized");
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("SB:Error sending init event:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Error sending init event:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 

--- a/modules/sb/fsw/src/cfe_sb_util.c
+++ b/modules/sb/fsw/src/cfe_sb_util.c
@@ -92,7 +92,7 @@ void *CFE_SB_GetUserData(CFE_MSG_Message_t *MsgPtr)
 
     if (MsgPtr == NULL)
     {
-        CFE_ES_WriteToSysLog("CFE_SB:GetUserData-Failed invalid arguments\n");
+        CFE_ES_WriteToSysLog("%s: Failed invalid arguments\n", __func__);
         return 0;
     }
 
@@ -141,7 +141,7 @@ void CFE_SB_SetUserDataLength(CFE_MSG_Message_t *MsgPtr, size_t DataLength)
 
     if (MsgPtr == NULL)
     {
-        CFE_ES_WriteToSysLog("CFE_SB:SetUserDataLength-Failed invalid arguments\n");
+        CFE_ES_WriteToSysLog("%s: Failed invalid arguments\n", __func__);
     }
     else
     {
@@ -154,7 +154,7 @@ void CFE_SB_SetUserDataLength(CFE_MSG_Message_t *MsgPtr, size_t DataLength)
         }
         else
         {
-            CFE_ES_WriteToSysLog("CFE_SB:SetUserDataLength-Failed TotalMsgSize too large\n");
+            CFE_ES_WriteToSysLog("%s: Failed TotalMsgSize too large\n", __func__);
         }
     }
 }

--- a/modules/tbl/fsw/src/cfe_tbl_api.c
+++ b/modules/tbl/fsw/src/cfe_tbl_api.c
@@ -85,7 +85,7 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
             /* Perform a buffer overrun safe copy of name for debug log message */
             strncpy(TblName, Name, sizeof(TblName) - 1);
             TblName[sizeof(TblName) - 1] = '\0';
-            CFE_ES_WriteToSysLog("CFE_TBL:Register-Table Name (%s) is bad length (%d)", TblName, (int)NameLen);
+            CFE_ES_WriteToSysLog("%s: Table Name (%s) is bad length (%d)", __func__, TblName, (int)NameLen);
         }
         else
         {
@@ -99,14 +99,14 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
             {
                 Status = CFE_TBL_ERR_INVALID_SIZE;
 
-                CFE_ES_WriteToSysLog("CFE_TBL:Register-Table %s has size of zero\n", Name);
+                CFE_ES_WriteToSysLog("%s: Table %s has size of zero\n", __func__, Name);
             }
             else if ((Size > CFE_PLATFORM_TBL_MAX_SNGL_TABLE_SIZE) &&
                      ((TblOptionFlags & CFE_TBL_OPT_BUFFER_MSK) == CFE_TBL_OPT_SNGL_BUFFER))
             {
                 Status = CFE_TBL_ERR_INVALID_SIZE;
 
-                CFE_ES_WriteToSysLog("CFE_TBL:Register-Single Buffered Table '%s' has size %d > %d\n", Name, (int)Size,
+                CFE_ES_WriteToSysLog("%s: Single Buffered Table '%s' has size %d > %d\n", __func__, Name, (int)Size,
                                      CFE_PLATFORM_TBL_MAX_SNGL_TABLE_SIZE);
             }
             else if ((Size > CFE_PLATFORM_TBL_MAX_DBL_TABLE_SIZE) &&
@@ -114,7 +114,7 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
             {
                 Status = CFE_TBL_ERR_INVALID_SIZE;
 
-                CFE_ES_WriteToSysLog("CFE_TBL:Register-Dbl Buffered Table '%s' has size %d > %d\n", Name, (int)Size,
+                CFE_ES_WriteToSysLog("%s: Dbl Buffered Table '%s' has size %d > %d\n", __func__, Name, (int)Size,
                                      CFE_PLATFORM_TBL_MAX_DBL_TABLE_SIZE);
             }
 
@@ -128,8 +128,8 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
                 {
                     Status = CFE_TBL_ERR_INVALID_OPTIONS;
 
-                    CFE_ES_WriteToSysLog(
-                        "CFE_TBL:Register-User Def tbl '%s' cannot be dbl buff, load/dump or critical\n", Name);
+                    CFE_ES_WriteToSysLog("%s: User Def tbl '%s' cannot be dbl buff, load/dump or critical\n", __func__,
+                                         Name);
                 }
             }
             else if ((TblOptionFlags & CFE_TBL_OPT_LD_DMP_MSK) == CFE_TBL_OPT_DUMP_ONLY)
@@ -140,7 +140,7 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
                 {
                     Status = CFE_TBL_ERR_INVALID_OPTIONS;
 
-                    CFE_ES_WriteToSysLog("CFE_TBL:Register-Dump Only tbl '%s' cannot be double buffered or critical\n",
+                    CFE_ES_WriteToSysLog("%s: Dump Only tbl '%s' cannot be double buffered or critical\n", __func__,
                                          Name);
                 }
             }
@@ -148,7 +148,7 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
     }
     else /* Application ID was invalid */
     {
-        CFE_ES_WriteToSysLog("CFE_TBL:Register-Bad AppId(%lu)\n", CFE_RESOURCEID_TO_ULONG(ThisAppId));
+        CFE_ES_WriteToSysLog("%s: Bad AppId(%lu)\n", __func__, CFE_RESOURCEID_TO_ULONG(ThisAppId));
     }
 
     /* If input parameters appear acceptable, register the table */
@@ -179,9 +179,8 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
                     /* to clean up this mess.                                        */
                     Status = CFE_TBL_ERR_DUPLICATE_DIFF_SIZE;
 
-                    CFE_ES_WriteToSysLog(
-                        "CFE_TBL:Register-Attempt to register existing table ('%s') with different size(%d!=%d)\n",
-                        TblName, (int)Size, (int)RegRecPtr->Size);
+                    CFE_ES_WriteToSysLog("%s: Attempt to register existing table ('%s') with different size(%d!=%d)\n",
+                                         __func__, TblName, (int)Size, (int)RegRecPtr->Size);
                 }
                 else
                 {
@@ -210,7 +209,7 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
             {
                 Status = CFE_TBL_ERR_DUPLICATE_NOT_OWNED;
 
-                CFE_ES_WriteToSysLog("CFE_TBL:Register-App(%lu) Registering Duplicate Table '%s' owned by App(%lu)\n",
+                CFE_ES_WriteToSysLog("%s: App(%lu) Registering Duplicate Table '%s' owned by App(%lu)\n", __func__,
                                      CFE_RESOURCEID_TO_ULONG(ThisAppId), TblName,
                                      CFE_RESOURCEID_TO_ULONG(RegRecPtr->OwnerAppId));
             }
@@ -225,7 +224,7 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
         if (RegIndx == CFE_TBL_NOT_FOUND)
         {
             Status = CFE_TBL_ERR_REGISTRY_FULL;
-            CFE_ES_WriteToSysLog("CFE_TBL:Register-Registry full\n");
+            CFE_ES_WriteToSysLog("%s: Registry full\n", __func__);
         }
 
         /* If this is a duplicate registration, no other work is required */
@@ -238,7 +237,7 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
             if (*TblHandlePtr == CFE_TBL_END_OF_LIST)
             {
                 Status = CFE_TBL_ERR_HANDLES_FULL;
-                CFE_ES_WriteToSysLog("CFE_TBL:Register-No more free handles\n");
+                CFE_ES_WriteToSysLog("%s: No more free handles\n", __func__);
             }
 
             /* If no errors, then initialize the table registry entry     */
@@ -259,9 +258,9 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
                     Status = CFE_ES_GetPoolBuf(&RegRecPtr->Buffers[0].BufferPtr, CFE_TBL_Global.Buf.PoolHdl, Size);
                     if (Status < 0)
                     {
-                        CFE_ES_WriteToSysLog(
-                            "CFE_TBL:Register-1st Buf Alloc GetPool fail Stat=0x%08X MemPoolHndl=0x%08lX\n",
-                            (unsigned int)Status, CFE_RESOURCEID_TO_ULONG(CFE_TBL_Global.Buf.PoolHdl));
+                        CFE_ES_WriteToSysLog("%s: 1st Buf Alloc GetPool fail Stat=0x%08X MemPoolHndl=0x%08lX\n",
+                                             __func__, (unsigned int)Status,
+                                             CFE_RESOURCEID_TO_ULONG(CFE_TBL_Global.Buf.PoolHdl));
                     }
                     else
                     {
@@ -284,9 +283,9 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
                     Status = CFE_ES_GetPoolBuf(&RegRecPtr->Buffers[1].BufferPtr, CFE_TBL_Global.Buf.PoolHdl, Size);
                     if (Status < 0)
                     {
-                        CFE_ES_WriteToSysLog(
-                            "CFE_TBL:Register-2nd Buf Alloc GetPool fail Stat=0x%08X MemPoolHndl=0x%08lX\n",
-                            (unsigned int)Status, CFE_RESOURCEID_TO_ULONG(CFE_TBL_Global.Buf.PoolHdl));
+                        CFE_ES_WriteToSysLog("%s: 2nd Buf Alloc GetPool fail Stat=0x%08X MemPoolHndl=0x%08lX\n",
+                                             __func__, (unsigned int)Status,
+                                             CFE_RESOURCEID_TO_ULONG(CFE_TBL_Global.Buf.PoolHdl));
                     }
                     else
                     {
@@ -369,9 +368,8 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
                                 /* do need to handle the error case because if the function */
                                 /* call did fail, WorkingBufferPtr would be a NULL pointer. */
                                 CFE_ES_GetAppName(AppName, ThisAppId, sizeof(AppName));
-                                CFE_ES_WriteToSysLog(
-                                    "CFE_TBL:Register-Failed to get work buffer for '%s.%s' (ErrCode=0x%08X)\n",
-                                    AppName, Name, (unsigned int)Status);
+                                CFE_ES_WriteToSysLog("%s: Failed to get work buffer for '%s.%s' (ErrCode=0x%08X)\n",
+                                                     __func__, AppName, Name, (unsigned int)Status);
                             }
                             else
                             {
@@ -381,9 +379,8 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
                                 if (Status != CFE_SUCCESS)
                                 {
                                     CFE_ES_GetAppName(AppName, ThisAppId, sizeof(AppName));
-                                    CFE_ES_WriteToSysLog(
-                                        "CFE_TBL:Register-Failed to recover '%s.%s' from CDS (ErrCode=0x%08X)\n",
-                                        AppName, Name, (unsigned int)Status);
+                                    CFE_ES_WriteToSysLog("%s: Failed to recover '%s.%s' from CDS (ErrCode=0x%08X)\n",
+                                                         __func__, AppName, Name, (unsigned int)Status);
                                 }
                             }
 
@@ -427,9 +424,8 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
                                     /* If an error occurred while trying to get the previous contents registry info, */
                                     /* Log the error in the System Log and pretend like we created a new CDS */
                                     CFE_ES_GetAppName(AppName, ThisAppId, sizeof(AppName));
-                                    CFE_ES_WriteToSysLog(
-                                        "CFE_TBL:Register-Failed to recover '%s.%s' info from CDS TblReg\n", AppName,
-                                        Name);
+                                    CFE_ES_WriteToSysLog("%s: Failed to recover '%s.%s' info from CDS TblReg\n",
+                                                         __func__, AppName, Name);
                                     Status = CFE_SUCCESS;
                                 }
                             }
@@ -459,9 +455,8 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
                             }
                             else
                             {
-                                CFE_ES_WriteToSysLog(
-                                    "CFE_TBL:Register-Failed to find a free Crit Tbl Reg Rec for '%s'\n",
-                                    RegRecPtr->Name);
+                                CFE_ES_WriteToSysLog("%s: Failed to find a free Crit Tbl Reg Rec for '%s'\n", __func__,
+                                                     RegRecPtr->Name);
                             }
 
                             /* Mark the table as critical for future reference */
@@ -469,9 +464,8 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
                         }
                         else if (Status != CFE_TBL_INFO_RECOVERED_TBL)
                         {
-                            CFE_ES_WriteToSysLog(
-                                "CFE_TBL:Register-Failed to register '%s.%s' as a CDS (ErrCode=0x%08X)\n", AppName,
-                                Name, (unsigned int)Status);
+                            CFE_ES_WriteToSysLog("%s: Failed to register '%s.%s' as a CDS (ErrCode=0x%08X)\n", __func__,
+                                                 AppName, Name, (unsigned int)Status);
 
                             /* Notify caller that although they asked for it to be critical, it isn't */
                             Status = CFE_TBL_WARN_NOT_CRITICAL;
@@ -553,7 +547,7 @@ CFE_Status_t CFE_TBL_Share(CFE_TBL_Handle_t *TblHandlePtr, const char *TblName)
             if (*TblHandlePtr == CFE_TBL_END_OF_LIST)
             {
                 Status = CFE_TBL_ERR_HANDLES_FULL;
-                CFE_ES_WriteToSysLog("CFE_TBL:Share-No more free handles\n");
+                CFE_ES_WriteToSysLog("%s: No more free handles\n", __func__);
             }
             else
             {
@@ -587,14 +581,14 @@ CFE_Status_t CFE_TBL_Share(CFE_TBL_Handle_t *TblHandlePtr, const char *TblName)
         {
             Status = CFE_TBL_ERR_INVALID_NAME;
 
-            CFE_ES_WriteToSysLog("CFE_TBL:Share-Table '%s' not found in Registry\n", TblName);
+            CFE_ES_WriteToSysLog("%s: Table '%s' not found in Registry\n", __func__, TblName);
         }
 
         CFE_TBL_UnlockRegistry();
     }
     else /* Application ID was invalid */
     {
-        CFE_ES_WriteToSysLog("CFE_TBL:Share-Bad AppId(%lu)\n", CFE_RESOURCEID_TO_ULONG(ThisAppId));
+        CFE_ES_WriteToSysLog("%s: Bad AppId(%lu)\n", __func__, CFE_RESOURCEID_TO_ULONG(ThisAppId));
     }
 
     /* On Error conditions, notify ground of screw up */
@@ -658,7 +652,7 @@ CFE_Status_t CFE_TBL_Unregister(CFE_TBL_Handle_t TblHandle)
     }
     else
     {
-        CFE_ES_WriteToSysLog("CFE_TBL:Unregister-App(%lu) does not have access to Tbl Handle=%d\n",
+        CFE_ES_WriteToSysLog("%s: App(%lu) does not have access to Tbl Handle=%d\n", __func__,
                              CFE_RESOURCEID_TO_ULONG(ThisAppId), (int)TblHandle);
     }
 
@@ -935,13 +929,13 @@ CFE_Status_t CFE_TBL_Update(CFE_TBL_Handle_t TblHandle)
 
         if (Status != CFE_SUCCESS)
         {
-            CFE_ES_WriteToSysLog("CFE_TBL:Update-App(%lu) fail to update Tbl '%s' (Stat=0x%08X)\n",
+            CFE_ES_WriteToSysLog("%s: App(%lu) fail to update Tbl '%s' (Stat=0x%08X)\n", __func__,
                                  CFE_RESOURCEID_TO_ULONG(ThisAppId), RegRecPtr->Name, (unsigned int)Status);
         }
     }
     else
     {
-        CFE_ES_WriteToSysLog("CFE_TBL:Update-App(%lu) does not have access to Tbl Handle=%d\n",
+        CFE_ES_WriteToSysLog("%s: App(%lu) does not have access to Tbl Handle=%d\n", __func__,
                              CFE_RESOURCEID_TO_ULONG(ThisAppId), (int)TblHandle);
     }
 
@@ -1017,7 +1011,7 @@ CFE_Status_t CFE_TBL_GetAddress(void **TblPtr, CFE_TBL_Handle_t TblHandle)
     }
     else
     {
-        CFE_ES_WriteToSysLog("CFE_TBL:GetAddress-Bad AppId=%lu\n", CFE_RESOURCEID_TO_ULONG(ThisAppId));
+        CFE_ES_WriteToSysLog("%s: Bad AppId=%lu\n", __func__, CFE_RESOURCEID_TO_ULONG(ThisAppId));
     }
 
     return Status;
@@ -1053,7 +1047,7 @@ CFE_Status_t CFE_TBL_ReleaseAddress(CFE_TBL_Handle_t TblHandle)
     }
     else
     {
-        CFE_ES_WriteToSysLog("CFE_TBL:ReleaseAddress-App(%lu) does not have access to Tbl Handle=%u\n",
+        CFE_ES_WriteToSysLog("%s: App(%lu) does not have access to Tbl Handle=%u\n", __func__,
                              CFE_RESOURCEID_TO_ULONG(ThisAppId), (unsigned int)TblHandle);
     }
 
@@ -1107,7 +1101,7 @@ CFE_Status_t CFE_TBL_GetAddresses(void **TblPtrs[], uint16 NumTables, const CFE_
     }
     else
     {
-        CFE_ES_WriteToSysLog("CFE_TBL:GetAddresses-Bad AppId=%lu\n", CFE_RESOURCEID_TO_ULONG(ThisAppId));
+        CFE_ES_WriteToSysLog("%s: Bad AppId=%lu\n", __func__, CFE_RESOURCEID_TO_ULONG(ThisAppId));
     }
 
     return Status;
@@ -1214,9 +1208,9 @@ CFE_Status_t CFE_TBL_Validate(CFE_TBL_Handle_t TblHandle)
 
                 if (Status > CFE_SUCCESS)
                 {
-                    CFE_ES_WriteToSysLog(
-                        "CFE_TBL:Validate-App(%lu) Validation func return code invalid (Stat=0x%08X) for '%s'\n",
-                        CFE_RESOURCEID_TO_ULONG(CFE_TBL_Global.TableTaskAppId), (unsigned int)Status, RegRecPtr->Name);
+                    CFE_ES_WriteToSysLog("%s: App(%lu) Validation func return code invalid (Stat=0x%08X) for '%s'\n",
+                                         __func__, CFE_RESOURCEID_TO_ULONG(CFE_TBL_Global.TableTaskAppId),
+                                         (unsigned int)Status, RegRecPtr->Name);
                 }
             }
 
@@ -1261,9 +1255,9 @@ CFE_Status_t CFE_TBL_Validate(CFE_TBL_Handle_t TblHandle)
 
                 if (Status > CFE_SUCCESS)
                 {
-                    CFE_ES_WriteToSysLog(
-                        "CFE_TBL:Validate-App(%lu) Validation func return code invalid (Stat=0x%08X) for '%s'\n",
-                        CFE_RESOURCEID_TO_ULONG(CFE_TBL_Global.TableTaskAppId), (unsigned int)Status, RegRecPtr->Name);
+                    CFE_ES_WriteToSysLog("%s: App(%lu) Validation func return code invalid (Stat=0x%08X) for '%s'\n",
+                                         __func__, CFE_RESOURCEID_TO_ULONG(CFE_TBL_Global.TableTaskAppId),
+                                         (unsigned int)Status, RegRecPtr->Name);
                 }
             }
 
@@ -1285,7 +1279,7 @@ CFE_Status_t CFE_TBL_Validate(CFE_TBL_Handle_t TblHandle)
     }
     else
     {
-        CFE_ES_WriteToSysLog("CFE_TBL:Validate-App(%lu) does not have access to Tbl Handle=%d\n",
+        CFE_ES_WriteToSysLog("%s: App(%lu) does not have access to Tbl Handle=%d\n", __func__,
                              CFE_RESOURCEID_TO_ULONG(ThisAppId), (int)TblHandle);
     }
 
@@ -1393,7 +1387,7 @@ CFE_Status_t CFE_TBL_GetStatus(CFE_TBL_Handle_t TblHandle)
     }
     else
     {
-        CFE_ES_WriteToSysLog("CFE_TBL:GetStatus-App(%lu) does not have access to Tbl Handle=%d\n",
+        CFE_ES_WriteToSysLog("%s: App(%lu) does not have access to Tbl Handle=%d\n", __func__,
                              CFE_RESOURCEID_TO_ULONG(ThisAppId), (int)TblHandle);
     }
 
@@ -1572,7 +1566,7 @@ CFE_Status_t CFE_TBL_Modified(CFE_TBL_Handle_t TblHandle)
     }
     else
     {
-        CFE_ES_WriteToSysLog("CFE_TBL:Modified-App(%lu) does not have access to Tbl Handle=%d\n",
+        CFE_ES_WriteToSysLog("%s: App(%lu) does not have access to Tbl Handle=%d\n", __func__,
                              CFE_RESOURCEID_TO_ULONG(ThisAppId), (int)TblHandle);
     }
 
@@ -1615,7 +1609,7 @@ CFE_Status_t CFE_TBL_NotifyByMessage(CFE_TBL_Handle_t TblHandle, CFE_SB_MsgId_t 
         else
         {
             Status = CFE_TBL_ERR_NO_ACCESS;
-            CFE_ES_WriteToSysLog("CFE_TBL:NotifyByMsg-App(%lu) does not own Tbl Handle=%d\n",
+            CFE_ES_WriteToSysLog("%s: App(%lu) does not own Tbl Handle=%d\n", __func__,
                                  CFE_RESOURCEID_TO_ULONG(ThisAppId), (int)TblHandle);
         }
     }

--- a/modules/tbl/fsw/src/cfe_tbl_internal.c
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.c
@@ -155,7 +155,7 @@ int32 CFE_TBL_EarlyInit(void)
         if (Status != CFE_SUCCESS)
         {
             /* Note if we were unable to recover error free Critical Table Registry from the CDS */
-            CFE_ES_WriteToSysLog("CFE_TBL:EarlyInit-Failed to recover Critical Table Registry (Err=0x%08X)\n",
+            CFE_ES_WriteToSysLog("%s: Failed to recover Critical Table Registry (Err=0x%08X)\n", __func__,
                                  (unsigned int)Status);
         }
 
@@ -166,7 +166,7 @@ int32 CFE_TBL_EarlyInit(void)
     {
         /* Not being able to support Critical Tables is not the end of the world */
         /* Note the problem and move on */
-        CFE_ES_WriteToSysLog("CFE_TBL:EarlyInit-Failed to create Critical Table Registry (Err=0x%08X)\n",
+        CFE_ES_WriteToSysLog("%s: Failed to create Critical Table Registry (Err=0x%08X)\n", __func__,
                              (unsigned int)Status);
 
         /* Failure to support critical tables is not a good enough reason to exit the cFE on start up */
@@ -181,7 +181,7 @@ int32 CFE_TBL_EarlyInit(void)
         {
             /* Not being able to support Critical Tables is not the end of the world */
             /* Note the problem and move on */
-            CFE_ES_WriteToSysLog("CFE_TBL:EarlyInit-Failed to save Critical Table Registry (Err=0x%08X)\n",
+            CFE_ES_WriteToSysLog("%s: Failed to save Critical Table Registry (Err=0x%08X)\n", __func__,
                                  (unsigned int)Status);
 
             /* Failure to support critical tables is not a good enough reason to exit the cFE on start up */
@@ -355,10 +355,9 @@ int32 CFE_TBL_RemoveAccessLink(CFE_TBL_Handle_t TblHandle)
 
             if (Status < 0)
             {
-                CFE_ES_WriteToSysLog(
-                    "CFE_TBL:RemoveAccessLink-PutPoolBuf[0] Fail Stat=0x%08X, Hndl=0x%08lX, Buf=0x%08lX\n",
-                    (unsigned int)Status, CFE_RESOURCEID_TO_ULONG(CFE_TBL_Global.Buf.PoolHdl),
-                    (unsigned long)RegRecPtr->Buffers[0].BufferPtr);
+                CFE_ES_WriteToSysLog("%s: PutPoolBuf[0] Fail Stat=0x%08X, Hndl=0x%08lX, Buf=0x%08lX\n", __func__,
+                                     (unsigned int)Status, CFE_RESOURCEID_TO_ULONG(CFE_TBL_Global.Buf.PoolHdl),
+                                     (unsigned long)RegRecPtr->Buffers[0].BufferPtr);
             }
 
             /* If a double buffered table, then free the second buffer as well */
@@ -369,10 +368,9 @@ int32 CFE_TBL_RemoveAccessLink(CFE_TBL_Handle_t TblHandle)
 
                 if (Status < 0)
                 {
-                    CFE_ES_WriteToSysLog(
-                        "CFE_TBL:RemoveAccessLink-PutPoolBuf[1] Fail Stat=0x%08X, Hndl=0x%08lX, Buf=0x%08lX\n",
-                        (unsigned int)Status, CFE_RESOURCEID_TO_ULONG(CFE_TBL_Global.Buf.PoolHdl),
-                        (unsigned long)RegRecPtr->Buffers[1].BufferPtr);
+                    CFE_ES_WriteToSysLog("%s: PutPoolBuf[1] Fail Stat=0x%08X, Hndl=0x%08lX, Buf=0x%08lX\n", __func__,
+                                         (unsigned int)Status, CFE_RESOURCEID_TO_ULONG(CFE_TBL_Global.Buf.PoolHdl),
+                                         (unsigned long)RegRecPtr->Buffers[1].BufferPtr);
                 }
             }
             else
@@ -429,7 +427,7 @@ int32 CFE_TBL_GetAddressInternal(void **TblPtr, CFE_TBL_Handle_t TblHandle, CFE_
             {
                 Status = CFE_TBL_ERR_UNREGISTERED;
 
-                CFE_ES_WriteToSysLog("CFE_TBL:GetAddressInternal-App(%lu) attempt to access unowned Tbl Handle=%d\n",
+                CFE_ES_WriteToSysLog("%s: App(%lu) attempt to access unowned Tbl Handle=%d\n", __func__,
                                      CFE_RESOURCEID_TO_ULONG(ThisAppId), (int)TblHandle);
             }
             else /* Table Registry Entry is valid */
@@ -453,14 +451,14 @@ int32 CFE_TBL_GetAddressInternal(void **TblPtr, CFE_TBL_Handle_t TblHandle, CFE_
         }
         else
         {
-            CFE_ES_WriteToSysLog("CFE_TBL:GetAddressInternal-App(%lu) does not have access to Tbl Handle=%d\n",
+            CFE_ES_WriteToSysLog("%s: App(%lu) does not have access to Tbl Handle=%d\n", __func__,
                                  CFE_RESOURCEID_TO_ULONG(ThisAppId), (int)TblHandle);
         }
     }
     else
     {
-        CFE_ES_WriteToSysLog("CFE_TBL:GetAddressInternal-App(%lu) using invalid Tbl Handle=%d\n",
-                             CFE_RESOURCEID_TO_ULONG(ThisAppId), (int)TblHandle);
+        CFE_ES_WriteToSysLog("%s: App(%lu) using invalid Tbl Handle=%d\n", __func__, CFE_RESOURCEID_TO_ULONG(ThisAppId),
+                             (int)TblHandle);
     }
 
     return Status;
@@ -719,9 +717,9 @@ int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr, CFE_TBL_Re
                     {
                         Status = CFE_TBL_ERR_NO_BUFFER_AVAIL;
 
-                        CFE_ES_WriteToSysLog(
-                            "CFE_TBL:GetWorkingBuffer-Inactive Dbl Buff Locked for '%s' by AppId=%lu\n",
-                            RegRecPtr->Name, CFE_RESOURCEID_TO_ULONG(CFE_TBL_Global.Handles[AccessIterator].AppId));
+                        CFE_ES_WriteToSysLog("%s: Inactive Dbl Buff Locked for '%s' by AppId=%lu\n", __func__,
+                                             RegRecPtr->Name,
+                                             CFE_RESOURCEID_TO_ULONG(CFE_TBL_Global.Handles[AccessIterator].AppId));
                     }
 
                     /* Move to next access descriptor in linked list */
@@ -744,7 +742,7 @@ int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr, CFE_TBL_Re
                 /* Make note of any errors but continue and hope for the best */
                 if (Status != OS_SUCCESS)
                 {
-                    CFE_ES_WriteToSysLog("CFE_TBL:GetWorkBuf-Internal error taking WorkBuf Mutex (Status=0x%08X)\n",
+                    CFE_ES_WriteToSysLog("%s: Internal error taking WorkBuf Mutex (Status=0x%08X)\n", __func__,
                                          (unsigned int)Status);
                 }
 
@@ -769,7 +767,7 @@ int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr, CFE_TBL_Re
                 {
                     Status = CFE_TBL_ERR_NO_BUFFER_AVAIL;
 
-                    CFE_ES_WriteToSysLog("CFE_TBL:GetWorkingBuffer-All shared buffers are locked\n");
+                    CFE_ES_WriteToSysLog("%s: All shared buffers are locked\n", __func__);
                 }
 
                 /* Allow others to obtain a shared working buffer */
@@ -974,7 +972,7 @@ int32 CFE_TBL_UpdateInternal(CFE_TBL_Handle_t TblHandle, CFE_TBL_RegistryRec_t *
             {
                 Status = CFE_TBL_INFO_TABLE_LOCKED;
 
-                CFE_ES_WriteToSysLog("CFE_TBL:UpdateInternal-Unable to update locked table Handle=%d\n", TblHandle);
+                CFE_ES_WriteToSysLog("%s: Unable to update locked table Handle=%d\n", __func__, TblHandle);
             }
             else
             {
@@ -1342,7 +1340,7 @@ void CFE_TBL_UpdateCriticalTblCDS(CFE_TBL_RegistryRec_t *RegRecPtr)
 
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("CFE_TBL:UpdateCritTbl-Unable to update Critical Table '%s' in CDS (Err=0x%08X)\n",
+        CFE_ES_WriteToSysLog("%s: Unable to update Critical Table '%s' in CDS (Err=0x%08X)\n", __func__,
                              RegRecPtr->Name, (unsigned int)Status);
     }
     else
@@ -1366,15 +1364,13 @@ void CFE_TBL_UpdateCriticalTblCDS(CFE_TBL_RegistryRec_t *RegRecPtr)
 
             if (Status != CFE_SUCCESS)
             {
-                CFE_ES_WriteToSysLog(
-                    "CFE_TBL:UpdateCritTbl-Unable to update Critical Table Registry in CDS (Err=0x%08X)\n",
-                    (unsigned int)Status);
+                CFE_ES_WriteToSysLog("%s: Unable to update Critical Table Registry in CDS (Err=0x%08X)\n", __func__,
+                                     (unsigned int)Status);
             }
         }
         else
         {
-            CFE_ES_WriteToSysLog("CFE_TBL:UpdateCritTbl-Error finding '%s' in Critical Table Registry\n",
-                                 RegRecPtr->Name);
+            CFE_ES_WriteToSysLog("%s: Error finding '%s' in Critical Table Registry\n", __func__, RegRecPtr->Name);
         }
     }
 

--- a/modules/tbl/fsw/src/cfe_tbl_task.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task.c
@@ -105,7 +105,7 @@ void CFE_TBL_TaskMain(void)
 
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("TBL:Application Init Failed,RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Application Init Failed,RC=0x%08X\n", __func__, (unsigned int)Status);
         CFE_ES_PerfLogExit(CFE_MISSION_TBL_MAIN_PERF_ID);
         /* Note: CFE_ES_ExitApp will not return */
         CFE_ES_ExitApp(CFE_ES_RunStatus_CORE_APP_INIT_ERROR);
@@ -139,7 +139,7 @@ void CFE_TBL_TaskMain(void)
         }
         else
         {
-            CFE_ES_WriteToSysLog("TBL:Error reading cmd pipe,RC=0x%08X\n", (unsigned int)Status);
+            CFE_ES_WriteToSysLog("%s: Error reading cmd pipe,RC=0x%08X\n", __func__, (unsigned int)Status);
         } /* end if */
 
     } /* end while */
@@ -172,7 +172,7 @@ int32 CFE_TBL_TaskInit(void)
 
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("TBL:Call to CFE_EVS_Register Failed:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Call to CFE_EVS_Register Failed:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 
@@ -182,7 +182,7 @@ int32 CFE_TBL_TaskInit(void)
     Status = CFE_SB_CreatePipe(&CFE_TBL_Global.CmdPipe, CFE_TBL_TASK_PIPE_DEPTH, CFE_TBL_TASK_PIPE_NAME);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("TBL:Error creating cmd pipe:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Error creating cmd pipe:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 
@@ -193,7 +193,7 @@ int32 CFE_TBL_TaskInit(void)
 
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("TBL:Error subscribing to HK Request:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Error subscribing to HK Request:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 
@@ -204,7 +204,7 @@ int32 CFE_TBL_TaskInit(void)
 
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("TBL:Error subscribing to gnd cmds:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Error subscribing to gnd cmds:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 
@@ -216,7 +216,7 @@ int32 CFE_TBL_TaskInit(void)
 
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("TBL:Error sending init event:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Error sending init event:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
@@ -110,7 +110,7 @@ int32 CFE_TBL_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
 
                     if (Status != CFE_SUCCESS)
                     {
-                        CFE_ES_WriteToSysLog("CFE_TBL:HkCmd-Unable to update timestamp in dump file '%s'\n",
+                        CFE_ES_WriteToSysLog("%s: Unable to update timestamp in dump file '%s'\n", __func__,
                                              DumpCtrlPtr->DumpBufferPtr->DataSource);
                     }
 
@@ -118,7 +118,7 @@ int32 CFE_TBL_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
                 }
                 else
                 {
-                    CFE_ES_WriteToSysLog("CFE_TBL:HkCmd-Unable to open dump file '%s' to update timestamp\n",
+                    CFE_ES_WriteToSysLog("%s: Unable to open dump file '%s' to update timestamp\n", __func__,
                                          DumpCtrlPtr->DumpBufferPtr->DataSource);
                 }
             }

--- a/modules/time/fsw/src/cfe_time_api.c
+++ b/modules/time/fsw/src/cfe_time_api.c
@@ -614,7 +614,7 @@ void CFE_TIME_Print(char *PrintBuffer, CFE_TIME_SysTime_t TimeToPrint)
 
     if (PrintBuffer == NULL)
     {
-        CFE_ES_WriteToSysLog("CFE_TIME:Print-Failed invalid arguments\n");
+        CFE_ES_WriteToSysLog("%s: Failed invalid arguments\n", __func__);
         return;
     }
 

--- a/modules/time/fsw/src/cfe_time_task.c
+++ b/modules/time/fsw/src/cfe_time_task.c
@@ -78,7 +78,7 @@ void CFE_TIME_TaskMain(void)
 
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("TIME:Application Init Failed,RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Application Init Failed,RC=0x%08X\n", __func__, (unsigned int)Status);
         CFE_ES_PerfLogExit(CFE_MISSION_TIME_MAIN_PERF_ID);
         /* Note: CFE_ES_ExitApp will not return */
         CFE_ES_ExitApp(CFE_ES_RunStatus_CORE_APP_INIT_ERROR);
@@ -113,7 +113,7 @@ void CFE_TIME_TaskMain(void)
         }
         else
         {
-            CFE_ES_WriteToSysLog("TIME:Error reading cmd pipe,RC=0x%08X\n", (unsigned int)Status);
+            CFE_ES_WriteToSysLog("%s: Error reading cmd pipe,RC=0x%08X\n", __func__, (unsigned int)Status);
         } /* end if */
 
     } /* end while */
@@ -139,7 +139,7 @@ int32 CFE_TIME_TaskInit(void)
     Status = CFE_EVS_Register(NULL, 0, 0);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("TIME:Call to CFE_EVS_Register Failed:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Call to CFE_EVS_Register Failed:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 
@@ -147,7 +147,7 @@ int32 CFE_TIME_TaskInit(void)
                              CFE_TIME_SEM_OPTIONS);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("TIME:Error creating tone semaphore:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Error creating tone semaphore:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 
@@ -155,7 +155,7 @@ int32 CFE_TIME_TaskInit(void)
                              CFE_TIME_SEM_OPTIONS);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("TIME:Error creating local semaphore:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Error creating local semaphore:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 
@@ -164,7 +164,7 @@ int32 CFE_TIME_TaskInit(void)
                                     CFE_PLATFORM_TIME_TONE_TASK_PRIORITY, CFE_TIME_TASK_FLAGS);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("TIME:Error creating tone 1Hz child task:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Error creating tone 1Hz child task:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 
@@ -173,21 +173,21 @@ int32 CFE_TIME_TaskInit(void)
                                     CFE_PLATFORM_TIME_1HZ_TASK_PRIORITY, CFE_TIME_TASK_FLAGS);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("TIME:Error creating local 1Hz child task:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Error creating local 1Hz child task:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 
     Status = CFE_SB_CreatePipe(&CFE_TIME_Global.CmdPipe, CFE_TIME_TASK_PIPE_DEPTH, CFE_TIME_TASK_PIPE_NAME);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("TIME:Error creating cmd pipe:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Error creating cmd pipe:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 
     Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_SEND_HK_MID), CFE_TIME_Global.CmdPipe);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("TIME:Error subscribing to HK Request:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Error subscribing to HK Request:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 
@@ -203,7 +203,7 @@ int32 CFE_TIME_TaskInit(void)
 #endif
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("TIME:Error subscribing to tone cmd:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Error subscribing to tone cmd:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 
@@ -219,7 +219,7 @@ int32 CFE_TIME_TaskInit(void)
 #endif
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("TIME:Error subscribing to time data cmd:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Error subscribing to time data cmd:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 
@@ -236,7 +236,8 @@ int32 CFE_TIME_TaskInit(void)
 
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("TIME:Error subscribing to fake tone signal cmds:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Error subscribing to fake tone signal cmds:RC=0x%08X\n", __func__,
+                             (unsigned int)Status);
         return Status;
     } /* end if */
 
@@ -247,7 +248,7 @@ int32 CFE_TIME_TaskInit(void)
     Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_SEND_CMD_MID), CFE_TIME_Global.CmdPipe);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("TIME:Error subscribing to time at the tone request data cmds:RC=0x%08X\n",
+        CFE_ES_WriteToSysLog("%s: Error subscribing to time at the tone request data cmds:RC=0x%08X\n", __func__,
                              (unsigned int)Status);
         return Status;
     } /* end if */
@@ -259,14 +260,14 @@ int32 CFE_TIME_TaskInit(void)
     Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_CMD_MID), CFE_TIME_Global.CmdPipe);
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("TIME:Error subscribing to time task gnd cmds:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Error subscribing to time task gnd cmds:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 
     Status = CFE_EVS_SendEvent(CFE_TIME_INIT_EID, CFE_EVS_EventType_INFORMATION, "cFE TIME Initialized");
     if (Status != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("TIME:Error sending init event:RC=0x%08X\n", (unsigned int)Status);
+        CFE_ES_WriteToSysLog("%s: Error sending init event:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
     } /* end if */
 
@@ -296,12 +297,12 @@ int32 CFE_TIME_TaskInit(void)
             Status = OS_TimerSet(TimerId, 500000, 1000000);
             if (Status != OS_SUCCESS)
             {
-                CFE_ES_WriteToSysLog("TIME:1Hz OS_TimerSet failed:RC=0x%08X\n", (unsigned int)Status);
+                CFE_ES_WriteToSysLog("%s: 1Hz OS_TimerSet failed:RC=0x%08X\n", __func__, (unsigned int)Status);
             }
         }
         else
         {
-            CFE_ES_WriteToSysLog("TIME:1Hz OS_TimerAdd failed:RC=0x%08X\n", (unsigned int)Status);
+            CFE_ES_WriteToSysLog("%s: 1Hz OS_TimerAdd failed:RC=0x%08X\n", __func__, (unsigned int)Status);
         }
     }
 

--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -43,9 +43,9 @@
 /*
 ** External global variables
 */
-const char *TIME_SYSLOG_MSGS[] = {NULL, "TIME:Error reading cmd pipe,RC=0x%08X\n",
-                                  "TIME:Application Init Failed,RC=0x%08X\n", "TIME:1Hz OS_TimerAdd failed:RC=0x%08X\n",
-                                  "TIME:1Hz OS_TimerSet failed:RC=0x%08X\n"};
+const char *TIME_SYSLOG_MSGS[] = {NULL, "%s: Error reading cmd pipe,RC=0x%08X\n",
+                                  "%s: Application Init Failed,RC=0x%08X\n", "%s: 1Hz OS_TimerAdd failed:RC=0x%08X\n",
+                                  "%s: 1Hz OS_TimerSet failed:RC=0x%08X\n"};
 
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_SEND_HK  = {.MsgId =
                                                                      CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_SEND_HK_MID)};


### PR DESCRIPTION
**Describe the contribution**
Fix #1325 - Standardizes system log messages with a prefixed function name

**Testing performed**
Built and passed unit tests.

**Expected behavior changes**
Only modified output string of syslog.

**System(s) tested on**
 - Hardware: Intel I5/Docker
 - OS: Ubuntu 18.04
 - Versions: cFS Bundle + this commit

**Additional context**
Note this will have a conflict with #1566, easy to resolve.  I fix once it's in.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC