### PR TITLE
Fix #1490, allow multiple sources in add_cfe_coverage_test

### DIFF
--- a/cmake/arch_build.cmake
+++ b/cmake/arch_build.cmake
@@ -262,11 +262,7 @@ function(add_cfe_coverage_dependency MODULE_NAME UNIT_NAME DEPENDENCY_MODULE)
     # (assuming it was added by the add_cfe_coverage_stubs above)
     set(DEP_LIST)
     foreach(DEP ${DEPENDENCY_MODULE} ${ARGN})
-        if (TARGET coverage-${DEP}-stubs)
-            list(APPEND DEP_LIST "coverage-${DEP}-stubs")
-        else()
-            list(APPEND DEP_LIST "${DEP}")
-        endif()
+        list(APPEND DEP_LIST "coverage-${DEP}-stubs")
     endforeach()
 
     target_link_libraries(coverage-${MODULE_NAME}-${UNIT_NAME}-testrunner

--- a/cmake/arch_build.cmake
+++ b/cmake/arch_build.cmake
@@ -262,7 +262,11 @@ function(add_cfe_coverage_dependency MODULE_NAME UNIT_NAME DEPENDENCY_MODULE)
     # (assuming it was added by the add_cfe_coverage_stubs above)
     set(DEP_LIST)
     foreach(DEP ${DEPENDENCY_MODULE} ${ARGN})
-        list(APPEND DEP_LIST "coverage-${DEP}-stubs")
+        if (TARGET coverage-${DEP}-stubs)
+            list(APPEND DEP_LIST "coverage-${DEP}-stubs")
+        else()
+            list(APPEND DEP_LIST "${DEP}")
+        endif()
     endforeach()
 
     target_link_libraries(coverage-${MODULE_NAME}-${UNIT_NAME}-testrunner
@@ -301,7 +305,7 @@ function(add_cfe_coverage_test MODULE_NAME UNIT_NAME TESTCASE_SRC UT_SRCS)
     # Compile the source unit(s) under test as a separate library
     # This is done so that special coverage-specific compile flags can be used on these files
     add_library(${OBJECT_TARGET} OBJECT
-        ${UT_SRCS}
+        ${UT_SRCS} ${ARGN}
     )
 
     # Apply the UT_COVERAGE_COMPILE_FLAGS to the units under test


### PR DESCRIPTION
**Describe the contribution**
Add ${ARGN} such that the user can specify multiple source files

Add a check for targets in the add_cfe_coverage_dependency, so this can be used to add arbitrary other non-stub libraries too.

Fixes #1490

**Testing performed**
Build and run all unit tests, confirm no change in behavior

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
