### PR TITLE
Fix #1614, standardize on "docs" subdirectory

### DIFF
--- a/cmake/Makefile.sample
+++ b/cmake/Makefile.sample
@@ -145,11 +145,11 @@ lcov:
 
 doc:
 	$(MAKE) --no-print-directory -C "$(O)" mission-doc
-	@/bin/echo -e "\n\nDetail Design: \nfile://$(CURDIR)/$(O)/doc/detaildesign/html/index.html\n"
+	@/bin/echo -e "\n\nDetail Design: \nfile://$(CURDIR)/$(O)/docs/detaildesign/html/index.html\n"
 
 usersguide:
 	$(MAKE) --no-print-directory -C "$(O)" cfe-usersguide
-	@/bin/echo -e "\n\ncFE Users Guide: \nfile://$(CURDIR)/$(O)/doc/users_guide/html/index.html\n"
+	@/bin/echo -e "\n\ncFE Users Guide: \nfile://$(CURDIR)/$(O)/docs/users_guide/html/index.html\n"
 
 osalguide:
 	$(MAKE) --no-print-directory -C "$(O)" osalguide

--- a/cmake/arch_build.cmake
+++ b/cmake/arch_build.cmake
@@ -616,14 +616,14 @@ function(process_arch SYSVAR)
   # Also extract the "-D" options within CFLAGS and inform Doxygen about these
   string(REGEX MATCHALL "-D[A-Za-z0-9_=]+" DOXYGEN_DEFINED_MACROS "${CMAKE_C_FLAGS}")
   string(REGEX REPLACE "-D" " " DOXYGEN_DEFINED_MACROS "${DOXYGEN_DEFINED_MACROS}")
-  file(APPEND "${MISSION_BINARY_DIR}/doc/mission-content.doxyfile"
+  file(APPEND "${MISSION_BINARY_DIR}/docs/mission-content.doxyfile"
     "PREDEFINED += ${DOXYGEN_DEFINED_MACROS}\n"
     "INPUT += ${MISSION_SOURCE_DIR}/osal/src/os/${OSAL_SYSTEM_OSTYPE}\n"
     "INPUT += ${MISSION_SOURCE_DIR}/psp/fsw/${CFE_SYSTEM_PSPNAME}\n"
     "INPUT += ${CMAKE_BINARY_DIR}/inc")
 
   # Append to usersguide.doxyfile
-  file(APPEND "${MISSION_BINARY_DIR}/doc/cfe-usersguide.doxyfile"
+  file(APPEND "${MISSION_BINARY_DIR}/docs/cfe-usersguide.doxyfile"
     "INPUT += ${MISSION_SOURCE_DIR}/psp/fsw/${CFE_SYSTEM_PSPNAME}/src\n"
     "INPUT += ${CMAKE_BINARY_DIR}/inc")
 

--- a/cmake/cfe-common.doxyfile.in
+++ b/cmake/cfe-common.doxyfile.in
@@ -55,7 +55,7 @@ GENERATE_DEPRECATEDLIST= YES
 # configuration options related to warning and progress messages
 #---------------------------------------------------------------------------
 WARN_NO_PARAMDOC       = YES
-WARN_LOGFILE           = @CMAKE_BINARY_DIR@/doc/warnings.log
+WARN_LOGFILE           = @CMAKE_BINARY_DIR@/docs/warnings.log
 #---------------------------------------------------------------------------
 # configuration options related to the input files
 #---------------------------------------------------------------------------

--- a/cmake/cfe-usersguide.doxyfile.in
+++ b/cmake/cfe-usersguide.doxyfile.in
@@ -6,7 +6,7 @@
 INPUT                 += @MISSION_SOURCE_DIR@/cfe/docs/src/main.dox
 
 # Common definitions, some of which are extended or overridden here.
-@INCLUDE               = @MISSION_BINARY_DIR@/doc/cfe-common.doxyfile
+@INCLUDE               = @MISSION_BINARY_DIR@/docs/cfe-common.doxyfile
 PROJECT_NAME           = "Core Flight Executive Users Guide"
 OUTPUT_DIRECTORY       = users_guide
 GENERATE_LATEX         = YES

--- a/cmake/mission-detaildesign.doxyfile.in
+++ b/cmake/mission-detaildesign.doxyfile.in
@@ -3,7 +3,7 @@
 #---------------------------------------------------------------------------
 
 # Start with the common definitions, some of which are extended or overridden here.
-@INCLUDE               = @MISSION_BINARY_DIR@/doc/cfe-common.doxyfile
+@INCLUDE               = @MISSION_BINARY_DIR@/docs/cfe-common.doxyfile
 PROJECT_NAME           = "@MISSION_NAME@"
 PROJECT_BRIEF          = "Core Flight System project built using \"@MISSIONCONFIG@\" configuration"
 OUTPUT_DIRECTORY       = detaildesign
@@ -30,4 +30,4 @@ STRIP_FROM_PATH       += @MISSION_DEFS@
 #---------------------------------------------------------------------------
 # The user content doxyfile contains paths to the mission-specific applications
 #---------------------------------------------------------------------------
-@INCLUDE               = @CMAKE_BINARY_DIR@/doc/mission-content.doxyfile
+@INCLUDE               = @CMAKE_BINARY_DIR@/docs/mission-content.doxyfile

--- a/cmake/mission_build.cmake
+++ b/cmake/mission_build.cmake
@@ -234,7 +234,7 @@ function(prepare)
 
   # Doxygen-based documentation generation targets
   # Create a directory for documentation output
-  file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/doc")
+  file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/docs")
 
   # Generate a customized Doxyfile file for the Doxygen docs.
   # This file must be present in the directory where "doxygen" is executed
@@ -242,9 +242,9 @@ function(prepare)
   # then assume they have also set PROJECT_NAME and PROJECT_BRIEF in that.
   # Otherwise, generate reasonable strings for these values.
   set(MISSION_DOXYFILE_USER_CONTENT)
-  if (EXISTS "${MISSION_SOURCE_DIR}/doc/Doxyfile")
-    list(APPEND MISSION_DOXYFILE_USER_CONTENT "@INCLUDE = ${MISSION_SOURCE_DIR}/doc/Doxyfile\n")
-  endif (EXISTS "${MISSION_SOURCE_DIR}/doc/Doxyfile")
+  if (EXISTS "${MISSION_SOURCE_DIR}/docs/Doxyfile")
+    list(APPEND MISSION_DOXYFILE_USER_CONTENT "@INCLUDE = ${MISSION_SOURCE_DIR}/docs/Doxyfile\n")
+  endif (EXISTS "${MISSION_SOURCE_DIR}/docs/Doxyfile")
 
   foreach(APP ${MISSION_DEPS})
     # OSAL is handled specially, as only part of it is used
@@ -253,8 +253,8 @@ function(prepare)
         # If the module provides its own doxyfile, then include it directly
         # This allows for app-specific fine-tuning of the sources, based on its own source tree
         configure_file("${${APP}_MISSION_DIR}/docs/${APP}.doxyfile.in"
-            "${CMAKE_BINARY_DIR}/doc/${APP}.doxyfile")
-        list(APPEND MISSION_DOXYFILE_USER_CONTENT "@INCLUDE = ${CMAKE_BINARY_DIR}/doc/${APP}.doxyfile\n")
+            "${CMAKE_BINARY_DIR}/docs/${APP}.doxyfile")
+        list(APPEND MISSION_DOXYFILE_USER_CONTENT "@INCLUDE = ${CMAKE_BINARY_DIR}/docs/${APP}.doxyfile\n")
       else()
         # Otherwise just add this entire directory to the "INPUT" list
         list(APPEND MISSION_DOXYFILE_USER_CONTENT "INPUT += ${${APP}_MISSION_DIR}\n")
@@ -263,20 +263,20 @@ function(prepare)
   endforeach()
 
   # In all cases it is assumed to include the CFE documentation as well (could be configurable?)
-  file(WRITE "${CMAKE_BINARY_DIR}/doc/mission-content.doxyfile"
+  file(WRITE "${CMAKE_BINARY_DIR}/docs/mission-content.doxyfile"
       ${MISSION_DOXYFILE_USER_CONTENT})
 
   configure_file("${CFE_SOURCE_DIR}/cmake/cfe-common.doxyfile.in"
-    "${CMAKE_BINARY_DIR}/doc/cfe-common.doxyfile")
+    "${CMAKE_BINARY_DIR}/docs/cfe-common.doxyfile")
 
   configure_file("${CFE_SOURCE_DIR}/cmake/mission-detaildesign.doxyfile.in"
-    "${CMAKE_BINARY_DIR}/doc/mission-detaildesign.doxyfile")
+    "${CMAKE_BINARY_DIR}/docs/mission-detaildesign.doxyfile")
 
   # Generate an "empty" osconfig.h file for doxygen purposes
   # this does not have the actual user-defined values, but will
   # have the documentation associated with each macro definition.
   configure_file("${osal_MISSION_DIR}/osconfig.h.in"
-    "${CMAKE_BINARY_DIR}/doc/osconfig-example.h")
+    "${CMAKE_BINARY_DIR}/docs/osconfig-example.h")
 
   # The user guide should include the doxygen from the _public_ API files from CFE + OSAL
   # NOTE: the userguide is built against the headers of the default core apps. Even if
@@ -290,28 +290,28 @@ function(prepare)
   endforeach()
   file(GLOB MISSION_USERGUIDE_HEADERFILES
     ${SUBMODULE_HEADER_PATHS}
-    "${CMAKE_BINARY_DIR}/doc/osconfig-example.h"
+    "${CMAKE_BINARY_DIR}/docs/osconfig-example.h"
   )
 
   string(REPLACE ";" " \\\n" MISSION_USERGUIDE_HEADERFILES "${MISSION_USERGUIDE_HEADERFILES}")
 
   configure_file("${CFE_SOURCE_DIR}/cmake/cfe-usersguide.doxyfile.in"
-    "${CMAKE_BINARY_DIR}/doc/cfe-usersguide.doxyfile")
+    "${CMAKE_BINARY_DIR}/docs/cfe-usersguide.doxyfile")
 
   add_custom_target(mission-doc
     doxygen mission-detaildesign.doxyfile
-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/doc")
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/docs")
 
   add_custom_target(cfe-usersguide
     doxygen cfe-usersguide.doxyfile
-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/doc")
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/docs")
 
   # OSAL API GUIDE include PUBLIC API
   set(OSAL_API_INCLUDE_DIRECTORIES
     "${osal_MISSION_DIR}/src/os/inc"
-    "${CMAKE_BINARY_DIR}/doc"
+    "${CMAKE_BINARY_DIR}/docs"
   )
-  add_subdirectory(${osal_MISSION_DIR}/doc/src ${CMAKE_BINARY_DIR}/doc/osalguide)
+  add_subdirectory(${osal_MISSION_DIR}/docs/src ${CMAKE_BINARY_DIR}/docs/osalguide)
   add_custom_target(osalguide)
   add_dependencies(osalguide osal-apiguide)
 


### PR DESCRIPTION
**Describe the contribution**
Use "docs" instead of "doc" in both source and binary/build directory names for documentation and related files.

Fixes #1614

**Testing performed**
Build cFE and OSAL documentation targets, confirm working as expected

**Expected behavior changes**
No change, just consistent naming

**System(s) tested on**
Ubuntu

**Additional context**
**DEPENDENCY:** Should be merged at the same time as nasa/osal#1071 and nasa/psp#294

This also changes the names of the build tree/binary directories too (IMO it seemed odd to keep the binary dirs named differently from source dirs, so I made everything "docs").

However, it does **NOT** update the names of the makefile targets (`mission-doc` in the CMake build, and `doc` in the sample top-level target Makefile).  I figured there were probably many build/workflow scripts that depended on these target specific target names.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.