### PR TITLE
Fix #1629, correct path to users guide warning log

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Build Usersguide
         run: |
           make usersguide > make_usersguide_stdout.txt 2> make_usersguide_stderr.txt
-          mv build/doc/warnings.log usersguide_warnings.log
+          mv build/docs/cfe-usersguide-warnings.log usersguide_warnings.log
 
       - name: Archive Users Guide Build Logs
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
**Describe the contribution**
Corrects the path to the warning log file for CFE users guide build

Fixes #1629 

**Testing performed**
Check CFE workflow

**Expected behavior changes**
Workflow should succeed

**System(s) tested on**
Github

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
