### PR TITLE
Fix #1625, add test log file

### DIFF
--- a/modules/cfe_assert/inc/cfe_assert.h
+++ b/modules/cfe_assert/inc/cfe_assert.h
@@ -109,4 +109,40 @@ void CFE_Assert_ExecuteTest(void);
  */
 void CFE_Assert_RegisterCallback(CFE_Assert_StatusCallback_t Callback);
 
+/************************************************************************/
+/** \brief Start a test log file
+ *
+ *  \par Description
+ *        Sets the name of a file which will store the results of all tests
+ *        The output is saved to the log file in addition to the normal callback
+ *        function provided in CFE_Assert_RegisterCallback().
+ *
+ *  \par Assumptions, External Events, and Notes:
+ *        Only the test outputs are saved to this log file, thereby providing
+ *        a file that can be checked by a script.  During test operation, the
+ *        file is first created with a "tmp" extension, and then will be renamed
+ *        to the name given here once the test is complete.
+ *
+ * \param[in] Filename  Name of log file to write
+ *
+ * \return CFE Status code
+ * \retval #CFE_SUCCESS if file was opened successfully
+ *
+ */
+int32 CFE_Assert_OpenLogFile(const char *Filename);
+
+/************************************************************************/
+/** \brief Complete a test log file
+ *
+ *  \par Description
+ *        Closes the test log file that was previously opened via CFE_Assert_OpenLogFile
+ *
+ *  \par Assumptions, External Events, and Notes:
+ *        This should be called once test cases have completed
+ *
+ * \return None
+ *
+ */
+void CFE_Assert_CloseLogFile(void);
+
 #endif /* CFE_ASSERT_H */

--- a/modules/cfe_assert/src/cfe_assert_io.c
+++ b/modules/cfe_assert/src/cfe_assert_io.c
@@ -84,6 +84,14 @@ void UT_BSP_SysLogStatusReport(uint8 MessageType, const char *Prefix, const char
     }
 }
 
+void UT_BSP_WriteLogFile(osal_id_t FileDesc, uint8 MessageType, const char *Prefix, const char *OutputMessage)
+{
+    char LogFileBuffer[CFE_ASSERT_MAX_LOG_LINE_LENGTH];
+
+    snprintf(LogFileBuffer, sizeof(LogFileBuffer), "[%5s] %s\n", Prefix, OutputMessage);
+    OS_write(FileDesc, LogFileBuffer, strlen(LogFileBuffer));
+}
+
 void UT_BSP_DoText(uint8 MessageType, const char *OutputMessage)
 {
     const char *                Prefix;
@@ -138,6 +146,11 @@ void UT_BSP_DoText(uint8 MessageType, const char *OutputMessage)
     }
 
     StatusCallback(MessageType, Prefix, OutputMessage);
+
+    if (OS_ObjectIdDefined(CFE_Assert_Global.LogFileDesc))
+    {
+        UT_BSP_WriteLogFile(CFE_Assert_Global.LogFileDesc, MessageType, Prefix, OutputMessage);
+    }
 
     /*
      * If any ABORT (major failure) message is thrown,

--- a/modules/cfe_assert/src/cfe_assert_priv.h
+++ b/modules/cfe_assert/src/cfe_assert_priv.h
@@ -39,7 +39,16 @@
 *************************************************************************/
 #include "common_types.h"
 #include "cfe_assert.h"
+#include "osconfig.h"
 #include "cfe_mission_cfg.h"
+
+/**
+ * Maximum length of a single line in the test log file
+ *
+ * Note this only applies to the log file.  The user callback
+ * may have other limitations.
+ */
+#define CFE_ASSERT_MAX_LOG_LINE_LENGTH 512
 
 /**
  * State of the CFE assert library.
@@ -76,6 +85,27 @@ typedef struct
      * Function to invoke to report test status
      */
     CFE_Assert_StatusCallback_t StatusCallback;
+
+    /**
+     * Name of final log file for test results
+     *
+     * The temporary file will be renamed to this at the end of testing
+     */
+    char LogFileFinal[OS_MAX_PATH_LEN];
+
+    /**
+     * Name of temporary log file for test results
+     *
+     * This is the file name that is actively written during the test
+     */
+    char LogFileTemp[OS_MAX_PATH_LEN];
+
+    /**
+     * Log File descriptor
+     *
+     * Should be set to OS_OBJECT_ID_UNDEFINED if no log file is open
+     */
+    osal_id_t LogFileDesc;
 
     /**
      * Mutex to control access to UtAssert structures.

--- a/modules/cfe_assert/src/cfe_assert_runner.c
+++ b/modules/cfe_assert/src/cfe_assert_runner.c
@@ -222,6 +222,7 @@ void CFE_Assert_ExecuteTest(void)
     /* unregister the callback and unset the appid */
     UT_BSP_Lock();
     CFE_Assert_RegisterCallback(NULL);
+    CFE_Assert_CloseLogFile();
     CFE_Assert_Global.OwnerAppId = CFE_ES_APPID_UNDEFINED;
     UT_BSP_Unlock();
 }

--- a/modules/cfe_testcase/src/cfe_test.c
+++ b/modules/cfe_testcase/src/cfe_test.c
@@ -46,6 +46,7 @@ void CFE_TestMain(void)
      * state and gets ownership of the UtAssert subsystem
      */
     CFE_Assert_RegisterTest("CFE API");
+    CFE_Assert_OpenLogFile(CFE_ASSERT_LOG_FILE_NAME);
 
     /*
      * Register test cases in UtAssert

--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -43,6 +43,15 @@
 #include "uttest.h"
 #include "utassert.h"
 
+/**
+ * Name of log file to write
+ *
+ * This file captures all of the test results, independently of the
+ * events generated during the test run.  The file can be used as part
+ * of scripted tests and/or capturing test artifacts.
+ */
+#define CFE_ASSERT_LOG_FILE_NAME "/cf/cfe_test.log"
+
 /* Compare two Resource IDs */
 #define UtAssert_ResourceID_EQ(actual, expect)                                                \
     UtAssert_True(CFE_RESOURCEID_TEST_EQUAL(actual, expect), "%s (%lu) == %s (%lu)", #actual, \


### PR DESCRIPTION
**Describe the contribution**
Add cfe_assert capability to "tee" all test log output to a file in addition to the regular output (console/event).

This aids in scripting and automation, by creating a file containing only test results, not intermixed with other info, and not subject
to the length limitations of events.

Fixes #1625

**Testing performed**
Build and run CFE functional tests

**Expected behavior changes**
Test results now stored in `/cf/cfe_test.log` in addition to normal output

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.