### PR TITLE
Fix #467, #1636 Complete coverage for cfe_es_start.c and cfe_es_syslog.c

### DIFF
--- a/modules/es/fsw/src/cfe_es_log.h
+++ b/modules/es/fsw/src/cfe_es_log.h
@@ -265,23 +265,6 @@ void CFE_ES_SysLog_vsnprintf(char *Buffer, size_t BufferSize, const char *SpecSt
 
 /*---------------------------------------------------------------------------------------*/
 /**
- * \brief Format a message intended for output to the system log
- *
- * Identical to the CFE_ES_SysLog_vsnprintf() call but with a variable argument set,
- * for use in functions that need to directly handle a log message string.
- *
- * Similar in definition to the "snprintf()" C library call.
- *
- * \param Buffer        User supplied buffer to output formatted sting into
- * \param BufferSize    Size of "Buffer" parameter.  Should be greater than (CFE_TIME_PRINTED_STRING_SIZE+2)
- * \param SpecStringPtr Printf-style format string
- *
- * \sa CFE_ES_SysLogAppend_Unsync()
- */
-void CFE_ES_SysLog_snprintf(char *Buffer, size_t BufferSize, const char *SpecStringPtr, ...) OS_PRINTF(3, 4);
-
-/*---------------------------------------------------------------------------------------*/
-/**
  * \brief Write the contents of the syslog to a disk file
  *
  * Writes the current contents of the syslog buffer to a file specified

--- a/modules/es/fsw/src/cfe_es_syslog.c
+++ b/modules/es/fsw/src/cfe_es_syslog.c
@@ -444,23 +444,6 @@ void CFE_ES_SysLog_vsnprintf(char *Buffer, size_t BufferSize, const char *SpecSt
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_SysLog_snprintf
- *
- * Application-scope internal function
- * See description in header file for argument/return detail
- *
- *-----------------------------------------------------------------*/
-void CFE_ES_SysLog_snprintf(char *Buffer, size_t BufferSize, const char *SpecStringPtr, ...)
-{
-    va_list ArgPtr;
-
-    va_start(ArgPtr, SpecStringPtr);
-    CFE_ES_SysLog_vsnprintf(Buffer, BufferSize, SpecStringPtr, ArgPtr);
-    va_end(ArgPtr);
-}
-
-/*----------------------------------------------------------------
- *
  * Function: CFE_ES_SysLogDump
  *
  * Application-scope internal function

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -4844,6 +4844,18 @@ void TestSysLog(void)
     CFE_UtAssert_MEMOFFSET_EQ(SysLogBuffer.BlockSize, 1);
     UtAssert_ZERO(SysLogBuffer.SizeLeft);
 
+    /* Test case where calculated blocksize results in 0 */
+    ES_ResetUnitTest();
+    SysLogBuffer.EndIdx   = 0;
+    SysLogBuffer.SizeLeft = 1;
+
+    CFE_ES_SysLogReadData(&SysLogBuffer);
+
+    UtAssert_UINT32_EQ(SysLogBuffer.EndIdx, 0);
+    CFE_UtAssert_MEMOFFSET_EQ(SysLogBuffer.LastOffset, 0);
+    CFE_UtAssert_MEMOFFSET_EQ(SysLogBuffer.BlockSize, 0);
+    UtAssert_INT32_EQ(SysLogBuffer.SizeLeft, 1);
+
     /* Test nominal flow through CFE_ES_SysLogDump
      * with multiple reads and writes  */
     ES_ResetUnitTest();

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -696,7 +696,15 @@ void TestStartupErrorPaths(void)
     UtAssert_STUB_COUNT(CFE_PSP_Panic, 1);
     UtAssert_UINT32_EQ(PanicStatus, CFE_PSP_PANIC_STARTUP_SEM);
 
-    /* Perform ES main startup with a file open failure */
+    /* Perform ES main startup with a ES Perf Data mutex creation failure */
+    ES_ResetUnitTest();
+    UT_SetDeferredRetcode(UT_KEY(OS_MutSemCreate), 2, OS_ERROR);
+    UT_SetDataBuffer(UT_KEY(CFE_PSP_Panic), &PanicStatus, sizeof(PanicStatus), false);
+    CFE_ES_Main(CFE_PSP_RST_TYPE_POWERON, 1, 1, "ut_startup");
+    UtAssert_UINT32_EQ(PanicStatus, CFE_PSP_PANIC_STARTUP_SEM);
+    UtAssert_UINT32_EQ(UT_GetStubCount(UT_KEY(CFE_PSP_Panic)), 1);
+
+    /* Perform ES main startup with a ES Shared Data mutex creation failure */
     ES_ResetUnitTest();
     UT_SetDummyFuncRtn(OS_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
@@ -925,6 +933,13 @@ void TestStartupErrorPaths(void)
     CFE_ES_CreateObjects();
     CFE_UtAssert_PRINTF(UT_OSP_MESSAGES[UT_OSP_NO_FREE_CORE_APP_SLOTS]);
     CFE_UtAssert_PRINTF(UT_OSP_MESSAGES[UT_OSP_FUNCTION_POINTER]);
+
+    /* Test reading the object table with unknown object type */
+    ES_ResetUnitTest();
+    UT_SetDefaultReturnValue(UT_KEY(CFE_ResourceId_FindNext), OS_ERROR);
+    CFE_ES_ObjectTable[CFE_PLATFORM_ES_OBJECT_TABLE_SIZE - 1].ObjectType = -1;
+    CFE_ES_CreateObjects();
+    CFE_UtAssert_PRINTF(UT_OSP_MESSAGES[UT_OSP_NO_FREE_CORE_APP_SLOTS]);
 
     /* Test response to an invalid startup type */
     ES_ResetUnitTest();


### PR DESCRIPTION
**Describe the contribution**
Completed code coverage for `cfe_es_start.c` and `cfe_es_syslog.c` with the following changes:

Fixes #467 The following tests were added:
- `CFE_ES_Main` with a ES Perf Data mutex creation failure
- `CFE_ES_CreateObjects` with unknown object type
- `CFE_ES_SysLogReadData` when calculated blocksize is 0
 
Fixes #1636 removed function `CFE_ES_SysLog_snprintf`

**Testing performed**
Manually ran unit tests for ES: `$ make -C build/native/default_cpu1/es test`
Verified 100% coverage on files with `gcov cfe_es_syslog.c.gcno` and `gcov cfe_es_start.c.gcno`

**Expected behavior changes**
Increased overall code coverage

**System(s) tested on**
 - Ubuntu 18.04 VM

**Additional context**

**Contributor Info - All information REQUIRED for consideration of pull request**
Jose F. Martinez Pedraza/NASA GSFC
