### PR TITLE
Fix #1480, Expand FS Header Functional tests.

### DIFF
--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -53,16 +53,16 @@
 #define CFE_ASSERT_LOG_FILE_NAME "/cf/cfe_test.log"
 
 /* Compare two Resource IDs */
-#define UtAssert_ResourceID_EQ(actual, expect)                                                \
+#define cFE_FTAssert_ResourceID_EQ(actual, expect)                                            \
     UtAssert_True(CFE_RESOURCEID_TEST_EQUAL(actual, expect), "%s (%lu) == %s (%lu)", #actual, \
                   CFE_RESOURCEID_TO_ULONG(actual), #expect, CFE_RESOURCEID_TO_ULONG(expect))
 
 /* Check if a Resource ID is Undefined */
-#define UtAssert_ResourceID_Undefined(id) \
+#define cFE_FTAssert_ResourceID_Undefined(id) \
     UtAssert_True(!CFE_RESOURCEID_TEST_DEFINED(id), "%s (%lu) not defined", #id, CFE_RESOURCEID_TO_ULONG(id))
 
 /* Assert a return code is not equal to cfe_success */
-#define UtAssert_NOT_CFE_SUCCESS(actual)                                          \
+#define cFE_FTAssert_NOT_CFE_SUCCESS(actual)                                      \
     do                                                                            \
     {                                                                             \
         int32 rcact = (int32)(actual);                                            \
@@ -70,7 +70,7 @@
     } while (0)
 
 /* Log calls to void functions */
-#define UtAssert_VOIDCALL(func) (func, UtAssert(true, #func, __FILE__, __LINE__))
+#define cFE_FTAssert_VOIDCALL(func) (func, UtAssert(true, #func, __FILE__, __LINE__))
 
 void CFE_TestMain(void);
 void ESInfoTestSetup(void);

--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -61,6 +61,17 @@
 #define UtAssert_ResourceID_Undefined(id) \
     UtAssert_True(!CFE_RESOURCEID_TEST_DEFINED(id), "%s (%lu) not defined", #id, CFE_RESOURCEID_TO_ULONG(id))
 
+/* Assert a return code is not equal to cfe_success */
+#define UtAssert_NOT_CFE_SUCCESS(actual)                                          \
+    do                                                                            \
+    {                                                                             \
+        int32 rcact = (int32)(actual);                                            \
+        UtAssert_True(rcact < CFE_SUCCESS, "%s == (%ld) ", #actual, (long)rcact); \
+    } while (0)
+
+/* Log calls to void functions */
+#define UtAssert_VOIDCALL(func) (func, UtAssert(true, #func, __FILE__, __LINE__))
+
 void CFE_TestMain(void);
 void ESInfoTestSetup(void);
 void ESTaskTestSetup(void);

--- a/modules/cfe_testcase/src/es_cds_test.c
+++ b/modules/cfe_testcase/src/es_cds_test.c
@@ -82,7 +82,7 @@ void TestCDSName(void)
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockName(CDSNameBuf, CDSHandlePtr, sizeof(CDSNameBuf)), CFE_SUCCESS);
     UtAssert_StrCmp(CDSNameBuf, CDSName, "CFE_ES_GetCDSBlockName() = %s", CDSNameBuf);
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockIDByName(&IdByName, CDSNameBuf), CFE_SUCCESS);
-    UtAssert_ResourceID_EQ(CDSHandlePtr, IdByName);
+    cFE_FTAssert_ResourceID_EQ(CDSHandlePtr, IdByName);
 
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockName(NULL, CDSHandlePtr, sizeof(CDSNameBuf)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockName(CDSNameBuf, CFE_ES_CDS_BAD_HANDLE, sizeof(CDSNameBuf)),

--- a/modules/cfe_testcase/src/es_info_test.c
+++ b/modules/cfe_testcase/src/es_info_test.c
@@ -52,7 +52,7 @@ void TestAppInfo(void)
 
     UtAssert_INT32_EQ(CFE_ES_GetAppIDByName(&AppIdByName, TEST_EXPECTED_APP_NAME), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetAppID(&TestAppId), CFE_SUCCESS);
-    UtAssert_ResourceID_EQ(TestAppId, AppIdByName);
+    cFE_FTAssert_ResourceID_EQ(TestAppId, AppIdByName);
     UtAssert_INT32_EQ(CFE_ES_GetAppName(AppNameBuf, TestAppId, sizeof(AppNameBuf)), CFE_SUCCESS);
     UtAssert_StrCmp(AppNameBuf, TEST_EXPECTED_APP_NAME, "CFE_ES_GetAppName() = %s", AppNameBuf);
 
@@ -122,7 +122,7 @@ void TestAppInfo(void)
     UtAssert_True(ESAppInfo.NumOfChildTasks > 0, "ES App Info -> Child Tasks  = %d", (int)ESAppInfo.NumOfChildTasks);
 
     UtAssert_INT32_EQ(CFE_ES_GetAppIDByName(&AppIdByName, INVALID_APP_NAME), CFE_ES_ERR_NAME_NOT_FOUND);
-    UtAssert_ResourceID_Undefined(AppIdByName);
+    cFE_FTAssert_ResourceID_Undefined(AppIdByName);
     UtAssert_INT32_EQ(CFE_ES_GetAppID(NULL), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetAppIDByName(NULL, TEST_EXPECTED_APP_NAME), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetAppName(AppNameBuf, CFE_ES_APPID_UNDEFINED, sizeof(AppNameBuf)),
@@ -146,15 +146,15 @@ void TestTaskInfo(void)
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskInfo(&TaskInfo, AppInfo.MainTaskId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetTaskID(&TaskId), CFE_SUCCESS);
-    UtAssert_ResourceID_EQ(TaskId, AppInfo.MainTaskId);
+    cFE_FTAssert_ResourceID_EQ(TaskId, AppInfo.MainTaskId);
 
     UtAssert_StrCmp(TaskInfo.AppName, AppInfo.Name, "TaskInfo.AppName (%s) = AppInfo.name (%s)", TaskInfo.AppName,
                     AppInfo.Name);
     UtAssert_StrCmp(TaskInfo.TaskName, AppInfo.MainTaskName, "TaskInfo.TaskName (%s) = AppInfo.MainTaskName (%s)",
                     TaskInfo.TaskName, AppInfo.MainTaskName);
 
-    UtAssert_ResourceID_EQ(TaskInfo.TaskId, AppInfo.MainTaskId);
-    UtAssert_ResourceID_EQ(TaskInfo.AppId, AppId);
+    cFE_FTAssert_ResourceID_EQ(TaskInfo.TaskId, AppInfo.MainTaskId);
+    cFE_FTAssert_ResourceID_EQ(TaskInfo.AppId, AppId);
     UtAssert_INT32_EQ(TaskInfo.ExecutionCounter, AppInfo.ExecutionCounter);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskInfo(&TaskInfo, CFE_ES_TASKID_UNDEFINED), CFE_ES_ERR_RESOURCEID_NOT_VALID);
@@ -205,7 +205,7 @@ void TestLibInfo(void)
 
     UtAssert_INT32_EQ(LibInfo.ExceptionAction, 0);
     UtAssert_True(LibInfo.Priority == 0, "Lib Info -> Priority  = %d", (int)LibInfo.Priority);
-    UtAssert_ResourceID_Undefined(LibInfo.MainTaskId);
+    cFE_FTAssert_ResourceID_Undefined(LibInfo.MainTaskId);
     UtAssert_True(LibInfo.ExecutionCounter == 0, "Lib Info -> ExecutionCounter  = %d", (int)LibInfo.ExecutionCounter);
     UtAssert_True(strlen(LibInfo.MainTaskName) == 0, "Lib Info -> Task Name  = %s", LibInfo.MainTaskName);
     UtAssert_True(LibInfo.NumOfChildTasks == 0, "Lib Info -> Child Tasks  = %d", (int)LibInfo.NumOfChildTasks);

--- a/modules/cfe_testcase/src/es_task_test.c
+++ b/modules/cfe_testcase/src/es_task_test.c
@@ -108,14 +108,14 @@ void TestChildTaskName(void)
                       CFE_SUCCESS);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(&TaskIdByName, TaskName), CFE_SUCCESS);
-    UtAssert_ResourceID_EQ(TaskIdByName, TaskId);
+    cFE_FTAssert_ResourceID_EQ(TaskIdByName, TaskId);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(TaskNameBuf, TaskId, sizeof(TaskNameBuf)), CFE_SUCCESS);
     UtAssert_StrCmp(TaskNameBuf, TaskName, "CFE_ES_GetTaskName() = %s", TaskNameBuf);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(NULL, TaskName), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(&TaskIdByName, INVALID_TASK_NAME), CFE_ES_ERR_NAME_NOT_FOUND);
-    UtAssert_ResourceID_Undefined(TaskIdByName);
+    cFE_FTAssert_ResourceID_Undefined(TaskIdByName);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(NULL, TaskId, sizeof(TaskNameBuf)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(TaskNameBuf, CFE_ES_TASKID_UNDEFINED, sizeof(TaskNameBuf)),

--- a/modules/cfe_testcase/src/fs_header_test.c
+++ b/modules/cfe_testcase/src/fs_header_test.c
@@ -54,15 +54,15 @@ void TestCreateHeader(void)
 
     UtPrintf("Testing: CFE_FS_InitHeader, CFE_FS_WriteHeader");
 
-    UtAssert_VOIDCALL(CFE_FS_InitHeader(&Header, TestDescription, CFE_FS_SubType_ES_ERLOG));
+    cFE_FTAssert_VOIDCALL(CFE_FS_InitHeader(&Header, TestDescription, CFE_FS_SubType_ES_ERLOG));
     UtAssert_INT32_EQ(CFE_FS_WriteHeader(fd, &Header), sizeof(CFE_FS_Header_t));
 
     UtAssert_INT32_EQ(CFE_FS_WriteHeader(fd, NULL), CFE_FS_BAD_ARGUMENT);
-    UtAssert_NOT_CFE_SUCCESS(CFE_FS_WriteHeader(OS_OBJECT_ID_UNDEFINED, &Header));
+    cFE_FTAssert_NOT_CFE_SUCCESS(CFE_FS_WriteHeader(OS_OBJECT_ID_UNDEFINED, &Header));
 
-    UtAssert_VOIDCALL(CFE_FS_InitHeader(NULL, TestDescription, CFE_FS_SubType_ES_ERLOG));
-    UtAssert_VOIDCALL(CFE_FS_InitHeader(&HeaderFail, NULL, CFE_FS_SubType_ES_ERLOG));
-    UtAssert_VOIDCALL(CFE_FS_InitHeader(&HeaderFail, TestDescription, 256));
+    cFE_FTAssert_VOIDCALL(CFE_FS_InitHeader(NULL, TestDescription, CFE_FS_SubType_ES_ERLOG));
+    cFE_FTAssert_VOIDCALL(CFE_FS_InitHeader(&HeaderFail, NULL, CFE_FS_SubType_ES_ERLOG));
+    cFE_FTAssert_VOIDCALL(CFE_FS_InitHeader(&HeaderFail, TestDescription, 256));
 
     OS_close(fd);
     OS_remove(OS_TEST_HEADER_FILENAME);
@@ -77,7 +77,7 @@ void TestReadHeader(void)
 
     UtPrintf("Testing: CFE_FS_ReadHeader");
 
-    UtAssert_VOIDCALL(CFE_FS_InitHeader(&Header, TestDescription, CFE_FS_SubType_ES_ERLOG));
+    cFE_FTAssert_VOIDCALL(CFE_FS_InitHeader(&Header, TestDescription, CFE_FS_SubType_ES_ERLOG));
     UtAssert_INT32_EQ(CFE_FS_WriteHeader(fd, &Header), sizeof(CFE_FS_Header_t));
     UtAssert_INT32_EQ(CFE_FS_ReadHeader(&ReadHeader, fd), sizeof(CFE_FS_Header_t));
 
@@ -86,7 +86,7 @@ void TestReadHeader(void)
     UtAssert_StrCmp(TestDescription, ReadHeader.Description, "ReadHeader.Description = %s", ReadHeader.Description);
 
     UtAssert_INT32_EQ(CFE_FS_ReadHeader(NULL, fd), CFE_FS_BAD_ARGUMENT);
-    UtAssert_NOT_CFE_SUCCESS(CFE_FS_ReadHeader(&ReadHeader, OS_OBJECT_ID_UNDEFINED));
+    cFE_FTAssert_NOT_CFE_SUCCESS(CFE_FS_ReadHeader(&ReadHeader, OS_OBJECT_ID_UNDEFINED));
 
     OS_close(fd);
     OS_remove(OS_TEST_HEADER_FILENAME);
@@ -102,7 +102,7 @@ void TestTimeStamp(void)
 
     UtPrintf("Testing: CFE_FS_SetTimestamp");
 
-    UtAssert_VOIDCALL(CFE_FS_InitHeader(&Header, TestDescription, CFE_FS_SubType_ES_ERLOG));
+    cFE_FTAssert_VOIDCALL(CFE_FS_InitHeader(&Header, TestDescription, CFE_FS_SubType_ES_ERLOG));
     UtAssert_INT32_EQ(CFE_FS_WriteHeader(fd, &Header), sizeof(CFE_FS_Header_t));
     UtAssert_INT32_EQ(CFE_FS_SetTimestamp(fd, NewTimestamp), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_FS_ReadHeader(&ReadHeader, fd), sizeof(CFE_FS_Header_t));
@@ -110,7 +110,7 @@ void TestTimeStamp(void)
     UtAssert_UINT32_EQ(0xFFFFFFFF, ReadHeader.TimeSeconds);
     UtAssert_UINT32_EQ(0xFFFFFFFF, ReadHeader.TimeSubSeconds);
 
-    UtAssert_NOT_CFE_SUCCESS(CFE_FS_SetTimestamp(OS_OBJECT_ID_UNDEFINED, NewTimestamp));
+    cFE_FTAssert_NOT_CFE_SUCCESS(CFE_FS_SetTimestamp(OS_OBJECT_ID_UNDEFINED, NewTimestamp));
 
     OS_close(fd);
     OS_remove(OS_TEST_HEADER_FILENAME);


### PR DESCRIPTION
**Describe the contribution**
Fixes #1480
Expands FS Header functional tests to include error checking. 

**Testing performed**
Build and run unit test

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC