### PR TITLE
Fix #1635, Change CI to use Test Log.

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -65,25 +65,25 @@ jobs:
 
       - name: Run cFS
         run: |
-          ./core-cpu1 | tee cFS_startup_cpu1.txt &
+          ./core-cpu1 &
           sleep 10
           ../host/cmdUtil --pktid=0x1806 --cmdcode=4 --endian=LE --string="20:CFE_TEST_APP" --string="20:CFE_TestMain" --string="64:cfe_testcase" --uint32=16384 --uint8=0 --uint8=0 --uint16=100 &
 
           sleep 30
-          counter=$(grep -c "CFE_TEST_APP" cFS_startup_cpu1.txt) &
+          counter=$(grep -c "BEGIN" cf/cfe_test.log) &
 
-          while [[ -z $(grep -i "SUMMARY" cFS_startup_cpu1.txt) ]]; do
+          while [[ -z $(grep -i "SUMMARY" cf/cfe_test.log) ]]; do
             echo "Waiting for CFE Tests"
             sleep 60
 
-            temp=$(grep -c "CFE_TEST_APP" cFS_startup_cpu1.txt) &
+            temp=$(grep -c "BEGIN" cf/cfe_test.log) &
               
             if [ $temp -eq $counter ]; then
               echo "Test is frozen. Quiting"
               break
             fi
 
-            counter=$(grep -c "CFE_TEST_APP" cFS_startup_cpu1.txt) &              
+            counter=$(grep -c "BEGIN" cf/cfe_test.log) &              
           done
           
           ../host/cmdUtil --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002
@@ -93,14 +93,14 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: cFS-startup-log-deprecate-true-${{ matrix.buildtype }}
-          path: ./build/exe/cpu1/cFS_startup_cpu1.txt
+          path: ./build/exe/cpu1/cf/cfe_test.log
 
       - name: Check for cFS Warnings
         run: |  
-          if [[ -z $(grep -i "SUMMARY.*FAIL::0.*TSF::0.*TTF::0" cFS_startup_cpu1.txt) ]]; then
+          if [[ -z $(grep -i "SUMMARY.*FAIL::0.*TSF::0.*TTF::0" cf/cfe_test.log) ]]; then
                   echo "Must resolve Test Failures in cFS Test App before submitting a pull request"
                   echo ""
-                  grep -i '\[ FAIL]\|\[  TSF]\|\[  TTF]' cFS_startup_cpu1.txt
+                  grep -i '\[ FAIL]\|\[  TSF]\|\[  TTF]' cf/cfe_test.log
                   exit -1
           fi
         working-directory: ./build/exe/cpu1/  

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -70,20 +70,19 @@ jobs:
           ../host/cmdUtil --pktid=0x1806 --cmdcode=4 --endian=LE --string="20:CFE_TEST_APP" --string="20:CFE_TestMain" --string="64:cfe_testcase" --uint32=16384 --uint8=0 --uint8=0 --uint16=100 &
 
           sleep 30
-          counter=$(grep -c "BEGIN" cf/cfe_test.log) &
+          counter=0 
 
-          while [[ -z $(grep -i "SUMMARY" cf/cfe_test.log) ]]; do
-            echo "Waiting for CFE Tests"
-            sleep 60
-
-            temp=$(grep -c "BEGIN" cf/cfe_test.log) &
+          while [[ ! -f cf/cfe_test.log ]]; do 
+            temp=$(grep -c "BEGIN" cf/cfe_test.tmp) 
               
             if [ $temp -eq $counter ]; then
               echo "Test is frozen. Quiting"
               break
             fi
 
-            counter=$(grep -c "BEGIN" cf/cfe_test.log) &              
+            counter=$(grep -c "BEGIN" cf/cfe_test.tmp)            
+            echo "Waiting for CFE Tests"
+            sleep 60
           done
           
           ../host/cmdUtil --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002


### PR DESCRIPTION
**Describe the contribution**
Fixes #1635  
Change CI to use the test log file instead of tee. 

**Testing performed**
Build and run unit test

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC