### PR TITLE
Fix #1546, use cfe time clock state enum t in cmd/tlm and handling

### DIFF
--- a/modules/time/fsw/inc/cfe_time_msg.h
+++ b/modules/time/fsw/inc/cfe_time_msg.h
@@ -767,10 +767,11 @@ typedef struct CFE_TIME_SetLeapSecondsCmd
  */
 typedef struct CFE_TIME_StateCmd_Payload
 {
-    int16 ClockState; /**< \brief #CFE_TIME_ClockState_INVALID=Spacecraft time has not been accurately set,
-                                  #CFE_TIME_ClockState_VALID=Spacecraft clock has been accurately set,
-                                  #CFE_TIME_ClockState_FLYWHEEL=Force into FLYWHEEL mode   */
-                      /**< Selects the current clock state */
+    CFE_TIME_ClockState_Enum_t ClockState; /**< \brief #CFE_TIME_ClockState_INVALID=Spacecraft time has
+                                  not been accurately set, #CFE_TIME_ClockState_VALID=Spacecraft clock
+                                  has been accurately set, #CFE_TIME_ClockState_FLYWHEEL=Force into
+                                  FLYWHEEL mode   */
+                                           /**< Selects the current clock state */
 } CFE_TIME_StateCmd_Payload_t;
 
 /**
@@ -883,10 +884,10 @@ typedef CFE_TIME_OneHzAdjustmentCmd_t CFE_TIME_Sub1HZAdjustmentCmd_t;
  */
 typedef struct CFE_TIME_ToneDataCmd_Payload
 {
-    CFE_TIME_SysTime_t AtToneMET;         /**< \brief MET at time of tone */
-    CFE_TIME_SysTime_t AtToneSTCF;        /**< \brief STCF at time of tone */
-    int16              AtToneLeapSeconds; /**< \brief Leap Seconds at time of tone */
-    int16              AtToneState;       /**< \brief Clock state at time of tone */
+    CFE_TIME_SysTime_t         AtToneMET;         /**< \brief MET at time of tone */
+    CFE_TIME_SysTime_t         AtToneSTCF;        /**< \brief STCF at time of tone */
+    int16                      AtToneLeapSeconds; /**< \brief Leap Seconds at time of tone */
+    CFE_TIME_ClockState_Enum_t AtToneState;       /**< \brief Clock state at time of tone */
 } CFE_TIME_ToneDataCmd_Payload_t;
 
 /**
@@ -916,10 +917,10 @@ typedef struct CFE_TIME_HousekeepingTlm_Payload
     /*
     ** Clock state flags and "as calculated" clock state...
     */
-    uint16 ClockStateFlags; /**< \cfetlmmnemonic \TIME_STATEFLG
-                                 \brief State Flags */
-    int16 ClockStateAPI;    /**< \cfetlmmnemonic \TIME_APISTATE
-                                 \brief API State */
+    uint16 ClockStateFlags;                   /**< \cfetlmmnemonic \TIME_STATEFLG
+                                                   \brief State Flags */
+    CFE_TIME_ClockState_Enum_t ClockStateAPI; /**< \cfetlmmnemonic
+                              \TIME_APISTATE \brief API State */
 
     /*
     ** Leap Seconds...
@@ -987,10 +988,10 @@ typedef struct CFE_TIME_DiagnosticTlm_Payload
     CFE_TIME_SysTime_t AtToneLatch; /**< \cfetlmmnemonic \TIME_TVALIDS
                                                \brief Local clock latched at time of tone */
 
-    int16 AtToneLeapSeconds; /**< \cfetlmmnemonic \TIME_LEAPS
-                                  \brief Leap Seconds at time of tone */
-    int16 ClockStateAPI;     /**< \cfetlmmnemonic \TIME_APISTATE
-                                        \brief Clock state as per API */
+    int16 AtToneLeapSeconds;                  /**< \cfetlmmnemonic \TIME_LEAPS
+                                                   \brief Leap Seconds at time of tone */
+    CFE_TIME_ClockState_Enum_t ClockStateAPI; /**< \cfetlmmnemonic \TIME_APISTATE
+                                    \brief Clock state as per API */
 
     /*
      ** Data values that reflect the time (right now)...

--- a/modules/time/fsw/src/cfe_time_utils.c
+++ b/modules/time/fsw/src/cfe_time_utils.c
@@ -393,7 +393,7 @@ void CFE_TIME_GetHkData(const CFE_TIME_Reference_t *Reference)
     /*
     ** Current "as calculated" clock state...
     */
-    CFE_TIME_Global.HkPacket.Payload.ClockStateAPI = (int16)CFE_TIME_CalculateState(Reference);
+    CFE_TIME_Global.HkPacket.Payload.ClockStateAPI = (CFE_TIME_ClockState_Enum_t)CFE_TIME_CalculateState(Reference);
 
     /*
     ** Current clock state flags...
@@ -728,9 +728,9 @@ CFE_TIME_SysTime_t CFE_TIME_CalculateUTC(const CFE_TIME_Reference_t *Reference)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int16 CFE_TIME_CalculateState(const CFE_TIME_Reference_t *Reference)
+CFE_TIME_ClockState_Enum_t CFE_TIME_CalculateState(const CFE_TIME_Reference_t *Reference)
 {
-    int16 ClockState;
+    CFE_TIME_ClockState_Enum_t ClockState;
 
     /*
     ** Determine the current clock state...
@@ -782,7 +782,7 @@ int16 CFE_TIME_CalculateState(const CFE_TIME_Reference_t *Reference)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-void CFE_TIME_SetState(int16 NewState)
+void CFE_TIME_SetState(CFE_TIME_ClockState_Enum_t NewState)
 {
     volatile CFE_TIME_ReferenceState_t *RefState;
 

--- a/modules/time/fsw/src/cfe_time_utils.h
+++ b/modules/time/fsw/src/cfe_time_utils.h
@@ -186,10 +186,10 @@ typedef struct
     /*
     ** Pending data values (from "time at tone" command data)...
     */
-    CFE_TIME_SysTime_t PendingMET;
-    CFE_TIME_SysTime_t PendingSTCF;
-    int16              PendingLeaps;
-    int16              PendingState;
+    CFE_TIME_SysTime_t         PendingMET;
+    CFE_TIME_SysTime_t         PendingSTCF;
+    int16                      PendingLeaps;
+    CFE_TIME_ClockState_Enum_t PendingState;
 
     /*
     ** STCF adjustment values...
@@ -395,13 +395,13 @@ CFE_TIME_SysTime_t CFE_TIME_CalculateUTC(const CFE_TIME_Reference_t *Reference);
 /**
  * @brief determine current time state (per API)
  */
-int16 CFE_TIME_CalculateState(const CFE_TIME_Reference_t *Reference);
+CFE_TIME_ClockState_Enum_t CFE_TIME_CalculateState(const CFE_TIME_Reference_t *Reference);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * @brief set clock state
  */
-void CFE_TIME_SetState(int16 NewState);
+void CFE_TIME_SetState(CFE_TIME_ClockState_Enum_t NewState);
 
 #if (CFE_PLATFORM_TIME_CFG_SOURCE == true)
 


### PR DESCRIPTION
**Describe the contribution**
Fixes issue #1546 by replacing uint16 with CFE_TIME_ClockState_Enum_t

**Testing performed**
Steps taken to test the contribution:
Built and ran unit tests

**Expected behavior changes**
no impact to behavior

**System(s) tested on**
 Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Oliver Hamburger GSFC
