### PR TITLE
Fix #1662, remove default .dat extension

### DIFF
--- a/modules/fs/fsw/src/cfe_fs_api.c
+++ b/modules/fs/fsw/src/cfe_fs_api.c
@@ -43,7 +43,6 @@
  * Fixed default file system extensions (not platform dependent)
  */
 const char CFE_FS_DEFAULT_SCRIPT_EXTENSION[]    = ".scr";
-const char CFE_FS_DEFAULT_DUMP_FILE_EXTENSION[] = ".dat";
 const char CFE_FS_DEFAULT_TEMP_FILE_EXTENSION[] = ".tmp";
 const char CFE_FS_DEFAULT_LOG_FILE_EXTENSION[]  = ".log";
 
@@ -104,9 +103,6 @@ const char *CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_t FileCategory)
             break;
         case CFE_FS_FileCategory_TEMP:
             Result = CFE_FS_DEFAULT_TEMP_FILE_EXTENSION;
-            break;
-        case CFE_FS_FileCategory_BINARY_DATA_DUMP:
-            Result = CFE_FS_DEFAULT_DUMP_FILE_EXTENSION;
             break;
         case CFE_FS_FileCategory_TEXT_LOG:
             Result = CFE_FS_DEFAULT_LOG_FILE_EXTENSION;

--- a/modules/fs/ut-coverage/fs_UT.c
+++ b/modules/fs/ut-coverage/fs_UT.c
@@ -407,7 +407,7 @@ void Test_CFE_FS_DefaultFileStrings(void)
     UtAssert_NULL(CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_UNKNOWN));
     UtAssert_ADDRESS_EQ(CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_DYNAMIC_MODULE),
                         GLOBAL_CONFIGDATA.Default_ModuleExtension);
-    UtAssert_NOT_NULL(CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_BINARY_DATA_DUMP));
+    UtAssert_NULL(CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_BINARY_DATA_DUMP));
     UtAssert_NOT_NULL(CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_TEXT_LOG));
     UtAssert_NOT_NULL(CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_SCRIPT));
     UtAssert_NOT_NULL(CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_TEMP));


### PR DESCRIPTION
**Describe the contribution**
Do not enforce/add a default extension to binary data files

Fixes #1662

**Testing performed**
Build and run all tests
Send SB "dump route table" command using filename without extension and confirm output file has no extension.

**Expected behavior changes**
No longer adds a ".dat" extension if omitted from command

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
