### PR TITLE
cFE Integration candidate: 2021-07-20

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -65,25 +65,24 @@ jobs:
 
       - name: Run cFS
         run: |
-          ./core-cpu1 | tee cFS_startup_cpu1.txt &
+          ./core-cpu1 &
           sleep 10
           ../host/cmdUtil --pktid=0x1806 --cmdcode=4 --endian=LE --string="20:CFE_TEST_APP" --string="20:CFE_TestMain" --string="64:cfe_testcase" --uint32=16384 --uint8=0 --uint8=0 --uint16=100 &
 
           sleep 30
-          counter=$(grep -c "CFE_TEST_APP" cFS_startup_cpu1.txt) &
+          counter=0 
 
-          while [[ -z $(grep -i "SUMMARY" cFS_startup_cpu1.txt) ]]; do
-            echo "Waiting for CFE Tests"
-            sleep 60
-
-            temp=$(grep -c "CFE_TEST_APP" cFS_startup_cpu1.txt) &
+          while [[ ! -f cf/cfe_test.log ]]; do 
+            temp=$(grep -c "BEGIN" cf/cfe_test.tmp) 
               
             if [ $temp -eq $counter ]; then
               echo "Test is frozen. Quiting"
               break
             fi
 
-            counter=$(grep -c "CFE_TEST_APP" cFS_startup_cpu1.txt) &              
+            counter=$(grep -c "BEGIN" cf/cfe_test.tmp)            
+            echo "Waiting for CFE Tests"
+            sleep 60
           done
           
           ../host/cmdUtil --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002
@@ -93,14 +92,14 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: cFS-startup-log-deprecate-true-${{ matrix.buildtype }}
-          path: ./build/exe/cpu1/cFS_startup_cpu1.txt
+          path: ./build/exe/cpu1/cf/cfe_test.log
 
       - name: Check for cFS Warnings
         run: |  
-          if [[ -z $(grep -i "SUMMARY.*FAIL::0.*TSF::0.*TTF::0" cFS_startup_cpu1.txt) ]]; then
+          if [[ -z $(grep -i "SUMMARY.*FAIL::0.*TSF::0.*TTF::0" cf/cfe_test.log) ]]; then
                   echo "Must resolve Test Failures in cFS Test App before submitting a pull request"
                   echo ""
-                  grep -i '\[ FAIL]\|\[  TSF]\|\[  TTF]' cFS_startup_cpu1.txt
+                  grep -i '\[ FAIL]\|\[  TSF]\|\[  TTF]' cf/cfe_test.log
                   exit -1
           fi
         working-directory: ./build/exe/cpu1/  

--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ The detailed cFE user's guide can be viewed at <https://github.com/nasa/cFS/blob
 
 ## Version History
 
+### Development Build: v6.8.0-rc1+dev762
+
+- Change CI to use Test Log.
+- remove default .dat extension
+- Update API doxygen list
+- update documentation for CFE_ES_GetPoolBufInfo
+- CFE_SB_MsgHdrSize returns size_t
+- improve SB coverage test
+- correct function name in UT_BSP_Unlock
+- See <https://github.com/nasa/cfe/pull/1665> and <https://github.com/nasa/cfs/pull/311>
+
 ### Development Build: v6.8.0-rc1+dev746
 
 - Size unit test table load buffer based on config

--- a/docs/cFE Application Developers Guide.md
+++ b/docs/cFE Application Developers Guide.md
@@ -971,10 +971,30 @@ ensure that sufficient memory is provided to store the mempool
 management structures in addition to the memory needed by the
 application. After initialization, mempool allocates fixed size blocks
 as requested from the application memory block. As each block is
-requested mempool creates a 12 byte block descriptor with management
+requested mempool creates a block descriptor with management
 structures as well as space for the user application data (see Figure
 5.1). The space for user data will be fixed in size and greater than or
 equal to the requested block size.
+
+The specific size of the management structure depends on the platform
+architecture word size and alignment requirements, and padding may be
+added as necessary to meet the system requirements.  For illustrative
+purposes, the examples below use sizes that are respresentative of a
+32-bit CPU with 32-bit buffer alignment with no extra alignment padding 
+added.  The pool overhead will increase on a 64-bit CPU with 64-bit
+alignment, or if pool alignment configured greater than 32 bits.  For
+more information on pool buffer alignment, see the description of 
+the `CFE_PLATFORM_ES_MEMPOOL_ALIGN_SIZE_MIN` configuration parameter.
+
+It should also be noted that while 64-bit CPU architectures are fully
+supported by the memory pool internal implementation in current CFE 
+versions, the API is carried over from older CFE versions in order to
+be backward compatible.  Some memory pool API functions (e.g.
+`CFE_ES_GetPoolBufInfo`, `CFE_ES_PutPoolBuf`, etc) return a buffer size
+on success, which is encoded into an `int32` return type.  As a result,
+individual memory pools should not exceed 2GB in size, even on 64-bit
+platforms, to avoid exceeding the representable range of an `int32` data
+type.
 
 ![](.//media/cFE_Application_Developers_Guide_image13.png)
 

--- a/docs/src/cfe_api.dox
+++ b/docs/src/cfe_api.dox
@@ -25,20 +25,29 @@
     <UL>
       <LI> #CFE_ES_GetResetType - \copybrief CFE_ES_GetResetType
       <LI> #CFE_ES_GetAppID - \copybrief CFE_ES_GetAppID
+      <LI> #CFE_ES_GetTaskID - \copybrief CFE_ES_GetTaskID
       <LI> #CFE_ES_GetAppIDByName - \copybrief CFE_ES_GetAppIDByName
+      <LI> #CFE_ES_GetLibIDByName - \copybrief CFE_ES_GetLibIDByName
       <LI> #CFE_ES_GetAppName - \copybrief CFE_ES_GetAppName
+      <LI> #CFE_ES_GetLibName - \copybrief CFE_ES_GetLibName
       <LI> #CFE_ES_GetAppInfo - \copybrief CFE_ES_GetAppInfo
       <LI> #CFE_ES_GetTaskInfo - \copybrief CFE_ES_GetTaskInfo
+      <LI> #CFE_ES_GetLibInfo - \copybrief CFE_ES_GetLibInfo
+      <LI> #CFE_ES_GetModuleInfo - \copybrief CFE_ES_GetModuleInfo
     </UL>
     <LI> \ref CFEAPIESChildTask
     <UL>
       <LI> #CFE_ES_CreateChildTask - \copybrief CFE_ES_CreateChildTask
+      <LI> #CFE_ES_GetTaskIDByName - \copybrief CFE_ES_GetTaskIDByName
+      <LI> #CFE_ES_GetTaskName - \copybrief CFE_ES_GetTaskName
       <LI> #CFE_ES_DeleteChildTask - \copybrief CFE_ES_DeleteChildTask
       <LI> #CFE_ES_ExitChildTask - \copybrief CFE_ES_ExitChildTask
     </UL>
     <LI> \ref CFEAPIESCritData
     <UL>
       <LI> #CFE_ES_RegisterCDS - \copybrief CFE_ES_RegisterCDS
+      <LI> #CFE_ES_GetCDSBlockIDByName - \copybrief CFE_ES_GetCDSBlockIDByName
+      <LI> #CFE_ES_GetCDSBlockName - \copybrief CFE_ES_GetCDSBlockName
       <LI> #CFE_ES_CopyToCDS - \copybrief CFE_ES_CopyToCDS
       <LI> #CFE_ES_RestoreFromCDS - \copybrief CFE_ES_RestoreFromCDS
     </UL>
@@ -47,6 +56,7 @@
       <LI> #CFE_ES_PoolCreate - \copybrief CFE_ES_PoolCreate
       <LI> #CFE_ES_PoolCreateEx - \copybrief CFE_ES_PoolCreateEx
       <LI> #CFE_ES_PoolCreateNoSem - \copybrief CFE_ES_PoolCreateNoSem
+      <LI> #CFE_ES_PoolDelete - \copybrief CFE_ES_PoolDelete
       <LI> #CFE_ES_GetPoolBuf - \copybrief CFE_ES_GetPoolBuf
       <LI> #CFE_ES_PutPoolBuf - \copybrief CFE_ES_PutPoolBuf
       <LI> #CFE_ES_GetMemPoolStats - \copybrief CFE_ES_GetMemPoolStats
@@ -66,12 +76,21 @@
       <LI> #CFE_ES_SetGenCount - \copybrief CFE_ES_SetGenCount
       <LI> #CFE_ES_GetGenCount - \copybrief CFE_ES_GetGenCount
       <LI> #CFE_ES_GetGenCounterIDByName - \copybrief CFE_ES_GetGenCounterIDByName
+      <LI> #CFE_ES_GetGenCounterName - \copybrief CFE_ES_GetGenCounterName
     </UL>
     <LI> \ref CFEAPIESMisc
     <UL>
+      <LI> #CFE_ES_BackgroundWakeup - \copybrief CFE_ES_BackgroundWakeup
       <LI> #CFE_ES_CalculateCRC - \copybrief CFE_ES_CalculateCRC
       <LI> #CFE_ES_WriteToSysLog - \copybrief CFE_ES_WriteToSysLog
       <LI> #CFE_ES_ProcessAsyncEvent - \copybrief CFE_ES_ProcessAsyncEvent
+    </UL>
+    <LI> \ref CFEAPIESResourceID
+    <UL>
+      <LI> #CFE_ES_AppID_ToIndex - \copybrief CFE_ES_AppID_ToIndex
+      <LI> #CFE_ES_LibID_ToIndex - \copybrief CFE_ES_LibID_ToIndex
+      <LI> #CFE_ES_TaskID_ToIndex - \copybrief CFE_ES_TaskID_ToIndex
+      <LI> #CFE_ES_CounterID_ToIndex - \copybrief CFE_ES_CounterID_ToIndex
     </UL>
   </UL>
 
@@ -105,16 +124,83 @@
     </UL>
     <LI> \ref CFEAPIFSUtil
     <UL>
+          <LI> #CFE_FS_GetDefaultMountPoint - \copybrief CFE_FS_GetDefaultMountPoint
+          <LI> #CFE_FS_GetDefaultExtension - \copybrief CFE_FS_GetDefaultExtension
+          <LI> #CFE_FS_ParseInputFileNameEx - \copybrief CFE_FS_ParseInputFileNameEx
+          <LI> #CFE_FS_ParseInputFileName - \copybrief CFE_FS_ParseInputFileName
 	  <LI> #CFE_FS_ExtractFilenameFromPath - \copybrief CFE_FS_ExtractFilenameFromPath
+          <LI> #CFE_FS_BackgroundFileDumpRequest - \copybrief CFE_FS_BackgroundFileDumpRequest
+          <LI> #CFE_FS_BackgroundFileDumpIsPending - \copybrief CFE_FS_BackgroundFileDumpIsPending
     </UL>
   </UL>
 
-  <H4> Software Bus API </H4>
+  <H4> Message API </H4>
+  <UL>
+    <LI> \ref CFEAPIMSGHeader
+    <UL>
+      <LI> #CFE_MSG_Init - \copybrief CFE_MSG_Init
+      <LI> #CFE_MSG_GetSize - \copybrief CFE_MSG_GetSize
+      <LI> #CFE_MSG_SetSize - \copybrief CFE_MSG_SetSize
+      <LI> #CFE_MSG_GetType - \copybrief CFE_MSG_GetType
+      <LI> #CFE_MSG_SetType - \copybrief CFE_MSG_SetType
+      <LI> #CFE_MSG_GetHeaderVersion - \copybrief CFE_MSG_GetHeaderVersion
+      <LI> #CFE_MSG_SetHeaderVersion - \copybrief CFE_MSG_SetHeaderVersion
+      <LI> #CFE_MSG_GetHasSecondaryHeader - \copybrief CFE_MSG_GetHasSecondaryHeader
+      <LI> #CFE_MSG_SetHasSecondaryHeader - \copybrief CFE_MSG_SetHasSecondaryHeader
+      <LI> #CFE_MSG_GetApId - \copybrief CFE_MSG_GetApId
+      <LI> #CFE_MSG_SetApId - \copybrief CFE_MSG_SetApId
+      <LI> #CFE_MSG_GetSegmentationFlag - \copybrief CFE_MSG_GetSegmentationFlag
+      <LI> #CFE_MSG_SetSegmentationFlag - \copybrief CFE_MSG_SetSegmentationFlag
+      <LI> #CFE_MSG_GetSequenceCount - \copybrief CFE_MSG_GetSequenceCount
+      <LI> #CFE_MSG_SetSequenceCount - \copybrief CFE_MSG_SetSequenceCount
+      <LI> #CFE_MSG_GetNextSequenceCount - \copybrief CFE_MSG_GetNextSequenceCount
+      <LI> #CFE_MSG_GetEDSVersion - \copybrief CFE_MSG_GetEDSVersion
+      <LI> #CFE_MSG_SetEDSVersion - \copybrief CFE_MSG_SetEDSVersion
+      <LI> #CFE_MSG_GetEndian - \copybrief CFE_MSG_GetEndian
+      <LI> #CFE_MSG_SetEndian - \copybrief CFE_MSG_SetEndian
+      <LI> #CFE_MSG_GetPlaybackFlag - \copybrief CFE_MSG_GetPlaybackFlag
+      <LI> #CFE_MSG_SetPlaybackFlag - \copybrief CFE_MSG_SetPlaybackFlag
+      <LI> #CFE_MSG_GetSubsystem - \copybrief CFE_MSG_GetSubsystem
+      <LI> #CFE_MSG_SetSubsystem - \copybrief CFE_MSG_SetSubsystem
+      <LI> #CFE_MSG_GetSystem - \copybrief CFE_MSG_GetSystem
+      <LI> #CFE_MSG_SetSystem - \copybrief CFE_MSG_SetSystem
+      <LI> #CFE_MSG_GenerateChecksum - \copybrief CFE_MSG_GenerateChecksum
+      <LI> #CFE_MSG_ValidateChecksum - \copybrief CFE_MSG_ValidateChecksum
+      <LI> #CFE_MSG_SetFcnCode - \copybrief CFE_MSG_SetFcnCode
+      <LI> #CFE_MSG_GetFcnCode - \copybrief CFE_MSG_GetFcnCode
+      <LI> #CFE_MSG_GetMsgTime - \copybrief CFE_MSG_GetMsgTime
+      <LI> #CFE_MSG_SetMsgTime - \copybrief CFE_MSG_SetMsgTime
+    </UL>
+    <LI> \ref CFEAPIMSGMsgId
+    <UL>
+      <LI> #CFE_MSG_GetMsgId - \copybrief CFE_MSG_GetMsgId
+      <LI> #CFE_MSG_SetMsgId - \copybrief CFE_MSG_SetMsgId
+      <LI> #CFE_MSG_GetTypeFromMsgId - \copybrief CFE_MSG_GetTypeFromMsgId
+    </UL>
+  </UL>
+
+  <H4> Resource ID API </H4>
+  <UL>
+    <LI> cFE Resource Misc APIs
+    <UL>
+      <LI> #CFE_ResourceId_ToInteger - \copybrief CFE_ResourceId_ToInteger
+      <LI> #CFE_ResourceId_FromInteger - \copybrief CFE_ResourceId_FromInteger
+      <LI> #CFE_ResourceId_Equal - \copybrief CFE_ResourceId_Equal
+      <LI> #CFE_ResourceId_IsDefined - \copybrief CFE_ResourceId_IsDefined
+      <LI> #CFE_ResourceId_GetBase - \copybrief CFE_ResourceId_GetBase
+      <LI> #CFE_ResourceId_GetSerial - \copybrief CFE_ResourceId_GetSerial
+      <LI> #CFE_ResourceId_FindNext - \copybrief CFE_ResourceId_FindNext
+      <LI> #CFE_ResourceId_ToIndex - \copybrief CFE_ResourceId_ToIndex
+    </UL>
+  </UL>
+
+  <H4> Software Bus Services API </H4>
   <UL>
     <LI> \ref CFEAPISBPipe
     <UL>
       <LI> #CFE_SB_CreatePipe - \copybrief CFE_SB_CreatePipe
       <LI> #CFE_SB_DeletePipe - \copybrief CFE_SB_DeletePipe
+      <LI> #CFE_SB_PipeId_ToIndex - \copybrief CFE_SB_PipeId_ToIndex
       <LI> #CFE_SB_SetPipeOpts - \copybrief CFE_SB_SetPipeOpts
       <LI> #CFE_SB_GetPipeOpts - \copybrief CFE_SB_GetPipeOpts
       <LI> #CFE_SB_GetPipeName - \copybrief CFE_SB_GetPipeName
@@ -141,29 +227,19 @@
     </UL>
     <LI> \ref CFEAPISBSetMessage
     <UL>
-      <LI> #CFE_MSG_Init - \copybrief CFE_MSG_Init
-      <LI> #CFE_MSG_SetMsgId - \copybrief CFE_MSG_SetMsgId
       <LI> #CFE_SB_SetUserDataLength - \copybrief CFE_SB_SetUserDataLength
-      <LI> #CFE_MSG_SetSize - \copybrief CFE_MSG_SetSize
-      <LI> #CFE_MSG_SetMsgTime - \copybrief CFE_MSG_SetMsgTime
       <LI> #CFE_SB_TimeStampMsg - \copybrief CFE_SB_TimeStampMsg
-      <LI> #CFE_MSG_SetFcnCode - \copybrief CFE_MSG_SetFcnCode
-      <LI> #CFE_MSG_SetSequenceCount - \copybrief CFE_MSG_SetSequenceCount
       <LI> #CFE_SB_MessageStringSet - \copybrief CFE_SB_MessageStringSet
     </UL>
     <LI> \ref CFEAPIGetMessage
     <UL>
       <LI> #CFE_SB_GetUserData - \copybrief CFE_SB_GetUserData
-      <LI> #CFE_MSG_GetMsgId - \copybrief CFE_MSG_GetMsgId
       <LI> #CFE_SB_GetUserDataLength - \copybrief CFE_SB_GetUserDataLength
-      <LI> #CFE_MSG_GetSize - \copybrief CFE_MSG_GetSize
-      <LI> #CFE_MSG_GetMsgTime - \copybrief CFE_MSG_GetMsgTime
-      <LI> #CFE_MSG_GetFcnCode - \copybrief CFE_MSG_GetFcnCode
-      <LI> #CFE_MSG_GetTypeFromMsgId - \copybrief CFE_MSG_GetTypeFromMsgId
       <LI> #CFE_SB_MessageStringGet - \copybrief CFE_SB_MessageStringGet
     </UL>
     <LI> \ref CFEAPISBMessageID
     <UL>
+      <LI> #CFE_SB_IsValidMsgId - \copybrief CFE_SB_IsValidMsgId
       <LI> #CFE_SB_MsgId_Equal - \copybrief CFE_SB_MsgId_Equal
       <LI> #CFE_SB_MsgIdToValue - \copybrief CFE_SB_MsgIdToValue
       <LI> #CFE_SB_ValueToMsgId - \copybrief CFE_SB_ValueToMsgId

--- a/modules/cfe_assert/src/cfe_assert_io.c
+++ b/modules/cfe_assert/src/cfe_assert_io.c
@@ -56,7 +56,7 @@ void UT_BSP_Unlock(void)
     rc = OS_MutSemGive(CFE_Assert_Global.AccessMutex);
     if (rc != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("%s(): Error from OS_MutSemTake(): %d\n", __func__, (int)rc);
+        CFE_ES_WriteToSysLog("%s(): Error from OS_MutSemGive(): %d\n", __func__, (int)rc);
     }
 }
 

--- a/modules/core_api/fsw/inc/cfe_es.h
+++ b/modules/core_api/fsw/inc/cfe_es.h
@@ -1343,8 +1343,7 @@ int32 CFE_ES_GetPoolBuf(CFE_ES_MemPoolBuf_t *BufPtr, CFE_ES_MemHandle_t Handle, 
 **
 ** \param[in]   BufPtr  A pointer to the memory buffer to provide status for.
 **
-** \return Execution status, see \ref CFEReturnCodes
-** \retval #CFE_SUCCESS                       \copybrief CFE_SUCCESS
+** \return Size of the buffer if successful, or status code if not successful, see \ref CFEReturnCodes
 ** \retval #CFE_ES_ERR_RESOURCEID_NOT_VALID   \copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID
 ** \retval #CFE_ES_BUFFER_NOT_IN_POOL         \copybrief CFE_ES_BUFFER_NOT_IN_POOL
 ** \retval #CFE_ES_BAD_ARGUMENT               \copybrief CFE_ES_BAD_ARGUMENT

--- a/modules/core_api/fsw/inc/cfe_sb.h
+++ b/modules/core_api/fsw/inc/cfe_sb.h
@@ -686,6 +686,7 @@ void *CFE_SB_GetUserData(CFE_MSG_Message_t *MsgPtr);
 **                     This must point to the first byte of the message header.
 **
 ** \return The size (in bytes) of the user data in the software bus message.
+** \retval 0 if an error occurs, such as if the MsgPtr argument is not valid.
 **/
 size_t CFE_SB_GetUserDataLength(const CFE_MSG_Message_t *MsgPtr);
 

--- a/modules/core_api/fsw/inc/cfe_version.h
+++ b/modules/core_api/fsw/inc/cfe_version.h
@@ -28,7 +28,7 @@
 #define CFE_VERSION_H
 
 /* Development Build Macro Definitions */
-#define CFE_BUILD_NUMBER   746          /**< @brief Development: Number of development commits since baseline */
+#define CFE_BUILD_NUMBER   762          /**< @brief Development: Number of development commits since baseline */
 #define CFE_BUILD_BASELINE "v6.8.0-rc1" /**< @brief Development: Reference git tag for build number */
 
 /* Version Macro Definitions updated for official releases only */

--- a/modules/fs/fsw/src/cfe_fs_api.c
+++ b/modules/fs/fsw/src/cfe_fs_api.c
@@ -43,7 +43,6 @@
  * Fixed default file system extensions (not platform dependent)
  */
 const char CFE_FS_DEFAULT_SCRIPT_EXTENSION[]    = ".scr";
-const char CFE_FS_DEFAULT_DUMP_FILE_EXTENSION[] = ".dat";
 const char CFE_FS_DEFAULT_TEMP_FILE_EXTENSION[] = ".tmp";
 const char CFE_FS_DEFAULT_LOG_FILE_EXTENSION[]  = ".log";
 
@@ -104,9 +103,6 @@ const char *CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_t FileCategory)
             break;
         case CFE_FS_FileCategory_TEMP:
             Result = CFE_FS_DEFAULT_TEMP_FILE_EXTENSION;
-            break;
-        case CFE_FS_FileCategory_BINARY_DATA_DUMP:
-            Result = CFE_FS_DEFAULT_DUMP_FILE_EXTENSION;
             break;
         case CFE_FS_FileCategory_TEXT_LOG:
             Result = CFE_FS_DEFAULT_LOG_FILE_EXTENSION;

--- a/modules/fs/ut-coverage/fs_UT.c
+++ b/modules/fs/ut-coverage/fs_UT.c
@@ -407,7 +407,7 @@ void Test_CFE_FS_DefaultFileStrings(void)
     UtAssert_NULL(CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_UNKNOWN));
     UtAssert_ADDRESS_EQ(CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_DYNAMIC_MODULE),
                         GLOBAL_CONFIGDATA.Default_ModuleExtension);
-    UtAssert_NOT_NULL(CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_BINARY_DATA_DUMP));
+    UtAssert_NULL(CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_BINARY_DATA_DUMP));
     UtAssert_NOT_NULL(CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_TEXT_LOG));
     UtAssert_NOT_NULL(CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_SCRIPT));
     UtAssert_NOT_NULL(CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_TEMP));

--- a/modules/sb/fsw/src/cfe_sb_priv.h
+++ b/modules/sb/fsw/src/cfe_sb_priv.h
@@ -757,7 +757,8 @@ CFE_SB_DestinationD_t *CFE_SB_GetDestPtr(CFE_SBR_RouteId_t RouteId, CFE_SB_PipeI
 **                     if SB messages are implemented as CCSDS packets, the size of the header
 **                     is different for command vs. telemetry packets.
 **
-** \returns Estimated number of bytes in the message header for the given message
+** \returns Estimated number of bytes in the message header for the given message.
+** \retval 0 if an error occurs, such as if the MsgPtr argument is not valid or header type cannot be identified.
 **/
 size_t CFE_SB_MsgHdrSize(const CFE_MSG_Message_t *MsgPtr);
 

--- a/modules/sb/fsw/src/cfe_sb_util.c
+++ b/modules/sb/fsw/src/cfe_sb_util.c
@@ -53,7 +53,7 @@ size_t CFE_SB_MsgHdrSize(const CFE_MSG_Message_t *MsgPtr)
 
     if (MsgPtr == NULL)
     {
-        return CFE_SB_BAD_ARGUMENT;
+        return size;
     }
 
     CFE_MSG_GetHasSecondaryHeader(MsgPtr, &hassechdr);
@@ -117,7 +117,7 @@ size_t CFE_SB_GetUserDataLength(const CFE_MSG_Message_t *MsgPtr)
 
     if (MsgPtr == NULL)
     {
-        return CFE_SB_BAD_ARGUMENT;
+        return TotalMsgSize;
     }
 
     CFE_MSG_GetSize(MsgPtr, &TotalMsgSize);

--- a/modules/sb/ut-coverage/sb_UT.h
+++ b/modules/sb/ut-coverage/sb_UT.h
@@ -213,6 +213,22 @@ void Test_SB_AppInit_Sub2Fail(void);
 
 /*****************************************************************************/
 /**
+** \brief Test task init with a failure on third subscription request
+**
+** \par Description
+**        This function tests task init with a failure on third subscription
+**        request.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+******************************************************************************/
+void Test_SB_AppInit_Sub3Fail(void);
+
+/*****************************************************************************/
+/**
 ** \brief Test task init with a GetPool failure
 **
 ** \par Description
@@ -286,6 +302,21 @@ void Test_SB_Main_RcvErr(void);
 **        This function does not return a value.
 ******************************************************************************/
 void Test_SB_Main_InitErr(void);
+
+/*****************************************************************************/
+/**
+** \brief Test main task nominal path
+**
+** \par Description
+**        This function tests main task that gets a command successfully
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+******************************************************************************/
+void Test_SB_Main_Nominal(void);
 
 /*****************************************************************************/
 /**
@@ -1579,6 +1610,23 @@ void Test_Unsubscribe_Local(void);
 
 /*****************************************************************************/
 /**
+** \brief Test CFE internal API used to unsubscribe to a message with AppId
+**        (successful)
+**
+** \par Description
+**        This function tests locally unsubscribing to a message
+**        (successful).
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+******************************************************************************/
+void Test_Unsubscribe_AppId(void);
+
+/*****************************************************************************/
+/**
 ** \brief Test message unsubscription response to an invalid message ID
 **
 ** \par Description
@@ -2017,6 +2065,22 @@ void Test_TransmitMsgValidate_NoSubscribers(void);
 
 /*****************************************************************************/
 /**
+** \brief Test response to sending a message which has an invalid Msg ID
+**
+** \par Description
+**        This function tests the response to sending a message which has an
+**        invalid Message ID
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+******************************************************************************/
+void Test_TransmitMsgValidate_InvalidMsgId(void);
+
+/*****************************************************************************/
+/**
 ** \brief Test response to sending a message with the message size larger
 **        than allowed
 **
@@ -2254,6 +2318,21 @@ void Test_CFE_SB_SetGetUserDataLength(void);
 **        This function does not return a value.
 ******************************************************************************/
 void Test_CFE_SB_ValidateMsgId(void);
+
+/*****************************************************************************/
+/**
+** \brief Test Tracking List functions
+**
+** \par Description
+**        Test tracking list functions (some of which are inline)
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+******************************************************************************/
+void Test_CFE_SB_ZeroCopyReleaseAppId(void);
 
 /*****************************************************************************/
 /**


### PR DESCRIPTION
## Context

Part of <https://github.com/nasa/cfs/pull/311>

### Tests

cFE <https://github.com/nasa/cFE/pull/1665/checks>
Bundle <https://github.com/nasa/cfs/pull/311/checks>

## Description

### PR  #1660 

Fix #1635, Change CI to use Test Log.

### PR #1664

Fix #1662, remove default .dat extension 

### PR #1670

Fix #1646, Update API doxygen list

### PR #1671

Fix #1606, update documentation for CFE_ES_GetPoolBufInfo

### PR #1674

Fix #1667, CFE_SB_MsgHdrSize returns size_t 

### PR #1668 

Fix #471, improve SB coverage test 

### PR #1694  

Fix #1693, correct function name in UT_BSP_Unlock 
