### PR TITLE
Fix #471, improve SB coverage test

### DIFF
--- a/modules/sb/ut-coverage/sb_UT.h
+++ b/modules/sb/ut-coverage/sb_UT.h
@@ -213,6 +213,22 @@ void Test_SB_AppInit_Sub2Fail(void);
 
 /*****************************************************************************/
 /**
+** \brief Test task init with a failure on third subscription request
+**
+** \par Description
+**        This function tests task init with a failure on third subscription
+**        request.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+******************************************************************************/
+void Test_SB_AppInit_Sub3Fail(void);
+
+/*****************************************************************************/
+/**
 ** \brief Test task init with a GetPool failure
 **
 ** \par Description
@@ -286,6 +302,21 @@ void Test_SB_Main_RcvErr(void);
 **        This function does not return a value.
 ******************************************************************************/
 void Test_SB_Main_InitErr(void);
+
+/*****************************************************************************/
+/**
+** \brief Test main task nominal path
+**
+** \par Description
+**        This function tests main task that gets a command successfully
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+******************************************************************************/
+void Test_SB_Main_Nominal(void);
 
 /*****************************************************************************/
 /**
@@ -1579,6 +1610,23 @@ void Test_Unsubscribe_Local(void);
 
 /*****************************************************************************/
 /**
+** \brief Test CFE internal API used to unsubscribe to a message with AppId
+**        (successful)
+**
+** \par Description
+**        This function tests locally unsubscribing to a message
+**        (successful).
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+******************************************************************************/
+void Test_Unsubscribe_AppId(void);
+
+/*****************************************************************************/
+/**
 ** \brief Test message unsubscription response to an invalid message ID
 **
 ** \par Description
@@ -2017,6 +2065,22 @@ void Test_TransmitMsgValidate_NoSubscribers(void);
 
 /*****************************************************************************/
 /**
+** \brief Test response to sending a message which has an invalid Msg ID
+**
+** \par Description
+**        This function tests the response to sending a message which has an
+**        invalid Message ID
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+******************************************************************************/
+void Test_TransmitMsgValidate_InvalidMsgId(void);
+
+/*****************************************************************************/
+/**
 ** \brief Test response to sending a message with the message size larger
 **        than allowed
 **
@@ -2254,6 +2318,21 @@ void Test_CFE_SB_SetGetUserDataLength(void);
 **        This function does not return a value.
 ******************************************************************************/
 void Test_CFE_SB_ValidateMsgId(void);
+
+/*****************************************************************************/
+/**
+** \brief Test Tracking List functions
+**
+** \par Description
+**        Test tracking list functions (some of which are inline)
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+******************************************************************************/
+void Test_CFE_SB_ZeroCopyReleaseAppId(void);
 
 /*****************************************************************************/
 /**


### PR DESCRIPTION
**Describe the contribution**
Add test cases to exercise all functions, lines, and branches to the extent reasonably possible.  Improves the coverage stats
significantly:

  functions 98.9% -> 100%
  lines 96.4% -> 99.8%
  branches 87.1% -> 94.9%

Fixes #471

**Testing performed**
Build and run coverage test, check LCOV reports

**Expected behavior changes**
More complete branch/line coverage

**System(s) tested on**
Ubuntu

**Additional context**
Remaining uncovered lines/branches are not possible to be reached due to the way the code is structured, or because it would require an alternate implementation of SBR (note that SB+SBR are currently tested as a single unit, even though they are technically separate modules now).  For example, the "direct" SBR implementation cannot have collisions, hence the collision handling in SB cannot be reached.  Making stubs for SBR may allow this to be tested.  For example this conditional is not reachable with direct mode: https://github.com/nasa/cFE/blob/2afdbc16e360530a9b4bbe4e0dcc814f675c1acb/modules/sb/fsw/src/cfe_sb_api.c#L1125-L1130

Other lines in CFE_SB_AppInit are also not reachable (will report in separate issue ticket).

Additionally, many internal `switch` statements can only be reached with values for which there is a corresponding `case` - that is, there is no default case nor is it possible to reach the switch statement with any value other than the listed values.  However gcov still reports this as an un-executed branch even though all possible cases are indeed covered.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

