### PR TITLE
Fix #1667, CFE_SB_MsgHdrSize returns size_t but still attempts to ret…

### DIFF
--- a/modules/core_api/fsw/inc/cfe_sb.h
+++ b/modules/core_api/fsw/inc/cfe_sb.h
@@ -685,7 +685,7 @@ void *CFE_SB_GetUserData(CFE_MSG_Message_t *MsgPtr);
 ** \param[in]  MsgPtr  A pointer to the buffer that contains the software bus message.
 **                     This must point to the first byte of the message header.
 **
-** \return The size (in bytes) of the user data in the software bus message.
+** \return The size (in bytes) of the user data in the software bus message, returns 0 if *MsgPtr is Null
 **/
 size_t CFE_SB_GetUserDataLength(const CFE_MSG_Message_t *MsgPtr);
 

--- a/modules/core_api/fsw/inc/cfe_sb.h
+++ b/modules/core_api/fsw/inc/cfe_sb.h
@@ -685,7 +685,8 @@ void *CFE_SB_GetUserData(CFE_MSG_Message_t *MsgPtr);
 ** \param[in]  MsgPtr  A pointer to the buffer that contains the software bus message.
 **                     This must point to the first byte of the message header.
 **
-** \return The size (in bytes) of the user data in the software bus message, returns 0 if *MsgPtr is Null
+** \return The size (in bytes) of the user data in the software bus message.
+** \retval 0 if an error occurs, such as if the MsgPtr argument is not valid.
 **/
 size_t CFE_SB_GetUserDataLength(const CFE_MSG_Message_t *MsgPtr);
 

--- a/modules/sb/fsw/src/cfe_sb_priv.h
+++ b/modules/sb/fsw/src/cfe_sb_priv.h
@@ -757,7 +757,8 @@ CFE_SB_DestinationD_t *CFE_SB_GetDestPtr(CFE_SBR_RouteId_t RouteId, CFE_SB_PipeI
 **                     if SB messages are implemented as CCSDS packets, the size of the header
 **                     is different for command vs. telemetry packets.
 **
-** \returns Estimated number of bytes in the message header for the given message, returns 0 if *MsgPtr is Null
+** \returns Estimated number of bytes in the message header for the given message.
+** \retval 0 if an error occurs, such as if the MsgPtr argument is not valid or header type cannot be identified.
 **/
 size_t CFE_SB_MsgHdrSize(const CFE_MSG_Message_t *MsgPtr);
 

--- a/modules/sb/fsw/src/cfe_sb_priv.h
+++ b/modules/sb/fsw/src/cfe_sb_priv.h
@@ -757,7 +757,7 @@ CFE_SB_DestinationD_t *CFE_SB_GetDestPtr(CFE_SBR_RouteId_t RouteId, CFE_SB_PipeI
 **                     if SB messages are implemented as CCSDS packets, the size of the header
 **                     is different for command vs. telemetry packets.
 **
-** \returns Estimated number of bytes in the message header for the given message
+** \returns Estimated number of bytes in the message header for the given message, returns 0 if *MsgPtr is Null
 **/
 size_t CFE_SB_MsgHdrSize(const CFE_MSG_Message_t *MsgPtr);
 

--- a/modules/sb/fsw/src/cfe_sb_util.c
+++ b/modules/sb/fsw/src/cfe_sb_util.c
@@ -53,7 +53,7 @@ size_t CFE_SB_MsgHdrSize(const CFE_MSG_Message_t *MsgPtr)
 
     if (MsgPtr == NULL)
     {
-        return CFE_SB_BAD_ARGUMENT;
+        return size;
     }
 
     CFE_MSG_GetHasSecondaryHeader(MsgPtr, &hassechdr);
@@ -117,7 +117,7 @@ size_t CFE_SB_GetUserDataLength(const CFE_MSG_Message_t *MsgPtr)
 
     if (MsgPtr == NULL)
     {
-        return CFE_SB_BAD_ARGUMENT;
+        return TotalMsgSize;
     }
 
     CFE_MSG_GetSize(MsgPtr, &TotalMsgSize);


### PR DESCRIPTION
**Describe the contribution**
Fixes Issue #1667 by changing the return type in CFE_SB_MsgHdrSize and CFE_SB_GetUserDataLength

**Testing performed**
Build and ran unit tests

**Expected behavior changes**
CFE_SB_MsgHdrSize and CFE_SB_GetUserDataLength now return 0 when *MsgPtr is NULL

**System(s) tested on**
 Ubuntu 20.04

**Additional context**
Add any other context about the contribution here.

**Contributor Info**
Oliver Hamburger GSFC
