### PR TITLE
Fix #1693, correct function name in UT_BSP_Unlock

### DIFF
--- a/modules/cfe_assert/src/cfe_assert_io.c
+++ b/modules/cfe_assert/src/cfe_assert_io.c
@@ -56,7 +56,7 @@ void UT_BSP_Unlock(void)
     rc = OS_MutSemGive(CFE_Assert_Global.AccessMutex);
     if (rc != CFE_SUCCESS)
     {
-        CFE_ES_WriteToSysLog("%s(): Error from OS_MutSemTake(): %d\n", __func__, (int)rc);
+        CFE_ES_WriteToSysLog("%s(): Error from OS_MutSemGive(): %d\n", __func__, (int)rc);
     }
 }
 


### PR DESCRIPTION
**Describe the contribution**
Corrects the log message in UT_BSP_Unlock (in cfe_assert module) to match the OSAL function called (OS_MutSemGive).

Fixes #1693 

**Testing performed**
Build and run tests

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu

**Additional context**
Just for correctness, this log never happens in normal operation.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

