### PR TITLE
Fix #1698, correct return code check

### DIFF
--- a/modules/es/fsw/src/cfe_es_start.c
+++ b/modules/es/fsw/src/cfe_es_start.c
@@ -794,7 +794,7 @@ void CFE_ES_CreateObjects(void)
                      */
                     CFE_ES_LockSharedData(__func__, __LINE__);
 
-                    if (ReturnCode == OS_SUCCESS)
+                    if (ReturnCode == CFE_SUCCESS)
                     {
                         CFE_ES_AppRecordSetUsed(AppRecPtr, PendingAppId);
 
@@ -802,7 +802,6 @@ void CFE_ES_CreateObjects(void)
                         ** Increment the Core App counter.
                         */
                         CFE_ES_Global.RegisteredCoreApps++;
-                        ReturnCode = CFE_SUCCESS;
                     }
                     else
                     {


### PR DESCRIPTION
**Describe the contribution**
The return code of CFE_ES_StartAppTask is a CFE status code, so it should be compared to CFE_SUCCESS, not OS_SUCCESS.

Fixes #1698

**Testing performed**
Build and sanity check CFE, run all tests

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu

**Additional context**
No change to actual behavior here, this is just for type/symbol correctness

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
