### PR TITLE
Fix #1705, correct return code mismatches

### DIFF
--- a/modules/cfe_assert/src/cfe_assert_io.c
+++ b/modules/cfe_assert/src/cfe_assert_io.c
@@ -43,7 +43,7 @@ void UT_BSP_Lock(void)
     int32 rc;
 
     rc = OS_MutSemTake(CFE_Assert_Global.AccessMutex);
-    if (rc != CFE_SUCCESS)
+    if (rc != OS_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s(): Error from OS_MutSemTake(): %d\n", __func__, (int)rc);
     }
@@ -54,7 +54,7 @@ void UT_BSP_Unlock(void)
     int32 rc;
 
     rc = OS_MutSemGive(CFE_Assert_Global.AccessMutex);
-    if (rc != CFE_SUCCESS)
+    if (rc != OS_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s(): Error from OS_MutSemGive(): %d\n", __func__, (int)rc);
     }

--- a/modules/es/fsw/src/cfe_es_backgroundtask.c
+++ b/modules/es/fsw/src/cfe_es_backgroundtask.c
@@ -188,7 +188,7 @@ int32 CFE_ES_BackgroundInit(void)
                                     CFE_ES_BACKGROUND_CHILD_STACK_SIZE, CFE_ES_BACKGROUND_CHILD_PRIORITY,
                                     CFE_ES_BACKGROUND_CHILD_FLAGS);
 
-    if (status != OS_SUCCESS)
+    if (status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s: Failed to create background task: %08lx\n", __func__, (unsigned long)status);
         return status;

--- a/modules/es/fsw/src/cfe_es_cds.c
+++ b/modules/es/fsw/src/cfe_es_cds.c
@@ -488,7 +488,7 @@ int32 CFE_ES_ValidateCDS(void)
     /* Perform 2 checks to validate the CDS Memory Pool */
     /* First, determine if the first validity check field is correct */
     Status = CFE_ES_CDS_CacheFetch(&CDS->Cache, CDS_SIG_BEGIN_OFFSET, SIG_CDS_SIZE);
-    if (Status != CFE_PSP_SUCCESS)
+    if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s: 1st ReadFromCDS Failed. Status=0x%X\n", __func__, (unsigned int)Status);
         return Status;
@@ -504,7 +504,7 @@ int32 CFE_ES_ValidateCDS(void)
     TrailerOffset -= sizeof(CFE_ES_CDS_PersistentTrailer_t);
 
     Status = CFE_ES_CDS_CacheFetch(&CDS->Cache, TrailerOffset, SIG_CDS_SIZE);
-    if (Status != CFE_PSP_SUCCESS)
+    if (Status != CFE_SUCCESS)
     {
         /* BSP reported an error reading from CDS */
         CFE_ES_WriteToSysLog("%s: 2nd ReadFromCDS Failed. Status=0x%X\n", __func__, (unsigned int)Status);
@@ -599,7 +599,7 @@ int32 CFE_ES_InitCDSSignatures(void)
 
     CFE_ES_CDS_CachePreload(&CDS->Cache, CFE_ES_CDS_SIGNATURE_END, SigOffset, CFE_ES_CDS_SIGNATURE_LEN);
     Status = CFE_ES_CDS_CacheFlush(&CDS->Cache);
-    if (Status != CFE_PSP_SUCCESS)
+    if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s: '_CDSEnd_' write failed. Status=0x%08X\n", __func__,
                              (unsigned int)CDS->Cache.AccessStatus);

--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -1998,7 +1998,7 @@ int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistryCmd_t *data)
                                          CFE_FS_GetDefaultMountPoint(CFE_FS_FileCategory_BINARY_DATA_DUMP),
                                          CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_BINARY_DATA_DUMP));
 
-    if (Status != OS_SUCCESS)
+    if (Status != CFE_SUCCESS)
     {
         CFE_EVS_SendEvent(CFE_ES_CREATING_CDS_DUMP_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Error parsing CDS dump filename, Status=0x%08X", (unsigned int)Status);

--- a/modules/evs/fsw/src/cfe_evs_log.c
+++ b/modules/evs/fsw/src/cfe_evs_log.c
@@ -144,7 +144,7 @@ int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFileCmd_t *data)
                                          CFE_FS_GetDefaultMountPoint(CFE_FS_FileCategory_BINARY_DATA_DUMP),
                                          CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_BINARY_DATA_DUMP));
 
-    if (Result != OS_SUCCESS)
+    if (Result != CFE_SUCCESS)
     {
         EVS_SendEvent(CFE_EVS_ERR_CRLOGFILE_EID, CFE_EVS_EventType_ERROR,
                       "Write Log File Command Error: CFE_FS_ParseInputFileNameEx() = 0x%08X", (unsigned int)Result);

--- a/modules/time/fsw/src/cfe_time_task.c
+++ b/modules/time/fsw/src/cfe_time_task.c
@@ -145,7 +145,7 @@ int32 CFE_TIME_TaskInit(void)
 
     Status = OS_BinSemCreate(&CFE_TIME_Global.ToneSemaphore, CFE_TIME_SEM_TONE_NAME, CFE_TIME_SEM_VALUE,
                              CFE_TIME_SEM_OPTIONS);
-    if (Status != CFE_SUCCESS)
+    if (Status != OS_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s: Error creating tone semaphore:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
@@ -153,7 +153,7 @@ int32 CFE_TIME_TaskInit(void)
 
     Status = OS_BinSemCreate(&CFE_TIME_Global.LocalSemaphore, CFE_TIME_SEM_1HZ_NAME, CFE_TIME_SEM_VALUE,
                              CFE_TIME_SEM_OPTIONS);
-    if (Status != CFE_SUCCESS)
+    if (Status != OS_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s: Error creating local semaphore:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;


### PR DESCRIPTION
**Describe the contribution**
Make sure functions documented as CFE status check for CFE_SUCCESS, and functions documented as OSAL status check for OS_SUCCESS.

Fixes #1705

**Testing performed**
Build CFE, and run all tests

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu

**Additional context**
In practice all these symbols had value of 0, so this is no change, but its just using the correct success symbol per documented function return.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
