### PR TITLE
Fix #1645, Add resource ID API functional tests

### DIFF
--- a/modules/cfe_testcase/CMakeLists.txt
+++ b/modules/cfe_testcase/CMakeLists.txt
@@ -7,6 +7,7 @@ add_cfe_app(cfe_testcase
     src/es_cds_test.c
     src/es_misc_test.c
     src/es_mempool_test.c
+    src/es_resource_id_test.c
     src/evs_send_test.c
     src/fs_header_test.c
     src/fs_util_test.c

--- a/modules/cfe_testcase/src/cfe_test.c
+++ b/modules/cfe_testcase/src/cfe_test.c
@@ -55,6 +55,7 @@ void CFE_TestMain(void)
     ESInfoTestSetup();
     ESMemPoolTestSetup();
     ESMiscTestSetup();
+    ESResourceIDTestSetup();
     ESTaskTestSetup();
     EVSSendTestSetup();
     FSHeaderTestSetup();

--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -84,6 +84,7 @@ void ESCDSTestSetup(void);
 void ESInfoTestSetup(void);
 void ESMemPoolTestSetup(void);
 void ESMiscTestSetup(void);
+void ESResourceIDTestSetup(void);
 void ESTaskTestSetup(void);
 void EVSSendTestSetup(void);
 void FSHeaderTestSetup(void);

--- a/modules/cfe_testcase/src/es_resource_id_test.c
+++ b/modules/cfe_testcase/src/es_resource_id_test.c
@@ -1,0 +1,105 @@
+/*************************************************************************
+**
+**      GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**      Copyright (c) 2006-2019 United States Government as represented by
+**      the Administrator of the National Aeronautics and Space Administration.
+**      All Rights Reserved.
+**
+**      Licensed under the Apache License, Version 2.0 (the "License");
+**      you may not use this file except in compliance with the License.
+**      You may obtain a copy of the License at
+**
+**        http://www.apache.org/licenses/LICENSE-2.0
+**
+**      Unless required by applicable law or agreed to in writing, software
+**      distributed under the License is distributed on an "AS IS" BASIS,
+**      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**      See the License for the specific language governing permissions and
+**      limitations under the License.
+**
+** File: es_resource_id_test.c
+**
+** Purpose:
+**   Functional test of ES Resource ID APIs
+**
+**   Demonstration of how to register and use the UT assert functions.
+**
+*************************************************************************/
+
+/*
+ * Includes
+ */
+
+#include "cfe_test.h"
+
+void TestAppIDToIndex(void)
+{
+    UtPrintf("Testing: CFE_ES_AppID_ToIndex");
+    CFE_ES_AppId_t TestAppId;
+    uint32         TestAppIdx;
+    uint32         idx;
+    UtAssert_INT32_EQ(CFE_ES_GetAppID(&TestAppId), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_AppID_ToIndex(TestAppId, &TestAppIdx), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_AppID_ToIndex(TestAppId, &idx), CFE_SUCCESS);
+    UtAssert_UINT32_EQ(idx, TestAppIdx);
+
+    UtAssert_INT32_EQ(CFE_ES_AppID_ToIndex(TestAppId, NULL), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_AppID_ToIndex(CFE_ES_APPID_UNDEFINED, &TestAppIdx), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+}
+
+void TestLibIDToIndex(void)
+{
+    UtPrintf("Testing: CFE_ES_LibID_ToIndex");
+    const char *   LibName = "ASSERT_LIB";
+    CFE_ES_LibId_t LibId;
+    uint32         LibIdx;
+    uint32         idx;
+    UtAssert_INT32_EQ(CFE_ES_GetLibIDByName(&LibId, LibName), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_LibID_ToIndex(LibId, &LibIdx), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_LibID_ToIndex(LibId, &idx), CFE_SUCCESS);
+    UtAssert_UINT32_EQ(idx, LibIdx);
+
+    UtAssert_INT32_EQ(CFE_ES_LibID_ToIndex(LibId, NULL), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_LibID_ToIndex(CFE_ES_LIBID_UNDEFINED, &LibIdx), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+}
+
+void TestTaskIDToIndex(void)
+{
+    UtPrintf("Testing: CFE_ES_TaskID_ToIndex");
+    CFE_ES_TaskId_t TaskId;
+    uint32          TaskIdx;
+    uint32          idx;
+    UtAssert_INT32_EQ(CFE_ES_GetTaskID(&TaskId), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_TaskID_ToIndex(TaskId, &TaskIdx), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_TaskID_ToIndex(TaskId, &idx), CFE_SUCCESS);
+    UtAssert_UINT32_EQ(idx, TaskIdx);
+
+    UtAssert_INT32_EQ(CFE_ES_TaskID_ToIndex(TaskId, NULL), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_TaskID_ToIndex(CFE_ES_TASKID_UNDEFINED, &TaskIdx), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+}
+
+void TestCounterIDToIndex(void)
+{
+    UtPrintf("Testing: CFE_ES_CounterID_ToIndex");
+    const char *       CounterName = "TEST_COUNTER";
+    CFE_ES_CounterId_t CounterId;
+    uint32             CounterIdx;
+    uint32             idx;
+    UtAssert_UINT32_EQ(CFE_ES_RegisterGenCounter(&CounterId, CounterName), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_CounterID_ToIndex(CounterId, &CounterIdx), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_CounterID_ToIndex(CounterId, &idx), CFE_SUCCESS);
+    UtAssert_UINT32_EQ(idx, CounterIdx);
+
+    UtAssert_INT32_EQ(CFE_ES_CounterID_ToIndex(CounterId, NULL), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_CounterID_ToIndex(CFE_ES_COUNTERID_UNDEFINED, &CounterIdx),
+                      CFE_ES_ERR_RESOURCEID_NOT_VALID);
+}
+
+void ESResourceIDTestSetup(void)
+{
+    UtTest_Add(TestAppIDToIndex, NULL, NULL, "Test Obtaining indices from App ID");
+    UtTest_Add(TestLibIDToIndex, NULL, NULL, "Test Obtaining indices from Lib ID");
+    UtTest_Add(TestTaskIDToIndex, NULL, NULL, "Test Obtaining indices from Task ID");
+    UtTest_Add(TestCounterIDToIndex, NULL, NULL, "Test Obtaining indices from Counter ID");
+}


### PR DESCRIPTION
**Describe the contribution**
- Fixes #1645
- Adds functional tests for each of the following functions
  - CFE_ES_AppID_ToIndex
  - CFE_ES_LibID_ToIndex
  - CFE_ES_TaskID_ToIndex
  - CFE_ES_CounterID_ToIndex

**Testing performed**
Steps taken to test the contribution:
1. Build CFE and run all functional tests

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - no impact to behavior

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Niall Mullane - GSFC 582 Intern