### PR TITLE
Fix #1396, scrub command documentation

### DIFF
--- a/docs/cFE Application Developers Guide.md
+++ b/docs/cFE Application Developers Guide.md
@@ -980,14 +980,14 @@ The specific size of the management structure depends on the platform
 architecture word size and alignment requirements, and padding may be
 added as necessary to meet the system requirements.  For illustrative
 purposes, the examples below use sizes that are respresentative of a
-32-bit CPU with 32-bit buffer alignment with no extra alignment padding 
+32-bit CPU with 32-bit buffer alignment with no extra alignment padding
 added.  The pool overhead will increase on a 64-bit CPU with 64-bit
 alignment, or if pool alignment configured greater than 32 bits.  For
-more information on pool buffer alignment, see the description of 
+more information on pool buffer alignment, see the description of
 the `CFE_PLATFORM_ES_MEMPOOL_ALIGN_SIZE_MIN` configuration parameter.
 
 It should also be noted that while 64-bit CPU architectures are fully
-supported by the memory pool internal implementation in current CFE 
+supported by the memory pool internal implementation in current CFE
 versions, the API is carried over from older CFE versions in order to
 be backward compatible.  Some memory pool API functions (e.g.
 `CFE_ES_GetPoolBufInfo`, `CFE_ES_PutPoolBuf`, etc) return a buffer size
@@ -1893,7 +1893,7 @@ SAMPLE_AppData_t  SAMPLE_AppData;  /* Instantiate Task Data */
     CFE_SB_TransmitMsg(&SAMPLE_APP_Data.HkTlm.TlmHeader.Msg, true);
    ...
 }
-```  
+```
 
 ## 6.7 Receiving Software Bus Messages
 
@@ -2057,7 +2057,7 @@ SAMPLE_AppData_t  SAMPLE_AppData;  /* Instantiate Task Data */
 
 ## 6.9 Best Practices for using Software Bus
 
-The following are recommended "best practices" for applications using EVS.
+The following are recommended "best practices" for applications using SB.
 1. Applications should use the Software Bus for all communication with other
    applications.
 2. Pipe depth and message limits are dependent on the entire software system.

--- a/docs/src/cfe_es.dox
+++ b/docs/src/cfe_es.dox
@@ -404,7 +404,7 @@
 
   Or the #CFE_ES_QUERY_ALL_CC command can be used to get information about
   all the applications that are currently registered with ES. This command
-  writes the application data to a file and has a one parameter which 
+  writes the application data to a file and has a one parameter which
   specifies the path and filename of the output file.
 
   For either command, the following Application information is made available:
@@ -824,6 +824,13 @@
 
 /**
   \page cfeescmds cFE Executive Services Commands
+
+  Upon receipt of any command, the Executive Services application will confirm that the
+  message length embedded within the header (from `CFE_MSG_GetSize()`) matches the expected
+  length of that message, based on the size of the C structure defining that command.
+  If there is any discrepancy between the expected and actual message size, ES will generate
+  the #CFE_ES_LEN_ERR_EID event, increment the command error counter (\ES_CMDEC), and the
+  command will _not_ be accepted for processing.
 
   The following is a list of commands that are processed by the cFE Executive Services Task.
 **/

--- a/docs/src/cfe_evs.dox
+++ b/docs/src/cfe_evs.dox
@@ -108,7 +108,7 @@
   EVS can be configured to control the Local Event Log to either discard or overwrite
   the contents of the log when it becomes full.  If the mode is set to overwrite, the
   log is treated like a circular buffer, overwriting the oldest event message contained
-  in the log first.  This control is configured by default in the cfe_platform_cfg.h 
+  in the log first.  This control is configured by default in the cfe_platform_cfg.h
   file but can be modified by \link #CFE_EVS_SET_LOG_MODE_CC a command \endlink.
 
 
@@ -170,7 +170,7 @@
   the events that it wants to register for filtering along with the
   \ref cfeevsugmsgfilter (only the Binary Filtering Scheme
   exists currently).   Note that applications are limited in the number of events that
-  they can register for filtering (see #CFE_PLATFORM_EVS_MAX_EVENT_FILTERS in cfe_platform_cfg.h 
+  they can register for filtering (see #CFE_PLATFORM_EVS_MAX_EVENT_FILTERS in cfe_platform_cfg.h
   for the mission defined limit).  The filtering method uses a mask to determine if the
   message is forwarded to the software bus, making it available in telemetry (see
   \ref cfeevsugmsgfilter for a description on filtering).  Commands are available to
@@ -500,6 +500,13 @@
 /**
 **  \page cfeevscmds cFE Event Services Commands
 **
+**  Upon receipt of any command, the Event Services application will confirm that the
+**  message length embedded within the header (from `CFE_MSG_GetSize()`) matches the expected
+**  length of that message, based on the size of the C structure defining that command.
+**  If there is any discrepancy between the expected and actual message size, EVS will generate
+**  the #CFE_EVS_LEN_ERR_EID event, increment the command error counter (\EVS_CMDEC), and the
+**  command will _not_ be accepted for processing.
+**
 **  The following is a list of commands that are processed by the cFE Event Services Task.
 **/
 
@@ -515,4 +522,3 @@
 **  The following are configuration parameters used to configure the cFE Event Services
 **  either for each platform or for a mission as a whole.
 **/
-

--- a/docs/src/cfe_sb.dox
+++ b/docs/src/cfe_sb.dox
@@ -584,6 +584,13 @@
 /**
 **  \page cfesbcmds cFE Software Bus Commands
 **
+**  Upon receipt of any command, the Software Bus application will confirm that the
+**  message length embedded within the header (from `CFE_MSG_GetSize()`) matches the expected
+**  length of that message, based on the size of the C structure defining that command.
+**  If there is any discrepancy between the expected and actual message size, SB will generate
+**  the #CFE_SB_LEN_ERR_EID event, increment the command error counter (\SB_CMDEC), and the
+**  command will _not_ be accepted for processing.
+**
 **  The following is a list of commands that are processed by the cFE Software Bus Task.
 **/
 

--- a/docs/src/cfe_tbl.dox
+++ b/docs/src/cfe_tbl.dox
@@ -39,7 +39,7 @@
   updated (or in the case of dump-only tables, dumped).  Most Applications perform this periodic
   management at the same time as housekeeping requests are processed.  This table management is
   performed by the cFE Application that "owns" a table (ie - the cFE Application that registered
-  the table with cFE Table Services).  It is possible for cFE Applications to "share" a table with 
+  the table with cFE Table Services).  It is possible for cFE Applications to "share" a table with
   other cFE Applications.  An Application that shares a table does not typically perform any of the
   management duties associated with that table.
 
@@ -414,6 +414,13 @@
 /**
 **  \page cfetblcmds cFE Table Services Commands
 **
+**  Upon receipt of any command, the Table Services application will confirm that the
+**  message length embedded within the header (from `CFE_MSG_GetSize()`) matches the expected
+**  length of that message, based on the size of the C structure defining that command.
+**  If there is any discrepancy between the expected and actual message size, TBL will generate
+**  the #CFE_TBL_LEN_ERR_EID event, increment the command error counter (\TBL_CMDEC), and the
+**  command will _not_ be accepted for processing.
+**
 **  The following is a list of commands that are processed by the cFE Table Services Task.
 **/
 
@@ -429,4 +436,3 @@
 **  The following are configuration parameters used to configure the cFE Table Services
 **  either for each platform or for a mission as a whole.
 **/
-

--- a/docs/src/cfe_time.dox
+++ b/docs/src/cfe_time.dox
@@ -215,7 +215,7 @@
   In the third system, the MET is located on hardware connected via spacewire.  When MET seconds
   increment, a spacewire time tick triggers a local processor interrupt to signal the tone.
   Shortly after announcing the tone, the hardware containing the MET also generates a spacewire
-  data packet containing the MET value corresponding to the tone.  TIME must wait until both 
+  data packet containing the MET value corresponding to the tone.  TIME must wait until both
   the tone and data packet have been received before validating the tone.  The tone must have
   occurred approximately one second after the previous tone signal and the data packet must
   have been received within a specified window in time following the tone.
@@ -766,7 +766,7 @@
   that can be made to the STCF to compensate for oscillator drift.
   Mission specific ground correlation should be used to assist in
   determining the proper values to use. The Leap Seconds should be
-  set to the current TAI-UTC. Note that the International Earth 
+  set to the current TAI-UTC. Note that the International Earth
   Rotation and Reference Systems Service Bulletin C, which defines
   the current difference, reports it as UTC-TAI, and thus that value
   must be negated. <B>The Leap Seconds value will always be a positive
@@ -825,6 +825,13 @@
 /**
 **  \page cfetimecmds cFE Time Services Commands
 **
+**  Upon receipt of any command, the Time Services application will confirm that the
+**  message length embedded within the header (from `CFE_MSG_GetSize()`) matches the expected
+**  length of that message, based on the size of the C structure defining that command.
+**  If there is any discrepancy between the expected and actual message size, TIME will generate
+**  the #CFE_TIME_LEN_ERR_EID event, increment the command error counter (\TIME_CMDEC), and the
+**  command will _not_ be accepted for processing.
+**
 **  The following is a list of commands that are processed by the cFE Time Services Task.
 **/
 
@@ -840,4 +847,3 @@
 **  The following are configuration parameters used to configure the cFE Time Services
 **  either for each platform or for a mission as a whole.
 **/
-

--- a/modules/evs/fsw/inc/cfe_evs_msg.h
+++ b/modules/evs/fsw/inc/cfe_evs_msg.h
@@ -94,8 +94,10 @@
 **  \par Command Verification
 **       Successful execution of this command may be verified with
 **       the following telemetry:
-**       - \b \c \EVS_CMDPC - command execution counter will
-**         increment
+**       - \b \c \EVS_CMDPC - command execution counter
+**         will be reset to 0
+**       - \b \c \EVS_CMDEC - command error counter
+**         will be reset to 0
 **       - The #CFE_EVS_RSTCNT_EID debug event message will be
 **         generated
 **
@@ -146,8 +148,7 @@
 **
 **  \par Error Conditions
 **        This command may fail for the following reason(s):
-**
-**    	Invalid Event Type selection
+**    	 - BitMask field invalid - mask cannot be zero, and only bits 0-3 may be set
 **
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \EVS_CMDEC - command error counter will increment
@@ -195,9 +196,8 @@
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):
+**    	 - BitMask field invalid - mask cannot be zero, and only bits 0-3 may be set
 **
-**       - Invalid Event Type selection
-
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \EVS_CMDEC - command error counter will increment
 **       - An Error specific event message
@@ -245,9 +245,8 @@
 **       - The generation of #CFE_EVS_SETEVTFMTMOD_EID debug message
 **
 **  \par Error Conditions
-**      This command may fail for the following reason(s):
-**  	Invalid SB message (command) length
-**  	Invalid MODE selection
+**       This command may fail for the following reason(s):
+**  	 - Invalid MsgFormat mode selection
 **
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \EVS_CMDEC - command error counter will increment
@@ -295,8 +294,9 @@
 **       - The generation of #CFE_EVS_ENAAPPEVTTYPE_EID debug event message
 **
 **  \par Error Conditions
-**      This command may fail for the following reason(s):
-**      - Invalid Event Type Selection
+**       This command may fail for the following reason(s):
+**    	 - BitMask field invalid - mask cannot be zero, and only bits 0-3 may be set
+**       - Application name is not valid or not registered with event services
 **
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \EVS_CMDEC - command error counter will increment
@@ -346,8 +346,9 @@
 **       - The clearing of the Event Type Active Flag in The Event Type Active Flag in EVS App Data File
 **
 **  \par Error Conditions
-**      This command may fail for the following reason(s):
-**      - Invalid Event Type Selection
+**       This command may fail for the following reason(s):
+**    	 - BitMask field invalid - mask cannot be zero, and only bits 0-3 may be set
+**       - Application name is not valid or not registered with event services
 **
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \EVS_CMDEC - command error counter will increment
@@ -386,10 +387,8 @@
 **       - The setting of the Active Flag in The Active Flag in EVS App Data File
 **
 **  \par Error Conditions
-**      This command may fail for the following reason(s):
-**      - Invalid SB message (command) length
-**      - Application selected is not registered to receive Event Service
-**      - Application ID is out of range
+**       This command may fail for the following reason(s):
+**       - Application name is not valid or not registered with event services
 **
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \EVS_CMDEC - command error counter will increment
@@ -426,10 +425,8 @@
 **       - The generation of #CFE_EVS_DISAPPEVT_EID debug event message
 **
 **  \par Error Conditions
-**      This command may fail for the following reason(s):
-**      - Invalid SB message (command) length
-**      - Application selected is not registered to receive Event Service
-**      - Application ID is out of range
+**       This command may fail for the following reason(s):
+**       - Application name is not valid or not registered with event services
 **
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \EVS_CMDEC - command error counter will increment
@@ -467,10 +464,8 @@
 **       - The generation of #CFE_EVS_RSTEVTCNT_EID debug event message
 **
 **  \par Error Conditions
-**      This command may fail for the following reason(s):
-**      - Invalid SB message (command) length
-**      - Application selected is not registered to receive Event Service
-**      - Application ID is out of range
+**       This command may fail for the following reason(s):
+**       - Application name is not valid or not registered with event services
 **
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \EVS_CMDEC - command error counter will increment
@@ -506,10 +501,9 @@
 **       - The generation of #CFE_EVS_SETFILTERMSK_EID debug event message
 **
 **  \par Error Conditions
-**      This command may fail for the following reason(s):
-**      - Invalid SB message (command) length
-**      - Application selected is not registered to receive Event Service
-**      - Application ID is out of range
+**       This command may fail for the following reason(s):
+**       - Application name is not valid or not registered with event services
+**       - Specified event ID is not found in the application event filter
 **
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \EVS_CMDEC - command error counter will increment
@@ -553,9 +547,8 @@
 **       - The generation of #CFE_EVS_ENAPORT_EID debug event message
 **
 **  \par Error Conditions
-**      This command may fail for the following reason(s):
-**      - Invalid SB message (command) length
-**      - Invalid PORT selection
+**       This command may fail for the following reason(s):
+**    	 - BitMask field invalid - mask cannot be zero, and only bits 0-3 may be set
 **
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \EVS_CMDEC - command error counter will increment
@@ -593,9 +586,8 @@
 **       - The generation of #CFE_EVS_DISPORT_EID debug event message
 **
 **  \par Error Conditions
-**      This command may fail for the following reason(s):
-**      - Invalid SB message (command) length
-**      - Invalid PORT selection
+**       This command may fail for the following reason(s):
+**    	 - BitMask field invalid - mask cannot be zero, and only bits 0-3 may be set
 **
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \EVS_CMDEC - command error counter will increment
@@ -628,10 +620,9 @@
 **       - The generation of #CFE_EVS_RSTFILTER_EID debug event message
 **
 **  \par Error Conditions
-**      This command may fail for the following reason(s):
-**      - Invalid SB message (command) length
-**      - Application selected is not registered to receive Event Service
-**      - Application ID is out of range
+**       This command may fail for the following reason(s):
+**       - Application name is not valid or not registered with event services
+**       - Specified event ID is not found in the application event filter
 **
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \EVS_CMDEC - command error counter will increment
@@ -665,10 +656,8 @@
 **       - The generation of #CFE_EVS_RSTALLFILTER_EID debug event message
 **
 **  \par Error Conditions
-**      This command may fail for the following reason(s):
-**      - Invalid SB message (command) length
-**      - Application selected is not registered to receive Event Service
-**      - Application ID is out of range
+**       This command may fail for the following reason(s):
+**       - Application name is not valid or not registered with event services
 **
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \EVS_CMDEC - command error counter will increment
@@ -701,10 +690,10 @@
 **       - The generation of #CFE_EVS_ADDFILTER_EID debug event message
 **
 **  \par Error Conditions
-**      This command may fail for the following reason(s):
-**      - Invalid SB message (command) length
-**      - Application selected is not registered to receive Event Service
-**      - Application ID is out of range
+**       This command may fail for the following reason(s):
+**       - Application name is not valid or not registered with event services
+**       - Specified event ID is already added to the application event filter
+**       - Maximum number of event IDs already added to filter
 **
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \EVS_CMDEC - command error counter will increment
@@ -737,10 +726,9 @@
 **       - The generation of #CFE_EVS_DELFILTER_EID debug event message
 **
 **  \par Error Conditions
-**      This command may fail for the following reason(s):
-**      - Invalid SB message (command) length
-**      - Application selected is not registered to receive Event Service
-**      - Application ID is out of range
+**       This command may fail for the following reason(s):
+**       - Application name is not valid or not registered with event services
+**       - Specified event ID is not found in the application event filter
 **
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \EVS_CMDEC - command error counter will increment
@@ -771,11 +759,14 @@
 **       - \b \c \EVS_CMDPC - command execution counter will
 **       increment
 **       - The generation of #CFE_EVS_WRDAT_EID debug event message
-**       - The generation of the file written to
+**       - The file specified in the command (or the default specified
+**         by the #CFE_PLATFORM_EVS_DEFAULT_APP_DATA_FILE configuration parameter) will be
+**         updated with the lastest information.
 **
 **  \par Error Conditions
-**      This command may fail for the following reason(s):
-**      - Invalid SB message (command) length
+**       This command may fail for the following reason(s):
+**       - The specified FileName cannot be parsed
+**       - An Error occurs while trying to write to the file
 **
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \EVS_CMDEC - command error counter will increment
@@ -808,8 +799,9 @@
 **       - The generation of #CFE_EVS_WRLOG_EID debug event message
 **
 **  \par Error Conditions
-**      This command may fail for the following reason(s):
-**      - Invalid SB message (command) length
+**       This command may fail for the following reason(s):
+**       - The specified FileName cannot be parsed
+**       - An Error occurs while trying to write to the file
 **
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \EVS_CMDEC - command error counter will increment
@@ -841,9 +833,9 @@
 **       - The generation of #CFE_EVS_LOGMODE_EID debug event message
 **
 **  \par Error Conditions
-**      This command may fail for the following reason(s):
-**      - Invalid SB message (command) length
-**      - Invalid MODE selected
+**       This command may fail for the following reason(s):
+**       - Invalid LogMode selected - must be either #CFE_EVS_LogMode_OVERWRITE
+**         or #CFE_EVS_LogMode_DISCARD
 **
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \EVS_CMDEC - command error counter will increment
@@ -874,21 +866,21 @@
 **       the following telemetry:
 **       - \b \c \EVS_CMDPC - command execution counter will
 **       increment
+**       - \b \c \EVS_LOGFULL - The LogFullFlag in the Housekeeping
+**       telemetry will be cleared
+**       - \b \c \EVS_LOGOVERFLOWC - The LogOverflowCounter in the
+**       Housekeeping telemetry will be reset to 0
 **
 **  \par Error Conditions
-**      This command may fail for the following reason(s):
-**      - Invalid SB message (command) length
-**
-**       Evidence of failure may be found in the following telemetry:
-**       - \b \c \EVS_CMDEC - command error counter will increment
-**       - An Error specific event message
+**       There are no error conditions for this command. If the Event
+**       Services receives the command, the log is cleared.
 **
 **  \par Criticality
 **       Clearing the local event log is not particularly hazardous, as the
-**      result may be making available space to record valuable event data.
-**      However, inappropriately clearing the local event log could result
-**      in a loss of critical information.  Note: the event log is a back-up
-**      log to the on-board recorder.
+**       result may be making available space to record valuable event data.
+**       However, inappropriately clearing the local event log could result
+**       in a loss of critical information.  Note: the event log is a back-up
+**       log to the on-board recorder.
 **
 **  \sa #CFE_EVS_WRITE_LOG_DATA_FILE_CC, #CFE_EVS_SET_LOG_MODE_CC
 */

--- a/modules/sb/fsw/inc/cfe_sb_msg.h
+++ b/modules/sb/fsw/inc/cfe_sb_msg.h
@@ -84,6 +84,15 @@
 **       Bus housekeeping telemetry:
 **       - Command Execution Counter (\SB_CMDPC)
 **       - Command Error Counter (\SB_CMDEC)
+**       - No Subscribers Counter (\SB_NOSUBEC)
+**       - Duplicate Subscriptions Counter (\SB_DUPSUBCNT)
+**       - Msg Send Error Counter (\SB_MSGSNDEC)
+**       - Msg Receive Error Counter (\SB_MSGRECEC)
+**       - Internal Error Counter (\SB_INTERNALEC)
+**       - Create Pipe Error Counter (\SB_NEWPIPEEC)
+**       - Subscribe Error Counter (\SB_SUBSCREC)
+**       - Pipe Overflow Error Counter (\SB_PIPEOVREC)
+**       - Msg Limit Error Counter (\SB_MSGLIMEC)
 **
 **  \cfecmdmnemonic \SB_RESETCTRS
 **
@@ -94,7 +103,8 @@
 **       Successful execution of this command may be verified with the
 **       following telemetry:
 **       - \b \c \SB_CMDPC - command execution counter will
-**         increment
+**         be reset to 0
+**       - All other counters listed in description will be reset to 0
 **       - The #CFE_SB_CMD1_RCVD_EID informational event message will
 **         be generated
 **
@@ -132,8 +142,7 @@
 **       following telemetry:
 **       - \b \c \SB_CMDPC - command execution counter will increment
 **       - Receipt of statistics packet with MsgId #CFE_SB_STATS_TLM_MID
-**       - The #CFE_SB_SND_STATS_EID debug event message will be generated. All
-**         debug events are filtered by default.
+**       - The #CFE_SB_SND_STATS_EID debug event message will be generated
 **
 **  \par Error Conditions
 **       There are no error conditions for this command. If the Software
@@ -170,14 +179,17 @@
 **       Successful execution of this command may be verified with the
 **       following telemetry:
 **       - \b \c \SB_CMDPC - command execution counter will increment.
-**       - Specified filename created at specified location. See description.
-**       - The #CFE_SB_SND_RTG_EID debug event message will be generated. All
-**         debug events are filtered by default.
+**         NOTE: the command counter is incremented when the request is accepted,
+**         before writing the file, which is performed as a background task.
+**       - The file specified in the command (or the default specified
+**         by the #CFE_PLATFORM_SB_DEFAULT_ROUTING_FILENAME configuration parameter) will be
+**         updated with the lastest information.
+**       - The #CFE_SB_SND_RTG_EID debug event message will be generated
 **
 **  \par Error Conditions
-**       - Errors may occur during write operations to the file. Possible
-**         causes might be insufficient space in the file system or the
-**         filename or file path is improperly specified.
+**       This command may fail for the following reason(s):
+**       - A previous request to write a software bus information file has not yet completed
+**       - The specified FileName cannot be parsed
 **
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \SB_CMDEC - command error counter will increment
@@ -211,14 +223,14 @@
 **       - \b \c \SB_CMDPC - command execution counter will increment
 **       - View routing information #CFE_SB_WRITE_ROUTING_INFO_CC to verify
 **         enable/disable state change
-**       - The #CFE_SB_ENBL_RTE2_EID debug event message will be generated. All
-**         debug events are filtered by default.
-**       - Destination will begin receiving messages.
+**       - The #CFE_SB_ENBL_RTE2_EID debug event message will be generated
+**       - Destination will begin receiving messages
 **
 **  \par Error Conditions
-**       An Error may occur if the MsgId or PipeId parmaters do not pass
-**       validation or the destination does not exist.
-
+**       This command may fail for the following reason(s):
+**       - the MsgId or PipeId parmaters do not pass validation
+**       - the destination does not exist.
+**
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \SB_CMDEC - command error counter will increment
 **       - A command specific error event message is issued for all error
@@ -247,14 +259,14 @@
 **       - \b \c \SB_CMDPC - command execution counter will increment
 **       - View routing information #CFE_SB_WRITE_ROUTING_INFO_CC to verify
 **         enable/disable state change
-**       - The #CFE_SB_DSBL_RTE2_EID debug event message will be generated. All
-**         debug events are filtered by default.
-**       - Destination will stop receiving messages.
+**       - The #CFE_SB_DSBL_RTE2_EID debug event message will be generated
+**       - Destination will stop receiving messages
 **
 **  \par Error Conditions
-**       An Error may occur if the MsgId or PipeId parmaters do not pass
-**       validation or the destination does not exist.
-
+**       This command may fail for the following reason(s):
+**       - the MsgId or PipeId parmaters do not pass validation
+**       - the destination does not exist.
+**
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \SB_CMDEC - command error counter will increment
 **       - A command specific error event message is issued for all error
@@ -291,14 +303,17 @@
 **       Successful execution of this command may be verified with the
 **       following telemetry:
 **       - \b \c \SB_CMDPC - command execution counter will increment.
-**       - Specified filename created at specified location. See description.
-**       - The #CFE_SB_SND_RTG_EID debug event message will be generated. All
-**         debug events are filtered by default.
+**         NOTE: the command counter is incremented when the request is accepted,
+**         before writing the file, which is performed as a background task.
+**       - The file specified in the command (or the default specified
+**         by the #CFE_PLATFORM_SB_DEFAULT_PIPE_FILENAME configuration parameter) will be
+**         updated with the lastest information.
+**       - The #CFE_SB_SND_RTG_EID debug event message will be generated
 **
 **  \par Error Conditions
-**       - Errors may occur during write operations to the file. Possible
-**         causes might be insufficient space in the file system or the
-**         filename or file path is improperly specified.
+**       This command may fail for the following reason(s):
+**       - A previous request to write a software bus information file has not yet completed
+**       - The specified FileName cannot be parsed
 **
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \SB_CMDEC - command error counter will increment
@@ -334,14 +349,17 @@
 **       Successful execution of this command may be verified with the
 **       following telemetry:
 **       - \b \c \SB_CMDPC - command execution counter will increment.
-**       - Specified filename created at specified location. See description.
-**       - The #CFE_SB_SND_RTG_EID debug event message will be generated. All
-**         debug events are filtered by default.
+**         NOTE: the command counter is incremented when the request is accepted,
+**         before writing the file, which is performed as a background task.
+**       - The file specified in the command (or the default specified
+**         by the #CFE_PLATFORM_SB_DEFAULT_MAP_FILENAME configuration parameter) will be
+**         updated with the lastest information.
+**       - The #CFE_SB_SND_RTG_EID debug event message will be generated
 **
 **  \par Error Conditions
-**       - Errors may occur during write operations to the file. Possible
-**         causes might be insufficient space in the file system or the
-**         filename or file path is improperly specified.
+**       This command may fail for the following reason(s):
+**       - A previous request to write a software bus information file has not yet completed
+**       - The specified FileName cannot be parsed
 **
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \SB_CMDEC - command error counter will increment

--- a/modules/tbl/fsw/inc/cfe_tbl_msg.h
+++ b/modules/tbl/fsw/inc/cfe_tbl_msg.h
@@ -91,6 +91,7 @@
 **       - Successful Table Validations Counter (\TBL_VALSUCCESSCTR)
 **       - Failed Table Validations Counter (\TBL_VALFAILEDCTR)
 **       - Number of Table Validations Requested (\TBL_VALREQCTR)
+**       - Number of completed table validations (\TBL_VALCOMPLTDCTR)
 **
 **  \cfecmdmnemonic \TBL_RESETCTRS
 **
@@ -101,7 +102,7 @@
 **       Successful execution of this command may be verified with
 **       the following telemetry:
 **       - \b \c \TBL_CMDPC - command execution counter will
-**         increment
+**         be reset to 0
 **       - The #CFE_TBL_RESET_INF_EID debug event message will be
 **         generated
 **
@@ -145,16 +146,12 @@
 **       - Table name found in table image file's table header is not found
 **         in table registry (ie - The table associated with the table image
 **         in the file has not been registered by an application).
-**       - The table image file's header indicates the file contains 'x'
-**         number of bytes of data but the file contains less.
+**       - The table image file has an invalid or incorrect size.  The size of
+**         the image file must match the size field within in the header, and
+**         must also match the expected size of the table indicated in the registry.
 **       - No working buffers are available for the load.  This would indicate
 **         that too many single-buffered table loads are in progress at the same
 **         time.
-**       - The table image file's header indicates the data to be loaded is
-**         beyond the size of the table.  Either the number of bytes in the
-**         file are too many or the starting offset into the table is too high.
-**       - The table image file's header indicates there is no data in the
-**         file (ie - Number of bytes to load is zero).
 **       - An attempt is being made to load an uninitialized table with a file
 **         containing only a partial table image.
 **       - The table image file was unable to be opened.  Either the file does
@@ -254,7 +251,7 @@
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):
-**       - A single buffered table's inactive buffer was requested to be dumped
+**       - A single buffered table's inactive buffer was requested to be validated
 **         and no such buffer is currently allocated.
 **       - Too many validations have been requested simultaneously.  The operator
 **         must wait for one or more applications to perform their table validation
@@ -298,9 +295,9 @@
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):
-**       - A single buffered table's inactive buffer was requested to be
-**         dumped and no such buffer is currently allocated.
 **       - The specified table name was not found in the table registry.
+**       - The table was registered as a "dump only" type and thus cannot be activated
+**       - The table buffer has not been validated.
 **
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \TBL_CMDEC - command error counter will increment
@@ -340,6 +337,8 @@
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):
+**       - A table registry dump is already in progress, not yet completed
+**       - The specified DumpFilename could not be parsed
 **       - Error occurred during write operation to file. Possible
 **         causes might be insufficient space in the file system
 **         or the filename or file path is improperly specified.

--- a/modules/time/fsw/inc/cfe_time_msg.h
+++ b/modules/time/fsw/inc/cfe_time_msg.h
@@ -106,13 +106,14 @@
 **  \par Command Verification
 **       Successful execution of this command may be verified with the
 **       following telemetry:
-**       - \b \c \TIME_CMDPC - command execution counter will increment
+**       - \b \c \TIME_CMDPC - command execution counter will reset to 0
+**       - \b \c \TIME_CMDEC - command error counter will reset to 0
 **       - The #CFE_TIME_RESET_EID informational event message will be generated
 **
 **  \par Error Conditions
 **       There are no error conditions for this command. If the Time
 **       Services receives the command, the event is sent (although it
-**       may be filtered by EVS) and the counter is incremented
+**       may be filtered by EVS) and the counter is reset
 **       unconditionally.
 **
 **  \par Criticality
@@ -238,7 +239,7 @@
 **       Successful execution of this command may be verified with the
 **       following telemetry:
 **       - \b \c \TIME_CMDPC - command execution counter will increment
-**       - \b \c \TIME_STATEFLG - Housekeeping Telemetry point "may"l indicate the
+**       - \b \c \TIME_STATEFLG - Housekeeping Telemetry point "may" indicate the
 **         command specified value (see above)
 **       - The #CFE_TIME_STATE_EID informational event message will be generated
 **


### PR DESCRIPTION
**Describe the contribution**
Update documentation for all command codes in CFE core apps, in particular the error conditions, to confirm it matches the
actual implementation.

For common operations that apply to all commmands (length verification) this is now put into the users guide as a general statement rather than repeating the info in every command.

Fixes #1396 
Fixes #1395 

**Testing performed**
Build documentation and confirm output

**Expected behavior changes**
None (docs only)

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
