### PR TITLE
Fix #806, Add application control functional tests

### DIFF
--- a/modules/cfe_testcase/CMakeLists.txt
+++ b/modules/cfe_testcase/CMakeLists.txt
@@ -2,6 +2,7 @@
 # Create the app module
 add_cfe_app(cfe_testcase
     src/cfe_test.c
+    src/es_application_control_test.c
     src/es_info_test.c
     src/es_task_test.c
     src/es_cds_test.c

--- a/modules/cfe_testcase/src/cfe_test.c
+++ b/modules/cfe_testcase/src/cfe_test.c
@@ -51,6 +51,7 @@ void CFE_TestMain(void)
     /*
      * Register test cases in UtAssert
      */
+    ESApplicationControlTestSetup();
     ESCDSTestSetup();
     ESInfoTestSetup();
     ESMemPoolTestSetup();

--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -78,6 +78,7 @@ typedef struct
 #define cFE_FTAssert_VOIDCALL(func) (func, UtAssert(true, #func, __FILE__, __LINE__))
 
 void CFE_TestMain(void);
+void ESApplicationControlTestSetup(void);
 void ESCDSTestSetup(void);
 void ESInfoTestSetup(void);
 void ESMemPoolTestSetup(void);

--- a/modules/cfe_testcase/src/es_application_control_test.c
+++ b/modules/cfe_testcase/src/es_application_control_test.c
@@ -1,0 +1,62 @@
+/*************************************************************************
+**
+**      GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**      Copyright (c) 2006-2019 United States Government as represented by
+**      the Administrator of the National Aeronautics and Space Administration.
+**      All Rights Reserved.
+**
+**      Licensed under the Apache License, Version 2.0 (the "License");
+**      you may not use this file except in compliance with the License.
+**      You may obtain a copy of the License at
+**
+**        http://www.apache.org/licenses/LICENSE-2.0
+**
+**      Unless required by applicable law or agreed to in writing, software
+**      distributed under the License is distributed on an "AS IS" BASIS,
+**      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**      See the License for the specific language governing permissions and
+**      limitations under the License.
+**
+** File: es_application_control_test.c
+**
+** Purpose:
+**   Functional test of ES Application Control APIs
+**
+**   Tests only invalid calls to the application control functions.
+**
+**   Demonstration of how to register and use the UT assert functions.
+**
+*************************************************************************/
+
+/*
+ * Includes
+ */
+
+#include "cfe_test.h"
+
+void TestApplicationControl(void)
+{
+    UtPrintf("Testing: CFE_ES_RestartApp, CFE_ES_ReloadApp, CFE_ES_DeleteApp");
+    CFE_ES_AppId_t TestAppId;
+    UtAssert_INT32_EQ(CFE_ES_GetAppID(&TestAppId), CFE_SUCCESS);
+
+    UtAssert_UINT32_EQ(CFE_ES_RestartApp(CFE_ES_APPID_UNDEFINED), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+    /*
+     * This seems a bit strange that it throws a file io error
+     * CFE_ES_ReloadApp calls OS_stat with the null filename
+     * OS_stat should return OS_INVALID_POINTER, but the exact
+     * error is ignored in CFE_ES_ReloadApp and file io error is returned
+     * most other functions return a CFE_ES_BAD_ARGUMENT in this situation
+     */
+    UtAssert_UINT32_EQ(CFE_ES_ReloadApp(TestAppId, NULL), CFE_ES_FILE_IO_ERR);
+    UtAssert_UINT32_EQ(CFE_ES_ReloadApp(TestAppId, "/cf/NOT_cfe_testcase.so"), CFE_ES_FILE_IO_ERR);
+    UtAssert_UINT32_EQ(CFE_ES_ReloadApp(CFE_ES_APPID_UNDEFINED, "/cf/cfe_testcase.so"),
+                       CFE_ES_ERR_RESOURCEID_NOT_VALID);
+    UtAssert_UINT32_EQ(CFE_ES_DeleteApp(CFE_ES_APPID_UNDEFINED), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+}
+
+void ESApplicationControlTestSetup(void)
+{
+    UtTest_Add(TestApplicationControl, NULL, NULL, "Test Application Control API");
+}


### PR DESCRIPTION
**Describe the contribution**
A clear and concise description of what the contribution is.
- Fixes #806
- Fixes #1324
- Adds functional tests for
  - CFE_ES_RestartApp
  - CFE_ES_ReloadApp
  - CFE_ES_DeleteApp

**Testing performed**
Steps taken to test the contribution:
1. Build CFE and run all functional tests

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - no impact to behavior

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Niall Mullane - GSFC 582 Intern

EDIT - @skliper added #1324 link.
