### PR TITLE
Fix #1725 Update time_UT.c to use UtAssert_MIR

### DIFF
--- a/modules/cfe_testcase/src/es_misc_test.c
+++ b/modules/cfe_testcase/src/es_misc_test.c
@@ -64,8 +64,7 @@ void TestWriteToSysLog(void)
     CFE_ES_WriteToSysLog(NULL);
     CFE_ES_WriteToSysLog("%s", TestString);
 
-    UtAssertEx(false, UTASSERT_CASETYPE_MIR, __FILE__, __LINE__, "%s",
-               "MIR (Manual Inspection Required) for CFE_ES_WriteToSysLog");
+    UtAssert_MIR("MIR (Manual Inspection Required) for CFE_ES_WriteToSysLog");
 }
 
 void ESMiscTestSetup(void)

--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -848,9 +848,8 @@ void Test_Print(void)
     }
     else
     {
-        UtAssertEx(false, UTASSERT_CASETYPE_MIR, __FILE__, __LINE__,
-                   "Confirm adding seconds = %u, subseconds = %u to configured EPOCH results in time %s", time.Seconds,
-                   time.Subseconds, timeBuf);
+        UtAssert_MIR("Confirm adding seconds = %u, subseconds = %u to configured EPOCH results in time %s",
+                     (unsigned int)time.Seconds, (unsigned int)time.Subseconds, timeBuf);
     }
 
     /* Test with a time value that causes seconds >= 60 when
@@ -867,9 +866,8 @@ void Test_Print(void)
     }
     else
     {
-        UtAssertEx(false, UTASSERT_CASETYPE_MIR, __FILE__, __LINE__,
-                   "Confirm adding seconds = %u, subseconds = %u to configured EPOCH results in time %s", time.Seconds,
-                   time.Subseconds, timeBuf);
+        UtAssert_MIR("Confirm adding seconds = %u, subseconds = %u to configured EPOCH results in time %s",
+                     (unsigned int)time.Seconds, (unsigned int)time.Subseconds, timeBuf);
     }
 
     /* Test with mission representative time values */
@@ -884,9 +882,8 @@ void Test_Print(void)
     }
     else
     {
-        UtAssertEx(false, UTASSERT_CASETYPE_MIR, __FILE__, __LINE__,
-                   "Confirm adding seconds = %u, subseconds = %u to configured EPOCH results in time %s", time.Seconds,
-                   time.Subseconds, timeBuf);
+        UtAssert_MIR("Confirm adding seconds = %u, subseconds = %u to configured EPOCH results in time %s",
+                     (unsigned int)time.Seconds, (unsigned int)time.Subseconds, timeBuf);
     }
 
     /* Test with maximum seconds and subseconds values */
@@ -901,9 +898,8 @@ void Test_Print(void)
     }
     else
     {
-        UtAssertEx(false, UTASSERT_CASETYPE_MIR, __FILE__, __LINE__,
-                   "Confirm adding seconds = %u, subseconds = %u to configured EPOCH results in time %s", time.Seconds,
-                   time.Subseconds, timeBuf);
+        UtAssert_MIR("Confirm adding seconds = %u, subseconds = %u to configured EPOCH results in time %s",
+                     (unsigned int)time.Seconds, (unsigned int)time.Subseconds, timeBuf);
     }
 }
 


### PR DESCRIPTION
**Describe the contribution**
Fixes #1725 Updated time_UT.c to start using the new UtAssert_MIR to avoid incorrect use of UtAssertEx.

This update requires https://github.com/nasa/osal/pull/1122 to be merged first. cFS will fail to compile otherwise.

**Testing performed**
Steps taken to test the contribution:
1. Pulled OSAL repo with the UtAssert_MIR changes
2. Rebuild cFS
3. Run unit tests.... All passed.
4. Set a custom epoch time
5. rebuild and run unit tests... All passed.
6. Manually run ./coverage-time-ALL-testrunner and verify expected output:
`[  MIR] 06.004 time_UT.c:902 - Confirm adding seconds = 4294967295, subseconds = 4294967295 to configured EPOCH results in time 0214-039-06:28:15.99999`

7. Manually run functional tests and verify expected output:
`EVS Port1 66/1/CFE_TEST_APP 5: [  MIR] 15.001 es_misc_test.c:67 - MIR (Manual Inspection Required) for CFE_ES_WriteToSysLog`

**Expected behavior changes**
No expected changes in behavior. 


**System(s) tested on**
Ubuntu 18.04 VM

**Contributor Info - All information REQUIRED for consideration of pull request**
Jose F. Martinez Pedraza / NASA GSFC