### PR TITLE
Fix #1678 Add Functional Tests for cFE Message ID APIs

### DIFF
--- a/modules/cfe_testcase/CMakeLists.txt
+++ b/modules/cfe_testcase/CMakeLists.txt
@@ -9,6 +9,7 @@ add_cfe_app(cfe_testcase
     src/es_mempool_test.c
     src/fs_header_test.c
     src/fs_util_test.c
+    src/message_id_test.c
     src/sb_pipe_mang_test.c
     src/time_arithmetic_test.c
     src/time_current_test.c

--- a/modules/cfe_testcase/src/cfe_test.c
+++ b/modules/cfe_testcase/src/cfe_test.c
@@ -58,6 +58,7 @@ void CFE_TestMain(void)
     ESTaskTestSetup();
     FSHeaderTestSetup();
     FSUtilTestSetup();
+    MessageIdTestSetup();
     SBPipeMangSetup();
     TimeArithmeticTestSetup();
     TimeCurrentTestSetup();

--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -85,6 +85,7 @@ void ESMiscTestSetup(void);
 void ESTaskTestSetup(void);
 void FSHeaderTestSetup(void);
 void FSUtilTestSetup(void);
+void MessageIdTestSetup(void);
 void SBPipeMangSetup(void);
 void TimeArithmeticTestSetup(void);
 void TimeCurrentTestSetup(void);

--- a/modules/cfe_testcase/src/message_id_test.c
+++ b/modules/cfe_testcase/src/message_id_test.c
@@ -1,0 +1,83 @@
+/*************************************************************************
+**
+**      GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**      Copyright (c) 2006-2019 United States Government as represented by
+**      the Administrator of the National Aeronautics and Space Administration.
+**      All Rights Reserved.
+**
+**      Licensed under the Apache License, Version 2.0 (the "License");
+**      you may not use this file except in compliance with the License.
+**      You may obtain a copy of the License at
+**
+**        http://www.apache.org/licenses/LICENSE-2.0
+**
+**      Unless required by applicable law or agreed to in writing, software
+**      distributed under the License is distributed on an "AS IS" BASIS,
+**      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**      See the License for the specific language governing permissions and
+**      limitations under the License.
+**
+** File: message_id_test.c
+**
+** Purpose:
+**   Functional test of Message ID APIs
+**
+**   Demonstration....
+**
+*************************************************************************/
+
+/*
+ * Includes
+ */
+
+#include "cfe_test.h"
+
+void TestMsgId(void)
+{
+    UtPrintf("Testing: CFE_MSG_SetMsgId, CFE_MSG_GetMsgId");
+    CFE_MSG_Message_t msg;
+    CFE_SB_MsgId_t    msgid;
+    CFE_SB_MsgId_t    expectedmsgid = CFE_SB_ValueToMsgId(1);
+
+    UtAssert_INT32_EQ(CFE_MSG_SetMsgId(&msg, expectedmsgid), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&msg, &msgid), CFE_SUCCESS);
+    UtAssert_UINT32_EQ(msgid, expectedmsgid);
+
+    UtAssert_INT32_EQ(CFE_MSG_SetMsgId(NULL, msgid), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_SetMsgId(&msg, CFE_SB_INVALID_MSG_ID), CFE_MSG_BAD_ARGUMENT);
+
+    UtAssert_INT32_EQ(CFE_MSG_GetMsgId(NULL, &msgid), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&msg, NULL), CFE_MSG_BAD_ARGUMENT);
+}
+
+void TestGetTypeFromMsgId(void)
+{
+    UtPrintf("Testing: CFE_MSG_GetTypeFromMsgId");
+    CFE_SB_MsgId_t msgid = CFE_SB_ValueToMsgId(0);
+    CFE_MSG_Type_t msgtype;
+    int32          status;
+
+    /*
+     * Response not verified because msgid 0 could be out of range based on implementation and
+     * the msg to type relationship is also implementation defined, black box test just calls the routine
+     * to confirm things don't "break" with full range values and the implementation exists.
+     */
+
+    status = CFE_MSG_GetTypeFromMsgId(msgid, &msgtype);
+    UtAssert_True(status == CFE_SUCCESS || status == CFE_MSG_BAD_ARGUMENT, "CFE_MSG_GetTypeFromMsgId() == (%ld)",
+                  (long)status);
+
+    memset(&msgid, 0xFF, sizeof(msgid));
+    status = CFE_MSG_GetTypeFromMsgId(msgid, &msgtype);
+    UtAssert_True(status == CFE_SUCCESS || status == CFE_MSG_BAD_ARGUMENT, "CFE_MSG_GetTypeFromMsgId() == (%ld)",
+                  (long)status);
+
+    UtAssert_INT32_EQ(CFE_MSG_GetTypeFromMsgId(msgid, NULL), CFE_MSG_BAD_ARGUMENT);
+}
+
+void MessageIdTestSetup(void)
+{
+    UtTest_Add(TestMsgId, NULL, NULL, "Test Set/Get Message ID");
+    UtTest_Add(TestGetTypeFromMsgId, NULL, NULL, "Test Get Type From Message ID");
+}


### PR DESCRIPTION
**Describe the contribution**
Fixes #1678 
Add functional tests for cFE Message Id APIs
CFE_MSG_GetMsgId - Gets the message id from a message.
CFE_MSG_SetMsgId - Sets the message id bits in a message.
CFE_MSG_GetTypeFromMsgId - Gets message type using message ID.

**Testing performed**
Tested in functional tests and format check workflows on fork. 

**Expected behavior changes**
Tests functionality for cFE Message Id APIs

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal 
