### PR TITLE
Fix #1733, Move global count into test global struct.

### DIFF
--- a/modules/cfe_testcase/src/cfe_test.c
+++ b/modules/cfe_testcase/src/cfe_test.c
@@ -33,6 +33,8 @@
 #include "cfe_assert.h"
 #include "cfe_test.h"
 
+CFE_FT_Global_t CFE_FT_Global;
+
 /*
  * Test main function
  * Register this test routine with CFE Assert

--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -46,6 +46,7 @@
 typedef struct
 {
     CFE_FS_FileWriteMetaData_t FuncTestState;
+    int                        count;
 } CFE_FT_Global_t;
 
 /**

--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -46,8 +46,11 @@
 typedef struct
 {
     CFE_FS_FileWriteMetaData_t FuncTestState;
-    int                        count;
+    /* Generic utility counter */
+    int Count;
 } CFE_FT_Global_t;
+
+extern CFE_FT_Global_t CFE_FT_Global;
 
 /**
  * Name of log file to write

--- a/modules/cfe_testcase/src/es_task_test.c
+++ b/modules/cfe_testcase/src/es_task_test.c
@@ -33,13 +33,11 @@
 
 #include "cfe_test.h"
 
-CFE_FT_Global_t CFE_FT_Global;
-
 void TaskFunction(void)
 {
-    while (CFE_FT_Global.count < 200)
+    while (CFE_FT_Global.Count < 200)
     {
-        CFE_FT_Global.count += 1;
+        CFE_FT_Global.Count += 1;
         OS_TaskDelay(100);
     }
     return;
@@ -47,9 +45,9 @@ void TaskFunction(void)
 
 void TaskExitFunction(void)
 {
-    while (CFE_FT_Global.count < 200)
+    while (CFE_FT_Global.Count < 200)
     {
-        CFE_FT_Global.count += 1;
+        CFE_FT_Global.Count += 1;
         CFE_ES_ExitChildTask();
     }
     return;
@@ -67,14 +65,15 @@ void TestCreateChild(void)
     CFE_ES_TaskPriority_Atom_t Priority      = CFE_PLATFORM_ES_PERF_CHILD_PRIORITY;
     uint32                     Flags         = 0;
     int                        ExpectedCount = 5;
-    CFE_FT_Global.count                      = 0;
+
+    CFE_FT_Global.Count = 0;
 
     UtAssert_INT32_EQ(CFE_ES_CreateChildTask(&TaskId, TaskName, TaskFunction, StackPointer, StackSize, Priority, Flags),
                       CFE_SUCCESS);
     OS_TaskDelay(500);
 
-    UtAssert_True(ExpectedCount >= CFE_FT_Global.count - 1 && ExpectedCount <= CFE_FT_Global.count + 1,
-                  "countCopy (%d) == count (%d)", (int)ExpectedCount, (int)CFE_FT_Global.count);
+    UtAssert_True(ExpectedCount >= CFE_FT_Global.Count - 1 && ExpectedCount <= CFE_FT_Global.Count + 1,
+                  "countCopy (%d) == count (%d)", (int)ExpectedCount, (int)CFE_FT_Global.Count);
 
     UtAssert_INT32_EQ(
         CFE_ES_CreateChildTask(&TaskId2, TaskName, TaskFunction, StackPointer, StackSize, Priority, Flags),
@@ -131,29 +130,30 @@ void TestChildTaskDelete(void)
     UtPrintf("Testing: CFE_ES_DeleteChildTask");
 
     CFE_ES_TaskId_t            TaskId;
-    const char *               TaskName     = "CHILD_TASK_1";
-    CFE_ES_StackPointer_t      StackPointer = CFE_ES_TASK_STACK_ALLOCATE;
-    size_t                     StackSize    = CFE_PLATFORM_ES_PERF_CHILD_STACK_SIZE;
-    CFE_ES_TaskPriority_Atom_t Priority     = CFE_PLATFORM_ES_PERF_CHILD_PRIORITY;
-    uint32                     Flags        = 0;
-    CFE_FT_Global.count                     = 0;
-    int ExpectedCount                       = 5;
+    const char *               TaskName      = "CHILD_TASK_1";
+    CFE_ES_StackPointer_t      StackPointer  = CFE_ES_TASK_STACK_ALLOCATE;
+    size_t                     StackSize     = CFE_PLATFORM_ES_PERF_CHILD_STACK_SIZE;
+    CFE_ES_TaskPriority_Atom_t Priority      = CFE_PLATFORM_ES_PERF_CHILD_PRIORITY;
+    uint32                     Flags         = 0;
+    int                        ExpectedCount = 5;
+
+    CFE_FT_Global.Count = 0;
 
     UtAssert_INT32_EQ(CFE_ES_CreateChildTask(&TaskId, TaskName, TaskFunction, StackPointer, StackSize, Priority, Flags),
                       CFE_SUCCESS);
     OS_TaskDelay(500);
 
-    UtAssert_True(ExpectedCount >= CFE_FT_Global.count - 1 && ExpectedCount <= CFE_FT_Global.count + 1,
-                  "countCopy (%d) == count (%d)", (int)ExpectedCount, (int)CFE_FT_Global.count);
+    UtAssert_True(ExpectedCount >= CFE_FT_Global.Count - 1 && ExpectedCount <= CFE_FT_Global.Count + 1,
+                  "countCopy (%d) == count (%d)", (int)ExpectedCount, (int)CFE_FT_Global.Count);
 
-    ExpectedCount = CFE_FT_Global.count;
+    ExpectedCount = CFE_FT_Global.Count;
 
     UtAssert_INT32_EQ(CFE_ES_DeleteChildTask(TaskId), CFE_SUCCESS);
 
     OS_TaskDelay(500);
 
-    UtAssert_True(ExpectedCount == CFE_FT_Global.count || ExpectedCount == CFE_FT_Global.count + 1,
-                  "ExpectedCount (%d) == count (%d)", (int)ExpectedCount, (int)CFE_FT_Global.count);
+    UtAssert_True(ExpectedCount == CFE_FT_Global.Count || ExpectedCount == CFE_FT_Global.Count + 1,
+                  "ExpectedCount (%d) == count (%d)", (int)ExpectedCount, (int)CFE_FT_Global.Count);
 
     UtAssert_INT32_EQ(CFE_ES_DeleteChildTask(CFE_ES_TASKID_UNDEFINED), CFE_ES_ERR_RESOURCEID_NOT_VALID);
 }

--- a/modules/cfe_testcase/src/es_task_test.c
+++ b/modules/cfe_testcase/src/es_task_test.c
@@ -33,13 +33,13 @@
 
 #include "cfe_test.h"
 
-uint32 count = 0;
+CFE_FT_Global_t CFE_FT_Global;
 
 void TaskFunction(void)
 {
-    while (count < 200)
+    while (CFE_FT_Global.count < 200)
     {
-        count += 1;
+        CFE_FT_Global.count += 1;
         OS_TaskDelay(100);
     }
     return;
@@ -47,9 +47,9 @@ void TaskFunction(void)
 
 void TaskExitFunction(void)
 {
-    while (count < 200)
+    while (CFE_FT_Global.count < 200)
     {
-        count += 1;
+        CFE_FT_Global.count += 1;
         CFE_ES_ExitChildTask();
     }
     return;
@@ -67,13 +67,14 @@ void TestCreateChild(void)
     CFE_ES_TaskPriority_Atom_t Priority      = CFE_PLATFORM_ES_PERF_CHILD_PRIORITY;
     uint32                     Flags         = 0;
     int                        ExpectedCount = 5;
+    CFE_FT_Global.count                      = 0;
 
     UtAssert_INT32_EQ(CFE_ES_CreateChildTask(&TaskId, TaskName, TaskFunction, StackPointer, StackSize, Priority, Flags),
                       CFE_SUCCESS);
     OS_TaskDelay(500);
 
-    UtAssert_True(ExpectedCount >= count - 1 && ExpectedCount <= count + 1, "countCopy (%d) == count (%d)",
-                  (int)ExpectedCount, (int)count);
+    UtAssert_True(ExpectedCount >= CFE_FT_Global.count - 1 && ExpectedCount <= CFE_FT_Global.count + 1,
+                  "countCopy (%d) == count (%d)", (int)ExpectedCount, (int)CFE_FT_Global.count);
 
     UtAssert_INT32_EQ(
         CFE_ES_CreateChildTask(&TaskId2, TaskName, TaskFunction, StackPointer, StackSize, Priority, Flags),
@@ -135,24 +136,24 @@ void TestChildTaskDelete(void)
     size_t                     StackSize    = CFE_PLATFORM_ES_PERF_CHILD_STACK_SIZE;
     CFE_ES_TaskPriority_Atom_t Priority     = CFE_PLATFORM_ES_PERF_CHILD_PRIORITY;
     uint32                     Flags        = 0;
-    count                                   = 0;
+    CFE_FT_Global.count                     = 0;
     int ExpectedCount                       = 5;
 
     UtAssert_INT32_EQ(CFE_ES_CreateChildTask(&TaskId, TaskName, TaskFunction, StackPointer, StackSize, Priority, Flags),
                       CFE_SUCCESS);
     OS_TaskDelay(500);
 
-    UtAssert_True(ExpectedCount >= count - 1 && ExpectedCount <= count + 1, "countCopy (%d) == count (%d)",
-                  (int)ExpectedCount, (int)count);
+    UtAssert_True(ExpectedCount >= CFE_FT_Global.count - 1 && ExpectedCount <= CFE_FT_Global.count + 1,
+                  "countCopy (%d) == count (%d)", (int)ExpectedCount, (int)CFE_FT_Global.count);
 
-    ExpectedCount = count;
+    ExpectedCount = CFE_FT_Global.count;
 
     UtAssert_INT32_EQ(CFE_ES_DeleteChildTask(TaskId), CFE_SUCCESS);
 
     OS_TaskDelay(500);
 
-    UtAssert_True(ExpectedCount == count || ExpectedCount == count + 1, "ExpectedCount (%d) == count (%d)",
-                  (int)ExpectedCount, (int)count);
+    UtAssert_True(ExpectedCount == CFE_FT_Global.count || ExpectedCount == CFE_FT_Global.count + 1,
+                  "ExpectedCount (%d) == count (%d)", (int)ExpectedCount, (int)CFE_FT_Global.count);
 
     UtAssert_INT32_EQ(CFE_ES_DeleteChildTask(CFE_ES_TASKID_UNDEFINED), CFE_ES_ERR_RESOURCEID_NOT_VALID);
 }
@@ -162,13 +163,12 @@ void TestExitChild(void)
     UtPrintf("Testing: CFE_ES_ExitChildTask");
 
     CFE_ES_TaskId_t            TaskId;
-    const char *               TaskName     = "CHILD_TASK_1";
-    CFE_ES_StackPointer_t      StackPointer = CFE_ES_TASK_STACK_ALLOCATE;
-    size_t                     StackSize    = CFE_PLATFORM_ES_PERF_CHILD_STACK_SIZE;
-    CFE_ES_TaskPriority_Atom_t Priority     = CFE_PLATFORM_ES_PERF_CHILD_PRIORITY;
-    uint32                     Flags        = 0;
-    count                                   = 0;
-    int ExpectedCount                       = 1;
+    const char *               TaskName      = "CHILD_TASK_1";
+    CFE_ES_StackPointer_t      StackPointer  = CFE_ES_TASK_STACK_ALLOCATE;
+    size_t                     StackSize     = CFE_PLATFORM_ES_PERF_CHILD_STACK_SIZE;
+    CFE_ES_TaskPriority_Atom_t Priority      = CFE_PLATFORM_ES_PERF_CHILD_PRIORITY;
+    uint32                     Flags         = 0;
+    int                        ExpectedCount = 1;
 
     UtAssert_INT32_EQ(
         CFE_ES_CreateChildTask(&TaskId, TaskName, TaskExitFunction, StackPointer, StackSize, Priority, Flags),

--- a/modules/cfe_testcase/src/fs_util_test.c
+++ b/modules/cfe_testcase/src/fs_util_test.c
@@ -33,8 +33,6 @@
 
 #include "cfe_test.h"
 
-CFE_FT_Global_t CFE_FT_Global;
-
 void TestFileCategory(void)
 {
     UtPrintf("Testing: CFE_FS_GetDefaultMountPoint, CFE_FS_GetDefaultExtension");
@@ -138,7 +136,6 @@ void TestFileDump(void)
 
     UtAssert_INT32_EQ(CFE_FS_BackgroundFileDumpIsPending(&CFE_FT_Global.FuncTestState), false);
     UtAssert_INT32_EQ(CFE_FS_BackgroundFileDumpRequest(&CFE_FT_Global.FuncTestState), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_FS_BackgroundFileDumpIsPending(&CFE_FT_Global.FuncTestState), true);
 
     /* Wait for background task to complete */
     while (CFE_FS_BackgroundFileDumpIsPending(&CFE_FT_Global.FuncTestState) && count < MaxWait)


### PR DESCRIPTION
**Describe the contribution**
Fixes #1733 
Move global count into the test global struct

**Testing performed**
Build and run unit test

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC