### PR TITLE
Fix #1738 Add cast to MIR prints

### DIFF
--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -849,8 +849,8 @@ void Test_Print(void)
     else
     {
         UtAssertEx(false, UTASSERT_CASETYPE_MIR, __FILE__, __LINE__,
-                   "Confirm adding seconds = %u, subseconds = %u to configured EPOCH results in time %s", time.Seconds,
-                   time.Subseconds, timeBuf);
+                   "Confirm adding seconds = %u, subseconds = %u to configured EPOCH results in time %s",
+                   (unsigned int)time.Seconds, (unsigned int)time.Subseconds, timeBuf);
     }
 
     /* Test with a time value that causes seconds >= 60 when
@@ -868,8 +868,8 @@ void Test_Print(void)
     else
     {
         UtAssertEx(false, UTASSERT_CASETYPE_MIR, __FILE__, __LINE__,
-                   "Confirm adding seconds = %u, subseconds = %u to configured EPOCH results in time %s", time.Seconds,
-                   time.Subseconds, timeBuf);
+                   "Confirm adding seconds = %u, subseconds = %u to configured EPOCH results in time %s",
+                   (unsigned int)time.Seconds, (unsigned int)time.Subseconds, timeBuf);
     }
 
     /* Test with mission representative time values */
@@ -885,8 +885,8 @@ void Test_Print(void)
     else
     {
         UtAssertEx(false, UTASSERT_CASETYPE_MIR, __FILE__, __LINE__,
-                   "Confirm adding seconds = %u, subseconds = %u to configured EPOCH results in time %s", time.Seconds,
-                   time.Subseconds, timeBuf);
+                   "Confirm adding seconds = %u, subseconds = %u to configured EPOCH results in time %s",
+                   (unsigned int)time.Seconds, (unsigned int)time.Subseconds, timeBuf);
     }
 
     /* Test with maximum seconds and subseconds values */
@@ -902,8 +902,8 @@ void Test_Print(void)
     else
     {
         UtAssertEx(false, UTASSERT_CASETYPE_MIR, __FILE__, __LINE__,
-                   "Confirm adding seconds = %u, subseconds = %u to configured EPOCH results in time %s", time.Seconds,
-                   time.Subseconds, timeBuf);
+                   "Confirm adding seconds = %u, subseconds = %u to configured EPOCH results in time %s",
+                   (unsigned int)time.Seconds, (unsigned int)time.Subseconds, timeBuf);
     }
 }
 


### PR DESCRIPTION
**Describe the contribution**
Fixes #1738 Added cast to MIR prints in time_UT.c so that the RTEMS build doesn't break.

**Testing performed**
Steps taken to test the contribution:
1. Build and run time UT tests:
`make -C build/native/default_cpu1/time`
`make -C build/native/default_cpu1/time test`
2. Build and run cFS tests:
`make`
`make test`

**Expected behavior changes**
RTEMS workflow should build and run successfully.

**System(s) tested on**
 - Ubuntu 18.04 VM

**Contributor Info - All information REQUIRED for consideration of pull request**
Jose F. Martinez Pedraza / NASA GSFC