### PR TITLE
Fix #1649, Add Functional Test for EVS Reset Filters API.

### DIFF
--- a/modules/cfe_testcase/CMakeLists.txt
+++ b/modules/cfe_testcase/CMakeLists.txt
@@ -7,6 +7,7 @@ add_cfe_app(cfe_testcase
     src/es_cds_test.c
     src/es_misc_test.c
     src/es_mempool_test.c
+    src/evs_filters_test.c
     src/evs_send_test.c
     src/fs_header_test.c
     src/fs_util_test.c

--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -85,6 +85,7 @@ void ESInfoTestSetup(void);
 void ESMemPoolTestSetup(void);
 void ESMiscTestSetup(void);
 void ESTaskTestSetup(void);
+void EVSFiltersTestSetup(void);
 void EVSSendTestSetup(void);
 void FSHeaderTestSetup(void);
 void FSUtilTestSetup(void);

--- a/modules/cfe_testcase/src/evs_filters_test.c
+++ b/modules/cfe_testcase/src/evs_filters_test.c
@@ -37,6 +37,11 @@ void TestResetFilters(void)
 {
     UtPrintf("Testing: CFE_EVS_ResetFilter, CFE_EVS_ResetAllFilters");
 
+    /* Test logic below depends on the test case registering an EID of 1 and not registering 0, and the resets in theory
+     * could impact test behavior/management related to events. Although the expectation is either all or none of an EID
+     * would be filtered (no use case for a "counting" filter within the test app) so for normal use this is no impact.
+     */
+
     UtAssert_INT32_EQ(CFE_EVS_ResetFilter(1), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_EVS_ResetAllFilters(), CFE_SUCCESS);
 

--- a/modules/cfe_testcase/src/evs_filters_test.c
+++ b/modules/cfe_testcase/src/evs_filters_test.c
@@ -18,10 +18,11 @@
 **      See the License for the specific language governing permissions and
 **      limitations under the License.
 **
-** File: cfe_test.c
+** File: evs_filters_test.c
 **
 ** Purpose:
-**   Initialization routine for CFE functional test
+**   Functional test of basic EVS Reset Filters APIs
+**
 **   Demonstration of how to register and use the UT assert functions.
 **
 *************************************************************************/
@@ -30,49 +31,19 @@
  * Includes
  */
 
-#include "cfe_assert.h"
 #include "cfe_test.h"
 
-/*
- * Test main function
- * Register this test routine with CFE Assert
- */
-void CFE_TestMain(void)
+void TestResetFilters(void)
 {
-    /*
-     * Register this test app with CFE assert
-     *
-     * Note this also waits for the appropriate overall system
-     * state and gets ownership of the UtAssert subsystem
-     */
-    CFE_Assert_RegisterTest("CFE API");
-    CFE_Assert_OpenLogFile(CFE_ASSERT_LOG_FILE_NAME);
+    UtPrintf("Testing: CFE_EVS_ResetFilter, CFE_EVS_ResetAllFilters");
 
-    /*
-     * Register test cases in UtAssert
-     */
-    ESCDSTestSetup();
-    ESInfoTestSetup();
-    ESMemPoolTestSetup();
-    ESMiscTestSetup();
-    ESTaskTestSetup();
-    EVSFiltersTestSetup();
-    EVSSendTestSetup();
-    FSHeaderTestSetup();
-    FSUtilTestSetup();
-    MessageIdTestSetup();
-    SBPipeMangSetup();
-    TimeArithmeticTestSetup();
-    TimeCurrentTestSetup();
-    TimeConversionTestSetup();
+    UtAssert_INT32_EQ(CFE_EVS_ResetFilter(1), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_EVS_ResetAllFilters(), CFE_SUCCESS);
 
-    /*
-     * Execute the tests
-     *
-     * Note this also releases ownership of the UtAssert subsystem when complete
-     */
-    CFE_Assert_ExecuteTest();
+    UtAssert_INT32_EQ(CFE_EVS_ResetFilter(0), CFE_EVS_EVT_NOT_REGISTERED);
+}
 
-    /* Nothing more for this app to do */
-    CFE_ES_ExitApp(CFE_ES_RunStatus_APP_EXIT);
+void EVSFiltersTestSetup(void)
+{
+    UtTest_Add(TestResetFilters, NULL, NULL, "Test Reset Filters");
 }


### PR DESCRIPTION
**Describe the contribution**
Fixes #1649
Add Functional Test for EVS Reset Filters APIs.

**Testing performed**
Build and run unit test

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC