### PR TITLE
Fix #1751, Add null pointer check to table GetAddresses and ReleaseAddresses

### DIFF
--- a/modules/tbl/fsw/src/cfe_tbl_api.c
+++ b/modules/tbl/fsw/src/cfe_tbl_api.c
@@ -1068,7 +1068,7 @@ CFE_Status_t CFE_TBL_GetAddresses(void **TblPtrs[], uint16 NumTables, const CFE_
     int32          Status;
     CFE_ES_AppId_t ThisAppId;
 
-    if (TblPtrs == NULL)
+    if (TblPtrs == NULL || TblHandles == NULL)
     {
         return CFE_TBL_BAD_ARGUMENT;
     }
@@ -1119,6 +1119,11 @@ CFE_Status_t CFE_TBL_ReleaseAddresses(uint16 NumTables, const CFE_TBL_Handle_t T
 {
     CFE_Status_t Status = CFE_SUCCESS;
     uint16       i;
+
+    if (TblHandles == NULL)
+    {
+        return CFE_TBL_BAD_ARGUMENT;
+    }
 
     for (i = 0; i < NumTables; i++)
     {


### PR DESCRIPTION
**Describe the contribution**
- Fixes #1751
- Adds null check on TblHandles pointer in CFE_TBL_GetAddresses and CFE_TBL_ReleaseAddresses

**Testing performed**
1. Build and run CFE functional tests from #1734 

**Expected behavior changes**
 - No impact to behavior

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu 20.04


**Contributor Info - All information REQUIRED for consideration of pull request**
Niall Mullane - GSFC 582 Intern