### PR TITLE
Fix #1757, Handle fail status from internal functions of CFE_MSG_GetT…

### DIFF
--- a/modules/msg/fsw/src/cfe_msg_msgid_shared.c
+++ b/modules/msg/fsw/src/cfe_msg_msgid_shared.c
@@ -35,8 +35,8 @@
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetTypeFromMsgId(CFE_SB_MsgId_t MsgId, CFE_MSG_Type_t *Type)
 {
-
     CFE_MSG_Message_t msg;
+    int32             Status;
 
     /* Memset to initialize avoids possible GCC bug 53119 */
     memset(&msg, 0, sizeof(msg));
@@ -46,8 +46,11 @@ CFE_Status_t CFE_MSG_GetTypeFromMsgId(CFE_SB_MsgId_t MsgId, CFE_MSG_Type_t *Type
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    CFE_MSG_SetMsgId(&msg, MsgId);
-    CFE_MSG_GetType(&msg, Type);
+    Status = CFE_MSG_SetMsgId(&msg, MsgId);
+    if (Status == CFE_SUCCESS)
+    {
+        Status = CFE_MSG_GetType(&msg, Type);
+    }
 
-    return CFE_SUCCESS;
+    return Status;
 }


### PR DESCRIPTION
**Describe the contribution**
Fixes #1757  
 Handle fail status from internal functions of CFE_MSG_GetTypeFromMsgId

**Testing performed**
Build and run unit test

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC