### PR TITLE
Fix #1763, last char truncated in coverage log output

### DIFF
--- a/modules/core_private/ut-stubs/src/ut_support.c
+++ b/modules/core_private/ut-stubs/src/ut_support.c
@@ -828,7 +828,7 @@ bool CFE_UtAssert_MessageCheck_Impl(bool Status, const char *File, uint32 Line, 
 
     /* Locate the actual end of the string, but limited to length of local buffer */
     /* Reserve two extra chars for quotes */
-    EndPtr = memchr(FormatString, 0, sizeof(ScrubbedFormat) - 2);
+    EndPtr = memchr(FormatString, 0, sizeof(ScrubbedFormat) - 3);
     if (EndPtr != NULL)
     {
         FormatLen = EndPtr - FormatString;
@@ -848,8 +848,8 @@ bool CFE_UtAssert_MessageCheck_Impl(bool Status, const char *File, uint32 Line, 
     /* Need to make a copy, as the input string is "const" */
     ScrubbedFormat[0] = '\'';
     memcpy(&ScrubbedFormat[1], FormatString, FormatLen);
-    ScrubbedFormat[FormatLen]     = '\'';
-    ScrubbedFormat[FormatLen + 1] = 0;
+    ScrubbedFormat[FormatLen + 1] = '\'';
+    ScrubbedFormat[FormatLen + 2] = 0;
 
     return CFE_UtAssert_GenericSignedCompare_Impl(Status, CFE_UtAssert_Compare_GT, 0, File, Line, Desc, ScrubbedFormat,
                                                   "");


### PR DESCRIPTION
**Describe the contribution**
The "MessageCheck_Impl" routine used for printf/syslog checks was incorrectly truncating the last character of the log message.

Fixes #1763

**Testing performed**
Run all coverage tests, confirm print logs now contain the full string.

**Expected behavior changes**
Last char is no longer truncated in log

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
