### PR TITLE
Fix #1726, mark read only inputs as const

### DIFF
--- a/modules/core_api/fsw/inc/cfe_es.h
+++ b/modules/core_api/fsw/inc/cfe_es.h
@@ -1131,7 +1131,7 @@ CFE_Status_t CFE_ES_GetCDSBlockName(char *BlockName, CFE_ES_CDSHandle_t BlockId,
 ** \sa #CFE_ES_RegisterCDS, #CFE_ES_RestoreFromCDS
 **
 */
-CFE_Status_t CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, void *DataToCopy);
+CFE_Status_t CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, const void *DataToCopy);
 
 /*****************************************************************************/
 /**

--- a/modules/core_api/fsw/inc/cfe_sb.h
+++ b/modules/core_api/fsw/inc/cfe_sb.h
@@ -423,7 +423,7 @@ CFE_Status_t CFE_SB_UnsubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeI
 ** \retval #CFE_SB_MSG_TOO_BIG  \copybrief CFE_SB_MSG_TOO_BIG
 ** \retval #CFE_SB_BUF_ALOC_ERR \copybrief CFE_SB_BUF_ALOC_ERR
 **/
-CFE_Status_t CFE_SB_TransmitMsg(CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount);
+CFE_Status_t CFE_SB_TransmitMsg(const CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount);
 
 /*****************************************************************************/
 /**

--- a/modules/core_api/ut-stubs/src/cfe_es_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_es_stubs.c
@@ -98,12 +98,12 @@ uint32 CFE_ES_CalculateCRC(const void *DataPtr, size_t DataLength, uint32 InputC
  * Generated stub function for CFE_ES_CopyToCDS()
  * ----------------------------------------------------
  */
-CFE_Status_t CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, void *DataToCopy)
+CFE_Status_t CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, const void *DataToCopy)
 {
     UT_GenStub_SetupReturnBuffer(CFE_ES_CopyToCDS, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_ES_CopyToCDS, CFE_ES_CDSHandle_t, Handle);
-    UT_GenStub_AddParam(CFE_ES_CopyToCDS, void *, DataToCopy);
+    UT_GenStub_AddParam(CFE_ES_CopyToCDS, const void *, DataToCopy);
 
     UT_GenStub_Execute(CFE_ES_CopyToCDS, Basic, UT_DefaultHandler_CFE_ES_CopyToCDS);
 

--- a/modules/core_api/ut-stubs/src/cfe_sb_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_sb_stubs.c
@@ -403,11 +403,11 @@ CFE_Status_t CFE_SB_TransmitBuffer(CFE_SB_Buffer_t *BufPtr, bool IncrementSequen
  * Generated stub function for CFE_SB_TransmitMsg()
  * ----------------------------------------------------
  */
-CFE_Status_t CFE_SB_TransmitMsg(CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount)
+CFE_Status_t CFE_SB_TransmitMsg(const CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount)
 {
     UT_GenStub_SetupReturnBuffer(CFE_SB_TransmitMsg, CFE_Status_t);
 
-    UT_GenStub_AddParam(CFE_SB_TransmitMsg, CFE_MSG_Message_t *, MsgPtr);
+    UT_GenStub_AddParam(CFE_SB_TransmitMsg, const CFE_MSG_Message_t *, MsgPtr);
     UT_GenStub_AddParam(CFE_SB_TransmitMsg, bool, IncrementSequenceCount);
 
     UT_GenStub_Execute(CFE_SB_TransmitMsg, Basic, UT_DefaultHandler_CFE_SB_TransmitMsg);

--- a/modules/es/fsw/src/cfe_es_api.c
+++ b/modules/es/fsw/src/cfe_es_api.c
@@ -1858,7 +1858,7 @@ CFE_Status_t CFE_ES_GetCDSBlockName(char *BlockName, CFE_ES_CDSHandle_t BlockId,
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-CFE_Status_t CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, void *DataToCopy)
+CFE_Status_t CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, const void *DataToCopy)
 {
     if (DataToCopy == NULL)
     {

--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -1323,7 +1323,7 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint8
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-CFE_Status_t CFE_SB_TransmitMsg(CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount)
+CFE_Status_t CFE_SB_TransmitMsg(const CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount)
 {
     int32             Status;
     CFE_MSG_Size_t    Size  = 0;
@@ -1430,7 +1430,7 @@ CFE_Status_t CFE_SB_TransmitMsg(CFE_MSG_Message_t *MsgPtr, bool IncrementSequenc
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_TransmitMsgValidate(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgIdPtr, CFE_MSG_Size_t *SizePtr,
+int32 CFE_SB_TransmitMsgValidate(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgIdPtr, CFE_MSG_Size_t *SizePtr,
                                  CFE_SBR_RouteId_t *RouteIdPtr)
 {
     CFE_ES_TaskId_t TskId;

--- a/modules/sb/fsw/src/cfe_sb_priv.h
+++ b/modules/sb/fsw/src/cfe_sb_priv.h
@@ -434,7 +434,7 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint8
  *
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_TransmitMsgValidate(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgIdPtr, CFE_MSG_Size_t *SizePtr,
+int32 CFE_SB_TransmitMsgValidate(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgIdPtr, CFE_MSG_Size_t *SizePtr,
                                  CFE_SBR_RouteId_t *RouteIdPtr);
 
 /*---------------------------------------------------------------------------------------*/


### PR DESCRIPTION
**Describe the contribution**
The following functions have read-only inputs which are passed by pointer, so it should be "const" qualified:

CFE_ES_CopyToCDS
CFE_SB_TransmitMsg
CFE_SB_TransmitMsgValidate

Fixes #1726

**Testing performed**
Build and sanity check CFE, run all tests

**Expected behavior changes**
None, input was already read only, this just corrects the prototype to reflect that.

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
