### PR TITLE
Fix #807, Add ES Application Behavior Functional Tests

### DIFF
--- a/modules/cfe_testcase/CMakeLists.txt
+++ b/modules/cfe_testcase/CMakeLists.txt
@@ -6,6 +6,7 @@ add_cfe_app(cfe_testcase
     src/cfe_test.c
     src/cfe_test_table.c
     src/es_application_control_test.c
+    src/es_behavior_test.c
     src/es_info_test.c
     src/es_task_test.c
     src/es_cds_test.c

--- a/modules/cfe_testcase/src/cfe_test.c
+++ b/modules/cfe_testcase/src/cfe_test.c
@@ -59,6 +59,7 @@ void CFE_TestMain(void)
      * Register test cases in UtAssert
      */
     ESApplicationControlTestSetup();
+    ESBehaviorestSetup();
     ESCDSTestSetup();
     ESCounterTestSetup();
     ESInfoTestSetup();
@@ -77,8 +78,8 @@ void CFE_TestMain(void)
     TBLInformationTestSetup();
     TBLRegistrationTestSetup();
     TimeArithmeticTestSetup();
-    TimeCurrentTestSetup();
     TimeConversionTestSetup();
+    TimeCurrentTestSetup();
     TimeMiscTestSetup();
 
     /*

--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -90,6 +90,7 @@ bool TimeInRange(CFE_TIME_SysTime_t Time, CFE_TIME_SysTime_t Target, OS_time_t d
 
 void CFE_TestMain(void);
 void ESApplicationControlTestSetup(void);
+void ESBehaviorestSetup(void);
 void ESCDSTestSetup(void);
 void ESCounterTestSetup(void);
 void ESInfoTestSetup(void);
@@ -108,8 +109,8 @@ void TBLContentMangTestSetup(void);
 void TBLInformationTestSetup(void);
 void TBLRegistrationTestSetup(void);
 void TimeArithmeticTestSetup(void);
-void TimeCurrentTestSetup(void);
 void TimeConversionTestSetup(void);
+void TimeCurrentTestSetup(void);
 void TimeMiscTestSetup(void);
 
 #endif /* CFE_TEST_H */

--- a/modules/cfe_testcase/src/es_behavior_test.c
+++ b/modules/cfe_testcase/src/es_behavior_test.c
@@ -1,0 +1,93 @@
+/*************************************************************************
+**
+**      GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**      Copyright (c) 2006-2019 United States Government as represented by
+**      the Administrator of the National Aeronautics and Space Administration.
+**      All Rights Reserved.
+**
+**      Licensed under the Apache License, Version 2.0 (the "License");
+**      you may not use this file except in compliance with the License.
+**      You may obtain a copy of the License at
+**
+**        http://www.apache.org/licenses/LICENSE-2.0
+**
+**      Unless required by applicable law or agreed to in writing, software
+**      distributed under the License is distributed on an "AS IS" BASIS,
+**      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**      See the License for the specific language governing permissions and
+**      limitations under the License.
+**
+** File: es_behavior_test.c
+**
+** Purpose:
+**   Functional test of basic ES Application Behavior APIs
+**
+**   Demonstration of how to register and use the UT assert functions.
+**
+*************************************************************************/
+
+/*
+ * Includes
+ */
+
+#include "cfe_test.h"
+
+void TestRunCounter(void)
+{
+    CFE_ES_TaskId_t   TaskId;
+    CFE_ES_TaskInfo_t TaskInfo;
+    uint32            ExecutionCounter;
+    uint32            RunStatus = CFE_ES_RunStatus_APP_RUN;
+
+    UtPrintf("Testing: CFE_ES_RunLoop, CFE_ES_IncrementTaskCounter");
+
+    UtAssert_INT32_EQ(CFE_ES_GetTaskID(&TaskId), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_GetTaskInfo(&TaskInfo, TaskId), CFE_SUCCESS);
+    ExecutionCounter = TaskInfo.ExecutionCounter;
+
+    UtAssert_BOOL_TRUE(CFE_ES_RunLoop(&RunStatus));
+    UtAssert_INT32_EQ(CFE_ES_GetTaskInfo(&TaskInfo, TaskId), CFE_SUCCESS);
+    UtAssert_UINT32_EQ(TaskInfo.ExecutionCounter, (ExecutionCounter + 1));
+
+    UtAssert_BOOL_TRUE(CFE_ES_RunLoop(NULL));
+    UtAssert_INT32_EQ(CFE_ES_GetTaskInfo(&TaskInfo, TaskId), CFE_SUCCESS);
+    UtAssert_UINT32_EQ(TaskInfo.ExecutionCounter, (ExecutionCounter + 2));
+
+    UtAssert_VOIDCALL(CFE_ES_IncrementTaskCounter());
+    UtAssert_INT32_EQ(CFE_ES_GetTaskInfo(&TaskInfo, TaskId), CFE_SUCCESS);
+    UtAssert_UINT32_EQ(TaskInfo.ExecutionCounter, (ExecutionCounter + 3));
+
+    RunStatus = CFE_ES_RunStatus_UNDEFINED;
+    UtAssert_BOOL_FALSE(CFE_ES_RunLoop(&RunStatus));
+}
+
+void TestWaitBehavior(void)
+{
+    CFE_TIME_SysTime_t start;
+    CFE_TIME_SysTime_t end;
+    CFE_TIME_SysTime_t TimePassed;
+    CFE_TIME_SysTime_t TimeExpected = {8, 0};
+
+    start = CFE_TIME_GetTime();
+
+    /* MinSystemStates of CFE_ES_SystemState_SHUTDOWN and higher not tested because they cause a shutdown */
+    UtAssert_INT32_EQ(CFE_ES_WaitForSystemState(CFE_ES_SystemState_UNDEFINED, 10000), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_WaitForSystemState(CFE_ES_SystemState_EARLY_INIT, 10000), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_WaitForSystemState(CFE_ES_SystemState_CORE_STARTUP, 10000), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_WaitForSystemState(CFE_ES_SystemState_CORE_READY, 10000), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_WaitForSystemState(CFE_ES_SystemState_APPS_INIT, 10000), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_WaitForSystemState(CFE_ES_SystemState_OPERATIONAL, 10000), CFE_SUCCESS);
+    UtAssert_VOIDCALL(CFE_ES_WaitForStartupSync(10000));
+
+    end        = CFE_TIME_GetTime();
+    TimePassed = CFE_TIME_Subtract(end, start);
+
+    UtAssert_UINT32_EQ(CFE_TIME_Compare(TimePassed, TimeExpected), CFE_TIME_A_LT_B);
+}
+
+void ESBehaviorestSetup(void)
+{
+    UtTest_Add(TestRunCounter, NULL, NULL, "Test Run Counter");
+    UtTest_Add(TestWaitBehavior, NULL, NULL, "Test Wait Behavior");
+}

--- a/modules/core_api/fsw/inc/cfe_es.h
+++ b/modules/core_api/fsw/inc/cfe_es.h
@@ -391,10 +391,9 @@ bool CFE_ES_RunLoop(uint32 *RunStatus);
 **
 ** \param[in]  MinSystemState        Determine the state of the App
 ** \param[in]  TimeOutMilliseconds   The timeout value in Milliseconds.
-**                                   This parameter must be at least 1000. Lower values
-**                                   will be rounded up. There is not an option to
-**                                   wait indefinitely to avoid hanging a critical
-**                                   application because a non-critical app did not start.
+**                                   There is not an option to wait indefinitely to
+**                                   avoid hanging a critical application because a
+**                                   non-critical app did not start.
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                State successfully achieved


### PR DESCRIPTION
**Describe the contribution**
Fixes #807
Add ES Application Behavior Functional Tests

**Testing performed**
Build and run unit test

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Additional context**
CFE_ES_ExitApp was not directly tested. https://github.com/nasa/cFE/issues/1761 will be needed to test that. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC