### PR TITLE
Fix #1775, #1773 -  Adds invalid id syslog to for CFE_ES_DeleteApp and CFE_ES_ReloadApp and verifies required reporting

### DIFF
--- a/modules/core_private/ut-stubs/inc/ut_osprintf_stubs.h
+++ b/modules/core_private/ut-stubs/inc/ut_osprintf_stubs.h
@@ -95,6 +95,15 @@
 #define UT_OSP_STARTUP_SYNC_FAIL_2        67
 #define UT_OSP_MODULE_UNLOAD_FAILED       68
 #define UT_OSP_TASKEXIT_BAD_CONTEXT       69
-#define UT_OSP_BACKGROUND_TAKE            71
+#define UT_OSP_BACKGROUND_TAKE            70
+#define UT_OSP_INVALID_ID                 71
+#define UT_OSP_RESTART_NO_FILE            72
+#define UT_OSP_CREATECHILD_FROM_CHILD     73
+#define UT_OSP_DELETECHID_MAIN_TASK       74
+#define UT_OSP_POOLCREATE_TOO_SMALL       75
+#define UT_OSP_GETPOOL_BAD_HANDLE         76
+#define UT_OSP_PUTPOOL_BAD_HANDLE         77
+#define UT_OSP_FORMAT_VOLATILE            78
+#define UT_OSP_RELOAD_NO_FILE             79
 
 #endif /* UT_OSPRINTF_STUBS_H */

--- a/modules/core_private/ut-stubs/src/ut_osprintf_stubs.c
+++ b/modules/core_private/ut-stubs/src/ut_osprintf_stubs.c
@@ -101,4 +101,13 @@ const char *UT_OSP_MESSAGES[] = {
     [UT_OSP_RECORD_USED]                = "%s: Error: ES_TaskTable slot for ID %lx in use at task creation!\n",
     [UT_OSP_TASKEXIT_BAD_CONTEXT]       = "%s: Called from invalid task context\n",
     [UT_OSP_BACKGROUND_TAKE]            = "%s: Failed to take background sem: %08lx\n",
+    [UT_OSP_INVALID_ID]                 = "%s: Invalid Application ID received, AppID = %lu\n",
+    [UT_OSP_RESTART_NO_FILE]            = "%s: Cannot Restart Application %s, File %s does not exist.\n",
+    [UT_OSP_CREATECHILD_FROM_CHILD]     = "%s: Error: Cannot call from a Child Task (for Task '%s').\n",
+    [UT_OSP_DELETECHID_MAIN_TASK]       = "%s: Error: Task %lu is a cFE Main Task.\n",
+    [UT_OSP_POOLCREATE_TOO_SMALL]       = "%s: Pool size(%lu) too small, need >=%lu bytes\n",
+    [UT_OSP_GETPOOL_BAD_HANDLE]         = "%s: Err:Bad handle(0x%08lX) AppId=%lu\n",
+    [UT_OSP_PUTPOOL_BAD_HANDLE]         = "%s: Err:Invalid Memory Handle (0x%08lX).\n",
+    [UT_OSP_FORMAT_VOLATILE]            = "%s: Formatting Volatile(RAM) Volume.\n",
+    [UT_OSP_RELOAD_NO_FILE]             = "%s: Cannot Reload Application %s, File %s does not exist.\n",
 };

--- a/modules/es/fsw/src/cfe_es_api.c
+++ b/modules/es/fsw/src/cfe_es_api.c
@@ -240,51 +240,57 @@ CFE_Status_t CFE_ES_ReloadApp(CFE_ES_AppId_t AppID, const char *AppFileName)
     os_fstat_t          FileStatus;
     CFE_ES_AppRecord_t *AppRecPtr = CFE_ES_LocateAppRecordByID(AppID);
 
-    if (AppRecPtr == NULL)
+    if (AppRecPtr != NULL)
     {
-        return CFE_ES_ERR_RESOURCEID_NOT_VALID;
-    }
 
-    CFE_ES_LockSharedData(__func__, __LINE__);
+        CFE_ES_LockSharedData(__func__, __LINE__);
 
-    /*
-    ** Check to see if the App is an external cFE App.
-    */
-    if (AppRecPtr->Type == CFE_ES_AppType_CORE)
-    {
-        CFE_ES_SysLogWrite_Unsync("%s: Cannot Reload a CORE Application: %s.\n", __func__,
-                                  CFE_ES_AppRecordGetName(AppRecPtr));
-        ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
-    }
-    else if (AppRecPtr->AppState != CFE_ES_AppState_RUNNING)
-    {
-        CFE_ES_SysLogWrite_Unsync("%s: Cannot Reload Application %s, It is not running.\n", __func__,
-                                  CFE_ES_AppRecordGetName(AppRecPtr));
-        ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
-    }
-    else
-    {
         /*
-        ** Check to see if the file exists
+        ** Check to see if the App is an external cFE App.
         */
-        if (OS_stat(AppFileName, &FileStatus) == OS_SUCCESS)
+        if (AppRecPtr->Type == CFE_ES_AppType_CORE)
         {
-            CFE_ES_SysLogWrite_Unsync("%s: Reload Application %s Initiated. New filename = %s\n", __func__,
-                                      CFE_ES_AppRecordGetName(AppRecPtr), AppFileName);
-            strncpy(AppRecPtr->StartParams.BasicInfo.FileName, AppFileName,
-                    sizeof(AppRecPtr->StartParams.BasicInfo.FileName) - 1);
-            AppRecPtr->StartParams.BasicInfo.FileName[sizeof(AppRecPtr->StartParams.BasicInfo.FileName) - 1] = 0;
-            AppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_SYS_RELOAD;
+            CFE_ES_SysLogWrite_Unsync("%s: Cannot Reload a CORE Application: %s.\n", __func__,
+                                      CFE_ES_AppRecordGetName(AppRecPtr));
+            ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
+        }
+        else if (AppRecPtr->AppState != CFE_ES_AppState_RUNNING)
+        {
+            CFE_ES_SysLogWrite_Unsync("%s: Cannot Reload Application %s, It is not running.\n", __func__,
+                                      CFE_ES_AppRecordGetName(AppRecPtr));
+            ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
         }
         else
         {
-            CFE_ES_SysLogWrite_Unsync("%s: Cannot Reload Application %s, File %s does not exist.\n", __func__,
-                                      CFE_ES_AppRecordGetName(AppRecPtr), AppFileName);
-            ReturnCode = CFE_ES_FILE_IO_ERR;
+            /*
+            ** Check to see if the file exists
+            */
+            if (OS_stat(AppFileName, &FileStatus) == OS_SUCCESS)
+            {
+                CFE_ES_SysLogWrite_Unsync("%s: Reload Application %s Initiated. New filename = %s\n", __func__,
+                                          CFE_ES_AppRecordGetName(AppRecPtr), AppFileName);
+                strncpy(AppRecPtr->StartParams.BasicInfo.FileName, AppFileName,
+                        sizeof(AppRecPtr->StartParams.BasicInfo.FileName) - 1);
+                AppRecPtr->StartParams.BasicInfo.FileName[sizeof(AppRecPtr->StartParams.BasicInfo.FileName) - 1] = 0;
+                AppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_SYS_RELOAD;
+            }
+            else
+            {
+                CFE_ES_SysLogWrite_Unsync("%s: Cannot Reload Application %s, File %s does not exist.\n", __func__,
+                                          CFE_ES_AppRecordGetName(AppRecPtr), AppFileName);
+                ReturnCode = CFE_ES_FILE_IO_ERR;
+            }
         }
-    }
 
-    CFE_ES_UnlockSharedData(__func__, __LINE__);
+        CFE_ES_UnlockSharedData(__func__, __LINE__);
+    }
+    else /* App ID is not valid */
+    {
+        ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
+
+        CFE_ES_WriteToSysLog("%s: Invalid Application ID received, AppID = %lu\n", __func__,
+                             CFE_RESOURCEID_TO_ULONG(AppID));
+    }
 
     return (ReturnCode);
 }
@@ -302,36 +308,42 @@ CFE_Status_t CFE_ES_DeleteApp(CFE_ES_AppId_t AppID)
     int32               ReturnCode = CFE_SUCCESS;
     CFE_ES_AppRecord_t *AppRecPtr  = CFE_ES_LocateAppRecordByID(AppID);
 
-    if (AppRecPtr == NULL)
+    if (AppRecPtr != NULL)
     {
-        return CFE_ES_ERR_RESOURCEID_NOT_VALID;
+
+        CFE_ES_LockSharedData(__func__, __LINE__);
+
+        /*
+        ** Check to see if the App is an external cFE App.
+        */
+        if (AppRecPtr->Type == CFE_ES_AppType_CORE)
+        {
+            CFE_ES_SysLogWrite_Unsync("%s: Cannot Delete a CORE Application: %s.\n", __func__,
+                                      CFE_ES_AppRecordGetName(AppRecPtr));
+            ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
+        }
+        else if (AppRecPtr->AppState != CFE_ES_AppState_RUNNING)
+        {
+            CFE_ES_SysLogWrite_Unsync("%s: Cannot Delete Application %s, It is not running.\n", __func__,
+                                      CFE_ES_AppRecordGetName(AppRecPtr));
+            ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
+        }
+        else
+        {
+            CFE_ES_SysLogWrite_Unsync("%s: Delete Application %s Initiated\n", __func__,
+                                      CFE_ES_AppRecordGetName(AppRecPtr));
+            AppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_SYS_DELETE;
+        }
+
+        CFE_ES_UnlockSharedData(__func__, __LINE__);
     }
-
-    CFE_ES_LockSharedData(__func__, __LINE__);
-
-    /*
-    ** Check to see if the App is an external cFE App.
-    */
-    if (AppRecPtr->Type == CFE_ES_AppType_CORE)
+    else /* App ID is not valid */
     {
-        CFE_ES_SysLogWrite_Unsync("%s: Cannot Delete a CORE Application: %s.\n", __func__,
-                                  CFE_ES_AppRecordGetName(AppRecPtr));
         ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
-    }
-    else if (AppRecPtr->AppState != CFE_ES_AppState_RUNNING)
-    {
-        CFE_ES_SysLogWrite_Unsync("%s: Cannot Delete Application %s, It is not running.\n", __func__,
-                                  CFE_ES_AppRecordGetName(AppRecPtr));
-        ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
-    }
-    else
-    {
-        CFE_ES_SysLogWrite_Unsync("%s: Delete Application %s Initiated\n", __func__,
-                                  CFE_ES_AppRecordGetName(AppRecPtr));
-        AppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_SYS_DELETE;
-    }
 
-    CFE_ES_UnlockSharedData(__func__, __LINE__);
+        CFE_ES_WriteToSysLog("%s: Invalid Application ID received, AppID = %lu\n", __func__,
+                             CFE_RESOURCEID_TO_ULONG(AppID));
+    }
 
     return (ReturnCode);
 }


### PR DESCRIPTION
**Describe the contribution**
Fix #1775
Fix #1773 

**Testing performed**
Build and run unit tests, passed

**Expected behavior changes**
Will now report invalid ids to the syslog for CFE_ES_DeleteApp and CFE_ES_ReloadApp

**System(s) tested on**
 - Hardware: Intel i5/Docker
 - OS: Ubuntu 18.04
 - Versions: Bundle main + these commits

**Additional context**
Related to requirements verification

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC