### PR TITLE
Fix #1780, RTEMS CFE_FT_Global build failure

### DIFF
--- a/modules/cfe_testcase/CMakeLists.txt
+++ b/modules/cfe_testcase/CMakeLists.txt
@@ -2,9 +2,9 @@ include_directories(inc)
 
 # Filenames based on doxygen groups.
 # Create the app module
-add_cfe_app(cfe_testcase
-    src/cfe_test_table.c
+add_cfe_app(cfe_testcase    
     src/cfe_test.c
+    src/cfe_test_table.c
     src/es_application_control_test.c
     src/es_info_test.c
     src/es_task_test.c

--- a/modules/cfe_testcase/src/cfe_test.c
+++ b/modules/cfe_testcase/src/cfe_test.c
@@ -41,6 +41,11 @@ CFE_FT_Global_t CFE_FT_Global;
  */
 void CFE_TestMain(void)
 {
+    /* Constant Table information used by all table tests */
+    CFE_FT_Global.TblName           = "TestTable";
+    CFE_FT_Global.RegisteredTblName = "CFE_TEST_APP.TestTable";
+    CFE_FT_Global.TblFilename       = "test_tbl.tbl";
+
     /*
      * Register this test app with CFE assert
      *

--- a/modules/cfe_testcase/src/cfe_test_table.c
+++ b/modules/cfe_testcase/src/cfe_test_table.c
@@ -33,13 +33,10 @@
 #include "cfe_test.h"
 #include "cfe_test_table.h"
 
-/* Constant Table information used by all table tests */
-CFE_FT_Global_t CFE_FT_Global = {
-    .TblName = "TestTable", .RegisteredTblName = "CFE_TEST_APP.TestTable", .TblFilename = "test_tbl.tbl"};
-
 /* Setup function to register a table */
 void RegisterTestTable(void)
 {
+
     UtAssert_INT32_EQ(CFE_TBL_Register(&CFE_FT_Global.TblHandle, CFE_FT_Global.TblName, sizeof(TBL_TEST_Table_t),
                                        CFE_TBL_OPT_DEFAULT, NULL),
                       CFE_SUCCESS);

--- a/modules/cfe_testcase/src/cfe_test_table.h
+++ b/modules/cfe_testcase/src/cfe_test_table.h
@@ -39,8 +39,6 @@
  */
 #include "cfe_test.h"
 
-CFE_FT_Global_t CFE_FT_Global;
-
 void RegisterTestTable(void);
 void UnregisterTestTable(void);
 


### PR DESCRIPTION
**Describe the contribution**
- Fix #1780 

**Testing performed**
cFE CI and bundle CI
See succesful bundle tests at https://github.com/astrogeco/cFS/runs/3284780164

**Expected behavior changes**
No behavior change, fixes build failure on RTEMS 4.11 and 5.0

**System(s) tested on**
GitHub Actions CI

**Additional context**
Fixed as part of IC:2021-08-10

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
@astrogeco 
@nmullane