### PR TITLE
Fixes #1776, #1770, Stop memory leak & add cds size test.

### DIFF
--- a/modules/cfe_testcase/src/es_cds_test.c
+++ b/modules/cfe_testcase/src/es_cds_test.c
@@ -38,14 +38,15 @@ void TestRegisterCDS(void)
     CFE_ES_CDSHandle_t CDSHandlePtr;
     CFE_ES_CDSHandle_t CDSHandlePtr2;
 
-    size_t       BlockSize = 10;
-    const char * Name      = "CDS_Test";
-    const char * LongName  = "VERY_LONG_NAME_CDS_Test";
+    size_t       BlockSize  = 10;
+    size_t       BlockSize2 = 15;
+    const char * Name       = "CDS_Test";
+    const char * LongName   = "VERY_LONG_NAME_CDS_Test";
     CFE_Status_t status;
 
     UtPrintf("Testing: CFE_ES_RegisterCDS");
 
-    status = CFE_ES_RegisterCDS(&CDSHandlePtr, BlockSize, Name);
+    status = CFE_ES_RegisterCDS(&CDSHandlePtr, BlockSize2, Name);
 
     if (status == CFE_ES_CDS_ALREADY_EXISTS)
     {
@@ -56,7 +57,8 @@ void TestRegisterCDS(void)
         UtAssert_INT32_EQ(status, CFE_SUCCESS);
     }
 
-    UtAssert_INT32_EQ(CFE_ES_RegisterCDS(&CDSHandlePtr2, BlockSize, Name), CFE_ES_CDS_ALREADY_EXISTS);
+    UtAssert_INT32_EQ(CFE_ES_RegisterCDS(&CDSHandlePtr2, BlockSize2, Name), CFE_ES_CDS_ALREADY_EXISTS);
+    UtAssert_INT32_EQ(CFE_ES_RegisterCDS(&CDSHandlePtr2, BlockSize, Name), CFE_SUCCESS);
 
     UtAssert_INT32_EQ(CFE_ES_RegisterCDS(NULL, BlockSize, Name), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_RegisterCDS(&CDSHandlePtr, 0, Name), CFE_ES_CDS_INVALID_SIZE);

--- a/modules/cfe_testcase/src/es_mempool_test.c
+++ b/modules/cfe_testcase/src/es_mempool_test.c
@@ -44,11 +44,13 @@ void TestMemPoolCreate(void)
     UtAssert_INT32_EQ(CFE_ES_PoolCreateNoSem(NULL, Pool, sizeof(Pool)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_PoolCreateNoSem(&PoolID, NULL, sizeof(Pool)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_PoolCreateNoSem(&PoolID, Pool, 0), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_PoolDelete(PoolID), CFE_SUCCESS);
 
     UtAssert_INT32_EQ(CFE_ES_PoolCreate(&PoolID, Pool, sizeof(Pool)), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_PoolCreate(NULL, Pool, sizeof(Pool)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_PoolCreate(&PoolID, NULL, sizeof(Pool)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_PoolCreate(&PoolID, Pool, 0), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_PoolDelete(PoolID), CFE_SUCCESS);
 
     UtAssert_INT32_EQ(CFE_ES_PoolCreateEx(&PoolID, Pool, sizeof(Pool), 0, NULL, CFE_ES_NO_MUTEX), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_PoolCreateEx(NULL, Pool, sizeof(Pool), 0, NULL, CFE_ES_NO_MUTEX), CFE_ES_BAD_ARGUMENT);


### PR DESCRIPTION
**Describe the contribution**
Fixes #1776 
Delete memory pools to prevent memory leak. 

Fixes #1770
Add Test for registering CDS with same name and different size. 

**Testing performed**
Build and run unit test

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC