### PR TITLE
Fix #1784, add CFE assert macros to functional test

### DIFF
--- a/modules/cfe_assert/inc/cfe_assert.h
+++ b/modules/cfe_assert/inc/cfe_assert.h
@@ -39,12 +39,117 @@
 *************************************************************************/
 #include "common_types.h"
 #include "cfe_es_api_typedefs.h"
+#include "utassert.h"
+#include "cfe_error.h"
 
 /************************************************************************
 ** Type Definitions
 *************************************************************************/
 
 typedef void (*CFE_Assert_StatusCallback_t)(uint8 MessageType, const char *Prefix, const char *OutputMessage);
+
+/*************************************************************************
+** CFE-specific assertion macros
+** (similar to macros in the CFE coverage test)
+*************************************************************************/
+
+/*****************************************************************************/
+/**
+** \brief Asserts the nominal execution of the function being tested.
+**
+** \par Description
+**        The core of each unit test is the execution of the function being tested.
+**        This function and macro should be used to test the nominal execution of the
+**        function; the expectation is that it will return CFE_SUCCESS or an
+**        unspecified positive value.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+******************************************************************************/
+#define CFE_UtAssert_STATUS_OK(FN) \
+    CFE_UtAssert_StatusCheck(FN, true, UTASSERT_CASETYPE_FAILURE, __FILE__, __LINE__, #FN)
+
+/*****************************************************************************/
+/**
+** \brief Asserts the off-nominal execution of the function being tested.
+**
+** \par Description
+**        The core of each unit test is the execution of the function being tested.
+**        This function and macro should be used to test the generic off-nominal execution
+**        of the function; the expectation is that it will return an unspecified negative
+**        value.
+**
+** \par Assumptions, External Events, and Notes:
+**        This should be used in cases where a specific error for a particular condition
+**        is not known/documented.  Whenever a specific error is indicated by the documentation,
+**        tests should check for that error instead of using this.
+**
+******************************************************************************/
+#define CFE_UtAssert_STATUS_ERROR(FN) \
+    CFE_UtAssert_StatusCheck(FN, false, UTASSERT_CASETYPE_FAILURE, __FILE__, __LINE__, #FN)
+
+/*****************************************************************************/
+/**
+** \brief Macro to check CFE resource ID for equality
+**
+** \par Description
+**        A macro that checks two resource ID values for equality.
+**
+** \par Assumptions, External Events, and Notes:
+**        The generic #UtAssert_UINT32_EQ check should not be used, as ID values
+**        and integers may not be interchangable with strict type checking.
+**
+******************************************************************************/
+#define CFE_UtAssert_RESOURCEID_EQ(id1, id2)                                                                         \
+    UtAssert_GenericUnsignedCompare(CFE_RESOURCEID_TO_ULONG(id1), UtAssert_Compare_EQ, CFE_RESOURCEID_TO_ULONG(id2), \
+                                    UtAssert_Radix_HEX, __FILE__, __LINE__, "Resource ID Check: ", #id1, #id2)
+
+/*****************************************************************************/
+/**
+** \brief Check if a Resource ID is Undefined
+**
+** \par Description
+**        A macro that checks if resource ID value is undefined.
+**
+** \par Assumptions, External Events, and Notes:
+**        This utilizes the "TEST_DEFINED" macro provided by the resourceid module, as the
+**        set of undefined IDs is more than the single value of CFE_RESOURCEID_UNDEFINED.
+**
+******************************************************************************/
+#define CFE_UtAssert_RESOURCEID_UNDEFINED(id) \
+    UtAssert_True(!CFE_RESOURCEID_TEST_DEFINED(id), "%s (0x%lx) not defined", #id, CFE_RESOURCEID_TO_ULONG(id))
+
+/*****************************************************************************/
+/**
+** \brief Macro to check CFE memory size/offset for equality
+**
+** \par Description
+**        A macro that checks two memory offset/size values for equality.
+**
+** \par Assumptions, External Events, and Notes:
+**        This is a simple unsigned comparison which logs the values as hexadecimal
+**
+******************************************************************************/
+#define CFE_UtAssert_MEMOFFSET_EQ(off1, off2)                                                                \
+    UtAssert_GenericUnsignedCompare(off1, UtAssert_Compare_EQ, off2, UtAssert_Radix_HEX, __FILE__, __LINE__, \
+                                    "Offset Check: ", #off1, #off2)
+
+/*****************************************************************************/
+/**
+** \brief Macro to check CFE message ID for equality
+**
+** \par Description
+**        A macro that checks two message ID values for equality.
+**
+** \par Assumptions, External Events, and Notes:
+**        The generic #UtAssert_UINT32_EQ check should not be used, as CFE_SB_MsgId_t values
+**        and integers may not be interchangable with strict type checking.
+**
+******************************************************************************/
+#define CFE_UtAssert_MSGID_EQ(mid1, mid2)                                                                      \
+    UtAssert_GenericUnsignedCompare(CFE_SB_MsgIdToValue(mid1), UtAssert_Compare_EQ, CFE_SB_MsgIdToValue(mid2), \
+                                    UtAssert_Radix_HEX, __FILE__, __LINE__, "MsgId Check: ", #mid1, #mid2)
 
 /*************************************************************************
 ** Exported Functions
@@ -144,5 +249,31 @@ int32 CFE_Assert_OpenLogFile(const char *Filename);
  *
  */
 void CFE_Assert_CloseLogFile(void);
+
+/*****************************************************************************/
+/**
+** \brief Helper function for nominal CFE calls
+**
+** \par Description
+**        This helper function wraps the normal UtAssert function, intended for verifying
+**        CFE API calls that are expected to return successfully.
+**
+**        Note that this checks for a logical "success", which includes the specific #CFE_SUCCESS
+**        status code, as well as all other status codes that represent a successful completion
+**        of the function objectives (i.e. such as a nonzero size, from functions that return a
+**        size).
+**
+**        This can also be used to report with an alternative pass/fail marker by passing the CaseType
+**        parameter appropriately.
+**
+** \par Assumptions, External Events, and Notes:
+**        Note this will accept any non-negative value as logical "success", so it
+**        also works with functions that return a size or other non-error status.
+**
+** \returns Test pass status, returns true if status was successful, false if it failed.
+**
+******************************************************************************/
+bool CFE_UtAssert_StatusCheck(CFE_Status_t Status, bool ExpectSuccess, UtAssert_CaseType_t CaseType, const char *File,
+                              uint32 Line, const char *Text);
 
 #endif /* CFE_ASSERT_H */

--- a/modules/cfe_assert/src/cfe_assert_runner.c
+++ b/modules/cfe_assert/src/cfe_assert_runner.c
@@ -69,6 +69,26 @@ static CFE_EVS_BinFilter_t CFE_TR_EventFilters[] = {
     {UTASSERT_CASETYPE_DEBUG, CFE_EVS_NO_FILTER},
 };
 
+bool CFE_UtAssert_StatusCheck(CFE_Status_t Status, bool ExpectSuccess, UtAssert_CaseType_t CaseType, const char *File,
+                              uint32 Line, const char *Text)
+{
+    bool        Result = (Status >= CFE_SUCCESS);
+    const char *MatchText;
+
+    if (ExpectSuccess)
+    {
+        MatchText = "OK";
+    }
+    else
+    {
+        /* expecting non-success; result should be inverted */
+        Result    = !Result;
+        MatchText = "ERROR";
+    }
+
+    return UtAssertEx(Result, CaseType, File, Line, "%s (0x%lx) is %s", Text, (unsigned long)Status, MatchText);
+}
+
 void CFE_Assert_StatusReport(uint8 MessageType, const char *Prefix, const char *OutputMessage)
 {
     uint16 EventType;

--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -43,6 +43,7 @@
 
 #include "uttest.h"
 #include "utassert.h"
+#include "cfe_assert.h"
 
 typedef struct
 {
@@ -68,23 +69,6 @@ extern CFE_FT_Global_t CFE_FT_Global;
  * of scripted tests and/or capturing test artifacts.
  */
 #define CFE_ASSERT_LOG_FILE_NAME "/cf/cfe_test.log"
-
-/* Compare two Resource IDs */
-#define cFE_FTAssert_ResourceID_EQ(actual, expect)                                            \
-    UtAssert_True(CFE_RESOURCEID_TEST_EQUAL(actual, expect), "%s (%lu) == %s (%lu)", #actual, \
-                  CFE_RESOURCEID_TO_ULONG(actual), #expect, CFE_RESOURCEID_TO_ULONG(expect))
-
-/* Check if a Resource ID is Undefined */
-#define cFE_FTAssert_ResourceID_Undefined(id) \
-    UtAssert_True(!CFE_RESOURCEID_TEST_DEFINED(id), "%s (%lu) not defined", #id, CFE_RESOURCEID_TO_ULONG(id))
-
-/* Assert a return code is not equal to cfe_success */
-#define cFE_FTAssert_NOT_CFE_SUCCESS(actual)                                      \
-    do                                                                            \
-    {                                                                             \
-        int32 rcact = (int32)(actual);                                            \
-        UtAssert_True(rcact < CFE_SUCCESS, "%s == (%ld) ", #actual, (long)rcact); \
-    } while (0)
 
 bool TimeInRange(CFE_TIME_SysTime_t Time, CFE_TIME_SysTime_t Target, OS_time_t difference);
 

--- a/modules/cfe_testcase/src/es_cds_test.c
+++ b/modules/cfe_testcase/src/es_cds_test.c
@@ -82,7 +82,7 @@ void TestCDSName(void)
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockName(CDSNameBuf, CDSHandlePtr, sizeof(CDSNameBuf)), CFE_SUCCESS);
     UtAssert_StrCmp(CDSNameBuf, CDSName, "CFE_ES_GetCDSBlockName() = %s", CDSNameBuf);
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockIDByName(&IdByName, CDSNameBuf), CFE_SUCCESS);
-    cFE_FTAssert_ResourceID_EQ(CDSHandlePtr, IdByName);
+    CFE_UtAssert_RESOURCEID_EQ(CDSHandlePtr, IdByName);
 
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockName(NULL, CDSHandlePtr, sizeof(CDSNameBuf)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockName(CDSNameBuf, CFE_ES_CDS_BAD_HANDLE, sizeof(CDSNameBuf)),

--- a/modules/cfe_testcase/src/es_counter_test.c
+++ b/modules/cfe_testcase/src/es_counter_test.c
@@ -84,7 +84,7 @@ void TestCounterCreateDelete(void)
 
     /* Confirm conversion To/From Name */
     UtAssert_INT32_EQ(CFE_ES_GetGenCounterIDByName(&CheckId, CounterName), CFE_SUCCESS);
-    cFE_FTAssert_ResourceID_EQ(CheckId, TestId);
+    CFE_UtAssert_RESOURCEID_EQ(CheckId, TestId);
     UtAssert_INT32_EQ(CFE_ES_GetGenCounterName(CheckName, TestId, sizeof(CheckName)), CFE_SUCCESS);
     UtAssert_STRINGBUF_EQ(CheckName, sizeof(CheckName), CounterName, sizeof(CounterName));
 

--- a/modules/cfe_testcase/src/es_info_test.c
+++ b/modules/cfe_testcase/src/es_info_test.c
@@ -52,7 +52,7 @@ void TestAppInfo(void)
 
     UtAssert_INT32_EQ(CFE_ES_GetAppIDByName(&AppIdByName, TEST_EXPECTED_APP_NAME), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetAppID(&TestAppId), CFE_SUCCESS);
-    cFE_FTAssert_ResourceID_EQ(TestAppId, AppIdByName);
+    CFE_UtAssert_RESOURCEID_EQ(TestAppId, AppIdByName);
     UtAssert_INT32_EQ(CFE_ES_GetAppName(AppNameBuf, TestAppId, sizeof(AppNameBuf)), CFE_SUCCESS);
     UtAssert_StrCmp(AppNameBuf, TEST_EXPECTED_APP_NAME, "CFE_ES_GetAppName() = %s", AppNameBuf);
 
@@ -122,7 +122,7 @@ void TestAppInfo(void)
     UtAssert_True(ESAppInfo.NumOfChildTasks > 0, "ES App Info -> Child Tasks  = %d", (int)ESAppInfo.NumOfChildTasks);
 
     UtAssert_INT32_EQ(CFE_ES_GetAppIDByName(&AppIdByName, INVALID_APP_NAME), CFE_ES_ERR_NAME_NOT_FOUND);
-    cFE_FTAssert_ResourceID_Undefined(AppIdByName);
+    CFE_UtAssert_RESOURCEID_UNDEFINED(AppIdByName);
     UtAssert_INT32_EQ(CFE_ES_GetAppID(NULL), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetAppIDByName(NULL, TEST_EXPECTED_APP_NAME), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetAppName(AppNameBuf, CFE_ES_APPID_UNDEFINED, sizeof(AppNameBuf)),
@@ -146,15 +146,15 @@ void TestTaskInfo(void)
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskInfo(&TaskInfo, AppInfo.MainTaskId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetTaskID(&TaskId), CFE_SUCCESS);
-    cFE_FTAssert_ResourceID_EQ(TaskId, AppInfo.MainTaskId);
+    CFE_UtAssert_RESOURCEID_EQ(TaskId, AppInfo.MainTaskId);
 
     UtAssert_StrCmp(TaskInfo.AppName, AppInfo.Name, "TaskInfo.AppName (%s) = AppInfo.name (%s)", TaskInfo.AppName,
                     AppInfo.Name);
     UtAssert_StrCmp(TaskInfo.TaskName, AppInfo.MainTaskName, "TaskInfo.TaskName (%s) = AppInfo.MainTaskName (%s)",
                     TaskInfo.TaskName, AppInfo.MainTaskName);
 
-    cFE_FTAssert_ResourceID_EQ(TaskInfo.TaskId, AppInfo.MainTaskId);
-    cFE_FTAssert_ResourceID_EQ(TaskInfo.AppId, AppId);
+    CFE_UtAssert_RESOURCEID_EQ(TaskInfo.TaskId, AppInfo.MainTaskId);
+    CFE_UtAssert_RESOURCEID_EQ(TaskInfo.AppId, AppId);
     UtAssert_INT32_EQ(TaskInfo.ExecutionCounter, AppInfo.ExecutionCounter);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskInfo(&TaskInfo, CFE_ES_TASKID_UNDEFINED), CFE_ES_ERR_RESOURCEID_NOT_VALID);
@@ -205,7 +205,7 @@ void TestLibInfo(void)
 
     UtAssert_INT32_EQ(LibInfo.ExceptionAction, 0);
     UtAssert_True(LibInfo.Priority == 0, "Lib Info -> Priority  = %d", (int)LibInfo.Priority);
-    cFE_FTAssert_ResourceID_Undefined(LibInfo.MainTaskId);
+    CFE_UtAssert_RESOURCEID_UNDEFINED(LibInfo.MainTaskId);
     UtAssert_True(LibInfo.ExecutionCounter == 0, "Lib Info -> ExecutionCounter  = %d", (int)LibInfo.ExecutionCounter);
     UtAssert_True(strlen(LibInfo.MainTaskName) == 0, "Lib Info -> Task Name  = %s", LibInfo.MainTaskName);
     UtAssert_True(LibInfo.NumOfChildTasks == 0, "Lib Info -> Child Tasks  = %d", (int)LibInfo.NumOfChildTasks);

--- a/modules/cfe_testcase/src/es_task_test.c
+++ b/modules/cfe_testcase/src/es_task_test.c
@@ -108,14 +108,14 @@ void TestChildTaskName(void)
                       CFE_SUCCESS);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(&TaskIdByName, TaskName), CFE_SUCCESS);
-    cFE_FTAssert_ResourceID_EQ(TaskIdByName, TaskId);
+    CFE_UtAssert_RESOURCEID_EQ(TaskIdByName, TaskId);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(TaskNameBuf, TaskId, sizeof(TaskNameBuf)), CFE_SUCCESS);
     UtAssert_StrCmp(TaskNameBuf, TaskName, "CFE_ES_GetTaskName() = %s", TaskNameBuf);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(NULL, TaskName), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(&TaskIdByName, INVALID_TASK_NAME), CFE_ES_ERR_NAME_NOT_FOUND);
-    cFE_FTAssert_ResourceID_Undefined(TaskIdByName);
+    CFE_UtAssert_RESOURCEID_UNDEFINED(TaskIdByName);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(NULL, TaskId, sizeof(TaskNameBuf)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(TaskNameBuf, CFE_ES_TASKID_UNDEFINED, sizeof(TaskNameBuf)),

--- a/modules/cfe_testcase/src/fs_header_test.c
+++ b/modules/cfe_testcase/src/fs_header_test.c
@@ -59,7 +59,7 @@ void TestCreateHeader(void)
     UtAssert_INT32_EQ(OS_lseek(fd, 0, OS_SEEK_CUR), sizeof(CFE_FS_Header_t));
 
     UtAssert_INT32_EQ(CFE_FS_WriteHeader(fd, NULL), CFE_FS_BAD_ARGUMENT);
-    cFE_FTAssert_NOT_CFE_SUCCESS(CFE_FS_WriteHeader(OS_OBJECT_ID_UNDEFINED, &Header));
+    CFE_UtAssert_STATUS_ERROR(CFE_FS_WriteHeader(OS_OBJECT_ID_UNDEFINED, &Header));
 
     UtAssert_VOIDCALL(CFE_FS_InitHeader(NULL, TestDescription, CFE_FS_SubType_ES_ERLOG));
     UtAssert_VOIDCALL(CFE_FS_InitHeader(&HeaderFail, NULL, CFE_FS_SubType_ES_ERLOG));
@@ -88,7 +88,7 @@ void TestReadHeader(void)
     UtAssert_StrCmp(TestDescription, ReadHeader.Description, "ReadHeader.Description = %s", ReadHeader.Description);
 
     UtAssert_INT32_EQ(CFE_FS_ReadHeader(NULL, fd), CFE_FS_BAD_ARGUMENT);
-    cFE_FTAssert_NOT_CFE_SUCCESS(CFE_FS_ReadHeader(&ReadHeader, OS_OBJECT_ID_UNDEFINED));
+    CFE_UtAssert_STATUS_ERROR(CFE_FS_ReadHeader(&ReadHeader, OS_OBJECT_ID_UNDEFINED));
 
     OS_close(fd);
     OS_remove(OS_TEST_HEADER_FILENAME);
@@ -114,7 +114,7 @@ void TestTimeStamp(void)
     UtAssert_UINT32_EQ(0xFFFFFFFF, ReadHeader.TimeSeconds);
     UtAssert_UINT32_EQ(0xFFFFFFFF, ReadHeader.TimeSubSeconds);
 
-    cFE_FTAssert_NOT_CFE_SUCCESS(CFE_FS_SetTimestamp(OS_OBJECT_ID_UNDEFINED, NewTimestamp));
+    CFE_UtAssert_STATUS_ERROR(CFE_FS_SetTimestamp(OS_OBJECT_ID_UNDEFINED, NewTimestamp));
 
     OS_close(fd);
     OS_remove(OS_TEST_HEADER_FILENAME);

--- a/modules/cfe_testcase/src/sb_pipe_mang_test.c
+++ b/modules/cfe_testcase/src/sb_pipe_mang_test.c
@@ -112,7 +112,7 @@ void TestPipeName(void)
     UtAssert_StrCmp(PipeNameBuf, PipeName, "CFE_SB_GetPipeName() = %s", PipeNameBuf);
 
     UtAssert_INT32_EQ(CFE_SB_GetPipeIdByName(&PipeIdBuff, PipeName), CFE_SUCCESS);
-    cFE_FTAssert_ResourceID_EQ(PipeId, PipeIdBuff);
+    CFE_UtAssert_RESOURCEID_EQ(PipeId, PipeIdBuff);
 
     UtAssert_INT32_EQ(CFE_SB_GetPipeName(NULL, sizeof(PipeNameBuf), PipeId), CFE_SB_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_SB_GetPipeName(PipeNameBuf, 0, PipeId), CFE_SB_BAD_ARGUMENT);


### PR DESCRIPTION
**Describe the contribution**
Adds the following macros to CFE assert library in cfe_assert.h:

- CFE_UtAssert_STATUS_OK
- CFE_UtAssert_STATUS_ERROR
- CFE_UtAssert_RESOURCEID_EQ
- CFE_UtAssert_RESOURCEID_UNDEFINED
- CFE_UtAssert_MEMOFFSET_EQ
- CFE_UtAssert_MSGID_EQ

Fixes #1784

**Testing performed**
Build and run all tests (including with some new test cases that use the new macros) and confirm all is working as expected.

**Expected behavior changes**
None right now, these are new macros that test cases are not using yet.

**System(s) tested on**
Ubuntu

**Additional context**
Provides improved feature parity with coverage test environment, gives a common macro to use for common tests/asserts, and more consistent naming convention.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc