### PR TITLE
Fix #812 Add Perf API functional tests

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -63,11 +63,14 @@ jobs:
       - name: List cpu1
         run: ls build/exe/cpu1/
 
+      # Run cFS, send commands to set perf trigger and start perf data, and run functional tests
       - name: Run cFS
         run: |
           ./core-cpu1 &
           sleep 10
-          ../host/cmdUtil --pktid=0x1806 --cmdcode=4 --endian=LE --string="20:CFE_TEST_APP" --string="20:CFE_TestMain" --string="64:cfe_testcase" --uint32=16384 --uint8=0 --uint8=0 --uint16=100 &
+          ../host/cmdUtil --pktid=0x1806 --cmdcode=17 --endian=LE --uint32=3 --uint32=0x40000000
+          ../host/cmdUtil --pktid=0x1806 --cmdcode=14 --endian=LE --uint32=2
+          ../host/cmdUtil --pktid=0x1806 --cmdcode=4 --endian=LE --string="20:CFE_TEST_APP" --string="20:CFE_TestMain" --string="64:cfe_testcase" --uint32=16384 --uint8=0 --uint8=0 --uint16=100
 
           sleep 30
           counter=0 

--- a/modules/cfe_testcase/CMakeLists.txt
+++ b/modules/cfe_testcase/CMakeLists.txt
@@ -12,6 +12,7 @@ add_cfe_app(cfe_testcase
     src/es_counter_test.c
     src/es_misc_test.c
     src/es_mempool_test.c
+    src/es_perf_test.c
     src/es_resource_id_test.c
     src/evs_filters_test.c
     src/evs_send_test.c

--- a/modules/cfe_testcase/src/cfe_test.c
+++ b/modules/cfe_testcase/src/cfe_test.c
@@ -64,6 +64,7 @@ void CFE_TestMain(void)
     ESInfoTestSetup();
     ESMemPoolTestSetup();
     ESMiscTestSetup();
+    ESPerfTestSetup();
     ESResourceIDTestSetup();
     ESTaskTestSetup();
     EVSFiltersTestSetup();

--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -95,6 +95,7 @@ void ESCounterTestSetup(void);
 void ESInfoTestSetup(void);
 void ESMemPoolTestSetup(void);
 void ESMiscTestSetup(void);
+void ESPerfTestSetup(void);
 void ESResourceIDTestSetup(void);
 void ESTaskTestSetup(void);
 void EVSFiltersTestSetup(void);

--- a/modules/cfe_testcase/src/es_perf_test.c
+++ b/modules/cfe_testcase/src/es_perf_test.c
@@ -1,0 +1,74 @@
+/*************************************************************************
+**
+**      GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**      Copyright (c) 2006-2019 United States Government as represented by
+**      the Administrator of the National Aeronautics and Space Administration.
+**      All Rights Reserved.
+**
+**      Licensed under the Apache License, Version 2.0 (the "License");
+**      you may not use this file except in compliance with the License.
+**      You may obtain a copy of the License at
+**
+**        http://www.apache.org/licenses/LICENSE-2.0
+**
+**      Unless required by applicable law or agreed to in writing, software
+**      distributed under the License is distributed on an "AS IS" BASIS,
+**      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**      See the License for the specific language governing permissions and
+**      limitations under the License.
+**
+** File: es_perf_test.c
+**
+** Purpose:
+**   Functional test of ES Performance APIs
+**
+*************************************************************************/
+
+/*
+ * Includes
+ */
+
+#include "cfe_test.h"
+
+void TestPerfLogEntry(void)
+{
+    UtAssert_VOIDCALL(CFE_ES_PerfLogEntry(0));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogEntry(CFE_MISSION_ES_PERF_MAX_IDS - 1));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogEntry(CFE_MISSION_ES_PERF_MAX_IDS));
+}
+
+void TestPerfLogExit(void)
+{
+    UtAssert_VOIDCALL(CFE_ES_PerfLogExit(0));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogExit(CFE_MISSION_ES_PERF_MAX_IDS - 1));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogExit(CFE_MISSION_ES_PERF_MAX_IDS));
+}
+
+void TestPerfLogAdd(void)
+{
+    UtAssert_VOIDCALL(CFE_ES_PerfLogAdd(0, 0));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogAdd(0, 1));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogAdd(0, 0xFFFFFFFF));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogAdd(CFE_MISSION_ES_PERF_MAX_IDS - 1, 0));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogAdd(CFE_MISSION_ES_PERF_MAX_IDS - 1, 1));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogAdd(CFE_MISSION_ES_PERF_MAX_IDS - 1, 0xFFFFFFFF));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogAdd(CFE_MISSION_ES_PERF_MAX_IDS, 0));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogAdd(CFE_MISSION_ES_PERF_MAX_IDS, 1));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogAdd(CFE_MISSION_ES_PERF_MAX_IDS, 0xFFFFFFFF));
+}
+
+/* These commands should trigger and stop perf data (based on value commanded in functional test workflow) */
+void TestPerfLogTrigger(void)
+{
+    UtAssert_VOIDCALL(CFE_ES_PerfLogEntry(126));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogExit(126));
+}
+
+void ESPerfTestSetup(void)
+{
+    UtTest_Add(TestPerfLogEntry, NULL, NULL, "Test PerfLogEntry");
+    UtTest_Add(TestPerfLogExit, NULL, NULL, "Test PerfLogExit");
+    UtTest_Add(TestPerfLogAdd, NULL, NULL, "Test PerfLogAdd");
+    UtTest_Add(TestPerfLogTrigger, NULL, NULL, "Test Perf Trigger");
+}


### PR DESCRIPTION
**Describe the contribution**
Fixes #812 
Add Perf API functional tests and Add Perf Trigger and Perf Start commands to functional test workflow.
Functional Test will now send a command to set a Perf trigger, send command to start capturing Perf data and finally send command to start running the functional tests.

**Testing performed**
Steps taken to test the contribution:
1. Build with tests enabled
2. Run cFS
3. Send commands to set Perf trigger, and start Perf data
4. Send command to run Functional Tests
5. Verify tests pass
6. Push code to Github and verify workflow works

**Expected behavior changes**
New tests added to functional tests. Workflow now sends two more commands to cFS.

**System(s) tested on**
 - OS: Ubuntu 18.04 VM

**Contributor Info - All information REQUIRED for consideration of pull request**
Jose F. Martinez Pedraza / NASA GSFC