### PR TITLE
Fix #1805, Add test for ES BackgroundWakeup

### DIFF
--- a/modules/cfe_testcase/src/es_misc_test.c
+++ b/modules/cfe_testcase/src/es_misc_test.c
@@ -73,9 +73,16 @@ void TestProcessAsyncEvent(void)
     UtAssert_VOIDCALL(CFE_ES_ProcessAsyncEvent());
 }
 
+void TestBackgroundWakeup(void)
+{
+    UtPrintf("Testing: CFE_ES_BackgroundWakeup");
+    UtAssert_VOIDCALL(CFE_ES_BackgroundWakeup());
+}
+
 void ESMiscTestSetup(void)
 {
     UtTest_Add(TestCalculateCRC, NULL, NULL, "Test Calculate CRC");
     UtTest_Add(TestWriteToSysLog, NULL, NULL, "Test Write To Sys Log");
     UtTest_Add(TestProcessAsyncEvent, NULL, NULL, "Test Process Async Event");
+    UtTest_Add(TestBackgroundWakeup, NULL, NULL, "Test Background Wakeup");
 }


### PR DESCRIPTION
**Describe the contribution**
Fixes #1805 
- Adds missing test for CFE_ES_BackgroundWakeup

**Testing performed**
Build and run cfe functional tests

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Niall Mullane - GSFC 582 Intern