### PR TITLE
cFE Integration candidate 2021-08-17

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -63,11 +63,14 @@ jobs:
       - name: List cpu1
         run: ls build/exe/cpu1/
 
+      # Run cFS, send commands to set perf trigger and start perf data, and run functional tests
       - name: Run cFS
         run: |
           ./core-cpu1 &
           sleep 10
-          ../host/cmdUtil --pktid=0x1806 --cmdcode=4 --endian=LE --string="20:CFE_TEST_APP" --string="20:CFE_TestMain" --string="64:cfe_testcase" --uint32=16384 --uint8=0 --uint8=0 --uint16=100 &
+          ../host/cmdUtil --pktid=0x1806 --cmdcode=17 --endian=LE --uint32=3 --uint32=0x40000000
+          ../host/cmdUtil --pktid=0x1806 --cmdcode=14 --endian=LE --uint32=2
+          ../host/cmdUtil --pktid=0x1806 --cmdcode=4 --endian=LE --string="20:CFE_TEST_APP" --string="20:CFE_TestMain" --string="64:cfe_testcase" --uint32=16384 --uint8=0 --uint8=0 --uint16=100
 
           sleep 30
           counter=0 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,20 @@ The detailed cFE user's guide can be viewed at <https://github.com/nasa/cFS/blob
 
 ## Version History
 
+### Development Build: v6.8.0-rc1+dev873
+
+- Add CFE assert macros to functional test
+- Adds invalid id syslog to for CFE_ES_DeleteApp and CFE_ES_ReloadApp and verifies required reporting 
+- Stop memory leak & add cds size test. 
+- Mark read only inputs as const 
+- Check resource ID idx is less than max 
+- Update CFE_ES_RunLoop documentation 
+- Add Message Api Functional Test
+- Partial #1724, update in/out status and nonnull/nonzero tags
+- Add External Time Source Functional Tests
+- Add Perf API functional tests 
+See <https://github.com/nasa/cFE/pull/1808> and <https://github.com/nasa/cFS/pull/337> 
+
 ### Development Build: v6.8.0-rc1+dev844
 
 - Move global count into test global struct
@@ -25,6 +39,7 @@ The detailed cFE user's guide can be viewed at <https://github.com/nasa/cFS/blob
 - Replace cFE_FTAssert_VOIDCALL with new UtAssert_VOIDCALL
 - Remove multiple instantiations of CFE_FT_Global
 - Add functional tests for cFE Table APIs
+- See <https://github.com/nasa/cFE/pull/1759> and <https://github.com/nasa/cFS/pull/328>
 
 ### Development Build: v6.8.0-rc1+dev810
 

--- a/modules/cfe_assert/inc/cfe_assert.h
+++ b/modules/cfe_assert/inc/cfe_assert.h
@@ -39,12 +39,117 @@
 *************************************************************************/
 #include "common_types.h"
 #include "cfe_es_api_typedefs.h"
+#include "utassert.h"
+#include "cfe_error.h"
 
 /************************************************************************
 ** Type Definitions
 *************************************************************************/
 
 typedef void (*CFE_Assert_StatusCallback_t)(uint8 MessageType, const char *Prefix, const char *OutputMessage);
+
+/*************************************************************************
+** CFE-specific assertion macros
+** (similar to macros in the CFE coverage test)
+*************************************************************************/
+
+/*****************************************************************************/
+/**
+** \brief Asserts the nominal execution of the function being tested.
+**
+** \par Description
+**        The core of each unit test is the execution of the function being tested.
+**        This function and macro should be used to test the nominal execution of the
+**        function; the expectation is that it will return CFE_SUCCESS or an
+**        unspecified positive value.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+******************************************************************************/
+#define CFE_UtAssert_STATUS_OK(FN) \
+    CFE_UtAssert_StatusCheck(FN, true, UTASSERT_CASETYPE_FAILURE, __FILE__, __LINE__, #FN)
+
+/*****************************************************************************/
+/**
+** \brief Asserts the off-nominal execution of the function being tested.
+**
+** \par Description
+**        The core of each unit test is the execution of the function being tested.
+**        This function and macro should be used to test the generic off-nominal execution
+**        of the function; the expectation is that it will return an unspecified negative
+**        value.
+**
+** \par Assumptions, External Events, and Notes:
+**        This should be used in cases where a specific error for a particular condition
+**        is not known/documented.  Whenever a specific error is indicated by the documentation,
+**        tests should check for that error instead of using this.
+**
+******************************************************************************/
+#define CFE_UtAssert_STATUS_ERROR(FN) \
+    CFE_UtAssert_StatusCheck(FN, false, UTASSERT_CASETYPE_FAILURE, __FILE__, __LINE__, #FN)
+
+/*****************************************************************************/
+/**
+** \brief Macro to check CFE resource ID for equality
+**
+** \par Description
+**        A macro that checks two resource ID values for equality.
+**
+** \par Assumptions, External Events, and Notes:
+**        The generic #UtAssert_UINT32_EQ check should not be used, as ID values
+**        and integers may not be interchangable with strict type checking.
+**
+******************************************************************************/
+#define CFE_UtAssert_RESOURCEID_EQ(id1, id2)                                                                         \
+    UtAssert_GenericUnsignedCompare(CFE_RESOURCEID_TO_ULONG(id1), UtAssert_Compare_EQ, CFE_RESOURCEID_TO_ULONG(id2), \
+                                    UtAssert_Radix_HEX, __FILE__, __LINE__, "Resource ID Check: ", #id1, #id2)
+
+/*****************************************************************************/
+/**
+** \brief Check if a Resource ID is Undefined
+**
+** \par Description
+**        A macro that checks if resource ID value is undefined.
+**
+** \par Assumptions, External Events, and Notes:
+**        This utilizes the "TEST_DEFINED" macro provided by the resourceid module, as the
+**        set of undefined IDs is more than the single value of CFE_RESOURCEID_UNDEFINED.
+**
+******************************************************************************/
+#define CFE_UtAssert_RESOURCEID_UNDEFINED(id) \
+    UtAssert_True(!CFE_RESOURCEID_TEST_DEFINED(id), "%s (0x%lx) not defined", #id, CFE_RESOURCEID_TO_ULONG(id))
+
+/*****************************************************************************/
+/**
+** \brief Macro to check CFE memory size/offset for equality
+**
+** \par Description
+**        A macro that checks two memory offset/size values for equality.
+**
+** \par Assumptions, External Events, and Notes:
+**        This is a simple unsigned comparison which logs the values as hexadecimal
+**
+******************************************************************************/
+#define CFE_UtAssert_MEMOFFSET_EQ(off1, off2)                                                                \
+    UtAssert_GenericUnsignedCompare(off1, UtAssert_Compare_EQ, off2, UtAssert_Radix_HEX, __FILE__, __LINE__, \
+                                    "Offset Check: ", #off1, #off2)
+
+/*****************************************************************************/
+/**
+** \brief Macro to check CFE message ID for equality
+**
+** \par Description
+**        A macro that checks two message ID values for equality.
+**
+** \par Assumptions, External Events, and Notes:
+**        The generic #UtAssert_UINT32_EQ check should not be used, as CFE_SB_MsgId_t values
+**        and integers may not be interchangable with strict type checking.
+**
+******************************************************************************/
+#define CFE_UtAssert_MSGID_EQ(mid1, mid2)                                                                      \
+    UtAssert_GenericUnsignedCompare(CFE_SB_MsgIdToValue(mid1), UtAssert_Compare_EQ, CFE_SB_MsgIdToValue(mid2), \
+                                    UtAssert_Radix_HEX, __FILE__, __LINE__, "MsgId Check: ", #mid1, #mid2)
 
 /*************************************************************************
 ** Exported Functions
@@ -144,5 +249,31 @@ int32 CFE_Assert_OpenLogFile(const char *Filename);
  *
  */
 void CFE_Assert_CloseLogFile(void);
+
+/*****************************************************************************/
+/**
+** \brief Helper function for nominal CFE calls
+**
+** \par Description
+**        This helper function wraps the normal UtAssert function, intended for verifying
+**        CFE API calls that are expected to return successfully.
+**
+**        Note that this checks for a logical "success", which includes the specific #CFE_SUCCESS
+**        status code, as well as all other status codes that represent a successful completion
+**        of the function objectives (i.e. such as a nonzero size, from functions that return a
+**        size).
+**
+**        This can also be used to report with an alternative pass/fail marker by passing the CaseType
+**        parameter appropriately.
+**
+** \par Assumptions, External Events, and Notes:
+**        Note this will accept any non-negative value as logical "success", so it
+**        also works with functions that return a size or other non-error status.
+**
+** \returns Test pass status, returns true if status was successful, false if it failed.
+**
+******************************************************************************/
+bool CFE_UtAssert_StatusCheck(CFE_Status_t Status, bool ExpectSuccess, UtAssert_CaseType_t CaseType, const char *File,
+                              uint32 Line, const char *Text);
 
 #endif /* CFE_ASSERT_H */

--- a/modules/cfe_assert/src/cfe_assert_runner.c
+++ b/modules/cfe_assert/src/cfe_assert_runner.c
@@ -69,6 +69,26 @@ static CFE_EVS_BinFilter_t CFE_TR_EventFilters[] = {
     {UTASSERT_CASETYPE_DEBUG, CFE_EVS_NO_FILTER},
 };
 
+bool CFE_UtAssert_StatusCheck(CFE_Status_t Status, bool ExpectSuccess, UtAssert_CaseType_t CaseType, const char *File,
+                              uint32 Line, const char *Text)
+{
+    bool        Result = (Status >= CFE_SUCCESS);
+    const char *MatchText;
+
+    if (ExpectSuccess)
+    {
+        MatchText = "OK";
+    }
+    else
+    {
+        /* expecting non-success; result should be inverted */
+        Result    = !Result;
+        MatchText = "ERROR";
+    }
+
+    return UtAssertEx(Result, CaseType, File, Line, "%s (0x%lx) is %s", Text, (unsigned long)Status, MatchText);
+}
+
 void CFE_Assert_StatusReport(uint8 MessageType, const char *Prefix, const char *OutputMessage)
 {
     uint16 EventType;

--- a/modules/cfe_testcase/CMakeLists.txt
+++ b/modules/cfe_testcase/CMakeLists.txt
@@ -13,6 +13,7 @@ add_cfe_app(cfe_testcase
     src/es_counter_test.c
     src/es_misc_test.c
     src/es_mempool_test.c
+    src/es_perf_test.c
     src/es_resource_id_test.c
     src/evs_filters_test.c
     src/evs_send_test.c

--- a/modules/cfe_testcase/CMakeLists.txt
+++ b/modules/cfe_testcase/CMakeLists.txt
@@ -19,6 +19,7 @@ add_cfe_app(cfe_testcase
     src/fs_header_test.c
     src/fs_util_test.c
     src/message_id_test.c
+    src/msg_api_test.c
     src/sb_pipe_mang_test.c
     src/tbl_content_access_test.c
     src/tbl_content_mang_test.c

--- a/modules/cfe_testcase/CMakeLists.txt
+++ b/modules/cfe_testcase/CMakeLists.txt
@@ -28,6 +28,7 @@ add_cfe_app(cfe_testcase
     src/time_arithmetic_test.c
     src/time_current_test.c
     src/time_conversion_test.c
+    src/time_external_test.c
     src/time_misc_test.c
 )
 

--- a/modules/cfe_testcase/CMakeLists.txt
+++ b/modules/cfe_testcase/CMakeLists.txt
@@ -6,6 +6,7 @@ add_cfe_app(cfe_testcase
     src/cfe_test.c
     src/cfe_test_table.c
     src/es_application_control_test.c
+    src/es_behavior_test.c
     src/es_info_test.c
     src/es_task_test.c
     src/es_cds_test.c

--- a/modules/cfe_testcase/src/cfe_test.c
+++ b/modules/cfe_testcase/src/cfe_test.c
@@ -72,6 +72,7 @@ void CFE_TestMain(void)
     FSHeaderTestSetup();
     FSUtilTestSetup();
     MessageIdTestSetup();
+    MsgApiTestSetup();
     SBPipeMangSetup();
     TBLContentAccessTestSetup();
     TBLContentMangTestSetup();

--- a/modules/cfe_testcase/src/cfe_test.c
+++ b/modules/cfe_testcase/src/cfe_test.c
@@ -59,6 +59,7 @@ void CFE_TestMain(void)
      * Register test cases in UtAssert
      */
     ESApplicationControlTestSetup();
+    ESBehaviorestSetup();
     ESCDSTestSetup();
     ESCounterTestSetup();
     ESInfoTestSetup();
@@ -77,8 +78,8 @@ void CFE_TestMain(void)
     TBLInformationTestSetup();
     TBLRegistrationTestSetup();
     TimeArithmeticTestSetup();
-    TimeCurrentTestSetup();
     TimeConversionTestSetup();
+    TimeCurrentTestSetup();
     TimeMiscTestSetup();
 
     /*

--- a/modules/cfe_testcase/src/cfe_test.c
+++ b/modules/cfe_testcase/src/cfe_test.c
@@ -65,6 +65,7 @@ void CFE_TestMain(void)
     ESInfoTestSetup();
     ESMemPoolTestSetup();
     ESMiscTestSetup();
+    ESPerfTestSetup();
     ESResourceIDTestSetup();
     ESTaskTestSetup();
     EVSFiltersTestSetup();

--- a/modules/cfe_testcase/src/cfe_test.c
+++ b/modules/cfe_testcase/src/cfe_test.c
@@ -81,6 +81,7 @@ void CFE_TestMain(void)
     TimeArithmeticTestSetup();
     TimeConversionTestSetup();
     TimeCurrentTestSetup();
+    TimeExternalTestSetup();
     TimeMiscTestSetup();
 
     /*

--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -100,6 +100,7 @@ void ESCounterTestSetup(void);
 void ESInfoTestSetup(void);
 void ESMemPoolTestSetup(void);
 void ESMiscTestSetup(void);
+void ESPerfTestSetup(void);
 void ESResourceIDTestSetup(void);
 void ESTaskTestSetup(void);
 void EVSFiltersTestSetup(void);

--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -43,6 +43,7 @@
 
 #include "uttest.h"
 #include "utassert.h"
+#include "cfe_assert.h"
 
 typedef struct
 {
@@ -68,23 +69,6 @@ extern CFE_FT_Global_t CFE_FT_Global;
  * of scripted tests and/or capturing test artifacts.
  */
 #define CFE_ASSERT_LOG_FILE_NAME "/cf/cfe_test.log"
-
-/* Compare two Resource IDs */
-#define cFE_FTAssert_ResourceID_EQ(actual, expect)                                            \
-    UtAssert_True(CFE_RESOURCEID_TEST_EQUAL(actual, expect), "%s (%lu) == %s (%lu)", #actual, \
-                  CFE_RESOURCEID_TO_ULONG(actual), #expect, CFE_RESOURCEID_TO_ULONG(expect))
-
-/* Check if a Resource ID is Undefined */
-#define cFE_FTAssert_ResourceID_Undefined(id) \
-    UtAssert_True(!CFE_RESOURCEID_TEST_DEFINED(id), "%s (%lu) not defined", #id, CFE_RESOURCEID_TO_ULONG(id))
-
-/* Assert a return code is not equal to cfe_success */
-#define cFE_FTAssert_NOT_CFE_SUCCESS(actual)                                      \
-    do                                                                            \
-    {                                                                             \
-        int32 rcact = (int32)(actual);                                            \
-        UtAssert_True(rcact < CFE_SUCCESS, "%s == (%ld) ", #actual, (long)rcact); \
-    } while (0)
 
 bool TimeInRange(CFE_TIME_SysTime_t Time, CFE_TIME_SysTime_t Target, OS_time_t difference);
 

--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -74,6 +74,7 @@ bool TimeInRange(CFE_TIME_SysTime_t Time, CFE_TIME_SysTime_t Target, OS_time_t d
 
 void CFE_TestMain(void);
 void ESApplicationControlTestSetup(void);
+void ESBehaviorestSetup(void);
 void ESCDSTestSetup(void);
 void ESCounterTestSetup(void);
 void ESInfoTestSetup(void);
@@ -92,8 +93,8 @@ void TBLContentMangTestSetup(void);
 void TBLInformationTestSetup(void);
 void TBLRegistrationTestSetup(void);
 void TimeArithmeticTestSetup(void);
-void TimeCurrentTestSetup(void);
 void TimeConversionTestSetup(void);
+void TimeCurrentTestSetup(void);
 void TimeMiscTestSetup(void);
 
 #endif /* CFE_TEST_H */

--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -70,6 +70,26 @@ extern CFE_FT_Global_t CFE_FT_Global;
  */
 #define CFE_ASSERT_LOG_FILE_NAME "/cf/cfe_test.log"
 
+/* Compare two Resource IDs */
+#define cFE_FTAssert_ResourceID_EQ(actual, expect)                                            \
+    UtAssert_True(CFE_RESOURCEID_TEST_EQUAL(actual, expect), "%s (%lu) == %s (%lu)", #actual, \
+                  CFE_RESOURCEID_TO_ULONG(actual), #expect, CFE_RESOURCEID_TO_ULONG(expect))
+
+/* Check if a Resource ID is Undefined */
+#define cFE_FTAssert_ResourceID_Undefined(id) \
+    UtAssert_True(!CFE_RESOURCEID_TEST_DEFINED(id), "%s (%lu) not defined", #id, CFE_RESOURCEID_TO_ULONG(id))
+
+/* Assert a return code is not equal to cfe_success */
+#define cFE_FTAssert_NOT_CFE_SUCCESS(actual)                                      \
+    do                                                                            \
+    {                                                                             \
+        int32 rcact = (int32)(actual);                                            \
+        UtAssert_True(rcact < CFE_SUCCESS, "%s == (%ld) ", #actual, (long)rcact); \
+    } while (0)
+
+/* Assert if status is CFE_SUCCESS */
+#define cFE_FTAssert_SUCCESS(status) UtAssert_INT32_EQ(status, CFE_SUCCESS)
+
 bool TimeInRange(CFE_TIME_SysTime_t Time, CFE_TIME_SysTime_t Target, OS_time_t difference);
 
 void CFE_TestMain(void);
@@ -87,6 +107,7 @@ void EVSSendTestSetup(void);
 void FSHeaderTestSetup(void);
 void FSUtilTestSetup(void);
 void MessageIdTestSetup(void);
+void MsgApiTestSetup(void);
 void SBPipeMangSetup(void);
 void TBLContentAccessTestSetup(void);
 void TBLContentMangTestSetup(void);

--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -116,6 +116,7 @@ void TBLRegistrationTestSetup(void);
 void TimeArithmeticTestSetup(void);
 void TimeConversionTestSetup(void);
 void TimeCurrentTestSetup(void);
+void TimeExternalTestSetup(void);
 void TimeMiscTestSetup(void);
 
 #endif /* CFE_TEST_H */

--- a/modules/cfe_testcase/src/es_behavior_test.c
+++ b/modules/cfe_testcase/src/es_behavior_test.c
@@ -1,0 +1,93 @@
+/*************************************************************************
+**
+**      GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**      Copyright (c) 2006-2019 United States Government as represented by
+**      the Administrator of the National Aeronautics and Space Administration.
+**      All Rights Reserved.
+**
+**      Licensed under the Apache License, Version 2.0 (the "License");
+**      you may not use this file except in compliance with the License.
+**      You may obtain a copy of the License at
+**
+**        http://www.apache.org/licenses/LICENSE-2.0
+**
+**      Unless required by applicable law or agreed to in writing, software
+**      distributed under the License is distributed on an "AS IS" BASIS,
+**      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**      See the License for the specific language governing permissions and
+**      limitations under the License.
+**
+** File: es_behavior_test.c
+**
+** Purpose:
+**   Functional test of basic ES Application Behavior APIs
+**
+**   Demonstration of how to register and use the UT assert functions.
+**
+*************************************************************************/
+
+/*
+ * Includes
+ */
+
+#include "cfe_test.h"
+
+void TestRunCounter(void)
+{
+    CFE_ES_TaskId_t   TaskId;
+    CFE_ES_TaskInfo_t TaskInfo;
+    uint32            ExecutionCounter;
+    uint32            RunStatus = CFE_ES_RunStatus_APP_RUN;
+
+    UtPrintf("Testing: CFE_ES_RunLoop, CFE_ES_IncrementTaskCounter");
+
+    UtAssert_INT32_EQ(CFE_ES_GetTaskID(&TaskId), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_GetTaskInfo(&TaskInfo, TaskId), CFE_SUCCESS);
+    ExecutionCounter = TaskInfo.ExecutionCounter;
+
+    UtAssert_BOOL_TRUE(CFE_ES_RunLoop(&RunStatus));
+    UtAssert_INT32_EQ(CFE_ES_GetTaskInfo(&TaskInfo, TaskId), CFE_SUCCESS);
+    UtAssert_UINT32_EQ(TaskInfo.ExecutionCounter, (ExecutionCounter + 1));
+
+    UtAssert_BOOL_TRUE(CFE_ES_RunLoop(NULL));
+    UtAssert_INT32_EQ(CFE_ES_GetTaskInfo(&TaskInfo, TaskId), CFE_SUCCESS);
+    UtAssert_UINT32_EQ(TaskInfo.ExecutionCounter, (ExecutionCounter + 2));
+
+    UtAssert_VOIDCALL(CFE_ES_IncrementTaskCounter());
+    UtAssert_INT32_EQ(CFE_ES_GetTaskInfo(&TaskInfo, TaskId), CFE_SUCCESS);
+    UtAssert_UINT32_EQ(TaskInfo.ExecutionCounter, (ExecutionCounter + 3));
+
+    RunStatus = CFE_ES_RunStatus_UNDEFINED;
+    UtAssert_BOOL_FALSE(CFE_ES_RunLoop(&RunStatus));
+}
+
+void TestWaitBehavior(void)
+{
+    CFE_TIME_SysTime_t start;
+    CFE_TIME_SysTime_t end;
+    CFE_TIME_SysTime_t TimePassed;
+    CFE_TIME_SysTime_t TimeExpected = {8, 0};
+
+    start = CFE_TIME_GetTime();
+
+    /* MinSystemStates of CFE_ES_SystemState_SHUTDOWN and higher not tested because they cause a shutdown */
+    UtAssert_INT32_EQ(CFE_ES_WaitForSystemState(CFE_ES_SystemState_UNDEFINED, 10000), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_WaitForSystemState(CFE_ES_SystemState_EARLY_INIT, 10000), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_WaitForSystemState(CFE_ES_SystemState_CORE_STARTUP, 10000), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_WaitForSystemState(CFE_ES_SystemState_CORE_READY, 10000), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_WaitForSystemState(CFE_ES_SystemState_APPS_INIT, 10000), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_WaitForSystemState(CFE_ES_SystemState_OPERATIONAL, 10000), CFE_SUCCESS);
+    UtAssert_VOIDCALL(CFE_ES_WaitForStartupSync(10000));
+
+    end        = CFE_TIME_GetTime();
+    TimePassed = CFE_TIME_Subtract(end, start);
+
+    UtAssert_UINT32_EQ(CFE_TIME_Compare(TimePassed, TimeExpected), CFE_TIME_A_LT_B);
+}
+
+void ESBehaviorestSetup(void)
+{
+    UtTest_Add(TestRunCounter, NULL, NULL, "Test Run Counter");
+    UtTest_Add(TestWaitBehavior, NULL, NULL, "Test Wait Behavior");
+}

--- a/modules/cfe_testcase/src/es_cds_test.c
+++ b/modules/cfe_testcase/src/es_cds_test.c
@@ -38,14 +38,15 @@ void TestRegisterCDS(void)
     CFE_ES_CDSHandle_t CDSHandlePtr;
     CFE_ES_CDSHandle_t CDSHandlePtr2;
 
-    size_t       BlockSize = 10;
-    const char * Name      = "CDS_Test";
-    const char * LongName  = "VERY_LONG_NAME_CDS_Test";
+    size_t       BlockSize  = 10;
+    size_t       BlockSize2 = 15;
+    const char * Name       = "CDS_Test";
+    const char * LongName   = "VERY_LONG_NAME_CDS_Test";
     CFE_Status_t status;
 
     UtPrintf("Testing: CFE_ES_RegisterCDS");
 
-    status = CFE_ES_RegisterCDS(&CDSHandlePtr, BlockSize, Name);
+    status = CFE_ES_RegisterCDS(&CDSHandlePtr, BlockSize2, Name);
 
     if (status == CFE_ES_CDS_ALREADY_EXISTS)
     {
@@ -56,7 +57,8 @@ void TestRegisterCDS(void)
         UtAssert_INT32_EQ(status, CFE_SUCCESS);
     }
 
-    UtAssert_INT32_EQ(CFE_ES_RegisterCDS(&CDSHandlePtr2, BlockSize, Name), CFE_ES_CDS_ALREADY_EXISTS);
+    UtAssert_INT32_EQ(CFE_ES_RegisterCDS(&CDSHandlePtr2, BlockSize2, Name), CFE_ES_CDS_ALREADY_EXISTS);
+    UtAssert_INT32_EQ(CFE_ES_RegisterCDS(&CDSHandlePtr2, BlockSize, Name), CFE_SUCCESS);
 
     UtAssert_INT32_EQ(CFE_ES_RegisterCDS(NULL, BlockSize, Name), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_RegisterCDS(&CDSHandlePtr, 0, Name), CFE_ES_CDS_INVALID_SIZE);

--- a/modules/cfe_testcase/src/es_cds_test.c
+++ b/modules/cfe_testcase/src/es_cds_test.c
@@ -82,7 +82,7 @@ void TestCDSName(void)
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockName(CDSNameBuf, CDSHandlePtr, sizeof(CDSNameBuf)), CFE_SUCCESS);
     UtAssert_StrCmp(CDSNameBuf, CDSName, "CFE_ES_GetCDSBlockName() = %s", CDSNameBuf);
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockIDByName(&IdByName, CDSNameBuf), CFE_SUCCESS);
-    cFE_FTAssert_ResourceID_EQ(CDSHandlePtr, IdByName);
+    CFE_UtAssert_RESOURCEID_EQ(CDSHandlePtr, IdByName);
 
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockName(NULL, CDSHandlePtr, sizeof(CDSNameBuf)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockName(CDSNameBuf, CFE_ES_CDS_BAD_HANDLE, sizeof(CDSNameBuf)),

--- a/modules/cfe_testcase/src/es_counter_test.c
+++ b/modules/cfe_testcase/src/es_counter_test.c
@@ -84,7 +84,7 @@ void TestCounterCreateDelete(void)
 
     /* Confirm conversion To/From Name */
     UtAssert_INT32_EQ(CFE_ES_GetGenCounterIDByName(&CheckId, CounterName), CFE_SUCCESS);
-    cFE_FTAssert_ResourceID_EQ(CheckId, TestId);
+    CFE_UtAssert_RESOURCEID_EQ(CheckId, TestId);
     UtAssert_INT32_EQ(CFE_ES_GetGenCounterName(CheckName, TestId, sizeof(CheckName)), CFE_SUCCESS);
     UtAssert_STRINGBUF_EQ(CheckName, sizeof(CheckName), CounterName, sizeof(CounterName));
 

--- a/modules/cfe_testcase/src/es_info_test.c
+++ b/modules/cfe_testcase/src/es_info_test.c
@@ -52,7 +52,7 @@ void TestAppInfo(void)
 
     UtAssert_INT32_EQ(CFE_ES_GetAppIDByName(&AppIdByName, TEST_EXPECTED_APP_NAME), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetAppID(&TestAppId), CFE_SUCCESS);
-    cFE_FTAssert_ResourceID_EQ(TestAppId, AppIdByName);
+    CFE_UtAssert_RESOURCEID_EQ(TestAppId, AppIdByName);
     UtAssert_INT32_EQ(CFE_ES_GetAppName(AppNameBuf, TestAppId, sizeof(AppNameBuf)), CFE_SUCCESS);
     UtAssert_StrCmp(AppNameBuf, TEST_EXPECTED_APP_NAME, "CFE_ES_GetAppName() = %s", AppNameBuf);
 
@@ -122,7 +122,7 @@ void TestAppInfo(void)
     UtAssert_True(ESAppInfo.NumOfChildTasks > 0, "ES App Info -> Child Tasks  = %d", (int)ESAppInfo.NumOfChildTasks);
 
     UtAssert_INT32_EQ(CFE_ES_GetAppIDByName(&AppIdByName, INVALID_APP_NAME), CFE_ES_ERR_NAME_NOT_FOUND);
-    cFE_FTAssert_ResourceID_Undefined(AppIdByName);
+    CFE_UtAssert_RESOURCEID_UNDEFINED(AppIdByName);
     UtAssert_INT32_EQ(CFE_ES_GetAppID(NULL), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetAppIDByName(NULL, TEST_EXPECTED_APP_NAME), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetAppName(AppNameBuf, CFE_ES_APPID_UNDEFINED, sizeof(AppNameBuf)),
@@ -146,15 +146,15 @@ void TestTaskInfo(void)
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskInfo(&TaskInfo, AppInfo.MainTaskId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetTaskID(&TaskId), CFE_SUCCESS);
-    cFE_FTAssert_ResourceID_EQ(TaskId, AppInfo.MainTaskId);
+    CFE_UtAssert_RESOURCEID_EQ(TaskId, AppInfo.MainTaskId);
 
     UtAssert_StrCmp(TaskInfo.AppName, AppInfo.Name, "TaskInfo.AppName (%s) = AppInfo.name (%s)", TaskInfo.AppName,
                     AppInfo.Name);
     UtAssert_StrCmp(TaskInfo.TaskName, AppInfo.MainTaskName, "TaskInfo.TaskName (%s) = AppInfo.MainTaskName (%s)",
                     TaskInfo.TaskName, AppInfo.MainTaskName);
 
-    cFE_FTAssert_ResourceID_EQ(TaskInfo.TaskId, AppInfo.MainTaskId);
-    cFE_FTAssert_ResourceID_EQ(TaskInfo.AppId, AppId);
+    CFE_UtAssert_RESOURCEID_EQ(TaskInfo.TaskId, AppInfo.MainTaskId);
+    CFE_UtAssert_RESOURCEID_EQ(TaskInfo.AppId, AppId);
     UtAssert_INT32_EQ(TaskInfo.ExecutionCounter, AppInfo.ExecutionCounter);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskInfo(&TaskInfo, CFE_ES_TASKID_UNDEFINED), CFE_ES_ERR_RESOURCEID_NOT_VALID);
@@ -205,7 +205,7 @@ void TestLibInfo(void)
 
     UtAssert_INT32_EQ(LibInfo.ExceptionAction, 0);
     UtAssert_True(LibInfo.Priority == 0, "Lib Info -> Priority  = %d", (int)LibInfo.Priority);
-    cFE_FTAssert_ResourceID_Undefined(LibInfo.MainTaskId);
+    CFE_UtAssert_RESOURCEID_UNDEFINED(LibInfo.MainTaskId);
     UtAssert_True(LibInfo.ExecutionCounter == 0, "Lib Info -> ExecutionCounter  = %d", (int)LibInfo.ExecutionCounter);
     UtAssert_True(strlen(LibInfo.MainTaskName) == 0, "Lib Info -> Task Name  = %s", LibInfo.MainTaskName);
     UtAssert_True(LibInfo.NumOfChildTasks == 0, "Lib Info -> Child Tasks  = %d", (int)LibInfo.NumOfChildTasks);

--- a/modules/cfe_testcase/src/es_mempool_test.c
+++ b/modules/cfe_testcase/src/es_mempool_test.c
@@ -44,11 +44,13 @@ void TestMemPoolCreate(void)
     UtAssert_INT32_EQ(CFE_ES_PoolCreateNoSem(NULL, Pool, sizeof(Pool)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_PoolCreateNoSem(&PoolID, NULL, sizeof(Pool)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_PoolCreateNoSem(&PoolID, Pool, 0), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_PoolDelete(PoolID), CFE_SUCCESS);
 
     UtAssert_INT32_EQ(CFE_ES_PoolCreate(&PoolID, Pool, sizeof(Pool)), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_PoolCreate(NULL, Pool, sizeof(Pool)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_PoolCreate(&PoolID, NULL, sizeof(Pool)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_PoolCreate(&PoolID, Pool, 0), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_PoolDelete(PoolID), CFE_SUCCESS);
 
     UtAssert_INT32_EQ(CFE_ES_PoolCreateEx(&PoolID, Pool, sizeof(Pool), 0, NULL, CFE_ES_NO_MUTEX), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_PoolCreateEx(NULL, Pool, sizeof(Pool), 0, NULL, CFE_ES_NO_MUTEX), CFE_ES_BAD_ARGUMENT);

--- a/modules/cfe_testcase/src/es_perf_test.c
+++ b/modules/cfe_testcase/src/es_perf_test.c
@@ -1,0 +1,74 @@
+/*************************************************************************
+**
+**      GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**      Copyright (c) 2006-2019 United States Government as represented by
+**      the Administrator of the National Aeronautics and Space Administration.
+**      All Rights Reserved.
+**
+**      Licensed under the Apache License, Version 2.0 (the "License");
+**      you may not use this file except in compliance with the License.
+**      You may obtain a copy of the License at
+**
+**        http://www.apache.org/licenses/LICENSE-2.0
+**
+**      Unless required by applicable law or agreed to in writing, software
+**      distributed under the License is distributed on an "AS IS" BASIS,
+**      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**      See the License for the specific language governing permissions and
+**      limitations under the License.
+**
+** File: es_perf_test.c
+**
+** Purpose:
+**   Functional test of ES Performance APIs
+**
+*************************************************************************/
+
+/*
+ * Includes
+ */
+
+#include "cfe_test.h"
+
+void TestPerfLogEntry(void)
+{
+    UtAssert_VOIDCALL(CFE_ES_PerfLogEntry(0));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogEntry(CFE_MISSION_ES_PERF_MAX_IDS - 1));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogEntry(CFE_MISSION_ES_PERF_MAX_IDS));
+}
+
+void TestPerfLogExit(void)
+{
+    UtAssert_VOIDCALL(CFE_ES_PerfLogExit(0));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogExit(CFE_MISSION_ES_PERF_MAX_IDS - 1));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogExit(CFE_MISSION_ES_PERF_MAX_IDS));
+}
+
+void TestPerfLogAdd(void)
+{
+    UtAssert_VOIDCALL(CFE_ES_PerfLogAdd(0, 0));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogAdd(0, 1));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogAdd(0, 0xFFFFFFFF));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogAdd(CFE_MISSION_ES_PERF_MAX_IDS - 1, 0));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogAdd(CFE_MISSION_ES_PERF_MAX_IDS - 1, 1));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogAdd(CFE_MISSION_ES_PERF_MAX_IDS - 1, 0xFFFFFFFF));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogAdd(CFE_MISSION_ES_PERF_MAX_IDS, 0));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogAdd(CFE_MISSION_ES_PERF_MAX_IDS, 1));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogAdd(CFE_MISSION_ES_PERF_MAX_IDS, 0xFFFFFFFF));
+}
+
+/* These commands should trigger and stop perf data (based on value commanded in functional test workflow) */
+void TestPerfLogTrigger(void)
+{
+    UtAssert_VOIDCALL(CFE_ES_PerfLogEntry(126));
+    UtAssert_VOIDCALL(CFE_ES_PerfLogExit(126));
+}
+
+void ESPerfTestSetup(void)
+{
+    UtTest_Add(TestPerfLogEntry, NULL, NULL, "Test PerfLogEntry");
+    UtTest_Add(TestPerfLogExit, NULL, NULL, "Test PerfLogExit");
+    UtTest_Add(TestPerfLogAdd, NULL, NULL, "Test PerfLogAdd");
+    UtTest_Add(TestPerfLogTrigger, NULL, NULL, "Test Perf Trigger");
+}

--- a/modules/cfe_testcase/src/es_resource_id_test.c
+++ b/modules/cfe_testcase/src/es_resource_id_test.c
@@ -42,6 +42,7 @@ void TestAppIDToIndex(void)
     UtAssert_INT32_EQ(CFE_ES_GetAppID(&TestAppId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_AppID_ToIndex(TestAppId, &TestAppIdx), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_AppID_ToIndex(TestAppId, &idx), CFE_SUCCESS);
+    UtAssert_INT32_LTEQ(TestAppIdx, CFE_PLATFORM_ES_MAX_APPLICATIONS);
     UtAssert_UINT32_EQ(idx, TestAppIdx);
 
     UtAssert_INT32_EQ(CFE_ES_AppID_ToIndex(TestAppId, NULL), CFE_ES_BAD_ARGUMENT);
@@ -58,6 +59,7 @@ void TestLibIDToIndex(void)
     UtAssert_INT32_EQ(CFE_ES_GetLibIDByName(&LibId, LibName), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_LibID_ToIndex(LibId, &LibIdx), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_LibID_ToIndex(LibId, &idx), CFE_SUCCESS);
+    UtAssert_INT32_LTEQ(LibIdx, CFE_PLATFORM_ES_MAX_LIBRARIES);
     UtAssert_UINT32_EQ(idx, LibIdx);
 
     UtAssert_INT32_EQ(CFE_ES_LibID_ToIndex(LibId, NULL), CFE_ES_BAD_ARGUMENT);
@@ -73,6 +75,7 @@ void TestTaskIDToIndex(void)
     UtAssert_INT32_EQ(CFE_ES_GetTaskID(&TaskId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_TaskID_ToIndex(TaskId, &TaskIdx), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_TaskID_ToIndex(TaskId, &idx), CFE_SUCCESS);
+    UtAssert_INT32_LTEQ(TaskIdx, OS_MAX_TASKS);
     UtAssert_UINT32_EQ(idx, TaskIdx);
 
     UtAssert_INT32_EQ(CFE_ES_TaskID_ToIndex(TaskId, NULL), CFE_ES_BAD_ARGUMENT);
@@ -89,11 +92,15 @@ void TestCounterIDToIndex(void)
     UtAssert_UINT32_EQ(CFE_ES_RegisterGenCounter(&CounterId, CounterName), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_CounterID_ToIndex(CounterId, &CounterIdx), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_CounterID_ToIndex(CounterId, &idx), CFE_SUCCESS);
+    UtAssert_INT32_LTEQ(CounterIdx, CFE_PLATFORM_ES_MAX_GEN_COUNTERS);
     UtAssert_UINT32_EQ(idx, CounterIdx);
 
     UtAssert_INT32_EQ(CFE_ES_CounterID_ToIndex(CounterId, NULL), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_CounterID_ToIndex(CFE_ES_COUNTERID_UNDEFINED, &CounterIdx),
                       CFE_ES_ERR_RESOURCEID_NOT_VALID);
+
+    /* Unregister Counter */
+    UtAssert_INT32_EQ(CFE_ES_DeleteGenCounter(CounterId), CFE_SUCCESS);
 }
 
 void ESResourceIDTestSetup(void)

--- a/modules/cfe_testcase/src/es_task_test.c
+++ b/modules/cfe_testcase/src/es_task_test.c
@@ -108,14 +108,14 @@ void TestChildTaskName(void)
                       CFE_SUCCESS);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(&TaskIdByName, TaskName), CFE_SUCCESS);
-    cFE_FTAssert_ResourceID_EQ(TaskIdByName, TaskId);
+    CFE_UtAssert_RESOURCEID_EQ(TaskIdByName, TaskId);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(TaskNameBuf, TaskId, sizeof(TaskNameBuf)), CFE_SUCCESS);
     UtAssert_StrCmp(TaskNameBuf, TaskName, "CFE_ES_GetTaskName() = %s", TaskNameBuf);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(NULL, TaskName), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(&TaskIdByName, INVALID_TASK_NAME), CFE_ES_ERR_NAME_NOT_FOUND);
-    cFE_FTAssert_ResourceID_Undefined(TaskIdByName);
+    CFE_UtAssert_RESOURCEID_UNDEFINED(TaskIdByName);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(NULL, TaskId, sizeof(TaskNameBuf)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(TaskNameBuf, CFE_ES_TASKID_UNDEFINED, sizeof(TaskNameBuf)),

--- a/modules/cfe_testcase/src/fs_header_test.c
+++ b/modules/cfe_testcase/src/fs_header_test.c
@@ -59,7 +59,7 @@ void TestCreateHeader(void)
     UtAssert_INT32_EQ(OS_lseek(fd, 0, OS_SEEK_CUR), sizeof(CFE_FS_Header_t));
 
     UtAssert_INT32_EQ(CFE_FS_WriteHeader(fd, NULL), CFE_FS_BAD_ARGUMENT);
-    cFE_FTAssert_NOT_CFE_SUCCESS(CFE_FS_WriteHeader(OS_OBJECT_ID_UNDEFINED, &Header));
+    CFE_UtAssert_STATUS_ERROR(CFE_FS_WriteHeader(OS_OBJECT_ID_UNDEFINED, &Header));
 
     UtAssert_VOIDCALL(CFE_FS_InitHeader(NULL, TestDescription, CFE_FS_SubType_ES_ERLOG));
     UtAssert_VOIDCALL(CFE_FS_InitHeader(&HeaderFail, NULL, CFE_FS_SubType_ES_ERLOG));
@@ -88,7 +88,7 @@ void TestReadHeader(void)
     UtAssert_StrCmp(TestDescription, ReadHeader.Description, "ReadHeader.Description = %s", ReadHeader.Description);
 
     UtAssert_INT32_EQ(CFE_FS_ReadHeader(NULL, fd), CFE_FS_BAD_ARGUMENT);
-    cFE_FTAssert_NOT_CFE_SUCCESS(CFE_FS_ReadHeader(&ReadHeader, OS_OBJECT_ID_UNDEFINED));
+    CFE_UtAssert_STATUS_ERROR(CFE_FS_ReadHeader(&ReadHeader, OS_OBJECT_ID_UNDEFINED));
 
     OS_close(fd);
     OS_remove(OS_TEST_HEADER_FILENAME);
@@ -114,7 +114,7 @@ void TestTimeStamp(void)
     UtAssert_UINT32_EQ(0xFFFFFFFF, ReadHeader.TimeSeconds);
     UtAssert_UINT32_EQ(0xFFFFFFFF, ReadHeader.TimeSubSeconds);
 
-    cFE_FTAssert_NOT_CFE_SUCCESS(CFE_FS_SetTimestamp(OS_OBJECT_ID_UNDEFINED, NewTimestamp));
+    CFE_UtAssert_STATUS_ERROR(CFE_FS_SetTimestamp(OS_OBJECT_ID_UNDEFINED, NewTimestamp));
 
     OS_close(fd);
     OS_remove(OS_TEST_HEADER_FILENAME);

--- a/modules/cfe_testcase/src/msg_api_test.c
+++ b/modules/cfe_testcase/src/msg_api_test.c
@@ -1,0 +1,238 @@
+/*************************************************************************
+**
+**      GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**      Copyright (c) 2006-2021 United States Government as represented by
+**      the Administrator of the National Aeronautics and Space Administration.
+**      All Rights Reserved.
+**
+**      Licensed under the Apache License, Version 2.0 (the "License");
+**      you may not use this file except in compliance with the License.
+**      You may obtain a copy of the License at
+**
+**        http://www.apache.org/licenses/LICENSE-2.0
+**
+**      Unless required by applicable law or agreed to in writing, software
+**      distributed under the License is distributed on an "AS IS" BASIS,
+**      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**      See the License for the specific language governing permissions and
+**      limitations under the License.
+**
+** File: msg_api_test.c
+**
+** Purpose:
+**   Functional test of cFE Message header APIs.
+**
+*************************************************************************/
+
+/*
+ * Includes
+ */
+
+#include "cfe_test.h"
+#include <string.h>
+
+void TestMsgApiBasic(void)
+{
+    UtPrintf("Testing: CFE_MSG_Init, CFE_MSG_GetSize, CFE_MSG_SetSize, CFE_MSG_GetType, "
+             "CFE_MSG_SetType, CFE_MSG_GetHeaderVersion, CFE_MSG_SetHeaderVersion, "
+             "CFE_MSG_GetHasSecondaryHeader, CFE_MSG_SetHasSecondaryHeader, "
+             "CFE_MSG_GetApId, CFE_MSG_SetApId");
+
+    /* declare local vars */
+    CFE_MSG_CommandHeader_t cmd;
+    CFE_MSG_Size_t          size;
+    CFE_MSG_Type_t          type;
+    CFE_SB_MsgId_t          msgId;
+    CFE_MSG_HeaderVersion_t hdrVer;
+    CFE_MSG_ApId_t          appId;
+
+    memset(&cmd, 0xFF, sizeof(cmd));
+    msgId = CFE_SB_ValueToMsgId(0);
+
+    /* test msg-init */
+    UtAssert_INT32_EQ(CFE_MSG_Init(NULL, CFE_SB_ValueToMsgId(0), sizeof(cmd)), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_Init(&cmd.Msg, msgId, 0), CFE_MSG_BAD_ARGUMENT);
+
+    cFE_FTAssert_SUCCESS(CFE_MSG_Init(&cmd.Msg, msgId, sizeof(cmd)));
+
+    /* test set-msg-size */
+    UtAssert_INT32_EQ(CFE_MSG_SetSize(NULL, 12), CFE_MSG_BAD_ARGUMENT);
+
+    cFE_FTAssert_SUCCESS(CFE_MSG_SetSize(&cmd.Msg, 12));
+
+    /* test get-msg-size */
+    UtAssert_INT32_EQ(CFE_MSG_GetSize(NULL, &size), CFE_MSG_BAD_ARGUMENT);
+
+    cFE_FTAssert_SUCCESS(CFE_MSG_GetSize(&cmd.Msg, &size));
+    UtAssert_UINT32_EQ(size, 12);
+
+    /* test get-type */
+    UtAssert_INT32_EQ(CFE_MSG_SetType(NULL, CFE_MSG_Type_Cmd), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_GetType(NULL, &type), CFE_MSG_BAD_ARGUMENT);
+    cFE_FTAssert_SUCCESS(CFE_MSG_SetType(&cmd.Msg, CFE_MSG_Type_Cmd));
+
+    cFE_FTAssert_SUCCESS(CFE_MSG_GetType(&cmd.Msg, &type));
+    UtAssert_INT32_EQ(type, CFE_MSG_Type_Cmd);
+
+    /* test msg set-type */
+    cFE_FTAssert_SUCCESS(CFE_MSG_SetType(&cmd.Msg, CFE_MSG_Type_Tlm));
+    /* check if set-type works like expected */
+    cFE_FTAssert_SUCCESS(CFE_MSG_GetType(&cmd.Msg, &type));
+    UtAssert_INT32_EQ(type, CFE_MSG_Type_Tlm);
+
+    /* test get header-version */
+    UtAssert_INT32_EQ(CFE_MSG_GetHeaderVersion(NULL, &hdrVer), CFE_MSG_BAD_ARGUMENT);
+    cFE_FTAssert_SUCCESS(CFE_MSG_GetHeaderVersion(&cmd.Msg, &hdrVer));
+    UtAssert_INT32_EQ(CFE_MSG_GetHeaderVersion(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
+
+    /* test set header-version */
+    UtAssert_INT32_EQ(CFE_MSG_SetHeaderVersion(NULL, hdrVer), CFE_MSG_BAD_ARGUMENT);
+    cFE_FTAssert_SUCCESS(CFE_MSG_SetHeaderVersion(&cmd.Msg, 0));
+    cFE_FTAssert_SUCCESS(CFE_MSG_GetHeaderVersion(&cmd.Msg, &hdrVer));
+    UtAssert_True(hdrVer == 0, "hdrVer = 0");
+
+    /* test get-has-secondary-header and set-has-scondary-header*/
+    bool _expected = true;
+    bool _returned = false;
+
+    UtAssert_INT32_EQ(CFE_MSG_GetHasSecondaryHeader(NULL, &_expected), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_GetHasSecondaryHeader(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
+
+    cFE_FTAssert_SUCCESS(CFE_MSG_SetHasSecondaryHeader(&cmd.Msg, _expected));
+    cFE_FTAssert_SUCCESS(CFE_MSG_GetHasSecondaryHeader(&cmd.Msg, &_returned));
+    UtAssert_UINT32_EQ(_expected, _returned);
+
+    /* test get-apid */
+    UtAssert_INT32_EQ(CFE_MSG_GetApId(NULL, &appId), CFE_MSG_BAD_ARGUMENT);
+    cFE_FTAssert_SUCCESS(CFE_MSG_GetApId(&cmd.Msg, &appId));
+    UtAssert_INT32_EQ(CFE_MSG_GetApId(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
+
+    /* test set-apid */
+    UtAssert_INT32_EQ(CFE_MSG_GetApId(NULL, 0), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_SetApId(&cmd.Msg, 0xFFFF), CFE_MSG_BAD_ARGUMENT);
+
+    cFE_FTAssert_SUCCESS(CFE_MSG_SetApId(&cmd.Msg, 0));
+    cFE_FTAssert_SUCCESS(CFE_MSG_GetApId(&cmd.Msg, &appId));
+    UtAssert_True(appId == 0, "CFE_MSG_SetApId => apid = 0");
+}
+
+void TestMsgApiAdvanced1(void)
+{
+    UtPrintf("Testing: CFE_MSG_GetSegmentationFlag, CFE_MSG_SetSegmentationFlag, "
+             "CFE_MSG_GetSequenceCount, CFE_MSG_SetSequenceCount, CFE_MSG_GetNextSequenceCount");
+
+    /* declare local vars */
+    CFE_MSG_CommandHeader_t    cmd;
+    CFE_SB_MsgId_t             msgId;
+    CFE_MSG_SegmentationFlag_t segFlag;
+    CFE_MSG_SequenceCount_t    seqCnt;
+
+    memset(&cmd, 0xFF, sizeof(cmd));
+    msgId = CFE_SB_ValueToMsgId(0);
+
+    /* test msg-init */
+    UtAssert_INT32_EQ(CFE_MSG_Init(NULL, CFE_SB_ValueToMsgId(0), sizeof(cmd)), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_Init(&cmd.Msg, msgId, 0), CFE_MSG_BAD_ARGUMENT);
+
+    cFE_FTAssert_SUCCESS(CFE_MSG_Init(&cmd.Msg, msgId, sizeof(cmd)));
+
+    /* test get/set-segmentation-flag */
+    UtAssert_INT32_EQ(CFE_MSG_GetSegmentationFlag(NULL, &segFlag), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_GetSegmentationFlag(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_SetSegmentationFlag(NULL, CFE_MSG_SegFlag_Continue), CFE_MSG_BAD_ARGUMENT);
+
+    cFE_FTAssert_SUCCESS(CFE_MSG_SetSegmentationFlag(&cmd.Msg, CFE_MSG_SegFlag_Continue));
+    cFE_FTAssert_SUCCESS(CFE_MSG_GetSegmentationFlag(&cmd.Msg, &segFlag));
+    UtAssert_True(segFlag == CFE_MSG_SegFlag_Continue,
+                  "CFE_MSG_SetSegmentationFlag => segFlag = CFE_MSG_SegFlag_Continue");
+
+    /* test set/get-sequence-count */
+    UtAssert_INT32_EQ(CFE_MSG_SetSequenceCount(NULL, 2), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(NULL, &seqCnt), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
+
+    cFE_FTAssert_SUCCESS(CFE_MSG_SetSequenceCount(&cmd.Msg, 2));
+    cFE_FTAssert_SUCCESS(CFE_MSG_GetSequenceCount(&cmd.Msg, &seqCnt));
+
+    UtAssert_True(seqCnt == 2, "CFE_MSG_SetSequenceCount => seqCnt = 2");
+
+    /* test get-next-sequence-count */
+
+    /* 0x3FFF <- bad because defined CFE_MSG_SEQCNT_MASK value but not public */
+    /* UtAssert_True(CFE_MSG_GetNextSequenceCount(0x3FFF) == 0, "CFE_MSG_GetNextSequenceCount(0x3FFF) = 0"); */
+    UtAssert_True(CFE_MSG_GetNextSequenceCount(2) == 3, "CFE_MSG_GetNextSequenceCount(2) = 3");
+}
+
+void TestMsgApiAdvanced2(void)
+{
+    UtPrintf("Testing: CFE_MSG_GenerateChecksum, CFE_MSG_ValidateChecksum, CFE_MSG_SetFcnCode, "
+             "CFE_MSG_GetFcnCode, CFE_MSG_GetMsgTime, CFE_MSG_SetMsgTime ");
+
+    /* declare local vars */
+    CFE_MSG_CommandHeader_t cmd;
+    CFE_SB_MsgId_t          msgId;
+    CFE_MSG_FcnCode_t       fcnCode;
+    CFE_TIME_SysTime_t      msgTime;
+
+    memset(&cmd, 0xFF, sizeof(cmd));
+    msgId = CFE_SB_ValueToMsgId(0);
+
+    /* msg-init */
+    UtAssert_INT32_EQ(CFE_MSG_Init(NULL, CFE_SB_ValueToMsgId(0), sizeof(cmd)), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_Init(&cmd.Msg, msgId, 0), CFE_MSG_BAD_ARGUMENT);
+
+    cFE_FTAssert_SUCCESS(CFE_MSG_Init(&cmd.Msg, msgId, sizeof(cmd)));
+    cFE_FTAssert_SUCCESS(CFE_MSG_SetHasSecondaryHeader(&cmd.Msg, true));
+
+    /* test generate-checksum */
+    UtAssert_INT32_EQ(CFE_MSG_GenerateChecksum(NULL), CFE_MSG_BAD_ARGUMENT);
+    cFE_FTAssert_SUCCESS(CFE_MSG_SetType(&cmd.Msg, CFE_MSG_Type_Tlm));
+    UtAssert_INT32_EQ(CFE_MSG_GenerateChecksum(&cmd.Msg), CFE_MSG_WRONG_MSG_TYPE);
+    cFE_FTAssert_SUCCESS(CFE_MSG_SetType(&cmd.Msg, CFE_MSG_Type_Cmd));
+
+    /* create new cmd message */
+    CFE_MSG_CommandHeader_t cmd2;
+    bool                    isValid = true;
+
+    memset(&cmd2, 0, sizeof(cmd2));
+    cFE_FTAssert_SUCCESS(CFE_MSG_Init(&cmd2.Msg, CFE_SB_ValueToMsgId(1), sizeof(cmd2)));
+    cFE_FTAssert_SUCCESS(CFE_MSG_SetHasSecondaryHeader(&cmd2.Msg, true));
+    cFE_FTAssert_SUCCESS(CFE_MSG_SetType(&cmd2.Msg, CFE_MSG_Type_Cmd));
+
+    cFE_FTAssert_SUCCESS(CFE_MSG_ValidateChecksum(&cmd2.Msg, &isValid));
+    UtAssert_True(!isValid, "Is checksum valid = false");
+    cFE_FTAssert_SUCCESS(CFE_MSG_GenerateChecksum(&cmd2.Msg));
+    cFE_FTAssert_SUCCESS(CFE_MSG_ValidateChecksum(&cmd2.Msg, &isValid));
+    UtAssert_True(isValid, "Checksum is valid");
+
+    /* test get/set-fcn-code */
+    UtAssert_INT32_EQ(CFE_MSG_SetFcnCode(NULL, 4), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_GetFcnCode(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_GetFcnCode(NULL, &fcnCode), CFE_MSG_BAD_ARGUMENT);
+
+    cFE_FTAssert_SUCCESS(CFE_MSG_SetFcnCode(&cmd.Msg, 4));
+    cFE_FTAssert_SUCCESS(CFE_MSG_GetFcnCode(&cmd.Msg, &fcnCode));
+
+    UtAssert_True(fcnCode == 4, "CFE_MSG_SetFcnCode => fcnCode = 4");
+
+    /* test get/set-msg-time */
+    CFE_TIME_SysTime_t currentTime = CFE_TIME_GetTime();
+    cFE_FTAssert_SUCCESS(CFE_MSG_SetType(&cmd.Msg, CFE_MSG_Type_Tlm));
+
+    UtAssert_INT32_EQ(CFE_MSG_GetMsgTime(NULL, &msgTime), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_GetMsgTime(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_SetMsgTime(NULL, currentTime), CFE_MSG_BAD_ARGUMENT);
+
+    cFE_FTAssert_SUCCESS(CFE_MSG_SetMsgTime(&cmd.Msg, currentTime));
+    cFE_FTAssert_SUCCESS(CFE_MSG_GetMsgTime(&cmd.Msg, &msgTime));
+
+    UtAssert_UINT32_EQ(CFE_TIME_Compare(msgTime, currentTime), CFE_TIME_A_LT_B);
+}
+
+void MsgApiTestSetup(void)
+{
+    UtTest_Add(TestMsgApiBasic, NULL, NULL, "Test basic message header apis");
+    UtTest_Add(TestMsgApiAdvanced1, NULL, NULL, "Test advanced message header apis part 1");
+    UtTest_Add(TestMsgApiAdvanced2, NULL, NULL, "Test advanced message header apis part 2");
+}

--- a/modules/cfe_testcase/src/sb_pipe_mang_test.c
+++ b/modules/cfe_testcase/src/sb_pipe_mang_test.c
@@ -112,7 +112,7 @@ void TestPipeName(void)
     UtAssert_StrCmp(PipeNameBuf, PipeName, "CFE_SB_GetPipeName() = %s", PipeNameBuf);
 
     UtAssert_INT32_EQ(CFE_SB_GetPipeIdByName(&PipeIdBuff, PipeName), CFE_SUCCESS);
-    cFE_FTAssert_ResourceID_EQ(PipeId, PipeIdBuff);
+    CFE_UtAssert_RESOURCEID_EQ(PipeId, PipeIdBuff);
 
     UtAssert_INT32_EQ(CFE_SB_GetPipeName(NULL, sizeof(PipeNameBuf), PipeId), CFE_SB_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_SB_GetPipeName(PipeNameBuf, 0, PipeId), CFE_SB_BAD_ARGUMENT);

--- a/modules/cfe_testcase/src/time_external_test.c
+++ b/modules/cfe_testcase/src/time_external_test.c
@@ -1,0 +1,104 @@
+/*************************************************************************
+**
+**      GSC-18128-1, "Core Flight Executive Version 6.7"
+**
+**      Copyright (c) 2006-2019 United States Government as represented by
+**      the Administrator of the National Aeronautics and Space Administration.
+**      All Rights Reserved.
+**
+**      Licensed under the Apache License, Version 2.0 (the "License");
+**      you may not use this file except in compliance with the License.
+**      You may obtain a copy of the License at
+**
+**        http://www.apache.org/licenses/LICENSE-2.0
+**
+**      Unless required by applicable law or agreed to in writing, software
+**      distributed under the License is distributed on an "AS IS" BASIS,
+**      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+**      See the License for the specific language governing permissions and
+**      limitations under the License.
+**
+** File: time_external_test.c
+**
+** Purpose:
+**   Functional test of basic External Time Source APIs
+**
+**   Demonstration of how to register and use the UT assert functions.
+**
+*************************************************************************/
+
+/*
+ * Includes
+ */
+
+#include "cfe_test.h"
+
+int32 TestCallbackFunction(void)
+{
+    CFE_FT_Global.Count += 1;
+    return CFE_SUCCESS;
+}
+
+int32 TestCallbackFunction2(void)
+{
+    CFE_FT_Global.Count = 0;
+    return CFE_SUCCESS;
+}
+
+void TestCallback(void)
+{
+    CFE_FT_Global.Count = 1;
+
+    UtPrintf("Testing: CFE_TIME_RegisterSynchCallback, CFE_TIME_UnregisterSynchCallback");
+
+    UtAssert_INT32_EQ(CFE_TIME_RegisterSynchCallback(&TestCallbackFunction), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_TIME_RegisterSynchCallback(&TestCallbackFunction2), CFE_TIME_TOO_MANY_SYNCH_CALLBACKS);
+
+    OS_TaskDelay(2500);
+    if (CFE_FT_Global.Count < 2)
+    {
+        UtAssert_MIR("CFE_TIME_RegisterSynchCallback requires manual inspection to determine if failure is with the "
+                     "API or due to an insufficient timing performance of this machine");
+    }
+
+    CFE_FT_Global.Count = 1;
+    UtAssert_INT32_EQ(CFE_TIME_UnregisterSynchCallback(&TestCallbackFunction), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_TIME_UnregisterSynchCallback(&TestCallbackFunction), CFE_TIME_CALLBACK_NOT_REGISTERED);
+
+    OS_TaskDelay(2500);
+    UtAssert_INT32_LTEQ(CFE_FT_Global.Count, 2);
+
+    UtAssert_INT32_EQ(CFE_TIME_UnregisterSynchCallback(NULL), CFE_TIME_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_TIME_RegisterSynchCallback(NULL), CFE_TIME_BAD_ARGUMENT);
+}
+
+void TestExternal(void)
+{
+#if ((CFE_PLATFORM_TIME_CFG_SRC_MET == true) || (CFE_PLATFORM_TIME_CFG_SRC_GPS == true) || \
+     (CFE_PLATFORM_TIME_CFG_SRC_TIME == true))
+    CFE_TIME_SysTime_t time = {1000, 0};
+#endif
+
+    UtPrintf("Testing: CFE_TIME_ExternalTone, CFE_TIME_ExternalMET, CFE_TIME_ExternalGPS, CFE_TIME_ExternalTime");
+    /* These time calls could impact the system timekeeping. Likely impact is incorrect time for one update cycle, a
+     * rejected external time update, multiple tone's or external updates detected, or similar. */
+    UtAssert_VOIDCALL(CFE_TIME_ExternalTone());
+
+#if (CFE_PLATFORM_TIME_CFG_SRC_MET == true)
+    UtAssert_VOIDCALL(CFE_TIME_ExternalMET(time));
+#endif
+
+#if (CFE_PLATFORM_TIME_CFG_SRC_GPS == true)
+    UtAssert_VOIDCALL(CFE_TIME_ExternalGPS(time, 5));
+#endif
+
+#if (CFE_PLATFORM_TIME_CFG_SRC_TIME == true)
+    UtAssert_VOIDCALL(CFE_TIME_ExternalTime(time));
+#endif
+}
+
+void TimeExternalTestSetup(void)
+{
+    UtTest_Add(TestCallback, NULL, NULL, "Test Time Synch Callbacks");
+    UtTest_Add(TestExternal, NULL, NULL, "Test External Sources");
+}

--- a/modules/core_api/fsw/inc/cfe_es.h
+++ b/modules/core_api/fsw/inc/cfe_es.h
@@ -391,10 +391,9 @@ bool CFE_ES_RunLoop(uint32 *RunStatus);
 **
 ** \param[in]  MinSystemState        Determine the state of the App
 ** \param[in]  TimeOutMilliseconds   The timeout value in Milliseconds.
-**                                   This parameter must be at least 1000. Lower values
-**                                   will be rounded up. There is not an option to
-**                                   wait indefinitely to avoid hanging a critical
-**                                   application because a non-critical app did not start.
+**                                   There is not an option to wait indefinitely to
+**                                   avoid hanging a critical application because a
+**                                   non-critical app did not start.
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                State successfully achieved

--- a/modules/core_api/fsw/inc/cfe_es.h
+++ b/modules/core_api/fsw/inc/cfe_es.h
@@ -88,7 +88,7 @@
  * for future use.
  *
  * @param[in]   AppID  Application ID to convert
- * @param[out]  Idx    Buffer where the calculated index will be stored
+ * @param[out]  Idx    Buffer where the calculated index will be stored @nonnull
  *
  * @return Execution status, see @ref CFEReturnCodes
  * @retval #CFE_SUCCESS                      @copybrief CFE_SUCCESS
@@ -113,7 +113,7 @@ CFE_Status_t CFE_ES_AppID_ToIndex(CFE_ES_AppId_t AppID, uint32 *Idx);
  * for future use.
  *
  * @param[in]   LibId  Library ID to convert
- * @param[out]  Idx    Buffer where the calculated index will be stored
+ * @param[out]  Idx    Buffer where the calculated index will be stored @nonnull
  *
  * @return Execution status, see @ref CFEReturnCodes
  * @retval #CFE_SUCCESS                      @copybrief CFE_SUCCESS
@@ -138,11 +138,12 @@ int32 CFE_ES_LibID_ToIndex(CFE_ES_LibId_t LibId, uint32 *Idx);
  * for future use.
  *
  * @param[in]   TaskID  Task ID to convert
- * @param[out]  Idx     Buffer where the calculated index will be stored
+ * @param[out]  Idx     Buffer where the calculated index will be stored @nonnull
  *
  * @return Execution status, see @ref CFEReturnCodes
  * @retval #CFE_SUCCESS                      @copybrief CFE_SUCCESS
  * @retval #CFE_ES_ERR_RESOURCEID_NOT_VALID  @copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID
+ * @retval #CFE_ES_BAD_ARGUMENT              @copybrief CFE_ES_BAD_ARGUMENT
  */
 CFE_Status_t CFE_ES_TaskID_ToIndex(CFE_ES_TaskId_t TaskID, uint32 *Idx);
 
@@ -262,6 +263,9 @@ CFE_Status_t CFE_ES_ResetCFE(uint32 ResetType);
 ** \param[in]  AppID       Identifies the application to be reset.
 **
 ** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_ES_ERR_RESOURCEID_NOT_VALID \copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID
+** \retval #CFE_ES_FILE_IO_ERR              \copybrief CFE_ES_FILE_IO_ERR
+** \retval #CFE_SUCCESS                     \copybrief CFE_SUCCESS
 **
 ** \sa #CFE_ES_ReloadApp, #CFE_ES_DeleteApp
 **
@@ -292,9 +296,12 @@ CFE_Status_t CFE_ES_RestartApp(CFE_ES_AppId_t AppID);
 **
 ** \param[in]  AppID       Identifies the application to be reset.
 **
-** \param[in]  AppFileName Identifies the new file to start.
+** \param[in]  AppFileName Identifies the new file to start @nonnull
 **
 ** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_ES_ERR_RESOURCEID_NOT_VALID \copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID
+** \retval #CFE_SUCCESS                     \copybrief CFE_SUCCESS
+** \retval #CFE_ES_FILE_IO_ERR              \copybrief CFE_ES_FILE_IO_ERR
 **
 ** \sa #CFE_ES_RestartApp, #CFE_ES_DeleteApp, #CFE_ES_START_APP_CC
 **
@@ -314,6 +321,8 @@ CFE_Status_t CFE_ES_ReloadApp(CFE_ES_AppId_t AppID, const char *AppFileName);
 ** \param[in]  AppID       Identifies the application to be reset.
 **
 ** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_ES_ERR_RESOURCEID_NOT_VALID \copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID
+** \retval #CFE_SUCCESS                     \copybrief CFE_SUCCESS
 **
 ** \sa #CFE_ES_RestartApp, #CFE_ES_ReloadApp
 **
@@ -512,7 +521,7 @@ int32 CFE_ES_GetResetType(uint32 *ResetSubtypePtr);
 ** \par Assumptions, External Events, and Notes:
 **        NOTE: \b All tasks associated with the Application would return the same Application ID.
 **
-** \param[out]   AppIdPtr       Pointer to variable that is to receive the Application's ID.
+** \param[out]   AppIdPtr       Pointer to variable that is to receive the Application's ID @nonnull.
 **                              *AppIdPtr will be set to the application ID of the calling Application.
 **
 ** \return Execution status, see \ref CFEReturnCodes
@@ -537,7 +546,7 @@ CFE_Status_t CFE_ES_GetAppID(CFE_ES_AppId_t *AppIdPtr);
 **        CFE_ES_TaskGetInfo() should use this API rather than getting the ID
 **        from OSAL directly via OS_TaskGetId().
 **
-** \param[out]   TaskIdPtr      Pointer to variable that is to receive the ID.
+** \param[out]   TaskIdPtr      Pointer to variable that is to receive the ID @nonnull.
 **                              Will be set to the ID of the calling task.
 **
 ** \return Execution status, see \ref CFEReturnCodes
@@ -559,8 +568,8 @@ CFE_Status_t CFE_ES_GetTaskID(CFE_ES_TaskId_t *TaskIdPtr);
 ** \par Assumptions, External Events, and Notes:
 **        None
 **
-** \param[out]  AppIdPtr       Pointer to variable that is to receive the Application's ID.
-** \param[in]   AppName        Pointer to null terminated character string containing an Application name.
+** \param[out]  AppIdPtr       Pointer to variable that is to receive the Application's ID @nonnull.
+** \param[in]   AppName        Pointer to null terminated character string containing an Application name @nonnull.
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                 \copybrief CFE_SUCCESS
@@ -583,8 +592,8 @@ CFE_Status_t CFE_ES_GetAppIDByName(CFE_ES_AppId_t *AppIdPtr, const char *AppName
 ** \par Assumptions, External Events, and Notes:
 **        None
 **
-** \param[out]  LibIdPtr       Pointer to variable that is to receive the Library's ID.
-** \param[in]   LibName        Pointer to null terminated character string containing a Library name.
+** \param[out]  LibIdPtr       Pointer to variable that is to receive the Library's ID @nonnull.
+** \param[in]   LibName        Pointer to null terminated character string containing a Library name @nonnull.
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                 \copybrief CFE_SUCCESS
@@ -607,7 +616,7 @@ CFE_Status_t CFE_ES_GetLibIDByName(CFE_ES_LibId_t *LibIdPtr, const char *LibName
 ** \par Assumptions, External Events, and Notes:
 **        In the case of a failure (#CFE_ES_ERR_RESOURCEID_NOT_VALID), an empty string is returned.
 **
-** \param[out]  AppName       Pointer to a character array of at least \c BufferLength in size that will
+** \param[out]  AppName       Pointer to a character array @nonnull of at least \c BufferLength in size that will
 **                            be filled with the appropriate Application name.
 **
 ** \param[in]   AppId         Application ID of Application whose name is being requested.
@@ -637,7 +646,7 @@ CFE_Status_t CFE_ES_GetAppName(char *AppName, CFE_ES_AppId_t AppId, size_t Buffe
 ** \par Assumptions, External Events, and Notes:
 **        In the case of a failure (#CFE_ES_ERR_RESOURCEID_NOT_VALID), an empty string is returned.
 **
-** \param[out]  LibName       Pointer to a character array of at least \c BufferLength in size that will
+** \param[out]  LibName       Pointer to a character array @nonnull of at least \c BufferLength in size that will
 **                            be filled with the Library name.
 **
 ** \param[in]   LibId         Library ID of Library whose name is being requested.
@@ -668,7 +677,7 @@ CFE_Status_t CFE_ES_GetLibName(char *LibName, CFE_ES_LibId_t LibId, size_t Buffe
 ** \par Assumptions, External Events, and Notes:
 **        None
 **
-** \param[out]  AppInfo      Pointer to a structure that will be filled with
+** \param[out]  AppInfo      Pointer to a structure @nonnull that will be filled with
 **                           resource name and memory addresses information.
 ** \param[in]   AppId        ID of application to obtain information about
 **
@@ -694,7 +703,7 @@ CFE_Status_t CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, CFE_ES_AppId_t AppId);
 ** \par Assumptions, External Events, and Notes:
 **        None
 **
-** \param[out]   TaskInfo     Pointer to a \c CFE_ES_TaskInfo_t structure that holds the specific
+** \param[out]   TaskInfo     Pointer to a \c CFE_ES_TaskInfo_t structure @nonnull that holds the specific
 **                            task information. *TaskInfo is the filled out \c CFE_ES_TaskInfo_t structure containing
 **                            the Task Name, Parent App Name, Parent App ID among other fields.
 **
@@ -728,7 +737,7 @@ CFE_Status_t CFE_ES_GetTaskInfo(CFE_ES_TaskInfo_t *TaskInfo, CFE_ES_TaskId_t Tas
 ** \par Assumptions, External Events, and Notes:
 **        None
 **
-** \param[out]  LibInfo      Pointer to a structure that will be filled with
+** \param[out]  LibInfo      Pointer to a structure @nonnull that will be filled with
 **                           resource name and memory addresses information.
 ** \param[in]   LibId        ID of application to obtain information about
 **
@@ -760,7 +769,7 @@ int32 CFE_ES_GetLibInfo(CFE_ES_AppInfo_t *LibInfo, CFE_ES_LibId_t LibId);
 ** \par Assumptions, External Events, and Notes:
 **        None
 **
-** \param[out]  ModuleInfo   Pointer to a structure that will be filled with
+** \param[out]  ModuleInfo   Pointer to a structure @nonnull that will be filled with
 **                           resource name and memory addresses information.
 ** \param[in]   ResourceId   ID of application or library to obtain information about
 **
@@ -790,22 +799,21 @@ int32 CFE_ES_GetModuleInfo(CFE_ES_AppInfo_t *ModuleInfo, CFE_ResourceId_t Resour
 ** \par Assumptions, External Events, and Notes:
 **        None
 **
-** \param[in, out]   TaskIdPtr     A pointer to a variable that will be filled in with the new task's ID. *TaskIdPtr is
+** \param[out]   TaskIdPtr     A pointer to a variable that will be filled in with the new task's ID @nonnull.
+**TaskIdPtr is
 **                                 the Task ID of the newly created child task.
 **
-** \param[in]   TaskName      A pointer to a string containing the desired name of the new task.
+** \param[in]   TaskName      A pointer to a string containing the desired name of the new task @nonnull.
 **                            This can be up to #OS_MAX_API_NAME characters, including the trailing null.
 **
-** \param[in]   FunctionPtr   A pointer to the function that will be spawned as a new task.  This function
-**                            must have the following signature: uint32 function(void).  Input parameters
-**                            for the new task are not supported.
+** \param[in]   FunctionPtr   A pointer to the function that will be spawned as a new task @nonnull.
 **
 ** \param[in]   StackPtr      A pointer to the location where the child task's stack pointer should start.
 **                            NOTE: Not all underlying operating systems support this parameter.
 **                            The CFE_ES_TASK_STACK_ALLOCATE constant may be passed to indicate that the
 **                            stack should be dynamically allocated.
 **
-** \param[in]   StackSize     The number of bytes to allocate for the new task's stack.
+** \param[in]   StackSize     The number of bytes to allocate for the new task's stack @nonzero.
 **
 ** \param[in]   Priority      The priority for the new task.  Lower numbers are higher priority, with 0 being
 **                            the highest priority.
@@ -813,9 +821,10 @@ int32 CFE_ES_GetModuleInfo(CFE_ES_AppInfo_t *ModuleInfo, CFE_ResourceId_t Resour
 ** \param[in]   Flags         Reserved for future expansion.
 **
 ** \return Execution status, see \ref CFEReturnCodes
-** \retval #CFE_SUCCESS                  \copybrief CFE_SUCCESS
-** \retval #CFE_ES_ERR_CHILD_TASK_CREATE \copybrief CFE_ES_ERR_CHILD_TASK_CREATE
-** \retval #CFE_ES_BAD_ARGUMENT          \copybrief CFE_ES_BAD_ARGUMENT
+** \retval #CFE_SUCCESS                      \copybrief CFE_SUCCESS
+** \retval #CFE_ES_ERR_CHILD_TASK_CREATE     \copybrief CFE_ES_ERR_CHILD_TASK_CREATE
+** \retval #CFE_ES_BAD_ARGUMENT              \copybrief CFE_ES_BAD_ARGUMENT
+** \retval #CFE_ES_ERR_RESOURCEID_NOT_VALID  \copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID
 **
 ** \sa #CFE_ES_DeleteChildTask, #CFE_ES_ExitChildTask
 **
@@ -835,8 +844,8 @@ CFE_Status_t CFE_ES_CreateChildTask(CFE_ES_TaskId_t *TaskIdPtr, const char *Task
 ** \par Assumptions, External Events, and Notes:
 **        None
 **
-** \param[out]  TaskIdPtr       Pointer to variable that is to receive the Task's ID.
-** \param[in]   TaskName        Pointer to null terminated character string containing an Task name.
+** \param[out]  TaskIdPtr       Pointer to variable that is to receive the Task's ID @nonnull.
+** \param[in]   TaskName        Pointer to null terminated character string containing an Task name @nonnull.
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                 \copybrief CFE_SUCCESS
@@ -859,7 +868,7 @@ CFE_Status_t CFE_ES_GetTaskIDByName(CFE_ES_TaskId_t *TaskIdPtr, const char *Task
 ** \par Assumptions, External Events, and Notes:
 **        In the case of a failure (#CFE_ES_ERR_RESOURCEID_NOT_VALID), an empty string is returned.
 **
-** \param[out]  TaskName      Pointer to a character array of at least \c BufferLength in size that will
+** \param[out]  TaskName      Pointer to a character array @nonnull of at least \c BufferLength in size that will
 **                            be filled with the Task name.
 **
 ** \param[in]   TaskId        Task ID of Task whose name is being requested.
@@ -893,8 +902,11 @@ CFE_Status_t CFE_ES_GetTaskName(char *TaskName, CFE_ES_TaskId_t TaskId, size_t B
 *#CFE_ES_CreateChildTask API.
 **
 ** \return Execution status, see \ref CFEReturnCodes
-** \retval #CFE_SUCCESS            \copybrief CFE_SUCCESS
-** \retval #CFE_ES_NOT_IMPLEMENTED \copybrief CFE_ES_NOT_IMPLEMENTED
+** \retval #CFE_SUCCESS                             \copybrief CFE_SUCCESS
+** \retval #CFE_ES_NOT_IMPLEMENTED                  \copybrief CFE_ES_NOT_IMPLEMENTED
+** \retval #CFE_ES_ERR_CHILD_TASK_DELETE            \copybrief CFE_ES_ERR_CHILD_TASK_DELETE
+** \retval #CFE_ES_ERR_CHILD_TASK_DELETE_MAIN_TASK  \copybrief CFE_ES_ERR_CHILD_TASK_DELETE_MAIN_TASK
+** \retval #CFE_ES_ERR_RESOURCEID_NOT_VALID         \copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID
 **
 ** \sa #CFE_ES_CreateChildTask, #CFE_ES_ExitChildTask
 **
@@ -958,7 +970,7 @@ void CFE_ES_BackgroundWakeup(void);
 ** \par Assumptions, External Events, and Notes:
 **        None
 **
-** \param[in]   SpecStringPtr     The format string for the log message.
+** \param[in]   SpecStringPtr     The format string for the log message @nonnull.
 **                                This is similar to the format string for a printf() call.
 **
 ** \return Execution status, see \ref CFEReturnCodes
@@ -1044,13 +1056,13 @@ void CFE_ES_ProcessAsyncEvent(void);
 **        This is indicated by a #CFE_SUCCESS return code, and in this case the calling application should
 **        ensure that it also calls CFE_ES_CopyToCDS() to fill the block with valid data.
 **
-** \param[in, out]   CDSHandlePtr   Pointer Application's variable that will contain the CDS Memory Block Handle.
+** \param[out]   CDSHandlePtr   Pointer Application's variable that will contain the CDS Memory Block Handle @nonnull.
 **                                  HandlePtr is the handle of the CDS block that can be used in
 **                                  #CFE_ES_CopyToCDS and #CFE_ES_RestoreFromCDS.
 **
-** \param[in]   BlockSize   The number of bytes needed in the CDS.
+** \param[in]   BlockSize   The number of bytes needed in the CDS @nonzero.
 **
-** \param[in]   Name        A pointer to a character string containing an application
+** \param[in]   Name        A pointer to a character string @nonnull containing an application
 **                          unique name of #CFE_MISSION_ES_CDS_MAX_NAME_LENGTH characters or less.
 **
 ** \return Execution status, see \ref CFEReturnCodes
@@ -1060,6 +1072,7 @@ void CFE_ES_ProcessAsyncEvent(void);
 ** \retval #CFE_ES_CDS_INVALID_SIZE   \copybrief CFE_ES_CDS_INVALID_SIZE
 ** \retval #CFE_ES_CDS_INVALID_NAME   \copybrief CFE_ES_CDS_INVALID_NAME
 ** \retval #CFE_ES_BAD_ARGUMENT       \copybrief CFE_ES_BAD_ARGUMENT
+** \retval #CFE_ES_CDS_INVALID        \copybrief CFE_ES_CDS_INVALID
 **
 ** \sa #CFE_ES_CopyToCDS, #CFE_ES_RestoreFromCDS
 **
@@ -1077,13 +1090,14 @@ CFE_Status_t CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *CDSHandlePtr, size_t BlockSi
 ** \par Assumptions, External Events, and Notes:
 **        None
 **
-** \param[out]  BlockIdPtr       Pointer to variable that is to receive the CDS Block ID.
-** \param[in]   BlockName        Pointer to null terminated character string containing a CDS Block name.
+** \param[out]  BlockIdPtr       Pointer to variable that is to receive the CDS Block ID @nonnull.
+** \param[in]   BlockName        Pointer to null terminated character string containing a CDS Block name @nonnull.
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                 \copybrief CFE_SUCCESS
 ** \retval #CFE_ES_ERR_NAME_NOT_FOUND   \copybrief CFE_ES_ERR_NAME_NOT_FOUND
 ** \retval #CFE_ES_BAD_ARGUMENT         \copybrief CFE_ES_BAD_ARGUMENT
+** \retval #CFE_ES_NOT_IMPLEMENTED      The processor does not support a Critical Data Store.
 **
 ** \sa #CFE_ES_GetCDSBlockName
 **
@@ -1101,7 +1115,7 @@ CFE_Status_t CFE_ES_GetCDSBlockIDByName(CFE_ES_CDSHandle_t *BlockIdPtr, const ch
 ** \par Assumptions, External Events, and Notes:
 **        In the case of a failure (#CFE_ES_ERR_RESOURCEID_NOT_VALID), an empty string is returned.
 **
-** \param[out]  BlockName     Pointer to a character array of at least \c BufferLength in size that will
+** \param[out]  BlockName     Pointer to a character array @nonnull of at least \c BufferLength in size that will
 **                            be filled with the CDS Block name.
 **
 ** \param[in]   BlockId       Block ID/Handle of CDS registry entry whose name is being requested.
@@ -1114,6 +1128,7 @@ CFE_Status_t CFE_ES_GetCDSBlockIDByName(CFE_ES_CDSHandle_t *BlockIdPtr, const ch
 ** \retval #CFE_SUCCESS                      \copybrief CFE_SUCCESS
 ** \retval #CFE_ES_ERR_RESOURCEID_NOT_VALID  \copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID
 ** \retval #CFE_ES_BAD_ARGUMENT              \copybrief CFE_ES_BAD_ARGUMENT
+** \retval #CFE_ES_NOT_IMPLEMENTED           The processor does not support a Critical Data Store.
 **
 ** \sa #CFE_ES_GetCDSBlockIDByName
 **
@@ -1134,7 +1149,7 @@ CFE_Status_t CFE_ES_GetCDSBlockName(char *BlockName, CFE_ES_CDSHandle_t BlockId,
 **
 ** \param[in]   Handle       The handle of the CDS block that was previously obtained from #CFE_ES_RegisterCDS.
 **
-** \param[in]   DataToCopy   A Pointer to the block of memory to be copied into the CDS.
+** \param[in]   DataToCopy   A Pointer to the block of memory to be copied into the CDS @nonnull.
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                       \copybrief CFE_SUCCESS
@@ -1163,7 +1178,8 @@ CFE_Status_t CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, const void *DataToCopy)
 **
 ** \param[in]   Handle             The handle of the CDS block that was previously obtained from #CFE_ES_RegisterCDS.
 **
-** \param[in, out]   RestoreToMemory    A Pointer to the block of memory that is to be restored with the contents of
+** \param[out]   RestoreToMemory    A Pointer to the block of memory @nonnull that is to be restored with the contents
+*of
 **                                      the CDS. *RestoreToMemory is the contents of the specified CDS.
 **
 ** \return Execution status, see \ref CFEReturnCodes
@@ -1195,14 +1211,17 @@ CFE_Status_t CFE_ES_RestoreFromCDS(void *RestoreToMemory, CFE_ES_CDSHandle_t Han
 **        -# The start address of the pool must be 32-bit aligned
 **        -# 168 bytes are used for internal bookkeeping, therefore, they will not be available for allocation.
 **
-** \param[in, out]   PoolID   A pointer to the variable the caller wishes to have the memory pool handle kept in.
+** \param[out]   PoolID       A pointer to the variable the caller wishes to have the memory pool handle kept in
+*@nonnull.
 **                            PoolID is the memory pool handle.
 **
-** \param[in]   MemPtr        A Pointer to the pool of memory created by the calling application. This address must
+** \param[in]   MemPtr        A Pointer to the pool of memory created by the calling application @nonnull. This address
+*must
 **                            be aligned suitably for the processor architecture.  The #CFE_ES_STATIC_POOL_TYPE
 **                            macro may be used to assist in creating properly aligned memory pools.
 **
-** \param[in]   Size          The size of the pool of memory.  Note that this must be an integral multiple of the
+** \param[in]   Size          The size of the pool of memory @nonzero.  Note that this must be an integral multiple of
+*the
 **                            memory alignment of the processor architecture.
 **
 ** \return Execution status, see \ref CFEReturnCodes
@@ -1227,14 +1246,17 @@ CFE_Status_t CFE_ES_PoolCreateNoSem(CFE_ES_MemHandle_t *PoolID, void *MemPtr, si
 **        -# The start address of the pool must be 32-bit aligned
 **        -# 168 bytes are used for internal bookkeeping, therefore, they will not be available for allocation.
 **
-** \param[in, out]   PoolID   A pointer to the variable the caller wishes to have the memory pool handle kept in.
+** \param[out]   PoolID       A pointer to the variable the caller wishes to have the memory pool handle kept in
+*@nonnull.
 **                            PoolID is the memory pool handle.
 **
-** \param[in]   MemPtr        A Pointer to the pool of memory created by the calling application. This address must
+** \param[in]   MemPtr        A Pointer to the pool of memory created by the calling application @nonnull. This address
+*must
 **                            be aligned suitably for the processor architecture.  The #CFE_ES_STATIC_POOL_TYPE
 **                            macro may be used to assist in creating properly aligned memory pools.
 **
-** \param[in]   Size          The size of the pool of memory.  Note that this must be an integral multiple of the
+** \param[in]   Size          The size of the pool of memory @nonzero.  Note that this must be an integral multiple of
+*the
 **                            memory alignment of the processor architecture.
 **
 ** \return Execution status, see \ref CFEReturnCodes
@@ -1258,14 +1280,17 @@ CFE_Status_t CFE_ES_PoolCreate(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t 
 **        -# The start address of the pool must be 32-bit aligned
 **        -# 168 bytes are used for internal bookkeeping, therefore, they will not be available for allocation.
 **
-** \param[in, out]   PoolID    A pointer to the variable the caller wishes to have the memory pool handle kept in.
+** \param[out]   PoolID        A pointer to the variable the caller wishes to have the memory pool handle kept in
+*@nonnull.
 **                             PoolID is the memory pool handle.
 **
-** \param[in]   MemPtr         A Pointer to the pool of memory created by the calling application. This address must
+** \param[in]   MemPtr         A Pointer to the pool of memory created by the calling application @nonnull. This address
+*must
 **                             be aligned suitably for the processor architecture.  The #CFE_ES_STATIC_POOL_TYPE
 **                             macro may be used to assist in creating properly aligned memory pools.
 **
-** \param[in]   Size           The size of the pool of memory.  Note that this must be an integral multiple of the
+** \param[in]   Size           The size of the pool of memory @nonzero.  Note that this must be an integral multiple of
+*the
 **                             memory alignment of the processor architecture.
 **
 ** \param[in]   NumBlockSizes  The number of different block sizes specified in the \c BlockSizes array. If set
@@ -1281,8 +1306,11 @@ CFE_Status_t CFE_ES_PoolCreate(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t 
 **                             not. Valid parameter values are #CFE_ES_USE_MUTEX and #CFE_ES_NO_MUTEX
 **
 ** \return Execution status, see \ref CFEReturnCodes
-** \retval #CFE_SUCCESS           \copybrief CFE_SUCCESS
-** \retval #CFE_ES_BAD_ARGUMENT   \copybrief CFE_ES_BAD_ARGUMENT
+** \retval #CFE_SUCCESS                       \copybrief CFE_SUCCESS
+** \retval #CFE_ES_BAD_ARGUMENT               \copybrief CFE_ES_BAD_ARGUMENT
+** \retval #CFE_ES_NO_RESOURCE_IDS_AVAILABLE  \copybrief CFE_ES_NO_RESOURCE_IDS_AVAILABLE
+** \retval #CFE_ES_POOL_BOUNDS_ERROR          \copybrief CFE_ES_POOL_BOUNDS_ERROR
+** \retval #CFE_STATUS_EXTERNAL_RESOURCE_FAIL \copybrief CFE_STATUS_EXTERNAL_RESOURCE_FAIL
 **
 ** \sa #CFE_ES_PoolCreate, #CFE_ES_PoolCreateNoSem, #CFE_ES_GetPoolBuf, #CFE_ES_PutPoolBuf, #CFE_ES_GetMemPoolStats
 **
@@ -1324,12 +1352,12 @@ int32 CFE_ES_PoolDelete(CFE_ES_MemHandle_t PoolID);
 ** \par Assumptions, External Events, and Notes:
 **        -# The size allocated from the memory pool is, at a minimum, 12 bytes more than requested.
 **
-** \param[in, out]   BufPtr      A pointer to the Application's pointer in which will be stored the address of the
-**                               allocated memory buffer. *BufPtr is the address of the requested buffer.
+** \param[out]   BufPtr     A pointer to the Application's pointer @nonnull in which will be stored the address of the
+**                          allocated memory buffer. *BufPtr is the address of the requested buffer.
 **
 ** \param[in]   Handle      The handle to the memory pool as returned by #CFE_ES_PoolCreate or #CFE_ES_PoolCreateNoSem.
 **
-** \param[in]   Size        The size of the buffer requested.  NOTE: The size allocated may be larger.
+** \param[in]   Size        The size of the buffer requested @nonzero.  NOTE: The size allocated may be larger.
 **
 ** \return Bytes Allocated, or error code \ref CFEReturnCodes
 ** \retval #CFE_ES_ERR_RESOURCEID_NOT_VALID   \copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID
@@ -1354,7 +1382,7 @@ int32 CFE_ES_GetPoolBuf(CFE_ES_MemPoolBuf_t *BufPtr, CFE_ES_MemHandle_t Handle, 
 **
 ** \param[in]   Handle  The handle to the memory pool as returned by #CFE_ES_PoolCreate or #CFE_ES_PoolCreateNoSem.
 **
-** \param[in]   BufPtr  A pointer to the memory buffer to provide status for.
+** \param[in]   BufPtr  A pointer to the memory buffer to provide status for @nonnull.
 **
 ** \return Size of the buffer if successful, or status code if not successful, see \ref CFEReturnCodes
 ** \retval #CFE_ES_ERR_RESOURCEID_NOT_VALID   \copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID
@@ -1379,11 +1407,13 @@ CFE_Status_t CFE_ES_GetPoolBufInfo(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_
 **
 ** \param[in]   Handle The handle to the memory pool as returned by #CFE_ES_PoolCreate or #CFE_ES_PoolCreateNoSem.
 **
-** \param[in]   BufPtr A pointer to the memory buffer to be released.
+** \param[in]   BufPtr A pointer to the memory buffer to be released @nonnull.
 **
 ** \return Bytes released, or error code \ref CFEReturnCodes
 ** \retval #CFE_ES_ERR_RESOURCEID_NOT_VALID  \copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID
 ** \retval #CFE_ES_BAD_ARGUMENT              \copybrief CFE_ES_BAD_ARGUMENT
+** \retval #CFE_ES_BUFFER_NOT_IN_POOL        \copybrief CFE_ES_BUFFER_NOT_IN_POOL
+** \retval #CFE_ES_POOL_BLOCK_INVALID        \copybrief CFE_ES_POOL_BLOCK_INVALID
 **
 ** \sa #CFE_ES_PoolCreate, #CFE_ES_PoolCreateNoSem, #CFE_ES_PoolCreateEx, #CFE_ES_GetPoolBuf, #CFE_ES_GetMemPoolStats,
 *#CFE_ES_GetPoolBufInfo
@@ -1403,9 +1433,9 @@ int32 CFE_ES_PutPoolBuf(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_t BufPtr);
 ** \par Assumptions, External Events, and Notes:
 **        None
 **
-** \param[in, out]   BufPtr      Pointer to #CFE_ES_MemPoolStats_t data structure to be
-**                               filled with memory statistics. *BufPtr is the Memory Pool Statistics stored in given
-**                               data structure.
+** \param[out]   BufPtr      Pointer to #CFE_ES_MemPoolStats_t data structure @nonnull to be
+**                           filled with memory statistics. *BufPtr is the Memory Pool Statistics stored in given
+**                           data structure.
 **
 ** \param[in]   Handle      The handle to the memory pool whose statistics are desired.
 **
@@ -1514,9 +1544,10 @@ void CFE_ES_PerfLogAdd(uint32 Marker, uint32 EntryExit);
 **
 **
 ** \return Execution status, see \ref CFEReturnCodes
-** \retval #CFE_SUCCESS               \copybrief CFE_SUCCESS
-** \retval #CFE_ES_BAD_ARGUMENT       \copybrief CFE_ES_BAD_ARGUMENT
-** \retval #CFE_ES_ERR_DUPLICATE_NAME \copybrief CFE_ES_ERR_DUPLICATE_NAME
+** \retval #CFE_SUCCESS                       \copybrief CFE_SUCCESS
+** \retval #CFE_ES_BAD_ARGUMENT               \copybrief CFE_ES_BAD_ARGUMENT
+** \retval #CFE_ES_ERR_DUPLICATE_NAME         \copybrief CFE_ES_ERR_DUPLICATE_NAME
+** \retval #CFE_ES_NO_RESOURCE_IDS_AVAILABLE  \copybrief CFE_ES_NO_RESOURCE_IDS_AVAILABLE
 **
 ** \sa #CFE_ES_IncrementGenCounter, #CFE_ES_DeleteGenCounter, #CFE_ES_SetGenCount, #CFE_ES_GetGenCount,
 *#CFE_ES_GetGenCounterIDByName

--- a/modules/core_api/fsw/inc/cfe_es.h
+++ b/modules/core_api/fsw/inc/cfe_es.h
@@ -1131,7 +1131,7 @@ CFE_Status_t CFE_ES_GetCDSBlockName(char *BlockName, CFE_ES_CDSHandle_t BlockId,
 ** \sa #CFE_ES_RegisterCDS, #CFE_ES_RestoreFromCDS
 **
 */
-CFE_Status_t CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, void *DataToCopy);
+CFE_Status_t CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, const void *DataToCopy);
 
 /*****************************************************************************/
 /**

--- a/modules/core_api/fsw/inc/cfe_es.h
+++ b/modules/core_api/fsw/inc/cfe_es.h
@@ -352,18 +352,32 @@ void CFE_ES_ExitApp(uint32 ExitStatus);
 **
 ** \par Description
 **        This is the API that allows an app to check for exit requests from
-**         the system.
+**        the system, or request shutdown from the system.
 **
 ** \par Assumptions, External Events, and Notes:
 **        This API updates the internal task counter tracked by ES for the calling task.
 **        For ES to report application counters correctly this API should be called
 **        from the main app task as part of it's main processing loop.
 **
-** \param[in]  RunStatus    A pointer to a variable containing the Application's
-**                          desired run status.  Acceptable values are:
-**                          \arg #CFE_ES_RunStatus_APP_RUN - \copybrief CFE_ES_RunStatus_APP_RUN
-**                          \arg #CFE_ES_RunStatus_APP_EXIT - \copybrief CFE_ES_RunStatus_APP_EXIT
-**                          \arg #CFE_ES_RunStatus_APP_ERROR - \copybrief CFE_ES_RunStatus_APP_ERROR
+**        In the event of a externally initiated app shutdown request (such as the APP_STOP,
+**        APP_RELOAD, and APP_RESTART commands) or if a system error occurs requiring the app
+**        to be shut down administratively, this function returns "false" and optionally sets
+**        the "RunStatus" output to further indicate the specific application state.
+**
+**        If "RunStatus" is passed as non-NULL, it should point to a local status variable
+**        containing the requested status to ES.  Normally, this should be initialized to
+**        #CFE_ES_RunStatus_APP_RUN during application start up, and should remain as this value
+**        during normal operation.
+**
+**        If "RunStatus" is set to #CFE_ES_RunStatus_APP_EXIT or #CFE_ES_RunStatus_APP_ERROR on input,
+**        this acts as a shutdown request - CFE_ES_RunLoop() function will return "false", and a shutdown
+**        will be initiated similar to if ES had been externally commanded to shut down the app.
+**
+**        If "RunStatus" is not used, it should be passed as NULL.  In this mode, only the boolean
+**        return value is relevant, which will indicate if an externally-initiated shutdown request
+**        is pending.
+**
+** \param[inout] RunStatus  Optional pointer to a variable containing the desired run status
 **
 ** \return Boolean indicating application should continue running
 ** \retval true  Application should continue running

--- a/modules/core_api/fsw/inc/cfe_evs.h
+++ b/modules/core_api/fsw/inc/cfe_evs.h
@@ -102,6 +102,7 @@
 ** \retval #CFE_EVS_APP_FILTER_OVERLOAD \copybrief CFE_EVS_APP_FILTER_OVERLOAD
 ** \retval #CFE_EVS_UNKNOWN_FILTER      \copybrief CFE_EVS_UNKNOWN_FILTER
 ** \retval #CFE_EVS_APP_ILLEGAL_APP_ID  \copybrief CFE_EVS_APP_ILLEGAL_APP_ID
+** \retval #CFE_ES_BAD_ARGUMENT         \copybrief CFE_ES_BAD_ARGUMENT
 **/
 CFE_Status_t CFE_EVS_Register(const void *Filters, uint16 NumEventFilters, uint16 FilterScheme);
 /**@}*/
@@ -133,7 +134,7 @@ CFE_Status_t CFE_EVS_Register(const void *Filters, uint16 NumEventFilters, uint1
 **                                   \arg #CFE_EVS_EventType_ERROR
 **                                   \arg #CFE_EVS_EventType_CRITICAL
 **
-** \param[in] Spec               A pointer to a null terminated text string describing the output format
+** \param[in] Spec               A pointer to a null terminated text string @nonnull describing the output format
 **                               for the event.  This is the same type of format string used for the ANSI
 **                               \c printf function.  Nominally the post-conversion string is limited to 80
 **                               characters, but this limit is configurable through the parameter
@@ -148,6 +149,7 @@ CFE_Status_t CFE_EVS_Register(const void *Filters, uint16 NumEventFilters, uint1
 ** \retval #CFE_SUCCESS                \copybrief CFE_SUCCESS
 ** \retval #CFE_EVS_APP_NOT_REGISTERED \copybrief CFE_EVS_APP_NOT_REGISTERED
 ** \retval #CFE_EVS_APP_ILLEGAL_APP_ID \copybrief CFE_EVS_APP_ILLEGAL_APP_ID
+** \retval #CFE_EVS_INVALID_PARAMETER  \copybrief CFE_EVS_INVALID_PARAMETER
 **
 ** \sa #CFE_EVS_SendEventWithAppID, #CFE_EVS_SendTimedEvent
 **
@@ -181,7 +183,7 @@ CFE_Status_t CFE_EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spe
 **
 ** \param[in] AppID              The Application ID from which the event message should appear.
 **
-** \param[in] Spec               A pointer to a null terminated text string describing the output format
+** \param[in] Spec               A pointer to a null terminated text string @nonnull describing the output format
 **                               for the event.  This is the same type of format string used for the ANSI
 **                               \c printf function.  Nominally the post-conversion string is limited to 80
 **                               characters, but this limit is configurable through the parameter
@@ -196,6 +198,7 @@ CFE_Status_t CFE_EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spe
 ** \retval #CFE_SUCCESS                \copybrief CFE_SUCCESS
 ** \retval #CFE_EVS_APP_NOT_REGISTERED \copybrief CFE_EVS_APP_NOT_REGISTERED
 ** \retval #CFE_EVS_APP_ILLEGAL_APP_ID \copybrief CFE_EVS_APP_ILLEGAL_APP_ID
+** \retval #CFE_EVS_INVALID_PARAMETER  \copybrief CFE_EVS_INVALID_PARAMETER
 **
 ** \sa #CFE_EVS_SendEvent, #CFE_EVS_SendTimedEvent
 **
@@ -230,7 +233,7 @@ CFE_Status_t CFE_EVS_SendEventWithAppID(uint16 EventID, uint16 EventType, CFE_ES
 **                                   \arg #CFE_EVS_EventType_ERROR
 **                                   \arg #CFE_EVS_EventType_CRITICAL
 **
-** \param[in] Spec               A pointer to a null terminated text string describing the output format
+** \param[in] Spec               A pointer to a null terminated text string @nonnull describing the output format
 **                               for the event.  This is the same type of format string used for the ANSI
 **                               \c printf function.  Nominally the post-conversion string is limited to 80
 **                               characters, but this limit is configurable through the parameter
@@ -245,6 +248,7 @@ CFE_Status_t CFE_EVS_SendEventWithAppID(uint16 EventID, uint16 EventType, CFE_ES
 ** \retval #CFE_SUCCESS                \copybrief CFE_SUCCESS
 ** \retval #CFE_EVS_APP_NOT_REGISTERED \copybrief CFE_EVS_APP_NOT_REGISTERED
 ** \retval #CFE_EVS_APP_ILLEGAL_APP_ID \copybrief CFE_EVS_APP_ILLEGAL_APP_ID
+** \retval #CFE_EVS_INVALID_PARAMETER  \copybrief CFE_EVS_INVALID_PARAMETER
 **
 ** \sa #CFE_EVS_SendEvent, #CFE_EVS_SendEventWithAppID
 **
@@ -275,6 +279,7 @@ CFE_Status_t CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time, uint16 EventID, uin
 ** \retval #CFE_SUCCESS                \copybrief CFE_SUCCESS
 ** \retval #CFE_EVS_APP_NOT_REGISTERED \copybrief CFE_EVS_APP_NOT_REGISTERED
 ** \retval #CFE_EVS_APP_ILLEGAL_APP_ID \copybrief CFE_EVS_APP_ILLEGAL_APP_ID
+** \retval #CFE_EVS_EVT_NOT_REGISTERED \copybrief CFE_EVS_EVT_NOT_REGISTERED
 **
 ** \sa #CFE_EVS_ResetAllFilters
 **

--- a/modules/core_api/fsw/inc/cfe_fs.h
+++ b/modules/core_api/fsw/inc/cfe_fs.h
@@ -60,13 +60,14 @@
 **        -# File offset behavior: Agnostic on entry since it will move the offset to the start of the file,
 **           on success the offset will be at the end of the header, undefined offset behavior for error cases.
 **
-** \param[in, out] Hdr     Pointer to a variable of type #CFE_FS_Header_t that will be
+** \param[out] Hdr         Pointer to a variable of type #CFE_FS_Header_t @nonnull that will be
 **                         filled with the contents of the Standard cFE File Header. *Hdr is the contents of the
 **                         Standard cFE File Header for the specified file.
 ** \param[in] FileDes      File Descriptor obtained from a previous call to #OS_OpenCreate
 **                         that is associated with the file whose header is to be read.
 **
 ** \return Bytes read or error status from OSAL
+** \retval #CFE_FS_BAD_ARGUMENT  \copybrief CFE_FS_BAD_ARGUMENT
 **
 ** \note This function invokes OSAL API routines and the current implementation may return
 **       OSAL error codes to the caller if failure occurs.  In a future version of CFE, the
@@ -88,7 +89,7 @@ CFE_Status_t CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, osal_id_t FileDes);
 ** \param[in] Hdr          Pointer to a variable of type #CFE_FS_Header_t that will be
 **                         cleared and initialized
 **
-** \param[in] *Description Initializes Header's Description
+** \param[in]  Description Initializes Header's Description @nonnull
 **
 ** \param[in]  SubType     Initializes Header's SubType
 **
@@ -128,11 +129,12 @@ void CFE_FS_InitHeader(CFE_FS_Header_t *Hdr, const char *Description, uint32 Sub
 ** \param[in] FileDes File Descriptor obtained from a previous call to #OS_OpenCreate
 **                    that is associated with the file whose header is to be read.
 **
-** \param[in, out] Hdr     Pointer to a variable of type #CFE_FS_Header_t that will be
-**                         filled with the contents of the Standard cFE File Header. *Hdr is the contents of the
-**                         Standard cFE File Header for the specified file.
+** \param[out] Hdr    Pointer to a variable of type #CFE_FS_Header_t @nonnull that will be
+**                    filled with the contents of the Standard cFE File Header. *Hdr is the contents of the
+**                    Standard cFE File Header for the specified file.
 **
 ** \return Bytes read or error status from OSAL
+** \retval #CFE_FS_BAD_ARGUMENT  \copybrief CFE_FS_BAD_ARGUMENT
 **
 ** \note This function invokes OSAL API routines and the current implementation may return
 **       OSAL error codes to the caller if failure occurs.  In a future version of CFE, the
@@ -166,6 +168,8 @@ CFE_Status_t CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr);
 **                         to be put into the file's Standard cFE File Header.
 **
 ** \return Execution status, see \ref CFEReturnCodes, or OSAL status
+** \retval #CFE_STATUS_EXTERNAL_RESOURCE_FAIL  \copybrief CFE_STATUS_EXTERNAL_RESOURCE_FAIL
+** \retval #CFE_SUCCESS                        \copybrief CFE_SUCCESS
 **
 ** \note This function invokes OSAL API routines and the current implementation may return
 **       OSAL error codes to the caller if failure occurs.  In a future version of CFE, the
@@ -192,7 +196,8 @@ CFE_Status_t CFE_FS_SetTimestamp(osal_id_t FileDes, CFE_TIME_SysTime_t NewTimest
 ** This returns the expected directory for a given class of files in the form
 ** of a virtual OSAL mount point string.
 **
-** \returns String containing the mount point, or NULL if unkown/invalid
+** \returns String containing the mount point
+** \retval  NULL if no mount point is known for the given file category
 */
 const char *CFE_FS_GetDefaultMountPoint(CFE_FS_FileCategory_t FileCategory);
 
@@ -208,7 +213,8 @@ const char *CFE_FS_GetDefaultMountPoint(CFE_FS_FileCategory_t FileCategory);
 ** build environment to get the default/expected extension for a given file
 ** category.
 **
-** \returns String containing the extension, or NULL if unkown/invalid
+** \returns String containing the extension
+** \retval  NULL if no default extension is known for the given file category
 */
 const char *CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_t FileCategory);
 
@@ -235,15 +241,19 @@ const char *CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_t FileCategory);
 **            and does not need to be null terminated.  However parsing will stop
 **            at the first null char, when the input is shorter than the maximum.
 **
-** \param[out] OutputBuffer     Buffer to store result.
-** \param[in]  InputBuffer      A input buffer that may contain a file name (e.g. from command).
-** \param[in]  OutputBufSize    Maximum Size of output buffer.
+** \param[out] OutputBuffer     Buffer to store result @nonnull.
+** \param[in]  InputBuffer      A input buffer that may contain a file name (e.g. from command) @nonnull.
+** \param[in]  OutputBufSize    Maximum Size of output buffer @nonzero.
 ** \param[in]  InputBufSize     Maximum Size of input buffer.
 ** \param[in]  DefaultInput     Default value to use for input if InputBffer is empty
 ** \param[in]  DefaultPath      Default value to use for pathname if omitted from input
 ** \param[in]  DefaultExtension Default value to use for extension if omitted from input
 **
 ** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_FS_BAD_ARGUMENT    \copybrief CFE_FS_BAD_ARGUMENT
+** \retval #CFE_FS_FNAME_TOO_LONG  \copybrief CFE_FS_FNAME_TOO_LONG
+** \retval #CFE_FS_INVALID_PATH    \copybrief CFE_FS_INVALID_PATH
+** \retval #CFE_SUCCESS            \copybrief CFE_SUCCESS
 **
 ******************************************************************************/
 int32 CFE_FS_ParseInputFileNameEx(char *OutputBuffer, const char *InputBuffer, size_t OutputBufSize,
@@ -267,9 +277,9 @@ int32 CFE_FS_ParseInputFileNameEx(char *OutputBuffer, const char *InputBuffer, s
 **
 ** \sa CFE_FS_ParseInputFileNameEx()
 **
-** \param[out] OutputBuffer     Buffer to store result.
-** \param[in]  InputName        A null terminated input string
-** \param[in]  OutputBufSize    Maximum Size of output buffer.
+** \param[out] OutputBuffer     Buffer to store result @nonnull.
+** \param[in]  InputName        A null terminated input string @nonnull.
+** \param[in]  OutputBufSize    Maximum Size of output buffer @nonzero.
 ** \param[in]  FileCategory     The generalized category of file (implies default path/extension)
 **
 ** \return Execution status, see \ref CFEReturnCodes
@@ -293,10 +303,14 @@ int32 CFE_FS_ParseInputFileName(char *OutputBuffer, const char *InputName, size_
 **            filenames separated by "/" characters.
 **        -# The extracted filename (including terminator) is no longer than #OS_MAX_PATH_LEN
 **
-** \param[in] OriginalPath The original path.
-** \param[out] FileNameOnly The filename that is extracted from the path.
+** \param[in] OriginalPath The original path @nonnull
+** \param[out] FileNameOnly The filename that is extracted from the path @nonnull
 **
 ** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_FS_BAD_ARGUMENT    \copybrief CFE_FS_BAD_ARGUMENT
+** \retval #CFE_FS_FNAME_TOO_LONG  \copybrief CFE_FS_FNAME_TOO_LONG
+** \retval #CFE_FS_INVALID_PATH    \copybrief CFE_FS_INVALID_PATH
+** \retval #CFE_SUCCESS            \copybrief CFE_SUCCESS
 **
 ******************************************************************************/
 CFE_Status_t CFE_FS_ExtractFilenameFromPath(const char *OriginalPath, char *FileNameOnly);
@@ -313,9 +327,13 @@ CFE_Status_t CFE_FS_ExtractFilenameFromPath(const char *OriginalPath, char *File
 **        it must remain accessible by the file writer task throughout the asynchronous
 **        job operation.
 **
-** \param[inout] Meta        The background file write persistent state object
+** \param[inout] Meta        The background file write persistent state object @nonnull
 **
 ** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_FS_BAD_ARGUMENT                 \copybrief CFE_FS_BAD_ARGUMENT
+** \retval #CFE_FS_INVALID_PATH                 \copybrief CFE_FS_INVALID_PATH
+** \retval #CFE_STATUS_REQUEST_ALREADY_PENDING  \copybrief CFE_STATUS_REQUEST_ALREADY_PENDING
+** \retval #CFE_SUCCESS                         \copybrief CFE_SUCCESS
 **
 ******************************************************************************/
 int32 CFE_FS_BackgroundFileDumpRequest(CFE_FS_FileWriteMetaData_t *Meta);
@@ -331,9 +349,11 @@ int32 CFE_FS_BackgroundFileDumpRequest(CFE_FS_FileWriteMetaData_t *Meta);
 ** \par Assumptions, External Events, and Notes:
 **        None
 **
-** \param[inout] Meta        The background file write persistent state object
+** \param[inout] Meta        The background file write persistent state object @nonnull
 **
-** \return true if request is already pending, false if not
+** \return boolean value indicating if request is already pending
+** \retval true if request is pending
+** \retval false if request is not pending
 **
 ******************************************************************************/
 bool CFE_FS_BackgroundFileDumpIsPending(const CFE_FS_FileWriteMetaData_t *Meta);

--- a/modules/core_api/fsw/inc/cfe_msg.h
+++ b/modules/core_api/fsw/inc/cfe_msg.h
@@ -52,7 +52,7 @@
  *          set to zero (based on size), defaults are set, then the
  *          size and bits from MsgId are set.
  *
- * \param[in, out]  MsgPtr      A pointer to the buffer that contains the message.
+ * \param[out]      MsgPtr      A pointer to the buffer that contains the message @nonnull.
  * \param[in]       MsgId       MsgId that corresponds to message
  * \param[in]       Size        Total size of the mesage (used to set length field)
  *
@@ -69,8 +69,8 @@ CFE_Status_t CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_M
  * \par Description
  *          This routine gets the total size of the message.
  *
- * \param[in]  MsgPtr      A pointer to the buffer that contains the message.
- * \param[out] Size        Total message size
+ * \param[in]  MsgPtr      A pointer to the buffer that contains the message @nonnull.
+ * \param[out] Size        Total message size @nonnull
  *
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
@@ -85,7 +85,7 @@ CFE_Status_t CFE_MSG_GetSize(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t *Si
  * \par Description
  *          This routine sets the total size of the message.
  *
- * \param[in, out]  MsgPtr      A pointer to the buffer that contains the message.
+ * \param[in, out]  MsgPtr      A pointer to the buffer that contains the message @nonnull.
  * \param[in]       Size        Total message size
  *
  * \return Execution status, see \ref CFEReturnCodes
@@ -101,8 +101,8 @@ CFE_Status_t CFE_MSG_SetSize(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t Size);
  * \par Description
  *          This routine gets the message type.
  *
- * \param[in]  MsgPtr      A pointer to the buffer that contains the message.
- * \param[out] Type        Message type
+ * \param[in]  MsgPtr      A pointer to the buffer that contains the message @nonnull.
+ * \param[out] Type        Message type @nonnull
  *
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
@@ -117,7 +117,7 @@ CFE_Status_t CFE_MSG_GetType(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t *Ty
  * \par Description
  *          This routine sets the message type.
  *
- * \param[in, out]  MsgPtr      A pointer to the buffer that contains the message.
+ * \param[in, out]  MsgPtr      A pointer to the buffer that contains the message @nonnull.
  * \param[in]       Type        Message type
  *
  * \return Execution status, see \ref CFEReturnCodes
@@ -133,8 +133,8 @@ CFE_Status_t CFE_MSG_SetType(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t Type);
  * \par Description
  *          This routine gets the message header version.
  *
- * \param[in]  MsgPtr      A pointer to the buffer that contains the message.
- * \param[out] Version     Header version
+ * \param[in]  MsgPtr      A pointer to the buffer that contains the message @nonnull.
+ * \param[out] Version     Header version  @nonnull
  *
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
@@ -166,8 +166,8 @@ CFE_Status_t CFE_MSG_SetHeaderVersion(CFE_MSG_Message_t *MsgPtr, CFE_MSG_HeaderV
  * \par Description
  *          This routine gets the message secondary header boolean.
  *
- * \param[in]  MsgPtr       A pointer to the buffer that contains the message.
- * \param[out] HasSecondary Has secondary header flag
+ * \param[in]  MsgPtr       A pointer to the buffer that contains the message @nonnull.
+ * \param[out] HasSecondary Has secondary header flag @nonnull
  *
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
@@ -183,7 +183,7 @@ CFE_Status_t CFE_MSG_GetHasSecondaryHeader(const CFE_MSG_Message_t *MsgPtr, bool
  *          This routine sets the message has secondary header boolean. Typically only
  *          set within message initialization and not used by APPs.
  *
- * \param[in, out]  MsgPtr       A pointer to the buffer that contains the message.
+ * \param[in, out]  MsgPtr       A pointer to the buffer that contains the message @nonnull.
  * \param[in]       HasSecondary Has secondary header flag
  *
  * \return Execution status, see \ref CFEReturnCodes
@@ -199,8 +199,8 @@ CFE_Status_t CFE_MSG_SetHasSecondaryHeader(CFE_MSG_Message_t *MsgPtr, bool HasSe
  * \par Description
  *          This routine gets the message application ID.
  *
- * \param[in]  MsgPtr       A pointer to the buffer that contains the message.
- * \param[out] ApId         Application ID
+ * \param[in]  MsgPtr       A pointer to the buffer that contains the message @nonnull.
+ * \param[out] ApId         Application ID @nonnull
  *
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
@@ -217,7 +217,7 @@ CFE_Status_t CFE_MSG_GetApId(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t *Ap
  *          at initialization using the MsgId, but API available to set
  *          bits that may not be included in MsgId.
  *
- * \param[in, out]  MsgPtr       A pointer to the buffer that contains the message.
+ * \param[in, out]  MsgPtr       A pointer to the buffer that contains the message @nonnull.
  * \param[in]       ApId         Application ID
  *
  * \return Execution status, see \ref CFEReturnCodes
@@ -233,8 +233,8 @@ CFE_Status_t CFE_MSG_SetApId(CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t ApId);
  * \par Description
  *          This routine gets the message segmentation flag
  *
- * \param[in]  MsgPtr       A pointer to the buffer that contains the message.
- * \param[out] SegFlag      Segmentation flag
+ * \param[in]  MsgPtr       A pointer to the buffer that contains the message @nonnull.
+ * \param[out] SegFlag      Segmentation flag @nonnull
  *
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
@@ -249,7 +249,7 @@ CFE_Status_t CFE_MSG_GetSegmentationFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MS
  * \par Description
  *          This routine sets the message segmentation flag.
  *
- * \param[in, out]  MsgPtr       A pointer to the buffer that contains the message.
+ * \param[in, out]  MsgPtr       A pointer to the buffer that contains the message @nonnull.
  * \param[in]       SegFlag      Segmentation flag
  *
  * \return Execution status, see \ref CFEReturnCodes
@@ -265,8 +265,8 @@ CFE_Status_t CFE_MSG_SetSegmentationFlag(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Segm
  * \par Description
  *          This routine gets the message sequence count.
  *
- * \param[in]    MsgPtr      A pointer to the buffer that contains the message.
- * \param[out]   SeqCnt      Sequence count
+ * \param[in]    MsgPtr      A pointer to the buffer that contains the message @nonnull.
+ * \param[out]   SeqCnt      Sequence count @nonnull
  *
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
@@ -281,7 +281,7 @@ CFE_Status_t CFE_MSG_GetSequenceCount(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_S
  * \par Description
  *          This routine sets the message sequence count.
  *
- * \param[in, out]  MsgPtr      A pointer to the buffer that contains the message.
+ * \param[in, out]  MsgPtr      A pointer to the buffer that contains the message @nonnull.
  * \param[in]       SeqCnt      Sequence count
  *
  * \return Execution status, see \ref CFEReturnCodes
@@ -313,8 +313,8 @@ CFE_MSG_SequenceCount_t CFE_MSG_GetNextSequenceCount(CFE_MSG_SequenceCount_t Seq
  * \par Description
  *          This routine gets the message EDS version.
  *
- * \param[in]    MsgPtr      A pointer to the buffer that contains the message.
- * \param[out]   Version     EDS Version
+ * \param[in]    MsgPtr      A pointer to the buffer that contains the message @nonnull.
+ * \param[out]   Version     EDS Version @nonnull
  *
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
@@ -329,7 +329,7 @@ CFE_Status_t CFE_MSG_GetEDSVersion(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_EDSV
  * \par Description
  *          This routine sets the message EDS version.
  *
- * \param[in, out]  MsgPtr      A pointer to the buffer that contains the message.
+ * \param[in, out]  MsgPtr      A pointer to the buffer that contains the message @nonnull.
  * \param[in]       Version     EDS Version
  *
  * \return Execution status, see \ref CFEReturnCodes
@@ -345,8 +345,8 @@ CFE_Status_t CFE_MSG_SetEDSVersion(CFE_MSG_Message_t *MsgPtr, CFE_MSG_EDSVersion
  * \par Description
  *          This routine gets the message endian.
  *
- * \param[in]    MsgPtr      A pointer to the buffer that contains the message.
- * \param[out]   Endian      Endian
+ * \param[in]    MsgPtr      A pointer to the buffer that contains the message @nonnull.
+ * \param[out]   Endian      Endian @nonnull
  *
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
@@ -362,7 +362,7 @@ CFE_Status_t CFE_MSG_GetEndian(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Endian_t
  *          This routine sets the message endian.  Invalid endian selection
  *          will set big endian.
  *
- * \param[in, out]  MsgPtr      A pointer to the buffer that contains the message.
+ * \param[in, out]  MsgPtr      A pointer to the buffer that contains the message @nonnull.
  * \param[in]       Endian      Endian
  *
  * \return Execution status, see \ref CFEReturnCodes
@@ -378,8 +378,8 @@ CFE_Status_t CFE_MSG_SetEndian(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Endian_t Endia
  * \par Description
  *          This routine gets the message playback flag.
  *
- * \param[in]    MsgPtr      A pointer to the buffer that contains the message.
- * \param[out]   PlayFlag    Playback Flag
+ * \param[in]    MsgPtr      A pointer to the buffer that contains the message @nonnull.
+ * \param[out]   PlayFlag    Playback Flag @nonnull
  *
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
@@ -394,7 +394,7 @@ CFE_Status_t CFE_MSG_GetPlaybackFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Pl
  * \par Description
  *          This routine sets the message playback flag.
  *
- * \param[in, out]    MsgPtr      A pointer to the buffer that contains the message.
+ * \param[in, out]    MsgPtr      A pointer to the buffer that contains the message @nonnull.
  * \param[in]         PlayFlag    Playback Flag
  *
  * \return Execution status, see \ref CFEReturnCodes
@@ -410,8 +410,8 @@ CFE_Status_t CFE_MSG_SetPlaybackFlag(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Playback
  * \par Description
  *          This routine gets the message subsystem
  *
- * \param[in]  MsgPtr       A pointer to the buffer that contains the message.
- * \param[out] Subsystem    Subsystem
+ * \param[in]  MsgPtr       A pointer to the buffer that contains the message @nonnull.
+ * \param[out] Subsystem    Subsystem @nonnull
  *
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
@@ -428,7 +428,7 @@ CFE_Status_t CFE_MSG_GetSubsystem(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Subsy
  *          be set at initialization using the MsgId, but API available to set
  *          bits that may not be included in MsgId.
  *
- * \param[in, out]  MsgPtr       A pointer to the buffer that contains the message.
+ * \param[in, out]  MsgPtr       A pointer to the buffer that contains the message @nonnull.
  * \param[in]       Subsystem    Subsystem
  *
  * \return Execution status, see \ref CFEReturnCodes
@@ -444,8 +444,8 @@ CFE_Status_t CFE_MSG_SetSubsystem(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Subsystem_t
  * \par Description
  *          This routine gets the message system id
  *
- * \param[in]  MsgPtr       A pointer to the buffer that contains the message.
- * \param[out] System       System
+ * \param[in]  MsgPtr       A pointer to the buffer that contains the message @nonnull.
+ * \param[out] System       System @nonnull
  *
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
@@ -462,7 +462,7 @@ CFE_Status_t CFE_MSG_GetSystem(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_System_t
  *          be set at initialization using the MsgId, but API available to set
  *          bits that may not be included in MsgId.
  *
- * \param[in, out]  MsgPtr       A pointer to the buffer that contains the message.
+ * \param[in, out]  MsgPtr       A pointer to the buffer that contains the message @nonnull.
  * \param[in]       System       System
  *
  * \return Execution status, see \ref CFEReturnCodes
@@ -487,7 +487,7 @@ CFE_Status_t CFE_MSG_SetSystem(CFE_MSG_Message_t *MsgPtr, CFE_MSG_System_t Syste
  *            include a checksum field, then this routine will return
  *            #CFE_MSG_WRONG_MSG_TYPE
  *
- * \param[in, out]  MsgPtr      A pointer to the buffer that contains the message.
+ * \param[in, out]  MsgPtr      A pointer to the buffer that contains the message @nonnull.
  *
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
@@ -509,9 +509,9 @@ CFE_Status_t CFE_MSG_GenerateChecksum(CFE_MSG_Message_t *MsgPtr);
  *            include a checksum field, then this routine will return
  *            #CFE_MSG_WRONG_MSG_TYPE and set the IsValid parameter false.
  *
- * \param[in]  MsgPtr      A pointer to the buffer that contains the message.
+ * \param[in]  MsgPtr      A pointer to the buffer that contains the message @nonnull.
  *                         This must point to the first byte of the message header.
- * \param[out] IsValid     Checksum validation result
+ * \param[out] IsValid     Checksum validation result @nonnull
  *                         \arg true - valid
  *                         \arg false - invalid or not supported/implemented
  *
@@ -534,7 +534,7 @@ CFE_Status_t CFE_MSG_ValidateChecksum(const CFE_MSG_Message_t *MsgPtr, bool *IsV
  *            include a function code field, then this routine will do nothing to
  *            the message contents and will return #CFE_MSG_WRONG_MSG_TYPE.
  *
- * \param[in, out]  MsgPtr      A pointer to the buffer that contains the message.
+ * \param[in, out]  MsgPtr      A pointer to the buffer that contains the message @nonnull.
  * \param[in]       FcnCode     The function code to include in the message.
  *
  * \return Execution status, see \ref CFEReturnCodes
@@ -557,8 +557,8 @@ CFE_Status_t CFE_MSG_SetFcnCode(CFE_MSG_Message_t *MsgPtr, CFE_MSG_FcnCode_t Fcn
  *            include a function code field, then this routine will
  *            set FcnCode to zero and return #CFE_MSG_WRONG_MSG_TYPE
  *
- * \param[in]  MsgPtr      A pointer to the buffer that contains the message.
- * \param[out] FcnCode     The function code from the message
+ * \param[in]  MsgPtr      A pointer to the buffer that contains the message @nonnull.
+ * \param[out] FcnCode     The function code from the message @nonnull
  *
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS            \copybrief CFE_SUCCESS
@@ -580,8 +580,8 @@ CFE_Status_t CFE_MSG_GetFcnCode(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_FcnCode
  *            to zero and return #CFE_MSG_WRONG_MSG_TYPE
  *          - Note default implementation of command messages do not have a time field.
  *
- * \param[in]  MsgPtr      A pointer to the buffer that contains the message.
- * \param[out] Time        Time from the message
+ * \param[in]  MsgPtr      A pointer to the buffer that contains the message @nonnull.
+ * \param[out] Time        Time from the message @nonnull
  *
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS            \copybrief CFE_SUCCESS
@@ -606,7 +606,7 @@ CFE_Status_t CFE_MSG_GetMsgTime(const CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTim
  *            and will return #CFE_MSG_WRONG_MSG_TYPE.
  *          - Note default implementation of command messages do not have a time field.
  *
- * \param[in, out]  MsgPtr      A pointer to the message.
+ * \param[in, out]  MsgPtr      A pointer to the message @nonnull.
  * \param[in]       NewTime     The time to include in the message.  This will usually be a time
  *                              from #CFE_TIME_GetTime.
  *
@@ -633,8 +633,8 @@ CFE_Status_t CFE_MSG_SetMsgTime(CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t Ne
  *        routing.  Message id needs to be unique for each endpoint
  *        in the system.
  *
- * \param[in]  MsgPtr      A pointer to the buffer that contains the message.
- * \param[out] MsgId       Message id
+ * \param[in]  MsgPtr      A pointer to the buffer that contains the message @nonnull.
+ * \param[out] MsgId       Message id @nonnull
  *
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS            \copybrief CFE_SUCCESS
@@ -655,8 +655,8 @@ CFE_Status_t CFE_MSG_GetMsgId(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *M
  *        This API only sets the bits in the header that make up the message ID.
  *        No other values in the header are modified.
  *
- * \param[in]  MsgPtr      A pointer to the buffer that contains the message.
- * \param[out] MsgId       Message id
+ * \param[in, out]  MsgPtr      A pointer to the buffer that contains the message @nonnull.
+ * \param[in]       MsgId       Message id
  *
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS            \copybrief CFE_SUCCESS
@@ -672,7 +672,7 @@ CFE_Status_t CFE_MSG_SetMsgId(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId);
  *        This routine gets the message type using the message ID
  *
  * \param[in]  MsgId       Message id
- * \param[out] Type        Message type
+ * \param[out] Type        Message type @nonnull
  *
  * \return Execution status, see \ref CFEReturnCodes
  * \retval #CFE_SUCCESS            \copybrief CFE_SUCCESS

--- a/modules/core_api/fsw/inc/cfe_resourceid.h
+++ b/modules/core_api/fsw/inc/cfe_resourceid.h
@@ -212,7 +212,11 @@ CFE_ResourceId_t CFE_ResourceId_FindNext(CFE_ResourceId_t StartId, uint32 TableS
  * @param[in]  BaseValue The respective ID base value corresponding to the ID type
  * @param[in]  TableSize The actual size of the internal table (MAX index value + 1)
  * @param[out] Idx       The output index
- * @returns Status code, CFE_SUCCESS if successful.
+ *
+ * @return Execution status, see @ref CFEReturnCodes
+ * @retval #CFE_SUCCESS                     @copybrief CFE_SUCCESS
+ * @retval #CFE_ES_BAD_ARGUMENT             @copybrief CFE_ES_BAD_ARGUMENT
+ * @retval #CFE_ES_ERR_RESOURCEID_NOT_VALID @copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID
  */
 int32 CFE_ResourceId_ToIndex(CFE_ResourceId_t Id, uint32 BaseValue, uint32 TableSize, uint32 *Idx);
 

--- a/modules/core_api/fsw/inc/cfe_sb.h
+++ b/modules/core_api/fsw/inc/cfe_sb.h
@@ -68,14 +68,14 @@
 ** \par Assumptions, External Events, and Notes:
 **          None
 **
-** \param[in, out]  PipeIdPtr    A pointer to a variable of type #CFE_SB_PipeId_t,
+** \param[out]  PipeIdPtr   A pointer to a variable of type #CFE_SB_PipeId_t @nonnull,
 **                          which will be filled in with the pipe ID information
 **                          by the #CFE_SB_CreatePipe routine. *PipeIdPtr is the identifier for the created pipe.
 **
 ** \param[in]  Depth        The maximum number of messages that will be allowed on
 **                          this pipe at one time.
 **
-** \param[in]  PipeName     A string to be used to identify this pipe in error messages
+** \param[in]  PipeName     A string @nonnull to be used to identify this pipe in error messages
 **                          and routing information telemetry.  The string must be no
 **                          longer than #OS_MAX_API_NAME (including terminator).
 **                          Longer strings will be truncated.
@@ -136,7 +136,7 @@ CFE_Status_t CFE_SB_DeletePipe(CFE_SB_PipeId_t PipeId);
  * for future use.
  *
  * @param[in]   PipeID  Pipe ID to convert
- * @param[out]  Idx    Buffer where the calculated index will be stored
+ * @param[out]  Idx    Buffer where the calculated index will be stored @nonnull
  *
  * @return Execution status, see @ref CFEReturnCodes
  * @retval #CFE_SUCCESS                      @copybrief CFE_SUCCESS
@@ -173,7 +173,7 @@ CFE_Status_t CFE_SB_SetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 Opts);
 **
 ** \param[in]  PipeId       The pipe ID of the pipe to get options from.
 **
-** \param[out] *OptsPtr     A bit field of options: \ref CFESBPipeOptions
+** \param[out] OptsPtr     A bit field of options: \ref CFESBPipeOptions  @nonnull
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS         \copybrief CFE_SUCCESS
@@ -190,9 +190,9 @@ CFE_Status_t CFE_SB_GetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 *OptsPtr);
 ** \par Description
 **          This routine finds the pipe name for a pipe id.
 **
-** \param[out] PipeNameBuf  The buffer to receive the pipe name.
+** \param[out] PipeNameBuf  The buffer to receive the pipe name @nonnull.
 **
-** \param[in] PipeNameSize  The size (in chars) of the PipeName buffer.
+** \param[in] PipeNameSize  The size (in chars) of the PipeName buffer @nonzero.
 **
 ** \param[in] PipeId        The PipeId for that name.
 **
@@ -211,9 +211,9 @@ CFE_Status_t CFE_SB_GetPipeName(char *PipeNameBuf, size_t PipeNameSize, CFE_SB_P
 ** \par Description
 **          This routine finds the pipe id for a pipe name.
 **
-** \param[in]  PipeName     The name of the pipe.
+** \param[in]  PipeName     The name of the pipe @nonnull.
 **
-** \param[out] PipeIdPtr    The PipeId for that name.
+** \param[out] PipeIdPtr    The PipeId for that name @nonnull.
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS         \copybrief CFE_SUCCESS
@@ -411,7 +411,7 @@ CFE_Status_t CFE_SB_UnsubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeI
 **            this message, that task may get to run before returning
 **            control to the caller.
 **
-** \param[in]  MsgPtr       A pointer to the message to be sent.  This must point
+** \param[in]  MsgPtr       A pointer to the message to be sent @nonnull.  This must point
 **                          to the first byte of the message header.
 ** \param[in] IncrementSequenceCount Boolean to increment the internally tracked
 **                                   sequence count and update the message if the
@@ -439,7 +439,7 @@ CFE_Status_t CFE_SB_TransmitMsg(const CFE_MSG_Message_t *MsgPtr, bool IncrementS
 **          random. Therefore, it is recommended that the return code be tested
 **          for CFE_SUCCESS before processing the message.
 **
-** \param[in, out] BufPtr   A pointer to the software bus buffer to receive to.
+** \param[in, out] BufPtr   A pointer to the software bus buffer to receive to @nonnull.
 **                          Typically a caller declares a ptr of type CFE_SB_Buffer_t
 **                          (i.e. CFE_SB_Buffer_t *Ptr) then gives the address of that
 **                          pointer (&Ptr) as this parmeter. After a successful
@@ -515,7 +515,7 @@ CFE_SB_Buffer_t *CFE_SB_AllocateMessageBuffer(size_t MsgSize);
 **             CFE_SB_AllocateMessageBuffer(), but (due to some error condition) never
 **             uses that pointer in a call to CFE_SB_TransmitBuffer().
 **
-** \param[in]  BufPtr  A pointer to the SB internal buffer.  This must be a
+** \param[in]  BufPtr  A pointer to the SB internal buffer @nonnull.  This must be a
 **                     pointer returned by a call to CFE_SB_AllocateMessageBuffer(),
 **                     but never used in a call to CFE_SB_TransmitBuffer().
 **
@@ -555,7 +555,7 @@ CFE_Status_t CFE_SB_ReleaseMessageBuffer(CFE_SB_Buffer_t *BufPtr);
 **          -# This function will increment and apply the internally tracked
 **             sequence counter if set to do so.
 **
-** \param[in] BufPtr                 A pointer to the buffer to be sent.
+** \param[in] BufPtr                 A pointer to the buffer to be sent @nonnull.
 ** \param[in] IncrementSequenceCount Boolean to increment the internally tracked
 **                                   sequence count and update the message if the
 **                                   buffer contains a telemetry message
@@ -588,7 +588,7 @@ CFE_Status_t CFE_SB_TransmitBuffer(CFE_SB_Buffer_t *BufPtr, bool IncrementSequen
 **          - You must set a valid message ID in the SB message header before
 **            calling this function.
 **
-** \param[in]  MsgPtr      A pointer to the buffer that contains the software bus message.
+** \param[in]  MsgPtr      A pointer to the buffer that contains the software bus message @nonnull.
 **                         This must point to the first byte of the message header.
 **
 ** \param[in]  DataLength  The length to set (size of the user data, in bytes).
@@ -608,7 +608,7 @@ void CFE_SB_SetUserDataLength(CFE_MSG_Message_t *MsgPtr, size_t DataLength);
 **          - If the underlying implementation of software bus messages does not
 **            include a time field, then this routine will do nothing.
 **
-** \param[in]  MsgPtr      A pointer to the buffer that contains the software bus message.
+** \param[in]  MsgPtr      A pointer to the buffer that contains the software bus message @nonnull.
 **                         This must point to the first byte of the message header.
 **/
 void CFE_SB_TimeStampMsg(CFE_MSG_Message_t *MsgPtr);
@@ -637,12 +637,13 @@ void CFE_SB_TimeStampMsg(CFE_MSG_Message_t *MsgPtr);
 **    implementation.  It is only necessary to use this when termination of the source
 **    buffer is not guaranteed.
 **
-** \param[out] DestStringPtr    Pointer to destination buffer (component of SB message definition)
-** \param[in]  SourceStringPtr  Pointer to source buffer
+** \param[out] DestStringPtr    Pointer to destination buffer (component of SB message definition) @nonnull
+** \param[in]  SourceStringPtr  Pointer to source buffer @nonnull
 ** \param[in]  DestMaxSize      Size of destination buffer as defined by the message definition
 ** \param[in]  SourceMaxSize    Size of source buffer
 **
 ** \return Number of characters copied or error code, see \ref CFEReturnCodes
+** \retval #CFE_SB_BAD_ARGUMENT  \copybrief CFE_SB_BAD_ARGUMENT
 **
 */
 int32 CFE_SB_MessageStringSet(char *DestStringPtr, const char *SourceStringPtr, size_t DestMaxSize,
@@ -666,7 +667,7 @@ int32 CFE_SB_MessageStringSet(char *DestStringPtr, const char *SourceStringPtr, 
 ** \par Assumptions, External Events, and Notes:
 **          None
 **
-** \param[in]  MsgPtr  A pointer to the buffer that contains the software bus message.
+** \param[in]  MsgPtr  A pointer to the buffer that contains the software bus message @nonnull.
 **
 ** \return A pointer to the first byte of user data within the software bus message.
 **/
@@ -682,7 +683,7 @@ void *CFE_SB_GetUserData(CFE_MSG_Message_t *MsgPtr);
 ** \par Assumptions, External Events, and Notes:
 **          None
 **
-** \param[in]  MsgPtr  A pointer to the buffer that contains the software bus message.
+** \param[in]  MsgPtr  A pointer to the buffer that contains the software bus message @nonnull.
 **                     This must point to the first byte of the message header.
 **
 ** \return The size (in bytes) of the user data in the software bus message.
@@ -720,13 +721,14 @@ size_t CFE_SB_GetUserDataLength(const CFE_MSG_Message_t *MsgPtr);
 **    If the destination buffer is too small to store the entire string, it will be
 **    truncated, but it will still be null terminated.
 **
-** \param[out] DestStringPtr    Pointer to destination buffer
-** \param[in]  SourceStringPtr  Pointer to source buffer (component of SB message definition)
+** \param[out] DestStringPtr    Pointer to destination buffer @nonnull
+** \param[in]  SourceStringPtr  Pointer to source buffer (component of SB message definition) @nonnull
 ** \param[in]  DefaultString    Default string to use if source is empty
 ** \param[in]  DestMaxSize      Size of destination storage buffer (must be at least 2)
 ** \param[in]  SourceMaxSize    Size of source buffer as defined by the message definition
 **
 ** \return Number of characters copied or error code, see \ref CFEReturnCodes
+** \retval #CFE_SB_BAD_ARGUMENT  \copybrief CFE_SB_BAD_ARGUMENT
 **
 */
 int32 CFE_SB_MessageStringGet(char *DestStringPtr, const char *SourceStringPtr, const char *DefaultString,

--- a/modules/core_api/fsw/inc/cfe_sb.h
+++ b/modules/core_api/fsw/inc/cfe_sb.h
@@ -423,7 +423,7 @@ CFE_Status_t CFE_SB_UnsubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeI
 ** \retval #CFE_SB_MSG_TOO_BIG  \copybrief CFE_SB_MSG_TOO_BIG
 ** \retval #CFE_SB_BUF_ALOC_ERR \copybrief CFE_SB_BUF_ALOC_ERR
 **/
-CFE_Status_t CFE_SB_TransmitMsg(CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount);
+CFE_Status_t CFE_SB_TransmitMsg(const CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount);
 
 /*****************************************************************************/
 /**

--- a/modules/core_api/fsw/inc/cfe_tbl.h
+++ b/modules/core_api/fsw/inc/cfe_tbl.h
@@ -64,7 +64,7 @@
 **                their own tables.  An application should create any table(s) and provide the handle(s)
 **                to the interrupt service routine.
 **
-** \param[in, out] TblHandlePtr    a pointer to a #CFE_TBL_Handle_t type variable that will be assigned the table's
+** \param[out] TblHandlePtr    a pointer to a #CFE_TBL_Handle_t type variable @nonnull that will be assigned the table's
 **                                 handle.  The table handle is required for other API calls when accessing the data
 **                                 contained in the table. *TblHandlePtr is the handle used to identify table to cFE
 **                                 when performing Table operations. This value is returned at  ddress specified by
@@ -75,7 +75,8 @@
 **                                 This application specific name will be used in commands
 **                                 for modifying or viewing the contents of the table.
 **
-** \param[in] Size                 The size, in bytes, of the table to be created.  This is the size that will be
+** \param[in] Size                 The size, in bytes, of the table to be created @nonzero.  This is the size that will
+*be
 **                                 allocated as a shared memory resource between the Table Management Service and
 **                                 the calling application.
 **
@@ -180,6 +181,10 @@
 ** \retval #CFE_TBL_ERR_INVALID_SIZE         \copybrief CFE_TBL_ERR_INVALID_SIZE
 ** \retval #CFE_TBL_ERR_INVALID_NAME         \copybrief CFE_TBL_ERR_INVALID_NAME
 ** \retval #CFE_TBL_ERR_BAD_APP_ID           \copybrief CFE_TBL_ERR_BAD_APP_ID
+** \retval #CFE_TBL_BAD_ARGUMENT             \copybrief CFE_TBL_BAD_ARGUMENT
+** \retval #CFE_TBL_ERR_INVALID_OPTIONS      \copybrief CFE_TBL_ERR_INVALID_OPTIONS
+** \retval #CFE_TBL_WARN_DUPLICATE           \copybrief CFE_TBL_WARN_DUPLICATE
+** \retval #CFE_TBL_WARN_NOT_CRITICAL        \copybrief CFE_TBL_WARN_NOT_CRITICAL
 **
 ** \sa #CFE_TBL_Unregister, #CFE_TBL_Share
 **/
@@ -199,7 +204,7 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
 ** \par Assumptions, External Events, and Notes:
 **          None
 **
-** \param[in, out]  TblHandlePtr  A pointer to a #CFE_TBL_Handle_t type variable
+** \param[out]  TblHandlePtr  A pointer to a #CFE_TBL_Handle_t type variable @nonnull
 **                           that will be assigned the table's handle.  The
 **                           table handle is required for other API calls
 **                           when accessing the data contained in the table. *TblHandlePtr is the handle used to
@@ -216,6 +221,7 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
 ** \retval #CFE_TBL_ERR_HANDLES_FULL \copybrief CFE_TBL_ERR_HANDLES_FULL
 ** \retval #CFE_TBL_ERR_INVALID_NAME \copybrief CFE_TBL_ERR_INVALID_NAME
 ** \retval #CFE_TBL_ERR_BAD_APP_ID   \copybrief CFE_TBL_ERR_BAD_APP_ID
+** \retval #CFE_TBL_BAD_ARGUMENT     \copybrief CFE_TBL_BAD_ARGUMENT
 **
 ** \sa #CFE_TBL_Unregister, #CFE_TBL_Register
 **
@@ -290,7 +296,7 @@ CFE_Status_t CFE_TBL_Unregister(CFE_TBL_Handle_t TblHandle);
 **                          \arg #CFE_TBL_SRC_FILE    - \copybrief CFE_TBL_SRC_FILE
 **                          \arg #CFE_TBL_SRC_ADDRESS - \copybrief CFE_TBL_SRC_ADDRESS
 **
-** \param[in] SrcDataPtr Pointer to either a character string specifying a filename or
+** \param[in] SrcDataPtr Pointer @nonnull to either a character string specifying a filename or
 **                       a memory address of a block of binary data to be loaded into a table or,
 **                       if the table was registered with the #CFE_TBL_OPT_USR_DEF_ADDR option,
 **                       the address of the active table buffer.
@@ -310,6 +316,8 @@ CFE_Status_t CFE_TBL_Unregister(CFE_TBL_Handle_t TblHandle);
 ** \retval #CFE_TBL_ERR_FILE_TOO_LARGE    \copybrief CFE_TBL_ERR_FILE_TOO_LARGE
 ** \retval #CFE_TBL_ERR_BAD_CONTENT_ID    \copybrief CFE_TBL_ERR_BAD_CONTENT_ID
 ** \retval #CFE_TBL_ERR_PARTIAL_LOAD      \copybrief CFE_TBL_ERR_PARTIAL_LOAD
+** \retval #CFE_TBL_BAD_ARGUMENT          \copybrief CFE_TBL_BAD_ARGUMENT
+** \retval #CFE_TBL_WARN_PARTIAL_LOAD     \copybrief CFE_TBL_WARN_PARTIAL_LOAD
 **
 ** \sa #CFE_TBL_Update, #CFE_TBL_Validate, #CFE_TBL_Manage
 **
@@ -389,11 +397,14 @@ CFE_Status_t CFE_TBL_Validate(CFE_TBL_Handle_t TblHandle);
 **                       identifies the Table to be managed.
 **
 ** \return Execution status, see \ref CFEReturnCodes
-** \retval #CFE_SUCCESS                \copybrief CFE_SUCCESS
-** \retval #CFE_TBL_INFO_UPDATED       \copybrief CFE_TBL_INFO_UPDATED
-** \retval #CFE_TBL_ERR_BAD_APP_ID     \copybrief CFE_TBL_ERR_BAD_APP_ID
-** \retval #CFE_TBL_ERR_NO_ACCESS      \copybrief CFE_TBL_ERR_NO_ACCESS
-** \retval #CFE_TBL_ERR_INVALID_HANDLE \copybrief CFE_TBL_ERR_INVALID_HANDLE
+** \retval #CFE_SUCCESS                     \copybrief CFE_SUCCESS
+** \retval #CFE_TBL_INFO_UPDATED            \copybrief CFE_TBL_INFO_UPDATED
+** \retval #CFE_TBL_ERR_BAD_APP_ID          \copybrief CFE_TBL_ERR_BAD_APP_ID
+** \retval #CFE_TBL_ERR_NO_ACCESS           \copybrief CFE_TBL_ERR_NO_ACCESS
+** \retval #CFE_TBL_ERR_INVALID_HANDLE      \copybrief CFE_TBL_ERR_INVALID_HANDLE
+** \retval #CFE_TBL_INFO_DUMP_PENDING       \copybrief CFE_TBL_INFO_DUMP_PENDING
+** \retval #CFE_TBL_INFO_UPDATE_PENDING     \copybrief CFE_TBL_INFO_UPDATE_PENDING
+** \retval #CFE_TBL_INFO_VALIDATION_PENDING \copybrief CFE_TBL_INFO_VALIDATION_PENDING
 **
 ** \sa #CFE_TBL_Update, #CFE_TBL_Validate, #CFE_TBL_Load, #CFE_TBL_DumpToBuffer
 **
@@ -420,6 +431,7 @@ CFE_Status_t CFE_TBL_Manage(CFE_TBL_Handle_t TblHandle);
 ** \retval #CFE_TBL_ERR_BAD_APP_ID     \copybrief CFE_TBL_ERR_BAD_APP_ID
 ** \retval #CFE_TBL_ERR_NO_ACCESS      \copybrief CFE_TBL_ERR_NO_ACCESS
 ** \retval #CFE_TBL_ERR_INVALID_HANDLE \copybrief CFE_TBL_ERR_INVALID_HANDLE
+** \retval #CFE_TBL_INFO_DUMP_PENDING  \copybrief CFE_TBL_INFO_DUMP_PENDING
 **
 ** \sa #CFE_TBL_Manage
 **
@@ -484,7 +496,7 @@ CFE_Status_t CFE_TBL_Modified(CFE_TBL_Handle_t TblHandle);
 **           This pointer mush be released with the #CFE_TBL_ReleaseAddress API before
 **           the table can be loaded with data.
 **
-** \param[in, out]  TblPtr     The address of a pointer that will be loaded with the address of
+** \param[out]  TblPtr    The address of a pointer @nonnull that will be loaded with the address of
 **                        the first byte of the table.  This pointer can then be typecast
 **                        by the calling application to the appropriate table data structure. *TblPtr is the address of
 **                        the first byte of data associated with the specified table.
@@ -500,6 +512,7 @@ CFE_Status_t CFE_TBL_Modified(CFE_TBL_Handle_t TblHandle);
 ** \retval #CFE_TBL_ERR_INVALID_HANDLE \copybrief CFE_TBL_ERR_INVALID_HANDLE
 ** \retval #CFE_TBL_ERR_UNREGISTERED   \copybrief CFE_TBL_ERR_UNREGISTERED
 ** \retval #CFE_TBL_ERR_NEVER_LOADED   \copybrief CFE_TBL_ERR_NEVER_LOADED
+** \retval #CFE_TBL_BAD_ARGUMENT       \copybrief CFE_TBL_BAD_ARGUMENT
 **
 ** \sa #CFE_TBL_ReleaseAddress, #CFE_TBL_GetAddresses, #CFE_TBL_ReleaseAddresses
 **
@@ -563,7 +576,7 @@ CFE_Status_t CFE_TBL_ReleaseAddress(CFE_TBL_Handle_t TblHandle);
 **           This pointer mush be released with the #CFE_TBL_ReleaseAddress API before
 **           the table can be loaded with data.
 **
-** \param[in, out] TblPtrs    Array of Pointers to variables that calling Application
+** \param[out] TblPtrs   Array of Pointers @nonnull to variables that calling Application
 **                       wishes to hold the start addresses of the Tables. *TblPtrs is an array of addresses of the
 **                       first byte of data associated with the specified tables.
 **
@@ -580,6 +593,7 @@ CFE_Status_t CFE_TBL_ReleaseAddress(CFE_TBL_Handle_t TblHandle);
 ** \retval #CFE_TBL_ERR_INVALID_HANDLE \copybrief CFE_TBL_ERR_INVALID_HANDLE
 ** \retval #CFE_TBL_ERR_UNREGISTERED   \copybrief CFE_TBL_ERR_UNREGISTERED
 ** \retval #CFE_TBL_ERR_NEVER_LOADED   \copybrief CFE_TBL_ERR_NEVER_LOADED
+** \retval #CFE_TBL_BAD_ARGUMENT       \copybrief CFE_TBL_BAD_ARGUMENT
 **
 ** \sa #CFE_TBL_GetAddress, #CFE_TBL_ReleaseAddress, #CFE_TBL_ReleaseAddresses
 **
@@ -602,7 +616,7 @@ CFE_Status_t CFE_TBL_GetAddresses(void **TblPtrs[], uint16 NumTables, const CFE_
 **
 ** \param[in] NumTables  Size of TblHandles array.
 **
-** \param[in] TblHandles Array of Table Handles, previously obtained from #CFE_TBL_Register or #CFE_TBL_Share,
+** \param[in] TblHandles Array of Table Handles @nonnull, previously obtained from #CFE_TBL_Register or #CFE_TBL_Share,
 **                       of those tables whose start addresses are to be released.
 **
 ** \return Execution status, see \ref CFEReturnCodes
@@ -612,6 +626,7 @@ CFE_Status_t CFE_TBL_GetAddresses(void **TblPtrs[], uint16 NumTables, const CFE_
 ** \retval #CFE_TBL_ERR_NO_ACCESS      \copybrief CFE_TBL_ERR_NO_ACCESS
 ** \retval #CFE_TBL_ERR_INVALID_HANDLE \copybrief CFE_TBL_ERR_INVALID_HANDLE
 ** \retval #CFE_TBL_ERR_NEVER_LOADED   \copybrief CFE_TBL_ERR_NEVER_LOADED
+** \retval #CFE_TBL_BAD_ARGUMENT       \copybrief CFE_TBL_BAD_ARGUMENT
 **
 ** \sa #CFE_TBL_GetAddress, #CFE_TBL_ReleaseAddress, #CFE_TBL_GetAddresses
 **
@@ -670,11 +685,11 @@ CFE_Status_t CFE_TBL_GetStatus(CFE_TBL_Handle_t TblHandle);
 ** \par Assumptions, External Events, and Notes:
 **          None
 **
-** \param[in, out]  TblInfoPtr    A pointer to a CFE_TBL_Info_t data structure that is to be populated
+** \param[out]  TblInfoPtr   A pointer to a CFE_TBL_Info_t data structure @nonnull that is to be populated
 **                           with table characteristics and information. *TblInfoPtr is the description of the tables
 **                           characteristics and registry information stored in the #CFE_TBL_Info_t data structure
 **                           format.
-** \param[in]  TblName       The application specific name of the table of the form "AppName.RawTableName",
+** \param[in]  TblName       The application specific name @nonnull of the table of the form "AppName.RawTableName",
 **                           where RawTableName is the name specified in the #CFE_TBL_Register API call.
 **                           Example: "ACS.TamParams" for a table called "TamParams"
 **                           that was registered by the application called "ACS".
@@ -682,6 +697,7 @@ CFE_Status_t CFE_TBL_GetStatus(CFE_TBL_Handle_t TblHandle);
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS              \copybrief CFE_SUCCESS
 ** \retval #CFE_TBL_ERR_INVALID_NAME \copybrief CFE_TBL_ERR_INVALID_NAME
+** \retval #CFE_TBL_BAD_ARGUMENT     \copybrief CFE_TBL_BAD_ARGUMENT
 **
 ** \sa #CFE_TBL_GetStatus
 **

--- a/modules/core_api/fsw/inc/cfe_time.h
+++ b/modules/core_api/fsw/inc/cfe_time.h
@@ -633,9 +633,12 @@ void CFE_TIME_ExternalTime(CFE_TIME_SysTime_t NewTime);
 **        If an application requires triggering multiple child tasks at 1Hz, it should distribute
 **        the timing signal internally, rather than registering for multiple callbacks.
 **
+** \param[in]  CallbackFuncPtr   Function to call at synchronization interval @nonnull
+**
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                       \copybrief CFE_SUCCESS
 ** \retval #CFE_TIME_TOO_MANY_SYNCH_CALLBACKS \copybrief CFE_TIME_TOO_MANY_SYNCH_CALLBACKS
+** \retval #CFE_TIME_BAD_ARGUMENT             \copybrief CFE_TIME_BAD_ARGUMENT
 **
 ** \sa #CFE_TIME_UnregisterSynchCallback
 **
@@ -655,9 +658,12 @@ CFE_Status_t CFE_TIME_RegisterSynchCallback(CFE_TIME_SynchCallbackPtr_t Callback
 **        Only a single callback per application is supported, and this function should only
 **        be called from a single thread within each application (typically the apps main thread).
 **
+** \param[in]  CallbackFuncPtr   Function to remove from synchronization call list @nonnull
+**
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                      \copybrief CFE_SUCCESS
 ** \retval #CFE_TIME_CALLBACK_NOT_REGISTERED \copybrief CFE_TIME_CALLBACK_NOT_REGISTERED
+** \retval #CFE_TIME_BAD_ARGUMENT            \copybrief CFE_TIME_BAD_ARGUMENT
 **
 ** \sa #CFE_TIME_RegisterSynchCallback
 **
@@ -696,7 +702,7 @@ CFE_Status_t CFE_TIME_UnregisterSynchCallback(CFE_TIME_SynchCallbackPtr_t Callba
 **          the maximum amount of time represented by a CFE_TIME_SysTime
 **          structure is approximately 136 years.
 **
-** \param[in, out]  PrintBuffer   Pointer to a character array of at least
+** \param[out]  PrintBuffer   Pointer to a character array @nonnull of at least
 **                           #CFE_TIME_PRINTED_STRING_SIZE characters in length. *PrintBuffer is the time as a
 **                           character string as described above.
 **

--- a/modules/core_api/fsw/inc/cfe_version.h
+++ b/modules/core_api/fsw/inc/cfe_version.h
@@ -28,7 +28,7 @@
 #define CFE_VERSION_H
 
 /* Development Build Macro Definitions */
-#define CFE_BUILD_NUMBER   844          /**< @brief Development: Number of development commits since baseline */
+#define CFE_BUILD_NUMBER   873          /**< @brief Development: Number of development commits since baseline */
 #define CFE_BUILD_BASELINE "v6.8.0-rc1" /**< @brief Development: Reference git tag for build number */
 
 /* Version Macro Definitions updated for official releases only */

--- a/modules/core_api/ut-stubs/src/cfe_es_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_es_stubs.c
@@ -98,12 +98,12 @@ uint32 CFE_ES_CalculateCRC(const void *DataPtr, size_t DataLength, uint32 InputC
  * Generated stub function for CFE_ES_CopyToCDS()
  * ----------------------------------------------------
  */
-CFE_Status_t CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, void *DataToCopy)
+CFE_Status_t CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, const void *DataToCopy)
 {
     UT_GenStub_SetupReturnBuffer(CFE_ES_CopyToCDS, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_ES_CopyToCDS, CFE_ES_CDSHandle_t, Handle);
-    UT_GenStub_AddParam(CFE_ES_CopyToCDS, void *, DataToCopy);
+    UT_GenStub_AddParam(CFE_ES_CopyToCDS, const void *, DataToCopy);
 
     UT_GenStub_Execute(CFE_ES_CopyToCDS, Basic, UT_DefaultHandler_CFE_ES_CopyToCDS);
 

--- a/modules/core_api/ut-stubs/src/cfe_sb_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_sb_stubs.c
@@ -403,11 +403,11 @@ CFE_Status_t CFE_SB_TransmitBuffer(CFE_SB_Buffer_t *BufPtr, bool IncrementSequen
  * Generated stub function for CFE_SB_TransmitMsg()
  * ----------------------------------------------------
  */
-CFE_Status_t CFE_SB_TransmitMsg(CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount)
+CFE_Status_t CFE_SB_TransmitMsg(const CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount)
 {
     UT_GenStub_SetupReturnBuffer(CFE_SB_TransmitMsg, CFE_Status_t);
 
-    UT_GenStub_AddParam(CFE_SB_TransmitMsg, CFE_MSG_Message_t *, MsgPtr);
+    UT_GenStub_AddParam(CFE_SB_TransmitMsg, const CFE_MSG_Message_t *, MsgPtr);
     UT_GenStub_AddParam(CFE_SB_TransmitMsg, bool, IncrementSequenceCount);
 
     UT_GenStub_Execute(CFE_SB_TransmitMsg, Basic, UT_DefaultHandler_CFE_SB_TransmitMsg);

--- a/modules/core_private/ut-stubs/inc/ut_osprintf_stubs.h
+++ b/modules/core_private/ut-stubs/inc/ut_osprintf_stubs.h
@@ -95,6 +95,15 @@
 #define UT_OSP_STARTUP_SYNC_FAIL_2        67
 #define UT_OSP_MODULE_UNLOAD_FAILED       68
 #define UT_OSP_TASKEXIT_BAD_CONTEXT       69
-#define UT_OSP_BACKGROUND_TAKE            71
+#define UT_OSP_BACKGROUND_TAKE            70
+#define UT_OSP_INVALID_ID                 71
+#define UT_OSP_RESTART_NO_FILE            72
+#define UT_OSP_CREATECHILD_FROM_CHILD     73
+#define UT_OSP_DELETECHID_MAIN_TASK       74
+#define UT_OSP_POOLCREATE_TOO_SMALL       75
+#define UT_OSP_GETPOOL_BAD_HANDLE         76
+#define UT_OSP_PUTPOOL_BAD_HANDLE         77
+#define UT_OSP_FORMAT_VOLATILE            78
+#define UT_OSP_RELOAD_NO_FILE             79
 
 #endif /* UT_OSPRINTF_STUBS_H */

--- a/modules/core_private/ut-stubs/src/ut_osprintf_stubs.c
+++ b/modules/core_private/ut-stubs/src/ut_osprintf_stubs.c
@@ -101,4 +101,13 @@ const char *UT_OSP_MESSAGES[] = {
     [UT_OSP_RECORD_USED]                = "%s: Error: ES_TaskTable slot for ID %lx in use at task creation!\n",
     [UT_OSP_TASKEXIT_BAD_CONTEXT]       = "%s: Called from invalid task context\n",
     [UT_OSP_BACKGROUND_TAKE]            = "%s: Failed to take background sem: %08lx\n",
+    [UT_OSP_INVALID_ID]                 = "%s: Invalid Application ID received, AppID = %lu\n",
+    [UT_OSP_RESTART_NO_FILE]            = "%s: Cannot Restart Application %s, File %s does not exist.\n",
+    [UT_OSP_CREATECHILD_FROM_CHILD]     = "%s: Error: Cannot call from a Child Task (for Task '%s').\n",
+    [UT_OSP_DELETECHID_MAIN_TASK]       = "%s: Error: Task %lu is a cFE Main Task.\n",
+    [UT_OSP_POOLCREATE_TOO_SMALL]       = "%s: Pool size(%lu) too small, need >=%lu bytes\n",
+    [UT_OSP_GETPOOL_BAD_HANDLE]         = "%s: Err:Bad handle(0x%08lX) AppId=%lu\n",
+    [UT_OSP_PUTPOOL_BAD_HANDLE]         = "%s: Err:Invalid Memory Handle (0x%08lX).\n",
+    [UT_OSP_FORMAT_VOLATILE]            = "%s: Formatting Volatile(RAM) Volume.\n",
+    [UT_OSP_RELOAD_NO_FILE]             = "%s: Cannot Reload Application %s, File %s does not exist.\n",
 };

--- a/modules/es/fsw/src/cfe_es_api.c
+++ b/modules/es/fsw/src/cfe_es_api.c
@@ -1870,7 +1870,7 @@ CFE_Status_t CFE_ES_GetCDSBlockName(char *BlockName, CFE_ES_CDSHandle_t BlockId,
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-CFE_Status_t CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, void *DataToCopy)
+CFE_Status_t CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, const void *DataToCopy)
 {
     if (DataToCopy == NULL)
     {

--- a/modules/es/fsw/src/cfe_es_api.c
+++ b/modules/es/fsw/src/cfe_es_api.c
@@ -240,51 +240,57 @@ CFE_Status_t CFE_ES_ReloadApp(CFE_ES_AppId_t AppID, const char *AppFileName)
     os_fstat_t          FileStatus;
     CFE_ES_AppRecord_t *AppRecPtr = CFE_ES_LocateAppRecordByID(AppID);
 
-    if (AppRecPtr == NULL)
+    if (AppRecPtr != NULL)
     {
-        return CFE_ES_ERR_RESOURCEID_NOT_VALID;
-    }
 
-    CFE_ES_LockSharedData(__func__, __LINE__);
+        CFE_ES_LockSharedData(__func__, __LINE__);
 
-    /*
-    ** Check to see if the App is an external cFE App.
-    */
-    if (AppRecPtr->Type == CFE_ES_AppType_CORE)
-    {
-        CFE_ES_SysLogWrite_Unsync("%s: Cannot Reload a CORE Application: %s.\n", __func__,
-                                  CFE_ES_AppRecordGetName(AppRecPtr));
-        ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
-    }
-    else if (AppRecPtr->AppState != CFE_ES_AppState_RUNNING)
-    {
-        CFE_ES_SysLogWrite_Unsync("%s: Cannot Reload Application %s, It is not running.\n", __func__,
-                                  CFE_ES_AppRecordGetName(AppRecPtr));
-        ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
-    }
-    else
-    {
         /*
-        ** Check to see if the file exists
+        ** Check to see if the App is an external cFE App.
         */
-        if (OS_stat(AppFileName, &FileStatus) == OS_SUCCESS)
+        if (AppRecPtr->Type == CFE_ES_AppType_CORE)
         {
-            CFE_ES_SysLogWrite_Unsync("%s: Reload Application %s Initiated. New filename = %s\n", __func__,
-                                      CFE_ES_AppRecordGetName(AppRecPtr), AppFileName);
-            strncpy(AppRecPtr->StartParams.BasicInfo.FileName, AppFileName,
-                    sizeof(AppRecPtr->StartParams.BasicInfo.FileName) - 1);
-            AppRecPtr->StartParams.BasicInfo.FileName[sizeof(AppRecPtr->StartParams.BasicInfo.FileName) - 1] = 0;
-            AppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_SYS_RELOAD;
+            CFE_ES_SysLogWrite_Unsync("%s: Cannot Reload a CORE Application: %s.\n", __func__,
+                                      CFE_ES_AppRecordGetName(AppRecPtr));
+            ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
+        }
+        else if (AppRecPtr->AppState != CFE_ES_AppState_RUNNING)
+        {
+            CFE_ES_SysLogWrite_Unsync("%s: Cannot Reload Application %s, It is not running.\n", __func__,
+                                      CFE_ES_AppRecordGetName(AppRecPtr));
+            ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
         }
         else
         {
-            CFE_ES_SysLogWrite_Unsync("%s: Cannot Reload Application %s, File %s does not exist.\n", __func__,
-                                      CFE_ES_AppRecordGetName(AppRecPtr), AppFileName);
-            ReturnCode = CFE_ES_FILE_IO_ERR;
+            /*
+            ** Check to see if the file exists
+            */
+            if (OS_stat(AppFileName, &FileStatus) == OS_SUCCESS)
+            {
+                CFE_ES_SysLogWrite_Unsync("%s: Reload Application %s Initiated. New filename = %s\n", __func__,
+                                          CFE_ES_AppRecordGetName(AppRecPtr), AppFileName);
+                strncpy(AppRecPtr->StartParams.BasicInfo.FileName, AppFileName,
+                        sizeof(AppRecPtr->StartParams.BasicInfo.FileName) - 1);
+                AppRecPtr->StartParams.BasicInfo.FileName[sizeof(AppRecPtr->StartParams.BasicInfo.FileName) - 1] = 0;
+                AppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_SYS_RELOAD;
+            }
+            else
+            {
+                CFE_ES_SysLogWrite_Unsync("%s: Cannot Reload Application %s, File %s does not exist.\n", __func__,
+                                          CFE_ES_AppRecordGetName(AppRecPtr), AppFileName);
+                ReturnCode = CFE_ES_FILE_IO_ERR;
+            }
         }
-    }
 
-    CFE_ES_UnlockSharedData(__func__, __LINE__);
+        CFE_ES_UnlockSharedData(__func__, __LINE__);
+    }
+    else /* App ID is not valid */
+    {
+        ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
+
+        CFE_ES_WriteToSysLog("%s: Invalid Application ID received, AppID = %lu\n", __func__,
+                             CFE_RESOURCEID_TO_ULONG(AppID));
+    }
 
     return (ReturnCode);
 }
@@ -302,36 +308,42 @@ CFE_Status_t CFE_ES_DeleteApp(CFE_ES_AppId_t AppID)
     int32               ReturnCode = CFE_SUCCESS;
     CFE_ES_AppRecord_t *AppRecPtr  = CFE_ES_LocateAppRecordByID(AppID);
 
-    if (AppRecPtr == NULL)
+    if (AppRecPtr != NULL)
     {
-        return CFE_ES_ERR_RESOURCEID_NOT_VALID;
+
+        CFE_ES_LockSharedData(__func__, __LINE__);
+
+        /*
+        ** Check to see if the App is an external cFE App.
+        */
+        if (AppRecPtr->Type == CFE_ES_AppType_CORE)
+        {
+            CFE_ES_SysLogWrite_Unsync("%s: Cannot Delete a CORE Application: %s.\n", __func__,
+                                      CFE_ES_AppRecordGetName(AppRecPtr));
+            ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
+        }
+        else if (AppRecPtr->AppState != CFE_ES_AppState_RUNNING)
+        {
+            CFE_ES_SysLogWrite_Unsync("%s: Cannot Delete Application %s, It is not running.\n", __func__,
+                                      CFE_ES_AppRecordGetName(AppRecPtr));
+            ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
+        }
+        else
+        {
+            CFE_ES_SysLogWrite_Unsync("%s: Delete Application %s Initiated\n", __func__,
+                                      CFE_ES_AppRecordGetName(AppRecPtr));
+            AppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_SYS_DELETE;
+        }
+
+        CFE_ES_UnlockSharedData(__func__, __LINE__);
     }
-
-    CFE_ES_LockSharedData(__func__, __LINE__);
-
-    /*
-    ** Check to see if the App is an external cFE App.
-    */
-    if (AppRecPtr->Type == CFE_ES_AppType_CORE)
+    else /* App ID is not valid */
     {
-        CFE_ES_SysLogWrite_Unsync("%s: Cannot Delete a CORE Application: %s.\n", __func__,
-                                  CFE_ES_AppRecordGetName(AppRecPtr));
         ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
-    }
-    else if (AppRecPtr->AppState != CFE_ES_AppState_RUNNING)
-    {
-        CFE_ES_SysLogWrite_Unsync("%s: Cannot Delete Application %s, It is not running.\n", __func__,
-                                  CFE_ES_AppRecordGetName(AppRecPtr));
-        ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
-    }
-    else
-    {
-        CFE_ES_SysLogWrite_Unsync("%s: Delete Application %s Initiated\n", __func__,
-                                  CFE_ES_AppRecordGetName(AppRecPtr));
-        AppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_SYS_DELETE;
-    }
 
-    CFE_ES_UnlockSharedData(__func__, __LINE__);
+        CFE_ES_WriteToSysLog("%s: Invalid Application ID received, AppID = %lu\n", __func__,
+                             CFE_RESOURCEID_TO_ULONG(AppID));
+    }
 
     return (ReturnCode);
 }

--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -1323,7 +1323,7 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint8
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-CFE_Status_t CFE_SB_TransmitMsg(CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount)
+CFE_Status_t CFE_SB_TransmitMsg(const CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount)
 {
     int32             Status;
     CFE_MSG_Size_t    Size  = 0;
@@ -1430,7 +1430,7 @@ CFE_Status_t CFE_SB_TransmitMsg(CFE_MSG_Message_t *MsgPtr, bool IncrementSequenc
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_TransmitMsgValidate(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgIdPtr, CFE_MSG_Size_t *SizePtr,
+int32 CFE_SB_TransmitMsgValidate(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgIdPtr, CFE_MSG_Size_t *SizePtr,
                                  CFE_SBR_RouteId_t *RouteIdPtr)
 {
     CFE_ES_TaskId_t TskId;

--- a/modules/sb/fsw/src/cfe_sb_priv.h
+++ b/modules/sb/fsw/src/cfe_sb_priv.h
@@ -434,7 +434,7 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint8
  *
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_TransmitMsgValidate(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgIdPtr, CFE_MSG_Size_t *SizePtr,
+int32 CFE_SB_TransmitMsgValidate(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgIdPtr, CFE_MSG_Size_t *SizePtr,
                                  CFE_SBR_RouteId_t *RouteIdPtr);
 
 /*---------------------------------------------------------------------------------------*/


### PR DESCRIPTION
**Describe the contribution**

PR #1790

- Fix #1784, add CFE assert macros to functional test

PR #1779 

Adds invalid id syslog to for CFE_ES_DeleteApp and CFE_ES_ReloadApp and verifies required reporting 

- Fix #1775 
- Fix #1773 

PR #1785 

Stop memory leak & add cds size test. 

- Fix #1776
- Fix #1770

PR #1765 
- Fix #1726, mark read only inputs as const 

PR #1804 

- Fix #1760, check resource ID idx is less than max 

PR #1801 

- Fix #1762, Update CFE_ES_RunLoop documentation 

PR #1745

- Fix #1677, Add Message Api Functional Test


PR #1798 
- Partial #1724, update in/out status and nonnull/nonzero tags

PR #1783

- Fix #1691, Add External Time Source Functional Tests

PR #1800 
- Fix #812, Add Perf API functional tests 


**Testing performed**
Ubuntu CI

**Expected behavior changes**

See PR

**System(s) tested on**
Ubuntu 18.04

**Additional context**
Part of nasa/cfs#337

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
@jphickey 
@nmullane 
@pavll 
@zanzaben 
@skliper 