### PR TITLE
Fix #1787, Success Test for CFE_ES_GetMemPoolStats

### DIFF
--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -4619,6 +4619,10 @@ void TestESMempool(void)
      */
     UtAssert_INT32_EQ(CFE_ES_GetMemPoolStats(&Stats, CFE_ES_MEMHANDLE_UNDEFINED), CFE_ES_ERR_RESOURCEID_NOT_VALID);
 
+    /* Test successfully getting memory pool statistics
+     */
+    CFE_UtAssert_SUCCESS(CFE_ES_GetMemPoolStats(&Stats, PoolID1));
+
     /* Test allocating a pool buffer where the memory block doesn't fit within
      * the remaining memory
      */


### PR DESCRIPTION
**Describe the contribution**
Fixes #1787 

**Testing performed**
Tested through GitHub Actions Workflows.

**Expected behavior changes**
There is a success test for CFE_ES_GetMemPoolStats in cFE/modules/es/ut-coverage/es_UT.c.

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal