### PR TITLE
Fix #1786, Success Test for CFE_ES_RestartApp

### DIFF
--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -3522,6 +3522,11 @@ void TestAPI(void)
     AppId = CFE_ES_APPID_C(ES_UT_MakeAppIdForIndex(99999));
     UtAssert_INT32_EQ(CFE_ES_RestartApp(AppId), CFE_ES_ERR_RESOURCEID_NOT_VALID);
 
+    /* Test successfully restarting an app */   
+    ES_ResetUnitTest();
+    AppId = CFE_ES_AppRecordGetID(UtAppRecPtr); 
+    UtAssert_INT32_EQ(CFE_ES_RestartApp(AppId), CFE_SUCCESS);
+
     /* Test CFE_ES_ReloadApp with bad AppID argument */
     ES_ResetUnitTest();
     UtAssert_INT32_EQ(CFE_ES_ReloadApp(CFE_ES_APPID_UNDEFINED, "filename"), CFE_ES_ERR_RESOURCEID_NOT_VALID);

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -3522,9 +3522,10 @@ void TestAPI(void)
     AppId = CFE_ES_APPID_C(ES_UT_MakeAppIdForIndex(99999));
     UtAssert_INT32_EQ(CFE_ES_RestartApp(AppId), CFE_ES_ERR_RESOURCEID_NOT_VALID);
 
-    /* Test successfully restarting an app */   
+    /* Test successfully restarting an app */
     ES_ResetUnitTest();
-    AppId = CFE_ES_AppRecordGetID(UtAppRecPtr); 
+    ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
+    AppId = CFE_ES_AppRecordGetID(UtAppRecPtr);
     UtAssert_INT32_EQ(CFE_ES_RestartApp(AppId), CFE_SUCCESS);
 
     /* Test CFE_ES_ReloadApp with bad AppID argument */


### PR DESCRIPTION
**Describe the contribution**
Fixes #1786 

**Testing performed**
Used GitHub Actions Workflow.

**Expected behavior changes**
There is a success test for CFE_ES_RestartApp in cFE/modules/es/ut-coverage/es_UT.c.

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal 
