### PR TITLE
Fix #1794, Subscribe to Message Limit Greater Than CFE_PLATFORM_SB_DEFAULT_MSG_LIMIT

### DIFF
--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -2436,6 +2436,12 @@ void Test_Subscribe_LocalSubscription(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
     CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
+    /* Test_Subscribe_LocalSubscription with message
+     * limit greater than CFE_PLATFORM_SB_DEFAULT_MSG_LIMIT
+     */
+    CFE_UtAssert_SUCCESS(CFE_SB_Unsubscribe(MsgId, PipeId));
+    UtAssert_INT32_EQ(CFE_SB_SubscribeLocal(MsgId, PipeId, UINT16_MAX), CFE_SUCCESS);
+
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
 
 } /* end Test_Subscribe_LocalSubscription */


### PR DESCRIPTION
**Describe the contribution**
Fixes #1794 

**Testing performed**
GitHub Actions Workflows

**Expected behavior changes**
Subscribe locally to a message with limit greater than CFE_PLATFORM_SB_DEFAULT_MSG_LIMIT

**Additional context**
CFE_PLATFORM_SB_DEFAULT_MSG_LIMIT is equal to 4. Used UINT16_MAX.

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal 