### PR TITLE
Fix #1815, add retroactive CFE status asserts

### DIFF
--- a/modules/cfe_assert/src/cfe_assert_io.c
+++ b/modules/cfe_assert/src/cfe_assert_io.c
@@ -86,10 +86,14 @@ void UT_BSP_SysLogStatusReport(uint8 MessageType, const char *Prefix, const char
 
 void UT_BSP_WriteLogFile(osal_id_t FileDesc, uint8 MessageType, const char *Prefix, const char *OutputMessage)
 {
-    char LogFileBuffer[CFE_ASSERT_MAX_LOG_LINE_LENGTH];
+    char   LogFileBuffer[CFE_ASSERT_MAX_LOG_LINE_LENGTH];
+    uint32 MsgEnabled = CFE_Assert_Global.CurrVerbosity >> MessageType;
 
-    snprintf(LogFileBuffer, sizeof(LogFileBuffer), "[%5s] %s\n", Prefix, OutputMessage);
-    OS_write(FileDesc, LogFileBuffer, strlen(LogFileBuffer));
+    if (MsgEnabled & 1)
+    {
+        snprintf(LogFileBuffer, sizeof(LogFileBuffer), "[%5s] %s\n", Prefix, OutputMessage);
+        OS_write(FileDesc, LogFileBuffer, strlen(LogFileBuffer));
+    }
 }
 
 void UT_BSP_DoText(uint8 MessageType, const char *OutputMessage)
@@ -97,45 +101,7 @@ void UT_BSP_DoText(uint8 MessageType, const char *OutputMessage)
     const char *                Prefix;
     CFE_Assert_StatusCallback_t StatusCallback;
 
-    switch (MessageType)
-    {
-        case UTASSERT_CASETYPE_ABORT:
-            Prefix = "ABORT";
-            break;
-        case UTASSERT_CASETYPE_FAILURE:
-            Prefix = "FAIL";
-            break;
-        case UTASSERT_CASETYPE_MIR:
-            Prefix = "MIR";
-            break;
-        case UTASSERT_CASETYPE_TSF:
-            Prefix = "TSF";
-            break;
-        case UTASSERT_CASETYPE_TTF:
-            Prefix = "TTF";
-            break;
-        case UTASSERT_CASETYPE_NA:
-            Prefix = "N/A";
-            break;
-        case UTASSERT_CASETYPE_BEGIN:
-            Prefix = "BEGIN";
-            break;
-        case UTASSERT_CASETYPE_END:
-            Prefix = "END";
-            break;
-        case UTASSERT_CASETYPE_PASS:
-            Prefix = "PASS";
-            break;
-        case UTASSERT_CASETYPE_INFO:
-            Prefix = "INFO";
-            break;
-        case UTASSERT_CASETYPE_DEBUG:
-            Prefix = "DEBUG";
-            break;
-        default:
-            Prefix = "OTHER";
-            break;
-    }
+    Prefix = UtAssert_GetCaseTypeAbbrev(MessageType);
 
     StatusCallback = CFE_Assert_Global.StatusCallback;
 

--- a/modules/cfe_assert/src/cfe_assert_priv.h
+++ b/modules/cfe_assert/src/cfe_assert_priv.h
@@ -136,6 +136,28 @@ typedef struct
      */
     char CurrentTestName[CFE_MISSION_MAX_API_LEN];
 
+    /* The following members support the "Deferred" assert feature */
+
+    /**
+     * Actual CFE status value from a previous function call
+     */
+    CFE_Status_t StoredStatus;
+
+    /**
+     * Full text of previous function call that produced "StoredStatus"
+     */
+    char StoredText[CFE_ASSERT_MAX_LOG_LINE_LENGTH];
+
+    /**
+     * File name of source file that produced "StoredStatus"
+     */
+    char StoredFile[CFE_MISSION_MAX_PATH_LEN];
+
+    /**
+     * Line number of source file that produced "StoredStatus"
+     */
+    uint32 StoredLine;
+
 } CFE_Assert_Global_t;
 
 extern CFE_Assert_Global_t CFE_Assert_Global;


### PR DESCRIPTION
**Describe the contribution**
Add a set of macros that decouple the function call from the expected status:

- `CFE_Assert_STATUS_STORE`
- `CFE_Assert_STATUS_MAY_BE`
- `CFE_Assert_STATUS_MUST_BE`

The first will make the function call and put the status into a temporary holding area, but will not assert on any particular
result.

The others will check the value of the holding area.

Fixes #1815

**Testing performed**
Build and run all tests
Also Add new test cases that need this paradigm and confirm macros working as expected (will be in other PRs).

**Expected behavior changes**
None, new test macros only, not used yet.

**System(s) tested on**
Ubuntu

**Additional context**
These macros should be used whenever a specific status is not predictable before the call, but other checks after the call can determine if the result was OK or not.

A typical use case for a function that might return any of 3 status values (e.g. status1, status2, status3) would be something like:

```
CFE_Assert_STATUS_STORE(...)
if (CFE_Assert_STATUS_MAY_BE(status1))
{
... do other checks after getting status1
}
else if (CFE_Assert_STATUS_MAY_BE(status1))
{
... do other checks after getting status2
}
else
{
   CFE_Assert_STATUS_MUST_BE(status3);
... do other checks after getting status3
}
```

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
