### PR TITLE
Fix #1821, Group MSG APIs documentation by header type

### DIFF
--- a/docs/src/cfe_api.dox
+++ b/docs/src/cfe_api.dox
@@ -139,6 +139,9 @@
     <LI> \ref CFEAPIMSGHeader
     <UL>
       <LI> #CFE_MSG_Init - \copybrief CFE_MSG_Init
+    </UL>
+    <LI> \ref CFEAPIMSGHeaderPri
+    <UL>
       <LI> #CFE_MSG_GetSize - \copybrief CFE_MSG_GetSize
       <LI> #CFE_MSG_SetSize - \copybrief CFE_MSG_SetSize
       <LI> #CFE_MSG_GetType - \copybrief CFE_MSG_GetType
@@ -154,6 +157,9 @@
       <LI> #CFE_MSG_GetSequenceCount - \copybrief CFE_MSG_GetSequenceCount
       <LI> #CFE_MSG_SetSequenceCount - \copybrief CFE_MSG_SetSequenceCount
       <LI> #CFE_MSG_GetNextSequenceCount - \copybrief CFE_MSG_GetNextSequenceCount
+    </UL>
+    <LI> \ref CFEAPIMSGHeaderExt
+    <UL>
       <LI> #CFE_MSG_GetEDSVersion - \copybrief CFE_MSG_GetEDSVersion
       <LI> #CFE_MSG_SetEDSVersion - \copybrief CFE_MSG_SetEDSVersion
       <LI> #CFE_MSG_GetEndian - \copybrief CFE_MSG_GetEndian
@@ -164,6 +170,9 @@
       <LI> #CFE_MSG_SetSubsystem - \copybrief CFE_MSG_SetSubsystem
       <LI> #CFE_MSG_GetSystem - \copybrief CFE_MSG_GetSystem
       <LI> #CFE_MSG_SetSystem - \copybrief CFE_MSG_SetSystem
+    </UL>
+    <LI> \ref CFEAPIMSGHeaderSec
+    <UL>
       <LI> #CFE_MSG_GenerateChecksum - \copybrief CFE_MSG_GenerateChecksum
       <LI> #CFE_MSG_ValidateChecksum - \copybrief CFE_MSG_ValidateChecksum
       <LI> #CFE_MSG_SetFcnCode - \copybrief CFE_MSG_SetFcnCode

--- a/modules/core_api/fsw/inc/cfe_msg.h
+++ b/modules/core_api/fsw/inc/cfe_msg.h
@@ -39,7 +39,7 @@
 #include "cfe_sb_api_typedefs.h"
 #include "cfe_time_api_typedefs.h"
 
-/** \defgroup CFEAPIMSGHeader cFE Message header APIs
+/** \defgroup CFEAPIMSGHeader cFE Generic Message APIs
  * \{
  */
 
@@ -61,6 +61,11 @@
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
 CFE_Status_t CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_MSG_Size_t Size);
+/**\}*/
+
+/** \defgroup CFEAPIMSGHeaderPri cFE Message Primary Header APIs
+ * \{
+ */
 
 /*****************************************************************************/
 /**
@@ -305,6 +310,11 @@ CFE_Status_t CFE_MSG_SetSequenceCount(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Sequenc
  * \return The next valid sequence count value
  */
 CFE_MSG_SequenceCount_t CFE_MSG_GetNextSequenceCount(CFE_MSG_SequenceCount_t SeqCnt);
+/**\}*/
+
+/** \defgroup CFEAPIMSGHeaderExt cFE Message Extended Header APIs
+ * \{
+ */
 
 /*****************************************************************************/
 /**
@@ -470,6 +480,11 @@ CFE_Status_t CFE_MSG_GetSystem(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_System_t
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
 CFE_Status_t CFE_MSG_SetSystem(CFE_MSG_Message_t *MsgPtr, CFE_MSG_System_t System);
+/**\}*/
+
+/** \defgroup CFEAPIMSGHeaderSec cFE Message Secondary Header APIs
+ * \{
+ */
 
 /*****************************************************************************/
 /**


### PR DESCRIPTION
**Describe the contribution**
Fix #1821 
Improves MSG API grouping in documentation

**Testing performed**
CI - documentation change only

**Expected behavior changes**
None

**System(s) tested on**
CI

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC