### PR TITLE
Fix #1831, Consolidate msg get/set doxygen group

### DIFF
--- a/docs/src/cfe_api.dox
+++ b/docs/src/cfe_api.dox
@@ -225,14 +225,11 @@
       <LI> #CFE_SB_ReleaseMessageBuffer - \copybrief CFE_SB_ReleaseMessageBuffer
       <LI> #CFE_SB_TransmitBuffer - \copybrief CFE_SB_TransmitBuffer
     </UL>
-    <LI> \ref CFEAPISBSetMessage
+    <LI> \ref CFEAPISBMessageCharacteristics
     <UL>
       <LI> #CFE_SB_SetUserDataLength - \copybrief CFE_SB_SetUserDataLength
       <LI> #CFE_SB_TimeStampMsg - \copybrief CFE_SB_TimeStampMsg
       <LI> #CFE_SB_MessageStringSet - \copybrief CFE_SB_MessageStringSet
-    </UL>
-    <LI> \ref CFEAPIGetMessage
-    <UL>
       <LI> #CFE_SB_GetUserData - \copybrief CFE_SB_GetUserData
       <LI> #CFE_SB_GetUserDataLength - \copybrief CFE_SB_GetUserDataLength
       <LI> #CFE_SB_MessageStringGet - \copybrief CFE_SB_MessageStringGet

--- a/modules/core_api/fsw/inc/cfe_sb.h
+++ b/modules/core_api/fsw/inc/cfe_sb.h
@@ -569,7 +569,7 @@ CFE_Status_t CFE_SB_TransmitBuffer(CFE_SB_Buffer_t *BufPtr, bool IncrementSequen
 
 /** @} */
 
-/** @defgroup CFEAPISBSetMessage cFE Setting Message Characteristics APIs
+/** @defgroup CFEAPISBMessageCharacteristics cFE Message Characteristics APIs
  * @{
  */
 
@@ -647,11 +647,6 @@ void CFE_SB_TimeStampMsg(CFE_MSG_Message_t *MsgPtr);
 */
 int32 CFE_SB_MessageStringSet(char *DestStringPtr, const char *SourceStringPtr, size_t DestMaxSize,
                               size_t SourceMaxSize);
-/** @} */
-
-/** @defgroup CFEAPIGetMessage cFE Getting Message Characteristics APIs
- * @{
- */
 
 /*****************************************************************************/
 /**


### PR DESCRIPTION
**Describe the contribution**
Fix #1831 
Makes one group for SB Message Characteristics (get/set combined).  Note the setter name was also out of family (didn't include SB).

**Testing performed**
CI - doc only

**Expected behavior changes**
None

**System(s) tested on**
CI

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC