### PR TITLE
Fix #1824, Add missing cases for msg id func tests

### DIFF
--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -70,26 +70,6 @@ extern CFE_FT_Global_t CFE_FT_Global;
  */
 #define CFE_ASSERT_LOG_FILE_NAME "/cf/cfe_test.log"
 
-/* Compare two Resource IDs */
-#define cFE_FTAssert_ResourceID_EQ(actual, expect)                                            \
-    UtAssert_True(CFE_RESOURCEID_TEST_EQUAL(actual, expect), "%s (%lu) == %s (%lu)", #actual, \
-                  CFE_RESOURCEID_TO_ULONG(actual), #expect, CFE_RESOURCEID_TO_ULONG(expect))
-
-/* Check if a Resource ID is Undefined */
-#define cFE_FTAssert_ResourceID_Undefined(id) \
-    UtAssert_True(!CFE_RESOURCEID_TEST_DEFINED(id), "%s (%lu) not defined", #id, CFE_RESOURCEID_TO_ULONG(id))
-
-/* Assert a return code is not equal to cfe_success */
-#define cFE_FTAssert_NOT_CFE_SUCCESS(actual)                                      \
-    do                                                                            \
-    {                                                                             \
-        int32 rcact = (int32)(actual);                                            \
-        UtAssert_True(rcact < CFE_SUCCESS, "%s == (%ld) ", #actual, (long)rcact); \
-    } while (0)
-
-/* Assert if status is CFE_SUCCESS */
-#define cFE_FTAssert_SUCCESS(status) UtAssert_INT32_EQ(status, CFE_SUCCESS)
-
 bool TimeInRange(CFE_TIME_SysTime_t Time, CFE_TIME_SysTime_t Target, OS_time_t difference);
 
 void CFE_TestMain(void);

--- a/modules/cfe_testcase/src/msg_api_test.c
+++ b/modules/cfe_testcase/src/msg_api_test.c
@@ -46,6 +46,8 @@ void TestMsgApiBasic(void)
     CFE_SB_MsgId_t          msgId;
     CFE_MSG_HeaderVersion_t hdrVer;
     CFE_MSG_ApId_t          appId;
+    bool                    _expected = true;
+    bool                    _returned = false;
 
     memset(&cmd, 0xFF, sizeof(cmd));
     msgId = CFE_SB_ValueToMsgId(0);
@@ -53,71 +55,78 @@ void TestMsgApiBasic(void)
     /* test msg-init */
     UtAssert_INT32_EQ(CFE_MSG_Init(NULL, CFE_SB_ValueToMsgId(0), sizeof(cmd)), CFE_MSG_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_MSG_Init(&cmd.Msg, msgId, 0), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_Init(&cmd.Msg, CFE_PLATFORM_SB_HIGHEST_VALID_MSGID + 1, sizeof(cmd)),
+                      CFE_MSG_BAD_ARGUMENT);
 
-    cFE_FTAssert_SUCCESS(CFE_MSG_Init(&cmd.Msg, msgId, sizeof(cmd)));
+    UtAssert_INT32_EQ(CFE_MSG_Init(&cmd.Msg, msgId, sizeof(cmd)), CFE_SUCCESS);
 
     /* test set-msg-size */
     UtAssert_INT32_EQ(CFE_MSG_SetSize(NULL, 12), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_SetSize(&cmd.Msg, 0), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_SetSize(&cmd.Msg, UINT32_MAX), CFE_MSG_BAD_ARGUMENT);
 
-    cFE_FTAssert_SUCCESS(CFE_MSG_SetSize(&cmd.Msg, 12));
+    UtAssert_INT32_EQ(CFE_MSG_SetSize(&cmd.Msg, 12), CFE_SUCCESS);
 
     /* test get-msg-size */
     UtAssert_INT32_EQ(CFE_MSG_GetSize(NULL, &size), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_GetSize(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
 
-    cFE_FTAssert_SUCCESS(CFE_MSG_GetSize(&cmd.Msg, &size));
+    UtAssert_INT32_EQ(CFE_MSG_GetSize(&cmd.Msg, &size), CFE_SUCCESS);
     UtAssert_UINT32_EQ(size, 12);
 
     /* test get-type */
     UtAssert_INT32_EQ(CFE_MSG_SetType(NULL, CFE_MSG_Type_Cmd), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_GetType(NULL, &type), CFE_MSG_BAD_ARGUMENT);
-    cFE_FTAssert_SUCCESS(CFE_MSG_SetType(&cmd.Msg, CFE_MSG_Type_Cmd));
+    UtAssert_INT32_EQ(CFE_MSG_SetType(&cmd.Msg, CFE_MSG_Type_Invalid), CFE_MSG_BAD_ARGUMENT);
 
-    cFE_FTAssert_SUCCESS(CFE_MSG_GetType(&cmd.Msg, &type));
+    UtAssert_INT32_EQ(CFE_MSG_SetType(&cmd.Msg, CFE_MSG_Type_Cmd), CFE_SUCCESS);
+
+    UtAssert_INT32_EQ(CFE_MSG_GetType(NULL, &type), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_GetType(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
+
+    UtAssert_INT32_EQ(CFE_MSG_GetType(&cmd.Msg, &type), CFE_SUCCESS);
     UtAssert_INT32_EQ(type, CFE_MSG_Type_Cmd);
 
     /* test msg set-type */
-    cFE_FTAssert_SUCCESS(CFE_MSG_SetType(&cmd.Msg, CFE_MSG_Type_Tlm));
+    UtAssert_INT32_EQ(CFE_MSG_SetType(&cmd.Msg, CFE_MSG_Type_Tlm), CFE_SUCCESS);
     /* check if set-type works like expected */
-    cFE_FTAssert_SUCCESS(CFE_MSG_GetType(&cmd.Msg, &type));
+    UtAssert_INT32_EQ(CFE_MSG_GetType(&cmd.Msg, &type), CFE_SUCCESS);
     UtAssert_INT32_EQ(type, CFE_MSG_Type_Tlm);
 
     /* test get header-version */
     UtAssert_INT32_EQ(CFE_MSG_GetHeaderVersion(NULL, &hdrVer), CFE_MSG_BAD_ARGUMENT);
-    cFE_FTAssert_SUCCESS(CFE_MSG_GetHeaderVersion(&cmd.Msg, &hdrVer));
+    UtAssert_INT32_EQ(CFE_MSG_GetHeaderVersion(&cmd.Msg, &hdrVer), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetHeaderVersion(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
 
     /* test set header-version */
     UtAssert_INT32_EQ(CFE_MSG_SetHeaderVersion(NULL, hdrVer), CFE_MSG_BAD_ARGUMENT);
-    cFE_FTAssert_SUCCESS(CFE_MSG_SetHeaderVersion(&cmd.Msg, 0));
-    cFE_FTAssert_SUCCESS(CFE_MSG_GetHeaderVersion(&cmd.Msg, &hdrVer));
+    UtAssert_INT32_EQ(CFE_MSG_SetHeaderVersion(&cmd.Msg, UINT16_MAX), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_SetHeaderVersion(&cmd.Msg, 0), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_GetHeaderVersion(&cmd.Msg, &hdrVer), CFE_SUCCESS);
     UtAssert_True(hdrVer == 0, "hdrVer = 0");
 
     /* test get-has-secondary-header and set-has-scondary-header*/
-    bool _expected = true;
-    bool _returned = false;
-
     UtAssert_INT32_EQ(CFE_MSG_GetHasSecondaryHeader(NULL, &_expected), CFE_MSG_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_MSG_GetHasSecondaryHeader(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_SetHasSecondaryHeader(NULL, _expected), CFE_MSG_BAD_ARGUMENT);
 
-    cFE_FTAssert_SUCCESS(CFE_MSG_SetHasSecondaryHeader(&cmd.Msg, _expected));
-    cFE_FTAssert_SUCCESS(CFE_MSG_GetHasSecondaryHeader(&cmd.Msg, &_returned));
+    UtAssert_INT32_EQ(CFE_MSG_SetHasSecondaryHeader(&cmd.Msg, _expected), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_GetHasSecondaryHeader(&cmd.Msg, &_returned), CFE_SUCCESS);
     UtAssert_UINT32_EQ(_expected, _returned);
 
     /* test get-apid */
     UtAssert_INT32_EQ(CFE_MSG_GetApId(NULL, &appId), CFE_MSG_BAD_ARGUMENT);
-    cFE_FTAssert_SUCCESS(CFE_MSG_GetApId(&cmd.Msg, &appId));
     UtAssert_INT32_EQ(CFE_MSG_GetApId(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
 
     /* test set-apid */
-    UtAssert_INT32_EQ(CFE_MSG_GetApId(NULL, 0), CFE_MSG_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_MSG_SetApId(&cmd.Msg, 0xFFFF), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_SetApId(NULL, 0), CFE_MSG_BAD_ARGUMENT);
 
-    cFE_FTAssert_SUCCESS(CFE_MSG_SetApId(&cmd.Msg, 0));
-    cFE_FTAssert_SUCCESS(CFE_MSG_GetApId(&cmd.Msg, &appId));
-    UtAssert_True(appId == 0, "CFE_MSG_SetApId => apid = 0");
+    UtAssert_INT32_EQ(CFE_MSG_SetApId(&cmd.Msg, 5), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_GetApId(&cmd.Msg, &appId), CFE_SUCCESS);
+    UtAssert_INT32_EQ(appId, 5);
 }
 
-void TestMsgApiAdvanced1(void)
+void TestMsgApiAdvanced(void)
 {
     UtPrintf("Testing: CFE_MSG_GetSegmentationFlag, CFE_MSG_SetSegmentationFlag, "
              "CFE_MSG_GetSequenceCount, CFE_MSG_SetSequenceCount, CFE_MSG_GetNextSequenceCount");
@@ -131,108 +140,111 @@ void TestMsgApiAdvanced1(void)
     memset(&cmd, 0xFF, sizeof(cmd));
     msgId = CFE_SB_ValueToMsgId(0);
 
-    /* test msg-init */
-    UtAssert_INT32_EQ(CFE_MSG_Init(NULL, CFE_SB_ValueToMsgId(0), sizeof(cmd)), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_Init(&cmd.Msg, msgId, 0), CFE_MSG_BAD_ARGUMENT);
-
-    cFE_FTAssert_SUCCESS(CFE_MSG_Init(&cmd.Msg, msgId, sizeof(cmd)));
+    UtAssert_INT32_EQ(CFE_MSG_Init(&cmd.Msg, msgId, sizeof(cmd)), CFE_SUCCESS);
 
     /* test get/set-segmentation-flag */
     UtAssert_INT32_EQ(CFE_MSG_GetSegmentationFlag(NULL, &segFlag), CFE_MSG_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_MSG_GetSegmentationFlag(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_MSG_SetSegmentationFlag(NULL, CFE_MSG_SegFlag_Continue), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_SetSegmentationFlag(&cmd.Msg, CFE_MSG_SegFlag_Invalid), CFE_MSG_BAD_ARGUMENT);
 
-    cFE_FTAssert_SUCCESS(CFE_MSG_SetSegmentationFlag(&cmd.Msg, CFE_MSG_SegFlag_Continue));
-    cFE_FTAssert_SUCCESS(CFE_MSG_GetSegmentationFlag(&cmd.Msg, &segFlag));
-    UtAssert_True(segFlag == CFE_MSG_SegFlag_Continue,
-                  "CFE_MSG_SetSegmentationFlag => segFlag = CFE_MSG_SegFlag_Continue");
+    UtAssert_INT32_EQ(CFE_MSG_SetSegmentationFlag(&cmd.Msg, CFE_MSG_SegFlag_Continue), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetSegmentationFlag(&cmd.Msg, CFE_MSG_SegFlag_First), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetSegmentationFlag(&cmd.Msg, CFE_MSG_SegFlag_Last), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetSegmentationFlag(&cmd.Msg, CFE_MSG_SegFlag_Unsegmented), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_GetSegmentationFlag(&cmd.Msg, &segFlag), CFE_SUCCESS);
+    UtAssert_UINT32_EQ(segFlag, CFE_MSG_SegFlag_Unsegmented);
 
     /* test set/get-sequence-count */
     UtAssert_INT32_EQ(CFE_MSG_SetSequenceCount(NULL, 2), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_SetSequenceCount(&cmd.Msg, UINT16_MAX), CFE_MSG_BAD_ARGUMENT);
+
     UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(NULL, &seqCnt), CFE_MSG_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
 
-    cFE_FTAssert_SUCCESS(CFE_MSG_SetSequenceCount(&cmd.Msg, 2));
-    cFE_FTAssert_SUCCESS(CFE_MSG_GetSequenceCount(&cmd.Msg, &seqCnt));
-
-    UtAssert_True(seqCnt == 2, "CFE_MSG_SetSequenceCount => seqCnt = 2");
+    UtAssert_INT32_EQ(CFE_MSG_SetSequenceCount(&cmd.Msg, 2), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&cmd.Msg, &seqCnt), CFE_SUCCESS);
+    UtAssert_INT32_EQ(seqCnt, 2);
 
     /* test get-next-sequence-count */
-
-    /* 0x3FFF <- bad because defined CFE_MSG_SEQCNT_MASK value but not public */
-    /* UtAssert_True(CFE_MSG_GetNextSequenceCount(0x3FFF) == 0, "CFE_MSG_GetNextSequenceCount(0x3FFF) = 0"); */
-    UtAssert_True(CFE_MSG_GetNextSequenceCount(2) == 3, "CFE_MSG_GetNextSequenceCount(2) = 3");
+    UtAssert_INT32_EQ(CFE_MSG_GetNextSequenceCount(seqCnt), 3);
+    UtAssert_INT32_EQ(CFE_MSG_GetNextSequenceCount(UINT16_MAX), 0);
 }
 
-void TestMsgApiAdvanced2(void)
+void TestMsgHeaderSecondaryApi(void)
 {
     UtPrintf("Testing: CFE_MSG_GenerateChecksum, CFE_MSG_ValidateChecksum, CFE_MSG_SetFcnCode, "
              "CFE_MSG_GetFcnCode, CFE_MSG_GetMsgTime, CFE_MSG_SetMsgTime ");
 
     /* declare local vars */
     CFE_MSG_CommandHeader_t cmd;
-    CFE_SB_MsgId_t          msgId;
+    CFE_MSG_CommandHeader_t cmdTlm;
+    CFE_MSG_CommandHeader_t cmd2;
     CFE_MSG_FcnCode_t       fcnCode;
     CFE_TIME_SysTime_t      msgTime;
+    bool                    isValid     = true;
+    CFE_TIME_SysTime_t      currentTime = {1000, 0xFFFF0000};
 
-    memset(&cmd, 0xFF, sizeof(cmd));
-    msgId = CFE_SB_ValueToMsgId(0);
+    memset(&cmd, 0, sizeof(cmd));
+    memset(&cmdTlm, 0xFF, sizeof(cmdTlm));
+    memset(&cmd2, 0xFF, sizeof(cmd2));
 
     /* msg-init */
-    UtAssert_INT32_EQ(CFE_MSG_Init(NULL, CFE_SB_ValueToMsgId(0), sizeof(cmd)), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_Init(&cmd.Msg, msgId, 0), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_Init(&cmd.Msg, CFE_SB_ValueToMsgId(0), sizeof(cmd)), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetHasSecondaryHeader(&cmd.Msg, true), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetType(&cmd.Msg, CFE_MSG_Type_Cmd), CFE_SUCCESS);
 
-    cFE_FTAssert_SUCCESS(CFE_MSG_Init(&cmd.Msg, msgId, sizeof(cmd)));
-    cFE_FTAssert_SUCCESS(CFE_MSG_SetHasSecondaryHeader(&cmd.Msg, true));
+    UtAssert_INT32_EQ(CFE_MSG_Init(&cmdTlm.Msg, CFE_SB_ValueToMsgId(1), sizeof(cmdTlm)), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetHasSecondaryHeader(&cmdTlm.Msg, true), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetType(&cmdTlm.Msg, CFE_MSG_Type_Tlm), CFE_SUCCESS);
+
+    UtAssert_INT32_EQ(CFE_MSG_Init(&cmd2.Msg, CFE_SB_ValueToMsgId(2), sizeof(cmd2)), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetHasSecondaryHeader(&cmd2.Msg, true), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetType(&cmd2.Msg, CFE_MSG_Type_Cmd), CFE_SUCCESS);
 
     /* test generate-checksum */
     UtAssert_INT32_EQ(CFE_MSG_GenerateChecksum(NULL), CFE_MSG_BAD_ARGUMENT);
-    cFE_FTAssert_SUCCESS(CFE_MSG_SetType(&cmd.Msg, CFE_MSG_Type_Tlm));
-    UtAssert_INT32_EQ(CFE_MSG_GenerateChecksum(&cmd.Msg), CFE_MSG_WRONG_MSG_TYPE);
-    cFE_FTAssert_SUCCESS(CFE_MSG_SetType(&cmd.Msg, CFE_MSG_Type_Cmd));
+    UtAssert_INT32_EQ(CFE_MSG_GenerateChecksum(&cmdTlm.Msg), CFE_MSG_WRONG_MSG_TYPE);
+    UtAssert_INT32_EQ(CFE_MSG_ValidateChecksum(&cmdTlm.Msg, &isValid), CFE_MSG_WRONG_MSG_TYPE);
+    UtAssert_INT32_EQ(CFE_MSG_ValidateChecksum(NULL, &isValid), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_ValidateChecksum(&cmdTlm.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
 
-    /* create new cmd message */
-    CFE_MSG_CommandHeader_t cmd2;
-    bool                    isValid = true;
-
-    memset(&cmd2, 0, sizeof(cmd2));
-    cFE_FTAssert_SUCCESS(CFE_MSG_Init(&cmd2.Msg, CFE_SB_ValueToMsgId(1), sizeof(cmd2)));
-    cFE_FTAssert_SUCCESS(CFE_MSG_SetHasSecondaryHeader(&cmd2.Msg, true));
-    cFE_FTAssert_SUCCESS(CFE_MSG_SetType(&cmd2.Msg, CFE_MSG_Type_Cmd));
-
-    cFE_FTAssert_SUCCESS(CFE_MSG_ValidateChecksum(&cmd2.Msg, &isValid));
-    UtAssert_True(!isValid, "Is checksum valid = false");
-    cFE_FTAssert_SUCCESS(CFE_MSG_GenerateChecksum(&cmd2.Msg));
-    cFE_FTAssert_SUCCESS(CFE_MSG_ValidateChecksum(&cmd2.Msg, &isValid));
-    UtAssert_True(isValid, "Checksum is valid");
+    UtAssert_INT32_EQ(CFE_MSG_ValidateChecksum(&cmd.Msg, &isValid), CFE_SUCCESS);
+    UtAssert_True(!isValid, "Checksum isValid (%d) = false", isValid);
+    UtAssert_INT32_EQ(CFE_MSG_GenerateChecksum(&cmd.Msg), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_ValidateChecksum(&cmd.Msg, &isValid), CFE_SUCCESS);
+    UtAssert_True(isValid, "Checksum isValid (%d) = true", isValid);
 
     /* test get/set-fcn-code */
     UtAssert_INT32_EQ(CFE_MSG_SetFcnCode(NULL, 4), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_SetFcnCode(&cmdTlm.Msg, 4), CFE_MSG_WRONG_MSG_TYPE);
+
     UtAssert_INT32_EQ(CFE_MSG_GetFcnCode(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_MSG_GetFcnCode(NULL, &fcnCode), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_GetFcnCode(&cmdTlm.Msg, &fcnCode), CFE_MSG_WRONG_MSG_TYPE);
 
-    cFE_FTAssert_SUCCESS(CFE_MSG_SetFcnCode(&cmd.Msg, 4));
-    cFE_FTAssert_SUCCESS(CFE_MSG_GetFcnCode(&cmd.Msg, &fcnCode));
-
-    UtAssert_True(fcnCode == 4, "CFE_MSG_SetFcnCode => fcnCode = 4");
+    UtAssert_INT32_EQ(CFE_MSG_SetFcnCode(&cmd.Msg, 4), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_GetFcnCode(&cmd.Msg, &fcnCode), CFE_SUCCESS);
+    UtAssert_INT32_EQ(fcnCode, 4);
 
     /* test get/set-msg-time */
-    CFE_TIME_SysTime_t currentTime = CFE_TIME_GetTime();
-    cFE_FTAssert_SUCCESS(CFE_MSG_SetType(&cmd.Msg, CFE_MSG_Type_Tlm));
+    UtAssert_INT32_EQ(CFE_MSG_SetType(&cmd.Msg, CFE_MSG_Type_Tlm), CFE_SUCCESS);
 
     UtAssert_INT32_EQ(CFE_MSG_GetMsgTime(NULL, &msgTime), CFE_MSG_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgTime(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_GetMsgTime(&cmd2.Msg, &msgTime), CFE_MSG_WRONG_MSG_TYPE);
+
     UtAssert_INT32_EQ(CFE_MSG_SetMsgTime(NULL, currentTime), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_SetMsgTime(&cmd2.Msg, currentTime), CFE_MSG_WRONG_MSG_TYPE);
 
-    cFE_FTAssert_SUCCESS(CFE_MSG_SetMsgTime(&cmd.Msg, currentTime));
-    cFE_FTAssert_SUCCESS(CFE_MSG_GetMsgTime(&cmd.Msg, &msgTime));
-
-    UtAssert_UINT32_EQ(CFE_TIME_Compare(msgTime, currentTime), CFE_TIME_A_LT_B);
+    UtAssert_INT32_EQ(CFE_MSG_SetMsgTime(&cmd.Msg, currentTime), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_GetMsgTime(&cmd.Msg, &msgTime), CFE_SUCCESS);
+    UtAssert_UINT32_EQ(CFE_TIME_Compare(msgTime, currentTime), CFE_TIME_EQUAL);
 }
 
 void MsgApiTestSetup(void)
 {
     UtTest_Add(TestMsgApiBasic, NULL, NULL, "Test basic message header apis");
-    UtTest_Add(TestMsgApiAdvanced1, NULL, NULL, "Test advanced message header apis part 1");
-    UtTest_Add(TestMsgApiAdvanced2, NULL, NULL, "Test advanced message header apis part 2");
+    UtTest_Add(TestMsgApiAdvanced, NULL, NULL, "Test advanced message header apis");
+    UtTest_Add(TestMsgHeaderSecondaryApi, NULL, NULL, "Test message secondary header apis");
 }


### PR DESCRIPTION
**Describe the contribution**
Fixes #1824
Adds the missing cases and cleans up some minor style inconsistencies. 

**Testing performed**
Build and run unit test

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC