### PR TITLE
Fix #1840, Add Null check for CFE_ResourceId_FindNext

### DIFF
--- a/modules/core_api/fsw/inc/cfe_resourceid.h
+++ b/modules/core_api/fsw/inc/cfe_resourceid.h
@@ -200,6 +200,7 @@ uint32 CFE_ResourceId_GetSerial(CFE_ResourceId_t ResourceId);
  * @param[in]   CheckFunc a function to check if the given ID is available
  * @returns     Next ID value which does not map to a valid entry
  * @retval      #CFE_RESOURCEID_UNDEFINED if no open slots.
+ * @retval      #CFE_ES_BAD_ARGUMENT    @copybrief CFE_ES_BAD_ARGUMENT
  *
  */
 CFE_ResourceId_t CFE_ResourceId_FindNext(CFE_ResourceId_t StartId, uint32 TableSize,

--- a/modules/resourceid/fsw/src/cfe_resourceid_api.c
+++ b/modules/resourceid/fsw/src/cfe_resourceid_api.c
@@ -108,7 +108,7 @@ int32 CFE_ResourceId_ToIndex(CFE_ResourceId_t Id, uint32 BaseValue, uint32 Table
  *
  * Function: CFE_ResourceId_FindNext
  *
- * Application-scope internal function
+ * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
@@ -120,6 +120,11 @@ CFE_ResourceId_t CFE_ResourceId_FindNext(CFE_ResourceId_t StartId, uint32 TableS
     uint32           ResourceType;
     CFE_ResourceId_t CheckId;
     bool             IsTaken;
+
+    if (CheckFunc == NULL)
+    {
+        return CFE_ES_BAD_ARGUMENT;
+    }
 
     ResourceType = CFE_ResourceId_GetBase(StartId);
     Serial       = CFE_ResourceId_GetSerial(StartId);

--- a/modules/resourceid/ut-coverage/test_cfe_resourceid.c
+++ b/modules/resourceid/ut-coverage/test_cfe_resourceid.c
@@ -164,8 +164,12 @@ void TestResourceID(void)
                   CFE_ResourceId_ToInteger(Id), (unsigned long)RefIndex, (unsigned long)TestIndex);
 
     /* Validate off-nominal inputs */
-    Id = CFE_ResourceId_FindNext(CFE_RESOURCEID_UNDEFINED, 0, NULL);
+    Id = CFE_ResourceId_FindNext(CFE_RESOURCEID_UNDEFINED, 0, UT_ResourceId_CheckIdSlotUsed);
     UtAssert_True(CFE_ResourceId_Equal(Id, CFE_RESOURCEID_UNDEFINED), "CFE_ResourceId_FindNext() bad input: id=%lx",
+                  CFE_ResourceId_ToInteger(Id));
+
+    Id = CFE_ResourceId_FindNext(LastId, 0, NULL);
+    UtAssert_True(CFE_ResourceId_Equal(Id, CFE_ES_BAD_ARGUMENT), "CFE_ResourceId_FindNext() bad input: id=%lx",
                   CFE_ResourceId_ToInteger(Id));
 
     UtAssert_INT32_EQ(CFE_ResourceId_ToIndex(Id, RefBase, 1, NULL), CFE_ES_BAD_ARGUMENT);


### PR DESCRIPTION
**Describe the contribution**
Fixes #1840
Adds Null check to CFE_ResourceId_FindNext

**Testing performed**
Build and run unit test

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Additional context**
If this gets into master before https://github.com/nasa/cFE/pull/1782 then a Functional Test will need to be added there. Otherwise it should be added here. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC