### PR TITLE
Fix #1840, Hotfix for strict resource IDs.

### DIFF
--- a/modules/core_api/fsw/inc/cfe_resourceid.h
+++ b/modules/core_api/fsw/inc/cfe_resourceid.h
@@ -199,8 +199,7 @@ uint32 CFE_ResourceId_GetSerial(CFE_ResourceId_t ResourceId);
  * @param[in]   TableSize the maximum size of the target table
  * @param[in]   CheckFunc a function to check if the given ID is available
  * @returns     Next ID value which does not map to a valid entry
- * @retval      #CFE_RESOURCEID_UNDEFINED if no open slots.
- * @retval      #CFE_ES_BAD_ARGUMENT    @copybrief CFE_ES_BAD_ARGUMENT
+ * @retval      #CFE_RESOURCEID_UNDEFINED if no open slots or bad arguments.
  *
  */
 CFE_ResourceId_t CFE_ResourceId_FindNext(CFE_ResourceId_t StartId, uint32 TableSize,

--- a/modules/resourceid/fsw/src/cfe_resourceid_api.c
+++ b/modules/resourceid/fsw/src/cfe_resourceid_api.c
@@ -123,7 +123,7 @@ CFE_ResourceId_t CFE_ResourceId_FindNext(CFE_ResourceId_t StartId, uint32 TableS
 
     if (CheckFunc == NULL)
     {
-        return CFE_ES_BAD_ARGUMENT;
+        return CFE_RESOURCEID_UNDEFINED;
     }
 
     ResourceType = CFE_ResourceId_GetBase(StartId);

--- a/modules/resourceid/ut-coverage/test_cfe_resourceid.c
+++ b/modules/resourceid/ut-coverage/test_cfe_resourceid.c
@@ -169,7 +169,7 @@ void TestResourceID(void)
                   CFE_ResourceId_ToInteger(Id));
 
     Id = CFE_ResourceId_FindNext(LastId, 0, NULL);
-    UtAssert_True(CFE_ResourceId_Equal(Id, CFE_ES_BAD_ARGUMENT), "CFE_ResourceId_FindNext() bad input: id=%lx",
+    UtAssert_True(CFE_ResourceId_Equal(Id, CFE_RESOURCEID_UNDEFINED), "CFE_ResourceId_FindNext() bad input: id=%lx",
                   CFE_ResourceId_ToInteger(Id));
 
     UtAssert_INT32_EQ(CFE_ResourceId_ToIndex(Id, RefBase, 1, NULL), CFE_ES_BAD_ARGUMENT);


### PR DESCRIPTION
**Describe the contribution**
Fixes #1840   
Fixes strict resource id check. 

**Testing performed**
Build and run unit test

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 20.04

**Additional context**
Hotfix for issue from #1842

**Contributor Info - All information REQUIRED for consideration of pull request**
Alex Campbell GSFC