### PR TITLE
Fix #1847, enable strict resource id w/OMIT_DEPRECATED

### DIFF
--- a/cmake/sample_defs/global_build_options.cmake
+++ b/cmake/sample_defs/global_build_options.cmake
@@ -20,6 +20,8 @@ set(OMIT_DEPRECATED $ENV{OMIT_DEPRECATED} CACHE STRING "Omit deprecated elements
 if (OMIT_DEPRECATED)
   message (STATUS "OMIT_DEPRECATED=true: Not including deprecated elements in build")
   add_definitions(-DCFE_OMIT_DEPRECATED_6_8 -DCFE_OMIT_DEPRECATED_6_7 -DCFE_OMIT_DEPRECATED_6_6 -DOSAL_OMIT_DEPRECATED)
+  set(MISSION_RESOURCEID_MODE "STRICT") # more type safe, but less backward compatible
 else()
   message (STATUS "OMIT_DEPRECATED=false: Deprecated elements included in build")
+  set(MISSION_RESOURCEID_MODE "SIMPLE") # less type safe, but more backward compatible
 endif (OMIT_DEPRECATED)


### PR DESCRIPTION
**Describe the contribution**
When the user specifies the OMIT_DEPRECATED build option, also enable the strictly-typed resource IDs to catch common coding
errors.

Fixes #1847

**Testing performed**
Build and run all tests in both OMIT_DEPRECATED mode and without OMIT_DEPRECATED

**Expected behavior changes**
Strict types will be automatically enabled with OMIT_DEPRECATED mode

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
