### PR TITLE
Fix #1846, Disable Unit Tests in CodeQL

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   SIMULATION: native
-  ENABLE_UNIT_TESTS: true
+  ENABLE_UNIT_TESTS: false
   OMIT_DEPRECATED: true
   BUILDTYPE: release
 


### PR DESCRIPTION
**Describe the contribution**
Fix #1846 

**Testing performed**
Tested on forked repo: https://github.com/ArielSAdamsNASA/cFE-1/security/code-scanning?query=branch%3Afix-1846-disable-unit-tests-codeql

**Expected behavior changes**
Disabled unit tests for both CodeQL workflows. Alerts should only be shown for flight code. 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Adams, ASRC Federal