### PR TITLE
Fix #1827 Check error ctr to TransmitMsg test

### DIFF
--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -3049,12 +3049,14 @@ void Test_TransmitMsg_MaxMsgSizePlusOne(void)
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
+    CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter = 0;
 
     UtAssert_INT32_EQ(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true), CFE_SB_MSG_TOO_BIG);
 
     CFE_UtAssert_EVENTCOUNT(1);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_MSG_TOO_BIG_EID);
+    UtAssert_INT32_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter, 1);
 
 } /* end Test_TransmitMsg_MaxMsgSizePlusOne */
 


### PR DESCRIPTION
**Describe the contribution**
Fixes #1827 Verify error counter increments when using TransmitMsg for a message that is too big.

**Testing performed**
Steps taken to test the contribution:
1. `make SIMULATION=native ENABLE_UNIT_TESTS=true OMIT_DEPRECATED=BUILDTYPE=release prep`
2. `make -C build/native/default_cpu1/sb`
3. `make -C build/native/default_cpu1/sb test`
4. `make`
5. `make test`

**Expected behavior changes**
None.

**System(s) tested on**
 - OS: Ubuntu 18.04 VM

**Contributor Info - All information REQUIRED for consideration of pull request**
Jose F. Martinez Pedraza / NASA GSFC