### PR TITLE
Fix #1858, remove unused CFE_TBL_ERR_FILE_NOT_FOUND

### DIFF
--- a/modules/core_api/fsw/inc/cfe_error.h
+++ b/modules/core_api/fsw/inc/cfe_error.h
@@ -991,14 +991,6 @@ typedef int32 CFE_Status_t;
 #define CFE_TBL_ERR_LOAD_IN_PROGRESS ((CFE_Status_t)0xcc000012)
 
 /**
- * @brief File Not Found
- *
- *  The calling Application called #CFE_TBL_Load with a bad filename.
- *
- */
-#define CFE_TBL_ERR_FILE_NOT_FOUND ((CFE_Status_t)0xcc000013)
-
-/**
  * @brief File Too Large
  *
  *  The calling Application called #CFE_TBL_Load with a filename that specified a file

--- a/modules/core_api/fsw/inc/cfe_tbl.h
+++ b/modules/core_api/fsw/inc/cfe_tbl.h
@@ -312,7 +312,7 @@ CFE_Status_t CFE_TBL_Unregister(CFE_TBL_Handle_t TblHandle);
 ** \retval #CFE_TBL_ERR_ILLEGAL_SRC_TYPE  \copybrief CFE_TBL_ERR_ILLEGAL_SRC_TYPE
 ** \retval #CFE_TBL_ERR_LOAD_IN_PROGRESS  \copybrief CFE_TBL_ERR_LOAD_IN_PROGRESS
 ** \retval #CFE_TBL_ERR_NO_BUFFER_AVAIL   \copybrief CFE_TBL_ERR_NO_BUFFER_AVAIL
-** \retval #CFE_TBL_ERR_FILE_NOT_FOUND    \copybrief CFE_TBL_ERR_FILE_NOT_FOUND
+** \retval #CFE_TBL_ERR_ACCESS            \copybrief CFE_TBL_ERR_ACCESS
 ** \retval #CFE_TBL_ERR_FILE_TOO_LARGE    \copybrief CFE_TBL_ERR_FILE_TOO_LARGE
 ** \retval #CFE_TBL_ERR_BAD_CONTENT_ID    \copybrief CFE_TBL_ERR_BAD_CONTENT_ID
 ** \retval #CFE_TBL_ERR_PARTIAL_LOAD      \copybrief CFE_TBL_ERR_PARTIAL_LOAD


### PR DESCRIPTION
**Describe the contribution**
Status code no longer produced by current implementation, it returns CFE_TBL_ERR_ACCESS when unable to open a file.

Fixes #1858

**Testing performed**
Build and sanity check CFE, run all tests

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
