### PR TITLE
cmake: Fix support for non-standard psp source directory

### DIFF
--- a/cmake/arch_build.cmake
+++ b/cmake/arch_build.cmake
@@ -585,7 +585,7 @@ function(process_arch SYSVAR)
   set(CFE_PSP_EXPECTED_OSAL_BSPTYPE ${CFE_SYSTEM_PSPNAME})
 
   # Include any specific compiler flags or config from the selected PSP
-  include(${MISSION_SOURCE_DIR}/psp/fsw/${CFE_SYSTEM_PSPNAME}/make/build_options.cmake)
+  include(${psp_MISSION_DIR}/fsw/${CFE_SYSTEM_PSPNAME}/make/build_options.cmake)
 
   if (NOT DEFINED OSAL_SYSTEM_BSPTYPE)
       # Implicitly use the OSAL BSP that corresponds with the CFE PSP


### PR DESCRIPTION
**Describe the contribution**
This PR fixes a bug which prevents non-standard psp source directory specification via the environment variable `$CFS_APP_PATH` or the cmake variable `${psp_SEARCH_PATH}`.

The cFE cmake build infrastructure uses the environment / cmake variable `$CFS_APP_PATH` 
as well as the cmake meta-variable pattern `${${APP}_SEARCH_PATH}` to locate apps and other modules (such as psp), and subsequently sets the variable pattern `${${APP}_MISSION_DIR}` (see [mission_build.cmake lines 202-222](https://github.com/nasa/cFE/blob/5e41330979586bcdb113f491ea6c38ff9975fc72/cmake/mission_build.cmake#L202-L222)).

However, the resulting variable `${psp_MISSION_DIR}` is not used in `process_arch()` in [arch_build.cmake line 588](https://github.com/nasa/cFE/blob/5e41330979586bcdb113f491ea6c38ff9975fc72/cmake/arch_build.cmake#L588) when including a target platform's `build_options.cmake` file. This causes a cmake configuration failure when trying to use a non-standard psp location.


**Testing performed**
Build with psp in non-standard location, with the `CFS_APP_PATH` environment variable set:

```bash
# set up standard cFS bundle per https://github.com/nasa/cFS
git clone --recursive https://github.com/nasa/cFS.git
cd cFS
cp -R cfe/cmake/sample_defs .
cp cfe/cmake/Makefile.sample Makefile
# hide psp
mkdir alt
mv psp alt/psp
# define alternate search path
export CFS_APP_PATH=$(pwd)/alt
# build sample mission
make prep
make
```

Before this PR:
```
...

-- Generated cfe_platform_cfg.h from /***REDACTED**/cFS/sample_defs configuration
CMake Error at cmake/arch_build.cmake:588 (include):
  include could not find load file:

    /***REDACTED***/cFS/psp/fsw/pc-linux/make/build_options.cmake
Call Stack (most recent call first):
  CMakeLists.txt:124 (process_arch)


-- Configuring incomplete, errors occurred!

...
```

After this PR:
```
...

-- Generated cfe_platform_cfg.h from /***REDACTED***/cFS/sample_defs configuration
-- BSP Selection: generic-linux at /***REDACTED***/cFS/osal/src/bsp/generic-linux
-- OSAL Compile Definitions: _LINUX_OS_;_XOPEN_SOURCE=600
-- OSAL Selection: posix at /***REDACTED**/cFS/osal/src/os/posix
-- PSP Selection: pc-linux

...

Built target mission-all
```

**Expected behavior changes**
This should only affect projects which use the environment variable `$CFS_APP_PATH` or the cmake variable `${psp_SEARCH_PATH}`. Currently, they are being ignored for `psp`'s `build_options.cmake` path resolution, which means some users may be building with different target build options than they think they are based on the intended behavior.

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu 18.04
 - Versions: cFE `v6.8.0-rc1+dev933`

**Additional context**

Aside, this is also suggested as a method to specify a non-standard `psp` source directory in [mission_defaults.cmake line 67](https://github.com/nasa/cFE/blob/5e41330979586bcdb113f491ea6c38ff9975fc72/cmake/mission_defaults.cmake#L67) since PR #751 with the following:

```cmake
set(psp_SEARCH_PATH ".")
```

However, this will lead to the same cmake configure error as above without this fix.

**Third party code**
No thirdy party code included in this contribution.

**Contributor Info - All information REQUIRED for consideration of pull request**
Jonathan Bohren, Honeybee Robotics