### PR TITLE
Fix #1834 CFE_TBL_Modified: Test CRC, updated flag

### DIFF
--- a/modules/tbl/ut-coverage/tbl_UT.c
+++ b/modules/tbl/ut-coverage/tbl_UT.c
@@ -3104,10 +3104,18 @@ void Test_CFE_TBL_TblMod(void)
     CFE_UtAssert_EVENTSENT(CFE_TBL_LOAD_SUCCESS_INF_EID);
     CFE_UtAssert_EVENTCOUNT(1);
 
-    /* Notify Table Services that the table has been modified */
+    /*
+     * Notify Table Services that the table has been modified. Verify CRC has been
+     * calculated and table has been flagged as Updated
+     */
+    UT_SetDeferredRetcode(UT_KEY(CFE_ES_CalculateCRC), 1, 0xF00D);
+    CFE_TBL_Global.Handles[AccessIterator].Updated = false;
     CFE_UtAssert_SUCCESS(CFE_TBL_Modified(App1TblHandle1));
+    UtAssert_BOOL_TRUE(CFE_TBL_Global.Handles[AccessIterator].Updated);
     CFE_UtAssert_SUCCESS(CFE_TBL_GetInfo(&TblInfo1, "ut_cfe_tbl.UT_Table2"));
     UtAssert_INT32_EQ(TblInfo1.TimeOfLastUpdate.Seconds, TblInfo1.TimeOfLastUpdate.Subseconds);
+    UtAssert_UINT32_EQ(TblInfo1.Crc, 0xF00D);
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&TblDataPtr, App1TblHandle1), CFE_TBL_INFO_UPDATED);
 
     /*
      * LastFileLoaded (limited by mission) can be bigger than MyFilename (limited by osal),


### PR DESCRIPTION
**Describe the contribution**
Fixes #1834
Add verification that `CFE_TBL_Modified` successfully calculates and sets the table CRC and sets the Updated flag if the table has been modified.

**Testing performed**
Steps taken to test the contribution:
```
$ make SIMULATION=native ENABLE_UNIT_TESTS=true OMIT_DEPRECATED=true prep
$ make -C build/native/default_cpu1/tbl
$ make -C build/native/default_cpu1/tbl test
$ make
$ make test
```
- Verify GitHub workflows pass

**Expected behavior changes**
None.

**System(s) tested on**
 - Ubuntu 18.04 VM

**Contributor Info - All information REQUIRED for consideration of pull request**
Jose F. Martinez Pedraza / NASA GSFC
