### PR TITLE
Fix #1672, return type conversions in CFE_ES_GetTaskName

### DIFF
--- a/modules/cfe_testcase/src/es_task_test.c
+++ b/modules/cfe_testcase/src/es_task_test.c
@@ -120,7 +120,7 @@ void TestChildTaskName(void)
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(NULL, TaskId, sizeof(TaskNameBuf)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(TaskNameBuf, CFE_ES_TASKID_UNDEFINED, sizeof(TaskNameBuf)),
                       CFE_ES_ERR_RESOURCEID_NOT_VALID);
-    UtAssert_INT32_EQ(CFE_ES_GetTaskName(TaskNameBuf, TaskId, sizeof(TaskName) - 4), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+    UtAssert_INT32_EQ(CFE_ES_GetTaskName(TaskNameBuf, TaskId, sizeof(TaskName) - 4), CFE_ES_BAD_ARGUMENT);
 
     UtAssert_INT32_EQ(CFE_ES_DeleteChildTask(TaskId), CFE_SUCCESS);
 }

--- a/modules/es/fsw/src/cfe_es_api.c
+++ b/modules/es/fsw/src/cfe_es_api.c
@@ -1000,9 +1000,21 @@ CFE_Status_t CFE_ES_GetTaskName(char *TaskName, CFE_ES_TaskId_t TaskId, size_t B
     OsalId   = CFE_ES_TaskId_ToOSAL(TaskId);
     OsStatus = OS_GetResourceName(OsalId, TaskName, BufferLength);
 
+    if (OsStatus == OS_ERR_INVALID_ID)
+    {
+        /* Supplied ID is not a CFE task */
+        return CFE_ES_ERR_RESOURCEID_NOT_VALID;
+    }
+    if (OsStatus == OS_ERR_NAME_TOO_LONG)
+    {
+        /* Name is too long to fit in supplied buffer */
+        return CFE_ES_BAD_ARGUMENT;
+    }
     if (OsStatus != OS_SUCCESS)
     {
-        return CFE_ES_ERR_RESOURCEID_NOT_VALID;
+        /* Some other uncaught error */
+        CFE_ES_WriteToSysLog("%s(): Unexpected error from OS_GetResourceName(): %ld", __func__, (long)OsStatus);
+        return CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
     }
 
     return CFE_SUCCESS;

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -4004,8 +4004,12 @@ void TestAPI(void)
                       CFE_ES_ERR_RESOURCEID_NOT_VALID);
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(NULL, TaskId, sizeof(AppName)), CFE_ES_BAD_ARGUMENT);
     CFE_UtAssert_SUCCESS(CFE_ES_GetTaskName(AppName, TaskId, sizeof(AppName)));
-    UT_SetDeferredRetcode(UT_KEY(OS_GetResourceName), 1, OS_ERROR);
+    UT_SetDeferredRetcode(UT_KEY(OS_GetResourceName), 1, OS_ERR_INVALID_ID);
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(AppName, TaskId, sizeof(AppName)), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+    UT_SetDeferredRetcode(UT_KEY(OS_GetResourceName), 1, OS_ERR_NAME_TOO_LONG);
+    UtAssert_INT32_EQ(CFE_ES_GetTaskName(AppName, TaskId, sizeof(AppName)), CFE_ES_BAD_ARGUMENT);
+    UT_SetDeferredRetcode(UT_KEY(OS_GetResourceName), 1, OS_ERROR);
+    UtAssert_INT32_EQ(CFE_ES_GetTaskName(AppName, TaskId, sizeof(AppName)), CFE_STATUS_EXTERNAL_RESOURCE_FAIL);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(&TaskId, NULL), CFE_ES_BAD_ARGUMENT);
     CFE_UtAssert_SUCCESS(CFE_ES_GetTaskIDByName(&TaskId, AppName));


### PR DESCRIPTION
**Describe the contribution**
Provide better status code conversion from OS_GetResourceName

Fixes #1672

**Testing performed**
Build and sanity check CFE, run all tests

**Expected behavior changes**
Better status returns from CFE_ES_GetTaskName API

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
