### PR TITLE
Fix #1825, #1826, #1829, #1830, SB test improvements

### DIFF
--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -50,7 +50,7 @@ typedef struct
     CFE_FS_FileWriteMetaData_t FuncTestState;
 
     /* Generic utility counter */
-    int Count;
+    int32 Count;
 
     /* Table information used by all table tests */
     CFE_TBL_Handle_t TblHandle;

--- a/modules/cfe_testcase/src/es_info_test.c
+++ b/modules/cfe_testcase/src/es_info_test.c
@@ -125,11 +125,12 @@ void TestAppInfo(void)
     CFE_UtAssert_RESOURCEID_UNDEFINED(AppIdByName);
     UtAssert_INT32_EQ(CFE_ES_GetAppID(NULL), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetAppIDByName(NULL, TEST_EXPECTED_APP_NAME), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_GetAppIDByName(&AppIdByName, NULL), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetAppName(AppNameBuf, CFE_ES_APPID_UNDEFINED, sizeof(AppNameBuf)),
                       CFE_ES_ERR_RESOURCEID_NOT_VALID);
     UtAssert_INT32_EQ(CFE_ES_GetAppName(NULL, TestAppId, sizeof(AppNameBuf)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetAppInfo(&TestAppInfo, CFE_ES_APPID_UNDEFINED), CFE_ES_ERR_RESOURCEID_NOT_VALID);
-    UtAssert_INT32_EQ(CFE_ES_GetAppInfo(NULL, CFE_ES_APPID_UNDEFINED), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_GetAppInfo(NULL, TestAppId), CFE_ES_BAD_ARGUMENT);
 }
 
 void TestTaskInfo(void)
@@ -158,13 +159,14 @@ void TestTaskInfo(void)
     UtAssert_INT32_EQ(TaskInfo.ExecutionCounter, AppInfo.ExecutionCounter);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskInfo(&TaskInfo, CFE_ES_TASKID_UNDEFINED), CFE_ES_ERR_RESOURCEID_NOT_VALID);
-    UtAssert_INT32_EQ(CFE_ES_GetTaskInfo(NULL, CFE_ES_TASKID_UNDEFINED), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_GetTaskInfo(NULL, TaskId), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetTaskID(NULL), CFE_ES_BAD_ARGUMENT);
 }
 
 void TestLibInfo(void)
 {
-    CFE_ES_LibId_t   LibIdByName;
+    CFE_ES_LibId_t   LibId;
+    CFE_ES_LibId_t   CheckId;
     CFE_ES_AppInfo_t LibInfo;
     const char *     LibName     = "ASSERT_LIB";
     const char *     InvalidName = "INVALID_NAME";
@@ -172,9 +174,9 @@ void TestLibInfo(void)
 
     UtPrintf("Testing: CFE_ES_GetLibIDByName, CFE_ES_GetLibName, CFE_ES_GetLibInfo");
 
-    UtAssert_INT32_EQ(CFE_ES_GetLibIDByName(&LibIdByName, LibName), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_ES_GetLibInfo(&LibInfo, LibIdByName), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_ES_GetLibName(LibNameBuf, LibIdByName, sizeof(LibNameBuf)), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_GetLibIDByName(&LibId, LibName), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_GetLibInfo(&LibInfo, LibId), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_GetLibName(LibNameBuf, LibId, sizeof(LibNameBuf)), CFE_SUCCESS);
     UtAssert_StrCmp(LibNameBuf, LibName, "CFE_ES_GetLibName() = %s", LibNameBuf);
     UtAssert_True(LibInfo.Type == CFE_ES_AppType_LIBRARY, "Lib Info -> Type = %d", (int)LibInfo.Type);
     UtAssert_StrCmp(LibInfo.Name, LibName, "Lib Info -> Name = %s", LibInfo.Name);
@@ -210,13 +212,17 @@ void TestLibInfo(void)
     UtAssert_True(strlen(LibInfo.MainTaskName) == 0, "Lib Info -> Task Name  = %s", LibInfo.MainTaskName);
     UtAssert_True(LibInfo.NumOfChildTasks == 0, "Lib Info -> Child Tasks  = %d", (int)LibInfo.NumOfChildTasks);
 
-    UtAssert_INT32_EQ(CFE_ES_GetLibIDByName(&LibIdByName, InvalidName), CFE_ES_ERR_NAME_NOT_FOUND);
-    UtAssert_INT32_EQ(CFE_ES_GetLibInfo(&LibInfo, LibIdByName), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+    UtAssert_INT32_EQ(CFE_ES_GetLibIDByName(&CheckId, InvalidName), CFE_ES_ERR_NAME_NOT_FOUND);
+    CFE_UtAssert_RESOURCEID_UNDEFINED(CheckId);
+    UtAssert_INT32_EQ(CFE_ES_GetLibInfo(&LibInfo, CFE_ES_LIBID_UNDEFINED), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+    UtAssert_INT32_EQ(CFE_ES_GetLibInfo(NULL, LibId), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetLibIDByName(NULL, LibName), CFE_ES_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_ES_GetLibInfo(NULL, LibIdByName), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_GetLibIDByName(&CheckId, NULL), CFE_ES_BAD_ARGUMENT);
+    CFE_UtAssert_RESOURCEID_UNDEFINED(CheckId);
     UtAssert_INT32_EQ(CFE_ES_GetLibName(LibNameBuf, CFE_ES_LIBID_UNDEFINED, sizeof(LibNameBuf)),
                       CFE_ES_ERR_RESOURCEID_NOT_VALID);
-    UtAssert_INT32_EQ(CFE_ES_GetLibName(NULL, LibIdByName, sizeof(LibNameBuf)), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_GetLibName(LibNameBuf, LibId, 0), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_GetLibName(NULL, LibId, sizeof(LibNameBuf)), CFE_ES_BAD_ARGUMENT);
 }
 
 void TestResetType(void)

--- a/modules/cfe_testcase/src/es_mempool_test.c
+++ b/modules/cfe_testcase/src/es_mempool_test.c
@@ -33,52 +33,96 @@
 
 #include "cfe_test.h"
 
+typedef struct
+{
+    uint32 Mem[128];
+} CFE_FT_PoolMemBlock_t;
+
+static CFE_FT_PoolMemBlock_t CFE_FT_PoolMemBlock[CFE_PLATFORM_ES_MAX_MEMORY_POOLS + 1];
+
 void TestMemPoolCreate(void)
 {
     CFE_ES_MemHandle_t PoolID;
-    int8               Pool[1024];
 
     UtPrintf("Testing: CFE_ES_PoolCreateNoSem, CFE_ES_PoolCreate, CFE_ES_PoolCreateEx");
 
-    UtAssert_INT32_EQ(CFE_ES_PoolCreateNoSem(&PoolID, Pool, sizeof(Pool)), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_ES_PoolCreateNoSem(NULL, Pool, sizeof(Pool)), CFE_ES_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_ES_PoolCreateNoSem(&PoolID, NULL, sizeof(Pool)), CFE_ES_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_ES_PoolCreateNoSem(&PoolID, Pool, 0), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_PoolCreateNoSem(&PoolID, CFE_FT_PoolMemBlock, sizeof(CFE_FT_PoolMemBlock)), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_PoolCreateNoSem(NULL, CFE_FT_PoolMemBlock, sizeof(CFE_FT_PoolMemBlock)),
+                      CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_PoolCreateNoSem(&PoolID, NULL, sizeof(CFE_FT_PoolMemBlock)), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_PoolCreateNoSem(&PoolID, CFE_FT_PoolMemBlock, 0), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_PoolDelete(PoolID), CFE_SUCCESS);
 
-    UtAssert_INT32_EQ(CFE_ES_PoolCreate(&PoolID, Pool, sizeof(Pool)), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_ES_PoolCreate(NULL, Pool, sizeof(Pool)), CFE_ES_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_ES_PoolCreate(&PoolID, NULL, sizeof(Pool)), CFE_ES_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_ES_PoolCreate(&PoolID, Pool, 0), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_PoolCreate(&PoolID, CFE_FT_PoolMemBlock, sizeof(CFE_FT_PoolMemBlock)), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_ES_PoolCreate(NULL, CFE_FT_PoolMemBlock, sizeof(CFE_FT_PoolMemBlock)), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_PoolCreate(&PoolID, NULL, sizeof(CFE_FT_PoolMemBlock)), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_PoolCreate(&PoolID, CFE_FT_PoolMemBlock, 0), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_PoolDelete(PoolID), CFE_SUCCESS);
 
-    UtAssert_INT32_EQ(CFE_ES_PoolCreateEx(&PoolID, Pool, sizeof(Pool), 0, NULL, CFE_ES_NO_MUTEX), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_ES_PoolCreateEx(NULL, Pool, sizeof(Pool), 0, NULL, CFE_ES_NO_MUTEX), CFE_ES_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_ES_PoolCreateEx(&PoolID, NULL, sizeof(Pool), 0, NULL, CFE_ES_NO_MUTEX), CFE_ES_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_ES_PoolCreateEx(&PoolID, Pool, 0, 0, NULL, CFE_ES_NO_MUTEX), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(
+        CFE_ES_PoolCreateEx(&PoolID, CFE_FT_PoolMemBlock, sizeof(CFE_FT_PoolMemBlock), 0, NULL, CFE_ES_NO_MUTEX),
+        CFE_SUCCESS);
+    UtAssert_INT32_EQ(
+        CFE_ES_PoolCreateEx(NULL, CFE_FT_PoolMemBlock, sizeof(CFE_FT_PoolMemBlock), 0, NULL, CFE_ES_NO_MUTEX),
+        CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_PoolCreateEx(&PoolID, NULL, sizeof(CFE_FT_PoolMemBlock), 0, NULL, CFE_ES_NO_MUTEX),
+                      CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_PoolCreateEx(&PoolID, CFE_FT_PoolMemBlock, 0, 0, NULL, CFE_ES_NO_MUTEX),
+                      CFE_ES_BAD_ARGUMENT);
 
     UtAssert_INT32_EQ(CFE_ES_PoolDelete(PoolID), CFE_SUCCESS);
+}
+
+void TestMemPoolCreateMax(void)
+{
+    CFE_ES_MemHandle_t PoolID[CFE_PLATFORM_ES_MAX_MEMORY_POOLS + 1];
+    uint32             NumPools;
+
+    UtPrintf("Testing: CFE_ES_PoolCreate Max Limit");
+
+    NumPools = 0;
+    while (NumPools <= CFE_PLATFORM_ES_MAX_MEMORY_POOLS)
+    {
+        CFE_Assert_STATUS_STORE(CFE_ES_PoolCreateEx(&PoolID[NumPools], &CFE_FT_PoolMemBlock[NumPools],
+                                                    sizeof(CFE_FT_PoolMemBlock_t), 0, NULL, CFE_ES_NO_MUTEX));
+        if (CFE_Assert_STATUS_MAY_BE(CFE_ES_NO_RESOURCE_IDS_AVAILABLE))
+        {
+            /* limit reached */
+            break;
+        }
+        CFE_Assert_STATUS_MUST_BE(CFE_SUCCESS);
+        ++NumPools;
+    }
+
+    UtAssert_UINT32_LTEQ(NumPools, CFE_PLATFORM_ES_MAX_MEMORY_POOLS);
+
+    /* Clean up */
+    while (NumPools > 0)
+    {
+        --NumPools;
+        UtAssert_INT32_EQ(CFE_ES_PoolDelete(PoolID[NumPools]), CFE_SUCCESS);
+    }
 }
 
 void TestMemPoolGetBuf(void)
 {
     CFE_ES_MemHandle_t  PoolID;
     int8                Pool[1024];
-    size_t              Buffer    = 512;
-    size_t              BufferBig = 2048;
-    CFE_ES_MemPoolBuf_t addressp  = CFE_ES_MEMPOOLBUF_C(0);
+    size_t              BufferSize = 512;
+    size_t              BufferBig  = 2048;
+    CFE_ES_MemPoolBuf_t addressp   = CFE_ES_MEMPOOLBUF_C(0);
 
     UtPrintf("Testing: TestMemPoolGetBuf");
 
     UtAssert_INT32_EQ(CFE_ES_PoolCreate(&PoolID, Pool, sizeof(Pool)), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_ES_GetPoolBuf(&addressp, PoolID, Buffer), Buffer);
+    UtAssert_INT32_EQ(CFE_ES_GetPoolBuf(&addressp, PoolID, BufferSize), BufferSize);
 
-    UtAssert_INT32_EQ(CFE_ES_GetPoolBuf(NULL, PoolID, Buffer), CFE_ES_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_ES_GetPoolBuf(&addressp, CFE_ES_MEMHANDLE_UNDEFINED, Buffer),
+    UtAssert_INT32_EQ(CFE_ES_GetPoolBuf(NULL, PoolID, BufferSize), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_GetPoolBuf(&addressp, CFE_ES_MEMHANDLE_UNDEFINED, BufferSize),
                       CFE_ES_ERR_RESOURCEID_NOT_VALID);
 
-    UtAssert_INT32_EQ(CFE_ES_GetPoolBuf(&addressp, PoolID, Buffer), CFE_ES_ERR_MEM_BLOCK_SIZE);
-    UtAssert_INT32_EQ(CFE_ES_PutPoolBuf(PoolID, addressp), Buffer);
+    UtAssert_INT32_EQ(CFE_ES_GetPoolBuf(&addressp, PoolID, BufferSize), CFE_ES_ERR_MEM_BLOCK_SIZE);
+    UtAssert_INT32_EQ(CFE_ES_PutPoolBuf(PoolID, addressp), BufferSize);
 
     UtAssert_INT32_EQ(CFE_ES_GetPoolBuf(&addressp, PoolID, BufferBig), CFE_ES_ERR_MEM_BLOCK_SIZE);
 
@@ -103,6 +147,9 @@ void TestMemPoolBufInfo(void)
 
     UtAssert_INT32_EQ(CFE_ES_GetPoolBufInfo(CFE_ES_MEMHANDLE_UNDEFINED, addressp), CFE_ES_ERR_RESOURCEID_NOT_VALID);
     UtAssert_INT32_EQ(CFE_ES_GetPoolBufInfo(PoolID, NULL), CFE_ES_BAD_ARGUMENT);
+
+    /* Pass an address from some other memory which is not part of the pool */
+    UtAssert_INT32_EQ(CFE_ES_GetPoolBufInfo(PoolID, &Buffer), CFE_ES_BUFFER_NOT_IN_POOL);
 
     UtAssert_INT32_EQ(CFE_ES_PoolDelete(PoolID), CFE_SUCCESS);
 }
@@ -145,13 +192,19 @@ void TestMemPoolDelete(void)
     UtAssert_UINT32_EQ(Stats.CheckErrCtr, 0);
     UtAssert_UINT32_EQ(Stats.NumFreeBytes, sizeof(Buffer));
 
+    UtAssert_INT32_EQ(CFE_ES_GetMemPoolStats(NULL, PoolID), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_GetMemPoolStats(&Stats, CFE_ES_MEMHANDLE_UNDEFINED), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+
     UtAssert_INT32_EQ(CFE_ES_PoolDelete(PoolID), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetMemPoolStats(&Stats, PoolID), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+    UtAssert_INT32_EQ(CFE_ES_PoolDelete(PoolID), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+    UtAssert_INT32_EQ(CFE_ES_PoolDelete(CFE_ES_MEMHANDLE_UNDEFINED), CFE_ES_ERR_RESOURCEID_NOT_VALID);
 }
 
 void ESMemPoolTestSetup(void)
 {
     UtTest_Add(TestMemPoolCreate, NULL, NULL, "Test Mem Pool Create");
+    UtTest_Add(TestMemPoolCreateMax, NULL, NULL, "Test Mem Pool Create Maximum");
     UtTest_Add(TestMemPoolGetBuf, NULL, NULL, "Test Mem Pool Get Buf");
     UtTest_Add(TestMemPoolBufInfo, NULL, NULL, "Test Mem Pool Buf Info");
     UtTest_Add(TestMemPoolPutBuf, NULL, NULL, "Test Mem Pool Put Buf");

--- a/modules/cfe_testcase/src/sb_sendrecv_test.c
+++ b/modules/cfe_testcase/src/sb_sendrecv_test.c
@@ -142,8 +142,11 @@ void TestBasicTransmitRecv(void)
     /*
      * Note, the CFE_SB_TransmitMsg ignores the "IncrementSequence" flag for commands.
      * Thus, all the sequence numbers should come back with the original value set (11)
+     *
+     * Note this also utilizes the CFE_SB_PEND_FOREVER flag - if working correctly,
+     * there should be a message in the queue, so it should not block.
      */
-    UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId1, 100), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId1, CFE_SB_PEND_FOREVER), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf->Msg, &MsgId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&MsgBuf->Msg, &Seq1), CFE_SUCCESS);
     CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
@@ -151,7 +154,7 @@ void TestBasicTransmitRecv(void)
     UtAssert_UINT32_EQ(CmdPtr->CmdPayload, 0x0c0ffee);
     UtAssert_UINT32_EQ(Seq1, 11);
 
-    UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId1, 100), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId1, CFE_SB_PEND_FOREVER), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf->Msg, &MsgId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&MsgBuf->Msg, &Seq1), CFE_SUCCESS);
     CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
@@ -159,7 +162,7 @@ void TestBasicTransmitRecv(void)
     UtAssert_UINT32_EQ(CmdPtr->CmdPayload, 0x1c0ffee);
     UtAssert_UINT32_EQ(Seq1, 11);
 
-    UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId1, 100), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId1, CFE_SB_PEND_FOREVER), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf->Msg, &MsgId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&MsgBuf->Msg, &Seq1), CFE_SUCCESS);
     CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
@@ -168,6 +171,7 @@ void TestBasicTransmitRecv(void)
     UtAssert_UINT32_EQ(Seq1, 11);
 
     /* Final should not be in the pipe, should have been rejected due to MsgLim */
+    /* Must not use CFE_SB_PEND_FOREVER here, as this will cause the test to block */
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId1, 100), CFE_SB_TIME_OUT);
 
     /*

--- a/modules/cfe_testcase/src/tbl_content_access_test.c
+++ b/modules/cfe_testcase/src/tbl_content_access_test.c
@@ -51,7 +51,7 @@ void TestGetAddress(void)
     /* Never loaded */
     UtAssert_INT32_EQ(CFE_TBL_GetAddress(&TblPtr, CFE_FT_Global.TblHandle), CFE_TBL_ERR_NEVER_LOADED);
     UtAssert_INT32_EQ(CFE_TBL_GetAddress(&TblPtr, CFE_TBL_BAD_TABLE_HANDLE), CFE_TBL_ERR_INVALID_HANDLE);
-    UtAssert_INT32_EQ(CFE_TBL_GetAddress(NULL, CFE_TBL_BAD_TABLE_HANDLE), CFE_TBL_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress(NULL, CFE_FT_Global.TblHandle), CFE_TBL_BAD_ARGUMENT);
 
     /* Returns CFE_TBL_INFO_UPDATED since it was just loaded */
     LoadTable(&TestTable, CFE_SUCCESS);

--- a/modules/cfe_testcase/src/tbl_content_mang_test.c
+++ b/modules/cfe_testcase/src/tbl_content_mang_test.c
@@ -34,51 +34,174 @@
 #include "cfe_test.h"
 #include "cfe_test_table.h"
 
-/* Does not test partial loads */
+static const char TESTTBL_OTHER_NAME[] = "OtherTbl";
+
+/* A set of additional (generated) table images to test permutations of CFE_TBL_Load() */
+static const char TESTTBL_NOMINAL_FILE[] =
+    "/cf/cfe_test_tbl.tbl"; /**< nominal image file, from table tool (elf2cfetbl or similar) */
+static const char TESTTBL_NOTEXIST_FILE[] =
+    "/ram/notexist.tbl"; /**< a valid filename, but file does not actually exist */
+static const char TESTTBL_BAD_STDHDR_FILE[]  = "/ram/testtbl_shdr.tbl"; /**< bad image without a complete FS header */
+static const char TESTTBL_BAD_TBLHDR_FILE[]  = "/ram/testtbl_thdr.tbl"; /**< bad image without a complete TBL header */
+static const char TESTTBL_BAD_CONTENT_FILE[] = "/ram/testtbl_cid.tbl";  /**< image with incorrect "content ID" field */
+static const char TESTTBL_BAD_SUBTYPE_FILE[] = "/ram/testtbl_st.tbl";   /**< image with incorrect "subtype" field */
+static const char TESTTBL_ALTERNATE_FILE[] = "/ram/testtbl_alt.tbl"; /**< good/complete image with different content */
+static const char TESTTBL_OTHERTBL_FILE[] =
+    "/ram/testtbl_other.tbl"; /**< good/complete image with different content for a different table */
+static const char TESTTBL_TRUNCATED_FILE[] =
+    "/ram/testtbl_trunc.tbl"; /**< truncated version (header info has more bytes than file) */
+static const char TESTTBL_LONG_FILE[] =
+    "/ram/testtbl_long.tbl"; /**< long version (file has more bytes than header info) */
+static const char TESTTBL_SHORT_FILE[] =
+    "/ram/testtbl_short.tbl"; /**< short version (header info matches file but smaller than tbl) */
+static const char TESTTBL_PARTIAL_FILE[] =
+    "/ram/testtbl_part.tbl"; /**< partial (offset nonzero, remainder of data from short file) */
+
 void TestLoad(void)
 {
+    CFE_TBL_Handle_t  BadTblHandle;
+    const char *      BadTblName = "BadTableName";
+    CFE_TBL_Handle_t  DumpTblHandle;
+    const char *      DumpTblName = "DumpOnlyTable";
+    CFE_TBL_Handle_t  SharedTblHandle;
+    const char *      SharedTblName = CFE_FT_Global.RegisteredTblName;
+    TBL_TEST_Table_t  TestTable     = {0xd00d, 0xdad};
+    TBL_TEST_Table_t *TablePtr;
+    CFE_TBL_Handle_t  OtherHandle;
+
     UtPrintf("Testing: CFE_TBL_Load");
-    CFE_TBL_Handle_t BadTblHandle;
-    const char *     BadTblName = "BadTableName";
+
     UtAssert_INT32_EQ(
         CFE_TBL_Register(&BadTblHandle, BadTblName, sizeof(TBL_TEST_Table_t), CFE_TBL_OPT_DBL_BUFFER, NULL),
         CFE_SUCCESS);
 
-    /* Load from file */
-    UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_FILE, "/cf/cfe_test_tbl.tbl"), CFE_SUCCESS);
-    /* Load again */
-    UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_FILE, "/cf/cfe_test_tbl.tbl"), CFE_SUCCESS);
+    /* Create a second table handle, to keep things interesting */
+    UtAssert_INT32_EQ(CFE_TBL_Register(&OtherHandle, TESTTBL_OTHER_NAME, sizeof(TBL_TEST_Table_t), 0, NULL),
+                      CFE_SUCCESS);
+
+    /* Some basic failure checks */
+    UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_FILE, TESTTBL_BAD_STDHDR_FILE),
+                      CFE_TBL_ERR_NO_STD_HEADER);
+    UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_FILE, TESTTBL_BAD_TBLHDR_FILE),
+                      CFE_TBL_ERR_NO_TBL_HEADER);
+    UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_FILE, TESTTBL_BAD_CONTENT_FILE),
+                      CFE_TBL_ERR_BAD_CONTENT_ID);
+    UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_FILE, TESTTBL_BAD_SUBTYPE_FILE),
+                      CFE_TBL_ERR_BAD_SUBTYPE_ID);
+    UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, ~CFE_TBL_SRC_FILE, TESTTBL_NOMINAL_FILE),
+                      CFE_TBL_ERR_ILLEGAL_SRC_TYPE);
+
+    /* Load from partial file (offset nonzero, before any successful load) -
+     * This should be restricted and return an error  */
+    UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_FILE, TESTTBL_PARTIAL_FILE),
+                      CFE_TBL_ERR_PARTIAL_LOAD);
+
+    /* Load from short file (offset 0, but incomplete, also before any successful load) */
+    /* In the current TBL implementation, this actually returns SUCCESS here (which is misleading) */
+    UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_FILE, TESTTBL_SHORT_FILE), CFE_SUCCESS);
+
+    /* NOTE: _NOT_ checking content after above; although it returned a success code, it is not well defined
+     * as to what the content will be because the data was never fully loaded yet */
+
+    /* Load from file (nominal) - first full data load */
+    UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_FILE, TESTTBL_NOMINAL_FILE), CFE_SUCCESS);
+
+    /* confirm content (football) */
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&TablePtr, CFE_FT_Global.TblHandle), CFE_TBL_INFO_UPDATED);
+    UtAssert_UINT32_EQ(TablePtr->Int1, 0xf007);
+    UtAssert_UINT32_EQ(TablePtr->Int2, 0xba11);
+    UtAssert_INT32_EQ(CFE_TBL_ReleaseAddress(CFE_FT_Global.TblHandle), CFE_SUCCESS);
+
+    /* Load from file too big */
+    UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_FILE, TESTTBL_LONG_FILE),
+                      CFE_TBL_ERR_FILE_TOO_LARGE);
+
+    /* confirm content again (note content should not have been updated) */
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&TablePtr, CFE_FT_Global.TblHandle), CFE_SUCCESS);
+    UtAssert_UINT32_EQ(TablePtr->Int1, 0xf007);
+    UtAssert_UINT32_EQ(TablePtr->Int2, 0xba11);
+    UtAssert_INT32_EQ(CFE_TBL_ReleaseAddress(CFE_FT_Global.TblHandle), CFE_SUCCESS);
+
+    /* Load again with alternate content */
+    UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_FILE, TESTTBL_ALTERNATE_FILE), CFE_SUCCESS);
+
+    /* confirm content again (changed to alternate data) */
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&TablePtr, CFE_FT_Global.TblHandle), CFE_TBL_INFO_UPDATED);
+    UtAssert_UINT32_EQ(TablePtr->Int1, 0xdead);
+    UtAssert_UINT32_EQ(TablePtr->Int2, 0xbeef);
+    UtAssert_INT32_EQ(CFE_TBL_ReleaseAddress(CFE_FT_Global.TblHandle), CFE_SUCCESS);
+
+    /* Load from file truncated */
+    UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_FILE, TESTTBL_TRUNCATED_FILE),
+                      CFE_TBL_ERR_LOAD_INCOMPLETE);
+
+    /* confirm content again (should not be changed) */
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&TablePtr, CFE_FT_Global.TblHandle), CFE_SUCCESS);
+    UtAssert_UINT32_EQ(TablePtr->Int1, 0xdead);
+    UtAssert_UINT32_EQ(TablePtr->Int2, 0xbeef);
+    UtAssert_INT32_EQ(CFE_TBL_ReleaseAddress(CFE_FT_Global.TblHandle), CFE_SUCCESS);
+
+    /* Load the other table (nominal data) */
+    UtAssert_INT32_EQ(CFE_TBL_Load(OtherHandle, CFE_TBL_SRC_FILE, TESTTBL_OTHERTBL_FILE), CFE_SUCCESS);
+
+    /* confirm content of first table again (should not be changed) */
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&TablePtr, CFE_FT_Global.TblHandle), CFE_SUCCESS);
+    UtAssert_UINT32_EQ(TablePtr->Int1, 0xdead);
+    UtAssert_UINT32_EQ(TablePtr->Int2, 0xbeef);
+    UtAssert_INT32_EQ(CFE_TBL_ReleaseAddress(CFE_FT_Global.TblHandle), CFE_SUCCESS);
+
+    /* confirm content of other table (boatload) */
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&TablePtr, OtherHandle), CFE_TBL_INFO_UPDATED);
+    UtAssert_UINT32_EQ(TablePtr->Int1, 0xb0a7);
+    UtAssert_UINT32_EQ(TablePtr->Int2, 0x10ad);
+    UtAssert_INT32_EQ(CFE_TBL_ReleaseAddress(OtherHandle), CFE_SUCCESS);
+
+    /* Load from short file again (different response after successful load) */
+    UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_FILE, TESTTBL_SHORT_FILE), CFE_SUCCESS);
+
+    /* confirm content again (reported as updated from partial load) */
+    /* Should have updated the first word only */
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&TablePtr, CFE_FT_Global.TblHandle), CFE_TBL_INFO_UPDATED);
+    UtAssert_UINT32_EQ(TablePtr->Int1, 0x5555);
+    UtAssert_UINT32_EQ(TablePtr->Int2, 0xbeef);
+    UtAssert_INT32_EQ(CFE_TBL_ReleaseAddress(CFE_FT_Global.TblHandle), CFE_SUCCESS);
+
+    /* Load from short file again (different response after successful load) */
+    UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_FILE, TESTTBL_PARTIAL_FILE), CFE_SUCCESS);
+
+    /* confirm content again (reported as updated from partial load) */
+    /* Should have updated the second word only */
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&TablePtr, CFE_FT_Global.TblHandle), CFE_TBL_INFO_UPDATED);
+    UtAssert_UINT32_EQ(TablePtr->Int1, 0x5555);
+    UtAssert_UINT32_EQ(TablePtr->Int2, 0x6666);
+    UtAssert_INT32_EQ(CFE_TBL_ReleaseAddress(CFE_FT_Global.TblHandle), CFE_SUCCESS);
+
     /* Table name mismatches */
-    UtAssert_INT32_EQ(CFE_TBL_Load(BadTblHandle, CFE_TBL_SRC_FILE, "/cf/cfe_test_tbl.tbl"),
+    UtAssert_INT32_EQ(CFE_TBL_Load(BadTblHandle, CFE_TBL_SRC_FILE, TESTTBL_NOMINAL_FILE),
                       CFE_TBL_ERR_FILE_FOR_WRONG_TABLE);
-    UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_FILE, "/cf/sample_app_tbl.tbl"),
+    UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_FILE, TESTTBL_OTHERTBL_FILE),
                       CFE_TBL_ERR_FILE_FOR_WRONG_TABLE);
-    UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_FILE, "/cf/not_cfe_test_tbl.tbl"),
+    UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_FILE, TESTTBL_NOTEXIST_FILE),
                       CFE_TBL_ERR_ACCESS);
 
-    UtAssert_INT32_EQ(CFE_TBL_Load(CFE_TBL_BAD_TABLE_HANDLE, CFE_TBL_SRC_FILE, "/cf/cfe_test_tbl.tbl"),
+    UtAssert_INT32_EQ(CFE_TBL_Load(CFE_TBL_BAD_TABLE_HANDLE, CFE_TBL_SRC_FILE, TESTTBL_NOMINAL_FILE),
                       CFE_TBL_ERR_INVALID_HANDLE);
 
     /* Load from memory */
-    TBL_TEST_Table_t TestTable = {1, 2};
     UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_ADDRESS, &TestTable), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_ADDRESS, NULL), CFE_TBL_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_TBL_Load(CFE_TBL_BAD_TABLE_HANDLE, CFE_TBL_SRC_ADDRESS, &TestTable),
                       CFE_TBL_ERR_INVALID_HANDLE);
 
     /* Attempt to load a dump only table */
-    CFE_TBL_Handle_t DumpTblHandle;
-    const char *     DumpTblName = "DumpOnlyTable";
     UtAssert_INT32_EQ(
         CFE_TBL_Register(&DumpTblHandle, DumpTblName, sizeof(TBL_TEST_Table_t), CFE_TBL_OPT_DUMP_ONLY, NULL),
         CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_TBL_Load(DumpTblHandle, CFE_TBL_SRC_FILE, "/cf/cfe_test_tbl.tbl"), CFE_TBL_ERR_DUMP_ONLY);
+    UtAssert_INT32_EQ(CFE_TBL_Load(DumpTblHandle, CFE_TBL_SRC_FILE, TESTTBL_NOMINAL_FILE), CFE_TBL_ERR_DUMP_ONLY);
 
     /* Load a shared table */
-    CFE_TBL_Handle_t SharedTblHandle;
-    const char *     SharedTblName = "SAMPLE_APP.SampleAppTable";
     UtAssert_INT32_EQ(CFE_TBL_Share(&SharedTblHandle, SharedTblName), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_TBL_Load(SharedTblHandle, CFE_TBL_SRC_FILE, "/cf/sample_app_tbl.tbl"), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_TBL_Load(SharedTblHandle, CFE_TBL_SRC_FILE, TESTTBL_NOMINAL_FILE), CFE_SUCCESS);
 }
 
 void TestUpdate(void)
@@ -120,8 +243,239 @@ void TestModified(void)
     UtAssert_INT32_EQ(CFE_TBL_Modified(CFE_TBL_BAD_TABLE_HANDLE), CFE_TBL_ERR_INVALID_HANDLE);
 }
 
+/* Helper function to set a CFE_ES_MemOffset_t value (must be big-endian) */
+void TblTest_UpdateOffset(CFE_ES_MemOffset_t *TgtVal, CFE_ES_MemOffset_t SetVal)
+{
+    union
+    {
+        CFE_ES_MemOffset_t offset;
+        uint8              bytes[sizeof(CFE_ES_MemOffset_t)];
+    } offsetbuf;
+
+    offsetbuf.bytes[3] = SetVal & 0xFF;
+    SetVal >>= 8;
+    offsetbuf.bytes[2] = SetVal & 0xFF;
+    SetVal >>= 8;
+    offsetbuf.bytes[1] = SetVal & 0xFF;
+    SetVal >>= 8;
+    offsetbuf.bytes[0] = SetVal & 0xFF;
+
+    *TgtVal = offsetbuf.offset;
+}
+
+/*
+ * A helper function that intentionally creates flawed table image files -
+ * This takes the good image file produced during the build, and creates
+ * variants with certain header fields modified and data truncated, to
+ * validate the error detection logic in CFE_TBL_Load().
+ */
+void TblTest_GenerateTblFiles(void)
+{
+    osal_id_t fh1;
+    osal_id_t fh2;
+    uint32    PartialOffset;
+    uint32    PartialSize;
+    union
+    {
+        uint8              u8;
+        uint16             u16;
+        uint32             u32;
+        CFE_FS_Header_t    FsHdr;
+        CFE_TBL_File_Hdr_t TblHdr;
+        TBL_TEST_Table_t   Content;
+    } buf;
+
+    /* Open the original (correct) table image file for reference */
+    UtAssert_INT32_EQ(OS_OpenCreate(&fh1, TESTTBL_NOMINAL_FILE, 0, OS_READ_ONLY), OS_SUCCESS);
+
+    /* create a file which does not have a valid FS header */
+    UtAssert_INT32_EQ(
+        OS_OpenCreate(&fh2, TESTTBL_BAD_STDHDR_FILE, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY),
+        OS_SUCCESS);
+    buf.u32 = 0x12345678;
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.u32)), sizeof(buf.u32));
+    UtAssert_INT32_EQ(OS_close(fh2), OS_SUCCESS);
+
+    /* create a file which has an FS header but not a valid TBL header */
+    OS_lseek(fh1, 0, OS_SEEK_SET);
+    UtAssert_INT32_EQ(
+        OS_OpenCreate(&fh2, TESTTBL_BAD_TBLHDR_FILE, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY),
+        OS_SUCCESS);
+
+    UtAssert_INT32_EQ(OS_read(fh1, &buf, sizeof(buf.FsHdr)), sizeof(buf.FsHdr));
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.FsHdr)), sizeof(buf.FsHdr));
+    buf.u32 = 0x12345678;
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.u32)), sizeof(buf.u32));
+    UtAssert_INT32_EQ(OS_close(fh2), OS_SUCCESS);
+
+    /* Create a tbl image that has the wrong content ID field */
+    OS_lseek(fh1, 0, OS_SEEK_SET);
+    UtAssert_INT32_EQ(
+        OS_OpenCreate(&fh2, TESTTBL_BAD_CONTENT_FILE, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY),
+        OS_SUCCESS);
+
+    /* copy headers and modify */
+    UtAssert_INT32_EQ(OS_read(fh1, &buf, sizeof(buf.FsHdr)), sizeof(buf.FsHdr));
+    buf.FsHdr.ContentType = 0x09abcdef;
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.FsHdr)), sizeof(buf.FsHdr));
+    UtAssert_INT32_EQ(OS_read(fh1, &buf, sizeof(buf.TblHdr)), sizeof(buf.TblHdr));
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.TblHdr)), sizeof(buf.TblHdr));
+
+    /* Identifiable content, different from original */
+    buf.Content.Int1 = 0x7777;
+    buf.Content.Int2 = 0x8888;
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.Content)), sizeof(buf.Content));
+
+    UtAssert_INT32_EQ(OS_close(fh2), OS_SUCCESS);
+
+    /* Create a tbl image that has the wrong content ID field */
+    OS_lseek(fh1, 0, OS_SEEK_SET);
+    UtAssert_INT32_EQ(
+        OS_OpenCreate(&fh2, TESTTBL_BAD_SUBTYPE_FILE, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY),
+        OS_SUCCESS);
+
+    /* copy headers as-is */
+    UtAssert_INT32_EQ(OS_read(fh1, &buf, sizeof(buf.FsHdr)), sizeof(buf.FsHdr));
+    buf.FsHdr.SubType = 0x09abcdef;
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.FsHdr)), sizeof(buf.FsHdr));
+    UtAssert_INT32_EQ(OS_read(fh1, &buf, sizeof(buf.TblHdr)), sizeof(buf.TblHdr));
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.TblHdr)), sizeof(buf.TblHdr));
+
+    /* Identifiable content, different from original */
+    buf.Content.Int1 = 0x9999;
+    buf.Content.Int2 = 0xaaaa;
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.Content)), sizeof(buf.Content));
+
+    UtAssert_INT32_EQ(OS_close(fh2), OS_SUCCESS);
+
+    /* Create a tbl image that is complete but with different content */
+    OS_lseek(fh1, 0, OS_SEEK_SET);
+    UtAssert_INT32_EQ(
+        OS_OpenCreate(&fh2, TESTTBL_ALTERNATE_FILE, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY),
+        OS_SUCCESS);
+
+    /* copy headers as-is */
+    UtAssert_INT32_EQ(OS_read(fh1, &buf, sizeof(buf.FsHdr)), sizeof(buf.FsHdr));
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.FsHdr)), sizeof(buf.FsHdr));
+    UtAssert_INT32_EQ(OS_read(fh1, &buf, sizeof(buf.TblHdr)), sizeof(buf.TblHdr));
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.TblHdr)), sizeof(buf.TblHdr));
+
+    /* Identifiable content, different from original */
+    buf.Content.Int1 = 0xdead;
+    buf.Content.Int2 = 0xbeef;
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.Content)), sizeof(buf.Content));
+
+    UtAssert_INT32_EQ(OS_close(fh2), OS_SUCCESS);
+
+    /* Create a tbl image that is complete but for the OTHER table (also different content) */
+    OS_lseek(fh1, 0, OS_SEEK_SET);
+    UtAssert_INT32_EQ(
+        OS_OpenCreate(&fh2, TESTTBL_OTHERTBL_FILE, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY),
+        OS_SUCCESS);
+
+    /* copy headers as-is */
+    UtAssert_INT32_EQ(OS_read(fh1, &buf, sizeof(buf.FsHdr)), sizeof(buf.FsHdr));
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.FsHdr)), sizeof(buf.FsHdr));
+    UtAssert_INT32_EQ(OS_read(fh1, &buf, sizeof(buf.TblHdr)), sizeof(buf.TblHdr));
+    snprintf(buf.TblHdr.TableName, sizeof(buf.TblHdr.TableName), "%s.%s", "CFE_TEST_APP", TESTTBL_OTHER_NAME);
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.TblHdr)), sizeof(buf.TblHdr));
+
+    /* Identifiable content, different from original */
+    buf.Content.Int1 = 0xb0a7;
+    buf.Content.Int2 = 0x10ad;
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.Content)), sizeof(buf.Content));
+
+    UtAssert_INT32_EQ(OS_close(fh2), OS_SUCCESS);
+    /* Create a tbl image that is too big */
+    OS_lseek(fh1, 0, OS_SEEK_SET);
+    UtAssert_INT32_EQ(
+        OS_OpenCreate(&fh2, TESTTBL_LONG_FILE, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY), OS_SUCCESS);
+
+    /* copy headers as-is */
+    UtAssert_INT32_EQ(OS_read(fh1, &buf, sizeof(buf.FsHdr)), sizeof(buf.FsHdr));
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.FsHdr)), sizeof(buf.FsHdr));
+    UtAssert_INT32_EQ(OS_read(fh1, &buf, sizeof(buf.TblHdr)), sizeof(buf.TblHdr));
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.TblHdr)), sizeof(buf.TblHdr));
+
+    /* write content, but make it identifiable/unique */
+    buf.Content.Int1 = 0x1111;
+    buf.Content.Int1 = 0x2222;
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.Content)), sizeof(buf.Content));
+
+    /* Write extra byte at the end */
+    buf.u8 = 0x33;
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.u8)), sizeof(buf.u8));
+    UtAssert_INT32_EQ(OS_close(fh2), OS_SUCCESS);
+
+    /* Create a tbl image that is truncated; header byte count is larger than file */
+    OS_lseek(fh1, 0, OS_SEEK_SET);
+    UtAssert_INT32_EQ(
+        OS_OpenCreate(&fh2, TESTTBL_TRUNCATED_FILE, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY),
+        OS_SUCCESS);
+
+    /* copy headers as-is */
+    UtAssert_INT32_EQ(OS_read(fh1, &buf, sizeof(buf.FsHdr)), sizeof(buf.FsHdr));
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.FsHdr)), sizeof(buf.FsHdr));
+    UtAssert_INT32_EQ(OS_read(fh1, &buf, sizeof(buf.TblHdr)), sizeof(buf.TblHdr));
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.TblHdr)), sizeof(buf.TblHdr));
+
+    /* But write only one byte of data into the content part (so will be too small) */
+    buf.u8 = 0x44;
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.u8)), sizeof(buf.u8));
+
+    UtAssert_INT32_EQ(OS_close(fh2), OS_SUCCESS);
+
+    /* Make a file that is "short" (byte count is correct, just not enough bytes to fill table) */
+    OS_lseek(fh1, 0, OS_SEEK_SET);
+    UtAssert_INT32_EQ(
+        OS_OpenCreate(&fh2, TESTTBL_SHORT_FILE, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY),
+        OS_SUCCESS);
+
+    /* copy headers, but modify TBL header */
+    /* NOTE: headers must be in big-endian/network byte order! */
+    UtAssert_INT32_EQ(OS_read(fh1, &buf, sizeof(buf.FsHdr)), sizeof(buf.FsHdr));
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.FsHdr)), sizeof(buf.FsHdr));
+    UtAssert_INT32_EQ(OS_read(fh1, &buf, sizeof(buf.TblHdr)), sizeof(buf.TblHdr));
+    PartialOffset = 0;
+    PartialSize   = offsetof(TBL_TEST_Table_t, Int2);
+    TblTest_UpdateOffset(&buf.TblHdr.Offset, PartialOffset);
+    TblTest_UpdateOffset(&buf.TblHdr.NumBytes, PartialSize);
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.TblHdr)), sizeof(buf.TblHdr));
+
+    /* write partial content */
+    buf.Content.Int1 = 0x5555;
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, PartialSize), PartialSize);
+    UtAssert_INT32_EQ(OS_close(fh2), OS_SUCCESS);
+
+    /* Make a file that is "partial" (contains remainder of bytes from above) */
+    OS_lseek(fh1, 0, OS_SEEK_SET);
+    UtAssert_INT32_EQ(
+        OS_OpenCreate(&fh2, TESTTBL_PARTIAL_FILE, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY),
+        OS_SUCCESS);
+
+    /* copy headers, but modify TBL header */
+    UtAssert_INT32_EQ(OS_read(fh1, &buf, sizeof(buf.FsHdr)), sizeof(buf.FsHdr));
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.FsHdr)), sizeof(buf.FsHdr));
+    UtAssert_INT32_EQ(OS_read(fh1, &buf, sizeof(buf.TblHdr)), sizeof(buf.TblHdr));
+    PartialOffset = offsetof(TBL_TEST_Table_t, Int2);
+    PartialSize   = sizeof(buf.Content) - offsetof(TBL_TEST_Table_t, Int2);
+    TblTest_UpdateOffset(&buf.TblHdr.Offset, PartialOffset);
+    TblTest_UpdateOffset(&buf.TblHdr.NumBytes, PartialSize);
+    UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.TblHdr)), sizeof(buf.TblHdr));
+
+    /* Copy partial content */
+    buf.Content.Int2 = 0x6666;
+    UtAssert_INT32_EQ(OS_write(fh2, &buf.Content.Int2, PartialSize), PartialSize);
+    UtAssert_INT32_EQ(OS_close(fh2), OS_SUCCESS);
+
+    /* Close the source file */
+    UtAssert_INT32_EQ(OS_close(fh1), OS_SUCCESS);
+}
+
 void TBLContentMangTestSetup(void)
 {
+    TblTest_GenerateTblFiles();
+
     UtTest_Add(TestLoad, RegisterTestTable, UnregisterTestTable, "Test Table Load");
     UtTest_Add(TestUpdate, RegisterTestTable, UnregisterTestTable, "Test Table Update");
     UtTest_Add(TestValidate, RegisterTestTable, UnregisterTestTable, "Test Table Validate");

--- a/modules/cfe_testcase/src/tbl_information_test.c
+++ b/modules/cfe_testcase/src/tbl_information_test.c
@@ -33,6 +33,7 @@
 
 #include "cfe_test.h"
 #include "cfe_test_table.h"
+#include "cfe_msgids.h"
 
 void TestGetStatus(void)
 {
@@ -53,6 +54,7 @@ void TestGetInfo(void)
     UtAssert_INT32_EQ(CFE_TBL_GetInfo(&TblInfo, CFE_FT_Global.RegisteredTblName), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_TBL_GetInfo(NULL, CFE_FT_Global.TblName), CFE_TBL_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_TBL_GetInfo(&TblInfo, BadTblName), CFE_TBL_ERR_INVALID_NAME);
+    UtAssert_INT32_EQ(CFE_TBL_GetInfo(&TblInfo, NULL), CFE_TBL_BAD_ARGUMENT);
 
     /* This is only checking some parts of the TblInfo struct */
     size_t expectedSize        = sizeof(TBL_TEST_Table_t);
@@ -76,9 +78,13 @@ void TestNotifyByMessage(void)
     UtPrintf("Testing: CFE_TBL_NotifyByMessage");
     CFE_TBL_Handle_t  SharedTblHandle;
     const char *      SharedTblName = "SAMPLE_APP.SampleAppTable";
-    CFE_SB_MsgId_t    TestMsgId     = 0x9999;
-    CFE_MSG_FcnCode_t TestCmdCode   = 0x9999;
+    CFE_SB_MsgId_t    TestMsgId     = CFE_TEST_CMD_MID;
+    CFE_MSG_FcnCode_t TestCmdCode   = 0;
     uint32            TestParameter = 0;
+
+    UtAssert_INT32_EQ(CFE_TBL_NotifyByMessage(CFE_TBL_BAD_TABLE_HANDLE, TestMsgId, TestCmdCode, TestParameter),
+                      CFE_TBL_ERR_INVALID_HANDLE);
+
     UtAssert_INT32_EQ(CFE_TBL_NotifyByMessage(CFE_FT_Global.TblHandle, TestMsgId, TestCmdCode, TestParameter),
                       CFE_SUCCESS);
 

--- a/modules/cfe_testcase/src/tbl_registration_test.c
+++ b/modules/cfe_testcase/src/tbl_registration_test.c
@@ -33,6 +33,7 @@
 
 #include "cfe_test.h"
 #include "cfe_test_table.h"
+#include "cfe_msgids.h"
 
 int32 CallbackFunc(void *TblPtr)
 {
@@ -41,22 +42,38 @@ int32 CallbackFunc(void *TblPtr)
 
 void TestTableRegistration(void)
 {
+    char             BadTblName[CFE_TBL_MAX_FULL_NAME_LEN + 2];
+    CFE_TBL_Handle_t OtherHandle;
+
     UtPrintf("Testing: CFE_TBL_Register, CFE_TBL_Unregister");
-    char BadTblName[CFE_TBL_MAX_FULL_NAME_LEN + 2];
+
     BadTblName[CFE_TBL_MAX_FULL_NAME_LEN + 1] = '\0';
     memset(BadTblName, 'a', sizeof(BadTblName) - 1);
+
+    /* invalid table handle arg */
+    UtAssert_INT32_EQ(
+        CFE_TBL_Register(NULL, CFE_FT_Global.TblName, sizeof(TBL_TEST_Table_t), CFE_TBL_OPT_DEFAULT, &CallbackFunc),
+        CFE_TBL_BAD_ARGUMENT);
 
     /* Successfully create table */
     UtAssert_INT32_EQ(CFE_TBL_Register(&CFE_FT_Global.TblHandle, CFE_FT_Global.TblName, sizeof(TBL_TEST_Table_t),
                                        CFE_TBL_OPT_DEFAULT, &CallbackFunc),
                       CFE_SUCCESS);
 
-    /* Duplicate table */
-    UtAssert_INT32_EQ(CFE_TBL_Register(&CFE_FT_Global.TblHandle, CFE_FT_Global.TblName, sizeof(TBL_TEST_Table_t),
+    /* Duplicate table (should return the same handle) */
+    UtAssert_INT32_EQ(CFE_TBL_Register(&OtherHandle, CFE_FT_Global.TblName, sizeof(TBL_TEST_Table_t),
                                        CFE_TBL_OPT_DEFAULT, &CallbackFunc),
                       CFE_TBL_WARN_DUPLICATE);
 
+    UtAssert_INT32_EQ(OtherHandle, CFE_FT_Global.TblHandle);
+
+    /* Duplicate table with different size */
+    UtAssert_INT32_EQ(CFE_TBL_Register(&OtherHandle, CFE_FT_Global.TblName, sizeof(TBL_TEST_Table_t) / 2,
+                                       CFE_TBL_OPT_DEFAULT, &CallbackFunc),
+                      CFE_TBL_ERR_DUPLICATE_DIFF_SIZE);
+
     /* Unregister the table */
+    UtAssert_INT32_EQ(CFE_TBL_Unregister(CFE_TBL_BAD_TABLE_HANDLE), CFE_TBL_ERR_INVALID_HANDLE);
     UtAssert_INT32_EQ(CFE_TBL_Unregister(CFE_FT_Global.TblHandle), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_TBL_Unregister(CFE_FT_Global.TblHandle), CFE_TBL_ERR_INVALID_HANDLE);
 
@@ -88,6 +105,13 @@ void TestTableRegistration(void)
     UtAssert_INT32_EQ(CFE_TBL_Register(&CFE_FT_Global.TblHandle, CFE_FT_Global.TblName, sizeof(TBL_TEST_Table_t),
                                        CFE_TBL_OPT_CRITICAL | CFE_TBL_OPT_USR_DEF_ADDR, NULL),
                       CFE_TBL_ERR_INVALID_OPTIONS);
+}
+
+void TestTableMaxLimits(void)
+{
+    CFE_TBL_Handle_t Handles[CFE_PLATFORM_TBL_MAX_NUM_HANDLES + 1];
+    char             TblName[CFE_TBL_MAX_FULL_NAME_LEN];
+    uint32           numTblsCreated = 0; /* Track num created to unregister them all */
 
     /*
      * Create the maximum number of tables
@@ -95,28 +119,73 @@ void TestTableRegistration(void)
      * stop succeeding before it reaches the end of the loop
      * Check that after the loop no more tables can be created
      */
-    CFE_TBL_Handle_t TblHandles[CFE_PLATFORM_TBL_MAX_NUM_TABLES];
-    char             TblName2[10];
-    int              numTblsCreated = 0; /* Track num created to unregister them all */
-    for (int i = 0; i < CFE_PLATFORM_TBL_MAX_NUM_TABLES; i++)
+    while (numTblsCreated <= CFE_PLATFORM_TBL_MAX_NUM_HANDLES)
     {
-        sprintf(TblName2, "%d", i);
-        if (CFE_TBL_Register(&TblHandles[i], TblName2, sizeof(TBL_TEST_Table_t), CFE_TBL_OPT_DEFAULT, NULL) ==
-            CFE_SUCCESS)
+        snprintf(TblName, sizeof(TblName), "Tbl%u", (unsigned int)numTblsCreated);
+        CFE_Assert_STATUS_STORE(
+            CFE_TBL_Register(&Handles[numTblsCreated], TblName, sizeof(TBL_TEST_Table_t), CFE_TBL_OPT_DEFAULT, NULL));
+        if (CFE_Assert_STATUS_MAY_BE(CFE_TBL_ERR_REGISTRY_FULL))
         {
-            numTblsCreated++;
+            break;
         }
+        if (!CFE_Assert_STATUS_MUST_BE(CFE_SUCCESS))
+        {
+            break;
+        }
+        ++numTblsCreated;
     }
-    UtAssert_INT32_EQ(CFE_TBL_Register(&TblHandles[numTblsCreated], CFE_FT_Global.TblName, sizeof(TBL_TEST_Table_t),
-                                       CFE_TBL_OPT_DEFAULT, &CallbackFunc),
-                      CFE_TBL_ERR_REGISTRY_FULL);
-    /* Unregister the tables */
-    for (int i = 0; i < numTblsCreated; i++)
+
+    if (!UtAssert_NONZERO(numTblsCreated))
     {
-        if (CFE_TBL_Unregister(TblHandles[i]) != CFE_SUCCESS)
+        UtAssert_WARN("Table test cannot create any tables");
+        return;
+    }
+
+    UtAssert_UINT32_LT(numTblsCreated, CFE_PLATFORM_TBL_MAX_NUM_TABLES);
+    UtAssert_UINT32_LT(numTblsCreated, CFE_PLATFORM_TBL_MAX_NUM_HANDLES);
+
+    /* Delete one table so the registry isn't full anymore */
+    --numTblsCreated;
+    UtAssert_INT32_EQ(CFE_TBL_Unregister(Handles[numTblsCreated]), CFE_SUCCESS);
+
+    if (!UtAssert_NONZERO(numTblsCreated))
+    {
+        UtAssert_WARN("Table test cannot run CFE_TBL_Share max without at least one table");
+        return;
+    }
+
+    /*
+     * A shared table has a unique handle but not a unique entry in the registry.
+     * By calling CFE_TBL_Share it should consume handles but not registry entries
+     */
+    snprintf(TblName, sizeof(TblName), "CFE_TEST_APP.Tbl%u", (unsigned int)0);
+    while (numTblsCreated <= CFE_PLATFORM_TBL_MAX_NUM_HANDLES)
+    {
+        CFE_Assert_STATUS_STORE(CFE_TBL_Share(&Handles[numTblsCreated], TblName));
+        if (CFE_Assert_STATUS_MAY_BE(CFE_TBL_ERR_HANDLES_FULL))
         {
-            UtAssert_Failed("Failed to unregister table number %d", i);
+            break;
         }
+        if (!CFE_Assert_STATUS_MUST_BE(CFE_SUCCESS))
+        {
+            break;
+        }
+        ++numTblsCreated;
+    }
+
+    UtAssert_UINT32_LT(numTblsCreated, CFE_PLATFORM_TBL_MAX_NUM_HANDLES);
+
+    /* also confirm not able to register a new table, either */
+    snprintf(TblName, sizeof(TblName), "Tbl%u", (unsigned int)numTblsCreated);
+    UtAssert_INT32_EQ(
+        CFE_TBL_Register(&Handles[numTblsCreated], TblName, sizeof(TBL_TEST_Table_t), CFE_TBL_OPT_DEFAULT, NULL),
+        CFE_TBL_ERR_HANDLES_FULL);
+
+    /* Unregister all table handles */
+    while (numTblsCreated > 0)
+    {
+        --numTblsCreated;
+        UtAssert_INT32_EQ(CFE_TBL_Unregister(Handles[numTblsCreated]), CFE_SUCCESS);
     }
 }
 
@@ -126,13 +195,82 @@ void TestTableShare(void)
     CFE_TBL_Handle_t SharedTblHandle;
     const char *     SharedTblName = "SAMPLE_APP.SampleAppTable";
     const char *     BadTblName    = "SampleAppTable";
+
+    UtAssert_INT32_EQ(CFE_TBL_Share(NULL, SharedTblName), CFE_TBL_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_TBL_Share(&SharedTblHandle, SharedTblName), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_TBL_Share(&SharedTblHandle, NULL), CFE_TBL_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_TBL_Share(&SharedTblHandle, BadTblName), CFE_TBL_ERR_INVALID_NAME);
 }
 
+void TestTblNonAppContext(void)
+{
+    CFE_TBL_Handle_t Handle;
+    void *           TblPtr;
+
+    /* Attempt to register another table */
+    UtAssert_INT32_EQ(
+        CFE_TBL_Register(&Handle, "OtherTable", sizeof(TBL_TEST_Table_t), CFE_TBL_OPT_DEFAULT, &CallbackFunc),
+        CFE_ES_ERR_RESOURCEID_NOT_VALID);
+
+    /* Calling any other API (with a valid handle) should be rejected from this context */
+    UtAssert_INT32_EQ(CFE_TBL_DumpToBuffer(CFE_FT_Global.TblHandle), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress(&TblPtr, CFE_FT_Global.TblHandle), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+    UtAssert_INT32_EQ(CFE_TBL_GetStatus(CFE_FT_Global.TblHandle), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+    UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_FILE, "/cf/cfe_test_tbl.tbl"),
+                      CFE_ES_ERR_RESOURCEID_NOT_VALID);
+    UtAssert_INT32_EQ(CFE_TBL_Manage(CFE_FT_Global.TblHandle), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+    UtAssert_INT32_EQ(CFE_TBL_Modified(CFE_FT_Global.TblHandle), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+    UtAssert_INT32_EQ(CFE_TBL_NotifyByMessage(CFE_FT_Global.TblHandle, CFE_TEST_CMD_MID, 0, 0),
+                      CFE_ES_ERR_RESOURCEID_NOT_VALID);
+    UtAssert_INT32_EQ(CFE_TBL_ReleaseAddress(CFE_FT_Global.TblHandle), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+    UtAssert_INT32_EQ(CFE_TBL_Share(&Handle, CFE_FT_Global.TblName), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+    UtAssert_INT32_EQ(CFE_TBL_Update(CFE_FT_Global.TblHandle), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+    UtAssert_INT32_EQ(CFE_TBL_Validate(CFE_FT_Global.TblHandle), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+
+    /* Attempt to unregister a table */
+    UtAssert_INT32_EQ(CFE_TBL_Unregister(CFE_FT_Global.TblHandle), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+}
+
+void TestTableBadContext(void)
+{
+    uint32         RetryCount;
+    osal_id_t      OtherTaskId;
+    OS_task_prop_t TaskProp;
+
+    /* Create one (good) handle first from this task */
+    UtAssert_INT32_EQ(CFE_TBL_Register(&CFE_FT_Global.TblHandle, CFE_FT_Global.TblName, sizeof(TBL_TEST_Table_t),
+                                       CFE_TBL_OPT_DEFAULT, &CallbackFunc),
+                      CFE_SUCCESS);
+
+    /* Create a separate task to run the tests, to confirm TBL context checks */
+    UtAssert_INT32_EQ(OS_TaskCreate(&OtherTaskId, "NonCfe", TestTblNonAppContext, OSAL_TASK_STACK_ALLOCATE, 16384,
+                                    OSAL_PRIORITY_C(200), 0),
+                      OS_SUCCESS);
+
+    /* wait for task to exit itself */
+    RetryCount = 0;
+    while (RetryCount < 20)
+    {
+        /*
+         * poll until OS_TaskGetInfo() returns an error, then the task has exited
+         */
+        if (OS_TaskGetInfo(OtherTaskId, &TaskProp) != OS_SUCCESS)
+        {
+            break;
+        }
+
+        OS_TaskDelay(100);
+        ++RetryCount;
+    }
+
+    UtAssert_UINT32_LT(RetryCount, 20);
+    UtAssert_INT32_EQ(CFE_TBL_Unregister(CFE_FT_Global.TblHandle), CFE_SUCCESS);
+}
+
 void TBLRegistrationTestSetup(void)
 {
     UtTest_Add(TestTableRegistration, NULL, NULL, "Test Table Registration");
+    UtTest_Add(TestTableMaxLimits, NULL, NULL, "Table Max Limits");
     UtTest_Add(TestTableShare, NULL, NULL, "Test Table Sharing");
+    UtTest_Add(TestTableBadContext, NULL, NULL, "Test Table Bad Context");
 }

--- a/modules/cfe_testcase/tables/cfe_test_tbl.c
+++ b/modules/cfe_testcase/tables/cfe_test_tbl.c
@@ -32,5 +32,11 @@
 #include "cfe_tbl_filedef.h"
 #include "cfe_test_tbl.h"
 
-TBL_TEST_Table_t TestTable = {1, 2};
+/*
+ * The test table data should contain some identifiable numeric values,
+ * so any issues with paritial loading/byteswapping are morely likely
+ * to be detected.
+ */
+TBL_TEST_Table_t TestTable = {0xf007, 0xba11};
+
 CFE_TBL_FILEDEF(TestTable, CFE_TEST_APP.TestTable, Table Test Table, cfe_test_tbl.tbl)

--- a/modules/core_api/fsw/inc/cfe_es.h
+++ b/modules/core_api/fsw/inc/cfe_es.h
@@ -420,7 +420,7 @@ bool CFE_ES_RunLoop(uint32 *RunStatus);
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                State successfully achieved
-** \retval #CFE_ES_OPERATION_TIMED_OUT Timeout was reached
+** \retval #CFE_ES_OPERATION_TIMED_OUT \covtest Timeout was reached
 **
 ** \sa #CFE_ES_RunLoop
 **
@@ -651,7 +651,7 @@ CFE_Status_t CFE_ES_GetAppName(char *AppName, CFE_ES_AppId_t AppId, size_t Buffe
 **
 ** \param[in]   LibId         Library ID of Library whose name is being requested.
 **
-** \param[in]   BufferLength  The maximum number of characters, including the null terminator, that can be put
+** \param[in]   BufferLength  The maximum number of characters @nonzero, including the null terminator, that can be put
 **                            into the \c LibName buffer.  This routine will truncate the name to this length,
 **                            if necessary.
 **
@@ -903,8 +903,7 @@ CFE_Status_t CFE_ES_GetTaskName(char *TaskName, CFE_ES_TaskId_t TaskId, size_t B
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                             \copybrief CFE_SUCCESS
-** \retval #CFE_ES_NOT_IMPLEMENTED                  \copybrief CFE_ES_NOT_IMPLEMENTED
-** \retval #CFE_ES_ERR_CHILD_TASK_DELETE            \copybrief CFE_ES_ERR_CHILD_TASK_DELETE
+** \retval #CFE_ES_ERR_CHILD_TASK_DELETE            \covtest \copybrief CFE_ES_ERR_CHILD_TASK_DELETE
 ** \retval #CFE_ES_ERR_CHILD_TASK_DELETE_MAIN_TASK  \copybrief CFE_ES_ERR_CHILD_TASK_DELETE_MAIN_TASK
 ** \retval #CFE_ES_ERR_RESOURCEID_NOT_VALID         \copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID
 **
@@ -1072,7 +1071,7 @@ void CFE_ES_ProcessAsyncEvent(void);
 ** \retval #CFE_ES_CDS_INVALID_SIZE   \copybrief CFE_ES_CDS_INVALID_SIZE
 ** \retval #CFE_ES_CDS_INVALID_NAME   \copybrief CFE_ES_CDS_INVALID_NAME
 ** \retval #CFE_ES_BAD_ARGUMENT       \copybrief CFE_ES_BAD_ARGUMENT
-** \retval #CFE_ES_CDS_INVALID        \copybrief CFE_ES_CDS_INVALID
+** \retval #CFE_ES_CDS_INVALID        \covtest \copybrief CFE_ES_CDS_INVALID
 **
 ** \sa #CFE_ES_CopyToCDS, #CFE_ES_RestoreFromCDS
 **
@@ -1185,7 +1184,7 @@ CFE_Status_t CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, const void *DataToCopy)
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                       \copybrief CFE_SUCCESS
 ** \retval #CFE_ES_ERR_RESOURCEID_NOT_VALID   \copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID
-** \retval #CFE_ES_CDS_BLOCK_CRC_ERR          \copybrief CFE_ES_CDS_BLOCK_CRC_ERR
+** \retval #CFE_ES_CDS_BLOCK_CRC_ERR          \covtest \copybrief CFE_ES_CDS_BLOCK_CRC_ERR
 ** \retval #CFE_ES_BAD_ARGUMENT               \copybrief CFE_ES_BAD_ARGUMENT
 **
 ** \sa #CFE_ES_RegisterCDS, #CFE_ES_CopyToCDS
@@ -1309,7 +1308,7 @@ CFE_Status_t CFE_ES_PoolCreate(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t 
 ** \retval #CFE_SUCCESS                       \copybrief CFE_SUCCESS
 ** \retval #CFE_ES_BAD_ARGUMENT               \copybrief CFE_ES_BAD_ARGUMENT
 ** \retval #CFE_ES_NO_RESOURCE_IDS_AVAILABLE  \copybrief CFE_ES_NO_RESOURCE_IDS_AVAILABLE
-** \retval #CFE_STATUS_EXTERNAL_RESOURCE_FAIL \copybrief CFE_STATUS_EXTERNAL_RESOURCE_FAIL
+** \retval #CFE_STATUS_EXTERNAL_RESOURCE_FAIL \covtest \copybrief CFE_STATUS_EXTERNAL_RESOURCE_FAIL
 **
 ** \sa #CFE_ES_PoolCreate, #CFE_ES_PoolCreateNoSem, #CFE_ES_GetPoolBuf, #CFE_ES_PutPoolBuf, #CFE_ES_GetMemPoolStats
 **
@@ -1356,7 +1355,7 @@ int32 CFE_ES_PoolDelete(CFE_ES_MemHandle_t PoolID);
 **
 ** \param[in]   Handle      The handle to the memory pool as returned by #CFE_ES_PoolCreate or #CFE_ES_PoolCreateNoSem.
 **
-** \param[in]   Size        The size of the buffer requested @nonzero.  NOTE: The size allocated may be larger.
+** \param[in]   Size        The size of the buffer requested.  NOTE: The size allocated may be larger.
 **
 ** \return Bytes Allocated, or error code \ref CFEReturnCodes
 ** \retval #CFE_ES_ERR_RESOURCEID_NOT_VALID   \copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID

--- a/modules/core_api/fsw/inc/cfe_fs.h
+++ b/modules/core_api/fsw/inc/cfe_fs.h
@@ -168,7 +168,7 @@ CFE_Status_t CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr);
 **                         to be put into the file's Standard cFE File Header.
 **
 ** \return Execution status, see \ref CFEReturnCodes, or OSAL status
-** \retval #CFE_STATUS_EXTERNAL_RESOURCE_FAIL  \copybrief CFE_STATUS_EXTERNAL_RESOURCE_FAIL
+** \retval #CFE_STATUS_EXTERNAL_RESOURCE_FAIL  \covtest \copybrief CFE_STATUS_EXTERNAL_RESOURCE_FAIL
 ** \retval #CFE_SUCCESS                        \copybrief CFE_SUCCESS
 **
 ** \note This function invokes OSAL API routines and the current implementation may return

--- a/modules/core_api/fsw/inc/cfe_sb.h
+++ b/modules/core_api/fsw/inc/cfe_sb.h
@@ -259,10 +259,10 @@ CFE_Status_t CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *Pipe
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS          \copybrief CFE_SUCCESS
-** \retval #CFE_SB_MAX_MSGS_MET  \copybrief CFE_SB_MAX_MSGS_MET
+** \retval #CFE_SB_MAX_MSGS_MET  \covtest \copybrief CFE_SB_MAX_MSGS_MET
 ** \retval #CFE_SB_MAX_DESTS_MET \copybrief CFE_SB_MAX_DESTS_MET
 ** \retval #CFE_SB_BAD_ARGUMENT  \copybrief CFE_SB_BAD_ARGUMENT
-** \retval #CFE_SB_BUF_ALOC_ERR  \copybrief CFE_SB_BUF_ALOC_ERR
+** \retval #CFE_SB_BUF_ALOC_ERR  \covtest \copybrief CFE_SB_BUF_ALOC_ERR
 **
 ** \sa #CFE_SB_Subscribe, #CFE_SB_SubscribeLocal, #CFE_SB_Unsubscribe, #CFE_SB_UnsubscribeLocal
 **/
@@ -294,10 +294,10 @@ CFE_Status_t CFE_SB_SubscribeEx(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CF
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS          \copybrief CFE_SUCCESS
-** \retval #CFE_SB_MAX_MSGS_MET  \copybrief CFE_SB_MAX_MSGS_MET
+** \retval #CFE_SB_MAX_MSGS_MET  \covtest \copybrief CFE_SB_MAX_MSGS_MET
 ** \retval #CFE_SB_MAX_DESTS_MET \copybrief CFE_SB_MAX_DESTS_MET
 ** \retval #CFE_SB_BAD_ARGUMENT  \copybrief CFE_SB_BAD_ARGUMENT
-** \retval #CFE_SB_BUF_ALOC_ERR  \copybrief CFE_SB_BUF_ALOC_ERR
+** \retval #CFE_SB_BUF_ALOC_ERR  \covtest \copybrief CFE_SB_BUF_ALOC_ERR
 **
 ** \sa #CFE_SB_SubscribeEx, #CFE_SB_SubscribeLocal, #CFE_SB_Unsubscribe, #CFE_SB_UnsubscribeLocal
 **/
@@ -329,10 +329,10 @@ CFE_Status_t CFE_SB_Subscribe(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId);
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS          \copybrief CFE_SUCCESS
-** \retval #CFE_SB_MAX_MSGS_MET  \copybrief CFE_SB_MAX_MSGS_MET
+** \retval #CFE_SB_MAX_MSGS_MET  \covtest \copybrief CFE_SB_MAX_MSGS_MET
 ** \retval #CFE_SB_MAX_DESTS_MET \copybrief CFE_SB_MAX_DESTS_MET
 ** \retval #CFE_SB_BAD_ARGUMENT  \copybrief CFE_SB_BAD_ARGUMENT
-** \retval #CFE_SB_BUF_ALOC_ERR  \copybrief CFE_SB_BUF_ALOC_ERR
+** \retval #CFE_SB_BUF_ALOC_ERR  \covtest \copybrief CFE_SB_BUF_ALOC_ERR
 **
 ** \sa #CFE_SB_Subscribe, #CFE_SB_SubscribeEx, #CFE_SB_Unsubscribe, #CFE_SB_UnsubscribeLocal
 **/
@@ -357,7 +357,7 @@ CFE_Status_t CFE_SB_SubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId,
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS           \copybrief CFE_SUCCESS
-** \retval #CFE_SB_INTERNAL_ERR   \copybrief CFE_SB_INTERNAL_ERR
+** \retval #CFE_SB_BAD_ARGUMENT   \copybrief CFE_SB_BAD_ARGUMENT
 **
 ** \sa #CFE_SB_Subscribe, #CFE_SB_SubscribeEx, #CFE_SB_SubscribeLocal, #CFE_SB_UnsubscribeLocal
 **/
@@ -383,7 +383,7 @@ CFE_Status_t CFE_SB_Unsubscribe(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId);
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS           \copybrief CFE_SUCCESS
-** \retval #CFE_SB_INTERNAL_ERR   \copybrief CFE_SB_INTERNAL_ERR
+** \retval #CFE_SB_BAD_ARGUMENT   \copybrief CFE_SB_BAD_ARGUMENT
 **
 ** \sa #CFE_SB_Subscribe, #CFE_SB_SubscribeEx, #CFE_SB_SubscribeLocal, #CFE_SB_Unsubscribe
 **/
@@ -421,7 +421,7 @@ CFE_Status_t CFE_SB_UnsubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeI
 ** \retval #CFE_SUCCESS         \copybrief CFE_SUCCESS
 ** \retval #CFE_SB_BAD_ARGUMENT \copybrief CFE_SB_BAD_ARGUMENT
 ** \retval #CFE_SB_MSG_TOO_BIG  \copybrief CFE_SB_MSG_TOO_BIG
-** \retval #CFE_SB_BUF_ALOC_ERR \copybrief CFE_SB_BUF_ALOC_ERR
+** \retval #CFE_SB_BUF_ALOC_ERR \covtest \copybrief CFE_SB_BUF_ALOC_ERR
 **/
 CFE_Status_t CFE_SB_TransmitMsg(const CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount);
 
@@ -461,7 +461,7 @@ CFE_Status_t CFE_SB_TransmitMsg(const CFE_MSG_Message_t *MsgPtr, bool IncrementS
 ** \retval #CFE_SUCCESS         \copybrief CFE_SUCCESS
 ** \retval #CFE_SB_BAD_ARGUMENT \copybrief CFE_SB_BAD_ARGUMENT
 ** \retval #CFE_SB_TIME_OUT     \copybrief CFE_SB_TIME_OUT
-** \retval #CFE_SB_PIPE_RD_ERR  \copybrief CFE_SB_PIPE_RD_ERR
+** \retval #CFE_SB_PIPE_RD_ERR  \covtest \copybrief CFE_SB_PIPE_RD_ERR
 ** \retval #CFE_SB_NO_MESSAGE   \copybrief CFE_SB_NO_MESSAGE
 **/
 CFE_Status_t CFE_SB_ReceiveBuffer(CFE_SB_Buffer_t **BufPtr, CFE_SB_PipeId_t PipeId, int32 TimeOut);
@@ -717,9 +717,9 @@ size_t CFE_SB_GetUserDataLength(const CFE_MSG_Message_t *MsgPtr);
 **    truncated, but it will still be null terminated.
 **
 ** \param[out] DestStringPtr    Pointer to destination buffer @nonnull
-** \param[in]  SourceStringPtr  Pointer to source buffer (component of SB message definition) @nonnull
+** \param[in]  SourceStringPtr  Pointer to source buffer (component of SB message definition)
 ** \param[in]  DefaultString    Default string to use if source is empty
-** \param[in]  DestMaxSize      Size of destination storage buffer (must be at least 2)
+** \param[in]  DestMaxSize      Size of destination storage buffer @nonzero
 ** \param[in]  SourceMaxSize    Size of source buffer as defined by the message definition
 **
 ** \return Number of characters copied or error code, see \ref CFEReturnCodes

--- a/modules/core_api/fsw/inc/cfe_tbl.h
+++ b/modules/core_api/fsw/inc/cfe_tbl.h
@@ -303,21 +303,22 @@ CFE_Status_t CFE_TBL_Unregister(CFE_TBL_Handle_t TblHandle);
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS                     \copybrief CFE_SUCCESS
-** \retval #CFE_TBL_WARN_SHORT_FILE         \copybrief CFE_TBL_WARN_SHORT_FILE
-** \retval #CFE_TBL_WARN_PARTIAL_LOAD       \copybrief CFE_TBL_WARN_PARTIAL_LOAD
 ** \retval #CFE_ES_ERR_RESOURCEID_NOT_VALID \copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID
 ** \retval #CFE_TBL_ERR_NO_ACCESS           \copybrief CFE_TBL_ERR_NO_ACCESS
 ** \retval #CFE_TBL_ERR_INVALID_HANDLE      \copybrief CFE_TBL_ERR_INVALID_HANDLE
 ** \retval #CFE_TBL_ERR_DUMP_ONLY           \copybrief CFE_TBL_ERR_DUMP_ONLY
 ** \retval #CFE_TBL_ERR_ILLEGAL_SRC_TYPE    \copybrief CFE_TBL_ERR_ILLEGAL_SRC_TYPE
 ** \retval #CFE_TBL_ERR_LOAD_IN_PROGRESS    \copybrief CFE_TBL_ERR_LOAD_IN_PROGRESS
+** \retval #CFE_TBL_ERR_LOAD_INCOMPLETE     \copybrief CFE_TBL_ERR_LOAD_INCOMPLETE
 ** \retval #CFE_TBL_ERR_NO_BUFFER_AVAIL     \copybrief CFE_TBL_ERR_NO_BUFFER_AVAIL
 ** \retval #CFE_TBL_ERR_ACCESS              \copybrief CFE_TBL_ERR_ACCESS
 ** \retval #CFE_TBL_ERR_FILE_TOO_LARGE      \copybrief CFE_TBL_ERR_FILE_TOO_LARGE
 ** \retval #CFE_TBL_ERR_BAD_CONTENT_ID      \copybrief CFE_TBL_ERR_BAD_CONTENT_ID
+** \retval #CFE_TBL_ERR_BAD_SUBTYPE_ID      \copybrief CFE_TBL_ERR_BAD_SUBTYPE_ID
+** \retval #CFE_TBL_ERR_NO_STD_HEADER       \copybrief CFE_TBL_ERR_NO_STD_HEADER
+** \retval #CFE_TBL_ERR_NO_TBL_HEADER       \copybrief CFE_TBL_ERR_NO_TBL_HEADER
 ** \retval #CFE_TBL_ERR_PARTIAL_LOAD        \copybrief CFE_TBL_ERR_PARTIAL_LOAD
 ** \retval #CFE_TBL_BAD_ARGUMENT            \copybrief CFE_TBL_BAD_ARGUMENT
-** \retval #CFE_TBL_WARN_PARTIAL_LOAD       \copybrief CFE_TBL_WARN_PARTIAL_LOAD
 **
 ** \sa #CFE_TBL_Update, #CFE_TBL_Validate, #CFE_TBL_Manage
 **


### PR DESCRIPTION
**Describe the contribution**
A set of additional test cases to improve requirements coverage of the SB functional test.

Fixes #1825 - Adds unsubscribe of single pipe ID, confirms other subscriptions not changed
Fixes #1826 - Confirms that MsgLimit and PipeDepth are both honored and that delivery to other (open) pipes is not affected when some pipes have reached delivery limits
Fixes #1829 - Adds use of CFE_SB_PEND_FOREVER in some cases 
Fixes #1830 - Adds a sequence number validation to the Zero copy test.

**Testing performed**
Build and sanity check CFE, run all functional tests

**Expected behavior changes**
Functional test covers requirements as indicated in linked issues

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
