### PR TITLE
Fix #1890, Improve resource ID branch coverage

### DIFF
--- a/modules/resourceid/ut-coverage/test_cfe_resourceid.c
+++ b/modules/resourceid/ut-coverage/test_cfe_resourceid.c
@@ -163,6 +163,11 @@ void TestResourceID(void)
     UtAssert_True(TestIndex == RefIndex, "ID index after search: id=%lx, expected=%lu, got=%lu",
                   CFE_ResourceId_ToInteger(Id), (unsigned long)RefIndex, (unsigned long)TestIndex);
 
+    /* For valid Id check other invalid inputs */
+    UtAssert_INT32_EQ(CFE_ResourceId_ToIndex(Id, RefBase, 1, NULL), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ResourceId_ToIndex(Id, RefBase, 0, &TestIndex), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+    UtAssert_INT32_EQ(CFE_ResourceId_ToIndex(Id, ~RefBase, 1, &TestIndex), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+
     /* Validate off-nominal inputs */
     Id = CFE_ResourceId_FindNext(CFE_RESOURCEID_UNDEFINED, 0, UT_ResourceId_CheckIdSlotUsed);
     UtAssert_True(CFE_ResourceId_Equal(Id, CFE_RESOURCEID_UNDEFINED), "CFE_ResourceId_FindNext() bad input: id=%lx",
@@ -171,10 +176,6 @@ void TestResourceID(void)
     Id = CFE_ResourceId_FindNext(LastId, 0, NULL);
     UtAssert_True(CFE_ResourceId_Equal(Id, CFE_RESOURCEID_UNDEFINED), "CFE_ResourceId_FindNext() bad input: id=%lx",
                   CFE_ResourceId_ToInteger(Id));
-
-    UtAssert_INT32_EQ(CFE_ResourceId_ToIndex(Id, RefBase, 1, NULL), CFE_ES_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_ResourceId_ToIndex(Id, RefBase, 0, &TestIndex), CFE_ES_ERR_RESOURCEID_NOT_VALID);
-    UtAssert_INT32_EQ(CFE_ResourceId_ToIndex(Id, ~RefBase, 1, &TestIndex), CFE_ES_ERR_RESOURCEID_NOT_VALID);
 }
 
 void UtTest_Setup(void)


### PR DESCRIPTION
**Describe the contribution**
Fix #1890 - pushes resource ID coverage to 100/100

Note it was just an out-of-order test where Id was made invalid before the section that needed a valid Id to get full coverage, so swapped the tests.

**Testing performed**
Build/run/report coverage for unit tests

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: Intel i5/Docker
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC