### PR TITLE
Fix #1907, Cmake modifiable table tool path parameter

### DIFF
--- a/cmake/arch_build.cmake
+++ b/cmake/arch_build.cmake
@@ -169,7 +169,7 @@ function(add_cfe_tables APP_NAME TBL_SRC_FILES)
     # no automatic way to do this (at least in the older cmakes)
 
     # Create the intermediate table objects using the target compiler,
-    # then use "elf2cfetbl" to convert to a .tbl file
+    # then use "elf2cfetbl" or TABLETOOL_EXE to convert to a .tbl file
     foreach(TBL ${TBL_SRC_FILES} ${ARGN})
 
         # Get name without extension (NAME_WE) and append to list of tables
@@ -180,6 +180,13 @@ function(add_cfe_tables APP_NAME TBL_SRC_FILES)
             set(TABLE_DESTDIR "${CMAKE_CURRENT_BINARY_DIR}/${TABLE_LIBNAME}")
             set(TABLE_BINARY  "${TABLE_DESTDIR}/${TBLWE}.tbl")
             file(MAKE_DIRECTORY ${TABLE_DESTDIR})
+
+            # Get TBLTOOL executable location from cmake cache variable if available -> into local var
+            if (TABLETOOL_EXE)
+                set(TABLE_TOOL_EXECUTABLE ${TABLETOOL_EXE})
+            else() # else to default -> into local var
+                set(TABLE_TOOL_EXECUTABLE ${MISSION_BINARY_DIR}/tools/elf2cfetbl/elf2cfetbl)
+            endif()
 
             # Check if an override exists at the mission level (recommended practice)
             # This allows a mission to implement a customized table without modifying
@@ -226,10 +233,10 @@ function(add_cfe_tables APP_NAME TBL_SRC_FILES)
                     OUTPUT ${TABLE_BINARY}
                     COMMAND ${CMAKE_COMMAND}
                         -DCMAKE_AR=${CMAKE_AR}
-                        -DTBLTOOL=${MISSION_BINARY_DIR}/tools/elf2cfetbl/elf2cfetbl
+                        -DTBLTOOL=${TABLE_TOOL_EXECUTABLE}
                         -DLIB=$<TARGET_FILE:${TABLE_LIBNAME}>
                         -P ${CFE_SOURCE_DIR}/cmake/generate_table.cmake
-                    DEPENDS ${MISSION_BINARY_DIR}/tools/elf2cfetbl/elf2cfetbl ${TABLE_LIBNAME}
+                    DEPENDS ${TABLE_TOOL_EXECUTABLE} ${TABLE_LIBNAME}
                     WORKING_DIRECTORY ${TABLE_DESTDIR}
                 )
 

--- a/cmake/generate_table.cmake
+++ b/cmake/generate_table.cmake
@@ -11,7 +11,7 @@
 #
 # Required passed in values:
 #  CMAKE_AR => path to "ar" utility for working with static lib files
-#  TBLTOOL => path to "elf2cfetbl" utility
+#  TBLTOOL => path to "elf2cfetbl" utility or equivalent utility
 #  LIB => name of library file to convert
 #
 # This assumes/requires that the static library has a single object in it.
@@ -37,7 +37,7 @@ if (NOT RESULT EQUAL 0)
     message(FATAL_ERROR "Failure running ${CMAKE_AR} x ${LIB} ${OBJNAME}")
 endif()
 
-# Finally invoke the table tool (elf2cfetbl) on the object
+# Finally invoke the table tool (elf2cfetbl or other tool executable) on the object
 message("Executing Process: ${TBLTOOL} ${OBJNAME}")
 execute_process(COMMAND ${TBLTOOL} "${OBJNAME}"
     RESULT_VARIABLE RESULT

--- a/cmake/mission_build.cmake
+++ b/cmake/mission_build.cmake
@@ -70,6 +70,11 @@ function(initialize_globals)
     # Export values to parent level
     set(MISSION_DEFS ${MISSION_SOURCE_DIR}/${MISSIONCONFIG}_defs CACHE PATH "Full path to mission definitions directory")
 
+    # ... -DTABLETOOL_EXECUTABLE=/path/to/my/custom/tabletool
+    if (TABLETOOL_EXECUTABLE)
+        set(TABLETOOL_EXE ${TABLETOOL_EXECUTABLE} CACHE FILEPATH "Set executable used instead of default elf2cfetbl.")
+    endif()
+
 endfunction(initialize_globals)
 
 ##################################################################
@@ -386,9 +391,13 @@ function(prepare)
   )
   add_subdirectory(${MISSION_SOURCE_DIR}/tools tools)
 
-  # Add a dependency on the table generator tool as this is required for table builds
-  # The "elf2cfetbl" target should have been added by the "tools" above
-  add_dependencies(mission-prebuild elf2cfetbl)
+  # If no alternative table tool executable was set by cmake cache variable before, 
+  # ...add default tool as dependency
+  if (NOT DEFINED ${TABLETOOL_EXE})
+    # Add a dependency on the table generator tool as this is required for table builds
+    # The "elf2cfetbl" target should have been added by the "tools" above
+    add_dependencies(mission-prebuild elf2cfetbl)  
+  endif()
 
   # Build version information should be generated as part of the pre-build process
   add_dependencies(mission-prebuild mission-version)


### PR DESCRIPTION
Cmake option to change the path of the ef2cfetbl executable file via the TABLETOOL_EXE environment variable. This also enables the user to specify other tools as table tool if needed.

**Describe the contribution**
- Fixes #1907 

**Testing performed**
1. Github actions

**Expected behavior changes**
- Nothing only if `TABLETOOL_EXE` environment variable is set. Then the cmake would use the content as path to an executable used for transforming lib into tbl. 
  **IMPORTANT!**
  If `TABLETOOL_EXE` isn't set the build process does not change. But if it is set the program won't add the default ef2cfetbl tool 
  as a dependency in cmake and the with TABLETOOL_EXE specified executable will be run with the parameters like for the 
  ef2cfetbl utility.

**Additional context**
See above.

**Contributor Info - All information REQUIRED for consideration of pull request**
@pavll 
