### PR TITLE
Fix #1912, Update time tests to use bitmask check macros

### DIFF
--- a/modules/cfe_testcase/src/time_current_test.c
+++ b/modules/cfe_testcase/src/time_current_test.c
@@ -125,31 +125,30 @@ void TestClock(void)
 {
     UtPrintf("Testing: CFE_TIME_GetClockState, CFE_TIME_GetClockInfo");
 
-    CFE_TIME_ClockState_Enum_t state     = CFE_TIME_GetClockState();
-    uint16                     ClockInfo = CFE_TIME_GetClockInfo();
+    CFE_TIME_ClockState_Enum_t state = CFE_TIME_GetClockState();
 
     if (state >= 0)
     {
-        UtAssert_UINT32_EQ(ClockInfo, ClockInfo | CFE_TIME_FLAG_CLKSET);
+        UtAssert_BITMASK_SET(CFE_TIME_GetClockInfo(), CFE_TIME_FLAG_CLKSET);
 
         if (state == 0)
         {
-            UtAssert_UINT32_NEQ(ClockInfo, ClockInfo | CFE_TIME_FLAG_FLYING);
+            UtAssert_BITMASK_UNSET(CFE_TIME_GetClockInfo(), CFE_TIME_FLAG_FLYING);
         }
         else
         {
-            UtAssert_UINT32_EQ(ClockInfo, ClockInfo | CFE_TIME_FLAG_FLYING);
+            UtAssert_BITMASK_SET(CFE_TIME_GetClockInfo(), CFE_TIME_FLAG_FLYING);
         }
     }
     else
     {
-        UtAssert_UINT32_NEQ(ClockInfo, ClockInfo | CFE_TIME_FLAG_CLKSET);
+        UtAssert_BITMASK_UNSET(CFE_TIME_GetClockInfo(), CFE_TIME_FLAG_CLKSET);
     }
 
-    UtAssert_UINT32_EQ(ClockInfo, ClockInfo | CFE_TIME_FLAG_SRCINT);
-    UtAssert_UINT32_EQ(ClockInfo, ClockInfo | CFE_TIME_FLAG_SIGPRI);
-    UtAssert_UINT32_NEQ(ClockInfo, ClockInfo | CFE_TIME_FLAG_REFERR);
-    UtAssert_UINT32_NEQ(ClockInfo, ClockInfo | CFE_TIME_FLAG_UNUSED);
+    UtAssert_BITMASK_SET(CFE_TIME_GetClockInfo(), CFE_TIME_FLAG_SRCINT);
+    UtAssert_BITMASK_SET(CFE_TIME_GetClockInfo(), CFE_TIME_FLAG_SIGPRI);
+    UtAssert_BITMASK_UNSET(CFE_TIME_GetClockInfo(), CFE_TIME_FLAG_REFERR);
+    UtAssert_BITMASK_UNSET(CFE_TIME_GetClockInfo(), CFE_TIME_FLAG_UNUSED);
 }
 
 void TimeCurrentTestSetup(void)


### PR DESCRIPTION
**Describe the contribution**
The new bitmask check macros provide more concise information the resulting log file.  This updates the time test to use those macros when checking the state flags.

**Testing performed**
Build and run all tests, confirm log output is correct

**Expected behavior changes**
Improved test log file info

**System(s) tested on**
Ubuntu

**Additional context**
Note this also changes the code to call `CFE_TIME_GetClockInfo()` repeatedly, rather than storing in a local variable and checking that value.  The intent is to clearly indicate in the log that this function was invoked, not just what its output was.  This helps with tracking/confirming that the function is covered by the functional test.

This just reads a global so it should not be different in subsequent calls, unless the clock actually changes state during the test.  But that was already a risk with the separate call to `CFE_TIME_GetClockState`, this does not really change that - and the flags are not really connected otherwise.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.