### PR TITLE
Fix #1906, Enforce minimum code coverage

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -94,4 +94,21 @@ jobs:
         run: |
           lcov --capture --rc lcov_branch_coverage=1 --directory build --output-file coverage_test.info
           lcov --rc lcov_branch_coverage=1 --add-tracefile coverage_base.info --add-tracefile coverage_test.info --output-file coverage_total.info
-          genhtml coverage_total.info --branch-coverage --output-directory lcov
+          genhtml coverage_total.info --branch-coverage --output-directory lcov | tee lcov_out.txt
+
+      - name: Confirm Minimum Coverage
+        run: |
+          missed_branches=76
+          missed_lines=33
+          branch_nums=$(grep -A 3 "Overall coverage rate" lcov_out.txt | grep branches | grep -oP "[0-9]+[0-9]*")
+          line_nums=$(grep -A 3 "Overall coverage rate" lcov_out.txt | grep lines | grep -oP "[0-9]+[0-9]*")
+
+          branch_diff=$(echo $branch_nums | awk '{ print $4 - $3 }')
+          line_diff=$(echo $line_nums | awk '{ print $4 - $3 }')
+          if [ $branch_diff -gt $missed_branches ] || [ $line_diff -gt $missed_lines ]
+          then
+            grep -A 3 "Overall coverage rate" lcov_out.txt
+            echo "$branch_diff branches missed, $missed_branches allowed"
+            echo "$line_diff lines missed, $missed_lines allowed"
+            exit -1
+          fi


### PR DESCRIPTION
**Describe the contribution**
- Fix #1906

Added enforcement of minimum coverage to CI, currently set to numbers achieved once all coverage PR's are in (ES and SB pending)

**Testing performed**
See results on branch with ES/SB merges at: https://github.com/skliper/cFE/runs/3536944299?check_suite_focus=true (PASSED)

**Expected behavior changes**
Only impact is to fail the workflow if code is added without associated code coverage.

**System(s) tested on**
CI (also ran it locally for testing)

**Additional context**
The numbers can be adjusted if code is added that really can't be covered (although we should avoid this) and/or as we resolve open coverage issues (all are documented).

Needs #1936 and #1922 merged to pass.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC