### PR TITLE
Fix #1942, add missing inclusions in CFE API headers

### DIFF
--- a/modules/core_api/fsw/inc/cfe_es.h
+++ b/modules/core_api/fsw/inc/cfe_es.h
@@ -41,6 +41,7 @@
 #include "common_types.h"
 #include "cfe_error.h"
 #include "cfe_es_api_typedefs.h"
+#include "cfe_resourceid_api_typedefs.h"
 
 /*
 ** The OS_PRINTF macro may be defined by OSAL to enable

--- a/modules/core_api/fsw/inc/cfe_tbl_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_tbl_api_typedefs.h
@@ -40,6 +40,7 @@
 
 /********************* Include Files  ************************/
 #include "common_types.h" /* Basic Data Types */
+#include "cfe_mission_cfg.h"
 #include "cfe_tbl_extern_typedefs.h"
 #include "cfe_time_extern_typedefs.h"
 


### PR DESCRIPTION
**Describe the contribution**
Some CFE API headers were missing dependency inclusions, where the header was referencing a type or symbol but not directly including the header file that provides that type/symbol.

Adding the dependent include allows the headers to work more consistently.

Fixes #1942

**Testing performed**
Build and sanity check CFE

**Expected behavior changes**
None for framework config (these inclusions were already satisfied in existing use cases)
But fixes a broken build for external code that only included these headers directly.

**System(s) tested on**
Ubuntu

**Additional context**
This type of thing was intended to be caught by the "headercheck" concept in the module code, but that is currently not enabled/enforced in the build.

There theoretically could be other instances of stuff like this, but these are the only two noted so far.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
