### PR TITLE
Fix #1835, CFE_Assert macro names

### DIFF
--- a/modules/cfe_assert/inc/cfe_assert.h
+++ b/modules/cfe_assert/inc/cfe_assert.h
@@ -67,8 +67,7 @@ typedef void (*CFE_Assert_StatusCallback_t)(uint8 MessageType, const char *Prefi
 **        None
 **
 ******************************************************************************/
-#define CFE_UtAssert_STATUS_OK(FN) \
-    CFE_UtAssert_StatusCheck(FN, true, UTASSERT_CASETYPE_FAILURE, __FILE__, __LINE__, #FN)
+#define CFE_Assert_STATUS_OK(FN) CFE_Assert_StatusCheck(FN, true, UTASSERT_CASETYPE_FAILURE, __FILE__, __LINE__, #FN)
 
 /*****************************************************************************/
 /**
@@ -86,8 +85,8 @@ typedef void (*CFE_Assert_StatusCallback_t)(uint8 MessageType, const char *Prefi
 **        tests should check for that error instead of using this.
 **
 ******************************************************************************/
-#define CFE_UtAssert_STATUS_ERROR(FN) \
-    CFE_UtAssert_StatusCheck(FN, false, UTASSERT_CASETYPE_FAILURE, __FILE__, __LINE__, #FN)
+#define CFE_Assert_STATUS_ERROR(FN) \
+    CFE_Assert_StatusCheck(FN, false, UTASSERT_CASETYPE_FAILURE, __FILE__, __LINE__, #FN)
 
 /*****************************************************************************/
 /**
@@ -101,7 +100,7 @@ typedef void (*CFE_Assert_StatusCallback_t)(uint8 MessageType, const char *Prefi
 **        and integers may not be interchangeable with strict type checking.
 **
 ******************************************************************************/
-#define CFE_UtAssert_RESOURCEID_EQ(id1, id2)                                                                         \
+#define CFE_Assert_RESOURCEID_EQ(id1, id2)                                                                           \
     UtAssert_GenericUnsignedCompare(CFE_RESOURCEID_TO_ULONG(id1), UtAssert_Compare_EQ, CFE_RESOURCEID_TO_ULONG(id2), \
                                     UtAssert_Radix_HEX, __FILE__, __LINE__, "Resource ID Check: ", #id1, #id2)
 
@@ -117,7 +116,7 @@ typedef void (*CFE_Assert_StatusCallback_t)(uint8 MessageType, const char *Prefi
 **        set of undefined IDs is more than the single value of CFE_RESOURCEID_UNDEFINED.
 **
 ******************************************************************************/
-#define CFE_UtAssert_RESOURCEID_UNDEFINED(id) \
+#define CFE_Assert_RESOURCEID_UNDEFINED(id) \
     UtAssert_True(!CFE_RESOURCEID_TEST_DEFINED(id), "%s (0x%lx) not defined", #id, CFE_RESOURCEID_TO_ULONG(id))
 
 /*****************************************************************************/
@@ -131,7 +130,7 @@ typedef void (*CFE_Assert_StatusCallback_t)(uint8 MessageType, const char *Prefi
 **        This is a simple unsigned comparison which logs the values as hexadecimal
 **
 ******************************************************************************/
-#define CFE_UtAssert_MEMOFFSET_EQ(off1, off2)                                                                \
+#define CFE_Assert_MEMOFFSET_EQ(off1, off2)                                                                  \
     UtAssert_GenericUnsignedCompare(off1, UtAssert_Compare_EQ, off2, UtAssert_Radix_HEX, __FILE__, __LINE__, \
                                     "Offset Check: ", #off1, #off2)
 
@@ -147,7 +146,7 @@ typedef void (*CFE_Assert_StatusCallback_t)(uint8 MessageType, const char *Prefi
 **        and integers may not be interchangeable with strict type checking.
 **
 ******************************************************************************/
-#define CFE_UtAssert_MSGID_EQ(mid1, mid2)                                                                      \
+#define CFE_Assert_MSGID_EQ(mid1, mid2)                                                                        \
     UtAssert_GenericUnsignedCompare(CFE_SB_MsgIdToValue(mid1), UtAssert_Compare_EQ, CFE_SB_MsgIdToValue(mid2), \
                                     UtAssert_Radix_HEX, __FILE__, __LINE__, "MsgId Check: ", #mid1, #mid2)
 
@@ -368,8 +367,8 @@ void CFE_Assert_CloseLogFile(void);
 ** \returns Test pass status, returns true if status was successful, false if it failed.
 **
 ******************************************************************************/
-bool CFE_UtAssert_StatusCheck(CFE_Status_t Status, bool ExpectSuccess, UtAssert_CaseType_t CaseType, const char *File,
-                              uint32 Line, const char *Text);
+bool CFE_Assert_StatusCheck(CFE_Status_t Status, bool ExpectSuccess, UtAssert_CaseType_t CaseType, const char *File,
+                            uint32 Line, const char *Text);
 
 /*****************************************************************************/
 /**

--- a/modules/cfe_assert/src/cfe_assert_runner.c
+++ b/modules/cfe_assert/src/cfe_assert_runner.c
@@ -69,8 +69,8 @@ static CFE_EVS_BinFilter_t CFE_TR_EventFilters[] = {
     {UTASSERT_CASETYPE_DEBUG, CFE_EVS_NO_FILTER},
 };
 
-bool CFE_UtAssert_StatusCheck(CFE_Status_t Status, bool ExpectSuccess, UtAssert_CaseType_t CaseType, const char *File,
-                              uint32 Line, const char *Text)
+bool CFE_Assert_StatusCheck(CFE_Status_t Status, bool ExpectSuccess, UtAssert_CaseType_t CaseType, const char *File,
+                            uint32 Line, const char *Text)
 {
     bool        Result = (Status >= CFE_SUCCESS);
     const char *MatchText;

--- a/modules/cfe_testcase/src/es_cds_test.c
+++ b/modules/cfe_testcase/src/es_cds_test.c
@@ -102,7 +102,7 @@ void TestCDSName(void)
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockName(CDSNameBuf, CDSHandlePtr, sizeof(CDSNameBuf)), CFE_SUCCESS);
     UtAssert_StrCmp(CDSNameBuf, CDSName, "CFE_ES_GetCDSBlockName() = %s", CDSNameBuf);
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockIDByName(&IdByName, CDSNameBuf), CFE_SUCCESS);
-    CFE_UtAssert_RESOURCEID_EQ(CDSHandlePtr, IdByName);
+    CFE_Assert_RESOURCEID_EQ(CDSHandlePtr, IdByName);
 
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockName(NULL, CDSHandlePtr, sizeof(CDSNameBuf)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockName(CDSNameBuf, CFE_ES_CDS_BAD_HANDLE, sizeof(CDSNameBuf)),

--- a/modules/cfe_testcase/src/es_counter_test.c
+++ b/modules/cfe_testcase/src/es_counter_test.c
@@ -88,7 +88,7 @@ void TestCounterCreateDelete(void)
 
     /* Confirm conversion To/From Name */
     UtAssert_INT32_EQ(CFE_ES_GetGenCounterIDByName(&CheckId, CounterName), CFE_SUCCESS);
-    CFE_UtAssert_RESOURCEID_EQ(CheckId, TestId);
+    CFE_Assert_RESOURCEID_EQ(CheckId, TestId);
     UtAssert_INT32_EQ(CFE_ES_GetGenCounterName(CheckName, TestId, sizeof(CheckName)), CFE_SUCCESS);
     UtAssert_STRINGBUF_EQ(CheckName, sizeof(CheckName), CounterName, sizeof(CounterName));
 

--- a/modules/cfe_testcase/src/es_info_test.c
+++ b/modules/cfe_testcase/src/es_info_test.c
@@ -52,7 +52,7 @@ void TestAppInfo(void)
 
     UtAssert_INT32_EQ(CFE_ES_GetAppIDByName(&AppIdByName, TEST_EXPECTED_APP_NAME), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetAppID(&TestAppId), CFE_SUCCESS);
-    CFE_UtAssert_RESOURCEID_EQ(TestAppId, AppIdByName);
+    CFE_Assert_RESOURCEID_EQ(TestAppId, AppIdByName);
     UtAssert_INT32_EQ(CFE_ES_GetAppName(AppNameBuf, TestAppId, sizeof(AppNameBuf)), CFE_SUCCESS);
     UtAssert_StrCmp(AppNameBuf, TEST_EXPECTED_APP_NAME, "CFE_ES_GetAppName() = %s", AppNameBuf);
 
@@ -122,7 +122,7 @@ void TestAppInfo(void)
     UtAssert_True(ESAppInfo.NumOfChildTasks > 0, "ES App Info -> Child Tasks  = %d", (int)ESAppInfo.NumOfChildTasks);
 
     UtAssert_INT32_EQ(CFE_ES_GetAppIDByName(&AppIdByName, INVALID_APP_NAME), CFE_ES_ERR_NAME_NOT_FOUND);
-    CFE_UtAssert_RESOURCEID_UNDEFINED(AppIdByName);
+    CFE_Assert_RESOURCEID_UNDEFINED(AppIdByName);
     UtAssert_INT32_EQ(CFE_ES_GetAppID(NULL), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetAppIDByName(NULL, TEST_EXPECTED_APP_NAME), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetAppIDByName(&AppIdByName, NULL), CFE_ES_BAD_ARGUMENT);
@@ -147,15 +147,15 @@ void TestTaskInfo(void)
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskInfo(&TaskInfo, AppInfo.MainTaskId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetTaskID(&TaskId), CFE_SUCCESS);
-    CFE_UtAssert_RESOURCEID_EQ(TaskId, AppInfo.MainTaskId);
+    CFE_Assert_RESOURCEID_EQ(TaskId, AppInfo.MainTaskId);
 
     UtAssert_StrCmp(TaskInfo.AppName, AppInfo.Name, "TaskInfo.AppName (%s) = AppInfo.name (%s)", TaskInfo.AppName,
                     AppInfo.Name);
     UtAssert_StrCmp(TaskInfo.TaskName, AppInfo.MainTaskName, "TaskInfo.TaskName (%s) = AppInfo.MainTaskName (%s)",
                     TaskInfo.TaskName, AppInfo.MainTaskName);
 
-    CFE_UtAssert_RESOURCEID_EQ(TaskInfo.TaskId, AppInfo.MainTaskId);
-    CFE_UtAssert_RESOURCEID_EQ(TaskInfo.AppId, AppId);
+    CFE_Assert_RESOURCEID_EQ(TaskInfo.TaskId, AppInfo.MainTaskId);
+    CFE_Assert_RESOURCEID_EQ(TaskInfo.AppId, AppId);
     UtAssert_INT32_EQ(TaskInfo.ExecutionCounter, AppInfo.ExecutionCounter);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskInfo(&TaskInfo, CFE_ES_TASKID_UNDEFINED), CFE_ES_ERR_RESOURCEID_NOT_VALID);
@@ -207,18 +207,18 @@ void TestLibInfo(void)
 
     UtAssert_INT32_EQ(LibInfo.ExceptionAction, 0);
     UtAssert_True(LibInfo.Priority == 0, "Lib Info -> Priority  = %d", (int)LibInfo.Priority);
-    CFE_UtAssert_RESOURCEID_UNDEFINED(LibInfo.MainTaskId);
+    CFE_Assert_RESOURCEID_UNDEFINED(LibInfo.MainTaskId);
     UtAssert_True(LibInfo.ExecutionCounter == 0, "Lib Info -> ExecutionCounter  = %d", (int)LibInfo.ExecutionCounter);
     UtAssert_True(strlen(LibInfo.MainTaskName) == 0, "Lib Info -> Task Name  = %s", LibInfo.MainTaskName);
     UtAssert_True(LibInfo.NumOfChildTasks == 0, "Lib Info -> Child Tasks  = %d", (int)LibInfo.NumOfChildTasks);
 
     UtAssert_INT32_EQ(CFE_ES_GetLibIDByName(&CheckId, InvalidName), CFE_ES_ERR_NAME_NOT_FOUND);
-    CFE_UtAssert_RESOURCEID_UNDEFINED(CheckId);
+    CFE_Assert_RESOURCEID_UNDEFINED(CheckId);
     UtAssert_INT32_EQ(CFE_ES_GetLibInfo(&LibInfo, CFE_ES_LIBID_UNDEFINED), CFE_ES_ERR_RESOURCEID_NOT_VALID);
     UtAssert_INT32_EQ(CFE_ES_GetLibInfo(NULL, LibId), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetLibIDByName(NULL, LibName), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetLibIDByName(&CheckId, NULL), CFE_ES_BAD_ARGUMENT);
-    CFE_UtAssert_RESOURCEID_UNDEFINED(CheckId);
+    CFE_Assert_RESOURCEID_UNDEFINED(CheckId);
     UtAssert_INT32_EQ(CFE_ES_GetLibName(LibNameBuf, CFE_ES_LIBID_UNDEFINED, sizeof(LibNameBuf)),
                       CFE_ES_ERR_RESOURCEID_NOT_VALID);
     UtAssert_INT32_EQ(CFE_ES_GetLibName(LibNameBuf, LibId, 0), CFE_ES_BAD_ARGUMENT);

--- a/modules/cfe_testcase/src/es_task_test.c
+++ b/modules/cfe_testcase/src/es_task_test.c
@@ -205,7 +205,7 @@ void TestChildTaskName(void)
                       CFE_SUCCESS);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(&TaskIdByName, TaskName), CFE_SUCCESS);
-    CFE_UtAssert_RESOURCEID_EQ(TaskIdByName, TaskId);
+    CFE_Assert_RESOURCEID_EQ(TaskIdByName, TaskId);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(TaskNameBuf, TaskId, sizeof(TaskNameBuf)), CFE_SUCCESS);
     UtAssert_StrCmp(TaskNameBuf, TaskName, "CFE_ES_GetTaskName() = %s", TaskNameBuf);
@@ -213,7 +213,7 @@ void TestChildTaskName(void)
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(NULL, TaskName), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(&TaskIdByName, NULL), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(&TaskIdByName, INVALID_TASK_NAME), CFE_ES_ERR_NAME_NOT_FOUND);
-    CFE_UtAssert_RESOURCEID_UNDEFINED(TaskIdByName);
+    CFE_Assert_RESOURCEID_UNDEFINED(TaskIdByName);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(NULL, TaskId, sizeof(TaskNameBuf)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(TaskNameBuf, CFE_ES_TASKID_UNDEFINED, sizeof(TaskNameBuf)),

--- a/modules/cfe_testcase/src/fs_header_test.c
+++ b/modules/cfe_testcase/src/fs_header_test.c
@@ -59,7 +59,7 @@ void TestCreateHeader(void)
     UtAssert_INT32_EQ(OS_lseek(fd, 0, OS_SEEK_CUR), sizeof(CFE_FS_Header_t));
 
     UtAssert_INT32_EQ(CFE_FS_WriteHeader(fd, NULL), CFE_FS_BAD_ARGUMENT);
-    CFE_UtAssert_STATUS_ERROR(CFE_FS_WriteHeader(OS_OBJECT_ID_UNDEFINED, &Header));
+    CFE_Assert_STATUS_ERROR(CFE_FS_WriteHeader(OS_OBJECT_ID_UNDEFINED, &Header));
 
     UtAssert_VOIDCALL(CFE_FS_InitHeader(NULL, TestDescription, CFE_FS_SubType_ES_ERLOG));
     UtAssert_VOIDCALL(CFE_FS_InitHeader(&HeaderFail, NULL, CFE_FS_SubType_ES_ERLOG));
@@ -88,7 +88,7 @@ void TestReadHeader(void)
     UtAssert_StrCmp(TestDescription, ReadHeader.Description, "ReadHeader.Description = %s", ReadHeader.Description);
 
     UtAssert_INT32_EQ(CFE_FS_ReadHeader(NULL, fd), CFE_FS_BAD_ARGUMENT);
-    CFE_UtAssert_STATUS_ERROR(CFE_FS_ReadHeader(&ReadHeader, OS_OBJECT_ID_UNDEFINED));
+    CFE_Assert_STATUS_ERROR(CFE_FS_ReadHeader(&ReadHeader, OS_OBJECT_ID_UNDEFINED));
 
     OS_close(fd);
     OS_remove(OS_TEST_HEADER_FILENAME);
@@ -114,7 +114,7 @@ void TestTimeStamp(void)
     UtAssert_UINT32_EQ(0xFFFFFFFF, ReadHeader.TimeSeconds);
     UtAssert_UINT32_EQ(0xFFFFFFFF, ReadHeader.TimeSubSeconds);
 
-    CFE_UtAssert_STATUS_ERROR(CFE_FS_SetTimestamp(OS_OBJECT_ID_UNDEFINED, NewTimestamp));
+    CFE_Assert_STATUS_ERROR(CFE_FS_SetTimestamp(OS_OBJECT_ID_UNDEFINED, NewTimestamp));
 
     OS_close(fd);
     OS_remove(OS_TEST_HEADER_FILENAME);

--- a/modules/cfe_testcase/src/resource_id_misc_test.c
+++ b/modules/cfe_testcase/src/resource_id_misc_test.c
@@ -60,10 +60,10 @@ void TestToFromInteger(void)
     /* Test resource ID -> integer -> resource ID */
     Id1 = CFE_ResourceId_ToInteger(ResourceId1);
     Id2 = CFE_ResourceId_ToInteger(ResourceId2);
-    CFE_UtAssert_RESOURCEID_EQ((CFE_RESOURCEID_BASE_TYPE)CFE_RESOURCEID_WRAP(CFE_ResourceId_FromInteger(Id1)),
-                               (CFE_RESOURCEID_BASE_TYPE)CFE_RESOURCEID_WRAP(ResourceId1));
-    CFE_UtAssert_RESOURCEID_EQ((CFE_RESOURCEID_BASE_TYPE)CFE_RESOURCEID_WRAP(CFE_ResourceId_FromInteger(Id2)),
-                               (CFE_RESOURCEID_BASE_TYPE)CFE_RESOURCEID_WRAP(ResourceId2));
+    CFE_Assert_RESOURCEID_EQ((CFE_RESOURCEID_BASE_TYPE)CFE_RESOURCEID_WRAP(CFE_ResourceId_FromInteger(Id1)),
+                             (CFE_RESOURCEID_BASE_TYPE)CFE_RESOURCEID_WRAP(ResourceId1));
+    CFE_Assert_RESOURCEID_EQ((CFE_RESOURCEID_BASE_TYPE)CFE_RESOURCEID_WRAP(CFE_ResourceId_FromInteger(Id2)),
+                             (CFE_RESOURCEID_BASE_TYPE)CFE_RESOURCEID_WRAP(ResourceId2));
 }
 
 void TestIsDefined(void)
@@ -151,7 +151,7 @@ void TestGetBaseSerial(void)
                       CFE_RESOURCEID_UNWRAP(PoolIdBuf.ResourceID) - POOLID_BASE);
     UtAssert_INT32_EQ(CFE_ES_PoolDelete(PoolIdBuf.PoolId), CFE_SUCCESS);
     /* CDS Block Id */
-    CFE_UtAssert_STATUS_OK(CFE_ES_RegisterCDS(&CDSHandleIdBuf.CDSHandleId, CDSBlockSize, CDSName));
+    CFE_Assert_STATUS_OK(CFE_ES_RegisterCDS(&CDSHandleIdBuf.CDSHandleId, CDSBlockSize, CDSName));
     UtAssert_INT32_EQ(CFE_ResourceId_GetBase(CDSHandleIdBuf.ResourceID), CDSBLOCKID_BASE);
     UtAssert_INT32_EQ(CFE_ResourceId_GetSerial(CDSHandleIdBuf.ResourceID),
                       CFE_RESOURCEID_UNWRAP(CDSHandleIdBuf.ResourceID) - CDSBLOCKID_BASE);
@@ -179,13 +179,13 @@ void TestFindNext(void)
     /*
      * Why does this macro not accept a resource ID
      * The following line won't compile
-     * CFE_UtAssert_RESOURCEID_UNDEFINED(AppIdBuf.ResourceId);
+     * CFE_Assert_RESOURCEID_UNDEFINED(AppIdBuf.ResourceId);
      */
-    CFE_UtAssert_RESOURCEID_UNDEFINED(AppIdBuf.AppId);
+    CFE_Assert_RESOURCEID_UNDEFINED(AppIdBuf.AppId);
 
     /* maximum number of applications is 0 */
     AppIdBuf.ResourceID = CFE_ResourceId_FindNext(AppIdBuf.ResourceID, 0, TestReturnFalse);
-    CFE_UtAssert_RESOURCEID_UNDEFINED(AppIdBuf.AppId);
+    CFE_Assert_RESOURCEID_UNDEFINED(AppIdBuf.AppId);
 }
 
 void TestToIndex(void)

--- a/modules/cfe_testcase/src/sb_pipe_mang_test.c
+++ b/modules/cfe_testcase/src/sb_pipe_mang_test.c
@@ -162,7 +162,7 @@ void TestPipeName(void)
     UtAssert_StrCmp(PipeNameBuf, PipeName, "CFE_SB_GetPipeName() = %s", PipeNameBuf);
 
     UtAssert_INT32_EQ(CFE_SB_GetPipeIdByName(&PipeIdBuff, PipeName), CFE_SUCCESS);
-    CFE_UtAssert_RESOURCEID_EQ(PipeId, PipeIdBuff);
+    CFE_Assert_RESOURCEID_EQ(PipeId, PipeIdBuff);
 
     UtAssert_INT32_EQ(CFE_SB_GetPipeName(NULL, sizeof(PipeNameBuf), PipeId), CFE_SB_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_SB_GetPipeName(PipeNameBuf, 0, PipeId), CFE_SB_BAD_ARGUMENT);

--- a/modules/cfe_testcase/src/sb_sendrecv_test.c
+++ b/modules/cfe_testcase/src/sb_sendrecv_test.c
@@ -154,7 +154,7 @@ void TestBasicTransmitRecv(void)
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId1, CFE_SB_PEND_FOREVER), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf->Msg, &MsgId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&MsgBuf->Msg, &Seq1), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
     CmdPtr = (const CFE_FT_TestCmdMessage_t *)MsgBuf;
     UtAssert_UINT32_EQ(CmdPtr->CmdPayload, 0x0c0ffee);
     UtAssert_UINT32_EQ(Seq1, 11);
@@ -162,7 +162,7 @@ void TestBasicTransmitRecv(void)
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId1, CFE_SB_PEND_FOREVER), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf->Msg, &MsgId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&MsgBuf->Msg, &Seq1), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
     CmdPtr = (const CFE_FT_TestCmdMessage_t *)MsgBuf;
     UtAssert_UINT32_EQ(CmdPtr->CmdPayload, 0x1c0ffee);
     UtAssert_UINT32_EQ(Seq1, 11);
@@ -170,7 +170,7 @@ void TestBasicTransmitRecv(void)
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId1, CFE_SB_PEND_FOREVER), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf->Msg, &MsgId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&MsgBuf->Msg, &Seq1), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
     CmdPtr = (const CFE_FT_TestCmdMessage_t *)MsgBuf;
     UtAssert_UINT32_EQ(CmdPtr->CmdPayload, 0x2c0ffee);
     UtAssert_UINT32_EQ(Seq1, 11);
@@ -186,14 +186,14 @@ void TestBasicTransmitRecv(void)
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId2, 100), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf->Msg, &MsgId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&MsgBuf->Msg, &Seq1), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_TLM_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_TLM_MSGID);
     TlmPtr = (const CFE_FT_TestTlmMessage_t *)MsgBuf;
     UtAssert_UINT32_EQ(TlmPtr->TlmPayload, 0x0d00d1e);
 
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId2, 100), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf->Msg, &MsgId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&MsgBuf->Msg, &Seq2), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_TLM_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_TLM_MSGID);
     TlmPtr = (const CFE_FT_TestTlmMessage_t *)MsgBuf;
     UtAssert_UINT32_EQ(TlmPtr->TlmPayload, 0x1d00d1e);
     UtAssert_UINT32_EQ(Seq2, CFE_MSG_GetNextSequenceCount(Seq1));
@@ -201,7 +201,7 @@ void TestBasicTransmitRecv(void)
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId2, 100), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf->Msg, &MsgId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&MsgBuf->Msg, &Seq2), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_TLM_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_TLM_MSGID);
     TlmPtr = (const CFE_FT_TestTlmMessage_t *)MsgBuf;
     UtAssert_UINT32_EQ(TlmPtr->TlmPayload, 0x2d00d1e);
     UtAssert_UINT32_EQ(Seq2, 21);
@@ -272,7 +272,7 @@ void TestMsgBroadcast(void)
 
     /* Confirm content */
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf1->Msg, &MsgId), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
     CmdPtr = (const CFE_FT_TestCmdMessage_t *)MsgBuf1;
     UtAssert_UINT32_EQ(CmdPtr->CmdPayload, 0xbabb1e00);
 
@@ -288,7 +288,7 @@ void TestMsgBroadcast(void)
 
     /* Confirm content */
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf2->Msg, &MsgId), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
     CmdPtr = (const CFE_FT_TestCmdMessage_t *)MsgBuf2;
     UtAssert_UINT32_EQ(CmdPtr->CmdPayload, 0xbabb1e01);
 
@@ -303,7 +303,7 @@ void TestMsgBroadcast(void)
 
     /* Confirm content */
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf3->Msg, &MsgId), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
     CmdPtr = (const CFE_FT_TestCmdMessage_t *)MsgBuf3;
     UtAssert_UINT32_EQ(CmdPtr->CmdPayload, 0xbabb1e02);
 
@@ -315,7 +315,7 @@ void TestMsgBroadcast(void)
 
     /* Confirm content */
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf4->Msg, &MsgId), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
     CmdPtr = (const CFE_FT_TestCmdMessage_t *)MsgBuf4;
     UtAssert_UINT32_EQ(CmdPtr->CmdPayload, 0xbabb1e03);
 
@@ -342,7 +342,7 @@ void TestMsgBroadcast(void)
 
     /* Confirm content */
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf1->Msg, &MsgId), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
     CmdPtr = (const CFE_FT_TestCmdMessage_t *)MsgBuf1;
     UtAssert_UINT32_EQ(CmdPtr->CmdPayload, 0xbabb1e04);
 
@@ -357,7 +357,7 @@ void TestMsgBroadcast(void)
 
     /* Confirm content */
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf3->Msg, &MsgId), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
     CmdPtr = (const CFE_FT_TestCmdMessage_t *)MsgBuf3;
     UtAssert_UINT32_EQ(CmdPtr->CmdPayload, 0xbabb1e05);
 
@@ -437,14 +437,14 @@ void TestZeroCopyTransmitRecv(void)
 
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId1, 100), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf->Msg, &MsgId), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
     UtAssert_ADDRESS_EQ(MsgBuf, CmdBuf); /* should be the same actual buffer (not a copy) */
 
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId1, CFE_SB_POLL), CFE_SB_NO_MESSAGE);
 
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId2, 100), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf->Msg, &MsgId), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_TLM_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_TLM_MSGID);
     UtAssert_ADDRESS_EQ(MsgBuf, TlmBuf); /* should be the same actual buffer (not a copy) */
 
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId2, CFE_SB_POLL), CFE_SB_NO_MESSAGE);


### PR DESCRIPTION
**Describe the contribution**
Replace "CFE_UtAssert" macro prefix with "CFE_Assert", to match the naming convention.  (The "UtAssert" was a carry over from
the coverage test environment).

Fixes #1835

**Testing performed**
Build and sanity check CFE, run all tests

**Expected behavior changes**
None, just namespace consistency in code.

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
