### PR TITLE
Fix #1949, update msgid testcase to match implementation

### DIFF
--- a/modules/cfe_testcase/src/message_id_test.c
+++ b/modules/cfe_testcase/src/message_id_test.c
@@ -45,7 +45,20 @@ void TestMsgId(void)
     UtAssert_UINT32_EQ(msgid, expectedmsgid);
 
     UtAssert_INT32_EQ(CFE_MSG_SetMsgId(NULL, msgid), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_SetMsgId(&msg, CFE_SB_INVALID_MSG_ID), CFE_MSG_BAD_ARGUMENT);
+
+    /*
+     * The purpose of this test is to attempt to set a MsgId beyond the set of values that can
+     * be stored in the MSG header. However the criteria for being "storable" depends on the
+     * actual MSG implementation, and may be different in other implementations.  Currently both
+     * "v1" and "v2" implementations do define a specific highest MsgId value, but another
+     * implementation might not have a highest number concept at all.
+     *
+     * By passing the value of -1, when converted to a an unsigned value (either 16 or 32 bit)
+     * it should translate to a MsgId value with all bits being set.  In theory, at least some of
+     * those bits will be not mappable to the packet header bits, and it should therefore elicit
+     * the CFE_MSG_BAD_ARGUMENT response.
+     */
+    UtAssert_INT32_EQ(CFE_MSG_SetMsgId(&msg, CFE_SB_ValueToMsgId(-1)), CFE_MSG_BAD_ARGUMENT);
 
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(NULL, &msgid), CFE_MSG_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&msg, NULL), CFE_MSG_BAD_ARGUMENT);

--- a/modules/core_api/fsw/inc/cfe_msg.h
+++ b/modules/core_api/fsw/inc/cfe_msg.h
@@ -670,6 +670,11 @@ CFE_Status_t CFE_MSG_GetMsgId(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *M
  *        This API only sets the bits in the header that make up the message ID.
  *        No other values in the header are modified.
  *
+ *        The user should ensure that this function is only called with a valid
+ *        MsgId parameter value.  If called with an invalid value, the results
+ *        are implementation-defined.  The implementation may or may not return
+ *        the error code #CFE_MSG_BAD_ARGUMENT in this case.
+ *
  * \param[in, out]  MsgPtr      A pointer to the buffer that contains the message @nonnull.
  * \param[in]       MsgId       Message id
  *


### PR DESCRIPTION
**Describe the contribution**
Updates the test case for "CFE_MSG_SetMsgId()" to write a value that is outside the set of storable values for MsgId.  This currently
uses the value "-1" do this, assuming that this translates to a value with all bits set, and at least one of those bits will not correlate with an actual header field.

Caveat is that in other implementations, it is possible that all bits are storeable in the header.  That is, all MsgId values can be stored in a message or vice versa, even those MsgIds which are not route-able in SB.  

This also updates the documentation of CFE_MSG_SetMsgId to clarify if/when the CFE_MSG_BAD_ARGUMENT status code is returned, and that the set of MsgId values which are "settable" really depends on the MSG implementation.

Fixes #1949 

**Testing performed**
Build and sanity check CFE, run all tests.

**Expected behavior changes**
None with default MSG implementation and current config.

**System(s) tested on**
Ubuntu

**Additional context**
Note that the "CFE_SB_IsValidMsgId" and the related constants `CFE_SB_INVALID_MSG_ID` and `CFE_PLATFORM_SB_HIGHEST_VALID_MSGID` are really pertinent message routing in SB and SBR, more so than MSG.  

The general concept of what constitutes a "valid" msgid is different for MSG than SB/SBR.  For MSG it is just a matter of how many bits the real header has, and how this bits are mapped between the header and CFE_SB_MsgId_t type.  For example there are values which are "storable" in the CCSDS primary header, but are not valid for SB/SBR or usable with CFE.

In particular, it is possible that an application might be serving as an intermediate node in a DTN network - in which case it might need to decode and/or encode messages which are not actually routed on the CFE software bus at all.  It should be SB (and SBR) domain to determine if a MsgId is route-able.  MSG only should care if it is store-able in the header.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.