### PR TITLE
Fix #1952, patch for recursive event loop

### DIFF
--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -1503,24 +1503,42 @@ int32 CFE_SB_TransmitMsgValidate(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t
         switch (PendingEventID)
         {
             case CFE_SB_SEND_BAD_ARG_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_SEND_BAD_ARG_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
-                                           "Send Err:Bad input argument,Arg 0x%lx,App %s", (unsigned long)MsgPtr,
-                                           CFE_SB_GetAppTskName(TskId, FullName));
+                if (CFE_SB_RequestToSendEvent(TskId, CFE_SB_SEND_BAD_ARG_EID_BIT) == CFE_SB_GRANTED)
+                {
+                    CFE_EVS_SendEventWithAppID(CFE_SB_SEND_BAD_ARG_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
+                                               "Send Err:Bad input argument,Arg 0x%lx,App %s", (unsigned long)MsgPtr,
+                                               CFE_SB_GetAppTskName(TskId, FullName));
+
+                    /* clear the bit so the task may send this event again */
+                    CFE_SB_FinishSendEvent(TskId, CFE_SB_SEND_BAD_ARG_EID_BIT);
+                }
                 break;
 
             case CFE_SB_SEND_INV_MSGID_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_SEND_INV_MSGID_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
-                                           "Send Err:Invalid MsgId(0x%x)in msg,App %s",
-                                           (unsigned int)CFE_SB_MsgIdToValue(*MsgIdPtr),
-                                           CFE_SB_GetAppTskName(TskId, FullName));
+                if (CFE_SB_RequestToSendEvent(TskId, CFE_SB_SEND_INV_MSGID_EID_BIT) == CFE_SB_GRANTED)
+                {
+                    CFE_EVS_SendEventWithAppID(CFE_SB_SEND_INV_MSGID_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
+                                               "Send Err:Invalid MsgId(0x%x)in msg,App %s",
+                                               (unsigned int)CFE_SB_MsgIdToValue(*MsgIdPtr),
+                                               CFE_SB_GetAppTskName(TskId, FullName));
+
+                    /* clear the bit so the task may send this event again */
+                    CFE_SB_FinishSendEvent(TskId, CFE_SB_SEND_INV_MSGID_EID_BIT);
+                }
                 break;
 
             case CFE_SB_MSG_TOO_BIG_EID:
-                CFE_EVS_SendEventWithAppID(CFE_SB_MSG_TOO_BIG_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
-                                           "Send Err:Msg Too Big MsgId=0x%x,app=%s,size=%d,MaxSz=%d",
-                                           (unsigned int)CFE_SB_MsgIdToValue(*MsgIdPtr),
-                                           CFE_SB_GetAppTskName(TskId, FullName), (int)*SizePtr,
-                                           CFE_MISSION_SB_MAX_SB_MSG_SIZE);
+                if (CFE_SB_RequestToSendEvent(TskId, CFE_SB_MSG_TOO_BIG_EID_BIT) == CFE_SB_GRANTED)
+                {
+                    CFE_EVS_SendEventWithAppID(CFE_SB_MSG_TOO_BIG_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
+                                               "Send Err:Msg Too Big MsgId=0x%x,app=%s,size=%d,MaxSz=%d",
+                                               (unsigned int)CFE_SB_MsgIdToValue(*MsgIdPtr),
+                                               CFE_SB_GetAppTskName(TskId, FullName), (int)*SizePtr,
+                                               CFE_MISSION_SB_MAX_SB_MSG_SIZE);
+
+                    /* clear the bit so the task may send this event again */
+                    CFE_SB_FinishSendEvent(TskId, CFE_SB_MSG_TOO_BIG_EID_BIT);
+                }
                 break;
 
             case CFE_SB_SEND_NO_SUBS_EID:

--- a/modules/sb/fsw/src/cfe_sb_priv.h
+++ b/modules/sb/fsw/src/cfe_sb_priv.h
@@ -90,12 +90,14 @@
 #define CFE_SB_FILE_IO_ERR   (-5)
 
 /* bit map for stopping recursive event problem */
-#define CFE_SB_SEND_NO_SUBS_EID_BIT  0
-#define CFE_SB_GET_BUF_ERR_EID_BIT   1
-#define CFE_SB_MSGID_LIM_ERR_EID_BIT 2
-#define CFE_SB_Q_FULL_ERR_EID_BIT    3
-#define CFE_SB_Q_WR_ERR_EID_BIT      4
-
+#define CFE_SB_SEND_NO_SUBS_EID_BIT   0
+#define CFE_SB_GET_BUF_ERR_EID_BIT    1
+#define CFE_SB_MSGID_LIM_ERR_EID_BIT  2
+#define CFE_SB_Q_FULL_ERR_EID_BIT     3
+#define CFE_SB_Q_WR_ERR_EID_BIT       4
+#define CFE_SB_SEND_BAD_ARG_EID_BIT   5
+#define CFE_SB_SEND_INV_MSGID_EID_BIT 6
+#define CFE_SB_MSG_TOO_BIG_EID_BIT    7
 /*
 ** Type Definitions
 */

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -4545,6 +4545,37 @@ void Test_SB_TransmitMsgPaths_Nominal(void)
 
     CFE_UtAssert_EVENTCOUNT(3);
 
+    /*
+     * Test Additional paths within CFE_SB_TransmitMsgValidate that skip sending events to avoid a loop
+     * For all of these they should skip sending the event but still increment the MsgSendErrorCounter
+     */
+
+    /* CFE_SB_MSG_TOO_BIG_EID loop filter */
+    CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter = 0;
+    Size                                               = CFE_MISSION_SB_MAX_SB_MSG_SIZE + 1;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
+    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_MSG_TOO_BIG_EID_BIT);
+    CFE_SB_TransmitMsg(&Housekeeping.SBBuf.Msg, true);
+    CFE_UtAssert_EVENTNOTSENT(CFE_SB_MSG_TOO_BIG_EID);
+    UtAssert_UINT32_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter, 1);
+
+    /* CFE_SB_SEND_INV_MSGID_EID loop filter */
+    CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter = 0;
+    MsgId                                              = CFE_SB_INVALID_MSG_ID;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
+    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_SEND_INV_MSGID_EID_BIT);
+    CFE_SB_TransmitMsg(&Housekeeping.SBBuf.Msg, true);
+    CFE_UtAssert_EVENTNOTSENT(CFE_SB_SEND_INV_MSGID_EID);
+    UtAssert_UINT32_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter, 1);
+
+    /* CFE_SB_SEND_BAD_ARG_EID loop filter */
+    CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter = 0;
+    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_SEND_BAD_ARG_EID_BIT);
+    CFE_SB_TransmitMsg(NULL, true);
+    CFE_UtAssert_EVENTNOTSENT(CFE_SB_SEND_BAD_ARG_EID);
+    UtAssert_UINT32_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter, 1);
+
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
 } /* end Test_SB_TransmitMsgPaths */
 


### PR DESCRIPTION
**Describe the contribution**
Adds CFE_SB_RequestToSendEvent/CFE_SB_FinishSendEvent wrappers around all events generated by CFE_SB_TransmitMsgValidate.  This is avoids the potential for a recursive loop if configured improperly.

Fixes #1952

**Testing performed**
Build and sanity check CFE, run all tests.

**Expected behavior changes**
Tested with the mis-configuration where EVS had an invalid MID and confirmed that the system does not get into a recursive loop and segfault anymore.

**System(s) tested on**
Ubuntu

**Additional context**
This is just a minimal patch that does not change current architecture but avoids a crash.  A better fix for future versions would be to put this recursion protection into EVS in a more generic manner.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
