### PR TITLE
Fix #1955, Add static local to function test so data section is nonzero

### DIFF
--- a/modules/cfe_testcase/src/cfe_test.c
+++ b/modules/cfe_testcase/src/cfe_test.c
@@ -41,6 +41,9 @@ CFE_FT_Global_t CFE_FT_Global;
  */
 void CFE_TestMain(void)
 {
+    /* Static local so data section is not zero when checking app info */
+    static char TestName[] = "CFE API";
+
     /* Constant Table information used by all table tests */
     CFE_FT_Global.TblName           = "TestTable";
     CFE_FT_Global.RegisteredTblName = "CFE_TEST_APP.TestTable";
@@ -52,7 +55,7 @@ void CFE_TestMain(void)
      * Note this also waits for the appropriate overall system
      * state and gets ownership of the UtAssert subsystem
      */
-    CFE_Assert_RegisterTest("CFE API");
+    CFE_Assert_RegisterTest(TestName);
     CFE_Assert_OpenLogFile(CFE_ASSERT_LOG_FILE_NAME);
 
     /*


### PR DESCRIPTION
**Describe the contribution**
- Fix #1955 

Added a static local (TestName) just to make the data section nonzero so the test will pass when the addresses are valid.

**Testing performed**
Tested on MCP750

**Expected behavior changes**
Nonzero data section (size and address)

**System(s) tested on**
 - Hardware: MCP750
 - OS: VxWorks 6.9
 - Versions: Bundle main + #1953 + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC