### PR TITLE
Fix #1961, Single time domain in functional time tests

### DIFF
--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -70,7 +70,7 @@ extern CFE_FT_Global_t CFE_FT_Global;
  */
 #define CFE_ASSERT_LOG_FILE_NAME "/cf/cfe_test.log"
 
-bool TimeInRange(CFE_TIME_SysTime_t Time, CFE_TIME_SysTime_t Target, OS_time_t difference);
+void TimeInRange(CFE_TIME_SysTime_t Start, CFE_TIME_SysTime_t Time, CFE_TIME_SysTime_t Range, const char *Str);
 
 void CFE_TestMain(void);
 void ESApplicationControlTestSetup(void);

--- a/modules/cfe_testcase/src/time_conversion_test.c
+++ b/modules/cfe_testcase/src/time_conversion_test.c
@@ -34,62 +34,25 @@ void TestConvertMET2SCTime(void)
 {
     UtPrintf("Testing: CFE_TIME_MET2SCTime");
 
-    /* Mission Elapsed Time */
-    CFE_TIME_SysTime_t MET;
-    /* MET + SCTF */
-    CFE_TIME_SysTime_t TAI;
-    /* MET + SCTF - Leap Seconds */
-    CFE_TIME_SysTime_t UTC;
-    /* Spacecraft Time */
+    CFE_TIME_SysTime_t METStart;
+    CFE_TIME_SysTime_t METEnd;
+    CFE_TIME_SysTime_t Time;
     CFE_TIME_SysTime_t SCTime;
 
-    OS_time_t start;
-    OS_time_t end;
-    OS_time_t difference;
-
-    /* Print buffers */
-    char timeBuf1[sizeof("yyyy-ddd-hh:mm:ss.xxxxx_")];
-    char timeBuf2[sizeof("yyyy-ddd-hh:mm:ss.xxxxx_")];
-
-    OS_GetLocalTime(&start);
+    CFE_TIME_SysTime_t Range;
 
     /* Get Times */
-    MET = CFE_TIME_GetMET();
-    TAI = CFE_TIME_GetTAI();
-    UTC = CFE_TIME_GetUTC();
+    METStart = CFE_TIME_GetMET();
+    Time     = CFE_TIME_GetTime();
+    METEnd   = CFE_TIME_GetMET();
 
-    OS_GetLocalTime(&end);
+    Range = CFE_TIME_Subtract(METEnd, METStart);
 
     /* Convert - should produce a TAI or UTC at the moment of GetMET() */
-    SCTime = CFE_TIME_MET2SCTime(MET);
-
-    /* write Spacecraft Time into second buffer */
-    CFE_TIME_Print(timeBuf2, SCTime);
-
-    difference = OS_TimeSubtract(end, start);
+    SCTime = CFE_TIME_MET2SCTime(METStart);
 
     /* Check conversion */
-#if (CFE_MISSION_TIME_CFG_DEFAULT_TAI == true)
-    /* SCTime is TAI format */
-
-    /* avoid unused compiler warning */
-    (void)UTC;
-
-    /* write TAI into first buffer */
-    CFE_TIME_Print(timeBuf1, TAI);
-
-    UtAssert_True(TimeInRange(SCTime, TAI, difference), "TAI (%s) = MET2SCTime (%s)", timeBuf1, timeBuf2);
-#else
-    /* SCTime is UTC format */
-
-    /* avoid unused compiler warning */
-    (void)TAI;
-
-    /* write UTC into first buffer */
-    CFE_TIME_Print(timeBuf1, UTC);
-
-    UtAssert_True(TimeInRange(SCTime, UTC, difference), "UTC (%s) = MET2SCTime (%s)", timeBuf1, timeBuf2);
-#endif
+    TimeInRange(SCTime, Time, Range, "MET to SC Time vs default time");
 }
 
 void TestConvertSubSeconds2MicroSeconds(void)


### PR DESCRIPTION
**Describe the contribution**
- Fix #1961 

Functional test now uses consistent API's for bounding time, also fixed likely issue with MET rollover causing a false failure.

**Testing performed**
Build and ran on linux and MCP750, passed

**Expected behavior changes**
Functional test now passes on systems where OS_GetLocalTime resolution is less than CFE_PSP_GetTime.

**System(s) tested on**
 - Hardware: Intel i5/Docker, MCP750
 - OS: Ubuntu 18.04, VxWorks 6.9
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC