### PR TITLE
Fix #1963, Use existing /ram for FS header test

### DIFF
--- a/modules/cfe_testcase/src/fs_header_test.c
+++ b/modules/cfe_testcase/src/fs_header_test.c
@@ -33,14 +33,12 @@
 
 #include "cfe_test.h"
 
-#define OS_TEST_HEADER_FILENAME "/drive0/header_test.txt"
+#define OS_TEST_HEADER_FILENAME "/ram/header_test.txt"
 char *fsAddrPtr = NULL;
 
 static osal_id_t setup_file(void)
 {
     osal_id_t id;
-    OS_mkfs(fsAddrPtr, "/ramdev1", "RAM", 512, 20);
-    OS_mount("/ramdev1", "/drive0");
     UtAssert_INT32_EQ(OS_OpenCreate(&id, OS_TEST_HEADER_FILENAME, OS_FILE_FLAG_CREATE, OS_READ_WRITE), OS_SUCCESS);
     return id;
 }


### PR DESCRIPTION
**Describe the contribution**
- Fix #1963 

Removes OS_mkfs/OS_mount in the FS header functional test and replaces with just using existing /ram.  This avoids RAM being reformatted on the MCP750 mid-functional which was causing the table tests to fail since the tables created at the beginning of the function no longer existed.  Note any system that runs out of RAM would also not handle this well...

**Testing performed**
Tested on both Linux and VxWorks

**Expected behavior changes**
No longer formats RAM mid-test on MCP750

**System(s) tested on**
 - Hardware: Intel i5/Docker, MCP750
 - OS: Ubuntu 18.04, VxWorks 6.9
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC