### PR TITLE
Fix #1965, better message type pointer conversion

### DIFF
--- a/modules/cfe_testcase/src/msg_api_test.c
+++ b/modules/cfe_testcase/src/msg_api_test.c
@@ -54,75 +54,76 @@ void TestMsgApiBasic(void)
 
     /* test msg-init */
     UtAssert_INT32_EQ(CFE_MSG_Init(NULL, CFE_SB_ValueToMsgId(0), sizeof(cmd)), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_Init(&cmd.Msg, msgId, 0), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_Init(&cmd.Msg, CFE_PLATFORM_SB_HIGHEST_VALID_MSGID + 1, sizeof(cmd)),
-                      CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_Init(CFE_MSG_PTR(cmd), msgId, 0), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(
+        CFE_MSG_Init(CFE_MSG_PTR(cmd), CFE_SB_ValueToMsgId(CFE_PLATFORM_SB_HIGHEST_VALID_MSGID + 1), sizeof(cmd)),
+        CFE_MSG_BAD_ARGUMENT);
 
-    UtAssert_INT32_EQ(CFE_MSG_Init(&cmd.Msg, msgId, sizeof(cmd)), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_Init(CFE_MSG_PTR(cmd), msgId, sizeof(cmd)), CFE_SUCCESS);
 
     /* test set-msg-size */
     UtAssert_INT32_EQ(CFE_MSG_SetSize(NULL, 12), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_SetSize(&cmd.Msg, 0), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_SetSize(&cmd.Msg, UINT32_MAX), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_SetSize(CFE_MSG_PTR(cmd), 0), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_SetSize(CFE_MSG_PTR(cmd), UINT32_MAX), CFE_MSG_BAD_ARGUMENT);
 
-    UtAssert_INT32_EQ(CFE_MSG_SetSize(&cmd.Msg, 12), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetSize(CFE_MSG_PTR(cmd), 12), CFE_SUCCESS);
 
     /* test get-msg-size */
     UtAssert_INT32_EQ(CFE_MSG_GetSize(NULL, &size), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_GetSize(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_GetSize(CFE_MSG_PTR(cmd), NULL), CFE_MSG_BAD_ARGUMENT);
 
-    UtAssert_INT32_EQ(CFE_MSG_GetSize(&cmd.Msg, &size), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_GetSize(CFE_MSG_PTR(cmd), &size), CFE_SUCCESS);
     UtAssert_UINT32_EQ(size, 12);
 
     /* test get-type */
     UtAssert_INT32_EQ(CFE_MSG_SetType(NULL, CFE_MSG_Type_Cmd), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_SetType(&cmd.Msg, CFE_MSG_Type_Invalid), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_SetType(CFE_MSG_PTR(cmd), CFE_MSG_Type_Invalid), CFE_MSG_BAD_ARGUMENT);
 
-    UtAssert_INT32_EQ(CFE_MSG_SetType(&cmd.Msg, CFE_MSG_Type_Cmd), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetType(CFE_MSG_PTR(cmd), CFE_MSG_Type_Cmd), CFE_SUCCESS);
 
     UtAssert_INT32_EQ(CFE_MSG_GetType(NULL, &type), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_GetType(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_GetType(CFE_MSG_PTR(cmd), NULL), CFE_MSG_BAD_ARGUMENT);
 
-    UtAssert_INT32_EQ(CFE_MSG_GetType(&cmd.Msg, &type), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_GetType(CFE_MSG_PTR(cmd), &type), CFE_SUCCESS);
     UtAssert_INT32_EQ(type, CFE_MSG_Type_Cmd);
 
     /* test msg set-type */
-    UtAssert_INT32_EQ(CFE_MSG_SetType(&cmd.Msg, CFE_MSG_Type_Tlm), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetType(CFE_MSG_PTR(cmd), CFE_MSG_Type_Tlm), CFE_SUCCESS);
     /* check if set-type works like expected */
-    UtAssert_INT32_EQ(CFE_MSG_GetType(&cmd.Msg, &type), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_GetType(CFE_MSG_PTR(cmd), &type), CFE_SUCCESS);
     UtAssert_INT32_EQ(type, CFE_MSG_Type_Tlm);
 
     /* test get header-version */
     UtAssert_INT32_EQ(CFE_MSG_GetHeaderVersion(NULL, &hdrVer), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_GetHeaderVersion(&cmd.Msg, &hdrVer), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_MSG_GetHeaderVersion(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_GetHeaderVersion(CFE_MSG_PTR(cmd), &hdrVer), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_GetHeaderVersion(CFE_MSG_PTR(cmd), NULL), CFE_MSG_BAD_ARGUMENT);
 
     /* test set header-version */
     UtAssert_INT32_EQ(CFE_MSG_SetHeaderVersion(NULL, hdrVer), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_SetHeaderVersion(&cmd.Msg, UINT16_MAX), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_SetHeaderVersion(&cmd.Msg, 0), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_MSG_GetHeaderVersion(&cmd.Msg, &hdrVer), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetHeaderVersion(CFE_MSG_PTR(cmd), UINT16_MAX), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_SetHeaderVersion(CFE_MSG_PTR(cmd), 0), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_GetHeaderVersion(CFE_MSG_PTR(cmd), &hdrVer), CFE_SUCCESS);
     UtAssert_True(hdrVer == 0, "hdrVer = 0");
 
     /* test get-has-secondary-header and set-has-secondary-header*/
     UtAssert_INT32_EQ(CFE_MSG_GetHasSecondaryHeader(NULL, &_expected), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_GetHasSecondaryHeader(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_GetHasSecondaryHeader(CFE_MSG_PTR(cmd), NULL), CFE_MSG_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_MSG_SetHasSecondaryHeader(NULL, _expected), CFE_MSG_BAD_ARGUMENT);
 
-    UtAssert_INT32_EQ(CFE_MSG_SetHasSecondaryHeader(&cmd.Msg, _expected), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_MSG_GetHasSecondaryHeader(&cmd.Msg, &_returned), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetHasSecondaryHeader(CFE_MSG_PTR(cmd), _expected), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_GetHasSecondaryHeader(CFE_MSG_PTR(cmd), &_returned), CFE_SUCCESS);
     UtAssert_UINT32_EQ(_expected, _returned);
 
     /* test get-apid */
     UtAssert_INT32_EQ(CFE_MSG_GetApId(NULL, &appId), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_GetApId(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_GetApId(CFE_MSG_PTR(cmd), NULL), CFE_MSG_BAD_ARGUMENT);
 
     /* test set-apid */
-    UtAssert_INT32_EQ(CFE_MSG_SetApId(&cmd.Msg, 0xFFFF), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_SetApId(CFE_MSG_PTR(cmd), 0xFFFF), CFE_MSG_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_MSG_SetApId(NULL, 0), CFE_MSG_BAD_ARGUMENT);
 
-    UtAssert_INT32_EQ(CFE_MSG_SetApId(&cmd.Msg, 5), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_MSG_GetApId(&cmd.Msg, &appId), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetApId(CFE_MSG_PTR(cmd), 5), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_GetApId(CFE_MSG_PTR(cmd), &appId), CFE_SUCCESS);
     UtAssert_INT32_EQ(appId, 5);
 }
 
@@ -140,30 +141,30 @@ void TestMsgApiAdvanced(void)
     memset(&cmd, 0xFF, sizeof(cmd));
     msgId = CFE_SB_ValueToMsgId(0);
 
-    UtAssert_INT32_EQ(CFE_MSG_Init(&cmd.Msg, msgId, sizeof(cmd)), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_Init(CFE_MSG_PTR(cmd), msgId, sizeof(cmd)), CFE_SUCCESS);
 
     /* test get/set-segmentation-flag */
     UtAssert_INT32_EQ(CFE_MSG_GetSegmentationFlag(NULL, &segFlag), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_GetSegmentationFlag(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_GetSegmentationFlag(CFE_MSG_PTR(cmd), NULL), CFE_MSG_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_MSG_SetSegmentationFlag(NULL, CFE_MSG_SegFlag_Continue), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_SetSegmentationFlag(&cmd.Msg, CFE_MSG_SegFlag_Invalid), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_SetSegmentationFlag(CFE_MSG_PTR(cmd), CFE_MSG_SegFlag_Invalid), CFE_MSG_BAD_ARGUMENT);
 
-    UtAssert_INT32_EQ(CFE_MSG_SetSegmentationFlag(&cmd.Msg, CFE_MSG_SegFlag_Continue), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_MSG_SetSegmentationFlag(&cmd.Msg, CFE_MSG_SegFlag_First), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_MSG_SetSegmentationFlag(&cmd.Msg, CFE_MSG_SegFlag_Last), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_MSG_SetSegmentationFlag(&cmd.Msg, CFE_MSG_SegFlag_Unsegmented), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_MSG_GetSegmentationFlag(&cmd.Msg, &segFlag), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetSegmentationFlag(CFE_MSG_PTR(cmd), CFE_MSG_SegFlag_Continue), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetSegmentationFlag(CFE_MSG_PTR(cmd), CFE_MSG_SegFlag_First), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetSegmentationFlag(CFE_MSG_PTR(cmd), CFE_MSG_SegFlag_Last), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetSegmentationFlag(CFE_MSG_PTR(cmd), CFE_MSG_SegFlag_Unsegmented), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_GetSegmentationFlag(CFE_MSG_PTR(cmd), &segFlag), CFE_SUCCESS);
     UtAssert_UINT32_EQ(segFlag, CFE_MSG_SegFlag_Unsegmented);
 
     /* test set/get-sequence-count */
     UtAssert_INT32_EQ(CFE_MSG_SetSequenceCount(NULL, 2), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_SetSequenceCount(&cmd.Msg, UINT16_MAX), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_SetSequenceCount(CFE_MSG_PTR(cmd), UINT16_MAX), CFE_MSG_BAD_ARGUMENT);
 
     UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(NULL, &seqCnt), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(CFE_MSG_PTR(cmd), NULL), CFE_MSG_BAD_ARGUMENT);
 
-    UtAssert_INT32_EQ(CFE_MSG_SetSequenceCount(&cmd.Msg, 2), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&cmd.Msg, &seqCnt), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetSequenceCount(CFE_MSG_PTR(cmd), 2), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(CFE_MSG_PTR(cmd), &seqCnt), CFE_SUCCESS);
     UtAssert_INT32_EQ(seqCnt, 2);
 
     /* test get-next-sequence-count */
@@ -191,17 +192,17 @@ void TestMsgHeaderSecondaryApi(void)
     memset(&cmd2, 0xFF, sizeof(cmd2));
 
     /* msg-init */
-    UtAssert_INT32_EQ(CFE_MSG_Init(&cmd.Msg, CFE_SB_ValueToMsgId(0), sizeof(cmd)), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_MSG_SetHasSecondaryHeader(&cmd.Msg, true), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_MSG_SetType(&cmd.Msg, CFE_MSG_Type_Cmd), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_Init(CFE_MSG_PTR(cmd), CFE_SB_ValueToMsgId(1), sizeof(cmd)), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetHasSecondaryHeader(CFE_MSG_PTR(cmd), true), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetType(CFE_MSG_PTR(cmd), CFE_MSG_Type_Cmd), CFE_SUCCESS);
 
-    UtAssert_INT32_EQ(CFE_MSG_Init(&cmdTlm.Msg, CFE_SB_ValueToMsgId(1), sizeof(cmdTlm)), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_MSG_SetHasSecondaryHeader(&cmdTlm.Msg, true), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_MSG_SetType(&cmdTlm.Msg, CFE_MSG_Type_Tlm), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_Init(CFE_MSG_PTR(cmdTlm), CFE_SB_ValueToMsgId(2), sizeof(cmdTlm)), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetHasSecondaryHeader(CFE_MSG_PTR(cmdTlm), true), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetType(CFE_MSG_PTR(cmdTlm), CFE_MSG_Type_Tlm), CFE_SUCCESS);
 
-    UtAssert_INT32_EQ(CFE_MSG_Init(&cmd2.Msg, CFE_SB_ValueToMsgId(2), sizeof(cmd2)), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_MSG_SetHasSecondaryHeader(&cmd2.Msg, true), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_MSG_SetType(&cmd2.Msg, CFE_MSG_Type_Cmd), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_Init(CFE_MSG_PTR(cmd2), CFE_SB_ValueToMsgId(3), sizeof(cmd2)), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetHasSecondaryHeader(CFE_MSG_PTR(cmd2), true), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetType(CFE_MSG_PTR(cmd2), CFE_MSG_Type_Cmd), CFE_SUCCESS);
 
     /* test generate-checksum */
     status = CFE_MSG_GenerateChecksum(NULL);
@@ -212,37 +213,37 @@ void TestMsgHeaderSecondaryApi(void)
     else
     {
         UtAssert_INT32_EQ(CFE_MSG_GenerateChecksum(NULL), CFE_MSG_BAD_ARGUMENT);
-        UtAssert_INT32_EQ(CFE_MSG_GenerateChecksum(&cmdTlm.Msg), CFE_MSG_WRONG_MSG_TYPE);
-        UtAssert_INT32_EQ(CFE_MSG_ValidateChecksum(&cmdTlm.Msg, &isValid), CFE_MSG_WRONG_MSG_TYPE);
+        UtAssert_INT32_EQ(CFE_MSG_GenerateChecksum(CFE_MSG_PTR(cmdTlm)), CFE_MSG_WRONG_MSG_TYPE);
+        UtAssert_INT32_EQ(CFE_MSG_ValidateChecksum(CFE_MSG_PTR(cmdTlm), &isValid), CFE_MSG_WRONG_MSG_TYPE);
         UtAssert_INT32_EQ(CFE_MSG_ValidateChecksum(NULL, &isValid), CFE_MSG_BAD_ARGUMENT);
-        UtAssert_INT32_EQ(CFE_MSG_ValidateChecksum(&cmdTlm.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
+        UtAssert_INT32_EQ(CFE_MSG_ValidateChecksum(CFE_MSG_PTR(cmdTlm), NULL), CFE_MSG_BAD_ARGUMENT);
 
-        UtAssert_INT32_EQ(CFE_MSG_ValidateChecksum(&cmd.Msg, &isValid), CFE_SUCCESS);
+        UtAssert_INT32_EQ(CFE_MSG_ValidateChecksum(CFE_MSG_PTR(cmd), &isValid), CFE_SUCCESS);
         UtAssert_True(!isValid, "Checksum isValid (%d) = false", isValid);
-        UtAssert_INT32_EQ(CFE_MSG_GenerateChecksum(&cmd.Msg), CFE_SUCCESS);
-        UtAssert_INT32_EQ(CFE_MSG_ValidateChecksum(&cmd.Msg, &isValid), CFE_SUCCESS);
+        UtAssert_INT32_EQ(CFE_MSG_GenerateChecksum(CFE_MSG_PTR(cmd)), CFE_SUCCESS);
+        UtAssert_INT32_EQ(CFE_MSG_ValidateChecksum(CFE_MSG_PTR(cmd), &isValid), CFE_SUCCESS);
         UtAssert_True(isValid, "Checksum isValid (%d) = true", isValid);
     }
 
     /* test get/set-fcn-code */
     UtAssert_INT32_EQ(CFE_MSG_SetFcnCode(NULL, 4), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_SetFcnCode(&cmdTlm.Msg, 4), CFE_MSG_WRONG_MSG_TYPE);
+    UtAssert_INT32_EQ(CFE_MSG_SetFcnCode(CFE_MSG_PTR(cmdTlm), 4), CFE_MSG_WRONG_MSG_TYPE);
 
-    UtAssert_INT32_EQ(CFE_MSG_GetFcnCode(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_GetFcnCode(CFE_MSG_PTR(cmd), NULL), CFE_MSG_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_MSG_GetFcnCode(NULL, &fcnCode), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_GetFcnCode(&cmdTlm.Msg, &fcnCode), CFE_MSG_WRONG_MSG_TYPE);
+    UtAssert_INT32_EQ(CFE_MSG_GetFcnCode(CFE_MSG_PTR(cmdTlm), &fcnCode), CFE_MSG_WRONG_MSG_TYPE);
 
-    UtAssert_INT32_EQ(CFE_MSG_SetFcnCode(&cmd.Msg, 4), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_MSG_GetFcnCode(&cmd.Msg, &fcnCode), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetFcnCode(CFE_MSG_PTR(cmd), 4), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_GetFcnCode(CFE_MSG_PTR(cmd), &fcnCode), CFE_SUCCESS);
     UtAssert_INT32_EQ(fcnCode, 4);
 
     /* test get/set-msg-time */
-    UtAssert_INT32_EQ(CFE_MSG_SetType(&cmd.Msg, CFE_MSG_Type_Tlm), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetType(CFE_MSG_PTR(cmd), CFE_MSG_Type_Tlm), CFE_SUCCESS);
 
     UtAssert_INT32_EQ(CFE_MSG_GetMsgTime(NULL, &msgTime), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_GetMsgTime(&cmd.Msg, NULL), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_GetMsgTime(CFE_MSG_PTR(cmd), NULL), CFE_MSG_BAD_ARGUMENT);
 
-    CFE_Assert_STATUS_STORE(CFE_MSG_GetMsgTime(&cmd2.Msg, &msgTime));
+    CFE_Assert_STATUS_STORE(CFE_MSG_GetMsgTime(CFE_MSG_PTR(cmd2), &msgTime));
     if (!CFE_Assert_STATUS_MAY_BE(CFE_SUCCESS))
     {
         CFE_Assert_STATUS_MUST_BE(CFE_MSG_WRONG_MSG_TYPE);
@@ -250,14 +251,14 @@ void TestMsgHeaderSecondaryApi(void)
 
     UtAssert_INT32_EQ(CFE_MSG_SetMsgTime(NULL, currentTime), CFE_MSG_BAD_ARGUMENT);
 
-    CFE_Assert_STATUS_STORE(CFE_MSG_SetMsgTime(&cmd2.Msg, currentTime));
+    CFE_Assert_STATUS_STORE(CFE_MSG_SetMsgTime(CFE_MSG_PTR(cmd2), currentTime));
     if (!CFE_Assert_STATUS_MAY_BE(CFE_SUCCESS))
     {
         CFE_Assert_STATUS_MUST_BE(CFE_MSG_WRONG_MSG_TYPE);
     }
 
-    UtAssert_INT32_EQ(CFE_MSG_SetMsgTime(&cmd.Msg, currentTime), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_MSG_GetMsgTime(&cmd.Msg, &msgTime), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_SetMsgTime(CFE_MSG_PTR(cmd), currentTime), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_GetMsgTime(CFE_MSG_PTR(cmd), &msgTime), CFE_SUCCESS);
     UtAssert_UINT32_EQ(CFE_TIME_Compare(msgTime, currentTime), CFE_TIME_EQUAL);
 }
 

--- a/modules/cfe_testcase/src/sb_sendrecv_test.c
+++ b/modules/cfe_testcase/src/sb_sendrecv_test.c
@@ -39,15 +39,15 @@
 /* A simple command message */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t CmdHeader;
-    uint32                  CmdPayload;
+    CFE_MSG_CommandHeader_t CommandHeader;
+    uint64                  CmdPayload;
 } CFE_FT_TestCmdMessage_t;
 
 /* A simple telemetry message */
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t TlmHeader;
-    uint32                    TlmPayload;
+    CFE_MSG_TelemetryHeader_t TelemetryHeader;
+    uint64                    TlmPayload;
 } CFE_FT_TestTlmMessage_t;
 
 /* A message intended to be (overall) larger than the CFE_MISSION_SB_MAX_SB_MSG_SIZE */
@@ -90,34 +90,34 @@ void TestBasicTransmitRecv(void)
     UtAssert_INT32_EQ(CFE_SB_SubscribeEx(CFE_FT_TLM_MSGID, PipeId2, CFE_SB_DEFAULT_QOS, 3), CFE_SUCCESS);
 
     /* Initialize the message content */
-    UtAssert_INT32_EQ(CFE_MSG_Init(&CmdMsg.CmdHeader.Msg, CFE_FT_CMD_MSGID, sizeof(CmdMsg)), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_MSG_Init(&TlmMsg.TlmHeader.Msg, CFE_FT_TLM_MSGID, sizeof(TlmMsg)), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_Init(CFE_MSG_PTR(CmdMsg.CommandHeader), CFE_FT_CMD_MSGID, sizeof(CmdMsg)), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_Init(CFE_MSG_PTR(TlmMsg.TelemetryHeader), CFE_FT_TLM_MSGID, sizeof(TlmMsg)), CFE_SUCCESS);
 
-    CFE_MSG_SetSequenceCount(&CmdMsg.CmdHeader.Msg, 11);
-    CFE_MSG_SetSequenceCount(&TlmMsg.TlmHeader.Msg, 21);
+    CFE_MSG_SetSequenceCount(CFE_MSG_PTR(CmdMsg.CommandHeader), 11);
+    CFE_MSG_SetSequenceCount(CFE_MSG_PTR(TlmMsg.TelemetryHeader), 21);
 
     /* Sending with sequence update should ignore the sequence in the msg struct */
     CmdMsg.CmdPayload = 0x0c0ffee;
     TlmMsg.TlmPayload = 0x0d00d1e;
-    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(&CmdMsg.CmdHeader.Msg, true), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(&TlmMsg.TlmHeader.Msg, true), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(CFE_MSG_PTR(CmdMsg.CommandHeader), true), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmMsg.TelemetryHeader), true), CFE_SUCCESS);
 
     CmdMsg.CmdPayload = 0x1c0ffee;
     TlmMsg.TlmPayload = 0x1d00d1e;
-    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(&CmdMsg.CmdHeader.Msg, true), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(&TlmMsg.TlmHeader.Msg, true), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(CFE_MSG_PTR(CmdMsg.CommandHeader), true), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmMsg.TelemetryHeader), true), CFE_SUCCESS);
 
     /* Sending without sequence update should use the sequence in the msg struct */
     CmdMsg.CmdPayload = 0x2c0ffee;
     TlmMsg.TlmPayload = 0x2d00d1e;
-    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(&CmdMsg.CmdHeader.Msg, false), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(&TlmMsg.TlmHeader.Msg, false), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(CFE_MSG_PTR(CmdMsg.CommandHeader), false), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmMsg.TelemetryHeader), false), CFE_SUCCESS);
 
     /* Sending again should trigger MsgLimit errors on the pipe, however the call still returns CFE_SUCCESS */
     CmdMsg.CmdPayload = 0x3c0ffee;
     TlmMsg.TlmPayload = 0x3d00d1e;
-    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(&CmdMsg.CmdHeader.Msg, true), CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(&TlmMsg.TlmHeader.Msg, true), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(CFE_MSG_PTR(CmdMsg.CommandHeader), true), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmMsg.TelemetryHeader), true), CFE_SUCCESS);
 
     /* Attempt to send a msg which does not have a valid msgid  */
     memset(&CFE_FT_BigMsg, 0xFF, sizeof(CFE_FT_BigMsg));
@@ -247,17 +247,17 @@ void TestMsgBroadcast(void)
     UtAssert_INT32_EQ(CFE_SB_SubscribeEx(CFE_FT_CMD_MSGID, PipeId4, CFE_SB_DEFAULT_QOS, 6), CFE_SUCCESS);
 
     /* Initialize the message content */
-    UtAssert_INT32_EQ(CFE_MSG_Init(&CmdMsg.CmdHeader.Msg, CFE_FT_CMD_MSGID, sizeof(CmdMsg)), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_MSG_Init(CFE_MSG_PTR(CmdMsg.CommandHeader), CFE_FT_CMD_MSGID, sizeof(CmdMsg)), CFE_SUCCESS);
 
     /* Make unique content in each message. Sending should always be successful. */
     CmdMsg.CmdPayload = 0xbabb1e00;
-    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(&CmdMsg.CmdHeader.Msg, true), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(CFE_MSG_PTR(CmdMsg.CommandHeader), true), CFE_SUCCESS);
     CmdMsg.CmdPayload = 0xbabb1e01;
-    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(&CmdMsg.CmdHeader.Msg, true), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(CFE_MSG_PTR(CmdMsg.CommandHeader), true), CFE_SUCCESS);
     CmdMsg.CmdPayload = 0xbabb1e02;
-    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(&CmdMsg.CmdHeader.Msg, true), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(CFE_MSG_PTR(CmdMsg.CommandHeader), true), CFE_SUCCESS);
     CmdMsg.CmdPayload = 0xbabb1e03;
-    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(&CmdMsg.CmdHeader.Msg, true), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(CFE_MSG_PTR(CmdMsg.CommandHeader), true), CFE_SUCCESS);
 
     /* Now receive 1st message from Pipes, actual msg should appear on all (no limit violations here) */
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf1, PipeId1, CFE_SB_POLL), CFE_SUCCESS);
@@ -326,9 +326,9 @@ void TestMsgBroadcast(void)
 
     /* Send two more messages */
     CmdMsg.CmdPayload = 0xbabb1e04;
-    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(&CmdMsg.CmdHeader.Msg, true), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(CFE_MSG_PTR(CmdMsg.CommandHeader), true), CFE_SUCCESS);
     CmdMsg.CmdPayload = 0xbabb1e05;
-    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(&CmdMsg.CmdHeader.Msg, true), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(CFE_MSG_PTR(CmdMsg.CommandHeader), true), CFE_SUCCESS);
 
     /* poll all pipes again, message should appear on all except PipeId2 (Unsubscribed) */
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf1, PipeId1, CFE_SB_POLL), CFE_SUCCESS);

--- a/modules/es/fsw/inc/cfe_es_msg.h
+++ b/modules/es/fsw/inc/cfe_es_msg.h
@@ -1060,7 +1060,7 @@
 */
 typedef struct CFE_ES_NoArgsCmd
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 } CFE_ES_NoArgsCmd_t;
 
 /*
@@ -1093,8 +1093,8 @@ typedef struct CFE_ES_RestartCmd_Payload
  */
 typedef struct CFE_ES_RestartCmd
 {
-    CFE_MSG_CommandHeader_t     CmdHeader; /**< \brief Command header */
-    CFE_ES_RestartCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t     CommandHeader; /**< \brief Command header */
+    CFE_ES_RestartCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_ES_RestartCmd_t;
 
 /**
@@ -1116,8 +1116,8 @@ typedef struct CFE_ES_FileNameCmd_Payload
  */
 typedef struct CFE_ES_FileNameCmd
 {
-    CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
-    CFE_ES_FileNameCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
+    CFE_ES_FileNameCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_ES_FileNameCmd_t;
 
 /*
@@ -1147,8 +1147,8 @@ typedef struct CFE_ES_OverWriteSysLogCmd_Payload
  */
 typedef struct CFE_ES_OverWriteSysLogCmd
 {
-    CFE_MSG_CommandHeader_t             CmdHeader; /**< \brief Command header */
-    CFE_ES_OverWriteSysLogCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t             CommandHeader; /**< \brief Command header */
+    CFE_ES_OverWriteSysLogCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_ES_OverWriteSysLogCmd_t;
 
 /**
@@ -1179,8 +1179,8 @@ typedef struct CFE_ES_StartAppCmd_Payload
  */
 typedef struct CFE_ES_StartApp
 {
-    CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
-    CFE_ES_StartAppCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
+    CFE_ES_StartAppCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_ES_StartAppCmd_t;
 
 /**
@@ -1199,8 +1199,8 @@ typedef struct CFE_ES_AppNameCmd_Payload
  */
 typedef struct CFE_ES_AppNameCmd
 {
-    CFE_MSG_CommandHeader_t     CmdHeader; /**< \brief Command header */
-    CFE_ES_AppNameCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t     CommandHeader; /**< \brief Command header */
+    CFE_ES_AppNameCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_ES_AppNameCmd_t;
 
 /*
@@ -1230,8 +1230,8 @@ typedef struct CFE_ES_AppReloadCmd_Payload
  */
 typedef struct CFE_ES_ReloadAppCmd
 {
-    CFE_MSG_CommandHeader_t       CmdHeader; /**< \brief Command header */
-    CFE_ES_AppReloadCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t       CommandHeader; /**< \brief Command header */
+    CFE_ES_AppReloadCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_ES_ReloadAppCmd_t;
 
 /**
@@ -1251,8 +1251,8 @@ typedef struct CFE_ES_SetMaxPRCountCmd_Payload
  */
 typedef struct CFE_ES_SetMaxPRCountCmd
 {
-    CFE_MSG_CommandHeader_t           CmdHeader; /**< \brief Command header */
-    CFE_ES_SetMaxPRCountCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t           CommandHeader; /**< \brief Command header */
+    CFE_ES_SetMaxPRCountCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_ES_SetMaxPRCountCmd_t;
 
 /**
@@ -1273,8 +1273,8 @@ typedef struct CFE_ES_DeleteCDSCmd_Payload
  */
 typedef struct CFE_ES_DeleteCDSCmd
 {
-    CFE_MSG_CommandHeader_t       CmdHeader; /**< \brief Command header */
-    CFE_ES_DeleteCDSCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t       CommandHeader; /**< \brief Command header */
+    CFE_ES_DeleteCDSCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_ES_DeleteCDSCmd_t;
 
 /**
@@ -1293,8 +1293,8 @@ typedef struct CFE_ES_StartPerfCmd_Payload
  */
 typedef struct CFE_ES_StartPerfDataCmd
 {
-    CFE_MSG_CommandHeader_t       CmdHeader; /**< \brief Command header */
-    CFE_ES_StartPerfCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t       CommandHeader; /**< \brief Command header */
+    CFE_ES_StartPerfCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_ES_StartPerfDataCmd_t;
 
 /**
@@ -1314,8 +1314,8 @@ typedef struct CFE_ES_StopPerfCmd_Payload
  */
 typedef struct CFE_ES_StopPerfDataCmd
 {
-    CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
-    CFE_ES_StopPerfCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
+    CFE_ES_StopPerfCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_ES_StopPerfDataCmd_t;
 
 /**
@@ -1336,8 +1336,8 @@ typedef struct CFE_ES_SetPerfFilterMaskCmd_Payload
  */
 typedef struct CFE_ES_SetPerfFilterMaskCmd
 {
-    CFE_MSG_CommandHeader_t               CmdHeader; /**< \brief Command header */
-    CFE_ES_SetPerfFilterMaskCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t               CommandHeader; /**< \brief Command header */
+    CFE_ES_SetPerfFilterMaskCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_ES_SetPerfFilterMaskCmd_t;
 
 /**
@@ -1358,8 +1358,8 @@ typedef struct CFE_ES_SetPerfTrigMaskCmd_Payload
  */
 typedef struct CFE_ES_SetPerfTriggerMaskCmd
 {
-    CFE_MSG_CommandHeader_t             CmdHeader; /**< \brief Command header */
-    CFE_ES_SetPerfTrigMaskCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t             CommandHeader; /**< \brief Command header */
+    CFE_ES_SetPerfTrigMaskCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_ES_SetPerfTriggerMaskCmd_t;
 
 /**
@@ -1380,8 +1380,8 @@ typedef struct CFE_ES_SendMemPoolStatsCmd_Payload
  */
 typedef struct CFE_ES_SendMemPoolStatsCmd
 {
-    CFE_MSG_CommandHeader_t              CmdHeader; /**< \brief Command header */
-    CFE_ES_SendMemPoolStatsCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t              CommandHeader; /**< \brief Command header */
+    CFE_ES_SendMemPoolStatsCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_ES_SendMemPoolStatsCmd_t;
 
 /**
@@ -1401,8 +1401,8 @@ typedef struct CFE_ES_DumpCDSRegistryCmd_Payload
  */
 typedef struct CFE_ES_DumpCDSRegistryCmd
 {
-    CFE_MSG_CommandHeader_t             CmdHeader; /**< \brief Command header */
-    CFE_ES_DumpCDSRegistryCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t             CommandHeader; /**< \brief Command header */
+    CFE_ES_DumpCDSRegistryCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_ES_DumpCDSRegistryCmd_t;
 
 /*************************************************************************/
@@ -1425,8 +1425,8 @@ typedef struct CFE_ES_OneAppTlm_Payload
 
 typedef struct CFE_ES_OneAppTlm
 {
-    CFE_MSG_TelemetryHeader_t  TlmHeader; /**< \brief Telemetry header */
-    CFE_ES_OneAppTlm_Payload_t Payload;   /**< \brief Telemetry payload */
+    CFE_MSG_TelemetryHeader_t  TelemetryHeader; /**< \brief Telemetry header */
+    CFE_ES_OneAppTlm_Payload_t Payload;         /**< \brief Telemetry payload */
 } CFE_ES_OneAppTlm_t;
 
 /**
@@ -1441,8 +1441,8 @@ typedef struct CFE_ES_PoolStatsTlm_Payload
 
 typedef struct CFE_ES_MemStatsTlm
 {
-    CFE_MSG_TelemetryHeader_t     TlmHeader; /**< \brief Telemetry header */
-    CFE_ES_PoolStatsTlm_Payload_t Payload;   /**< \brief Telemetry payload */
+    CFE_MSG_TelemetryHeader_t     TelemetryHeader; /**< \brief Telemetry header */
+    CFE_ES_PoolStatsTlm_Payload_t Payload;         /**< \brief Telemetry payload */
 } CFE_ES_MemStatsTlm_t;
 
 /*************************************************************************/
@@ -1549,8 +1549,8 @@ typedef struct CFE_ES_HousekeepingTlm_Payload
 
 typedef struct CFE_ES_HousekeepingTlm
 {
-    CFE_MSG_TelemetryHeader_t        TlmHeader; /**< \brief Telemetry header */
-    CFE_ES_HousekeepingTlm_Payload_t Payload;   /**< \brief Telemetry payload */
+    CFE_MSG_TelemetryHeader_t        TelemetryHeader; /**< \brief Telemetry header */
+    CFE_ES_HousekeepingTlm_Payload_t Payload;         /**< \brief Telemetry payload */
 
 } CFE_ES_HousekeepingTlm_t;
 

--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -393,20 +393,20 @@ int32 CFE_ES_TaskInit(void)
     /*
     ** Initialize housekeeping packet (clear user data area)
     */
-    CFE_MSG_Init(&CFE_ES_Global.TaskData.HkPacket.TlmHeader.Msg, CFE_SB_ValueToMsgId(CFE_ES_HK_TLM_MID),
+    CFE_MSG_Init(CFE_MSG_PTR(CFE_ES_Global.TaskData.HkPacket.TelemetryHeader), CFE_SB_ValueToMsgId(CFE_ES_HK_TLM_MID),
                  sizeof(CFE_ES_Global.TaskData.HkPacket));
 
     /*
     ** Initialize single application telemetry packet
     */
-    CFE_MSG_Init(&CFE_ES_Global.TaskData.OneAppPacket.TlmHeader.Msg, CFE_SB_ValueToMsgId(CFE_ES_APP_TLM_MID),
-                 sizeof(CFE_ES_Global.TaskData.OneAppPacket));
+    CFE_MSG_Init(CFE_MSG_PTR(CFE_ES_Global.TaskData.OneAppPacket.TelemetryHeader),
+                 CFE_SB_ValueToMsgId(CFE_ES_APP_TLM_MID), sizeof(CFE_ES_Global.TaskData.OneAppPacket));
 
     /*
     ** Initialize memory pool statistics telemetry packet
     */
-    CFE_MSG_Init(&CFE_ES_Global.TaskData.MemStatsPacket.TlmHeader.Msg, CFE_SB_ValueToMsgId(CFE_ES_MEMSTATS_TLM_MID),
-                 sizeof(CFE_ES_Global.TaskData.MemStatsPacket));
+    CFE_MSG_Init(CFE_MSG_PTR(CFE_ES_Global.TaskData.MemStatsPacket.TelemetryHeader),
+                 CFE_SB_ValueToMsgId(CFE_ES_MEMSTATS_TLM_MID), sizeof(CFE_ES_Global.TaskData.MemStatsPacket));
 
     /*
     ** Create Software Bus message pipe
@@ -839,8 +839,8 @@ int32 CFE_ES_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
     /*
     ** Send housekeeping telemetry packet.
     */
-    CFE_SB_TimeStampMsg(&CFE_ES_Global.TaskData.HkPacket.TlmHeader.Msg);
-    CFE_SB_TransmitMsg(&CFE_ES_Global.TaskData.HkPacket.TlmHeader.Msg, true);
+    CFE_SB_TimeStampMsg(CFE_MSG_PTR(CFE_ES_Global.TaskData.HkPacket.TelemetryHeader));
+    CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_ES_Global.TaskData.HkPacket.TelemetryHeader), true);
 
     /*
     ** This command does not affect the command execution counter.
@@ -1235,8 +1235,8 @@ int32 CFE_ES_QueryOneCmd(const CFE_ES_QueryOneCmd_t *data)
         /*
         ** Send application status telemetry packet.
         */
-        CFE_SB_TimeStampMsg(&CFE_ES_Global.TaskData.OneAppPacket.TlmHeader.Msg);
-        Result = CFE_SB_TransmitMsg(&CFE_ES_Global.TaskData.OneAppPacket.TlmHeader.Msg, true);
+        CFE_SB_TimeStampMsg(CFE_MSG_PTR(CFE_ES_Global.TaskData.OneAppPacket.TelemetryHeader));
+        Result = CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_ES_Global.TaskData.OneAppPacket.TelemetryHeader), true);
         if (Result == CFE_SUCCESS)
         {
             CFE_ES_Global.TaskData.CommandCounter++;
@@ -1974,8 +1974,8 @@ int32 CFE_ES_SendMemPoolStatsCmd(const CFE_ES_SendMemPoolStatsCmd_t *data)
         /*
         ** Send memory statistics telemetry packet.
         */
-        CFE_SB_TimeStampMsg(&CFE_ES_Global.TaskData.MemStatsPacket.TlmHeader.Msg);
-        CFE_SB_TransmitMsg(&CFE_ES_Global.TaskData.MemStatsPacket.TlmHeader.Msg, true);
+        CFE_SB_TimeStampMsg(CFE_MSG_PTR(CFE_ES_Global.TaskData.MemStatsPacket.TelemetryHeader));
+        CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_ES_Global.TaskData.MemStatsPacket.TelemetryHeader), true);
 
         CFE_ES_Global.TaskData.CommandCounter++;
         CFE_EVS_SendEvent(CFE_ES_TLM_POOL_STATS_INFO_EID, CFE_EVS_EventType_DEBUG,

--- a/modules/es/fsw/src/cfe_es_task.h
+++ b/modules/es/fsw/src/cfe_es_task.h
@@ -44,6 +44,7 @@
 #include "cfe_fs_api_typedefs.h"
 #include "cfe_sb_api_typedefs.h"
 #include "cfe_es_erlog_typedef.h"
+#include "cfe_msg_api_typedefs.h"
 
 /*************************************************************************/
 

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -2456,7 +2456,7 @@ void TestTask(void)
     union
     {
         CFE_MSG_Message_t            Msg;
-        CFE_ES_NoArgsCmd_t           NoArgsCmd;
+        CFE_MSG_CommandHeader_t      NoArgsCmd;
         CFE_ES_ClearSysLogCmd_t      ClearSysLogCmd;
         CFE_ES_ClearERLogCmd_t       ClearERLogCmd;
         CFE_ES_ResetPRCountCmd_t     ResetPRCountCmd;

--- a/modules/evs/fsw/inc/cfe_evs_msg.h
+++ b/modules/evs/fsw/inc/cfe_evs_msg.h
@@ -906,7 +906,7 @@
 **/
 typedef struct CFE_EVS_NoArgsCmd
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 } CFE_EVS_NoArgsCmd_t;
 
 /*
@@ -934,8 +934,8 @@ typedef struct CFE_EVS_LogFileCmd_Payload
  */
 typedef struct CFE_EVS_WriteLogDataFileCmd
 {
-    CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
-    CFE_EVS_LogFileCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
+    CFE_EVS_LogFileCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_EVS_WriteLogDataFileCmd_t;
 
 /**
@@ -954,8 +954,8 @@ typedef struct CFE_EVS_AppDataCmd_Payload
  */
 typedef struct CFE_EVS_WriteAppDataFileCmd
 {
-    CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
-    CFE_EVS_AppDataCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
+    CFE_EVS_AppDataCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_EVS_WriteAppDataFileCmd_t;
 
 /**
@@ -975,8 +975,8 @@ typedef struct CFE_EVS_SetLogMode_Payload
  */
 typedef struct CFE_EVS_SetLogModeCmd
 {
-    CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
-    CFE_EVS_SetLogMode_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
+    CFE_EVS_SetLogMode_Payload_t Payload;       /**< \brief Command payload */
 } CFE_EVS_SetLogModeCmd_t;
 
 /**
@@ -996,8 +996,8 @@ typedef struct CFE_EVS_SetEventFormatCode_Payload
  */
 typedef struct CFE_EVS_SetEventFormatModeCmd
 {
-    CFE_MSG_CommandHeader_t              CmdHeader; /**< \brief Command header */
-    CFE_EVS_SetEventFormatMode_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t              CommandHeader; /**< \brief Command header */
+    CFE_EVS_SetEventFormatMode_Payload_t Payload;       /**< \brief Command payload */
 } CFE_EVS_SetEventFormatModeCmd_t;
 
 /**
@@ -1018,8 +1018,8 @@ typedef struct CFE_EVS_BitMaskCmd_Payload
  */
 typedef struct CFE_EVS_BitMaskCmd
 {
-    CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
-    CFE_EVS_BitMaskCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
+    CFE_EVS_BitMaskCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_EVS_BitMaskCmd_t;
 
 /*
@@ -1049,8 +1049,8 @@ typedef struct CFE_EVS_AppNameCmd_Payload
  */
 typedef struct CFE_EVS_AppNameCmd
 {
-    CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
-    CFE_EVS_AppNameCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
+    CFE_EVS_AppNameCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_EVS_AppNameCmd_t;
 
 /*
@@ -1080,8 +1080,8 @@ typedef struct CFE_EVS_AppNameEventIDCmd_Payload
  */
 typedef struct CFE_EVS_AppNameEventIDCmd
 {
-    CFE_MSG_CommandHeader_t             CmdHeader; /**< \brief Command header */
-    CFE_EVS_AppNameEventIDCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t             CommandHeader; /**< \brief Command header */
+    CFE_EVS_AppNameEventIDCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_EVS_AppNameEventIDCmd_t;
 
 /*
@@ -1110,8 +1110,8 @@ typedef struct CFE_EVS_AppNameBitMaskCmd_Payload
  */
 typedef struct CFE_EVS_AppNameBitMaskCmd
 {
-    CFE_MSG_CommandHeader_t             CmdHeader; /**< \brief Command header */
-    CFE_EVS_AppNameBitMaskCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t             CommandHeader; /**< \brief Command header */
+    CFE_EVS_AppNameBitMaskCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_EVS_AppNameBitMaskCmd_t;
 
 /*
@@ -1141,8 +1141,8 @@ typedef struct CFE_EVS_AppNameEventIDMaskCmd_Payload
  */
 typedef struct CFE_EVS_AppNameEventIDMaskCmd
 {
-    CFE_MSG_CommandHeader_t                 CmdHeader; /**< \brief Command header */
-    CFE_EVS_AppNameEventIDMaskCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t                 CommandHeader; /**< \brief Command header */
+    CFE_EVS_AppNameEventIDMaskCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_EVS_AppNameEventIDMaskCmd_t;
 
 /*
@@ -1214,8 +1214,8 @@ typedef struct CFE_EVS_HousekeepingTlm_Payload
 
 typedef struct CFE_EVS_HousekeepingTlm
 {
-    CFE_MSG_TelemetryHeader_t         TlmHeader; /**< \brief Telemetry header */
-    CFE_EVS_HousekeepingTlm_Payload_t Payload;   /**< \brief Telemetry payload */
+    CFE_MSG_TelemetryHeader_t         TelemetryHeader; /**< \brief Telemetry header */
+    CFE_EVS_HousekeepingTlm_Payload_t Payload;         /**< \brief Telemetry payload */
 } CFE_EVS_HousekeepingTlm_t;
 
 /** Telemetry packet structures */
@@ -1260,15 +1260,15 @@ typedef struct CFE_EVS_ShortEventTlm_Payload
 
 typedef struct CFE_EVS_LongEventTlm
 {
-    CFE_MSG_TelemetryHeader_t      TlmHeader; /**< \brief Telemetry header */
-    CFE_EVS_LongEventTlm_Payload_t Payload;   /**< \brief Telemetry payload */
+    CFE_MSG_TelemetryHeader_t      TelemetryHeader; /**< \brief Telemetry header */
+    CFE_EVS_LongEventTlm_Payload_t Payload;         /**< \brief Telemetry payload */
 
 } CFE_EVS_LongEventTlm_t;
 
 typedef struct CFE_EVS_ShortEventTlm
 {
-    CFE_MSG_TelemetryHeader_t       TlmHeader; /**< \brief Telemetry header */
-    CFE_EVS_ShortEventTlm_Payload_t Payload;   /**< \brief Telemetry payload */
+    CFE_MSG_TelemetryHeader_t       TelemetryHeader; /**< \brief Telemetry header */
+    CFE_EVS_ShortEventTlm_Payload_t Payload;         /**< \brief Telemetry payload */
 
 } CFE_EVS_ShortEventTlm_t;
 

--- a/modules/evs/fsw/src/cfe_evs_task.c
+++ b/modules/evs/fsw/src/cfe_evs_task.c
@@ -72,7 +72,7 @@ int32 CFE_EVS_EarlyInit(void)
     memset(&CFE_EVS_Global, 0, sizeof(CFE_EVS_Global));
 
     /* Initialize housekeeping packet */
-    CFE_MSG_Init(&CFE_EVS_Global.EVS_TlmPkt.TlmHeader.Msg, CFE_SB_ValueToMsgId(CFE_EVS_HK_TLM_MID),
+    CFE_MSG_Init(CFE_MSG_PTR(CFE_EVS_Global.EVS_TlmPkt.TelemetryHeader), CFE_SB_ValueToMsgId(CFE_EVS_HK_TLM_MID),
                  sizeof(CFE_EVS_Global.EVS_TlmPkt));
 
     /* Elements stored in the hk packet that have non-zero default values */
@@ -672,9 +672,9 @@ int32 CFE_EVS_ReportHousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
         AppTlmDataPtr->AppMessageSentCounter = 0;
     }
 
-    CFE_SB_TimeStampMsg(&CFE_EVS_Global.EVS_TlmPkt.TlmHeader.Msg);
+    CFE_SB_TimeStampMsg(CFE_MSG_PTR(CFE_EVS_Global.EVS_TlmPkt.TelemetryHeader));
 
-    CFE_SB_TransmitMsg(&CFE_EVS_Global.EVS_TlmPkt.TlmHeader.Msg, true);
+    CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_EVS_Global.EVS_TlmPkt.TelemetryHeader), true);
 
     return CFE_STATUS_NO_COUNTER_INCREMENT;
 }

--- a/modules/evs/fsw/src/cfe_evs_utils.c
+++ b/modules/evs/fsw/src/cfe_evs_utils.c
@@ -361,7 +361,8 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint1
     int                     ExpandedLength;
 
     /* Initialize EVS event packets */
-    CFE_MSG_Init(&LongEventTlm.TlmHeader.Msg, CFE_SB_ValueToMsgId(CFE_EVS_LONG_EVENT_MSG_MID), sizeof(LongEventTlm));
+    CFE_MSG_Init(CFE_MSG_PTR(LongEventTlm.TelemetryHeader), CFE_SB_ValueToMsgId(CFE_EVS_LONG_EVENT_MSG_MID),
+                 sizeof(LongEventTlm));
     LongEventTlm.Payload.PacketID.EventID   = EventID;
     LongEventTlm.Payload.PacketID.EventType = EventType;
 
@@ -388,7 +389,7 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint1
     LongEventTlm.Payload.PacketID.ProcessorID  = CFE_PSP_GetProcessorId();
 
     /* Set the packet timestamp */
-    CFE_MSG_SetMsgTime(&LongEventTlm.TlmHeader.Msg, *TimeStamp);
+    CFE_MSG_SetMsgTime(CFE_MSG_PTR(LongEventTlm.TelemetryHeader), *TimeStamp);
 
     /* Write event to the event log */
     EVS_AddLog(&LongEventTlm);
@@ -399,7 +400,7 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint1
     if (CFE_EVS_Global.EVS_TlmPkt.Payload.MessageFormatMode == CFE_EVS_MsgFormat_LONG)
     {
         /* Send long event via SoftwareBus */
-        CFE_SB_TransmitMsg(&LongEventTlm.TlmHeader.Msg, true);
+        CFE_SB_TransmitMsg(CFE_MSG_PTR(LongEventTlm.TelemetryHeader), true);
     }
     else if (CFE_EVS_Global.EVS_TlmPkt.Payload.MessageFormatMode == CFE_EVS_MsgFormat_SHORT)
     {
@@ -409,11 +410,11 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint1
          *
          * This goes out on a separate message ID.
          */
-        CFE_MSG_Init(&ShortEventTlm.TlmHeader.Msg, CFE_SB_ValueToMsgId(CFE_EVS_SHORT_EVENT_MSG_MID),
+        CFE_MSG_Init(CFE_MSG_PTR(ShortEventTlm.TelemetryHeader), CFE_SB_ValueToMsgId(CFE_EVS_SHORT_EVENT_MSG_MID),
                      sizeof(ShortEventTlm));
-        CFE_MSG_SetMsgTime(&ShortEventTlm.TlmHeader.Msg, *TimeStamp);
+        CFE_MSG_SetMsgTime(CFE_MSG_PTR(ShortEventTlm.TelemetryHeader), *TimeStamp);
         ShortEventTlm.Payload.PacketID = LongEventTlm.Payload.PacketID;
-        CFE_SB_TransmitMsg(&ShortEventTlm.TlmHeader.Msg, true);
+        CFE_SB_TransmitMsg(CFE_MSG_PTR(ShortEventTlm.TelemetryHeader), true);
     }
 
     /* Increment message send counters (prevent rollover) */

--- a/modules/evs/ut-coverage/evs_UT.c
+++ b/modules/evs/ut-coverage/evs_UT.c
@@ -853,7 +853,7 @@ void Test_Logging(void)
     char   tmpString[100];
     union
     {
-        CFE_EVS_NoArgsCmd_t           cmd;
+        CFE_MSG_CommandHeader_t       cmd;
         CFE_EVS_SetLogModeCmd_t       modecmd;
         CFE_EVS_WriteLogDataFileCmd_t logfilecmd;
     } CmdBuf;
@@ -1003,7 +1003,7 @@ void Test_WriteApp(void)
 {
     union
     {
-        CFE_EVS_NoArgsCmd_t           cmd;
+        CFE_MSG_CommandHeader_t       cmd;
         CFE_EVS_WriteAppDataFileCmd_t AppDataCmd;
         CFE_EVS_AppNameBitMaskCmd_t   appbitcmd;
     } CmdBuf;
@@ -1683,7 +1683,7 @@ void Test_FilterCmd(void)
 */
 void Test_InvalidCmd(void)
 {
-    CFE_EVS_NoArgsCmd_t cmd;
+    CFE_MSG_CommandHeader_t cmd;
 
     UtPrintf("Begin Test Invalid Command");
 
@@ -1816,7 +1816,7 @@ void Test_Misc(void)
     union
     {
         CFE_MSG_Message_t             msg;
-        CFE_EVS_NoArgsCmd_t           cmd;
+        CFE_MSG_CommandHeader_t       cmd;
         CFE_EVS_SetLogModeCmd_t       modecmd;
         CFE_EVS_WriteLogDataFileCmd_t writelogdatacmd;
     } PktBuf;

--- a/modules/msg/option_inc/default_cfe_msg_hdr_pri.h
+++ b/modules/msg/option_inc/default_cfe_msg_hdr_pri.h
@@ -38,6 +38,21 @@
 #include "cfe_msg_sechdr.h"
 #include "cfe_msg_api_typedefs.h"
 
+/*****************************************************************************/
+/**
+ * \brief Convert from a CFE_MSG_TelemetryHeader_t or CFE_MSG_CommandHeader_t to a CFE_MSG_Message_t
+ *
+ * \par Description
+ *       Given a pointer to a secondary header structure, return a pointer
+ *       to the CFE_MSG_Message_t (base header/primary header) object.
+ *
+ * \par Notes
+ *       Implemented as a macro, so it should work with both Command and Telemetry headers, as well as
+ *       both const and non-const headers.  The const-ness of the pointer type should be preserved.
+ *
+ */
+#define CFE_MSG_PTR(shdr) (&((shdr).Msg))
+
 /*
  * Type Definitions
  */

--- a/modules/msg/option_inc/default_cfe_msg_hdr_priext.h
+++ b/modules/msg/option_inc/default_cfe_msg_hdr_priext.h
@@ -37,6 +37,21 @@
 #include "ccsds_hdr.h"
 #include "cfe_msg_sechdr.h"
 
+/*****************************************************************************/
+/**
+ * \brief Convert from a CFE_MSG_TelemetryHeader_t or CFE_MSG_CommandHeader_t to a CFE_MSG_Message_t
+ *
+ * \par Description
+ *       Given a pointer to a secondary header structure, return a pointer
+ *       to the CFE_MSG_Message_t (base header/primary header) object.
+ *
+ * \par Notes
+ *       Implemented as a macro, so it should work with both Command and Telemetry headers, as well as
+ *       both const and non-const headers.  The const-ness of the pointer type should be preserved.
+ *
+ */
+#define CFE_MSG_PTR(shdr) (&((shdr).Msg))
+
 /*
  * Type Definitions
  */

--- a/modules/msg/ut-coverage/test_cfe_msg_checksum.c
+++ b/modules/msg/ut-coverage/test_cfe_msg_checksum.c
@@ -37,7 +37,7 @@
 void Test_MSG_Checksum(void)
 {
     CFE_MSG_CommandHeader_t cmd;
-    CFE_MSG_Message_t *     msgptr = &cmd.Msg;
+    CFE_MSG_Message_t *     msgptr = CFE_MSG_PTR(cmd);
     bool                    actual;
 
     UtPrintf("Bad parameter tests, Null pointers");

--- a/modules/msg/ut-coverage/test_cfe_msg_fc.c
+++ b/modules/msg/ut-coverage/test_cfe_msg_fc.c
@@ -42,7 +42,7 @@
 void Test_MSG_FcnCode(void)
 {
     CFE_MSG_CommandHeader_t cmd;
-    CFE_MSG_Message_t *     msgptr  = &cmd.Msg;
+    CFE_MSG_Message_t *     msgptr  = CFE_MSG_PTR(cmd);
     CFE_MSG_FcnCode_t       input[] = {0, TEST_FCNCODE_MAX / 2, TEST_FCNCODE_MAX};
     CFE_MSG_FcnCode_t       actual  = TEST_FCNCODE_MAX;
     int                     i;

--- a/modules/msg/ut-coverage/test_cfe_msg_init.c
+++ b/modules/msg/ut-coverage/test_cfe_msg_init.c
@@ -55,27 +55,28 @@ void Test_MSG_Init(void)
 
     UtPrintf("Bad parameter tests, Null pointer, invalid size, invalid msgid");
     UtAssert_INT32_EQ(CFE_MSG_Init(NULL, CFE_SB_ValueToMsgId(0), sizeof(cmd)), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_Init(&cmd.Msg, CFE_SB_ValueToMsgId(0), 0), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_Init(&cmd.Msg, CFE_SB_ValueToMsgId(CFE_PLATFORM_SB_HIGHEST_VALID_MSGID + 1), sizeof(cmd)),
-                      CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_Init(&cmd.Msg, CFE_SB_ValueToMsgId(-1), sizeof(cmd)), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_Init(CFE_MSG_PTR(cmd), CFE_SB_ValueToMsgId(0), 0), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(
+        CFE_MSG_Init(CFE_MSG_PTR(cmd), CFE_SB_ValueToMsgId(CFE_PLATFORM_SB_HIGHEST_VALID_MSGID + 1), sizeof(cmd)),
+        CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_Init(CFE_MSG_PTR(cmd), CFE_SB_ValueToMsgId(-1), sizeof(cmd)), CFE_MSG_BAD_ARGUMENT);
 
     UtPrintf("Set to all F's, msgid value = 0");
     memset(&cmd, 0xFF, sizeof(cmd));
     msgidval_exp = 0;
 
-    CFE_UtAssert_SUCCESS(CFE_MSG_Init(&cmd.Msg, CFE_SB_ValueToMsgId(msgidval_exp), sizeof(cmd)));
-    UT_DisplayPkt(&cmd.Msg, 0);
-    CFE_UtAssert_SUCCESS(CFE_MSG_GetMsgId(&cmd.Msg, &msgid_act));
+    CFE_UtAssert_SUCCESS(CFE_MSG_Init(CFE_MSG_PTR(cmd), CFE_SB_ValueToMsgId(msgidval_exp), sizeof(cmd)));
+    UT_DisplayPkt(CFE_MSG_PTR(cmd), 0);
+    CFE_UtAssert_SUCCESS(CFE_MSG_GetMsgId(CFE_MSG_PTR(cmd), &msgid_act));
     UtAssert_INT32_EQ(CFE_SB_MsgIdToValue(msgid_act), msgidval_exp);
-    CFE_UtAssert_SUCCESS(CFE_MSG_GetSize(&cmd.Msg, &size));
+    CFE_UtAssert_SUCCESS(CFE_MSG_GetSize(CFE_MSG_PTR(cmd), &size));
     CFE_UtAssert_MEMOFFSET_EQ(size, sizeof(cmd));
-    CFE_UtAssert_SUCCESS(CFE_MSG_GetSegmentationFlag(&cmd.Msg, &segflag));
+    CFE_UtAssert_SUCCESS(CFE_MSG_GetSegmentationFlag(CFE_MSG_PTR(cmd), &segflag));
     UtAssert_INT32_EQ(segflag, CFE_MSG_SegFlag_Unsegmented);
 
-    CFE_UtAssert_SUCCESS(CFE_MSG_GetApId(&cmd.Msg, &apid));
-    CFE_UtAssert_SUCCESS(CFE_MSG_GetHeaderVersion(&cmd.Msg, &hdrver));
-    CFE_UtAssert_SUCCESS(CFE_MSG_GetHasSecondaryHeader(&cmd.Msg, &hassec));
+    CFE_UtAssert_SUCCESS(CFE_MSG_GetApId(CFE_MSG_PTR(cmd), &apid));
+    CFE_UtAssert_SUCCESS(CFE_MSG_GetHeaderVersion(CFE_MSG_PTR(cmd), &hdrver));
+    CFE_UtAssert_SUCCESS(CFE_MSG_GetHasSecondaryHeader(CFE_MSG_PTR(cmd), &hassec));
 
     /* A zero msgid will set hassec to false for v1 */
     is_v1 = !hassec;
@@ -92,25 +93,25 @@ void Test_MSG_Init(void)
     }
 
     /* Confirm the rest of the fields not already explicitly checked */
-    UtAssert_UINT32_EQ(Test_MSG_Pri_NotZero(&cmd.Msg) & ~(MSG_APID_FLAG | MSG_HDRVER_FLAG | MSG_HASSEC_FLAG),
+    UtAssert_UINT32_EQ(Test_MSG_Pri_NotZero(CFE_MSG_PTR(cmd)) & ~(MSG_APID_FLAG | MSG_HDRVER_FLAG | MSG_HASSEC_FLAG),
                        MSG_LENGTH_FLAG | MSG_SEGMENT_FLAG);
 
     UtPrintf("Set to all 0, max msgid value");
     memset(&cmd, 0, sizeof(cmd));
     msgidval_exp = CFE_PLATFORM_SB_HIGHEST_VALID_MSGID;
 
-    CFE_UtAssert_SUCCESS(CFE_MSG_Init(&cmd.Msg, CFE_SB_ValueToMsgId(msgidval_exp), sizeof(cmd)));
-    UT_DisplayPkt(&cmd.Msg, 0);
-    CFE_UtAssert_SUCCESS(CFE_MSG_GetMsgId(&cmd.Msg, &msgid_act));
+    CFE_UtAssert_SUCCESS(CFE_MSG_Init(CFE_MSG_PTR(cmd), CFE_SB_ValueToMsgId(msgidval_exp), sizeof(cmd)));
+    UT_DisplayPkt(CFE_MSG_PTR(cmd), 0);
+    CFE_UtAssert_SUCCESS(CFE_MSG_GetMsgId(CFE_MSG_PTR(cmd), &msgid_act));
     UtAssert_INT32_EQ(CFE_SB_MsgIdToValue(msgid_act), msgidval_exp);
-    CFE_UtAssert_SUCCESS(CFE_MSG_GetSize(&cmd.Msg, &size));
+    CFE_UtAssert_SUCCESS(CFE_MSG_GetSize(CFE_MSG_PTR(cmd), &size));
     UtAssert_INT32_EQ(size, sizeof(cmd));
-    CFE_UtAssert_SUCCESS(CFE_MSG_GetSegmentationFlag(&cmd.Msg, &segflag));
+    CFE_UtAssert_SUCCESS(CFE_MSG_GetSegmentationFlag(CFE_MSG_PTR(cmd), &segflag));
     UtAssert_INT32_EQ(segflag, CFE_MSG_SegFlag_Unsegmented);
 
-    CFE_UtAssert_SUCCESS(CFE_MSG_GetApId(&cmd.Msg, &apid));
-    CFE_UtAssert_SUCCESS(CFE_MSG_GetHeaderVersion(&cmd.Msg, &hdrver));
-    CFE_UtAssert_SUCCESS(CFE_MSG_GetHasSecondaryHeader(&cmd.Msg, &hassec));
+    CFE_UtAssert_SUCCESS(CFE_MSG_GetApId(CFE_MSG_PTR(cmd), &apid));
+    CFE_UtAssert_SUCCESS(CFE_MSG_GetHeaderVersion(CFE_MSG_PTR(cmd), &hdrver));
+    CFE_UtAssert_SUCCESS(CFE_MSG_GetHasSecondaryHeader(CFE_MSG_PTR(cmd), &hassec));
     UtAssert_BOOL_TRUE(hassec);
     if (!is_v1)
     {
@@ -123,6 +124,6 @@ void Test_MSG_Init(void)
         UtAssert_INT32_EQ(hdrver, 0);
     }
 
-    UtAssert_UINT32_EQ(Test_MSG_Pri_NotZero(&cmd.Msg) & ~MSG_HDRVER_FLAG,
+    UtAssert_UINT32_EQ(Test_MSG_Pri_NotZero(CFE_MSG_PTR(cmd)) & ~MSG_HDRVER_FLAG,
                        MSG_APID_FLAG | MSG_HASSEC_FLAG | MSG_TYPE_FLAG | MSG_LENGTH_FLAG | MSG_SEGMENT_FLAG);
 }

--- a/modules/msg/ut-coverage/test_cfe_msg_time.c
+++ b/modules/msg/ut-coverage/test_cfe_msg_time.c
@@ -37,7 +37,7 @@
 void Test_MSG_Time(void)
 {
     CFE_MSG_TelemetryHeader_t tlm;
-    CFE_MSG_Message_t *       msgptr  = &tlm.Msg;
+    CFE_MSG_Message_t *       msgptr  = CFE_MSG_PTR(tlm);
     CFE_TIME_SysTime_t        input[] = {{0, 0}, {0x12345678, 0xABCDEF12}, {0xFFFFFFFF, 0xFFFFFFFF}};
     CFE_TIME_SysTime_t        actual  = {0xFFFFFFFF, 0xFFFFFFFF};
     int                       i;

--- a/modules/sb/fsw/inc/cfe_sb_msg.h
+++ b/modules/sb/fsw/inc/cfe_sb_msg.h
@@ -504,8 +504,8 @@ typedef struct CFE_SB_WriteFileInfoCmd_Payload
  */
 typedef struct CFE_SB_WriteFileInfoCmd
 {
-    CFE_MSG_CommandHeader_t           Hdr;     /**< \brief Command header */
-    CFE_SB_WriteFileInfoCmd_Payload_t Payload; /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t           CommandHeader; /**< \brief Command header */
+    CFE_SB_WriteFileInfoCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_SB_WriteFileInfoCmd_t;
 
 /*
@@ -536,8 +536,8 @@ typedef struct CFE_SB_RouteCmd_Payload
  */
 typedef struct CFE_SB_RouteCmd
 {
-    CFE_MSG_CommandHeader_t   Hdr;     /**< \brief Command header */
-    CFE_SB_RouteCmd_Payload_t Payload; /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t   CommandHeader; /**< \brief Command header */
+    CFE_SB_RouteCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_SB_RouteCmd_t;
 
 /*
@@ -599,8 +599,8 @@ typedef struct CFE_SB_HousekeepingTlm_Payload
 
 typedef struct CFE_SB_HousekeepingTlm
 {
-    CFE_MSG_TelemetryHeader_t        Hdr;     /**< \brief Telemetry header */
-    CFE_SB_HousekeepingTlm_Payload_t Payload; /**< \brief Telemetry payload */
+    CFE_MSG_TelemetryHeader_t        TelemetryHeader; /**< \brief Telemetry header */
+    CFE_SB_HousekeepingTlm_Payload_t Payload;         /**< \brief Telemetry payload */
 } CFE_SB_HousekeepingTlm_t;
 
 /**
@@ -705,8 +705,8 @@ typedef struct CFE_SB_StatsTlm_Payload
 
 typedef struct CFE_SB_StatsTlm
 {
-    CFE_MSG_TelemetryHeader_t Hdr;     /**< \brief Telemetry header */
-    CFE_SB_StatsTlm_Payload_t Payload; /**< \brief Telemetry payload */
+    CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief Telemetry header */
+    CFE_SB_StatsTlm_Payload_t Payload;         /**< \brief Telemetry payload */
 } CFE_SB_StatsTlm_t;
 
 /**
@@ -757,8 +757,8 @@ typedef struct CFE_SB_SingleSubscriptionTlm_Payload
 
 typedef struct CFE_SB_SingleSubscriptionTlm
 {
-    CFE_MSG_TelemetryHeader_t              Hdr;     /**< \brief Telemetry header */
-    CFE_SB_SingleSubscriptionTlm_Payload_t Payload; /**< \brief Telemetry payload */
+    CFE_MSG_TelemetryHeader_t              TelemetryHeader; /**< \brief Telemetry header */
+    CFE_SB_SingleSubscriptionTlm_Payload_t Payload;         /**< \brief Telemetry payload */
 } CFE_SB_SingleSubscriptionTlm_t;
 
 /**
@@ -798,8 +798,8 @@ typedef struct CFE_SB_AllSubscriptionsTlm_Payload
 
 typedef struct CFE_SB_AllSubscriptionsTlm
 {
-    CFE_MSG_TelemetryHeader_t            Hdr;     /**< \brief Telemetry header */
-    CFE_SB_AllSubscriptionsTlm_Payload_t Payload; /**< \brief Telemetry payload */
+    CFE_MSG_TelemetryHeader_t            TelemetryHeader; /**< \brief Telemetry header */
+    CFE_SB_AllSubscriptionsTlm_Payload_t Payload;         /**< \brief Telemetry payload */
 } CFE_SB_AllSubscriptionsTlm_t;
 
 #endif /* CFE_SB_MSG_H */

--- a/modules/sb/fsw/src/cfe_sb_init.c
+++ b/modules/sb/fsw/src/cfe_sb_init.c
@@ -89,7 +89,7 @@ int32 CFE_SB_EarlyInit(void)
     CFE_SBR_Init();
 
     /* Initialize the SB Statistics Pkt */
-    CFE_MSG_Init(&CFE_SB_Global.StatTlmMsg.Hdr.Msg, CFE_SB_ValueToMsgId(CFE_SB_STATS_TLM_MID),
+    CFE_MSG_Init(CFE_MSG_PTR(CFE_SB_Global.StatTlmMsg.TelemetryHeader), CFE_SB_ValueToMsgId(CFE_SB_STATS_TLM_MID),
                  sizeof(CFE_SB_Global.StatTlmMsg));
 
     return Stat;

--- a/modules/sb/fsw/src/cfe_sb_task.c
+++ b/modules/sb/fsw/src/cfe_sb_task.c
@@ -204,10 +204,10 @@ int32 CFE_SB_AppInit(void)
 
     CFE_ES_WriteToSysLog("%s: Registered %d events for filtering\n", __func__, (int)CfgFileEventsToFilter);
 
-    CFE_MSG_Init(&CFE_SB_Global.HKTlmMsg.Hdr.Msg, CFE_SB_ValueToMsgId(CFE_SB_HK_TLM_MID),
+    CFE_MSG_Init(CFE_MSG_PTR(CFE_SB_Global.HKTlmMsg.TelemetryHeader), CFE_SB_ValueToMsgId(CFE_SB_HK_TLM_MID),
                  sizeof(CFE_SB_Global.HKTlmMsg));
 
-    CFE_MSG_Init(&CFE_SB_Global.PrevSubMsg.Hdr.Msg, CFE_SB_ValueToMsgId(CFE_SB_ALLSUBS_TLM_MID),
+    CFE_MSG_Init(CFE_MSG_PTR(CFE_SB_Global.PrevSubMsg.TelemetryHeader), CFE_SB_ValueToMsgId(CFE_SB_ALLSUBS_TLM_MID),
                  sizeof(CFE_SB_Global.PrevSubMsg));
 
     /* Populate the fixed fields in the HK Tlm Msg */
@@ -535,8 +535,8 @@ int32 CFE_SB_SendHKTlmCmd(const CFE_MSG_CommandHeader_t *data)
 
     CFE_SB_UnlockSharedData(__FILE__, __LINE__);
 
-    CFE_SB_TimeStampMsg(&CFE_SB_Global.HKTlmMsg.Hdr.Msg);
-    CFE_SB_TransmitMsg(&CFE_SB_Global.HKTlmMsg.Hdr.Msg, true);
+    CFE_SB_TimeStampMsg(CFE_MSG_PTR(CFE_SB_Global.HKTlmMsg.TelemetryHeader));
+    CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_SB_Global.HKTlmMsg.TelemetryHeader), true);
 
     return CFE_SUCCESS;
 }
@@ -757,8 +757,8 @@ int32 CFE_SB_SendStatsCmd(const CFE_SB_SendSbStatsCmd_t *data)
         --PipeStatCount;
     }
 
-    CFE_SB_TimeStampMsg(&CFE_SB_Global.StatTlmMsg.Hdr.Msg);
-    CFE_SB_TransmitMsg(&CFE_SB_Global.StatTlmMsg.Hdr.Msg, true);
+    CFE_SB_TimeStampMsg(CFE_MSG_PTR(CFE_SB_Global.StatTlmMsg.TelemetryHeader));
+    CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_SB_Global.StatTlmMsg.TelemetryHeader), true);
 
     CFE_EVS_SendEvent(CFE_SB_SND_STATS_EID, CFE_EVS_EventType_DEBUG, "Software Bus Statistics packet sent");
 
@@ -865,14 +865,15 @@ int32 CFE_SB_SendSubscriptionReport(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId
 
     if (CFE_SB_Global.SubscriptionReporting == CFE_SB_ENABLE)
     {
-        CFE_MSG_Init(&SubRptMsg.Hdr.Msg, CFE_SB_ValueToMsgId(CFE_SB_ONESUB_TLM_MID), sizeof(SubRptMsg));
+        CFE_MSG_Init(CFE_MSG_PTR(SubRptMsg.TelemetryHeader), CFE_SB_ValueToMsgId(CFE_SB_ONESUB_TLM_MID),
+                     sizeof(SubRptMsg));
 
         SubRptMsg.Payload.MsgId   = MsgId;
         SubRptMsg.Payload.Pipe    = PipeId;
         SubRptMsg.Payload.Qos     = Quality;
         SubRptMsg.Payload.SubType = CFE_SB_SUBSCRIPTION;
 
-        Status = CFE_SB_TransmitMsg(&SubRptMsg.Hdr.Msg, true);
+        Status = CFE_SB_TransmitMsg(CFE_MSG_PTR(SubRptMsg.TelemetryHeader), true);
         CFE_EVS_SendEventWithAppID(CFE_SB_SUBSCRIPTION_RPT_EID, CFE_EVS_EventType_DEBUG, CFE_SB_Global.AppId,
                                    "Sending Subscription Report Msg=0x%x,Pipe=%lu,Stat=0x%x",
                                    (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(PipeId),
@@ -1334,7 +1335,7 @@ void CFE_SB_SendRouteSub(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
             if (CFE_SB_Global.PrevSubMsg.Payload.Entries >= CFE_SB_SUB_ENTRIES_PER_PKT)
             {
                 CFE_SB_UnlockSharedData(__func__, __LINE__);
-                status = CFE_SB_TransmitMsg(&CFE_SB_Global.PrevSubMsg.Hdr.Msg, true);
+                status = CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_SB_Global.PrevSubMsg.TelemetryHeader), true);
                 CFE_EVS_SendEvent(CFE_SB_FULL_SUB_PKT_EID, CFE_EVS_EventType_DEBUG,
                                   "Full Sub Pkt %d Sent,Entries=%d,Stat=0x%x\n",
                                   (int)CFE_SB_Global.PrevSubMsg.Payload.PktSegment,
@@ -1385,7 +1386,7 @@ int32 CFE_SB_SendPrevSubsCmd(const CFE_SB_SendPrevSubsCmd_t *data)
     /* if pkt has any number of entries, send it as a partial pkt */
     if (CFE_SB_Global.PrevSubMsg.Payload.Entries > 0)
     {
-        status = CFE_SB_TransmitMsg(&CFE_SB_Global.PrevSubMsg.Hdr.Msg, true);
+        status = CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_SB_Global.PrevSubMsg.TelemetryHeader), true);
         CFE_EVS_SendEvent(CFE_SB_PART_SUB_PKT_EID, CFE_EVS_EventType_DEBUG,
                           "Partial Sub Pkt %d Sent,Entries=%d,Stat=0x%x",
                           (int)CFE_SB_Global.PrevSubMsg.Payload.PktSegment,

--- a/modules/sb/fsw/src/cfe_sb_util.c
+++ b/modules/sb/fsw/src/cfe_sb_util.c
@@ -63,7 +63,7 @@ size_t CFE_SB_MsgHdrSize(const CFE_MSG_Message_t *MsgPtr)
     /* Since all cFE messages must have a secondary hdr this check is not needed */
     if (!hassechdr)
     {
-        size = sizeof(CCSDS_SpacePacket_t);
+        size = sizeof(CFE_MSG_Message_t);
     }
     else if (type == CFE_MSG_Type_Cmd)
     {

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -3071,7 +3071,7 @@ void Test_TransmitMsg_NoSubscribers(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
 
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
+    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
 
     CFE_UtAssert_EVENTCOUNT(1);
 
@@ -3092,7 +3092,7 @@ void Test_TransmitMsg_MaxMsgSizePlusOne(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter = 0;
 
-    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true), CFE_SB_MSG_TOO_BIG);
+    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true), CFE_SB_MSG_TOO_BIG);
 
     CFE_UtAssert_EVENTCOUNT(1);
 
@@ -3119,7 +3119,7 @@ void Test_TransmitMsg_BasicSend(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
 
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
+    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
 
     CFE_UtAssert_EVENTCOUNT(2);
 
@@ -3165,7 +3165,7 @@ void Test_TransmitMsg_SequenceCount(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
 
-    CFE_UtAssert_SETUP(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
+    CFE_UtAssert_SETUP(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
     UtAssert_STUB_COUNT(CFE_MSG_SetSequenceCount, 1);
     UtAssert_STUB_COUNT(CFE_MSG_GetNextSequenceCount, 1);
     UtAssert_INT32_EQ(SeqCnt, SeqCntExpected);
@@ -3173,7 +3173,7 @@ void Test_TransmitMsg_SequenceCount(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, false));
+    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), false));
 
     /* Assert sequence count wasn't set */
     UtAssert_STUB_COUNT(CFE_MSG_GetNextSequenceCount, 1);
@@ -3184,7 +3184,7 @@ void Test_TransmitMsg_SequenceCount(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
+    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
     UtAssert_INT32_EQ(SeqCnt, SeqCntExpected);
     UtAssert_STUB_COUNT(CFE_MSG_SetSequenceCount, 2);
     UtAssert_STUB_COUNT(CFE_MSG_GetNextSequenceCount, 2);
@@ -3199,7 +3199,7 @@ void Test_TransmitMsg_SequenceCount(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
-    CFE_UtAssert_SETUP(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true)); /* increment to 3 */
+    CFE_UtAssert_SETUP(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true)); /* increment to 3 */
     UtAssert_STUB_COUNT(CFE_MSG_SetSequenceCount, 3);
     UtAssert_STUB_COUNT(CFE_MSG_GetNextSequenceCount, 3);
 
@@ -3210,7 +3210,7 @@ void Test_TransmitMsg_SequenceCount(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
-    CFE_UtAssert_SETUP(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true)); /* increment to 4 */
+    CFE_UtAssert_SETUP(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true)); /* increment to 4 */
     UtAssert_INT32_EQ(SeqCnt, SeqCntExpected);
     UtAssert_STUB_COUNT(CFE_MSG_SetSequenceCount, 4);
     UtAssert_STUB_COUNT(CFE_MSG_GetNextSequenceCount, 4);
@@ -3238,7 +3238,7 @@ void Test_TransmitMsg_QueuePutError(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
 
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
+    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
 
     CFE_UtAssert_EVENTCOUNT(4);
 
@@ -3267,7 +3267,7 @@ void Test_TransmitMsg_PipeFull(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
 
     /* This send should pass */
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
+    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
 
     /* Tell the QueuePut stub to return OS_QUEUE_FULL on its next call */
     UT_SetDeferredRetcode(UT_KEY(OS_QueuePut), 1, OS_QUEUE_FULL);
@@ -3277,7 +3277,7 @@ void Test_TransmitMsg_PipeFull(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
 
     /* Pipe overflow causes TransmitMsg to return CFE_SUCCESS */
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
+    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
 
     CFE_UtAssert_EVENTCOUNT(4);
 
@@ -3309,7 +3309,7 @@ void Test_TransmitMsg_MsgLimitExceeded(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
 
     /* First send should pass */
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
+    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
@@ -3318,7 +3318,7 @@ void Test_TransmitMsg_MsgLimitExceeded(void)
     /* This send should produce a MsgId to Pipe Limit Exceeded message, but
      * return success
      */
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
+    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
 
     CFE_UtAssert_EVENTCOUNT(4);
 
@@ -3349,7 +3349,7 @@ void Test_TransmitMsg_GetPoolBufErr(void)
      * allocation failed)
      */
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetPoolBuf), 1, CFE_ES_ERR_MEM_BLOCK_SIZE);
-    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true), CFE_SB_BUF_ALOC_ERR);
+    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true), CFE_SB_BUF_ALOC_ERR);
 
     CFE_UtAssert_EVENTCOUNT(3);
     CFE_UtAssert_EVENTSENT(CFE_SB_GET_BUF_ERR_EID);
@@ -3359,7 +3359,7 @@ void Test_TransmitMsg_GetPoolBufErr(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetPoolBuf), 1, CFE_ES_ERR_MEM_BLOCK_SIZE);
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_TaskID_ToIndex), 1, -1);
-    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true), CFE_SB_BUF_ALOC_ERR);
+    UtAssert_INT32_EQ(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true), CFE_SB_BUF_ALOC_ERR);
 
     /* Confirm no additional events sent */
     CFE_UtAssert_EVENTCOUNT(3);
@@ -3621,7 +3621,7 @@ void Test_TransmitMsg_DisabledDestination(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
 
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
+    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
 
     CFE_UtAssert_EVENTCOUNT(2);
 
@@ -3680,7 +3680,7 @@ void Test_TransmitMsgValidate_MaxMsgSizePlusOne(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
 
-    UtAssert_INT32_EQ(CFE_SB_TransmitMsgValidate(&TlmPkt.Hdr.Msg, &MsgIdRtn, &SizeRtn, &RouteIdRtn),
+    UtAssert_INT32_EQ(CFE_SB_TransmitMsgValidate(CFE_MSG_PTR(TlmPkt.TelemetryHeader), &MsgIdRtn, &SizeRtn, &RouteIdRtn),
                       CFE_SB_MSG_TOO_BIG);
     CFE_UtAssert_MSGID_EQ(MsgIdRtn, MsgId);
     UtAssert_INT32_EQ(SizeRtn, Size);
@@ -3705,7 +3705,8 @@ void Test_TransmitMsgValidate_NoSubscribers(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
 
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsgValidate(&TlmPkt.Hdr.Msg, &MsgIdRtn, &SizeRtn, &RouteIdRtn));
+    CFE_UtAssert_SUCCESS(
+        CFE_SB_TransmitMsgValidate(CFE_MSG_PTR(TlmPkt.TelemetryHeader), &MsgIdRtn, &SizeRtn, &RouteIdRtn));
     CFE_UtAssert_MSGID_EQ(MsgIdRtn, MsgId);
     UtAssert_INT32_EQ(SizeRtn, Size);
     UtAssert_BOOL_FALSE(CFE_SBR_IsValidRouteId(RouteIdRtn));
@@ -3728,7 +3729,7 @@ void Test_TransmitMsgValidate_InvalidMsgId(void)
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
 
-    UtAssert_INT32_EQ(CFE_SB_TransmitMsgValidate(&TlmPkt.Hdr.Msg, &MsgIdRtn, &SizeRtn, &RouteIdRtn),
+    UtAssert_INT32_EQ(CFE_SB_TransmitMsgValidate(CFE_MSG_PTR(TlmPkt.TelemetryHeader), &MsgIdRtn, &SizeRtn, &RouteIdRtn),
                       CFE_SB_BAD_ARGUMENT);
     CFE_UtAssert_EVENTCOUNT(1);
     CFE_UtAssert_EVENTSENT(CFE_SB_SEND_INV_MSGID_EID);
@@ -3943,7 +3944,7 @@ void Test_ReceiveBuffer_PendForever(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
     CFE_UtAssert_SETUP(CFE_SB_Subscribe(MsgId, PipeId));
-    CFE_UtAssert_SETUP(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
+    CFE_UtAssert_SETUP(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
 
     CFE_UtAssert_SUCCESS(CFE_SB_ReceiveBuffer(&SBBufPtr, PipeId, CFE_SB_PEND_FOREVER));
 
@@ -4114,42 +4115,42 @@ void Test_CFE_SB_GetUserData(void)
     CFE_MSG_Type_t    type = CFE_MSG_Type_Invalid;
     struct
     {
-        CFE_MSG_CommandHeader_t cmd;
+        CFE_MSG_CommandHeader_t CommandHeader;
         uint8                   payload;
     } cmd_uint8;
     struct
     {
-        CFE_MSG_CommandHeader_t cmd;
+        CFE_MSG_CommandHeader_t CommandHeader;
         uint16                  payload;
     } cmd_uint16;
     struct
     {
-        CFE_MSG_CommandHeader_t cmd;
+        CFE_MSG_CommandHeader_t CommandHeader;
         uint32                  payload;
     } cmd_uint32;
     struct
     {
-        CFE_MSG_CommandHeader_t cmd;
+        CFE_MSG_CommandHeader_t CommandHeader;
         uint64                  payload;
     } cmd_uint64;
     struct
     {
-        CFE_MSG_TelemetryHeader_t tlm;
+        CFE_MSG_TelemetryHeader_t TelemetryHeader;
         uint8                     payload;
     } tlm_uint8;
     struct
     {
-        CFE_MSG_TelemetryHeader_t tlm;
+        CFE_MSG_TelemetryHeader_t TelemetryHeader;
         uint16                    payload;
     } tlm_uint16;
     struct
     {
-        CFE_MSG_TelemetryHeader_t tlm;
+        CFE_MSG_TelemetryHeader_t TelemetryHeader;
         uint32                    payload;
     } tlm_uint32;
     struct
     {
-        CFE_MSG_TelemetryHeader_t tlm;
+        CFE_MSG_TelemetryHeader_t TelemetryHeader;
         uint64                    payload;
     } tlm_uint64;
 
@@ -4159,7 +4160,7 @@ void Test_CFE_SB_GetUserData(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
 
     /* Expected return */
-    expected = (uint8 *)&msg + sizeof(CCSDS_SpacePacket_t);
+    expected = (uint8 *)&msg + sizeof(CFE_MSG_Message_t);
     UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&msg), expected);
 
     /* Commands */
@@ -4167,31 +4168,31 @@ void Test_CFE_SB_GetUserData(void)
     type   = CFE_MSG_Type_Cmd;
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
-    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&cmd_uint8.cmd.Msg), &(cmd_uint8.payload));
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(CFE_MSG_PTR(cmd_uint8.CommandHeader)), &(cmd_uint8.payload));
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
-    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&cmd_uint16.cmd.Msg), &(cmd_uint16.payload));
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(CFE_MSG_PTR(cmd_uint16.CommandHeader)), &(cmd_uint16.payload));
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
-    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&cmd_uint32.cmd.Msg), &(cmd_uint32.payload));
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(CFE_MSG_PTR(cmd_uint32.CommandHeader)), &(cmd_uint32.payload));
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
-    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&cmd_uint64.cmd.Msg), &(cmd_uint64.payload));
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(CFE_MSG_PTR(cmd_uint64.CommandHeader)), &(cmd_uint64.payload));
 
     /* Telemetry */
     type = CFE_MSG_Type_Tlm;
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
-    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&tlm_uint8.tlm.Msg), &(tlm_uint8.payload));
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(CFE_MSG_PTR(tlm_uint8.TelemetryHeader)), &(tlm_uint8.payload));
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
-    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&tlm_uint16.tlm.Msg), &(tlm_uint16.payload));
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(CFE_MSG_PTR(tlm_uint16.TelemetryHeader)), &(tlm_uint16.payload));
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
-    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&tlm_uint32.tlm.Msg), &(tlm_uint32.payload));
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(CFE_MSG_PTR(tlm_uint32.TelemetryHeader)), &(tlm_uint32.payload));
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
-    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(&tlm_uint64.tlm.Msg), &(tlm_uint64.payload));
+    UtAssert_ADDRESS_EQ(CFE_SB_GetUserData(CFE_MSG_PTR(tlm_uint64.TelemetryHeader)), &(tlm_uint64.payload));
 
     /* Bad inputs */
     UtAssert_NULL(CFE_SB_GetUserData(NULL));
@@ -4212,7 +4213,7 @@ void Test_CFE_SB_SetGetUserDataLength(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &size, sizeof(size), false);
-    UtAssert_INT32_EQ(CFE_SB_GetUserDataLength(&msg), size - sizeof(CCSDS_SpacePacket_t));
+    UtAssert_INT32_EQ(CFE_SB_GetUserDataLength(&msg), size - sizeof(CFE_MSG_Message_t));
 
     /*
      * Note, this function currently has a type mismatch - it attempts to
@@ -4541,7 +4542,7 @@ void Test_SB_TransmitMsgPaths_Nominal(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
 
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
+    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
 
     CFE_UtAssert_EVENTCOUNT(3);
 
@@ -4569,14 +4570,14 @@ void Test_SB_TransmitMsgPaths_LimitErr(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
 
     /* First send should pass */
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
+    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
 
     CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_MSGID_LIM_ERR_EID_BIT);
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
+    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
     CFE_SB_Global.StopRecurseFlags[1] = 0;
 
     CFE_UtAssert_EVENTNOTSENT(CFE_SB_MSGID_LIM_ERR_EID);
@@ -4604,7 +4605,7 @@ void Test_SB_TransmitMsgPaths_FullErr(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
 
     /* This send should pass */
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
+    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
@@ -4613,7 +4614,7 @@ void Test_SB_TransmitMsgPaths_FullErr(void)
     /* Tell the QueuePut stub to return OS_QUEUE_FULL on its next call */
     UT_SetDeferredRetcode(UT_KEY(OS_QueuePut), 1, OS_QUEUE_FULL);
     CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_Q_FULL_ERR_EID_BIT);
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
+    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
     CFE_SB_Global.StopRecurseFlags[1] = 0;
 
     CFE_UtAssert_EVENTNOTSENT(CFE_SB_Q_FULL_ERR_EID_BIT);
@@ -4643,14 +4644,14 @@ void Test_SB_TransmitMsgPaths_WriteErr(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
 
     CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_Q_WR_ERR_EID_BIT);
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
+    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
     CFE_SB_Global.StopRecurseFlags[1] = 0;
 
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
 
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
+    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
 
     CFE_UtAssert_EVENTCOUNT(2);
 
@@ -4682,7 +4683,7 @@ void Test_SB_TransmitMsgPaths_IgnoreOpt(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
 
     /* Test skipping this pipe and the send should pass */
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
+    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
     UtAssert_STUB_COUNT(OS_QueuePut, 0);
 
     /* Set up and send again without matching ApId and it should transmit */
@@ -4695,7 +4696,7 @@ void Test_SB_TransmitMsgPaths_IgnoreOpt(void)
 
     /* Also hit case where not the peak depth */
     PipeDscPtr->PeakQueueDepth += 2;
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
+    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
     UtAssert_STUB_COUNT(OS_QueuePut, 1);
 
     /* Set AppId back so it can be deleted */
@@ -4725,7 +4726,7 @@ void Test_ReceiveBuffer_UnsubResubPath(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
-    CFE_UtAssert_SETUP(CFE_SB_TransmitMsg(&TlmPkt.Hdr.Msg, true));
+    CFE_UtAssert_SETUP(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
 
     CFE_UtAssert_SETUP(CFE_SB_Unsubscribe(MsgId, PipeId));
     CFE_UtAssert_SETUP(CFE_SB_Subscribe(MsgId, PipeId));

--- a/modules/sb/ut-coverage/sb_UT.h
+++ b/modules/sb/ut-coverage/sb_UT.h
@@ -49,7 +49,7 @@
 */
 typedef struct
 {
-    CFE_MSG_CommandHeader_t Hdr;
+    CFE_MSG_CommandHeader_t CommandHeader;
     uint32                  Cmd32Param1;
     uint16                  Cmd16Param1;
     uint16                  Cmd16Param2;
@@ -61,7 +61,7 @@ typedef struct
 
 typedef struct
 {
-    CFE_MSG_TelemetryHeader_t Hdr;
+    CFE_MSG_TelemetryHeader_t TelemetryHeader;
     uint32                    Tlm32Param1;
     uint16                    Tlm16Param1;
     uint16                    Tlm16Param2;
@@ -73,7 +73,7 @@ typedef struct
 
 typedef struct
 {
-    CFE_MSG_Message_t Pri;
+    CFE_MSG_Message_t Message;
     uint8             Tlm8Param1;
     uint8             Tlm8Param2;
     uint32            Tlm32Param1;

--- a/modules/tbl/fsw/inc/cfe_tbl_msg.h
+++ b/modules/tbl/fsw/inc/cfe_tbl_msg.h
@@ -491,7 +491,7 @@
 */
 typedef struct CFE_TBL_NoArgsCmd
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 } CFE_TBL_NoArgsCmd_t;
 
 /*
@@ -518,8 +518,8 @@ typedef struct CFE_TBL_LoadCmd_Payload
  */
 typedef struct CFE_TBL_LoadCmd
 {
-    CFE_MSG_CommandHeader_t   CmdHeader; /**< \brief Command header */
-    CFE_TBL_LoadCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t   CommandHeader; /**< \brief Command header */
+    CFE_TBL_LoadCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_TBL_LoadCmd_t;
 
 /**
@@ -548,8 +548,8 @@ typedef struct CFE_TBL_DumpCmd_Payload
  */
 typedef struct CFE_TBL_DumpCmd
 {
-    CFE_MSG_CommandHeader_t   CmdHeader; /**< \brief Command header */
-    CFE_TBL_DumpCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t   CommandHeader; /**< \brief Command header */
+    CFE_TBL_DumpCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_TBL_DumpCmd_t;
 
 /**
@@ -575,8 +575,8 @@ typedef struct CFE_TBL_ValidateCmd_Payload
  */
 typedef struct CFE_TBL_ValidateCmd
 {
-    CFE_MSG_CommandHeader_t       CmdHeader; /**< \brief Command header */
-    CFE_TBL_ValidateCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t       CommandHeader; /**< \brief Command header */
+    CFE_TBL_ValidateCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_TBL_ValidateCmd_t;
 
 /**
@@ -596,8 +596,8 @@ typedef struct CFE_TBL_ActivateCmd_Payload
  */
 typedef struct CFE_TBL_ActivateCmd
 {
-    CFE_MSG_CommandHeader_t       CmdHeader; /**< \brief Command header */
-    CFE_TBL_ActivateCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t       CommandHeader; /**< \brief Command header */
+    CFE_TBL_ActivateCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_TBL_ActivateCmd_t;
 
 /**
@@ -618,8 +618,8 @@ typedef struct CFE_TBL_DumpRegistryCmd_Payload
  */
 typedef struct CFE_TBL_DumpRegistryCmd
 {
-    CFE_MSG_CommandHeader_t           CmdHeader; /**< \brief Command header */
-    CFE_TBL_DumpRegistryCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t           CommandHeader; /**< \brief Command header */
+    CFE_TBL_DumpRegistryCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_TBL_DumpRegistryCmd_t;
 
 /**
@@ -641,8 +641,8 @@ typedef struct CFE_TBL_SendRegistryCmd_Payload
  */
 typedef struct CFE_TBL_SendRegistryCmd
 {
-    CFE_MSG_CommandHeader_t           CmdHeader; /**< \brief Command header */
-    CFE_TBL_SendRegistryCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t           CommandHeader; /**< \brief Command header */
+    CFE_TBL_SendRegistryCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_TBL_SendRegistryCmd_t;
 
 /**
@@ -664,8 +664,8 @@ typedef struct CFE_TBL_DelCDSCmd_Payload
  */
 typedef struct CFE_TBL_DeleteCDSCmd
 {
-    CFE_MSG_CommandHeader_t     CmdHeader; /**< \brief Command header */
-    CFE_TBL_DelCDSCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t     CommandHeader; /**< \brief Command header */
+    CFE_TBL_DelCDSCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_TBL_DeleteCDSCmd_t;
 
 /**
@@ -685,8 +685,8 @@ typedef struct CFE_TBL_AbortLoadCmd_Payload
  */
 typedef struct CFE_TBL_AbortLoadCmd
 {
-    CFE_MSG_CommandHeader_t        CmdHeader; /**< \brief Command header */
-    CFE_TBL_AbortLoadCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t        CommandHeader; /**< \brief Command header */
+    CFE_TBL_AbortLoadCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_TBL_AbortLoadCmd_t;
 
 /*************************************************************************/
@@ -712,8 +712,8 @@ typedef struct CFE_TBL_NotifyCmd_Payload
  */
 typedef struct CFE_TBL_NotifyCmd
 {
-    CFE_MSG_CommandHeader_t     CmdHeader; /**< \brief Command header */
-    CFE_TBL_NotifyCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t     CommandHeader; /**< \brief Command header */
+    CFE_TBL_NotifyCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_TBL_NotifyCmd_t;
 
 /*************************************************************************/
@@ -784,8 +784,8 @@ typedef struct CFE_TBL_HousekeepingTlm_Payload
 
 typedef struct CFE_TBL_HousekeepingTlm
 {
-    CFE_MSG_TelemetryHeader_t         TlmHeader; /**< \brief Telemetry header */
-    CFE_TBL_HousekeepingTlm_Payload_t Payload;   /**< \brief Telemetry payload */
+    CFE_MSG_TelemetryHeader_t         TelemetryHeader; /**< \brief Telemetry header */
+    CFE_TBL_HousekeepingTlm_Payload_t Payload;         /**< \brief Telemetry payload */
 } CFE_TBL_HousekeepingTlm_t;
 
 /**
@@ -831,8 +831,8 @@ typedef struct CFE_TBL_TblRegPacket_Payload
 
 typedef struct CFE_TBL_TableRegistryTlm
 {
-    CFE_MSG_TelemetryHeader_t      TlmHeader; /**< \brief Telemetry header */
-    CFE_TBL_TblRegPacket_Payload_t Payload;   /**< \brief Telemetry payload */
+    CFE_MSG_TelemetryHeader_t      TelemetryHeader; /**< \brief Telemetry header */
+    CFE_TBL_TblRegPacket_Payload_t Payload;         /**< \brief Telemetry payload */
 } CFE_TBL_TableRegistryTlm_t;
 
 #endif /* CFE_TBL_MSG_H */

--- a/modules/tbl/fsw/src/cfe_tbl_internal.c
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.c
@@ -1423,16 +1423,16 @@ int32 CFE_TBL_SendNotificationMsg(CFE_TBL_RegistryRec_t *RegRecPtr)
     if (RegRecPtr->NotifyByMsg)
     {
         /* Set the message ID */
-        CFE_MSG_SetMsgId(&CFE_TBL_Global.NotifyMsg.CmdHeader.Msg, RegRecPtr->NotificationMsgId);
+        CFE_MSG_SetMsgId(CFE_MSG_PTR(CFE_TBL_Global.NotifyMsg.CommandHeader), RegRecPtr->NotificationMsgId);
 
         /* Set the command code */
-        CFE_MSG_SetFcnCode(&CFE_TBL_Global.NotifyMsg.CmdHeader.Msg, RegRecPtr->NotificationCC);
+        CFE_MSG_SetFcnCode(CFE_MSG_PTR(CFE_TBL_Global.NotifyMsg.CommandHeader), RegRecPtr->NotificationCC);
 
         /* Set the command parameter */
         CFE_TBL_Global.NotifyMsg.Payload.Parameter = RegRecPtr->NotificationParam;
 
-        CFE_SB_TimeStampMsg(&CFE_TBL_Global.NotifyMsg.CmdHeader.Msg);
-        Status = CFE_SB_TransmitMsg(&CFE_TBL_Global.NotifyMsg.CmdHeader.Msg, false);
+        CFE_SB_TimeStampMsg(CFE_MSG_PTR(CFE_TBL_Global.NotifyMsg.CommandHeader));
+        Status = CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TBL_Global.NotifyMsg.CommandHeader), false);
 
         if (Status != CFE_SUCCESS)
         {

--- a/modules/tbl/fsw/src/cfe_tbl_task.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task.c
@@ -238,14 +238,15 @@ void CFE_TBL_InitData(void)
     CFE_ES_GetAppID(&CFE_TBL_Global.TableTaskAppId);
 
     /* Initialize Packet Headers */
-    CFE_MSG_Init(&CFE_TBL_Global.HkPacket.TlmHeader.Msg, CFE_SB_ValueToMsgId(CFE_TBL_HK_TLM_MID),
+    CFE_MSG_Init(CFE_MSG_PTR(CFE_TBL_Global.HkPacket.TelemetryHeader), CFE_SB_ValueToMsgId(CFE_TBL_HK_TLM_MID),
                  sizeof(CFE_TBL_Global.HkPacket));
 
-    CFE_MSG_Init(&CFE_TBL_Global.TblRegPacket.TlmHeader.Msg, CFE_SB_ValueToMsgId(CFE_TBL_REG_TLM_MID),
+    CFE_MSG_Init(CFE_MSG_PTR(CFE_TBL_Global.TblRegPacket.TelemetryHeader), CFE_SB_ValueToMsgId(CFE_TBL_REG_TLM_MID),
                  sizeof(CFE_TBL_Global.TblRegPacket));
 
     /* Message ID is set when sent, so OK as 0 here */
-    CFE_MSG_Init(&CFE_TBL_Global.NotifyMsg.CmdHeader.Msg, CFE_SB_ValueToMsgId(0), sizeof(CFE_TBL_Global.NotifyMsg));
+    CFE_MSG_Init(CFE_MSG_PTR(CFE_TBL_Global.NotifyMsg.CommandHeader), CFE_SB_ValueToMsgId(0),
+                 sizeof(CFE_TBL_Global.NotifyMsg));
 }
 
 /*----------------------------------------------------------------

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
@@ -62,8 +62,8 @@ int32 CFE_TBL_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
     /*
     ** Send housekeeping telemetry packet
     */
-    CFE_SB_TimeStampMsg(&CFE_TBL_Global.HkPacket.TlmHeader.Msg);
-    Status = CFE_SB_TransmitMsg(&CFE_TBL_Global.HkPacket.TlmHeader.Msg, true);
+    CFE_SB_TimeStampMsg(CFE_MSG_PTR(CFE_TBL_Global.HkPacket.TelemetryHeader));
+    Status = CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TBL_Global.HkPacket.TelemetryHeader), true);
 
     if (Status != CFE_SUCCESS)
     {
@@ -79,8 +79,8 @@ int32 CFE_TBL_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
         /*
         ** Send Table Registry Info Packet
         */
-        CFE_SB_TimeStampMsg(&CFE_TBL_Global.TblRegPacket.TlmHeader.Msg);
-        CFE_SB_TransmitMsg(&CFE_TBL_Global.TblRegPacket.TlmHeader.Msg, true);
+        CFE_SB_TimeStampMsg(CFE_MSG_PTR(CFE_TBL_Global.TblRegPacket.TelemetryHeader));
+        CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TBL_Global.TblRegPacket.TelemetryHeader), true);
 
         /* Once the data has been sent, clear the index so that we don't send it again and again */
         CFE_TBL_Global.HkTlmTblRegIndex = CFE_TBL_NOT_FOUND;

--- a/modules/tbl/ut-coverage/tbl_UT.c
+++ b/modules/tbl/ut-coverage/tbl_UT.c
@@ -229,8 +229,8 @@ void Test_CFE_TBL_TaskInit(void)
     uint32 ExitCode;
     union
     {
-        CFE_TBL_NoArgsCmd_t NoArgsCmd;
-        CFE_MSG_Message_t   Msg;
+        CFE_MSG_CommandHeader_t NoArgsCmd;
+        CFE_MSG_Message_t       Msg;
     } CmdBuf;
     CFE_SB_MsgId_t    MsgId   = CFE_SB_INVALID_MSG_ID;
     CFE_MSG_FcnCode_t FcnCode = 0;

--- a/modules/time/fsw/inc/cfe_time_msg.h
+++ b/modules/time/fsw/inc/cfe_time_msg.h
@@ -730,7 +730,7 @@
  */
 typedef struct CFE_TIME_NoArgsCmd
 {
-    CFE_MSG_CommandHeader_t CmdHeader; /**< \brief Command header */
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 
 } CFE_TIME_NoArgsCmd_t;
 
@@ -759,8 +759,8 @@ typedef struct CFE_TIME_LeapsCmd_Payload
  */
 typedef struct CFE_TIME_SetLeapSecondsCmd
 {
-    CFE_MSG_CommandHeader_t     CmdHeader; /**< \brief Command header */
-    CFE_TIME_LeapsCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t     CommandHeader; /**< \brief Command header */
+    CFE_TIME_LeapsCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_TIME_SetLeapSecondsCmd_t;
 
 /**
@@ -779,8 +779,8 @@ typedef struct CFE_TIME_StateCmd_Payload
  */
 typedef struct CFE_TIME_SetStateCmd
 {
-    CFE_MSG_CommandHeader_t     CmdHeader; /**< \brief Command header */
-    CFE_TIME_StateCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t     CommandHeader; /**< \brief Command header */
+    CFE_TIME_StateCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_TIME_SetStateCmd_t;
 
 /**
@@ -798,8 +798,8 @@ typedef struct CFE_TIME_SourceCmd_Payload
  */
 typedef struct CFE_TIME_SetSourceCmd
 {
-    CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
-    CFE_TIME_SourceCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
+    CFE_TIME_SourceCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_TIME_SetSourceCmd_t;
 
 /**
@@ -817,8 +817,8 @@ typedef struct CFE_TIME_SignalCmd_Payload
  */
 typedef struct CFE_TIME_SetSignalCmd
 {
-    CFE_MSG_CommandHeader_t      CmdHeader; /**< \brief Command header */
-    CFE_TIME_SignalCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
+    CFE_TIME_SignalCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_TIME_SetSignalCmd_t;
 
 /**
@@ -835,8 +835,8 @@ typedef struct CFE_TIME_TimeCmd_Payload
  */
 typedef struct CFE_TIME_TimeCmd
 {
-    CFE_MSG_CommandHeader_t    CmdHeader; /**< \brief Command header */
-    CFE_TIME_TimeCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t    CommandHeader; /**< \brief Command header */
+    CFE_TIME_TimeCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_TIME_TimeCmd_t;
 
 /*
@@ -867,8 +867,8 @@ typedef struct CFE_TIME_OneHzAdjustmentCmd_Payload
  */
 typedef struct CFE_TIME_OneHzAdjustmentCmd
 {
-    CFE_MSG_CommandHeader_t               CmdHeader; /**< \brief Command header */
-    CFE_TIME_OneHzAdjustmentCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t               CommandHeader; /**< \brief Command header */
+    CFE_TIME_OneHzAdjustmentCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_TIME_OneHzAdjustmentCmd_t;
 
 /*
@@ -895,8 +895,8 @@ typedef struct CFE_TIME_ToneDataCmd_Payload
  */
 typedef struct CFE_TIME_ToneDataCmd
 {
-    CFE_MSG_CommandHeader_t        CmdHeader; /**< \brief Command header */
-    CFE_TIME_ToneDataCmd_Payload_t Payload;   /**< \brief Command payload */
+    CFE_MSG_CommandHeader_t        CommandHeader; /**< \brief Command header */
+    CFE_TIME_ToneDataCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_TIME_ToneDataCmd_t;
 
 /*************************************************************************/
@@ -965,8 +965,8 @@ typedef struct CFE_TIME_HousekeepingTlm_Payload
 
 typedef struct CFE_TIME_HousekeepingTlm
 {
-    CFE_MSG_TelemetryHeader_t          TlmHeader; /**< \brief Telemetry header */
-    CFE_TIME_HousekeepingTlm_Payload_t Payload;   /**< \brief Telemetry payload */
+    CFE_MSG_TelemetryHeader_t          TelemetryHeader; /**< \brief Telemetry header */
+    CFE_TIME_HousekeepingTlm_Payload_t Payload;         /**< \brief Telemetry payload */
 } CFE_TIME_HousekeepingTlm_t;
 
 /*************************************************************************/
@@ -1122,8 +1122,8 @@ typedef struct CFE_TIME_DiagnosticTlm_Payload
 
 typedef struct CFE_TIME_DiagnosticTlm
 {
-    CFE_MSG_TelemetryHeader_t        TlmHeader; /**< \brief Telemetry header */
-    CFE_TIME_DiagnosticTlm_Payload_t Payload;   /**< \brief Telemetry payload */
+    CFE_MSG_TelemetryHeader_t        TelemetryHeader; /**< \brief Telemetry header */
+    CFE_TIME_DiagnosticTlm_Payload_t Payload;         /**< \brief Telemetry payload */
 } CFE_TIME_DiagnosticTlm_t;
 
 #endif /* CFE_TIME_MSG_H */

--- a/modules/time/fsw/src/cfe_time_task.c
+++ b/modules/time/fsw/src/cfe_time_task.c
@@ -583,8 +583,8 @@ int32 CFE_TIME_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
     /*
     ** Send housekeeping telemetry packet...
     */
-    CFE_SB_TimeStampMsg(&CFE_TIME_Global.HkPacket.TlmHeader.Msg);
-    CFE_SB_TransmitMsg(&CFE_TIME_Global.HkPacket.TlmHeader.Msg, true);
+    CFE_SB_TimeStampMsg(CFE_MSG_PTR(CFE_TIME_Global.HkPacket.TelemetryHeader));
+    CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TIME_Global.HkPacket.TelemetryHeader), true);
 
     /*
     ** Note: we only increment the command execution counter when
@@ -772,8 +772,8 @@ int32 CFE_TIME_SendDiagnosticTlm(const CFE_TIME_SendDiagnosticCmd_t *data)
     /*
     ** Send diagnostics telemetry packet...
     */
-    CFE_SB_TimeStampMsg(&CFE_TIME_Global.DiagPacket.TlmHeader.Msg);
-    CFE_SB_TransmitMsg(&CFE_TIME_Global.DiagPacket.TlmHeader.Msg, true);
+    CFE_SB_TimeStampMsg(CFE_MSG_PTR(CFE_TIME_Global.DiagPacket.TelemetryHeader));
+    CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TIME_Global.DiagPacket.TelemetryHeader), true);
 
     CFE_EVS_SendEvent(CFE_TIME_DIAG_EID, CFE_EVS_EventType_DEBUG, "Request diagnostics command");
 

--- a/modules/time/fsw/src/cfe_time_tone.c
+++ b/modules/time/fsw/src/cfe_time_tone.c
@@ -154,7 +154,7 @@ void CFE_TIME_ToneSend(void)
     /*
     ** Send "time at the tone" command data packet...
     */
-    CFE_SB_TransmitMsg(&CFE_TIME_Global.ToneDataCmd.CmdHeader.Msg, false);
+    CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TIME_Global.ToneDataCmd.CommandHeader), false);
 
     /*
     ** Count of "time at the tone" commands sent with internal data...
@@ -1125,7 +1125,7 @@ void CFE_TIME_Tone1HzTask(void)
         /*
         ** Send tone signal command packet...
         */
-        CFE_SB_TransmitMsg(&CFE_TIME_Global.ToneSignalCmd.CmdHeader.Msg, false);
+        CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TIME_Global.ToneSignalCmd.CommandHeader), false);
 
 #if (CFE_MISSION_TIME_CFG_FAKE_TONE == true)
         /*
@@ -1133,7 +1133,7 @@ void CFE_TIME_Tone1HzTask(void)
         ** to send the tone to other time clients.
         ** (this is done by scheduler in non-fake mode)
         */
-        CFE_SB_TransmitMsg(&CFE_TIME_Global.ToneSendCmd.CmdHeader.Msg, false);
+        CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TIME_Global.ToneSendCmd.CommandHeader), false);
 #endif
 
         /*
@@ -1336,7 +1336,7 @@ void CFE_TIME_Local1HzTask(void)
         ** This used to be optional in previous CFE versions, but it is now required
         ** as TIME subscribes to this itself to do state machine tasks.
         */
-        CFE_SB_TransmitMsg(&CFE_TIME_Global.Local1HzCmd.CmdHeader.Msg, false);
+        CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TIME_Global.Local1HzCmd.CommandHeader), false);
 
         CFE_TIME_Global.LocalTaskCounter++;
 

--- a/modules/time/fsw/src/cfe_time_utils.c
+++ b/modules/time/fsw/src/cfe_time_utils.c
@@ -333,26 +333,26 @@ void CFE_TIME_InitData(void)
     /*
     ** Initialize housekeeping packet (clear user data area)...
     */
-    CFE_MSG_Init(&CFE_TIME_Global.HkPacket.TlmHeader.Msg, CFE_SB_ValueToMsgId(CFE_TIME_HK_TLM_MID),
+    CFE_MSG_Init(CFE_MSG_PTR(CFE_TIME_Global.HkPacket.TelemetryHeader), CFE_SB_ValueToMsgId(CFE_TIME_HK_TLM_MID),
                  sizeof(CFE_TIME_Global.HkPacket));
 
     /*
     ** Initialize diagnostic packet (clear user data area)...
     */
-    CFE_MSG_Init(&CFE_TIME_Global.DiagPacket.TlmHeader.Msg, CFE_SB_ValueToMsgId(CFE_TIME_DIAG_TLM_MID),
+    CFE_MSG_Init(CFE_MSG_PTR(CFE_TIME_Global.DiagPacket.TelemetryHeader), CFE_SB_ValueToMsgId(CFE_TIME_DIAG_TLM_MID),
                  sizeof(CFE_TIME_Global.DiagPacket));
 
     /*
     ** Initialize "time at the tone" signal command packet...
     */
-    CFE_MSG_Init(&CFE_TIME_Global.ToneSignalCmd.CmdHeader.Msg, CFE_SB_ValueToMsgId(CFE_TIME_TONE_CMD_MID),
+    CFE_MSG_Init(CFE_MSG_PTR(CFE_TIME_Global.ToneSignalCmd.CommandHeader), CFE_SB_ValueToMsgId(CFE_TIME_TONE_CMD_MID),
                  sizeof(CFE_TIME_Global.ToneSignalCmd));
 
 /*
 ** Initialize "time at the tone" data command packet...
 */
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
-    CFE_MSG_Init(&CFE_TIME_Global.ToneDataCmd.CmdHeader.Msg, CFE_SB_ValueToMsgId(CFE_TIME_DATA_CMD_MID),
+    CFE_MSG_Init(CFE_MSG_PTR(CFE_TIME_Global.ToneDataCmd.CommandHeader), CFE_SB_ValueToMsgId(CFE_TIME_DATA_CMD_MID),
                  sizeof(CFE_TIME_Global.ToneDataCmd));
 #endif
 
@@ -360,14 +360,14 @@ void CFE_TIME_InitData(void)
     ** Initialize simulated tone send message ("fake tone" mode only)...
     */
 #if (CFE_MISSION_TIME_CFG_FAKE_TONE == true)
-    CFE_MSG_Init(&CFE_TIME_Global.ToneSendCmd.CmdHeader.Msg, CFE_SB_ValueToMsgId(CFE_TIME_SEND_CMD_MID),
+    CFE_MSG_Init(CFE_MSG_PTR(CFE_TIME_Global.ToneSendCmd.CommandHeader), CFE_SB_ValueToMsgId(CFE_TIME_SEND_CMD_MID),
                  sizeof(CFE_TIME_Global.ToneSendCmd));
 #endif
 
     /*
     ** Initialize local 1Hz "wake-up" command packet (optional)...
     */
-    CFE_MSG_Init(&CFE_TIME_Global.Local1HzCmd.CmdHeader.Msg, CFE_SB_ValueToMsgId(CFE_TIME_1HZ_CMD_MID),
+    CFE_MSG_Init(CFE_MSG_PTR(CFE_TIME_Global.Local1HzCmd.CommandHeader), CFE_SB_ValueToMsgId(CFE_TIME_1HZ_CMD_MID),
                  sizeof(CFE_TIME_Global.Local1HzCmd));
 
     return;


### PR DESCRIPTION
**Describe the contribution**
Provides more abstract conversions between the local buffer pointers and the `CFE_MSG_Message_t*` pointer required for calling CFE_SB API, without assuming specific member names.

Fixes #1965

**Testing performed**
Build and sanity check CFE, run all tests

**Expected behavior changes**
None in framework build.
Improves source code compatibility when using an alternate MSG implementation that does not (directly) contain a `Msg` member.

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
