### PR TITLE
cFE Integration candidate: 2021-09-21

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@ The detailed cFE user's guide can be viewed at <https://github.com/nasa/cFS/blob
 
 ## Version History
 
+### Development Build: v6.8.0-rc1+dev1024
+
+- CFE_Assert macro names
+- Update msgid testcase to match implementation 
+- Single time domain in functional time tests
+- Add missing inclusions in CFE API headers 
+- Use existing /ram for FS header test
+- Add static local to function test so data section is nonzero
+- Make invalid buffer length consistent in es task test
+- Only check base filename in library info functional
+- Confirm sb/time reset requirements in coverage test
+- Avoid alias warning on some compilers
+- Fix broken link in Application Developers Guide
+- See <https://github.com/nasa/cFE/pull/1967> and <https://github.com/nasa/cFS/pull/359>
+
 ### Development Build: v6.8.0-rc1+dev994
 
 - Update directory diagrams in cFE Application Developers Guide 

--- a/docs/cFE Application Developers Guide.md
+++ b/docs/cFE Application Developers Guide.md
@@ -22,7 +22,7 @@ Table of Contents
        * [4.1.3 Multi-threaded Applications](#413-multi-threaded-applications)
      * [4.2 Best Practices](#42-best-practices)
        * [4.2.1 cFS Application Template](#421-cfs-application-template)
-       * [4.2.2 Avoid "Endian-ness" Dependencies](#422-avoid-endian-ess-dependencies)
+       * [4.2.2 Avoid "Endian-ness" Dependencies](#422-avoid-endian-ness-dependencies)
        * [4.2.3 Avoid Inter-Task Dependencies](#423-avoid-inter-task-dependencies)
        * [4.2.4 Consolidate Resource Allocations](#424-consolidate-resource-allocations)
    * [5. Executive Services Interface](#5-executive-services-interface)

--- a/modules/cfe_assert/inc/cfe_assert.h
+++ b/modules/cfe_assert/inc/cfe_assert.h
@@ -67,8 +67,7 @@ typedef void (*CFE_Assert_StatusCallback_t)(uint8 MessageType, const char *Prefi
 **        None
 **
 ******************************************************************************/
-#define CFE_UtAssert_STATUS_OK(FN) \
-    CFE_UtAssert_StatusCheck(FN, true, UTASSERT_CASETYPE_FAILURE, __FILE__, __LINE__, #FN)
+#define CFE_Assert_STATUS_OK(FN) CFE_Assert_StatusCheck(FN, true, UTASSERT_CASETYPE_FAILURE, __FILE__, __LINE__, #FN)
 
 /*****************************************************************************/
 /**
@@ -86,8 +85,8 @@ typedef void (*CFE_Assert_StatusCallback_t)(uint8 MessageType, const char *Prefi
 **        tests should check for that error instead of using this.
 **
 ******************************************************************************/
-#define CFE_UtAssert_STATUS_ERROR(FN) \
-    CFE_UtAssert_StatusCheck(FN, false, UTASSERT_CASETYPE_FAILURE, __FILE__, __LINE__, #FN)
+#define CFE_Assert_STATUS_ERROR(FN) \
+    CFE_Assert_StatusCheck(FN, false, UTASSERT_CASETYPE_FAILURE, __FILE__, __LINE__, #FN)
 
 /*****************************************************************************/
 /**
@@ -101,7 +100,7 @@ typedef void (*CFE_Assert_StatusCallback_t)(uint8 MessageType, const char *Prefi
 **        and integers may not be interchangeable with strict type checking.
 **
 ******************************************************************************/
-#define CFE_UtAssert_RESOURCEID_EQ(id1, id2)                                                                         \
+#define CFE_Assert_RESOURCEID_EQ(id1, id2)                                                                           \
     UtAssert_GenericUnsignedCompare(CFE_RESOURCEID_TO_ULONG(id1), UtAssert_Compare_EQ, CFE_RESOURCEID_TO_ULONG(id2), \
                                     UtAssert_Radix_HEX, __FILE__, __LINE__, "Resource ID Check: ", #id1, #id2)
 
@@ -117,7 +116,7 @@ typedef void (*CFE_Assert_StatusCallback_t)(uint8 MessageType, const char *Prefi
 **        set of undefined IDs is more than the single value of CFE_RESOURCEID_UNDEFINED.
 **
 ******************************************************************************/
-#define CFE_UtAssert_RESOURCEID_UNDEFINED(id) \
+#define CFE_Assert_RESOURCEID_UNDEFINED(id) \
     UtAssert_True(!CFE_RESOURCEID_TEST_DEFINED(id), "%s (0x%lx) not defined", #id, CFE_RESOURCEID_TO_ULONG(id))
 
 /*****************************************************************************/
@@ -131,7 +130,7 @@ typedef void (*CFE_Assert_StatusCallback_t)(uint8 MessageType, const char *Prefi
 **        This is a simple unsigned comparison which logs the values as hexadecimal
 **
 ******************************************************************************/
-#define CFE_UtAssert_MEMOFFSET_EQ(off1, off2)                                                                \
+#define CFE_Assert_MEMOFFSET_EQ(off1, off2)                                                                  \
     UtAssert_GenericUnsignedCompare(off1, UtAssert_Compare_EQ, off2, UtAssert_Radix_HEX, __FILE__, __LINE__, \
                                     "Offset Check: ", #off1, #off2)
 
@@ -147,7 +146,7 @@ typedef void (*CFE_Assert_StatusCallback_t)(uint8 MessageType, const char *Prefi
 **        and integers may not be interchangeable with strict type checking.
 **
 ******************************************************************************/
-#define CFE_UtAssert_MSGID_EQ(mid1, mid2)                                                                      \
+#define CFE_Assert_MSGID_EQ(mid1, mid2)                                                                        \
     UtAssert_GenericUnsignedCompare(CFE_SB_MsgIdToValue(mid1), UtAssert_Compare_EQ, CFE_SB_MsgIdToValue(mid2), \
                                     UtAssert_Radix_HEX, __FILE__, __LINE__, "MsgId Check: ", #mid1, #mid2)
 
@@ -368,8 +367,8 @@ void CFE_Assert_CloseLogFile(void);
 ** \returns Test pass status, returns true if status was successful, false if it failed.
 **
 ******************************************************************************/
-bool CFE_UtAssert_StatusCheck(CFE_Status_t Status, bool ExpectSuccess, UtAssert_CaseType_t CaseType, const char *File,
-                              uint32 Line, const char *Text);
+bool CFE_Assert_StatusCheck(CFE_Status_t Status, bool ExpectSuccess, UtAssert_CaseType_t CaseType, const char *File,
+                            uint32 Line, const char *Text);
 
 /*****************************************************************************/
 /**

--- a/modules/cfe_assert/src/cfe_assert_runner.c
+++ b/modules/cfe_assert/src/cfe_assert_runner.c
@@ -69,8 +69,8 @@ static CFE_EVS_BinFilter_t CFE_TR_EventFilters[] = {
     {UTASSERT_CASETYPE_DEBUG, CFE_EVS_NO_FILTER},
 };
 
-bool CFE_UtAssert_StatusCheck(CFE_Status_t Status, bool ExpectSuccess, UtAssert_CaseType_t CaseType, const char *File,
-                              uint32 Line, const char *Text)
+bool CFE_Assert_StatusCheck(CFE_Status_t Status, bool ExpectSuccess, UtAssert_CaseType_t CaseType, const char *File,
+                            uint32 Line, const char *Text)
 {
     bool        Result = (Status >= CFE_SUCCESS);
     const char *MatchText;

--- a/modules/cfe_testcase/src/cfe_test.c
+++ b/modules/cfe_testcase/src/cfe_test.c
@@ -41,6 +41,9 @@ CFE_FT_Global_t CFE_FT_Global;
  */
 void CFE_TestMain(void)
 {
+    /* Static local so data section is not zero when checking app info */
+    static char TestName[] = "CFE API";
+
     /* Constant Table information used by all table tests */
     CFE_FT_Global.TblName           = "TestTable";
     CFE_FT_Global.RegisteredTblName = "CFE_TEST_APP.TestTable";
@@ -52,7 +55,7 @@ void CFE_TestMain(void)
      * Note this also waits for the appropriate overall system
      * state and gets ownership of the UtAssert subsystem
      */
-    CFE_Assert_RegisterTest("CFE API");
+    CFE_Assert_RegisterTest(TestName);
     CFE_Assert_OpenLogFile(CFE_ASSERT_LOG_FILE_NAME);
 
     /*

--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -70,7 +70,7 @@ extern CFE_FT_Global_t CFE_FT_Global;
  */
 #define CFE_ASSERT_LOG_FILE_NAME "/cf/cfe_test.log"
 
-bool TimeInRange(CFE_TIME_SysTime_t Time, CFE_TIME_SysTime_t Target, OS_time_t difference);
+void TimeInRange(CFE_TIME_SysTime_t Start, CFE_TIME_SysTime_t Time, CFE_TIME_SysTime_t Range, const char *Str);
 
 void CFE_TestMain(void);
 void ESApplicationControlTestSetup(void);

--- a/modules/cfe_testcase/src/es_cds_test.c
+++ b/modules/cfe_testcase/src/es_cds_test.c
@@ -102,7 +102,7 @@ void TestCDSName(void)
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockName(CDSNameBuf, CDSHandlePtr, sizeof(CDSNameBuf)), CFE_SUCCESS);
     UtAssert_StrCmp(CDSNameBuf, CDSName, "CFE_ES_GetCDSBlockName() = %s", CDSNameBuf);
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockIDByName(&IdByName, CDSNameBuf), CFE_SUCCESS);
-    CFE_UtAssert_RESOURCEID_EQ(CDSHandlePtr, IdByName);
+    CFE_Assert_RESOURCEID_EQ(CDSHandlePtr, IdByName);
 
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockName(NULL, CDSHandlePtr, sizeof(CDSNameBuf)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockName(CDSNameBuf, CFE_ES_CDS_BAD_HANDLE, sizeof(CDSNameBuf)),

--- a/modules/cfe_testcase/src/es_counter_test.c
+++ b/modules/cfe_testcase/src/es_counter_test.c
@@ -88,7 +88,7 @@ void TestCounterCreateDelete(void)
 
     /* Confirm conversion To/From Name */
     UtAssert_INT32_EQ(CFE_ES_GetGenCounterIDByName(&CheckId, CounterName), CFE_SUCCESS);
-    CFE_UtAssert_RESOURCEID_EQ(CheckId, TestId);
+    CFE_Assert_RESOURCEID_EQ(CheckId, TestId);
     UtAssert_INT32_EQ(CFE_ES_GetGenCounterName(CheckName, TestId, sizeof(CheckName)), CFE_SUCCESS);
     UtAssert_STRINGBUF_EQ(CheckName, sizeof(CheckName), CounterName, sizeof(CounterName));
 

--- a/modules/cfe_testcase/src/es_info_test.c
+++ b/modules/cfe_testcase/src/es_info_test.c
@@ -169,6 +169,7 @@ void TestLibInfo(void)
     CFE_ES_LibId_t   CheckId;
     CFE_ES_AppInfo_t LibInfo;
     const char *     LibName     = "ASSERT_LIB";
+    const char *     FileName    = "cfe_assert";
     const char *     InvalidName = "INVALID_NAME";
     char             LibNameBuf[OS_MAX_API_NAME + 4];
 
@@ -181,7 +182,8 @@ void TestLibInfo(void)
     UtAssert_True(LibInfo.Type == CFE_ES_AppType_LIBRARY, "Lib Info -> Type = %d", (int)LibInfo.Type);
     UtAssert_StrCmp(LibInfo.Name, LibName, "Lib Info -> Name = %s", LibInfo.Name);
     UtAssert_StrCmp(LibInfo.EntryPoint, "CFE_Assert_LibInit", "Lib Info -> EntryPt  = %s", LibInfo.EntryPoint);
-    UtAssert_StrCmp(LibInfo.FileName, "/cf/cfe_assert.so", "Lib Info -> FileName = %s", LibInfo.FileName);
+    UtAssert_True(strstr(LibInfo.FileName, FileName) != NULL, "Lib Info -> FileName = %s contains %s", LibInfo.FileName,
+                  FileName);
     UtAssert_True(LibInfo.StackSize == 0, "Lib Info -> StackSz  = %d", (int)LibInfo.StackSize);
 
     if (LibInfo.AddressesAreValid)

--- a/modules/cfe_testcase/src/es_info_test.c
+++ b/modules/cfe_testcase/src/es_info_test.c
@@ -52,7 +52,7 @@ void TestAppInfo(void)
 
     UtAssert_INT32_EQ(CFE_ES_GetAppIDByName(&AppIdByName, TEST_EXPECTED_APP_NAME), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetAppID(&TestAppId), CFE_SUCCESS);
-    CFE_UtAssert_RESOURCEID_EQ(TestAppId, AppIdByName);
+    CFE_Assert_RESOURCEID_EQ(TestAppId, AppIdByName);
     UtAssert_INT32_EQ(CFE_ES_GetAppName(AppNameBuf, TestAppId, sizeof(AppNameBuf)), CFE_SUCCESS);
     UtAssert_StrCmp(AppNameBuf, TEST_EXPECTED_APP_NAME, "CFE_ES_GetAppName() = %s", AppNameBuf);
 
@@ -122,7 +122,7 @@ void TestAppInfo(void)
     UtAssert_True(ESAppInfo.NumOfChildTasks > 0, "ES App Info -> Child Tasks  = %d", (int)ESAppInfo.NumOfChildTasks);
 
     UtAssert_INT32_EQ(CFE_ES_GetAppIDByName(&AppIdByName, INVALID_APP_NAME), CFE_ES_ERR_NAME_NOT_FOUND);
-    CFE_UtAssert_RESOURCEID_UNDEFINED(AppIdByName);
+    CFE_Assert_RESOURCEID_UNDEFINED(AppIdByName);
     UtAssert_INT32_EQ(CFE_ES_GetAppID(NULL), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetAppIDByName(NULL, TEST_EXPECTED_APP_NAME), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetAppIDByName(&AppIdByName, NULL), CFE_ES_BAD_ARGUMENT);
@@ -147,15 +147,15 @@ void TestTaskInfo(void)
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskInfo(&TaskInfo, AppInfo.MainTaskId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetTaskID(&TaskId), CFE_SUCCESS);
-    CFE_UtAssert_RESOURCEID_EQ(TaskId, AppInfo.MainTaskId);
+    CFE_Assert_RESOURCEID_EQ(TaskId, AppInfo.MainTaskId);
 
     UtAssert_StrCmp(TaskInfo.AppName, AppInfo.Name, "TaskInfo.AppName (%s) = AppInfo.name (%s)", TaskInfo.AppName,
                     AppInfo.Name);
     UtAssert_StrCmp(TaskInfo.TaskName, AppInfo.MainTaskName, "TaskInfo.TaskName (%s) = AppInfo.MainTaskName (%s)",
                     TaskInfo.TaskName, AppInfo.MainTaskName);
 
-    CFE_UtAssert_RESOURCEID_EQ(TaskInfo.TaskId, AppInfo.MainTaskId);
-    CFE_UtAssert_RESOURCEID_EQ(TaskInfo.AppId, AppId);
+    CFE_Assert_RESOURCEID_EQ(TaskInfo.TaskId, AppInfo.MainTaskId);
+    CFE_Assert_RESOURCEID_EQ(TaskInfo.AppId, AppId);
     UtAssert_INT32_EQ(TaskInfo.ExecutionCounter, AppInfo.ExecutionCounter);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskInfo(&TaskInfo, CFE_ES_TASKID_UNDEFINED), CFE_ES_ERR_RESOURCEID_NOT_VALID);
@@ -207,18 +207,18 @@ void TestLibInfo(void)
 
     UtAssert_INT32_EQ(LibInfo.ExceptionAction, 0);
     UtAssert_True(LibInfo.Priority == 0, "Lib Info -> Priority  = %d", (int)LibInfo.Priority);
-    CFE_UtAssert_RESOURCEID_UNDEFINED(LibInfo.MainTaskId);
+    CFE_Assert_RESOURCEID_UNDEFINED(LibInfo.MainTaskId);
     UtAssert_True(LibInfo.ExecutionCounter == 0, "Lib Info -> ExecutionCounter  = %d", (int)LibInfo.ExecutionCounter);
     UtAssert_True(strlen(LibInfo.MainTaskName) == 0, "Lib Info -> Task Name  = %s", LibInfo.MainTaskName);
     UtAssert_True(LibInfo.NumOfChildTasks == 0, "Lib Info -> Child Tasks  = %d", (int)LibInfo.NumOfChildTasks);
 
     UtAssert_INT32_EQ(CFE_ES_GetLibIDByName(&CheckId, InvalidName), CFE_ES_ERR_NAME_NOT_FOUND);
-    CFE_UtAssert_RESOURCEID_UNDEFINED(CheckId);
+    CFE_Assert_RESOURCEID_UNDEFINED(CheckId);
     UtAssert_INT32_EQ(CFE_ES_GetLibInfo(&LibInfo, CFE_ES_LIBID_UNDEFINED), CFE_ES_ERR_RESOURCEID_NOT_VALID);
     UtAssert_INT32_EQ(CFE_ES_GetLibInfo(NULL, LibId), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetLibIDByName(NULL, LibName), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetLibIDByName(&CheckId, NULL), CFE_ES_BAD_ARGUMENT);
-    CFE_UtAssert_RESOURCEID_UNDEFINED(CheckId);
+    CFE_Assert_RESOURCEID_UNDEFINED(CheckId);
     UtAssert_INT32_EQ(CFE_ES_GetLibName(LibNameBuf, CFE_ES_LIBID_UNDEFINED, sizeof(LibNameBuf)),
                       CFE_ES_ERR_RESOURCEID_NOT_VALID);
     UtAssert_INT32_EQ(CFE_ES_GetLibName(LibNameBuf, LibId, 0), CFE_ES_BAD_ARGUMENT);

--- a/modules/cfe_testcase/src/es_misc_test.c
+++ b/modules/cfe_testcase/src/es_misc_test.c
@@ -35,24 +35,29 @@
 
 void TestCalculateCRC(void)
 {
-    const char *Data = "Random Stuff";
-    uint8       Data2[12];
-    uint32      expectedCrc      = 20824;
-    uint32      inputCrc         = 345353;
-    uint32      expectedBlockCrc = 2688;
+    const char *Data     = "Random Stuff";
+    uint32      inputCrc = 345353;
+    uint32      Result;
 
     UtPrintf("Testing: CFE_ES_CalculateCRC");
 
-    UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(Data, sizeof(Data), 0, CFE_MISSION_ES_DEFAULT_CRC), expectedCrc);
+    /* CRC is implementation specific, functional just checks that a result is produced and reports */
+    UtAssert_VOIDCALL(Result = CFE_ES_CalculateCRC(Data, sizeof(Data), 0, CFE_MISSION_ES_DEFAULT_CRC));
+    UtAssert_MIR("Confirm mission default CRC of \"%s\" is %lu", Data, (unsigned long)Result);
 
-    memset(Data2, 1, sizeof(Data2));
-    UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(&Data2, sizeof(Data2), inputCrc, CFE_MISSION_ES_CRC_16), expectedBlockCrc);
+    UtAssert_VOIDCALL(Result = CFE_ES_CalculateCRC(Data, sizeof(Data), inputCrc, CFE_MISSION_ES_CRC_16));
+    UtAssert_MIR("Confirm CRC16 of \"%s\" with input CRC of %lu is %lu", Data, (unsigned long)inputCrc,
+                 (unsigned long)Result);
 
-    UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(Data, sizeof(Data), 0, CFE_MISSION_ES_CRC_8), 0);
-    UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(Data, sizeof(Data), 0, CFE_MISSION_ES_CRC_32), 0);
+    UtAssert_VOIDCALL(Result = CFE_ES_CalculateCRC(Data, sizeof(Data), 0, CFE_MISSION_ES_CRC_8));
+    UtAssert_MIR("Confirm CRC8 of \"%s\" is %lu", Data, (unsigned long)Result);
 
-    UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(NULL, sizeof(Data), expectedCrc, CFE_MISSION_ES_CRC_16), expectedCrc);
-    UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(Data, 0, expectedBlockCrc, CFE_MISSION_ES_CRC_16), expectedBlockCrc);
+    UtAssert_VOIDCALL(Result = CFE_ES_CalculateCRC(Data, sizeof(Data), 0, CFE_MISSION_ES_CRC_32));
+    UtAssert_MIR("Confirm CRC32 of \"%s\" is %lu", Data, (unsigned long)Result);
+
+    /* NULL input or 0 size returns input crc */
+    UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(NULL, sizeof(Data), inputCrc, CFE_MISSION_ES_CRC_16), inputCrc);
+    UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(Data, 0, inputCrc, CFE_MISSION_ES_CRC_16), inputCrc);
 }
 
 void TestWriteToSysLog(void)

--- a/modules/cfe_testcase/src/es_task_test.c
+++ b/modules/cfe_testcase/src/es_task_test.c
@@ -192,8 +192,7 @@ void TestChildTaskName(void)
     UtPrintf("Testing: CFE_ES_GetTaskIDByName, CFE_ES_GetTaskName");
 
     CFE_ES_TaskId_t            TaskId;
-    const char *               TaskName            = "CHILD_TASK_1";
-    const char                 INVALID_TASK_NAME[] = "INVALID_NAME";
+    const char                 TaskName[] = "CHILD_TASK_1";
     CFE_ES_TaskId_t            TaskIdByName;
     char                       TaskNameBuf[OS_MAX_API_NAME + 4];
     CFE_ES_StackPointer_t      StackPointer = CFE_ES_TASK_STACK_ALLOCATE;
@@ -212,13 +211,14 @@ void TestChildTaskName(void)
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(NULL, TaskName), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(&TaskIdByName, NULL), CFE_ES_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(&TaskIdByName, INVALID_TASK_NAME), CFE_ES_ERR_NAME_NOT_FOUND);
-    CFE_Assert_RESOURCEID_UNDEFINED(TaskIdByName);
+    UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(&TaskIdByName, "INVALID_NAME"), CFE_ES_ERR_NAME_NOT_FOUND);
+    CFE_UtAssert_RESOURCEID_UNDEFINED(TaskIdByName);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(NULL, TaskId, sizeof(TaskNameBuf)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(TaskNameBuf, CFE_ES_TASKID_UNDEFINED, sizeof(TaskNameBuf)),
                       CFE_ES_ERR_RESOURCEID_NOT_VALID);
-    UtAssert_INT32_EQ(CFE_ES_GetTaskName(TaskNameBuf, TaskId, sizeof(TaskName) - 4), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+    UtAssert_INT32_EQ(CFE_ES_GetTaskName(TaskNameBuf, TaskId, 0), CFE_ES_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_ES_GetTaskName(TaskNameBuf, TaskId, sizeof(TaskName) - 1), CFE_ES_ERR_RESOURCEID_NOT_VALID);
 
     UtAssert_INT32_EQ(CFE_ES_DeleteChildTask(TaskId), CFE_SUCCESS);
 }

--- a/modules/cfe_testcase/src/es_task_test.c
+++ b/modules/cfe_testcase/src/es_task_test.c
@@ -205,7 +205,7 @@ void TestChildTaskName(void)
                       CFE_SUCCESS);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(&TaskIdByName, TaskName), CFE_SUCCESS);
-    CFE_UtAssert_RESOURCEID_EQ(TaskIdByName, TaskId);
+    CFE_Assert_RESOURCEID_EQ(TaskIdByName, TaskId);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(TaskNameBuf, TaskId, sizeof(TaskNameBuf)), CFE_SUCCESS);
     UtAssert_StrCmp(TaskNameBuf, TaskName, "CFE_ES_GetTaskName() = %s", TaskNameBuf);
@@ -213,7 +213,7 @@ void TestChildTaskName(void)
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(NULL, TaskName), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(&TaskIdByName, NULL), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(&TaskIdByName, INVALID_TASK_NAME), CFE_ES_ERR_NAME_NOT_FOUND);
-    CFE_UtAssert_RESOURCEID_UNDEFINED(TaskIdByName);
+    CFE_Assert_RESOURCEID_UNDEFINED(TaskIdByName);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(NULL, TaskId, sizeof(TaskNameBuf)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(TaskNameBuf, CFE_ES_TASKID_UNDEFINED, sizeof(TaskNameBuf)),

--- a/modules/cfe_testcase/src/es_task_test.c
+++ b/modules/cfe_testcase/src/es_task_test.c
@@ -212,7 +212,7 @@ void TestChildTaskName(void)
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(NULL, TaskName), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(&TaskIdByName, NULL), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(&TaskIdByName, "INVALID_NAME"), CFE_ES_ERR_NAME_NOT_FOUND);
-    CFE_UtAssert_RESOURCEID_UNDEFINED(TaskIdByName);
+    CFE_Assert_RESOURCEID_UNDEFINED(TaskIdByName);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(NULL, TaskId, sizeof(TaskNameBuf)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(TaskNameBuf, CFE_ES_TASKID_UNDEFINED, sizeof(TaskNameBuf)),

--- a/modules/cfe_testcase/src/fs_header_test.c
+++ b/modules/cfe_testcase/src/fs_header_test.c
@@ -33,14 +33,12 @@
 
 #include "cfe_test.h"
 
-#define OS_TEST_HEADER_FILENAME "/drive0/header_test.txt"
+#define OS_TEST_HEADER_FILENAME "/ram/header_test.txt"
 char *fsAddrPtr = NULL;
 
 static osal_id_t setup_file(void)
 {
     osal_id_t id;
-    OS_mkfs(fsAddrPtr, "/ramdev1", "RAM", 512, 20);
-    OS_mount("/ramdev1", "/drive0");
     UtAssert_INT32_EQ(OS_OpenCreate(&id, OS_TEST_HEADER_FILENAME, OS_FILE_FLAG_CREATE, OS_READ_WRITE), OS_SUCCESS);
     return id;
 }

--- a/modules/cfe_testcase/src/fs_header_test.c
+++ b/modules/cfe_testcase/src/fs_header_test.c
@@ -59,7 +59,7 @@ void TestCreateHeader(void)
     UtAssert_INT32_EQ(OS_lseek(fd, 0, OS_SEEK_CUR), sizeof(CFE_FS_Header_t));
 
     UtAssert_INT32_EQ(CFE_FS_WriteHeader(fd, NULL), CFE_FS_BAD_ARGUMENT);
-    CFE_UtAssert_STATUS_ERROR(CFE_FS_WriteHeader(OS_OBJECT_ID_UNDEFINED, &Header));
+    CFE_Assert_STATUS_ERROR(CFE_FS_WriteHeader(OS_OBJECT_ID_UNDEFINED, &Header));
 
     UtAssert_VOIDCALL(CFE_FS_InitHeader(NULL, TestDescription, CFE_FS_SubType_ES_ERLOG));
     UtAssert_VOIDCALL(CFE_FS_InitHeader(&HeaderFail, NULL, CFE_FS_SubType_ES_ERLOG));
@@ -88,7 +88,7 @@ void TestReadHeader(void)
     UtAssert_StrCmp(TestDescription, ReadHeader.Description, "ReadHeader.Description = %s", ReadHeader.Description);
 
     UtAssert_INT32_EQ(CFE_FS_ReadHeader(NULL, fd), CFE_FS_BAD_ARGUMENT);
-    CFE_UtAssert_STATUS_ERROR(CFE_FS_ReadHeader(&ReadHeader, OS_OBJECT_ID_UNDEFINED));
+    CFE_Assert_STATUS_ERROR(CFE_FS_ReadHeader(&ReadHeader, OS_OBJECT_ID_UNDEFINED));
 
     OS_close(fd);
     OS_remove(OS_TEST_HEADER_FILENAME);
@@ -114,7 +114,7 @@ void TestTimeStamp(void)
     UtAssert_UINT32_EQ(0xFFFFFFFF, ReadHeader.TimeSeconds);
     UtAssert_UINT32_EQ(0xFFFFFFFF, ReadHeader.TimeSubSeconds);
 
-    CFE_UtAssert_STATUS_ERROR(CFE_FS_SetTimestamp(OS_OBJECT_ID_UNDEFINED, NewTimestamp));
+    CFE_Assert_STATUS_ERROR(CFE_FS_SetTimestamp(OS_OBJECT_ID_UNDEFINED, NewTimestamp));
 
     OS_close(fd);
     OS_remove(OS_TEST_HEADER_FILENAME);

--- a/modules/cfe_testcase/src/message_id_test.c
+++ b/modules/cfe_testcase/src/message_id_test.c
@@ -45,7 +45,20 @@ void TestMsgId(void)
     UtAssert_UINT32_EQ(msgid, expectedmsgid);
 
     UtAssert_INT32_EQ(CFE_MSG_SetMsgId(NULL, msgid), CFE_MSG_BAD_ARGUMENT);
-    UtAssert_INT32_EQ(CFE_MSG_SetMsgId(&msg, CFE_SB_INVALID_MSG_ID), CFE_MSG_BAD_ARGUMENT);
+
+    /*
+     * The purpose of this test is to attempt to set a MsgId beyond the set of values that can
+     * be stored in the MSG header. However the criteria for being "storable" depends on the
+     * actual MSG implementation, and may be different in other implementations.  Currently both
+     * "v1" and "v2" implementations do define a specific highest MsgId value, but another
+     * implementation might not have a highest number concept at all.
+     *
+     * By passing the value of -1, when converted to a an unsigned value (either 16 or 32 bit)
+     * it should translate to a MsgId value with all bits being set.  In theory, at least some of
+     * those bits will be not mappable to the packet header bits, and it should therefore elicit
+     * the CFE_MSG_BAD_ARGUMENT response.
+     */
+    UtAssert_INT32_EQ(CFE_MSG_SetMsgId(&msg, CFE_SB_ValueToMsgId(-1)), CFE_MSG_BAD_ARGUMENT);
 
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(NULL, &msgid), CFE_MSG_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&msg, NULL), CFE_MSG_BAD_ARGUMENT);

--- a/modules/cfe_testcase/src/resource_id_misc_test.c
+++ b/modules/cfe_testcase/src/resource_id_misc_test.c
@@ -60,10 +60,10 @@ void TestToFromInteger(void)
     /* Test resource ID -> integer -> resource ID */
     Id1 = CFE_ResourceId_ToInteger(ResourceId1);
     Id2 = CFE_ResourceId_ToInteger(ResourceId2);
-    CFE_UtAssert_RESOURCEID_EQ((CFE_RESOURCEID_BASE_TYPE)CFE_RESOURCEID_WRAP(CFE_ResourceId_FromInteger(Id1)),
-                               (CFE_RESOURCEID_BASE_TYPE)CFE_RESOURCEID_WRAP(ResourceId1));
-    CFE_UtAssert_RESOURCEID_EQ((CFE_RESOURCEID_BASE_TYPE)CFE_RESOURCEID_WRAP(CFE_ResourceId_FromInteger(Id2)),
-                               (CFE_RESOURCEID_BASE_TYPE)CFE_RESOURCEID_WRAP(ResourceId2));
+    CFE_Assert_RESOURCEID_EQ((CFE_RESOURCEID_BASE_TYPE)CFE_RESOURCEID_WRAP(CFE_ResourceId_FromInteger(Id1)),
+                             (CFE_RESOURCEID_BASE_TYPE)CFE_RESOURCEID_WRAP(ResourceId1));
+    CFE_Assert_RESOURCEID_EQ((CFE_RESOURCEID_BASE_TYPE)CFE_RESOURCEID_WRAP(CFE_ResourceId_FromInteger(Id2)),
+                             (CFE_RESOURCEID_BASE_TYPE)CFE_RESOURCEID_WRAP(ResourceId2));
 }
 
 void TestIsDefined(void)
@@ -151,7 +151,7 @@ void TestGetBaseSerial(void)
                       CFE_RESOURCEID_UNWRAP(PoolIdBuf.ResourceID) - POOLID_BASE);
     UtAssert_INT32_EQ(CFE_ES_PoolDelete(PoolIdBuf.PoolId), CFE_SUCCESS);
     /* CDS Block Id */
-    CFE_UtAssert_STATUS_OK(CFE_ES_RegisterCDS(&CDSHandleIdBuf.CDSHandleId, CDSBlockSize, CDSName));
+    CFE_Assert_STATUS_OK(CFE_ES_RegisterCDS(&CDSHandleIdBuf.CDSHandleId, CDSBlockSize, CDSName));
     UtAssert_INT32_EQ(CFE_ResourceId_GetBase(CDSHandleIdBuf.ResourceID), CDSBLOCKID_BASE);
     UtAssert_INT32_EQ(CFE_ResourceId_GetSerial(CDSHandleIdBuf.ResourceID),
                       CFE_RESOURCEID_UNWRAP(CDSHandleIdBuf.ResourceID) - CDSBLOCKID_BASE);
@@ -179,13 +179,13 @@ void TestFindNext(void)
     /*
      * Why does this macro not accept a resource ID
      * The following line won't compile
-     * CFE_UtAssert_RESOURCEID_UNDEFINED(AppIdBuf.ResourceId);
+     * CFE_Assert_RESOURCEID_UNDEFINED(AppIdBuf.ResourceId);
      */
-    CFE_UtAssert_RESOURCEID_UNDEFINED(AppIdBuf.AppId);
+    CFE_Assert_RESOURCEID_UNDEFINED(AppIdBuf.AppId);
 
     /* maximum number of applications is 0 */
     AppIdBuf.ResourceID = CFE_ResourceId_FindNext(AppIdBuf.ResourceID, 0, TestReturnFalse);
-    CFE_UtAssert_RESOURCEID_UNDEFINED(AppIdBuf.AppId);
+    CFE_Assert_RESOURCEID_UNDEFINED(AppIdBuf.AppId);
 }
 
 void TestToIndex(void)

--- a/modules/cfe_testcase/src/sb_pipe_mang_test.c
+++ b/modules/cfe_testcase/src/sb_pipe_mang_test.c
@@ -162,7 +162,7 @@ void TestPipeName(void)
     UtAssert_StrCmp(PipeNameBuf, PipeName, "CFE_SB_GetPipeName() = %s", PipeNameBuf);
 
     UtAssert_INT32_EQ(CFE_SB_GetPipeIdByName(&PipeIdBuff, PipeName), CFE_SUCCESS);
-    CFE_UtAssert_RESOURCEID_EQ(PipeId, PipeIdBuff);
+    CFE_Assert_RESOURCEID_EQ(PipeId, PipeIdBuff);
 
     UtAssert_INT32_EQ(CFE_SB_GetPipeName(NULL, sizeof(PipeNameBuf), PipeId), CFE_SB_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_SB_GetPipeName(PipeNameBuf, 0, PipeId), CFE_SB_BAD_ARGUMENT);

--- a/modules/cfe_testcase/src/sb_sendrecv_test.c
+++ b/modules/cfe_testcase/src/sb_sendrecv_test.c
@@ -154,7 +154,7 @@ void TestBasicTransmitRecv(void)
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId1, CFE_SB_PEND_FOREVER), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf->Msg, &MsgId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&MsgBuf->Msg, &Seq1), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
     CmdPtr = (const CFE_FT_TestCmdMessage_t *)MsgBuf;
     UtAssert_UINT32_EQ(CmdPtr->CmdPayload, 0x0c0ffee);
     UtAssert_UINT32_EQ(Seq1, 11);
@@ -162,7 +162,7 @@ void TestBasicTransmitRecv(void)
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId1, CFE_SB_PEND_FOREVER), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf->Msg, &MsgId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&MsgBuf->Msg, &Seq1), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
     CmdPtr = (const CFE_FT_TestCmdMessage_t *)MsgBuf;
     UtAssert_UINT32_EQ(CmdPtr->CmdPayload, 0x1c0ffee);
     UtAssert_UINT32_EQ(Seq1, 11);
@@ -170,7 +170,7 @@ void TestBasicTransmitRecv(void)
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId1, CFE_SB_PEND_FOREVER), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf->Msg, &MsgId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&MsgBuf->Msg, &Seq1), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
     CmdPtr = (const CFE_FT_TestCmdMessage_t *)MsgBuf;
     UtAssert_UINT32_EQ(CmdPtr->CmdPayload, 0x2c0ffee);
     UtAssert_UINT32_EQ(Seq1, 11);
@@ -186,14 +186,14 @@ void TestBasicTransmitRecv(void)
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId2, 100), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf->Msg, &MsgId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&MsgBuf->Msg, &Seq1), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_TLM_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_TLM_MSGID);
     TlmPtr = (const CFE_FT_TestTlmMessage_t *)MsgBuf;
     UtAssert_UINT32_EQ(TlmPtr->TlmPayload, 0x0d00d1e);
 
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId2, 100), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf->Msg, &MsgId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&MsgBuf->Msg, &Seq2), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_TLM_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_TLM_MSGID);
     TlmPtr = (const CFE_FT_TestTlmMessage_t *)MsgBuf;
     UtAssert_UINT32_EQ(TlmPtr->TlmPayload, 0x1d00d1e);
     UtAssert_UINT32_EQ(Seq2, CFE_MSG_GetNextSequenceCount(Seq1));
@@ -201,7 +201,7 @@ void TestBasicTransmitRecv(void)
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId2, 100), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf->Msg, &MsgId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&MsgBuf->Msg, &Seq2), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_TLM_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_TLM_MSGID);
     TlmPtr = (const CFE_FT_TestTlmMessage_t *)MsgBuf;
     UtAssert_UINT32_EQ(TlmPtr->TlmPayload, 0x2d00d1e);
     UtAssert_UINT32_EQ(Seq2, 21);
@@ -272,7 +272,7 @@ void TestMsgBroadcast(void)
 
     /* Confirm content */
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf1->Msg, &MsgId), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
     CmdPtr = (const CFE_FT_TestCmdMessage_t *)MsgBuf1;
     UtAssert_UINT32_EQ(CmdPtr->CmdPayload, 0xbabb1e00);
 
@@ -288,7 +288,7 @@ void TestMsgBroadcast(void)
 
     /* Confirm content */
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf2->Msg, &MsgId), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
     CmdPtr = (const CFE_FT_TestCmdMessage_t *)MsgBuf2;
     UtAssert_UINT32_EQ(CmdPtr->CmdPayload, 0xbabb1e01);
 
@@ -303,7 +303,7 @@ void TestMsgBroadcast(void)
 
     /* Confirm content */
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf3->Msg, &MsgId), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
     CmdPtr = (const CFE_FT_TestCmdMessage_t *)MsgBuf3;
     UtAssert_UINT32_EQ(CmdPtr->CmdPayload, 0xbabb1e02);
 
@@ -315,7 +315,7 @@ void TestMsgBroadcast(void)
 
     /* Confirm content */
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf4->Msg, &MsgId), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
     CmdPtr = (const CFE_FT_TestCmdMessage_t *)MsgBuf4;
     UtAssert_UINT32_EQ(CmdPtr->CmdPayload, 0xbabb1e03);
 
@@ -342,7 +342,7 @@ void TestMsgBroadcast(void)
 
     /* Confirm content */
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf1->Msg, &MsgId), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
     CmdPtr = (const CFE_FT_TestCmdMessage_t *)MsgBuf1;
     UtAssert_UINT32_EQ(CmdPtr->CmdPayload, 0xbabb1e04);
 
@@ -357,7 +357,7 @@ void TestMsgBroadcast(void)
 
     /* Confirm content */
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf3->Msg, &MsgId), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
     CmdPtr = (const CFE_FT_TestCmdMessage_t *)MsgBuf3;
     UtAssert_UINT32_EQ(CmdPtr->CmdPayload, 0xbabb1e05);
 
@@ -437,14 +437,14 @@ void TestZeroCopyTransmitRecv(void)
 
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId1, 100), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf->Msg, &MsgId), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
     UtAssert_ADDRESS_EQ(MsgBuf, CmdBuf); /* should be the same actual buffer (not a copy) */
 
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId1, CFE_SB_POLL), CFE_SB_NO_MESSAGE);
 
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId2, 100), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf->Msg, &MsgId), CFE_SUCCESS);
-    CFE_UtAssert_MSGID_EQ(MsgId, CFE_FT_TLM_MSGID);
+    CFE_Assert_MSGID_EQ(MsgId, CFE_FT_TLM_MSGID);
     UtAssert_ADDRESS_EQ(MsgBuf, TlmBuf); /* should be the same actual buffer (not a copy) */
 
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId2, CFE_SB_POLL), CFE_SB_NO_MESSAGE);

--- a/modules/cfe_testcase/src/time_conversion_test.c
+++ b/modules/cfe_testcase/src/time_conversion_test.c
@@ -34,62 +34,25 @@ void TestConvertMET2SCTime(void)
 {
     UtPrintf("Testing: CFE_TIME_MET2SCTime");
 
-    /* Mission Elapsed Time */
-    CFE_TIME_SysTime_t MET;
-    /* MET + SCTF */
-    CFE_TIME_SysTime_t TAI;
-    /* MET + SCTF - Leap Seconds */
-    CFE_TIME_SysTime_t UTC;
-    /* Spacecraft Time */
+    CFE_TIME_SysTime_t METStart;
+    CFE_TIME_SysTime_t METEnd;
+    CFE_TIME_SysTime_t Time;
     CFE_TIME_SysTime_t SCTime;
 
-    OS_time_t start;
-    OS_time_t end;
-    OS_time_t difference;
-
-    /* Print buffers */
-    char timeBuf1[sizeof("yyyy-ddd-hh:mm:ss.xxxxx_")];
-    char timeBuf2[sizeof("yyyy-ddd-hh:mm:ss.xxxxx_")];
-
-    OS_GetLocalTime(&start);
+    CFE_TIME_SysTime_t Range;
 
     /* Get Times */
-    MET = CFE_TIME_GetMET();
-    TAI = CFE_TIME_GetTAI();
-    UTC = CFE_TIME_GetUTC();
+    METStart = CFE_TIME_GetMET();
+    Time     = CFE_TIME_GetTime();
+    METEnd   = CFE_TIME_GetMET();
 
-    OS_GetLocalTime(&end);
+    Range = CFE_TIME_Subtract(METEnd, METStart);
 
     /* Convert - should produce a TAI or UTC at the moment of GetMET() */
-    SCTime = CFE_TIME_MET2SCTime(MET);
-
-    /* write Spacecraft Time into second buffer */
-    CFE_TIME_Print(timeBuf2, SCTime);
-
-    difference = OS_TimeSubtract(end, start);
+    SCTime = CFE_TIME_MET2SCTime(METStart);
 
     /* Check conversion */
-#if (CFE_MISSION_TIME_CFG_DEFAULT_TAI == true)
-    /* SCTime is TAI format */
-
-    /* avoid unused compiler warning */
-    (void)UTC;
-
-    /* write TAI into first buffer */
-    CFE_TIME_Print(timeBuf1, TAI);
-
-    UtAssert_True(TimeInRange(SCTime, TAI, difference), "TAI (%s) = MET2SCTime (%s)", timeBuf1, timeBuf2);
-#else
-    /* SCTime is UTC format */
-
-    /* avoid unused compiler warning */
-    (void)TAI;
-
-    /* write UTC into first buffer */
-    CFE_TIME_Print(timeBuf1, UTC);
-
-    UtAssert_True(TimeInRange(SCTime, UTC, difference), "UTC (%s) = MET2SCTime (%s)", timeBuf1, timeBuf2);
-#endif
+    TimeInRange(SCTime, Time, Range, "MET to SC Time vs default time");
 }
 
 void TestConvertSubSeconds2MicroSeconds(void)

--- a/modules/core_api/fsw/inc/cfe_es.h
+++ b/modules/core_api/fsw/inc/cfe_es.h
@@ -41,6 +41,7 @@
 #include "common_types.h"
 #include "cfe_error.h"
 #include "cfe_es_api_typedefs.h"
+#include "cfe_resourceid_api_typedefs.h"
 
 /*
 ** The OS_PRINTF macro may be defined by OSAL to enable

--- a/modules/core_api/fsw/inc/cfe_msg.h
+++ b/modules/core_api/fsw/inc/cfe_msg.h
@@ -670,6 +670,11 @@ CFE_Status_t CFE_MSG_GetMsgId(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *M
  *        This API only sets the bits in the header that make up the message ID.
  *        No other values in the header are modified.
  *
+ *        The user should ensure that this function is only called with a valid
+ *        MsgId parameter value.  If called with an invalid value, the results
+ *        are implementation-defined.  The implementation may or may not return
+ *        the error code #CFE_MSG_BAD_ARGUMENT in this case.
+ *
  * \param[in, out]  MsgPtr      A pointer to the buffer that contains the message @nonnull.
  * \param[in]       MsgId       Message id
  *

--- a/modules/core_api/fsw/inc/cfe_tbl_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_tbl_api_typedefs.h
@@ -40,6 +40,7 @@
 
 /********************* Include Files  ************************/
 #include "common_types.h" /* Basic Data Types */
+#include "cfe_mission_cfg.h"
 #include "cfe_tbl_extern_typedefs.h"
 #include "cfe_time_extern_typedefs.h"
 

--- a/modules/core_api/fsw/inc/cfe_version.h
+++ b/modules/core_api/fsw/inc/cfe_version.h
@@ -28,7 +28,7 @@
 #define CFE_VERSION_H
 
 /* Development Build Macro Definitions */
-#define CFE_BUILD_NUMBER   994          /**< @brief Development: Number of development commits since baseline */
+#define CFE_BUILD_NUMBER   1024         /**< @brief Development: Number of development commits since baseline */
 #define CFE_BUILD_BASELINE "v6.8.0-rc1" /**< @brief Development: Reference git tag for build number */
 
 /* Version Macro Definitions updated for official releases only */

--- a/modules/sb/fsw/src/cfe_sb_buf.c
+++ b/modules/sb/fsw/src/cfe_sb_buf.c
@@ -104,15 +104,16 @@ void CFE_SB_TrackingListAdd(CFE_SB_BufferLink_t *List, CFE_SB_BufferLink_t *Node
  *-----------------------------------------------------------------*/
 CFE_SB_BufferD_t *CFE_SB_GetBufferFromPool(size_t MaxMsgSize)
 {
-    int32             stat1;
-    size_t            AllocSize;
-    CFE_SB_BufferD_t *bd = NULL;
+    int32               stat1;
+    size_t              AllocSize;
+    CFE_ES_MemPoolBuf_t addr = NULL;
+    CFE_SB_BufferD_t *  bd;
 
     /* The allocation needs to include enough space for the descriptor object */
     AllocSize = MaxMsgSize + CFE_SB_BUFFERD_CONTENT_OFFSET;
 
     /* Allocate a new buffer descriptor from the SB memory pool.*/
-    stat1 = CFE_ES_GetPoolBuf((CFE_ES_MemPoolBuf_t *)&bd, CFE_SB_Global.Mem.PoolHdl, AllocSize);
+    stat1 = CFE_ES_GetPoolBuf(&addr, CFE_SB_Global.Mem.PoolHdl, AllocSize);
     if (stat1 < 0)
     {
         return NULL;
@@ -134,6 +135,7 @@ CFE_SB_BufferD_t *CFE_SB_GetBufferFromPool(size_t MaxMsgSize)
     } /* end if */
 
     /* Initialize the buffer descriptor structure. */
+    bd = (CFE_SB_BufferD_t *)addr;
     memset(bd, 0, CFE_SB_BUFFERD_CONTENT_OFFSET);
 
     bd->MsgId         = CFE_SB_INVALID_MSG_ID;
@@ -214,11 +216,11 @@ void CFE_SB_DecrBufUseCnt(CFE_SB_BufferD_t *bd)
  *-----------------------------------------------------------------*/
 CFE_SB_DestinationD_t *CFE_SB_GetDestinationBlk(void)
 {
-    int32                  Stat;
-    CFE_SB_DestinationD_t *Dest = NULL;
+    int32               Stat;
+    CFE_ES_MemPoolBuf_t addr = NULL;
 
     /* Allocate a new destination descriptor from the SB memory pool.*/
-    Stat = CFE_ES_GetPoolBuf((CFE_ES_MemPoolBuf_t *)&Dest, CFE_SB_Global.Mem.PoolHdl, sizeof(CFE_SB_DestinationD_t));
+    Stat = CFE_ES_GetPoolBuf(&addr, CFE_SB_Global.Mem.PoolHdl, sizeof(CFE_SB_DestinationD_t));
     if (Stat < 0)
     {
         return NULL;
@@ -232,7 +234,7 @@ CFE_SB_DestinationD_t *CFE_SB_GetDestinationBlk(void)
         CFE_SB_Global.StatTlmMsg.Payload.PeakMemInUse = CFE_SB_Global.StatTlmMsg.Payload.MemInUse;
     } /* end if */
 
-    return Dest;
+    return (CFE_SB_DestinationD_t *)addr;
 }
 
 /*----------------------------------------------------------------

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -1767,8 +1767,35 @@ void Test_SB_EarlyInit_PoolCreateError(void)
 */
 void Test_SB_EarlyInit_NoErrors(void)
 {
+    /* Initialize global to nonzero to confirm resets */
+    memset(&CFE_SB_Global, 0xFF, sizeof(CFE_SB_Global));
     CFE_SB_EarlyInit();
     CFE_UtAssert_SUCCESS(CFE_SB_EarlyInit());
+
+    /* Confirm reset of values to cover reset requirements that are challenging operationaly */
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter);
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.NoSubscribersCounter);
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter);
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.MsgReceiveErrorCounter);
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.InternalErrorCounter);
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.CreatePipeErrorCounter);
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.SubscribeErrorCounter);
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.PipeOptsErrorCounter);
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.DuplicateSubscriptionsCounter);
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.GetPipeIdByNameErrorCounter);
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.PipeOverflowErrorCounter);
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.MsgLimitErrorCounter);
+    UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.MsgIdsInUse);
+    UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.PeakMsgIdsInUse);
+    UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.PipesInUse);
+    UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.PeakPipesInUse);
+    UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.MemInUse);
+    UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.PeakMemInUse);
+    UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.SubscriptionsInUse);
+    UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.PeakSubscriptionsInUse);
+    UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.SBBuffersInUse);
+    UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.PeakSBBuffersInUse);
+
 } /* end Test_SB_EarlyInit_NoErrors */
 
 /*

--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -1413,9 +1413,29 @@ void Test_PipeCmds(void)
 
     /* Test sending the reset counters command */
     UT_InitData();
+    CFE_TIME_Global.ToneMatchCounter      = 1;
+    CFE_TIME_Global.ToneMatchErrorCounter = 1;
+    CFE_TIME_Global.ToneSignalCounter     = 1;
+    CFE_TIME_Global.ToneDataCounter       = 1;
+    CFE_TIME_Global.ToneIntCounter        = 1;
+    CFE_TIME_Global.ToneIntErrorCounter   = 1;
+    CFE_TIME_Global.ToneTaskCounter       = 1;
+    CFE_TIME_Global.LocalIntCounter       = 1;
+    CFE_TIME_Global.LocalTaskCounter      = 1;
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.cmd), UT_TPID_CFE_TIME_CMD_RESET_COUNTERS_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_RESET_EID);
+
+    /* Confirm error counters get reset to help cover requirements that are difficult operationally */
+    UtAssert_ZERO(CFE_TIME_Global.ToneMatchCounter);
+    UtAssert_ZERO(CFE_TIME_Global.ToneMatchErrorCounter);
+    UtAssert_ZERO(CFE_TIME_Global.ToneSignalCounter);
+    UtAssert_ZERO(CFE_TIME_Global.ToneDataCounter);
+    UtAssert_ZERO(CFE_TIME_Global.ToneIntCounter);
+    UtAssert_ZERO(CFE_TIME_Global.ToneIntErrorCounter);
+    UtAssert_ZERO(CFE_TIME_Global.ToneTaskCounter);
+    UtAssert_ZERO(CFE_TIME_Global.LocalIntCounter);
+    UtAssert_ZERO(CFE_TIME_Global.LocalTaskCounter);
 
     /* Reset counters with bad size */
     UT_InitData();


### PR DESCRIPTION
**Describe the contribution**

PR #1948 

- Fix #1835, CFE_Assert macro names

PR #1950

- Fix #1949, update msgid testcase to match implementation 

PR #1962

- Fix #1961, Single time domain in functional time tests

PR #1943 

- Fix #1942, add missing inclusions in CFE API headers 

PR #1964  

- Fix #1963, Use existing /ram for FS header test 

PR #1956  

- Fix #1955, Add static local to function test so data section is nonzero 

PR #1960  

- Fix #1959, Make invalid buffer length consistent in es task test 

PR #1953  

- Fix #1951, Only check base filename in library info functional 

PR #1970 

- Fix #1969, Confirm sb/time reset requirements in coverage test 

PR #1947

- Fix broken link in Application Developers Guide

PR#1972
 
- Fix #1971, avoid alias warning on some compilers 

**Testing performed**
cFE Checks <https://github.com/nasa/cFE/pull/1967/checks>
cFS Bundle Checks <https://github.com/nasa/cFS/pull/359/checks>

**Expected behavior changes**
See PRs

**System(s) tested on**
Ubuntu
RTEMS (see cFS bundle PR)

**Additional context**
Part of https://github.com/nasa/cFS/pull/359

**Third party code**
none

**Contributor Info - All information REQUIRED for consideration of pull request**
@jphickey 
@skliper 
@Nodraak