### PR TITLE
Fix #1969, Confirm sb/time reset requirements in coverage test

### DIFF
--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -1767,8 +1767,35 @@ void Test_SB_EarlyInit_PoolCreateError(void)
 */
 void Test_SB_EarlyInit_NoErrors(void)
 {
+    /* Initialize global to nonzero to confirm resets */
+    memset(&CFE_SB_Global, 0xFF, sizeof(CFE_SB_Global));
     CFE_SB_EarlyInit();
     CFE_UtAssert_SUCCESS(CFE_SB_EarlyInit());
+
+    /* Confirm reset of values to cover reset requirements that are challenging operationaly */
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter);
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.NoSubscribersCounter);
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter);
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.MsgReceiveErrorCounter);
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.InternalErrorCounter);
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.CreatePipeErrorCounter);
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.SubscribeErrorCounter);
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.PipeOptsErrorCounter);
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.DuplicateSubscriptionsCounter);
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.GetPipeIdByNameErrorCounter);
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.PipeOverflowErrorCounter);
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.MsgLimitErrorCounter);
+    UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.MsgIdsInUse);
+    UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.PeakMsgIdsInUse);
+    UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.PipesInUse);
+    UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.PeakPipesInUse);
+    UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.MemInUse);
+    UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.PeakMemInUse);
+    UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.SubscriptionsInUse);
+    UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.PeakSubscriptionsInUse);
+    UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.SBBuffersInUse);
+    UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.PeakSBBuffersInUse);
+
 } /* end Test_SB_EarlyInit_NoErrors */
 
 /*

--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -1413,9 +1413,29 @@ void Test_PipeCmds(void)
 
     /* Test sending the reset counters command */
     UT_InitData();
+    CFE_TIME_Global.ToneMatchCounter      = 1;
+    CFE_TIME_Global.ToneMatchErrorCounter = 1;
+    CFE_TIME_Global.ToneSignalCounter     = 1;
+    CFE_TIME_Global.ToneDataCounter       = 1;
+    CFE_TIME_Global.ToneIntCounter        = 1;
+    CFE_TIME_Global.ToneIntErrorCounter   = 1;
+    CFE_TIME_Global.ToneTaskCounter       = 1;
+    CFE_TIME_Global.LocalIntCounter       = 1;
+    CFE_TIME_Global.LocalTaskCounter      = 1;
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.cmd), UT_TPID_CFE_TIME_CMD_RESET_COUNTERS_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_RESET_EID);
+
+    /* Confirm error counters get reset to help cover requirements that are difficult operationally */
+    UtAssert_ZERO(CFE_TIME_Global.ToneMatchCounter);
+    UtAssert_ZERO(CFE_TIME_Global.ToneMatchErrorCounter);
+    UtAssert_ZERO(CFE_TIME_Global.ToneSignalCounter);
+    UtAssert_ZERO(CFE_TIME_Global.ToneDataCounter);
+    UtAssert_ZERO(CFE_TIME_Global.ToneIntCounter);
+    UtAssert_ZERO(CFE_TIME_Global.ToneIntErrorCounter);
+    UtAssert_ZERO(CFE_TIME_Global.ToneTaskCounter);
+    UtAssert_ZERO(CFE_TIME_Global.LocalIntCounter);
+    UtAssert_ZERO(CFE_TIME_Global.LocalTaskCounter);
 
     /* Reset counters with bad size */
     UT_InitData();


### PR DESCRIPTION
**Describe the contribution**
- Fix #1969 

Just added confirmation of sb/time reset requirements that are hard to fully verify operationally.

**Testing performed**
Locally build/ran unit tests, CI

**Expected behavior changes**
No Impact

**System(s) tested on**
 - Hardware: Intel i5/Docker
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC