### PR TITLE
Fix #1982, extended header definitions and test updates

### DIFF
--- a/modules/msg/option_inc/default_cfe_msg_hdr_priext.h
+++ b/modules/msg/option_inc/default_cfe_msg_hdr_priext.h
@@ -36,6 +36,7 @@
 #include "common_types.h"
 #include "ccsds_hdr.h"
 #include "cfe_msg_sechdr.h"
+#include "cfe_msg_api_typedefs.h"
 
 /*
  * Type Definitions
@@ -60,34 +61,30 @@ typedef struct
 /**
  * \brief cFS generic base message
  */
-typedef union
+union CFE_MSG_Message
 {
     CCSDS_SpacePacket_t CCSDS;                             /**< \brief CCSDS Header (Pri or Pri + Ext) */
     uint8               Byte[sizeof(CCSDS_SpacePacket_t)]; /**< \brief Byte level access */
-} CFE_MSG_Message_t;
+};
 
 /**
  * \brief cFS command header
  */
-typedef struct
+struct CFE_MSG_CommandHeader
 {
-
     CFE_MSG_Message_t                Msg;      /**< \brief Base message */
     CFE_MSG_CommandSecondaryHeader_t Sec;      /**< \brief Secondary header */
     uint8                            Spare[4]; /**< /brief Pad to avoid compiler padding if payload
                                                            requires 64 bit alignment */
-
-} CFE_MSG_CommandHeader_t;
+};
 
 /**
  * \brief cFS telemetry header
  */
-typedef struct
+struct CFE_MSG_TelemetryHeader
 {
-
     CFE_MSG_Message_t                  Msg; /**< \brief Base message */
     CFE_MSG_TelemetrySecondaryHeader_t Sec; /**< \brief Secondary header */
-
-} CFE_MSG_TelemetryHeader_t;
+};
 
 #endif /* DEFAULT_CFE_MSG_HDR_PRIEXT_H */

--- a/modules/msg/ut-coverage/test_cfe_msg_ccsdsext.c
+++ b/modules/msg/ut-coverage/test_cfe_msg_ccsdsext.c
@@ -66,7 +66,7 @@ void Test_MSG_Init_Ext(void)
     is_v1 = !hassec;
 
     /* Set up return */
-    UT_SetForceFail(UT_KEY(CFE_PSP_GetSpacecraftId), sc_id);
+    UT_SetDefaultReturnValue(UT_KEY(CFE_PSP_GetSpacecraftId), sc_id);
 
     UtPrintf("Set to all F's, msgid value = 0");
     memset(&msg, 0xFF, sizeof(msg));


### PR DESCRIPTION
**Describe the contribution**
Do not double-typedef the CFE_MSG types when using extended headers.
This also corrects a call to UT_SetForceFail in the extended header test, which was renamed.

Fixes #1982

**Testing performed**
Build and run all CFE sanity checks, with extended headers enabled.

**Expected behavior changes**
Builds and runs correctly when extended headers are selected.

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
