### PR TITLE
Fix #1984, avoid aliasing warnings

### DIFF
--- a/modules/cfe_testcase/src/tbl_content_mang_test.c
+++ b/modules/cfe_testcase/src/tbl_content_mang_test.c
@@ -68,6 +68,7 @@ void TestLoad(void)
     TBL_TEST_Table_t  TestTable     = {0xd00d, 0xdad};
     TBL_TEST_Table_t *TablePtr;
     CFE_TBL_Handle_t  OtherHandle;
+    void *            TempPtr;
 
     UtPrintf("Testing: CFE_TBL_Load");
 
@@ -107,7 +108,8 @@ void TestLoad(void)
     UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_FILE, TESTTBL_NOMINAL_FILE), CFE_SUCCESS);
 
     /* confirm content (football) */
-    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&TablePtr, CFE_FT_Global.TblHandle), CFE_TBL_INFO_UPDATED);
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress(&TempPtr, CFE_FT_Global.TblHandle), CFE_TBL_INFO_UPDATED);
+    TablePtr = TempPtr;
     UtAssert_UINT32_EQ(TablePtr->Int1, 0xf007);
     UtAssert_UINT32_EQ(TablePtr->Int2, 0xba11);
     UtAssert_INT32_EQ(CFE_TBL_ReleaseAddress(CFE_FT_Global.TblHandle), CFE_SUCCESS);
@@ -117,7 +119,8 @@ void TestLoad(void)
                       CFE_TBL_ERR_FILE_TOO_LARGE);
 
     /* confirm content again (note content should not have been updated) */
-    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&TablePtr, CFE_FT_Global.TblHandle), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress(&TempPtr, CFE_FT_Global.TblHandle), CFE_SUCCESS);
+    TablePtr = TempPtr;
     UtAssert_UINT32_EQ(TablePtr->Int1, 0xf007);
     UtAssert_UINT32_EQ(TablePtr->Int2, 0xba11);
     UtAssert_INT32_EQ(CFE_TBL_ReleaseAddress(CFE_FT_Global.TblHandle), CFE_SUCCESS);
@@ -126,7 +129,8 @@ void TestLoad(void)
     UtAssert_INT32_EQ(CFE_TBL_Load(CFE_FT_Global.TblHandle, CFE_TBL_SRC_FILE, TESTTBL_ALTERNATE_FILE), CFE_SUCCESS);
 
     /* confirm content again (changed to alternate data) */
-    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&TablePtr, CFE_FT_Global.TblHandle), CFE_TBL_INFO_UPDATED);
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress(&TempPtr, CFE_FT_Global.TblHandle), CFE_TBL_INFO_UPDATED);
+    TablePtr = TempPtr;
     UtAssert_UINT32_EQ(TablePtr->Int1, 0xdead);
     UtAssert_UINT32_EQ(TablePtr->Int2, 0xbeef);
     UtAssert_INT32_EQ(CFE_TBL_ReleaseAddress(CFE_FT_Global.TblHandle), CFE_SUCCESS);
@@ -136,7 +140,8 @@ void TestLoad(void)
                       CFE_TBL_ERR_LOAD_INCOMPLETE);
 
     /* confirm content again (should not be changed) */
-    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&TablePtr, CFE_FT_Global.TblHandle), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress(&TempPtr, CFE_FT_Global.TblHandle), CFE_SUCCESS);
+    TablePtr = TempPtr;
     UtAssert_UINT32_EQ(TablePtr->Int1, 0xdead);
     UtAssert_UINT32_EQ(TablePtr->Int2, 0xbeef);
     UtAssert_INT32_EQ(CFE_TBL_ReleaseAddress(CFE_FT_Global.TblHandle), CFE_SUCCESS);
@@ -145,13 +150,15 @@ void TestLoad(void)
     UtAssert_INT32_EQ(CFE_TBL_Load(OtherHandle, CFE_TBL_SRC_FILE, TESTTBL_OTHERTBL_FILE), CFE_SUCCESS);
 
     /* confirm content of first table again (should not be changed) */
-    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&TablePtr, CFE_FT_Global.TblHandle), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress(&TempPtr, CFE_FT_Global.TblHandle), CFE_SUCCESS);
+    TablePtr = TempPtr;
     UtAssert_UINT32_EQ(TablePtr->Int1, 0xdead);
     UtAssert_UINT32_EQ(TablePtr->Int2, 0xbeef);
     UtAssert_INT32_EQ(CFE_TBL_ReleaseAddress(CFE_FT_Global.TblHandle), CFE_SUCCESS);
 
     /* confirm content of other table (boatload) */
-    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&TablePtr, OtherHandle), CFE_TBL_INFO_UPDATED);
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress(&TempPtr, OtherHandle), CFE_TBL_INFO_UPDATED);
+    TablePtr = TempPtr;
     UtAssert_UINT32_EQ(TablePtr->Int1, 0xb0a7);
     UtAssert_UINT32_EQ(TablePtr->Int2, 0x10ad);
     UtAssert_INT32_EQ(CFE_TBL_ReleaseAddress(OtherHandle), CFE_SUCCESS);
@@ -161,7 +168,8 @@ void TestLoad(void)
 
     /* confirm content again (reported as updated from partial load) */
     /* Should have updated the first word only */
-    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&TablePtr, CFE_FT_Global.TblHandle), CFE_TBL_INFO_UPDATED);
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress(&TempPtr, CFE_FT_Global.TblHandle), CFE_TBL_INFO_UPDATED);
+    TablePtr = TempPtr;
     UtAssert_UINT32_EQ(TablePtr->Int1, 0x5555);
     UtAssert_UINT32_EQ(TablePtr->Int2, 0xbeef);
     UtAssert_INT32_EQ(CFE_TBL_ReleaseAddress(CFE_FT_Global.TblHandle), CFE_SUCCESS);
@@ -171,7 +179,8 @@ void TestLoad(void)
 
     /* confirm content again (reported as updated from partial load) */
     /* Should have updated the second word only */
-    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&TablePtr, CFE_FT_Global.TblHandle), CFE_TBL_INFO_UPDATED);
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress(&TempPtr, CFE_FT_Global.TblHandle), CFE_TBL_INFO_UPDATED);
+    TablePtr = TempPtr;
     UtAssert_UINT32_EQ(TablePtr->Int1, 0x5555);
     UtAssert_UINT32_EQ(TablePtr->Int2, 0x6666);
     UtAssert_INT32_EQ(CFE_TBL_ReleaseAddress(CFE_FT_Global.TblHandle), CFE_SUCCESS);

--- a/modules/core_api/ut-stubs/src/cfe_es_handlers.c
+++ b/modules/core_api/ut-stubs/src/cfe_es_handlers.c
@@ -125,7 +125,7 @@ void UT_DefaultHandler_CFE_ES_GetAppID(void *UserObj, UT_EntryKey_t FuncKey, con
 {
     CFE_ES_AppId_t *AppIdPtr = UT_Hook_GetArgValueByName(Context, "AppIdPtr", CFE_ES_AppId_t *);
     int32           status;
-    CFE_ES_AppId_t *IdBuff;
+    void *          IdBuff;
     size_t          BuffSize;
     size_t          Position;
 
@@ -133,10 +133,10 @@ void UT_DefaultHandler_CFE_ES_GetAppID(void *UserObj, UT_EntryKey_t FuncKey, con
 
     if (status >= 0)
     {
-        UT_GetDataBuffer(UT_KEY(CFE_ES_GetAppID), (void **)&IdBuff, &BuffSize, &Position);
+        UT_GetDataBuffer(UT_KEY(CFE_ES_GetAppID), &IdBuff, &BuffSize, &Position);
         if (IdBuff != NULL && BuffSize == sizeof(*AppIdPtr))
         {
-            *AppIdPtr = *IdBuff;
+            memcpy(AppIdPtr, IdBuff, sizeof(*AppIdPtr));
         }
         else
         {
@@ -159,7 +159,7 @@ void UT_DefaultHandler_CFE_ES_GetTaskID(void *UserObj, UT_EntryKey_t FuncKey, co
 {
     CFE_ES_TaskId_t *TaskIdPtr = UT_Hook_GetArgValueByName(Context, "TaskIdPtr", CFE_ES_TaskId_t *);
     int32            status;
-    CFE_ES_TaskId_t *IdBuff;
+    void *           IdBuff;
     size_t           BuffSize;
     size_t           Position;
 
@@ -167,10 +167,10 @@ void UT_DefaultHandler_CFE_ES_GetTaskID(void *UserObj, UT_EntryKey_t FuncKey, co
 
     if (status >= 0)
     {
-        UT_GetDataBuffer(UT_KEY(CFE_ES_GetTaskID), (void **)&IdBuff, &BuffSize, &Position);
+        UT_GetDataBuffer(UT_KEY(CFE_ES_GetTaskID), &IdBuff, &BuffSize, &Position);
         if (IdBuff != NULL && BuffSize == sizeof(*TaskIdPtr))
         {
-            *TaskIdPtr = *IdBuff;
+            memcpy(TaskIdPtr, IdBuff, sizeof(*TaskIdPtr));
         }
         else
         {
@@ -194,11 +194,11 @@ void UT_DefaultHandler_CFE_ES_GetAppIDByName(void *UserObj, UT_EntryKey_t FuncKe
     CFE_ES_AppId_t *AppIdPtr = UT_Hook_GetArgValueByName(Context, "AppIdPtr", CFE_ES_AppId_t *);
     const char *    AppName  = UT_Hook_GetArgValueByName(Context, "AppName", const char *);
 
-    size_t          UserBuffSize;
-    size_t          BuffPosition;
-    const char *    NameBuff;
-    CFE_ES_AppId_t *IdBuff;
-    int32           status;
+    size_t UserBuffSize;
+    size_t BuffPosition;
+    void * NameBuff;
+    void * IdBuff;
+    int32  status;
 
     UT_Stub_GetInt32StatusCode(Context, &status);
 
@@ -207,15 +207,15 @@ void UT_DefaultHandler_CFE_ES_GetAppIDByName(void *UserObj, UT_EntryKey_t FuncKe
         if (UT_Stub_CopyToLocal(UT_KEY(CFE_ES_GetAppIDByName), AppIdPtr, sizeof(*AppIdPtr)) < sizeof(*AppIdPtr))
         {
             IdBuff = NULL;
-            UT_GetDataBuffer(UT_KEY(CFE_ES_GetAppName), (void **)&NameBuff, &UserBuffSize, &BuffPosition);
-            if (NameBuff != NULL && UserBuffSize > 0 && strncmp(NameBuff, AppName, UserBuffSize) == 0)
+            UT_GetDataBuffer(UT_KEY(CFE_ES_GetAppName), &NameBuff, &UserBuffSize, &BuffPosition);
+            if (NameBuff != NULL && UserBuffSize > 0 && strncmp((const char *)NameBuff, AppName, UserBuffSize) == 0)
             {
-                UT_GetDataBuffer(UT_KEY(CFE_ES_GetAppID), (void **)&IdBuff, &UserBuffSize, &BuffPosition);
+                UT_GetDataBuffer(UT_KEY(CFE_ES_GetAppID), &IdBuff, &UserBuffSize, &BuffPosition);
             }
 
             if (IdBuff != NULL && UserBuffSize == sizeof(*AppIdPtr))
             {
-                *AppIdPtr = *IdBuff;
+                memcpy(AppIdPtr, IdBuff, sizeof(*AppIdPtr));
             }
             else
             {
@@ -243,17 +243,22 @@ void UT_DefaultHandler_CFE_ES_GetAppName(void *UserObj, UT_EntryKey_t FuncKey, c
     size_t      UserBuffSize;
     size_t      BuffPosition;
     const char *NameBuff;
+    void *      TempBuff;
     int32       status;
 
     UT_Stub_GetInt32StatusCode(Context, &status);
 
     if (status >= 0 && BufferLength > 0)
     {
-        UT_GetDataBuffer(UT_KEY(CFE_ES_GetAppName), (void **)&NameBuff, &UserBuffSize, &BuffPosition);
-        if (NameBuff == NULL || UserBuffSize == 0)
+        UT_GetDataBuffer(UT_KEY(CFE_ES_GetAppName), &TempBuff, &UserBuffSize, &BuffPosition);
+        if (TempBuff == NULL || UserBuffSize == 0)
         {
             NameBuff     = "UT";
             UserBuffSize = 2;
+        }
+        else
+        {
+            NameBuff = TempBuff;
         }
 
         if (UserBuffSize < BufferLength)

--- a/modules/core_api/ut-stubs/src/cfe_fs_handlers.c
+++ b/modules/core_api/ut-stubs/src/cfe_fs_handlers.c
@@ -50,6 +50,7 @@ void UT_DefaultHandler_CFE_FS_GetDefaultMountPoint(void *UserObj, UT_EntryKey_t 
 {
     int32             Status;
     static const char DEFAULT_MOUNTPOINT[] = "/ut";
+    void *            TempBuff;
     const char *      Result;
 
     UT_Stub_GetInt32StatusCode(Context, &Status);
@@ -58,10 +59,14 @@ void UT_DefaultHandler_CFE_FS_GetDefaultMountPoint(void *UserObj, UT_EntryKey_t 
     if (Status == CFE_SUCCESS)
     {
         /* If the test case supplied a buffer, return it, otherwise return fixed value */
-        UT_GetDataBuffer(UT_KEY(CFE_FS_GetDefaultMountPoint), (void **)&Result, NULL, NULL);
-        if (Result == NULL)
+        UT_GetDataBuffer(UT_KEY(CFE_FS_GetDefaultMountPoint), &TempBuff, NULL, NULL);
+        if (TempBuff == NULL)
         {
             Result = DEFAULT_MOUNTPOINT;
+        }
+        else
+        {
+            Result = TempBuff;
         }
     }
 
@@ -77,6 +82,7 @@ void UT_DefaultHandler_CFE_FS_GetDefaultExtension(void *UserObj, UT_EntryKey_t F
 {
     int32             Status;
     static const char DEFAULT_EXTENSION[] = ".ut";
+    void *            TempBuff;
     const char *      Result;
 
     UT_Stub_GetInt32StatusCode(Context, &Status);
@@ -85,10 +91,14 @@ void UT_DefaultHandler_CFE_FS_GetDefaultExtension(void *UserObj, UT_EntryKey_t F
     if (Status == CFE_SUCCESS)
     {
         /* If the test case supplied a buffer, return it, otherwise return fixed value */
-        UT_GetDataBuffer(UT_KEY(CFE_FS_GetDefaultExtension), (void **)&Result, NULL, NULL);
-        if (Result == NULL)
+        UT_GetDataBuffer(UT_KEY(CFE_FS_GetDefaultExtension), &TempBuff, NULL, NULL);
+        if (TempBuff == NULL)
         {
             Result = DEFAULT_EXTENSION;
+        }
+        else
+        {
+            Result = TempBuff;
         }
     }
 

--- a/modules/core_api/ut-stubs/src/cfe_sb_handlers.c
+++ b/modules/core_api/ut-stubs/src/cfe_sb_handlers.c
@@ -50,12 +50,12 @@ typedef struct
 
 static CFE_SB_StubMsg_MetaData_t *CFE_SB_StubMsg_GetMetaData(const CFE_MSG_Message_t *MsgPtr)
 {
-    CFE_SB_StubMsg_MetaData_t *MetaPtr;
-    CFE_SB_StubMsg_MetaData_t  DefaultMeta;
-    size_t                     MetaSize;
-    UT_EntryKey_t              MsgKey = (UT_EntryKey_t)MsgPtr;
+    void *                    MetaPtr;
+    CFE_SB_StubMsg_MetaData_t DefaultMeta;
+    size_t                    MetaSize;
+    UT_EntryKey_t             MsgKey = (UT_EntryKey_t)MsgPtr;
 
-    UT_GetDataBuffer(MsgKey, (void **)&MetaPtr, &MetaSize, NULL);
+    UT_GetDataBuffer(MsgKey, &MetaPtr, &MetaSize, NULL);
     if (MetaPtr == NULL || MetaSize != sizeof(DefaultMeta))
     {
         memset(&DefaultMeta, 0, sizeof(DefaultMeta));
@@ -64,7 +64,7 @@ static CFE_SB_StubMsg_MetaData_t *CFE_SB_StubMsg_GetMetaData(const CFE_MSG_Messa
         UT_SetDataBuffer(MsgKey, &DefaultMeta, sizeof(DefaultMeta), true);
 
         /* Because "allocate copy" is true above, this gets a pointer to the copy */
-        UT_GetDataBuffer(MsgKey, (void **)&MetaPtr, &MetaSize, NULL);
+        UT_GetDataBuffer(MsgKey, &MetaPtr, &MetaSize, NULL);
     }
 
     return MetaPtr;
@@ -123,6 +123,7 @@ void UT_DefaultHandler_CFE_SB_GetPipeName(void *UserObj, UT_EntryKey_t FuncKey, 
 
     size_t      UserBuffSize;
     size_t      BuffPosition;
+    void *      TempBuff;
     const char *NameBuff;
     int32       status;
 
@@ -130,11 +131,15 @@ void UT_DefaultHandler_CFE_SB_GetPipeName(void *UserObj, UT_EntryKey_t FuncKey, 
 
     if (status >= 0 && PipeNameSize > 0)
     {
-        UT_GetDataBuffer(UT_KEY(CFE_SB_GetPipeName), (void **)&NameBuff, &UserBuffSize, &BuffPosition);
-        if (NameBuff == NULL || UserBuffSize == 0)
+        UT_GetDataBuffer(UT_KEY(CFE_SB_GetPipeName), &TempBuff, &UserBuffSize, &BuffPosition);
+        if (TempBuff == NULL || UserBuffSize == 0)
         {
             NameBuff     = "UT";
             UserBuffSize = 2;
+        }
+        else
+        {
+            NameBuff = TempBuff;
         }
 
         if (UserBuffSize < PipeNameSize)

--- a/modules/core_private/ut-stubs/src/ut_support.c
+++ b/modules/core_private/ut-stubs/src/ut_support.c
@@ -372,11 +372,13 @@ static bool UT_CheckEventHistoryFromFunc(UT_EntryKey_t Func, uint16 EventIDToSea
     bool    Result = false;
     size_t  Position;
     size_t  MaxSize;
+    void *  TempBuff;
     uint16 *EvBuf;
 
-    UT_GetDataBuffer(Func, (void **)&EvBuf, &MaxSize, &Position);
-    if (EvBuf != NULL && MaxSize > 0)
+    UT_GetDataBuffer(Func, &TempBuff, &MaxSize, &Position);
+    if (TempBuff != NULL && MaxSize > 0)
     {
+        EvBuf = TempBuff;
         Position /= sizeof(*EvBuf);
         while (Position > 0)
         {

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -133,12 +133,16 @@ CFE_ResourceId_t UT_SB_MakePipeIdForIndex(uint32 ArrayIdx)
  */
 CFE_ES_AppId_t UT_SB_AppID_Modify(CFE_ES_AppId_t InitialID, int32 Modifier)
 {
-    CFE_ES_AppId_t TempValue = InitialID;
+    CFE_ES_AppId_t OutValue;
+    uint32         InValue;
 
-    /* Underneath the wrapper(s) the IDs are 32-bit integer values, so it can be cast */
-    *((uint32 *)&TempValue) += Modifier;
+    InValue = CFE_RESOURCEID_TO_ULONG(InitialID);
+    InValue += Modifier;
 
-    return TempValue;
+    /* Underneath the wrapper(s) the IDs are 32-bit integer values, so it can be copied */
+    memcpy(&OutValue, &InValue, sizeof(OutValue));
+
+    return OutValue;
 }
 
 /*

--- a/modules/tbl/ut-coverage/tbl_UT.c
+++ b/modules/tbl/ut-coverage/tbl_UT.c
@@ -2045,7 +2045,7 @@ void Test_CFE_TBL_Load(void)
     UT_Table1_t                 TestTable1;
     CFE_FS_Header_t             StdFileHeader;
     CFE_TBL_File_Hdr_t          TblFileHeader;
-    UT_Table1_t *               App2TblPtr;
+    void *                      App2TblPtr;
     CFE_TBL_RegistryRec_t *     RegRecPtr;
     CFE_TBL_AccessDescriptor_t *AccessDescPtr;
 
@@ -2236,7 +2236,7 @@ void Test_CFE_TBL_Load(void)
     CFE_UtAssert_EVENTCOUNT(0);
 
     /* a. Test setup part 2 */
-    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&App2TblPtr, App2TblHandle1), CFE_TBL_INFO_UPDATED);
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress(&App2TblPtr, App2TblHandle1), CFE_TBL_INFO_UPDATED);
     CFE_UtAssert_EVENTCOUNT(0);
 
     /* c. Perform test */
@@ -2258,8 +2258,8 @@ void Test_CFE_TBL_Load(void)
 */
 void Test_CFE_TBL_GetAddress(void)
 {
-    UT_Table1_t *App3TblPtr;
-    UT_Table1_t *App2TblPtr;
+    void *App3TblPtr;
+    void *App2TblPtr;
 
     UtPrintf("Begin Test Get Address");
 
@@ -2272,19 +2272,18 @@ void Test_CFE_TBL_GetAddress(void)
      */
     UT_InitData();
     UT_SetAppID(UT_TBL_APPID_3);
-    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&App3TblPtr, App2TblHandle1), CFE_TBL_ERR_NO_ACCESS);
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress(&App3TblPtr, App2TblHandle1), CFE_TBL_ERR_NO_ACCESS);
     CFE_UtAssert_EVENTCOUNT(0);
 
     /* Test attempt to get the address with an invalid application ID */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppID), 1, CFE_ES_ERR_RESOURCEID_NOT_VALID);
-    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&App3TblPtr, App2TblHandle1), CFE_ES_ERR_RESOURCEID_NOT_VALID);
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress(&App3TblPtr, App2TblHandle1), CFE_ES_ERR_RESOURCEID_NOT_VALID);
     CFE_UtAssert_EVENTCOUNT(0);
 
     /* Test attempt to get the address with an invalid handle */
     UT_InitData();
-    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&App3TblPtr, CFE_PLATFORM_TBL_MAX_NUM_HANDLES),
-                      CFE_TBL_ERR_INVALID_HANDLE);
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress(&App3TblPtr, CFE_PLATFORM_TBL_MAX_NUM_HANDLES), CFE_TBL_ERR_INVALID_HANDLE);
     CFE_UtAssert_EVENTCOUNT(0);
 
     /* Attempt to get the address of an unregistered (unowned) table */
@@ -2297,7 +2296,7 @@ void Test_CFE_TBL_GetAddress(void)
     /* b. Perform test */
     UT_InitData();
     UT_SetAppID(UT_TBL_APPID_2);
-    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&App2TblPtr, App2TblHandle1), CFE_TBL_ERR_UNREGISTERED);
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress(&App2TblPtr, App2TblHandle1), CFE_TBL_ERR_UNREGISTERED);
     CFE_UtAssert_EVENTCOUNT(0);
 }
 
@@ -2528,7 +2527,7 @@ void Test_CFE_TBL_Manage(void)
     CFE_TBL_RegistryRec_t *     RegRecPtr;
     CFE_TBL_LoadBuff_t *        WorkingBufferPtr;
     UT_Table1_t                 TestTable1;
-    UT_Table1_t *               App2TblPtr;
+    void *                      App2TblPtr;
     CFE_TBL_AccessDescriptor_t *AccessDescPtr;
     CFE_TBL_Handle_t            AccessIterator;
 
@@ -2712,7 +2711,7 @@ void Test_CFE_TBL_Manage(void)
     CFE_UtAssert_EVENTCOUNT(0);
 
     /* a. Test setup - part 2 */
-    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&App2TblPtr, App2TblHandle1), CFE_TBL_ERR_NEVER_LOADED);
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress(&App2TblPtr, App2TblHandle1), CFE_TBL_ERR_NEVER_LOADED);
     CFE_UtAssert_EVENTCOUNT(0);
 
     /* c. Perform test */
@@ -3025,6 +3024,7 @@ void Test_CFE_TBL_TblMod(void)
     UT_TempFile_t               File;
     uint32                      Index;
     CFE_TBL_Info_t              TblInfo1;
+    void *                      TblDataAddr;
     UT_Table1_t *               TblDataPtr;
     char                        MyFilename[OS_MAX_PATH_LEN];
     CFE_TBL_AccessDescriptor_t *AccessDescPtr;
@@ -3087,7 +3087,8 @@ void Test_CFE_TBL_TblMod(void)
     CFE_UtAssert_EVENTSENT(CFE_TBL_LOAD_SUCCESS_INF_EID);
 
     /* Modify the contents of the table */
-    CFE_TBL_GetAddress((void **)&TblDataPtr, App1TblHandle1);
+    CFE_TBL_GetAddress(&TblDataAddr, App1TblHandle1);
+    TblDataPtr = TblDataAddr;
     TblDataPtr->TblElement1 ^= 0xFFFFFFFF;
     File.TblData.TblElement1 ^= 0xFFFFFFFF;
 
@@ -3164,7 +3165,7 @@ void Test_CFE_TBL_TblMod(void)
     CFE_UtAssert_SUCCESS(CFE_TBL_GetInfo(&TblInfo1, "ut_cfe_tbl.UT_Table2"));
     UtAssert_INT32_EQ(TblInfo1.TimeOfLastUpdate.Seconds, TblInfo1.TimeOfLastUpdate.Subseconds);
     UtAssert_UINT32_EQ(TblInfo1.Crc, ExpectedCrc);
-    UtAssert_INT32_EQ(CFE_TBL_GetAddress((void **)&TblDataPtr, App1TblHandle1), CFE_TBL_INFO_UPDATED);
+    UtAssert_INT32_EQ(CFE_TBL_GetAddress(&TblDataAddr, App1TblHandle1), CFE_TBL_INFO_UPDATED);
 
     /*
      * LastFileLoaded (limited by mission) can be bigger than MyFilename (limited by osal),


### PR DESCRIPTION
**Describe the contribution**
Use an actual `void*` value when invoking functions that output an opaque pointer value.  If necessary the value of this pointer can then be assigned to the real pointer type to dereference.

Fixes #1984

**Testing performed**
Build and sanity check CFE, run all tests

**Expected behavior changes**
No warnings when building with strict aliasing

**System(s) tested on**
Ubuntu 21.04 (gcc 10.3)

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
