### PR TITLE
Fix #1988, consolidate repeated MSG stub setup in sb_UT

### DIFF
--- a/modules/core_private/ut-stubs/inc/ut_support.h
+++ b/modules/core_private/ut-stubs/inc/ut_support.h
@@ -216,6 +216,27 @@ void UT_ResetPoolBufferIndex(void);
 
 /*****************************************************************************/
 /**
+** \brief Sets up stubs to follow the intended path through a dispatch call
+**
+** \par Description
+**        Configures the MSG stubs appropriately so the intended command handler
+**        is called when invoking a "TaskPipe" handler function.
+**
+**        DispatchReq should point to the intended MsgId + command code to set up.
+**
+**        If DispatchReq is NULL, then any existing stub config is cleared/reset.
+**
+**        If ExpectFailureEvent is set true, then it sets a second stub registration
+**        for both MsgId and FcnCode to account for failure event reporting
+**
+** \returns
+**        This function does not return a value.
+******************************************************************************/
+void UT_SetupBasicMsgDispatch(const UT_TaskPipeDispatchId_t *DispatchReq, CFE_MSG_Size_t MsgSize,
+                              bool ExpectFailureEvent);
+
+/*****************************************************************************/
+/**
 ** \brief Send a message via the software bus
 **
 ** \par Description

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -77,6 +77,49 @@ const CFE_SB_MsgId_t SB_UT_TLM_MID4 = CFE_SB_MSGID_WRAP_VALUE(SB_UT_TLM_MID_VALU
 const CFE_SB_MsgId_t SB_UT_TLM_MID5 = CFE_SB_MSGID_WRAP_VALUE(SB_UT_TLM_MID_VALUE_BASE + 5);
 const CFE_SB_MsgId_t SB_UT_TLM_MID6 = CFE_SB_MSGID_WRAP_VALUE(SB_UT_TLM_MID_VALUE_BASE + 6);
 
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_NOOP_CC = {.MsgId       = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_CMD_MID),
+                                                            .CommandCode = CFE_SB_NOOP_CC};
+
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_RESET_COUNTERS_CC = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_CMD_MID),
+                                                                      .CommandCode = CFE_SB_RESET_COUNTERS_CC};
+
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_SEND_SB_STATS_CC = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_CMD_MID),
+                                                                     .CommandCode = CFE_SB_SEND_SB_STATS_CC};
+
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_WRITE_ROUTING_INFO_CC = {
+    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_CMD_MID), .CommandCode = CFE_SB_WRITE_ROUTING_INFO_CC};
+
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_WRITE_PIPE_INFO_CC = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_CMD_MID),
+                                                                       .CommandCode = CFE_SB_WRITE_PIPE_INFO_CC};
+
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_WRITE_MAP_INFO_CC = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_CMD_MID),
+                                                                      .CommandCode = CFE_SB_WRITE_MAP_INFO_CC};
+
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_ENABLE_ROUTE_CC = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_CMD_MID),
+                                                                    .CommandCode = CFE_SB_ENABLE_ROUTE_CC};
+
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_DISABLE_ROUTE_CC = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_CMD_MID),
+                                                                     .CommandCode = CFE_SB_DISABLE_ROUTE_CC};
+
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_SEND_HK = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_SEND_HK_MID)};
+
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_SUB_RPT_CTL_SEND_PREV_SUBS_CC = {
+    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_SUB_RPT_CTRL_MID), .CommandCode = CFE_SB_SEND_PREV_SUBS_CC};
+
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_SUB_RPT_CTL_ENABLE_SUB_REPORTING_CC = {
+    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_SUB_RPT_CTRL_MID), .CommandCode = CFE_SB_ENABLE_SUB_REPORTING_CC};
+
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_SUB_RPT_CTL_DISABLE_SUB_REPORTING_CC = {
+    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_SUB_RPT_CTRL_MID), .CommandCode = CFE_SB_DISABLE_SUB_REPORTING_CC};
+
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_BAD_FCNCODE = {.MsgId       = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_CMD_MID),
+                                                                .CommandCode = 99};
+
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_SUB_RPT_CTRL_BAD_FCNCODE = {
+    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_SUB_RPT_CTRL_MID), .CommandCode = 99};
+
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_BAD_MSGID = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(SB_UT_TLM_MID_VALUE_BASE)};
+
 /*
  * A MsgId value which still qualifies as valid
  *
@@ -390,9 +433,7 @@ void Test_SB_Main_Nominal(void)
         CFE_SB_BufferD_t Desc;
         uint8            Data[sizeof(CFE_SB_NoopCmd_t) + offsetof(CFE_SB_BufferD_t, Content)];
     } Buffer;
-    CFE_MSG_FcnCode_t FcnCode = CFE_SB_NOOP_CC;
-    CFE_SB_MsgId_t    MsgId   = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size    = sizeof(CFE_SB_NoopCmd_t);
+    CFE_MSG_Size_t Size = sizeof(CFE_SB_NoopCmd_t);
 
     memset(&Buffer, 0, sizeof(Buffer));
     Buffer.Desc.UseCount      = 1;
@@ -404,9 +445,7 @@ void Test_SB_Main_Nominal(void)
     UT_SetDeferredRetcode(UT_KEY(OS_QueueGet), 2, OS_QUEUE_EMPTY);
 
     /* For the first pass it will call CFE_SB_ProcessCmdPacket which needs to decode it */
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+    UT_SetupBasicMsgDispatch(&UT_TPID_CFE_SB_CMD_NOOP_CC, Size, false);
 
     CFE_SB_TaskMain();
 
@@ -482,26 +521,14 @@ void Test_SB_Cmds_Noop(void)
         CFE_SB_Buffer_t  SBBuf;
         CFE_SB_NoopCmd_t Cmd;
     } Noop;
-    CFE_MSG_FcnCode_t FcnCode = CFE_SB_NOOP_CC;
-    CFE_SB_MsgId_t    MsgId   = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size    = sizeof(Noop.Cmd);
 
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    CFE_SB_ProcessCmdPipePkt(&Noop.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &Noop.SBBuf.Msg, sizeof(Noop.Cmd), UT_TPID_CFE_SB_CMD_NOOP_CC);
 
     CFE_UtAssert_EVENTCOUNT(1);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_CMD0_RCVD_EID);
 
-    --Size;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    CFE_SB_ProcessCmdPipePkt(&Noop.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &Noop.SBBuf.Msg, 0, UT_TPID_CFE_SB_CMD_NOOP_CC);
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
 
 } /* end Test_SB_Cmds_Noop */
@@ -516,26 +543,15 @@ void Test_SB_Cmds_RstCtrs(void)
         CFE_SB_Buffer_t           SBBuf;
         CFE_SB_ResetCountersCmd_t Cmd;
     } ResetCounters;
-    CFE_MSG_FcnCode_t FcnCode = CFE_SB_RESET_COUNTERS_CC;
-    CFE_SB_MsgId_t    MsgId   = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size    = sizeof(ResetCounters.Cmd);
 
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    CFE_SB_ProcessCmdPipePkt(&ResetCounters.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &ResetCounters.SBBuf.Msg, sizeof(ResetCounters.Cmd),
+                    UT_TPID_CFE_SB_CMD_RESET_COUNTERS_CC);
 
     CFE_UtAssert_EVENTCOUNT(1);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_CMD1_RCVD_EID);
 
-    --Size;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    CFE_SB_ProcessCmdPipePkt(&ResetCounters.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &ResetCounters.SBBuf.Msg, 0, UT_TPID_CFE_SB_CMD_RESET_COUNTERS_CC);
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
 
 } /* Test_SB_Cmds_RstCtrs */
@@ -550,31 +566,25 @@ void Test_SB_Cmds_Stats(void)
         CFE_SB_Buffer_t         SBBuf;
         CFE_SB_SendSbStatsCmd_t Cmd;
     } SendSbStats;
-    CFE_MSG_FcnCode_t FcnCode;
-    CFE_SB_MsgId_t    MsgId;
-    CFE_MSG_Size_t    Size;
-    CFE_SB_PipeId_t   PipeId1;
-    CFE_SB_PipeId_t   PipeId2;
-    CFE_SB_PipeId_t   PipeId3;
+    CFE_SB_MsgId_t  MsgId;
+    CFE_MSG_Size_t  Size;
+    CFE_SB_PipeId_t PipeId1;
+    CFE_SB_PipeId_t PipeId2;
+    CFE_SB_PipeId_t PipeId3;
 
     /* Make the pipe table non-empty so the stats command writes something */
     CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId1, 4, "TestPipe1"));
     CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId2, 4, "TestPipe2"));
     CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId3, 4, "TestPipe3"));
 
+    /* Generic command processing - The dispatch must be set up FIRST */
+    UT_SetupBasicMsgDispatch(&UT_TPID_CFE_SB_CMD_SEND_SB_STATS_CC, sizeof(SendSbStats.Cmd), false);
+
     /* For internal TransmitMsg call */
     MsgId = CFE_SB_ValueToMsgId(CFE_SB_STATS_TLM_MID);
     Size  = sizeof(CFE_SB_Global.StatTlmMsg);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-
-    /* For Generic command processing */
-    MsgId   = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    Size    = sizeof(SendSbStats.Cmd);
-    FcnCode = CFE_SB_SEND_SB_STATS_CC;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     CFE_SB_ProcessCmdPipePkt(&SendSbStats.SBBuf);
 
@@ -583,13 +593,7 @@ void Test_SB_Cmds_Stats(void)
 
     CFE_UtAssert_EVENTSENT(CFE_SB_SND_STATS_EID);
 
-    --Size;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    CFE_SB_ProcessCmdPipePkt(&SendSbStats.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &SendSbStats.SBBuf.Msg, 0, UT_TPID_CFE_SB_CMD_SEND_SB_STATS_CC);
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId1));
@@ -608,19 +612,14 @@ void Test_SB_Cmds_RoutingInfoDef(void)
         CFE_SB_Buffer_t              SBBuf;
         CFE_SB_WriteRoutingInfoCmd_t Cmd;
     } WriteRoutingInfo;
-    CFE_MSG_FcnCode_t FcnCode = CFE_SB_WRITE_ROUTING_INFO_CC;
-    CFE_SB_MsgId_t    MsgId   = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size    = sizeof(WriteRoutingInfo.Cmd);
 
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     WriteRoutingInfo.Cmd.Payload.Filename[0] = '\0';
 
     /* Make some routing info by calling CFE_SB_AppInit */
     CFE_UtAssert_SETUP(CFE_SB_AppInit());
 
-    CFE_SB_ProcessCmdPipePkt(&WriteRoutingInfo.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &WriteRoutingInfo.SBBuf.Msg, sizeof(WriteRoutingInfo.Cmd),
+                    UT_TPID_CFE_SB_CMD_WRITE_ROUTING_INFO_CC);
 
     CFE_UtAssert_EVENTCOUNT(5);
 
@@ -629,21 +628,13 @@ void Test_SB_Cmds_RoutingInfoDef(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
     /* Also test with a bad file name - should generate CFE_SB_SND_RTG_ERR1_EID */
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_ParseInputFileNameEx), 1, CFE_FS_INVALID_PATH);
-    CFE_SB_ProcessCmdPipePkt(&WriteRoutingInfo.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &WriteRoutingInfo.SBBuf.Msg, sizeof(WriteRoutingInfo.Cmd),
+                    UT_TPID_CFE_SB_CMD_WRITE_ROUTING_INFO_CC);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_SND_RTG_ERR1_EID);
 
-    --Size;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    CFE_SB_ProcessCmdPipePkt(&WriteRoutingInfo.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &WriteRoutingInfo.SBBuf.Msg, 0, UT_TPID_CFE_SB_CMD_WRITE_ROUTING_INFO_CC);
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(CFE_SB_Global.CmdPipe));
@@ -660,19 +651,14 @@ void Test_SB_Cmds_RoutingInfoAlreadyPending(void)
         CFE_SB_Buffer_t              SBBuf;
         CFE_SB_WriteRoutingInfoCmd_t Cmd;
     } WriteRoutingInfo;
-    CFE_MSG_FcnCode_t FcnCode = CFE_SB_WRITE_ROUTING_INFO_CC;
-    CFE_SB_MsgId_t    MsgId   = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size    = sizeof(WriteRoutingInfo.Cmd);
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_FS_BackgroundFileDumpIsPending), true);
 
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     strncpy(WriteRoutingInfo.Cmd.Payload.Filename, "RoutingTstFile", sizeof(WriteRoutingInfo.Cmd.Payload.Filename) - 1);
     WriteRoutingInfo.Cmd.Payload.Filename[sizeof(WriteRoutingInfo.Cmd.Payload.Filename) - 1] = '\0';
 
-    CFE_SB_ProcessCmdPipePkt(&WriteRoutingInfo.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &WriteRoutingInfo.SBBuf.Msg, sizeof(WriteRoutingInfo.Cmd),
+                    UT_TPID_CFE_SB_CMD_WRITE_ROUTING_INFO_CC);
 
     CFE_UtAssert_EVENTCOUNT(1);
 
@@ -767,17 +753,11 @@ void Test_SB_Cmds_PipeInfoDef(void)
         CFE_SB_Buffer_t           SBBuf;
         CFE_SB_WritePipeInfoCmd_t Cmd;
     } WritePipeInfo;
-    CFE_SB_PipeId_t   PipeId1;
-    CFE_SB_PipeId_t   PipeId2;
-    CFE_SB_PipeId_t   PipeId3;
-    uint16            PipeDepth = 10;
-    CFE_MSG_FcnCode_t FcnCode   = CFE_SB_WRITE_PIPE_INFO_CC;
-    CFE_SB_MsgId_t    MsgId     = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size      = sizeof(WritePipeInfo.Cmd);
+    CFE_SB_PipeId_t PipeId1;
+    CFE_SB_PipeId_t PipeId2;
+    CFE_SB_PipeId_t PipeId3;
+    uint16          PipeDepth = 10;
 
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     WritePipeInfo.Cmd.Payload.Filename[0] = '\0';
 
     /* Create some pipe info */
@@ -785,27 +765,20 @@ void Test_SB_Cmds_PipeInfoDef(void)
     CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId2, PipeDepth, "TestPipe2"));
     CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId3, PipeDepth, "TestPipe3"));
 
-    CFE_SB_ProcessCmdPipePkt(&WritePipeInfo.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &WritePipeInfo.SBBuf.Msg, sizeof(WritePipeInfo.Cmd),
+                    UT_TPID_CFE_SB_CMD_WRITE_PIPE_INFO_CC);
 
     CFE_UtAssert_EVENTCOUNT(3);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
 
     /* Also test with a bad file name - should generate CFE_SB_SND_RTG_ERR1_EID */
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_ParseInputFileNameEx), 1, CFE_FS_INVALID_PATH);
-    CFE_SB_ProcessCmdPipePkt(&WritePipeInfo.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &WritePipeInfo.SBBuf.Msg, sizeof(WritePipeInfo.Cmd),
+                    UT_TPID_CFE_SB_CMD_WRITE_PIPE_INFO_CC);
     CFE_UtAssert_EVENTSENT(CFE_SB_SND_RTG_ERR1_EID);
 
-    --Size;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    CFE_SB_ProcessCmdPipePkt(&WritePipeInfo.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &WritePipeInfo.SBBuf.Msg, 0, UT_TPID_CFE_SB_CMD_WRITE_PIPE_INFO_CC);
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId1));
@@ -824,19 +797,14 @@ void Test_SB_Cmds_PipeInfoAlreadyPending(void)
         CFE_SB_Buffer_t           SBBuf;
         CFE_SB_WritePipeInfoCmd_t Cmd;
     } WritePipeInfo;
-    CFE_MSG_FcnCode_t FcnCode = CFE_SB_WRITE_PIPE_INFO_CC;
-    CFE_SB_MsgId_t    MsgId   = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size    = sizeof(WritePipeInfo.Cmd);
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_FS_BackgroundFileDumpIsPending), true);
 
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     strncpy(WritePipeInfo.Cmd.Payload.Filename, "PipeTstFile", sizeof(WritePipeInfo.Cmd.Payload.Filename) - 1);
     WritePipeInfo.Cmd.Payload.Filename[sizeof(WritePipeInfo.Cmd.Payload.Filename) - 1] = '\0';
 
-    CFE_SB_ProcessCmdPipePkt(&WritePipeInfo.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &WritePipeInfo.SBBuf.Msg, sizeof(WritePipeInfo.Cmd),
+                    UT_TPID_CFE_SB_CMD_WRITE_PIPE_INFO_CC);
 
     CFE_UtAssert_EVENTCOUNT(1);
 
@@ -974,23 +942,17 @@ void Test_SB_Cmds_MapInfoDef(void)
         CFE_SB_Buffer_t          SBBuf;
         CFE_SB_WriteMapInfoCmd_t Cmd;
     } WriteMapInfo;
-    CFE_SB_PipeId_t   PipeId1;
-    CFE_SB_PipeId_t   PipeId2;
-    CFE_SB_PipeId_t   PipeId3;
-    CFE_SB_MsgId_t    MsgId0    = SB_UT_TLM_MID1;
-    CFE_SB_MsgId_t    MsgId1    = SB_UT_TLM_MID2;
-    CFE_SB_MsgId_t    MsgId2    = SB_UT_TLM_MID3;
-    CFE_SB_MsgId_t    MsgId3    = SB_UT_TLM_MID4;
-    CFE_SB_MsgId_t    MsgId4    = SB_UT_TLM_MID5;
-    CFE_SB_MsgId_t    MsgId5    = SB_UT_TLM_MID6;
-    uint16            PipeDepth = 10;
-    CFE_MSG_FcnCode_t FcnCode   = CFE_SB_WRITE_MAP_INFO_CC;
-    CFE_SB_MsgId_t    MsgId     = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size      = sizeof(WriteMapInfo.Cmd);
+    CFE_SB_PipeId_t PipeId1;
+    CFE_SB_PipeId_t PipeId2;
+    CFE_SB_PipeId_t PipeId3;
+    CFE_SB_MsgId_t  MsgId0    = SB_UT_TLM_MID1;
+    CFE_SB_MsgId_t  MsgId1    = SB_UT_TLM_MID2;
+    CFE_SB_MsgId_t  MsgId2    = SB_UT_TLM_MID3;
+    CFE_SB_MsgId_t  MsgId3    = SB_UT_TLM_MID4;
+    CFE_SB_MsgId_t  MsgId4    = SB_UT_TLM_MID5;
+    CFE_SB_MsgId_t  MsgId5    = SB_UT_TLM_MID6;
+    uint16          PipeDepth = 10;
 
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     WriteMapInfo.Cmd.Payload.Filename[0] = '\0';
 
     /* Create some map info */
@@ -1005,7 +967,8 @@ void Test_SB_Cmds_MapInfoDef(void)
     CFE_UtAssert_SETUP(CFE_SB_Subscribe(MsgId4, PipeId3));
     CFE_UtAssert_SETUP(CFE_SB_Subscribe(MsgId5, PipeId2));
 
-    CFE_SB_ProcessCmdPipePkt(&WriteMapInfo.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &WriteMapInfo.SBBuf.Msg, sizeof(WriteMapInfo.Cmd),
+                    UT_TPID_CFE_SB_CMD_WRITE_MAP_INFO_CC);
 
     CFE_UtAssert_EVENTCOUNT(10);
 
@@ -1014,20 +977,13 @@ void Test_SB_Cmds_MapInfoDef(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
     /* Also test with a bad file name - should generate CFE_SB_SND_RTG_ERR1_EID */
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_ParseInputFileNameEx), 1, CFE_FS_INVALID_PATH);
-    CFE_SB_ProcessCmdPipePkt(&WriteMapInfo.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &WriteMapInfo.SBBuf.Msg, sizeof(WriteMapInfo.Cmd),
+                    UT_TPID_CFE_SB_CMD_WRITE_MAP_INFO_CC);
     CFE_UtAssert_EVENTSENT(CFE_SB_SND_RTG_ERR1_EID);
 
-    --Size;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    CFE_SB_ProcessCmdPipePkt(&WriteMapInfo.SBBuf);
+    /* Bad Size */
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &WriteMapInfo.SBBuf.Msg, 0, UT_TPID_CFE_SB_CMD_WRITE_MAP_INFO_CC);
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId1));
@@ -1046,19 +1002,14 @@ void Test_SB_Cmds_MapInfoAlreadyPending(void)
         CFE_SB_Buffer_t          SBBuf;
         CFE_SB_WriteMapInfoCmd_t Cmd;
     } WriteMapInfo;
-    CFE_MSG_FcnCode_t FcnCode = CFE_SB_WRITE_MAP_INFO_CC;
-    CFE_SB_MsgId_t    MsgId   = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size    = sizeof(WriteMapInfo.Cmd);
 
     UT_SetDefaultReturnValue(UT_KEY(CFE_FS_BackgroundFileDumpIsPending), true);
 
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
     strncpy(WriteMapInfo.Cmd.Payload.Filename, "MapTstFile", sizeof(WriteMapInfo.Cmd.Payload.Filename) - 1);
     WriteMapInfo.Cmd.Payload.Filename[sizeof(WriteMapInfo.Cmd.Payload.Filename) - 1] = '\0';
 
-    CFE_SB_ProcessCmdPipePkt(&WriteMapInfo.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &WriteMapInfo.SBBuf.Msg, sizeof(WriteMapInfo.Cmd),
+                    UT_TPID_CFE_SB_CMD_WRITE_MAP_INFO_CC);
 
     CFE_UtAssert_EVENTCOUNT(1);
 
@@ -1077,23 +1028,17 @@ void Test_SB_Cmds_EnRouteValParam(void)
         CFE_SB_Buffer_t         SBBuf;
         CFE_SB_EnableRouteCmd_t Cmd;
     } EnableRoute;
-    CFE_SB_PipeId_t   PipeId;
-    CFE_SB_MsgId_t    MsgId     = SB_UT_TLM_MID;
-    uint16            PipeDepth = 5;
-    CFE_MSG_FcnCode_t FcnCode   = CFE_SB_ENABLE_ROUTE_CC;
-    CFE_SB_MsgId_t    MsgIdCmd  = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size      = sizeof(EnableRoute.Cmd);
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+    CFE_SB_PipeId_t PipeId;
+    CFE_SB_MsgId_t  MsgId     = SB_UT_TLM_MID;
+    uint16          PipeDepth = 5;
 
     CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "EnRouteTestPipe"));
     CFE_UtAssert_SETUP(CFE_SB_Subscribe(MsgId, PipeId));
     EnableRoute.Cmd.Payload.MsgId = MsgId;
     EnableRoute.Cmd.Payload.Pipe  = PipeId;
 
-    CFE_SB_ProcessCmdPipePkt(&EnableRoute.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &EnableRoute.SBBuf.Msg, sizeof(EnableRoute.Cmd),
+                    UT_TPID_CFE_SB_CMD_ENABLE_ROUTE_CC);
 
     CFE_UtAssert_EVENTCOUNT(3);
 
@@ -1103,13 +1048,8 @@ void Test_SB_Cmds_EnRouteValParam(void)
 
     CFE_UtAssert_EVENTSENT(CFE_SB_ENBL_RTE2_EID);
 
-    --Size;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    CFE_SB_ProcessCmdPipePkt(&EnableRoute.SBBuf);
+    /* Bad Size */
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &EnableRoute.SBBuf.Msg, 0, UT_TPID_CFE_SB_CMD_ENABLE_ROUTE_CC);
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
@@ -1126,17 +1066,10 @@ void Test_SB_Cmds_EnRouteNonExist(void)
         CFE_SB_Buffer_t         SBBuf;
         CFE_SB_EnableRouteCmd_t Cmd;
     } EnableRoute;
-    CFE_SB_PipeId_t   PipeId1;
-    CFE_SB_PipeId_t   PipeId2;
-    CFE_SB_MsgId_t    MsgId     = SB_UT_TLM_MID;
-    uint16            PipeDepth = 5;
-    CFE_MSG_FcnCode_t FcnCode   = CFE_SB_ENABLE_ROUTE_CC;
-    CFE_SB_MsgId_t    MsgIdCmd  = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size      = sizeof(EnableRoute.Cmd);
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+    CFE_SB_PipeId_t PipeId1;
+    CFE_SB_PipeId_t PipeId2;
+    CFE_SB_MsgId_t  MsgId     = SB_UT_TLM_MID;
+    uint16          PipeDepth = 5;
 
     CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId1, PipeDepth, "EnRouteTestPipe1"));
     CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId2, PipeDepth, "EnRouteTestPipe2"));
@@ -1144,7 +1077,8 @@ void Test_SB_Cmds_EnRouteNonExist(void)
     EnableRoute.Cmd.Payload.MsgId = MsgId;
     EnableRoute.Cmd.Payload.Pipe  = PipeId2;
 
-    CFE_SB_ProcessCmdPipePkt(&EnableRoute.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &EnableRoute.SBBuf.Msg, sizeof(EnableRoute.Cmd),
+                    UT_TPID_CFE_SB_CMD_ENABLE_ROUTE_CC);
 
     CFE_UtAssert_EVENTCOUNT(4);
 
@@ -1167,18 +1101,12 @@ void Test_SB_Cmds_EnRouteInvParam(void)
         CFE_SB_Buffer_t         SBBuf;
         CFE_SB_EnableRouteCmd_t Cmd;
     } EnableRoute;
-    CFE_MSG_FcnCode_t FcnCode  = CFE_SB_ENABLE_ROUTE_CC;
-    CFE_SB_MsgId_t    MsgIdCmd = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size     = sizeof(EnableRoute.Cmd);
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     EnableRoute.Cmd.Payload.MsgId = SB_UT_LAST_VALID_MID;
     EnableRoute.Cmd.Payload.Pipe  = SB_UT_PIPEID_3;
 
-    CFE_SB_ProcessCmdPipePkt(&EnableRoute.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &EnableRoute.SBBuf.Msg, sizeof(EnableRoute.Cmd),
+                    UT_TPID_CFE_SB_CMD_ENABLE_ROUTE_CC);
 
     CFE_UtAssert_EVENTCOUNT(1);
 
@@ -1196,18 +1124,12 @@ void Test_SB_Cmds_EnRouteInvParam2(void)
         CFE_SB_Buffer_t         SBBuf;
         CFE_SB_EnableRouteCmd_t Cmd;
     } EnableRoute;
-    CFE_MSG_FcnCode_t FcnCode  = CFE_SB_ENABLE_ROUTE_CC;
-    CFE_SB_MsgId_t    MsgIdCmd = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size     = sizeof(EnableRoute.Cmd);
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     EnableRoute.Cmd.Payload.MsgId = CFE_SB_INVALID_MSG_ID;
     EnableRoute.Cmd.Payload.Pipe  = SB_UT_PIPEID_3;
 
-    CFE_SB_ProcessCmdPipePkt(&EnableRoute.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &EnableRoute.SBBuf.Msg, sizeof(EnableRoute.Cmd),
+                    UT_TPID_CFE_SB_CMD_ENABLE_ROUTE_CC);
 
     CFE_UtAssert_EVENTCOUNT(1);
 
@@ -1226,18 +1148,12 @@ void Test_SB_Cmds_EnRouteInvParam3(void)
         CFE_SB_Buffer_t         SBBuf;
         CFE_SB_EnableRouteCmd_t Cmd;
     } EnableRoute;
-    CFE_MSG_FcnCode_t FcnCode  = CFE_SB_ENABLE_ROUTE_CC;
-    CFE_SB_MsgId_t    MsgIdCmd = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size     = sizeof(EnableRoute.Cmd);
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     EnableRoute.Cmd.Payload.MsgId = SB_UT_ALTERNATE_INVALID_MID;
     EnableRoute.Cmd.Payload.Pipe  = SB_UT_PIPEID_0;
 
-    CFE_SB_ProcessCmdPipePkt(&EnableRoute.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &EnableRoute.SBBuf.Msg, sizeof(EnableRoute.Cmd),
+                    UT_TPID_CFE_SB_CMD_ENABLE_ROUTE_CC);
 
     CFE_UtAssert_EVENTCOUNT(1);
 
@@ -1255,23 +1171,17 @@ void Test_SB_Cmds_DisRouteValParam(void)
         CFE_SB_Buffer_t          SBBuf;
         CFE_SB_DisableRouteCmd_t Cmd;
     } DisableRoute;
-    CFE_SB_PipeId_t   PipeId;
-    CFE_SB_MsgId_t    MsgId     = SB_UT_TLM_MID;
-    uint16            PipeDepth = 5;
-    CFE_MSG_FcnCode_t FcnCode   = CFE_SB_DISABLE_ROUTE_CC;
-    CFE_SB_MsgId_t    MsgIdCmd  = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size      = sizeof(DisableRoute.Cmd);
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+    CFE_SB_PipeId_t PipeId;
+    CFE_SB_MsgId_t  MsgId     = SB_UT_TLM_MID;
+    uint16          PipeDepth = 5;
 
     CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "DisRouteTestPipe"));
     CFE_UtAssert_SETUP(CFE_SB_Subscribe(MsgId, PipeId));
     DisableRoute.Cmd.Payload.MsgId = MsgId;
     DisableRoute.Cmd.Payload.Pipe  = PipeId;
 
-    CFE_SB_ProcessCmdPipePkt(&DisableRoute.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &DisableRoute.SBBuf.Msg, sizeof(DisableRoute.Cmd),
+                    UT_TPID_CFE_SB_CMD_DISABLE_ROUTE_CC);
 
     CFE_UtAssert_EVENTCOUNT(3);
 
@@ -1281,13 +1191,8 @@ void Test_SB_Cmds_DisRouteValParam(void)
 
     CFE_UtAssert_EVENTSENT(CFE_SB_DSBL_RTE2_EID);
 
-    --Size;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    CFE_SB_ProcessCmdPipePkt(&DisableRoute.SBBuf);
+    /* Bad Size */
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &DisableRoute.SBBuf.Msg, 0, UT_TPID_CFE_SB_CMD_DISABLE_ROUTE_CC);
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
@@ -1304,16 +1209,9 @@ void Test_SB_Cmds_DisRouteNonExist(void)
         CFE_SB_Buffer_t          SBBuf;
         CFE_SB_DisableRouteCmd_t Cmd;
     } DisableRoute;
-    CFE_SB_PipeId_t   PipeId1, PipeId2;
-    CFE_SB_MsgId_t    MsgId     = SB_UT_TLM_MID;
-    uint16            PipeDepth = 5;
-    CFE_MSG_FcnCode_t FcnCode   = CFE_SB_DISABLE_ROUTE_CC;
-    CFE_SB_MsgId_t    MsgIdCmd  = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size      = sizeof(DisableRoute.Cmd);
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+    CFE_SB_PipeId_t PipeId1, PipeId2;
+    CFE_SB_MsgId_t  MsgId     = SB_UT_TLM_MID;
+    uint16          PipeDepth = 5;
 
     CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId1, PipeDepth, "DisRouteTestPipe1"));
     CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId2, PipeDepth, "DisRouteTestPipe2"));
@@ -1321,7 +1219,8 @@ void Test_SB_Cmds_DisRouteNonExist(void)
     DisableRoute.Cmd.Payload.MsgId = MsgId;
     DisableRoute.Cmd.Payload.Pipe  = PipeId2;
 
-    CFE_SB_ProcessCmdPipePkt(&DisableRoute.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &DisableRoute.SBBuf.Msg, sizeof(DisableRoute.Cmd),
+                    UT_TPID_CFE_SB_CMD_DISABLE_ROUTE_CC);
 
     CFE_UtAssert_EVENTCOUNT(4);
 
@@ -1344,18 +1243,12 @@ void Test_SB_Cmds_DisRouteInvParam(void)
         CFE_SB_Buffer_t          SBBuf;
         CFE_SB_DisableRouteCmd_t Cmd;
     } DisableRoute;
-    CFE_MSG_FcnCode_t FcnCode  = CFE_SB_DISABLE_ROUTE_CC;
-    CFE_SB_MsgId_t    MsgIdCmd = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size     = sizeof(DisableRoute.Cmd);
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     DisableRoute.Cmd.Payload.MsgId = SB_UT_LAST_VALID_MID;
     DisableRoute.Cmd.Payload.Pipe  = SB_UT_PIPEID_3;
 
-    CFE_SB_ProcessCmdPipePkt(&DisableRoute.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &DisableRoute.SBBuf.Msg, sizeof(DisableRoute.Cmd),
+                    UT_TPID_CFE_SB_CMD_DISABLE_ROUTE_CC);
 
     CFE_UtAssert_EVENTCOUNT(1);
 
@@ -1373,18 +1266,12 @@ void Test_SB_Cmds_DisRouteInvParam2(void)
         CFE_SB_Buffer_t          SBBuf;
         CFE_SB_DisableRouteCmd_t Cmd;
     } DisableRoute;
-    CFE_MSG_FcnCode_t FcnCode  = CFE_SB_DISABLE_ROUTE_CC;
-    CFE_SB_MsgId_t    MsgIdCmd = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size     = sizeof(DisableRoute.Cmd);
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     DisableRoute.Cmd.Payload.MsgId = CFE_SB_INVALID_MSG_ID;
     DisableRoute.Cmd.Payload.Pipe  = SB_UT_PIPEID_3;
 
-    CFE_SB_ProcessCmdPipePkt(&DisableRoute.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &DisableRoute.SBBuf.Msg, sizeof(DisableRoute.Cmd),
+                    UT_TPID_CFE_SB_CMD_DISABLE_ROUTE_CC);
 
     CFE_UtAssert_EVENTCOUNT(1);
 
@@ -1403,18 +1290,12 @@ void Test_SB_Cmds_DisRouteInvParam3(void)
         CFE_SB_Buffer_t          SBBuf;
         CFE_SB_DisableRouteCmd_t Cmd;
     } DisableRoute;
-    CFE_MSG_FcnCode_t FcnCode  = CFE_SB_DISABLE_ROUTE_CC;
-    CFE_SB_MsgId_t    MsgIdCmd = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size     = sizeof(DisableRoute.Cmd);
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     DisableRoute.Cmd.Payload.MsgId = SB_UT_ALTERNATE_INVALID_MID;
     DisableRoute.Cmd.Payload.Pipe  = SB_UT_PIPEID_0;
 
-    CFE_SB_ProcessCmdPipePkt(&DisableRoute.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &DisableRoute.SBBuf.Msg, sizeof(DisableRoute.Cmd),
+                    UT_TPID_CFE_SB_CMD_DISABLE_ROUTE_CC);
 
     CFE_UtAssert_EVENTCOUNT(1);
 
@@ -1435,15 +1316,14 @@ void Test_SB_Cmds_SendHK(void)
     CFE_SB_MsgId_t MsgIdCmd;
     CFE_MSG_Size_t Size;
 
+    /* For HK command processing - set up FIRST */
+    UT_SetupBasicMsgDispatch(&UT_TPID_CFE_SB_SEND_HK, sizeof(Housekeeping.Cmd), false);
+
     /* For internal TransmitMsg call */
     MsgIdCmd = CFE_SB_ValueToMsgId(CFE_SB_HK_TLM_MID);
     Size     = sizeof(CFE_SB_Global.HKTlmMsg);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-
-    /* For HK command processing */
-    MsgIdCmd = CFE_SB_ValueToMsgId(CFE_SB_SEND_HK_MID);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
 
     CFE_SB_ProcessCmdPipePkt(&Housekeeping.SBBuf);
 
@@ -1464,16 +1344,15 @@ void Test_SB_Cmds_SendPrevSubs(void)
         CFE_SB_Buffer_t          SBBuf;
         CFE_SB_SendPrevSubsCmd_t Cmd;
     } SendPrevSubs;
-    CFE_SB_PipeId_t   PipeId1;
-    CFE_SB_PipeId_t   PipeId2;
-    CFE_SB_MsgId_t    MsgId     = SB_UT_BARE_TLM_MID3;
-    uint16            MsgLim    = 4;
-    uint16            PipeDepth = 50;
-    int32             i;
-    int32             NumEvts;
-    CFE_MSG_FcnCode_t FcnCode = CFE_SB_SEND_PREV_SUBS_CC;
-    CFE_SB_MsgId_t    MsgIdCmd;
-    CFE_MSG_Size_t    Size;
+    CFE_SB_PipeId_t PipeId1;
+    CFE_SB_PipeId_t PipeId2;
+    CFE_SB_MsgId_t  MsgId     = SB_UT_BARE_TLM_MID3;
+    uint16          MsgLim    = 4;
+    uint16          PipeDepth = 50;
+    int32           i;
+    int32           NumEvts;
+    CFE_MSG_Size_t  Size;
+    CFE_SB_MsgId_t  MsgIdCmd;
 
     CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId1, PipeDepth, "TestPipe1"));
     CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId2, PipeDepth, "TestPipe2"));
@@ -1499,6 +1378,9 @@ void Test_SB_Cmds_SendPrevSubs(void)
 
     CFE_UtAssert_SETUP(CFE_SB_SubscribeLocal(MsgId, PipeId2, MsgLim));
 
+    /* Set up for dispatch FIRST */
+    UT_SetupBasicMsgDispatch(&UT_TPID_CFE_SB_SUB_RPT_CTL_SEND_PREV_SUBS_CC, sizeof(SendPrevSubs.Cmd), false);
+
     /* For 3 internal TransmitMsg calls */
     MsgIdCmd = CFE_SB_ValueToMsgId(CFE_SB_ALLSUBS_TLM_MID);
     Size     = sizeof(CFE_SB_Global.PrevSubMsg);
@@ -1508,13 +1390,6 @@ void Test_SB_Cmds_SendPrevSubs(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-
-    /* Set buffers for gets */
-    MsgIdCmd = CFE_SB_ValueToMsgId(CFE_SB_SUB_RPT_CTRL_MID);
-    Size     = sizeof(SendPrevSubs.Cmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     CFE_SB_ProcessCmdPipePkt(&SendPrevSubs.SBBuf);
 
@@ -1542,6 +1417,9 @@ void Test_SB_Cmds_SendPrevSubs(void)
     /* Additional unique local route to hit while loop destptr == NULL branch */
     CFE_UtAssert_SETUP(CFE_SB_SubscribeLocal(CFE_SB_ValueToMsgId(i), PipeId2, MsgLim));
 
+    /* Set up for dispatch FIRST */
+    UT_SetupBasicMsgDispatch(&UT_TPID_CFE_SB_SUB_RPT_CTL_SEND_PREV_SUBS_CC, sizeof(SendPrevSubs.Cmd), false);
+
     /* For 3 internal TransmitMsg calls */
     MsgIdCmd = CFE_SB_ValueToMsgId(CFE_SB_ALLSUBS_TLM_MID);
     Size     = sizeof(CFE_SB_Global.PrevSubMsg);
@@ -1551,13 +1429,6 @@ void Test_SB_Cmds_SendPrevSubs(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-
-    /* Set buffers for gets */
-    MsgIdCmd = CFE_SB_ValueToMsgId(CFE_SB_SUB_RPT_CTRL_MID);
-    Size     = sizeof(SendPrevSubs.Cmd);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
 
     CFE_SB_ProcessCmdPipePkt(&SendPrevSubs.SBBuf);
 
@@ -1580,13 +1451,9 @@ void Test_SB_Cmds_SendPrevSubs(void)
 
     /* Test error paths in the CFE_SB_SEND_PREV_SUBS_CC handling */
     UT_ClearEventHistory();
-    Size = sizeof(SendPrevSubs.Cmd) - 1;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    CFE_SB_ProcessCmdPipePkt(&SendPrevSubs.SBBuf);
+
+    /* Bad Size */
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &SendPrevSubs.SBBuf.Msg, 0, UT_TPID_CFE_SB_SUB_RPT_CTL_SEND_PREV_SUBS_CC);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
 
@@ -1605,27 +1472,18 @@ void Test_SB_Cmds_SubRptOn(void)
         CFE_SB_Buffer_t                SBBuf;
         CFE_SB_EnableSubReportingCmd_t Cmd;
     } EnableSubReporting;
-    CFE_MSG_FcnCode_t FcnCode  = CFE_SB_ENABLE_SUB_REPORTING_CC;
-    CFE_SB_MsgId_t    MsgIdCmd = CFE_SB_ValueToMsgId(CFE_SB_SUB_RPT_CTRL_MID);
-    CFE_MSG_Size_t    Size     = sizeof(EnableSubReporting.Cmd);
 
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    CFE_SB_ProcessCmdPipePkt(&EnableSubReporting.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &EnableSubReporting.SBBuf.Msg, sizeof(EnableSubReporting.Cmd),
+                    UT_TPID_CFE_SB_SUB_RPT_CTL_ENABLE_SUB_REPORTING_CC);
 
     CFE_UtAssert_EVENTCOUNT(0);
 
     /* Test error paths in the CFE_SB_ENABLE_SUB_REPORTING_CC handling */
     UT_ClearEventHistory();
-    Size = sizeof(EnableSubReporting.Cmd) - 1;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    CFE_SB_ProcessCmdPipePkt(&EnableSubReporting.SBBuf);
+
+    /* Bad Size */
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &EnableSubReporting.SBBuf.Msg, 0,
+                    UT_TPID_CFE_SB_SUB_RPT_CTL_ENABLE_SUB_REPORTING_CC);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
 
@@ -1641,27 +1499,18 @@ void Test_SB_Cmds_SubRptOff(void)
         CFE_SB_Buffer_t                 SBBuf;
         CFE_SB_DisableSubReportingCmd_t Cmd;
     } DisableSubReporting;
-    CFE_MSG_FcnCode_t FcnCode  = CFE_SB_DISABLE_SUB_REPORTING_CC;
-    CFE_SB_MsgId_t    MsgIdCmd = CFE_SB_ValueToMsgId(CFE_SB_SUB_RPT_CTRL_MID);
-    CFE_MSG_Size_t    Size     = sizeof(DisableSubReporting.Cmd);
 
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    CFE_SB_ProcessCmdPipePkt(&DisableSubReporting.SBBuf);
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &DisableSubReporting.SBBuf.Msg, sizeof(DisableSubReporting.Cmd),
+                    UT_TPID_CFE_SB_SUB_RPT_CTL_DISABLE_SUB_REPORTING_CC);
 
     CFE_UtAssert_EVENTCOUNT(0);
 
     /* Test error paths in the CFE_SB_DISABLE_SUB_REPORTING_CC handling */
     UT_ClearEventHistory();
-    Size = sizeof(DisableSubReporting.Cmd) - 1;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    CFE_SB_ProcessCmdPipePkt(&DisableSubReporting.SBBuf);
+
+    /* Bad Size */
+    UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &DisableSubReporting.SBBuf.Msg, 0,
+                    UT_TPID_CFE_SB_SUB_RPT_CTL_DISABLE_SUB_REPORTING_CC);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
 
@@ -1672,20 +1521,12 @@ void Test_SB_Cmds_SubRptOff(void)
 */
 void Test_SB_Cmds_CmdUnexpCmdCode(void)
 {
-    CFE_MSG_FcnCode_t FcnCode  = 99;
-    CFE_SB_MsgId_t    MsgIdCmd = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    /* Use a command code known to be invalid */
+    UT_SetupBasicMsgDispatch(&UT_TPID_CFE_SB_CMD_BAD_FCNCODE, sizeof(CFE_MSG_CommandHeader_t), true);
     CFE_SB_ProcessCmdPipePkt((CFE_SB_Buffer_t *)NULL);
     CFE_UtAssert_EVENTCOUNT(1);
     CFE_UtAssert_EVENTSENT(CFE_SB_BAD_CMD_CODE_EID);
 
-    MsgIdCmd = CFE_SB_ValueToMsgId(CFE_SB_SUB_RPT_CTRL_MID);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
+    UT_SetupBasicMsgDispatch(&UT_TPID_CFE_SB_SUB_RPT_CTRL_BAD_FCNCODE, sizeof(CFE_MSG_CommandHeader_t), true);
     CFE_SB_ProcessCmdPipePkt((CFE_SB_Buffer_t *)NULL);
 
 } /* end Test_SB_Cmds_UnexpCmdCode */
@@ -1698,18 +1539,14 @@ void Test_SB_Cmds_BadCmdLength(void)
     /*
      * Just choosing "EnableRoute" command here as it has a non-empty payload
      */
-    CFE_MSG_FcnCode_t FcnCode  = CFE_SB_ENABLE_ROUTE_CC;
-    CFE_SB_MsgId_t    MsgIdCmd = CFE_SB_ValueToMsgId(CFE_SB_CMD_MID);
-    CFE_MSG_Size_t    Size     = sizeof(CFE_SB_EnableRouteCmd_t) - 1;
 
-    /* Second GetMsgId and GetFcnCode are for reporting */
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), &FcnCode, sizeof(FcnCode), false);
-
-    CFE_SB_ProcessCmdPipePkt((CFE_SB_Buffer_t *)NULL);
+    /*
+     * Note the length validation failure paths have already been checked
+     * in the other command processor tests.  The only thing unique about
+     * this dedicated test is that it does so with a non-zero size
+     */
+    UT_SetupBasicMsgDispatch(&UT_TPID_CFE_SB_CMD_ENABLE_ROUTE_CC, sizeof(CFE_SB_EnableRouteCmd_t) - 1, true);
+    CFE_SB_ProcessCmdPipePkt(NULL);
 
     CFE_UtAssert_EVENTCOUNT(1);
 
@@ -1722,11 +1559,8 @@ void Test_SB_Cmds_BadCmdLength(void)
 */
 void Test_SB_Cmds_UnexpMsgId(void)
 {
-    CFE_SB_MsgId_t MsgIdCmd = SB_UT_TLM_MID;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgIdCmd, sizeof(MsgIdCmd), false);
-
-    CFE_SB_ProcessCmdPipePkt((CFE_SB_Buffer_t *)NULL);
+    UT_SetupBasicMsgDispatch(&UT_TPID_CFE_SB_BAD_MSGID, sizeof(CFE_MSG_CommandHeader_t), true);
+    CFE_SB_ProcessCmdPipePkt(NULL);
 
     CFE_UtAssert_EVENTCOUNT(1);
 
@@ -4512,15 +4346,14 @@ void Test_SB_TransmitMsgPaths_Nominal(void)
     CFE_MSG_Size_t   Size;
     CFE_MSG_Type_t   Type;
 
+    /* Set up for dispatch FIRST */
+    UT_SetupBasicMsgDispatch(&UT_TPID_CFE_SB_SEND_HK, sizeof(Housekeeping.Cmd), false);
+
     /* For internal send message call */
     MsgId = CFE_SB_ValueToMsgId(CFE_SB_HK_TLM_MID);
     Size  = sizeof(CFE_SB_Global.HKTlmMsg);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-
-    /* For HK command processing */
-    MsgId = CFE_SB_ValueToMsgId(CFE_SB_SEND_HK_MID);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
 
     /* Repress sending the no subscriptions event and process request */
     CFE_SB_Global.HKTlmMsg.Payload.NoSubscribersCounter = 0;
@@ -4535,15 +4368,14 @@ void Test_SB_TransmitMsgPaths_Nominal(void)
     CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter = 0;
     CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_GET_BUF_ERR_EID_BIT);
 
+    /* Set up for dispatch FIRST */
+    UT_SetupBasicMsgDispatch(&UT_TPID_CFE_SB_SEND_HK, sizeof(Housekeeping.Cmd), false);
+
     /* For internal send message call */
     MsgId = CFE_SB_ValueToMsgId(CFE_SB_HK_TLM_MID);
     Size  = sizeof(CFE_SB_Global.HKTlmMsg);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-
-    /* For HK command processing */
-    MsgId = CFE_SB_ValueToMsgId(CFE_SB_SEND_HK_MID);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
 
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetPoolBuf), 1, CFE_ES_ERR_MEM_BLOCK_SIZE);
     CFE_SB_ProcessCmdPipePkt(&Housekeeping.SBBuf);


### PR DESCRIPTION
**Describe the contribution**
Utilize the common setup/wrapper functions in ut_support.c whenever possible MSG dispatching in the generic handler.

Fixes #1988

**Testing performed**
Build and sanity check CFE, run all tests
Confirm that branch coverage is **not** changed from baseline

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu

**Additional context**
Refactor for improved source maintenance/flexibility - but no behavior change, works identically

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.

