### PR TITLE
Fix #1928, checking against IsNewOffset only

### DIFF
--- a/modules/es/fsw/src/cfe_es_cds.c
+++ b/modules/es/fsw/src/cfe_es_cds.c
@@ -426,7 +426,7 @@ int32 CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr, size_t UserBlockSize, 
             CFE_ES_CDSBlockRecordSetUsed(RegRecPtr, PendingBlockId);
         }
 
-        if (Status == CFE_SUCCESS && (IsNewOffset || IsNewEntry))
+        if (Status == CFE_SUCCESS && IsNewOffset)
         {
             /* If we succeeded at creating a CDS, save updated registry in the CDS */
             RegUpdateStatus = CFE_ES_UpdateCDSRegistry();


### PR DESCRIPTION
**Describe the contribution**
- Fix #1928 

Removed redundant check of `IsNewOffset && IsNewEntry` only using `IsNewOffset` now.

**Testing performed**
None

**Expected behavior changes**
None

**Additional context**
Add any other context about the contribution here.


**Contributor Info - All information REQUIRED for consideration of pull request**
Personal- Zachary Gonzalez

