### PR TITLE
Fix #2024, osal_id_t type conversion in es_UT.c

### DIFF
--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -4519,7 +4519,7 @@ void TestAPI(void)
 
     /* Hit error case for NULL TaskRecPtr */
     ES_ResetUnitTest();
-    UT_SetDeferredRetcode(UT_KEY(OS_TaskGetId), 1, OS_OBJECT_ID_UNDEFINED);
+    UT_SetDeferredRetcode(UT_KEY(OS_TaskGetId), 1, OS_ObjectIdToInteger(OS_OBJECT_ID_UNDEFINED));
     UtAssert_INT32_EQ(CFE_ES_GetTaskID(&TaskId), CFE_ES_ERR_RESOURCEID_NOT_VALID);
 }
 


### PR DESCRIPTION
**Describe the contribution**
Corrects the implicit type conversion from an osal_id_t to an integer, making it explicit by using the OS_ObjectIdToInteger() conversion function.

Fixes #2024

**Testing performed**
Build with strict osal_id_t type definition.  Run all tests.

**Expected behavior changes**
None.

**System(s) tested on**
Ubuntu 21.10

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
