### PR TITLE
Fix #2028, Initialize BlockData in ES UT

### DIFF
--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -4670,6 +4670,8 @@ void TestCDS()
 
     UtPrintf("Begin Test CDS");
 
+    memset(BlockData, 0, sizeof(BlockData));
+
     /* Test init with a mutex create failure */
     UT_SetDeferredRetcode(UT_KEY(OS_MutSemCreate), 1, OS_ERROR);
     UtAssert_INT32_EQ(CFE_ES_CDS_EarlyInit(), CFE_STATUS_EXTERNAL_RESOURCE_FAIL);


### PR DESCRIPTION
**Describe the contribution**
- Fix #2028 
- Initializes BlockData in ES UT TestCDS

**Testing performed**
Build/run unit tests w/ valgrind

**Expected behavior changes**
Unit test only

**System(s) tested on**
 - Hardware: i5/Docker
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
Probably caught in static analysis but we've got way too many nuisance warnings...

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC