### PR TITLE
Fix #2030, array length calculation for perf structs

### DIFF
--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -48,13 +48,16 @@
 /*
 ** Defines
 */
+#define CFE_ES_PERF_MASK_ARRAY_SIZE(arr) (sizeof(arr) / sizeof(arr[0]))
+
 #define CFE_ES_PERF_TRIGGERMASK_INT_SIZE \
-    (sizeof(CFE_ES_Global.ResetDataPtr->Perf.MetaData.TriggerMask) / sizeof(uint32))
+    CFE_ES_PERF_MASK_ARRAY_SIZE(CFE_ES_Global.ResetDataPtr->Perf.MetaData.TriggerMask)
 #define CFE_ES_PERF_TRIGGERMASK_EXT_SIZE \
-    (sizeof(CFE_ES_Global.TaskData.HkPacket.Payload.PerfTriggerMask) / sizeof(uint32))
-#define CFE_ES_PERF_FILTERMASK_INT_SIZE (sizeof(CFE_ES_Global.ResetDataPtr->Perf.MetaData.FilterMask) / sizeof(uint32))
+    CFE_ES_PERF_MASK_ARRAY_SIZE(CFE_ES_Global.TaskData.HkPacket.Payload.PerfTriggerMask)
+#define CFE_ES_PERF_FILTERMASK_INT_SIZE \
+    CFE_ES_PERF_MASK_ARRAY_SIZE(CFE_ES_Global.ResetDataPtr->Perf.MetaData.FilterMask)
 #define CFE_ES_PERF_FILTERMASK_EXT_SIZE \
-    (sizeof(CFE_ES_Global.TaskData.HkPacket.Payload.PerfFilterMask) / sizeof(uint32))
+    CFE_ES_PERF_MASK_ARRAY_SIZE(CFE_ES_Global.TaskData.HkPacket.Payload.PerfFilterMask)
 
 /*
 ** This define should be put in the OS API headers -- Right now it matches what the OS API uses


### PR DESCRIPTION
**Describe the contribution**
Cleans up the array length calculation for perf structs to not assume a specific base element type (uint32).  This also makes the definitions much more readable.

Fixes #2030

**Testing performed**
Build and sanity check CFE

**Expected behavior changes**
None w/current structure definitions.  Just a bit of future-proofing and clean up.

**System(s) tested on**
Ubuntu 21.10

**Additional context**
Notably the EDS build actually does use a different base type for this array, so this is not just cosmetic.  But this is a worthwhile cleanup regardless.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
