### PR TITLE
Fix #2034, Update CodeQL workflow

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -2,12 +2,21 @@ name: "CodeQL Analysis"
 
 on:
   push:
+    paths-ignore: 
+    - '**/*.md'
+    - '**/*.txt'
+    - '**/*.dox'
+
   pull_request:
-  
+    paths-ignore: 
+    - '**/*.md'
+    - '**/*.txt'
+    - '**/*.dox'
+
 jobs:
   codeql:
-    name: CodeQL Analysis
-    uses: nasa/cFS/.github/workflows/codeql-build.yml@main
+    uses: nasa/cFS/.github/workflows/codeql-reusable.yml@main
     with: 
-      make-prep: 'make prep'
-      make: 'make -C build/native/default_cpu1 core_api core_private es evs fs msg resourceid sb sbr tbl time'
+      component-path: cfe
+      make: make -j8
+      test: true


### PR DESCRIPTION
**Describe the contribution**

Depends on nasa/cFS#413

Fixes #2034 

- Replace Checkout Action for bundle with git clone
- Use symlink to map calling repo workspace to expected cFS Bundle
directory location
- Replace bundle checkout action with git clone
- Adds component-path input parameter
- Adds "code snippets" to CodeQL Analyze action

**Testing performed**

See PR checks Tab

**Expected behavior changes**

CodeQL Action executes successfully. 

**System(s) tested on**
- Github actions, Ubuntu 18.04

**Additional context**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Gerardo E. Cruz-Ortiz, NASA