### PR TITLE
Fix #2040, Improve CFE_SB_IsValidMsgId handler

### DIFF
--- a/modules/core_api/ut-stubs/src/cfe_sb_handlers.c
+++ b/modules/core_api/ut-stubs/src/cfe_sb_handlers.c
@@ -398,12 +398,19 @@ void UT_DefaultHandler_CFE_SB_GetUserDataLength(void *UserObj, UT_EntryKey_t Fun
  *------------------------------------------------------------*/
 void UT_DefaultHandler_CFE_SB_IsValidMsgId(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
-    int32 status;
-    bool  return_value;
+    int32          status;
+    bool           return_value;
+    CFE_SB_MsgId_t MsgId = UT_Hook_GetArgValueByName(Context, "MsgId", CFE_SB_MsgId_t);
 
-    UT_Stub_GetInt32StatusCode(Context, &status);
-
-    return_value = status;
+    if (UT_Stub_GetInt32StatusCode(Context, &status))
+    {
+        return_value = status;
+    }
+    else
+    {
+        /* The only invalid value UT's should be using is CFE_SB_INVALID_MSG_ID */
+        return_value = !CFE_SB_MsgId_Equal(MsgId, CFE_SB_INVALID_MSG_ID);
+    }
 
     UT_Stub_SetReturnValue(FuncKey, return_value);
 }


### PR DESCRIPTION
**Describe the contribution**
- Fix #2040 
- If no return value override is set test against CFE_SB_INVALID_MSG_ID

**Testing performed**
Build/run unit tests, passed.
Used with DS and confirm units under test worked as expected based on valid/invalid MID use.

**Expected behavior changes**
Handler behaves more like expected

**System(s) tested on**
 - Hardware: i5/Docker
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC