### PR TITLE
Fix #2049, Remove explicit filename doxygen comments

### DIFF
--- a/cmake/target/src/target_config.c
+++ b/cmake/target/src/target_config.c
@@ -19,7 +19,7 @@
 */
 
 /**
- * \file target_config.c
+ * \file
  *
  *  Created on: Dec 3, 2013
  *  Created by: joseph.p.hickey@nasa.gov


### PR DESCRIPTION
**Describe the contribution**
- Fix #2049

**Testing performed**
Make doc, observe no filename warnings

**Expected behavior changes**
None

**System(s) tested on**
 - Hardware: i5/wsl
 - OS: Ubuntu 18.04
 - Versions: Bundle main + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC