### PR TITLE
Fix #2051, Resolve doxygen doc warnings and enforce in CI

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -60,6 +60,7 @@ jobs:
       - name: Build Docs
         run: |
           make doc > make_doc_stdout.txt 2> make_doc_stderr.txt
+          mv build/docs/detaildesign-warnings.log detaildesign-warnings.log
 
       # Upload documentation logs as artifacts
       - name: Archive Documentation Build Logs
@@ -69,11 +70,19 @@ jobs:
           path: |
             make_doc_stdout.txt
             make_doc_stderr.txt
+            detaildesign-warnings.log
 
       - name: Error Check
         run: |
           if [[ -s make_doc_stderr.txt ]]; then
             cat make_doc_stderr.txt
+            exit -1
+          fi
+
+      - name: Warning Check
+        run: |
+          if [[ -s detaildesign-warnings.log ]]; then
+            cat detaildesign-warnings.log
             exit -1
           fi
 

--- a/cmake/cfe-common.doxyfile.in
+++ b/cmake/cfe-common.doxyfile.in
@@ -80,6 +80,10 @@ EXCLUDE_PATTERNS       += "*/ut-stubs/*"
 EXCLUDE_PATTERNS       += "*/ut-coverage/*"
 EXCLUDE_PATTERNS       += "*/unit-test*/*"
 
+# Exclude contributing guides and readme's since they stand alone as repo documentation
+EXCLUDE_PATTERNS       += "*/CONTRIBUTING.md"
+EXCLUDE_PATTERNS       += "*/README.md"
+
 #---------------------------------------------------------------------------
 # configuration options related to source browsing
 #---------------------------------------------------------------------------

--- a/modules/sb/fsw/src/cfe_sb_priv.h
+++ b/modules/sb/fsw/src/cfe_sb_priv.h
@@ -693,7 +693,7 @@ int32 CFE_SB_ZeroCopyBufferValidate(CFE_SB_Buffer_t *BufPtr, CFE_SB_BufferD_t **
  * \note Assumes destination pointer is valid
  *
  * \param[in] RouteId The route ID to add destination node to
- * \param[in] DestPtr Pointer to the destination to add
+ * \param[in] NewNode Pointer to the destination to add
  */
 int32 CFE_SB_AddDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *NewNode);
 
@@ -705,8 +705,8 @@ int32 CFE_SB_AddDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *NewNo
  *
  * \note Assumes destination pointer is valid and in route
  *
- * \param[in] RouteId The route ID to remove destination node from
- * \param[in] DestPtr Pointer to the destination to remove
+ * \param[in] RouteId      The route ID to remove destination node from
+ * \param[in] NodeToRemove Pointer to the destination to remove
  */
 void CFE_SB_RemoveDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *NodeToRemove);
 

--- a/modules/tbl/fsw/src/cfe_tbl_task.h
+++ b/modules/tbl/fsw/src/cfe_tbl_task.h
@@ -402,7 +402,7 @@ int32 CFE_TBL_TaskInit(void);
 ** \par Assumptions, External Events, and Notes:
 **          None
 **
-** \param[in] MessagePtr a pointer to the message received from the command pipe
+** \param[in] SBBufPtr Pointer to the message received from the command pipe
 **
 */
 void CFE_TBL_TaskPipe(CFE_SB_Buffer_t *SBBufPtr);


### PR DESCRIPTION
**Describe the contribution**
- Fix #2051 

**Testing performed**
Built doc standalone and confirmed with all the merges it built without warnings

**Expected behavior changes**
None except warnings squashed

**System(s) tested on**
 - Hardware: i5/wsl2
 - OS: Ubuntu 18.04
 - Versions: Bundle main + dependent commits

**Additional context**
Needs nasa/osal#1219

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC