### PR TITLE
Fix #2064, Use osal-common.doxygen to resolve OSAL Doxygen refs

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Build Usersguide
         run: |
           make usersguide > make_usersguide_stdout.txt 2> make_usersguide_stderr.txt
-          mv build/docs/cfe-usersguide-warnings.log usersguide_warnings.log
+          mv build/docs/users_guide/cfe-usersguide-warnings.log cfe-usersguide-warnings.log
 
       - name: Archive Users Guide Build Logs
         uses: actions/upload-artifact@v2
@@ -131,7 +131,7 @@ jobs:
           path: |
             make_usersguide_stdout.txt
             make_usersguide_stderr.txt
-            usersguide_warnings.log
+            cfe-usersguide-warnings.log
 
       - name: Error Check
         run: |
@@ -142,7 +142,7 @@ jobs:
 
       - name: Warning Check
         run: |
-          if [[ -s usersguide_warnings.log ]]; then
-            cat usersguide_warnings.log
+          if [[ -s cfe-usersguide-warnings.log ]]; then
+            cat cfe-usersguide-warnings.log
             exit -1
           fi

--- a/cmake/cfe-usersguide.doxyfile.in
+++ b/cmake/cfe-usersguide.doxyfile.in
@@ -5,14 +5,16 @@
 # Allow overrides
 @INCLUDE_PATH          = @MISSION_SOURCE_DIR@
 
-# Common configuration and default settings
+# Common setup
 @INCLUDE               = @MISSION_BINARY_DIR@/docs/cfe-common.doxyfile
-@INCLUDE               = @MISSION_SOURCE_DIR@/osal/docs/src/default-settings.doxyfile
+
+# Include osal to resolve references and provide default settings
+@INCLUDE               = @MISSION_BINARY_DIR@/docs/osal-common.doxyfile
 
 # Document specific settings
 PROJECT_NAME           = "Core Flight Executive Users Guide"
 OUTPUT_DIRECTORY       = @CMAKE_BINARY_DIR@/docs/users_guide
-WARN_LOGFILE           = @CMAKE_BINARY_DIR@/docs/cfe-usersguide-warnings.log
+WARN_LOGFILE           = @CMAKE_BINARY_DIR@/docs/users_guide/cfe-usersguide-warnings.log
 
 # For purposes of the user guide, reference the "stock" mission configuration
 # Although missions may override these files, for the users guide we are mainly

--- a/cmake/mission-detaildesign.doxyfile.in
+++ b/cmake/mission-detaildesign.doxyfile.in
@@ -7,7 +7,6 @@
 
 # Common configuration and default settings
 @INCLUDE               = @MISSION_BINARY_DIR@/docs/cfe-common.doxyfile
-@INCLUDE               = @MISSION_SOURCE_DIR@/osal/docs/src/default-settings.doxyfile
 
 # Example detailed design setup
 PROJECT_NAME           = "@MISSION_NAME@"

--- a/cmake/mission_build.cmake
+++ b/cmake/mission_build.cmake
@@ -290,7 +290,6 @@ function(prepare)
   # NOTE: the userguide is built against the headers of the default core apps. Even if
   # an alternate version of the module is in use, it should adhere to the same interface.
   set(SUBMODULE_HEADER_PATHS
-    "${osal_MISSION_DIR}/src/os/inc/*.h"
     "${psp_MISSION_DIR}/psp/fsw/inc/*.h"
   )
   foreach(MODULE core_api ${MISSION_CORE_MODULES})
@@ -298,7 +297,6 @@ function(prepare)
   endforeach()
   file(GLOB MISSION_USERGUIDE_HEADERFILES
     ${SUBMODULE_HEADER_PATHS}
-    "${CMAKE_BINARY_DIR}/docs/osconfig-example.h"
   )
 
   string(REPLACE ";" " \\\n" MISSION_USERGUIDE_HEADERFILES "${MISSION_USERGUIDE_HEADERFILES}")


### PR DESCRIPTION
**Describe the contribution**
- Fix #2064

**Testing performed**
Built osal users guide and cfe users guide and mission doc from bundle level, confirmed contents.

**Expected behavior changes**
Docs only, reduces dependencies

**System(s) tested on**
 - Hardware: i5/wsl
 - OS:  Ubuntu 18.04
 - Versions: Bundle main + this commit + nasa/osal#1232

**Additional context**
nasa/osal#1332

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC