### PR TITLE
HOTFIX #2066: Revert changes to versioning information

### DIFF
--- a/docs/src/cfs_versions.dox
+++ b/docs/src/cfs_versions.dox
@@ -22,10 +22,10 @@
   bug fixes or major documentation updates.
   The Revision number may also be updated if there are other changes contained within a release that make
   it desirable for applications to distinguish one release from another.
-  WARNING: The revision number is set to the number 0xFF in development builds. To distinguish between development
+  WARNING: The revision number is set to the number 99 in development builds. To distinguish between development
   builds refer to the BUILD_NUMBER and BUILD_BASELINE detailed in the section "Identifying Development Builds".
 
-  The Mission Version number is set to zero in all official releases, and is reserved for the mission use.
+  The Mission Rev Version number is set to zero in all official releases, and is reserved for the mission use.
 
   <H2> How and Where Defined </H2>
 
@@ -33,8 +33,7 @@
   API definition; these macros must expand to simple integer values, so that they can be used in simple if
   directives by the macro preprocessor.
 
-  Note the Mission Version number is provided for missions to be able to identify unique changes they
-  have made to the released software (via clone and own).
+  Note the Mission Rev number is provided for missions to be able to identify unique changes they have made to the released software (via clone and own). Specicifally, the values 1-254 are reserved for mission use to denote patches/customizations while 0 and 0xFF are reserved for cFS open-source development use (pending resolution of nasa/cFS#440).
 
   <H2> Identifying Development Builds </H2>
 
@@ -42,7 +41,7 @@
 
   The BUILD_NUMBER reflects the number of commits since the BUILD_BASELINE, a baseline git tag, for each particular
   component. The BUILD_NUMBER integer monotonically increases for a given baseline. The BUILD_BASELINE
-  identifies the current development cycle and is a git tag with format vX.Y.Z. The Codename used in the version
+  identifies the current development cycle and is a git tag with format vMAJOR.MINOR.REVISION. The Codename used in the version
   string also refers to the current development cycle. When a new baseline tag and codename are created, the
   BUILD_NUMBER resets to zero and begins increasing from a new baseline.
 
@@ -53,15 +52,15 @@
   name; for example, osal uses OS_, psp uses CFE_PSP_IMPL, and so on.
 
   Suggested pattern for development:
-  - XXX_SRC_VERSION: REFERENCE_GIT_TAG"+dev"BUILD_NUMBER
+  - CFSCOMPONENT_SRC_VERSION: REFERENCE_GIT_TAG"+dev"BUILD_NUMBER
     - Example: "v6.8.0-rc1+dev123"
-  - XXX_VERSION_STRING: "XXX DEVELOPMENT BUILD "XXX_SRC_VERSION" (Codename: YYY), Last Official Release: ZZZ"
+  - CFSCOMPONENT_VERSION_STRING: "CFSCOMPONENT DEVELOPMENT BUILD "CFSCOMPONENT_SRC_VERSION" (Codename: CFSCONSTELLATION), Last Official Release: MAJOR.MINOR.REVISION"
     - Example: "cFE DEVELOPMENT BUILD v6.8.0-rc1+dev123 (Codename: Bootes), Last Official Release: cfe v6.7.0"
 
   Suggested pattern for official releases:
-  - XXX_SRC_VERSION: OFFICIAL_GIT_TAG
+  - CFSCOMPONENT_SRC_VERSION: OFFICIAL_GIT_TAG
     - Example: "v7.0.0"
-  - XXX_VERSION_STRING: "XXX OFFICIAL RELEASE "XXX_SRC_VERSION" (Codename: YYY)"
+  - COMPONENT_VERSION_STRING: "CFSCOMPONENT OFFICIAL RELEASE "CFSCOMPONENT_SRC_VERSION" (Codename: CFSCONSTELLATION)"
     - Example: "cFE OFFICIAL RELEASE v7.0.0 (Codename: Caelum)"
 
 **/

--- a/modules/core_api/fsw/inc/cfe_version.h
+++ b/modules/core_api/fsw/inc/cfe_version.h
@@ -28,21 +28,22 @@
 #define CFE_VERSION_H
 
 /* Development Build Macro Definitions */
-#define CFE_BUILD_NUMBER   80           /**< @brief Development: Number of development commits since baseline */
+#define CFE_BUILD_NUMBER   80 /**< @brief Development: Number of development git commits since CFE_BUILD_BASELINE */
 #define CFE_BUILD_BASELINE "v7.0.0-rc4" /**< @brief Development: Reference git tag for build number */
 
-/* Version Macro Definitions updated for official releases only */
-#define CFE_MAJOR_VERSION 6 /**< @brief Major release version (Former for Revision == 99) */
-#define CFE_MINOR_VERSION 7 /**< @brief Minor release version (Former for Revision == 99) */
-#define CFE_REVISION \
-    99 /*!< @brief * Set to 0 on OFFICIAL releases, and set to 99 on development versions. Revision number.      */
+/* See \ref cfsversions for definitions */
+#define CFE_MAJOR_VERSION 6  /**< @brief Major version number */
+#define CFE_MINOR_VERSION 7  /**< @brief Minor version number */
+#define CFE_REVISION      99 /**< @brief Revision version number. Value of 99 indicates a development version.*/
 
 /*!
  * @brief Mission revision.
  *
- * Reserved for mission use to denote patches/customizations as needed.
+ * Values 1-254 are reserved for mission use to denote patches/customizations as needed. NOTE: Reserving 0 and 0xFF for
+ * cFS open-source development use (pending resolution of nasa/cFS#440)
+ *
  */
-#define CFE_MISSION_REV 0
+#define CFE_MISSION_REV 0xFF
 
 #define CFE_STR_HELPER(x) #x                /**< @brief Convert argument to string */
 #define CFE_STR(x)        CFE_STR_HELPER(x) /**< @brief Expand macro before conversion */


### PR DESCRIPTION
**Describe the contribution**

Per conversation in CCB:2022-03-24 and in https://github.com/nasa/cFE/commit/e5be0612ad6bf9db09ddf640306a65292abce2d5#commitcomment-69358417

Ensuring REVISION number is set to 99
Correct cfs_versions.dox appropriately. 

**Testing performed**
Text and documentation only

**Expected behavior changes**
No behavior change

**System(s) tested on**
n/a

**Additional context**
https://github.com/nasa/cFE/commit/e5be0612ad6bf9db09ddf640306a65292abce2d5#commitcomment-69358417

**Third party code**
none

**Contributor Info - All information REQUIRED for consideration of pull request**
Gerardo E. Cruz-Ortiz, NASA