### PR TITLE
Fix #1097, adds truncation warning suppression flags

### DIFF
--- a/cmake/sample_defs/arch_build_custom.cmake
+++ b/cmake/sample_defs/arch_build_custom.cmake
@@ -26,13 +26,15 @@
 # and uses the same warning options that are applied at the mission level.
 #
 add_compile_options(
-    -std=c99                # Target the C99 standard (without gcc extensions)
-    -pedantic               # Issue all the warnings demanded by strict ISO C
-    -Wall                   # Warn about most questionable operations
-    -Wstrict-prototypes     # Warn about missing prototypes
-    -Wwrite-strings         # Warn if not treating string literals as "const"
-    -Wpointer-arith         # Warn about suspicious pointer operations
-    -Wcast-align            # Warn about casts that increase alignment requirements
-    -Werror                 # Treat warnings as errors (code should be clean)
+    -std=c99                    # Target the C99 standard (without gcc extensions)
+    -pedantic                   # Issue all the warnings demanded by strict ISO C
+    -Wall                       # Warn about most questionable operations
+    -Wstrict-prototypes         # Warn about missing prototypes
+    -Wwrite-strings             # Warn if not treating string literals as "const"
+    -Wpointer-arith             # Warn about suspicious pointer operations
+    -Wcast-align                # Warn about casts that increase alignment requirements
+    -Werror                     # Treat warnings as errors (code should be clean)
+    -Wno-format-truncation      # Inhibit printf-style format truncation warnings
+    -Wno-stringop-truncation    # Inhibit string operation truncation warnings
 )
 


### PR DESCRIPTION
**Describe the contribution**
- Fix #1097 

Adds printf-style format and string operation truncation warning suppression flags.

**Testing performed**
Tested on fork: https://github.com/chillfig/cFE/actions?query=branch%3Asupress_trunc_warnings

**Expected behavior changes**
None, flags should prevent warnings on future compilations using latest systems. 

**System(s) tested on**
Ubuntu 18.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, ASRC Federal

EDIT - JH: Added reference to issue so it will autolink
