### PR TITLE
Fix #2084, Add support for fractional seconds in epoch

### DIFF
--- a/cmake/sample_defs/sample_mission_cfg.h
+++ b/cmake/sample_defs/sample_mission_cfg.h
@@ -180,12 +180,14 @@
 **      Hour - 0 to 23
 **      Minute - 0 to 59
 **      Second - 0 to 59
+**      Micros - 0 to 999999
 */
 #define CFE_MISSION_TIME_EPOCH_YEAR   1980
 #define CFE_MISSION_TIME_EPOCH_DAY    1
 #define CFE_MISSION_TIME_EPOCH_HOUR   0
 #define CFE_MISSION_TIME_EPOCH_MINUTE 0
 #define CFE_MISSION_TIME_EPOCH_SECOND 0
+#define CFE_MISSION_TIME_EPOCH_MICROS 0
 
 /**
 **  \cfetimecfg Time File System Factor

--- a/modules/time/fsw/src/cfe_time_api.c
+++ b/modules/time/fsw/src/cfe_time_api.c
@@ -619,9 +619,13 @@ void CFE_TIME_Print(char *PrintBuffer, CFE_TIME_SysTime_t TimeToPrint)
     /*
     ** Convert the cFE time (offset from epoch) into calendar time...
     */
-    NumberOfMinutes = (TimeToPrint.Seconds / 60) + CFE_MISSION_TIME_EPOCH_MINUTE;
-    NumberOfSeconds = (TimeToPrint.Seconds % 60) + CFE_MISSION_TIME_EPOCH_SECOND;
+    NumberOfMicros = CFE_TIME_Sub2MicroSecs(TimeToPrint.Subseconds) + CFE_MISSION_TIME_EPOCH_MICROS;
 
+    NumberOfMinutes = (NumberOfMicros / 60000000) + (TimeToPrint.Seconds / 60) + CFE_MISSION_TIME_EPOCH_MINUTE;
+    NumberOfMicros  = NumberOfMicros % 60000000;
+
+    NumberOfSeconds = (NumberOfMicros / 1000000) + (TimeToPrint.Seconds % 60) + CFE_MISSION_TIME_EPOCH_SECOND;
+    NumberOfMicros  = NumberOfMicros % 1000000;
     /*
     ** Adding the epoch "seconds" after computing the minutes avoids
     **    overflow problems when the input time value (seconds) is
@@ -698,7 +702,7 @@ void CFE_TIME_Print(char *PrintBuffer, CFE_TIME_SysTime_t TimeToPrint)
     /*
     ** After computing microseconds, convert to 5 digits from 6 digits...
     */
-    NumberOfMicros = CFE_TIME_Sub2MicroSecs(TimeToPrint.Subseconds) / 10;
+    NumberOfMicros = NumberOfMicros / 10;
 
     /*
     ** Build formatted output string (yyyy-ddd-hh:mm:ss.xxxxx)...

--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -837,7 +837,7 @@ void Test_Print(void)
     UtPrintf("Begin Test Print");
 
     if (CFE_MISSION_TIME_EPOCH_YEAR != 1980 || CFE_MISSION_TIME_EPOCH_DAY != 1 || CFE_MISSION_TIME_EPOCH_HOUR != 0 ||
-        CFE_MISSION_TIME_EPOCH_MINUTE != 0 || CFE_MISSION_TIME_EPOCH_SECOND != 0)
+        CFE_MISSION_TIME_EPOCH_MINUTE != 0 || CFE_MISSION_TIME_EPOCH_SECOND != 0 || CFE_MISSION_TIME_EPOCH_MICROS != 0)
     {
         UtPrintf("Custom epoch time requires manual inspection for CFE_TIME_Print");
         usingDefaultEpoch = false;


### PR DESCRIPTION
Describe the contribution
Fix #2084

Testing performed
Build/run unit tests, confirm same coverage of time module

Expected behavior changes
Epoch contains a value for fractional seconds in the form of a CFE_MISSION_TIME_EPOCH_MICROS. This value is included in the time value before generating the printable string in CFE_TIME_Print

System(s) tested on

Hardware: i7/Virtual Box
OS: CentOS Linux 7.9
Versions: Bundle main plus this component
Additional context
None

Third party code
None

Contributor Info - All information REQUIRED for consideration of pull request
Jonathan Brandenburg - NASA/JSC