### PR TITLE
Fix #2092, Doc deploy from local workflow on main branch push

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -23,7 +23,7 @@ jobs:
   checkout-and-cache:
     name: Custom checkout and cache for cFS documents
     needs: checks-for-duplicates
-    if: ${{ needs.checks-for-duplicates.outputs.should_skip != 'true' }} 
+    if: ${{ needs.checks-for-duplicates.outputs.should_skip != 'true' || contains(github.ref, 'main') }} 
     runs-on: ubuntu-latest
 
     steps:
@@ -53,7 +53,7 @@ jobs:
       target: "[\"cfe-usersguide\"]"
       cache-key: cfs-doc-${{ github.run_number }}
       buildpdf: ${{ github.event_name == 'push' && contains(github.ref, 'main')}}
-      deploy: ${{ github.event_name == 'push' && contains(github.ref, 'main')}}
+      deploy: false  # Note can't use cache with deploy, deploy in following job instead
 
   build-mission-doc:
     needs: checkout-and-cache
@@ -65,3 +65,28 @@ jobs:
       cache-key: cfs-doc-${{ github.run_number }}
       deploy: false
       buildpdf: false # No need for mission pdf within cFE, done at bundle level
+
+  deploy-documentation:
+    needs: build-cfe-usersguide
+    if: ${{ github.event_name == 'push' && contains(github.ref, 'main')}}
+    name: Deploy documentation to gh-pages
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v3
+
+      - name: Display structure of downloaded files
+        run: ls -R
+
+      - name: Move pdfs to deployment directory
+        run: mkdir deploy; mv */*.pdf deploy
+
+      - name: Deploy to GitHub
+        uses: JamesIves/github-pages-deploy-action@3.7.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: deploy
+          SINGLE_COMMIT: true


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #2092

Workflow deploys document locally to avoid deployment password issues when trying to deploy from cache in reusable.  Also doesn't skip main branch actions so it will deploy on push to main.

**Testing performed**
CI

**Expected behavior changes**
Document deploy fixed

**System(s) tested on**
CI: tested on fork here - https://github.com/skliper/cFE/actions/runs/2203904971

**Additional context**
Depends on updates in cFS reusable workflow so it won't get skipped
- nasa/cFS#466

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC