### PR TITLE
Fix #2096 update rtems toolchain files

### DIFF
--- a/cmake/sample_defs/toolchain-i686-rtems4.11.cmake
+++ b/cmake/sample_defs/toolchain-i686-rtems4.11.cmake
@@ -14,51 +14,28 @@ set(CMAKE_SYSTEM_NAME       RTEMS)
 set(CMAKE_SYSTEM_PROCESSOR  i386)
 set(CMAKE_SYSTEM_VERSION    4.11)
 
-# The TOOLS and BSP are allowed to be installed in different locations.
-# If the README was followed they will both be installed under $HOME
-# By default it is assumed the BSP is installed to the same directory as the tools
-SET(RTEMS_TOOLS_PREFIX "$ENV{HOME}/rtems-${CMAKE_SYSTEM_VERSION}" CACHE PATH 
-    "RTEMS tools install directory")
-SET(RTEMS_BSP_PREFIX "${RTEMS_TOOLS_PREFIX}" CACHE PATH 
-    "RTEMS BSP install directory")
+# The RTEMS BSP that will be used for this build
+set(RTEMS_BSP               "pc686")
 
-# The BSP that will be used for this build
-set(RTEMS_BSP "pc686")
+# The CFE_SYSTEM_PSPNAME is specific to cFE and determines which
+# abstraction layers are built when using this toolchain
+SET(CFE_SYSTEM_PSPNAME      pc-rtems)
 
-# specify the cross compiler - adjust accord to compiler installation
-# This uses the compiler-wrapper toolchain that buildroot produces
-SET(SDKHOSTBINDIR               "${RTEMS_TOOLS_PREFIX}/bin")
-set(TARGETPREFIX                "${CMAKE_SYSTEM_PROCESSOR}-rtems${CMAKE_SYSTEM_VERSION}-")
-set(RTEMS_BSP_C_FLAGS           "-march=i686 -mtune=i686 -fno-common")
-set(RTEMS_BSP_CXX_FLAGS         ${RTEMS_BSP_C_FLAGS})
+# RTEMS_DYNAMIC_LOAD definition:
+# - Set to FALSE for platforms that create a RTEMS executable and link it
+#   to the cFE core.
+# - Set to TRUE for platforms that expect the cFE core to to be dynamically
+#   loaded into an existing runtime image.
+# This is tied to the OSAL-BSP and PSP implementation so generally cannot
+# be switched on a specific OSAL/PSP platform without modifications.
+set(RTEMS_DYNAMIC_LOAD      FALSE)
 
-SET(CMAKE_C_COMPILER            "${RTEMS_TOOLS_PREFIX}/bin/${TARGETPREFIX}gcc")
-SET(CMAKE_CXX_COMPILER          "${RTEMS_TOOLS_PREFIX}/bin/${TARGETPREFIX}g++")
-SET(CMAKE_LINKER                "${RTEMS_TOOLS_PREFIX}/bin/${TARGETPREFIX}ld")
-SET(CMAKE_ASM_COMPILER          "${RTEMS_TOOLS_PREFIX}/bin/${TARGETPREFIX}as")
-SET(CMAKE_STRIP                 "${RTEMS_TOOLS_PREFIX}/bin/${TARGETPREFIX}strip")
-SET(CMAKE_NM                    "${RTEMS_TOOLS_PREFIX}/bin/${TARGETPREFIX}nm")
-SET(CMAKE_AR                    "${RTEMS_TOOLS_PREFIX}/bin/${TARGETPREFIX}ar")
-SET(CMAKE_OBJDUMP               "${RTEMS_TOOLS_PREFIX}/bin/${TARGETPREFIX}objdump")
-SET(CMAKE_OBJCOPY               "${RTEMS_TOOLS_PREFIX}/bin/${TARGETPREFIX}objcopy")
+set(RTEMS_BSP_C_FLAGS       "-march=i686 -mtune=i686 -fno-common")
+set(RTEMS_BSP_CXX_FLAGS     ${RTEMS_BSP_C_FLAGS})
+set(RTEMS_BSP_SPECS_FLAGS   "-specs bsp_specs")
 
 # Exception handling is very iffy.  These two options disable eh_frame creation.
 set(CMAKE_C_COMPILE_OPTIONS_PIC -fno-exceptions -fno-asynchronous-unwind-tables)
-
-# search for programs in the build host directories
-SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM   NEVER)
-
-# for libraries and headers in the target directories
-SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY   ONLY)
-SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE   ONLY)
-
-SET(CMAKE_PREFIX_PATH                   /)
-
-# these settings are specific to cFE/OSAL and determines which
-# abstraction layers are built when using this toolchain
-SET(CFE_SYSTEM_PSPNAME                  pc-rtems)
-SET(OSAL_SYSTEM_BSPTYPE                 pc-rtems)
-SET(OSAL_SYSTEM_OSTYPE                  rtems)
 
 # Info regarding the RELOCADDR:
 #+--------------------------------------------------------------------------+
@@ -72,4 +49,41 @@ SET(OSAL_SYSTEM_OSTYPE                  rtems)
 #+--------------------------------------------------------------------------+
 set(RTEMS_RELOCADDR 0x00100000)
 
+# This is for version specific RTEMS ifdefs needed by the OSAL and PSP
+ADD_DEFINITIONS(-DOS_${CMAKE_SYSTEM_NAME}_4_DEPRECATED)
+# This define is deprecated and will be removed
+ADD_DEFINITIONS(-D_RTEMS_411_)
 
+#+---------------------------------------------------------------------------+ 
+#| Common RTEMS toolchain statements
+#+---------------------------------------------------------------------------+ 
+# The TOOLS and BSP are allowed to be installed in different locations.
+# If the README was followed they will both be installed under $HOME
+# By default it is assumed the BSP is installed to the same directory as the tools
+SET(RTEMS_TOOLS_PREFIX "$ENV{HOME}/rtems-${CMAKE_SYSTEM_VERSION}" CACHE PATH
+    "RTEMS tools install directory")
+SET(RTEMS_BSP_PREFIX "${RTEMS_TOOLS_PREFIX}" CACHE PATH
+    "RTEMS BSP install directory")
+
+# specify the cross compiler - adjust accord to compiler installation
+SET(SDKHOSTBINDIR               "${RTEMS_TOOLS_PREFIX}/bin")
+set(TARGETPREFIX                "${CMAKE_SYSTEM_PROCESSOR}-rtems${CMAKE_SYSTEM_VERSION}-")
+
+SET(CMAKE_C_COMPILER            "${RTEMS_TOOLS_PREFIX}/bin/${TARGETPREFIX}gcc")
+SET(CMAKE_CXX_COMPILER          "${RTEMS_TOOLS_PREFIX}/bin/${TARGETPREFIX}g++")
+SET(CMAKE_LINKER                "${RTEMS_TOOLS_PREFIX}/bin/${TARGETPREFIX}ld")
+SET(CMAKE_ASM_COMPILER          "${RTEMS_TOOLS_PREFIX}/bin/${TARGETPREFIX}as")
+SET(CMAKE_STRIP                 "${RTEMS_TOOLS_PREFIX}/bin/${TARGETPREFIX}strip")
+SET(CMAKE_NM                    "${RTEMS_TOOLS_PREFIX}/bin/${TARGETPREFIX}nm")
+SET(CMAKE_AR                    "${RTEMS_TOOLS_PREFIX}/bin/${TARGETPREFIX}ar")
+SET(CMAKE_OBJDUMP               "${RTEMS_TOOLS_PREFIX}/bin/${TARGETPREFIX}objdump")
+SET(CMAKE_OBJCOPY               "${RTEMS_TOOLS_PREFIX}/bin/${TARGETPREFIX}objcopy")
+
+# search for programs in the build host directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM   NEVER)
+
+# for libraries and headers in the target directories
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY   ONLY)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE   ONLY)
+
+SET(CMAKE_PREFIX_PATH                   /)

--- a/cmake/sample_defs/toolchain-i686-rtems6.cmake
+++ b/cmake/sample_defs/toolchain-i686-rtems6.cmake
@@ -12,7 +12,7 @@
 # Basic cross system configuration
 set(CMAKE_SYSTEM_NAME       RTEMS)
 set(CMAKE_SYSTEM_PROCESSOR  i386)
-set(CMAKE_SYSTEM_VERSION    5)
+set(CMAKE_SYSTEM_VERSION    6)
 
 # The RTEMS BSP that will be used for this build
 set(RTEMS_BSP               "pc686")
@@ -32,14 +32,14 @@ set(RTEMS_DYNAMIC_LOAD      FALSE)
 
 set(RTEMS_BSP_C_FLAGS       "-march=i686 -mtune=i686 -fno-common")
 set(RTEMS_BSP_CXX_FLAGS     ${RTEMS_BSP_C_FLAGS})
-set(RTEMS_BSP_SPECS_FLAGS   "-specs bsp_specs")
+set(RTEMS_BSP_SPECS_FLAGS   "")
 
 # Exception handling is very iffy.  These two options disable eh_frame creation.
 set(CMAKE_C_COMPILE_OPTIONS_PIC -fno-exceptions -fno-asynchronous-unwind-tables)
 
 # Link libraries needed for a RTEMS 5+ executable
 #  This was handled by the bsp_specs file in 4.11
-set(LINK_LIBRARIES              "-lrtemsdefaultconfig -lrtemsbsp -lrtemscpu")
+set(LINK_LIBRARIES          "-lrtemsdefaultconfig -lrtemsbsp -lrtemscpu")
 
 # Info regarding the RELOCADDR:
 #+--------------------------------------------------------------------------+
@@ -55,8 +55,6 @@ set(RTEMS_RELOCADDR 0x00100000)
 
 # This is for version specific RTEMS ifdefs needed by the OSAL and PSP
 ADD_DEFINITIONS(-DOS_${CMAKE_SYSTEM_NAME}_${CMAKE_SYSTEM_VERSION})
-# This define is deprecated and will be removed
-ADD_DEFINITIONS(-D_RTEMS_5_)
 
 #+---------------------------------------------------------------------------+ 
 #| Common RTEMS toolchain statements


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**

- Fix #2096 

Modifies the existing RTEMS 4.11 and RTEMS 5 toolchain files to:

- Change the OS define to avoid using a reserved identifier (_RTEMS_(x)_)
- Change the RTEMS 4.11 define to indicate it is deprecated
- Add a BSP_SPECS_FLAGS flag to allow for RTEMS version variations in the specs flags
- Add a dynamic load Cmake variable to allow for two types of CMAKE executable types in the platform file

Added a RTEMS 6 i686 toolchain file 

**Testing performed**

- Rebuilt and ran RTEMS 4.11 and RTEMS 5 tests
- Tested RTEMS 6 build and ran tests (using local OSAL mods and CI docker image with RTEMS 6)

**Expected behavior changes**

- No impact or behavior changes on RTEMS 4.11 and RTEMS 5

**System(s) tested on**
 
- RTEMS 4.11, RTEMS 5 Docker images used in CI workflows

**Additional context**

- The changes in the toolchain files for RTEMS 4.11 and RTEMS 5 are to accommodate the RTEMS 6 port and allow for additional RTEMS builds to use the same CMake Platform file for RTEMS.

**Contributor Info - All information REQUIRED for consideration of pull request**
Alan Cudmore, NASA/GSFC Code 582.0
