### PR TITLE
Fix #2114, Add macro for initializing command header

### DIFF
--- a/modules/msg/option_inc/default_cfe_msg_hdr_pri.h
+++ b/modules/msg/option_inc/default_cfe_msg_hdr_pri.h
@@ -51,6 +51,20 @@
  */
 #define CFE_MSG_PTR(shdr) (&((shdr).Msg))
 
+/**
+ * \brief Macro to initialize a command header, useful in tables that define commands
+ */
+#define CFE_MSG_CMD_HDR_INIT(mid, size, fc, cksum)                       \
+    {                                                                    \
+        .Msg.CCSDS =                                                     \
+            {                                                            \
+                .Pri = {.StreamId = {((mid) >> 8) & 0xFF, (mid)&0xFF},   \
+                        .Sequence = {0xC0, 0},                           \
+                        .Length   = {((size)-7) >> 8, ((size)-7) & 0xFF}}, \
+            },                                                           \
+        CFE_MSG_CMD_HDR_SEC_INIT(fc, cksum)                              \
+    }
+
 /*
  * Type Definitions
  */

--- a/modules/msg/option_inc/default_cfe_msg_hdr_priext.h
+++ b/modules/msg/option_inc/default_cfe_msg_hdr_priext.h
@@ -51,6 +51,28 @@
  */
 #define CFE_MSG_PTR(shdr) (&((shdr).Msg))
 
+/**
+ * \brief Macro to initialize a command header, useful in tables that define commands
+ */
+#define CFE_MSG_CMD_HDR_INIT(mid, size, fc, cksum)       \
+    {                                                    \
+    .Msg.CCSDS = \
+    { \
+        .Pri = \
+        { \
+            .StreamId = {(((mid)&0x80)<<5, (mid)&0x7F}, \
+            .Sequence = {0xC0, 0}, \
+            .Length = {((size)-7)>>8, ((size)-7)&0xFF} \
+        }, \
+        .Ext = \
+        { \
+            .Subsystem = {0, ((mid)>>8)&0xFF}, \
+            .SystemId = {0, 0) \
+        } \
+    }, \
+    CFE_MSG_CMD_HDR_SEC_INIT(fc, cksum) \
+}
+
 /*
  * Type Definitions
  */

--- a/modules/msg/option_inc/default_cfe_msg_sechdr.h
+++ b/modules/msg/option_inc/default_cfe_msg_sechdr.h
@@ -38,6 +38,11 @@
  * Defines
  */
 
+/**
+ * \brief Macro to initialize secondary header, used in macro to intialize entire header which is useful in tables
+ */
+#define CFE_MSG_CMD_HDR_SEC_INIT(fc, cksum) .Sec = {.FunctionCode = (fc), .Checksum = (cksum)}
+
 /*
  * Type Definitions
  */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #1224 

Just adds CFE_MSG_CMD_HDR_INIT

**Testing performed**
Built and ran with nasa/SC#35, and observed the commands getting sent

**Expected behavior changes**
None, just provides a more portable way to define tables with commands

**System(s) tested on**
 - Hardware: i5/wsl
 - OS: Ubuntu 18.04
 - Versions: Build main + the SC changes and this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC