### PR TITLE
Fix #2131, Increase event burst credit to not squelch at startup in CI

### DIFF
--- a/cmake/sample_defs/cpu1_platform_cfg.h
+++ b/cmake/sample_defs/cpu1_platform_cfg.h
@@ -1347,7 +1347,7 @@
 **  \par Limits
 **       This number must be less than or equal to INT_MAX/1000
 */
-#define CFE_PLATFORM_EVS_MAX_APP_EVENT_BURST 16
+#define CFE_PLATFORM_EVS_MAX_APP_EVENT_BURST 32
 
 /**
 **  \cfeevscfg Sustained number of event messages per second per app before squelching


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #2131 

Doubled the event squelch credit (16 to 32) to avoid ES event squelching at startup seen in app CI runs

**Testing performed**
Tested with 10 GSFC apps, no squelch observed

**Expected behavior changes**
Just increased the default credit, can burst up to 32 events before squelch.

**System(s) tested on**
CI

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC