### PR TITLE
Fix #2137, Squash uninit var static analysis warnings

### DIFF
--- a/modules/cfe_testcase/src/sb_sendrecv_test.c
+++ b/modules/cfe_testcase/src/sb_sendrecv_test.c
@@ -226,7 +226,7 @@ void TestMsgBroadcast(void)
     CFE_SB_PipeId_t                PipeId3 = CFE_SB_INVALID_PIPE;
     CFE_SB_PipeId_t                PipeId4 = CFE_SB_INVALID_PIPE;
     CFE_FT_TestCmdMessage_t        CmdMsg;
-    CFE_SB_MsgId_t                 MsgId;
+    CFE_SB_MsgId_t                 MsgId = CFE_SB_INVALID_MSG_ID;
     CFE_SB_Buffer_t *              MsgBuf1;
     CFE_SB_Buffer_t *              MsgBuf2;
     CFE_SB_Buffer_t *              MsgBuf3;

--- a/modules/evs/fsw/src/cfe_evs_utils.c
+++ b/modules/evs/fsw/src/cfe_evs_utils.c
@@ -301,7 +301,7 @@ bool EVS_CheckAndIncrementSquelchTokens(EVS_AppData_t *AppDataPtr)
 {
     bool      NotSquelched     = true;
     bool      SendSquelchEvent = false;
-    OS_time_t CurrentTime;
+    OS_time_t CurrentTime      = {0};
     int64     DeltaTimeMs;
     int64     CreditCount;
     char      AppName[OS_MAX_API_NAME];

--- a/modules/evs/ut-coverage/evs_UT.c
+++ b/modules/evs/ut-coverage/evs_UT.c
@@ -267,6 +267,9 @@ void Test_Init(void)
 
     UtPrintf("Begin Test Init");
 
+    memset(&bitmaskcmd, 0, sizeof(bitmaskcmd));
+    memset(&appbitcmd, 0, sizeof(appbitcmd));
+
     strncpy(appbitcmd.Payload.AppName, "ut_cfe_evs", sizeof(appbitcmd.Payload.AppName) - 1);
     appbitcmd.Payload.AppName[sizeof(appbitcmd.Payload.AppName) - 1] = '\0';
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #2137 

**Testing performed**
CI

**Expected behavior changes**
Just squashes warnings

**System(s) tested on**
CI

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC