### PR TITLE
Fix #1460, Duplicated Logic in CFE_SB_BroadcastBufferToRoute

### DIFF
--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -1658,22 +1658,22 @@ void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_
                     PipeDscPtr->PeakQueueDepth = PipeDscPtr->CurrentQueueDepth;
                 }
             }
-            else if (OsStatus == OS_QUEUE_FULL)
-            {
-                SBSndErr.EvtBuf[SBSndErr.EvtsToSnd].PipeId  = DestPtr->PipeId;
-                SBSndErr.EvtBuf[SBSndErr.EvtsToSnd].EventId = CFE_SB_Q_FULL_ERR_EID;
-                SBSndErr.EvtsToSnd++;
-                CFE_SB_Global.HKTlmMsg.Payload.PipeOverflowErrorCounter++;
-                PipeDscPtr->SendErrors++;
-            }
             else
             {
-                /* Unexpected error while writing to queue. */
-                SBSndErr.EvtBuf[SBSndErr.EvtsToSnd].PipeId   = DestPtr->PipeId;
-                SBSndErr.EvtBuf[SBSndErr.EvtsToSnd].EventId  = CFE_SB_Q_WR_ERR_EID;
-                SBSndErr.EvtBuf[SBSndErr.EvtsToSnd].OsStatus = OsStatus;
+                SBSndErr.EvtBuf[SBSndErr.EvtsToSnd].PipeId = DestPtr->PipeId;
+                if (OsStatus == OS_QUEUE_FULL)
+                {
+                    SBSndErr.EvtBuf[SBSndErr.EvtsToSnd].EventId = CFE_SB_Q_FULL_ERR_EID;
+                    CFE_SB_Global.HKTlmMsg.Payload.PipeOverflowErrorCounter++;
+                }
+                else
+                {
+                    /* Unexpected error while writing to queue. */
+                    SBSndErr.EvtBuf[SBSndErr.EvtsToSnd].EventId  = CFE_SB_Q_WR_ERR_EID;
+                    SBSndErr.EvtBuf[SBSndErr.EvtsToSnd].OsStatus = OsStatus;
+                    CFE_SB_Global.HKTlmMsg.Payload.InternalErrorCounter++;
+                }
                 SBSndErr.EvtsToSnd++;
-                CFE_SB_Global.HKTlmMsg.Payload.InternalErrorCounter++;
                 PipeDscPtr->SendErrors++;
             } /*end if */
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #1460
Removes duplicated logic in the final if/else in CFE_SB_BroadcastBufferToRoute.

**Testing performed**
Standard cFS bundle tests performed.
![lcov (cfe_sb_api c)](https://user-images.githubusercontent.com/9024662/192081997-c4f397b6-9958-4377-aebe-ee7022b74b8a.png)

**Expected behavior changes**
No impact on behavior.

**System(s) tested on**
Intel(R) Celeron(R) N4100 CPU @ 1.10GHz x86_64
Debian GNU/Linux 11 (bullseye)
cFE v7.0.0-rc4+dev171

**Contributor Info - All information REQUIRED for consideration of pull request**
@thnkslprpt
