### PR TITLE
Fix #2153, Remove unnecessary parentheses around return values.

### DIFF
--- a/modules/core_api/fsw/inc/cfe_resourceid.h
+++ b/modules/core_api/fsw/inc/cfe_resourceid.h
@@ -101,7 +101,7 @@
  */
 static inline unsigned long CFE_ResourceId_ToInteger(CFE_ResourceId_t id)
 {
-    return ((unsigned long)CFE_RESOURCEID_UNWRAP(id));
+    return (unsigned long)CFE_RESOURCEID_UNWRAP(id);
 }
 
 /**
@@ -120,7 +120,7 @@ static inline unsigned long CFE_ResourceId_ToInteger(CFE_ResourceId_t id)
  */
 static inline CFE_ResourceId_t CFE_ResourceId_FromInteger(unsigned long Value)
 {
-    return ((CFE_ResourceId_t)CFE_RESOURCEID_WRAP(Value));
+    return (CFE_ResourceId_t)CFE_RESOURCEID_WRAP(Value);
 }
 
 /**

--- a/modules/es/fsw/src/cfe_es_api.c
+++ b/modules/es/fsw/src/cfe_es_api.c
@@ -55,7 +55,7 @@ int32 CFE_ES_GetResetType(uint32 *ResetSubtypePtr)
         *ResetSubtypePtr = CFE_ES_Global.ResetDataPtr->ResetVars.ResetSubtype;
     }
 
-    return (CFE_ES_Global.ResetDataPtr->ResetVars.ResetType);
+    return CFE_ES_Global.ResetDataPtr->ResetVars.ResetType;
 }
 
 /*----------------------------------------------------------------
@@ -152,7 +152,7 @@ CFE_Status_t CFE_ES_ResetCFE(uint32 ResetType)
         ReturnCode = CFE_ES_BAD_ARGUMENT;
     }
 
-    return (ReturnCode);
+    return ReturnCode;
 }
 
 /*----------------------------------------------------------------
@@ -221,7 +221,7 @@ CFE_Status_t CFE_ES_RestartApp(CFE_ES_AppId_t AppID)
 
     } /* end if */
 
-    return (ReturnCode);
+    return ReturnCode;
 }
 
 /*----------------------------------------------------------------
@@ -290,7 +290,7 @@ CFE_Status_t CFE_ES_ReloadApp(CFE_ES_AppId_t AppID, const char *AppFileName)
                              CFE_RESOURCEID_TO_ULONG(AppID));
     }
 
-    return (ReturnCode);
+    return ReturnCode;
 }
 
 /*----------------------------------------------------------------
@@ -343,7 +343,7 @@ CFE_Status_t CFE_ES_DeleteApp(CFE_ES_AppId_t AppID)
                              CFE_RESOURCEID_TO_ULONG(AppID));
     }
 
-    return (ReturnCode);
+    return ReturnCode;
 }
 
 /*----------------------------------------------------------------
@@ -568,7 +568,7 @@ bool CFE_ES_RunLoop(uint32 *RunStatus)
 
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
-    return (ReturnCode);
+    return ReturnCode;
 }
 
 /*----------------------------------------------------------------
@@ -726,7 +726,7 @@ CFE_Status_t CFE_ES_GetAppIDByName(CFE_ES_AppId_t *AppIdPtr, const char *AppName
 
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
-    return (Result);
+    return Result;
 }
 
 /*----------------------------------------------------------------
@@ -767,7 +767,7 @@ CFE_Status_t CFE_ES_GetLibIDByName(CFE_ES_LibId_t *LibIdPtr, const char *LibName
 
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
-    return (Result);
+    return Result;
 }
 
 /*----------------------------------------------------------------
@@ -802,7 +802,7 @@ CFE_Status_t CFE_ES_GetTaskIDByName(CFE_ES_TaskId_t *TaskIdPtr, const char *Task
         *TaskIdPtr = CFE_ES_TASKID_UNDEFINED;
     }
 
-    return (Result);
+    return Result;
 }
 
 /*----------------------------------------------------------------
@@ -840,7 +840,7 @@ CFE_Status_t CFE_ES_GetAppID(CFE_ES_AppId_t *AppIdPtr)
 
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
-    return (Result);
+    return Result;
 }
 
 /*----------------------------------------------------------------
@@ -920,7 +920,7 @@ CFE_Status_t CFE_ES_GetAppName(char *AppName, CFE_ES_AppId_t AppId, size_t Buffe
 
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
-    return (Result);
+    return Result;
 }
 
 /*----------------------------------------------------------------
@@ -966,7 +966,7 @@ CFE_Status_t CFE_ES_GetLibName(char *LibName, CFE_ES_LibId_t LibId, size_t Buffe
 
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
-    return (Result);
+    return Result;
 }
 
 /*----------------------------------------------------------------
@@ -1209,7 +1209,7 @@ int32 CFE_ES_GetModuleInfo(CFE_ES_AppInfo_t *ModuleInfo, CFE_ResourceId_t Resour
             break;
     }
 
-    return (Status);
+    return Status;
 }
 
 /*----------------------------------------------------------------
@@ -1285,7 +1285,7 @@ CFE_Status_t CFE_ES_GetTaskInfo(CFE_ES_TaskInfo_t *TaskInfo, CFE_ES_TaskId_t Tas
 
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
-    return (Status);
+    return Status;
 }
 
 /*----------------------------------------------------------------
@@ -1381,7 +1381,7 @@ CFE_Status_t CFE_ES_CreateChildTask(CFE_ES_TaskId_t *TaskIdPtr, const char *Task
         ReturnCode = CFE_ES_StartAppTask(TaskIdPtr, TaskName, FunctionPtr, &Params, ParentAppId);
     }
 
-    return (ReturnCode);
+    return ReturnCode;
 }
 
 /*----------------------------------------------------------------
@@ -1528,7 +1528,7 @@ CFE_Status_t CFE_ES_DeleteChildTask(CFE_ES_TaskId_t TaskId)
         CFE_ES_WriteToSysLog("%s: Error: Invalid Task ID: %lu\n", __func__, CFE_RESOURCEID_TO_ULONG(TaskId));
         ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
     }
-    return (ReturnCode);
+    return ReturnCode;
 }
 
 /*----------------------------------------------------------------
@@ -1623,7 +1623,7 @@ CFE_Status_t CFE_ES_WriteToSysLog(const char *SpecStringPtr, ...)
     /* Output the entry to the console */
     OS_printf("%s", TmpString);
 
-    return (ReturnCode);
+    return ReturnCode;
 }
 
 /*----------------------------------------------------------------
@@ -1701,7 +1701,7 @@ uint32 CFE_ES_CalculateCRC(const void *DataPtr, size_t DataLength, uint32 InputC
         default:
             break;
     }
-    return (Crc);
+    return Crc;
 }
 
 /*----------------------------------------------------------------
@@ -2109,7 +2109,7 @@ CFE_Status_t CFE_ES_GetGenCounterIDByName(CFE_ES_CounterId_t *CounterIdPtr, cons
 
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
-    return (Result);
+    return Result;
 }
 
 /*----------------------------------------------------------------

--- a/modules/es/fsw/src/cfe_es_apps.c
+++ b/modules/es/fsw/src/cfe_es_apps.c
@@ -387,7 +387,7 @@ int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens)
         Status = CFE_ES_ERR_APP_CREATE;
     }
 
-    return (Status);
+    return Status;
 }
 
 /*----------------------------------------------------------------
@@ -545,7 +545,7 @@ int32 CFE_ES_GetTaskFunction(CFE_ES_TaskEntryFuncPtr_t *FuncPtr)
         *FuncPtr = EntryFunc;
     }
 
-    return (ReturnCode);
+    return ReturnCode;
 }
 
 /*----------------------------------------------------------------
@@ -976,7 +976,7 @@ int32 CFE_ES_LoadLibrary(CFE_ES_LibId_t *LibraryIdPtr, const char *LibName, cons
 
     *LibraryIdPtr = CFE_ES_LIBID_C(PendingResourceId);
 
-    return (Status);
+    return Status;
 }
 
 /*----------------------------------------------------------------
@@ -1556,7 +1556,7 @@ int32 CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId)
 
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
-    return (ReturnCode);
+    return ReturnCode;
 }
 
 /*
@@ -1739,7 +1739,7 @@ int32 CFE_ES_CleanupTaskResources(CFE_ES_TaskId_t TaskId)
         Result = CFE_ES_TASK_DELETE_ERR;
     }
 
-    return (Result);
+    return Result;
 }
 
 /*----------------------------------------------------------------

--- a/modules/es/fsw/src/cfe_es_cds.c
+++ b/modules/es/fsw/src/cfe_es_cds.c
@@ -468,7 +468,7 @@ int32 CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr, size_t UserBlockSize, 
 
     *HandlePtr = CFE_ES_CDSHANDLE_C(PendingBlockId);
 
-    return (Status);
+    return Status;
 }
 
 /*----------------------------------------------------------------

--- a/modules/es/fsw/src/cfe_es_cds.h
+++ b/modules/es/fsw/src/cfe_es_cds.h
@@ -328,7 +328,7 @@ static inline bool CFE_ES_CDSBlockRecordIsUsed(const CFE_ES_CDS_RegRec_t *CDSBlo
  */
 static inline CFE_ES_CDSHandle_t CFE_ES_CDSBlockRecordGetID(const CFE_ES_CDS_RegRec_t *CDSBlockRecPtr)
 {
-    return (CDSBlockRecPtr->BlockID);
+    return CDSBlockRecPtr->BlockID;
 }
 
 /*---------------------------------------------------------------------------------------*/

--- a/modules/es/fsw/src/cfe_es_erlog.c
+++ b/modules/es/fsw/src/cfe_es_erlog.c
@@ -142,7 +142,7 @@ int32 CFE_ES_WriteToERLogWithContext(CFE_ES_LogEntryType_Enum_t EntryType, uint3
      */
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
-    return (CFE_SUCCESS);
+    return CFE_SUCCESS;
 }
 
 /*----------------------------------------------------------------

--- a/modules/es/fsw/src/cfe_es_generic_pool.c
+++ b/modules/es/fsw/src/cfe_es_generic_pool.c
@@ -380,7 +380,7 @@ int32 CFE_ES_GenPoolGetBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockOf
     {
         CFE_ES_WriteToSysLog("%s: Err:size(%lu) > max(%lu)\n", __func__, (unsigned long)ReqSize,
                              (unsigned long)PoolRecPtr->Buckets[PoolRecPtr->NumBuckets - 1].BlockSize);
-        return (CFE_ES_ERR_MEM_BLOCK_SIZE);
+        return CFE_ES_ERR_MEM_BLOCK_SIZE;
     }
 
     /* first attempt to recycle any buffers from the same bucket that were freed */
@@ -391,7 +391,7 @@ int32 CFE_ES_GenPoolGetBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockOf
         Status = CFE_ES_GenPoolCreatePoolBlock(PoolRecPtr, BucketId, ReqSize, BlockOffsetPtr);
     }
 
-    return (Status);
+    return Status;
 }
 
 /*----------------------------------------------------------------

--- a/modules/es/fsw/src/cfe_es_mempool.c
+++ b/modules/es/fsw/src/cfe_es_mempool.c
@@ -218,7 +218,7 @@ CFE_Status_t CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_
     {
         CFE_ES_WriteToSysLog("%s: Num Block Sizes (%d) greater than max (%d)\n", __func__, (int)NumBlockSizes,
                              CFE_PLATFORM_ES_POOL_MAX_BUCKETS);
-        return (CFE_ES_BAD_ARGUMENT);
+        return CFE_ES_BAD_ARGUMENT;
     }
 
     /*
@@ -355,7 +355,7 @@ CFE_Status_t CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_
      */
     *PoolID = CFE_ES_MEMHANDLE_C(PendingID);
 
-    return (Status);
+    return Status;
 }
 
 /*----------------------------------------------------------------
@@ -441,7 +441,7 @@ int32 CFE_ES_GetPoolBuf(CFE_ES_MemPoolBuf_t *BufPtr, CFE_ES_MemHandle_t Handle, 
         CFE_ES_GetAppID(&AppId);
         CFE_ES_WriteToSysLog("%s: Err:Bad handle(0x%08lX) AppId=%lu\n", __func__, CFE_RESOURCEID_TO_ULONG(Handle),
                              CFE_RESOURCEID_TO_ULONG(AppId));
-        return (CFE_ES_ERR_RESOURCEID_NOT_VALID);
+        return CFE_ES_ERR_RESOURCEID_NOT_VALID;
     }
 
     /*
@@ -473,7 +473,7 @@ int32 CFE_ES_GetPoolBuf(CFE_ES_MemPoolBuf_t *BufPtr, CFE_ES_MemHandle_t Handle, 
     /* If not successful, return error now */
     if (Status != CFE_SUCCESS)
     {
-        return (Status);
+        return Status;
     }
 
     /* Compute the actual buffer address. */
@@ -507,7 +507,7 @@ CFE_Status_t CFE_ES_GetPoolBufInfo(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_
     /* basic sanity check */
     if (!CFE_ES_MemPoolRecordIsMatch(PoolRecPtr, Handle))
     {
-        return (CFE_ES_ERR_RESOURCEID_NOT_VALID);
+        return CFE_ES_ERR_RESOURCEID_NOT_VALID;
     }
 
     /*
@@ -571,7 +571,7 @@ int32 CFE_ES_PutPoolBuf(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_t BufPtr)
     {
         CFE_ES_WriteToSysLog("%s: Err:Invalid Memory Handle (0x%08lX).\n", __func__, CFE_RESOURCEID_TO_ULONG(Handle));
 
-        return (CFE_ES_ERR_RESOURCEID_NOT_VALID);
+        return CFE_ES_ERR_RESOURCEID_NOT_VALID;
     }
 
     /*
@@ -653,7 +653,7 @@ CFE_Status_t CFE_ES_GetMemPoolStats(CFE_ES_MemPoolStats_t *BufPtr, CFE_ES_MemHan
         CFE_ES_GetAppID(&AppId);
         CFE_ES_WriteToSysLog("%s: Err:Bad handle(0x%08lX) AppId=%lu\n", __func__, CFE_RESOURCEID_TO_ULONG(Handle),
                              CFE_RESOURCEID_TO_ULONG(AppId));
-        return (CFE_ES_ERR_RESOURCEID_NOT_VALID);
+        return CFE_ES_ERR_RESOURCEID_NOT_VALID;
     }
 
     /*

--- a/modules/es/fsw/src/cfe_es_mempool.h
+++ b/modules/es/fsw/src/cfe_es_mempool.h
@@ -158,7 +158,7 @@ static inline bool CFE_ES_MemPoolRecordIsUsed(const CFE_ES_MemPoolRecord_t *Pool
  */
 static inline CFE_ES_MemHandle_t CFE_ES_MemPoolRecordGetID(const CFE_ES_MemPoolRecord_t *PoolRecPtr)
 {
-    return (PoolRecPtr->PoolID);
+    return PoolRecPtr->PoolID;
 }
 
 /*---------------------------------------------------------------------------------------*/

--- a/modules/es/fsw/src/cfe_es_resource.h
+++ b/modules/es/fsw/src/cfe_es_resource.h
@@ -310,7 +310,7 @@ static inline CFE_ES_LibId_t CFE_ES_LibRecordGetID(const CFE_ES_LibRecord_t *Lib
      * The initial implementation does not store the ID in the entry;
      * the ID is simply the zero-based index into the table.
      */
-    return (LibRecPtr->LibId);
+    return LibRecPtr->LibId;
 }
 
 /*---------------------------------------------------------------------------------------*/
@@ -411,7 +411,7 @@ static inline const char *CFE_ES_LibRecordGetName(const CFE_ES_LibRecord_t *LibR
  */
 static inline CFE_ES_TaskId_t CFE_ES_TaskRecordGetID(const CFE_ES_TaskRecord_t *TaskRecPtr)
 {
-    return (TaskRecPtr->TaskId);
+    return TaskRecPtr->TaskId;
 }
 
 /*---------------------------------------------------------------------------------------*/

--- a/modules/es/fsw/src/cfe_es_syslog.c
+++ b/modules/es/fsw/src/cfe_es_syslog.c
@@ -248,7 +248,7 @@ int32 CFE_ES_SysLogAppend_Unsync(const char *LogString)
         ++CFE_ES_Global.ResetDataPtr->SystemLogEntryNum;
     }
 
-    return (ReturnCode);
+    return ReturnCode;
 }
 
 /*----------------------------------------------------------------

--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -317,7 +317,7 @@ int32 CFE_ES_TaskInit(void)
     if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s: Call to CFE_EVS_Register Failed, RC = 0x%08X\n", __func__, (unsigned int)Status);
-        return (Status);
+        return Status;
     }
 
     /*
@@ -345,7 +345,7 @@ int32 CFE_ES_TaskInit(void)
     if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s: Cannot Create SB Pipe, RC = 0x%08X\n", __func__, (unsigned int)Status);
-        return (Status);
+        return Status;
     }
 
     /*
@@ -355,7 +355,7 @@ int32 CFE_ES_TaskInit(void)
     if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s: Cannot Subscribe to HK packet, RC = 0x%08X\n", __func__, (unsigned int)Status);
-        return (Status);
+        return Status;
     }
 
     /*
@@ -366,7 +366,7 @@ int32 CFE_ES_TaskInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Cannot Subscribe to ES ground commands, RC = 0x%08X\n", __func__,
                              (unsigned int)Status);
-        return (Status);
+        return Status;
     }
 
     /*
@@ -413,7 +413,7 @@ int32 CFE_ES_TaskInit(void)
     if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s: Error sending init event:RC=0x%08X\n", __func__, (unsigned int)Status);
-        return (Status);
+        return Status;
     }
 
     Status =
@@ -424,7 +424,7 @@ int32 CFE_ES_TaskInit(void)
     if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s: Error sending init stats event:RC=0x%08X\n", __func__, (unsigned int)Status);
-        return (Status);
+        return Status;
     }
 
     /*
@@ -442,10 +442,10 @@ int32 CFE_ES_TaskInit(void)
     if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s: Error initializing background task:RC=0x%08X\n", __func__, (unsigned int)Status);
-        return (Status);
+        return Status;
     }
 
-    return (CFE_SUCCESS);
+    return CFE_SUCCESS;
 }
 
 /*----------------------------------------------------------------
@@ -1760,7 +1760,7 @@ bool CFE_ES_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
         CFE_ES_Global.TaskData.CommandErrorCounter++;
     }
 
-    return (result);
+    return result;
 }
 
 /*----------------------------------------------------------------

--- a/modules/evs/fsw/src/cfe_evs.c
+++ b/modules/evs/fsw/src/cfe_evs.c
@@ -109,7 +109,7 @@ CFE_Status_t CFE_EVS_Register(const void *Filters, uint16 NumEventFilters, uint1
         }
     }
 
-    return (Status);
+    return Status;
 }
 
 /*----------------------------------------------------------------
@@ -161,7 +161,7 @@ CFE_Status_t CFE_EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spe
         }
     }
 
-    return (Status);
+    return Status;
 }
 
 /*----------------------------------------------------------------
@@ -260,7 +260,7 @@ CFE_Status_t CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time, uint16 EventID, uin
         }
     }
 
-    return (Status);
+    return Status;
 }
 
 /*----------------------------------------------------------------
@@ -301,7 +301,7 @@ int32 CFE_EVS_ResetFilter(uint16 EventID)
         }
     }
 
-    return (Status);
+    return Status;
 }
 
 /*----------------------------------------------------------------
@@ -336,5 +336,5 @@ CFE_Status_t CFE_EVS_ResetAllFilters(void)
         }
     }
 
-    return (Status);
+    return Status;
 }

--- a/modules/evs/fsw/src/cfe_evs_log.c
+++ b/modules/evs/fsw/src/cfe_evs_log.c
@@ -232,7 +232,7 @@ int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFileCmd_t *data)
         OS_close(LogFileHandle);
     }
 
-    return (Result);
+    return Result;
 }
 
 /*----------------------------------------------------------------

--- a/modules/evs/fsw/src/cfe_evs_task.c
+++ b/modules/evs/fsw/src/cfe_evs_task.c
@@ -164,7 +164,7 @@ int32 CFE_EVS_EarlyInit(void)
         }
     }
 
-    return (Status);
+    return Status;
 }
 
 /*----------------------------------------------------------------
@@ -191,7 +191,7 @@ int32 CFE_EVS_CleanUpApp(CFE_ES_AppId_t AppID)
         EVS_AppDataSetFree(AppDataPtr);
     }
 
-    return (Status);
+    return Status;
 }
 
 /*----------------------------------------------------------------
@@ -598,7 +598,7 @@ bool CFE_EVS_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
         result = false;
     }
 
-    return (result);
+    return result;
 }
 
 /*----------------------------------------------------------------
@@ -1657,5 +1657,5 @@ int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFileCmd_t *data)
         OS_close(FileHandle);
     }
 
-    return (Result);
+    return Result;
 }

--- a/modules/evs/fsw/src/cfe_evs_utils.c
+++ b/modules/evs/fsw/src/cfe_evs_utils.c
@@ -64,7 +64,7 @@ EVS_AppData_t *EVS_GetAppDataByID(CFE_ES_AppId_t AppID)
         AppDataPtr = NULL;
     }
 
-    return (AppDataPtr);
+    return AppDataPtr;
 }
 
 /*----------------------------------------------------------------
@@ -186,7 +186,7 @@ int32 EVS_NotRegistered(EVS_AppData_t *AppDataPtr, CFE_ES_AppId_t CallerID)
                              AppName);
     }
 
-    return (CFE_EVS_APP_NOT_REGISTERED);
+    return CFE_EVS_APP_NOT_REGISTERED;
 }
 
 /*----------------------------------------------------------------
@@ -286,7 +286,7 @@ bool EVS_IsFiltered(EVS_AppData_t *AppDataPtr, uint16 EventID, uint16 EventType)
         }
     }
 
-    return (Filtered);
+    return Filtered;
 }
 
 /*----------------------------------------------------------------
@@ -425,11 +425,11 @@ EVS_BinFilter_t *EVS_FindEventID(uint16 EventID, EVS_BinFilter_t *FilterArray)
     {
         if (FilterArray[i].EventID == EventID)
         {
-            return (&FilterArray[i]);
+            return &FilterArray[i];
         }
     }
 
-    return ((EVS_BinFilter_t *)NULL);
+    return (EVS_BinFilter_t *)NULL;
 }
 
 /*----------------------------------------------------------------
@@ -693,5 +693,5 @@ int32 EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spec, ...)
         va_end(Ptr);
     }
 
-    return (CFE_SUCCESS);
+    return CFE_SUCCESS;
 }

--- a/modules/evs/fsw/src/cfe_evs_utils.h
+++ b/modules/evs/fsw/src/cfe_evs_utils.h
@@ -111,7 +111,7 @@ static inline CFE_ES_AppId_t EVS_AppDataGetID(EVS_AppData_t *AppDataPtr)
      * The initial implementation does not store the ID in the entry;
      * the ID is simply the zero-based index into the table.
      */
-    return (AppDataPtr->AppID);
+    return AppDataPtr->AppID;
 }
 
 /*---------------------------------------------------------------------------------------*/

--- a/modules/fs/fsw/src/cfe_fs_api.c
+++ b/modules/fs/fsw/src/cfe_fs_api.c
@@ -163,7 +163,7 @@ CFE_Status_t CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, osal_id_t FileDes)
         Result = CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
     }
 
-    return (Result);
+    return Result;
 }
 
 /*----------------------------------------------------------------
@@ -274,7 +274,7 @@ CFE_Status_t CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr)
         Result = CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
     }
 
-    return (Result);
+    return Result;
 }
 
 /*----------------------------------------------------------------
@@ -329,7 +329,7 @@ CFE_Status_t CFE_FS_SetTimestamp(osal_id_t FileDes, CFE_TIME_SysTime_t NewTimest
         Result = CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
     }
 
-    return (Result);
+    return Result;
 }
 
 /*----------------------------------------------------------------
@@ -680,7 +680,7 @@ CFE_Status_t CFE_FS_ExtractFilenameFromPath(const char *OriginalPath, char *File
         }
     }
 
-    return (ReturnCode);
+    return ReturnCode;
 }
 
 /*----------------------------------------------------------------

--- a/modules/sb/fsw/src/cfe_sb_task.c
+++ b/modules/sb/fsw/src/cfe_sb_task.c
@@ -316,7 +316,7 @@ bool CFE_SB_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
         ++CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter;
     }
 
-    return (result);
+    return result;
 }
 
 /*----------------------------------------------------------------

--- a/modules/time/fsw/src/cfe_time_api.c
+++ b/modules/time/fsw/src/cfe_time_api.c
@@ -56,7 +56,7 @@ CFE_TIME_SysTime_t CFE_TIME_GetTime(void)
 
 #endif
 
-    return (CurrentTime);
+    return CurrentTime;
 }
 
 /*----------------------------------------------------------------
@@ -87,7 +87,7 @@ CFE_TIME_SysTime_t CFE_TIME_GetTAI(void)
     */
     tai = CFE_TIME_CalculateTAI(&Reference);
 
-    return (tai);
+    return tai;
 }
 
 /*----------------------------------------------------------------
@@ -117,7 +117,7 @@ CFE_TIME_SysTime_t CFE_TIME_GetUTC(void)
     */
     utc = CFE_TIME_CalculateUTC(&Reference);
 
-    return (utc);
+    return utc;
 }
 
 /*----------------------------------------------------------------
@@ -158,7 +158,7 @@ CFE_TIME_SysTime_t CFE_TIME_MET2SCTime(CFE_TIME_SysTime_t METTime)
 
 #endif
 
-    return (ReturnTime);
+    return ReturnTime;
 }
 
 /*----------------------------------------------------------------
@@ -188,7 +188,7 @@ CFE_TIME_ClockState_Enum_t CFE_TIME_GetClockState(void)
     */
     state = (CFE_TIME_ClockState_Enum_t)CFE_TIME_CalculateState(&Reference);
 
-    return (state);
+    return state;
 }
 
 /*----------------------------------------------------------------
@@ -290,7 +290,7 @@ uint16 CFE_TIME_GetClockInfo(void)
         StateFlags |= CFE_TIME_FLAG_REFERR;
     }
 
-    return (StateFlags);
+    return StateFlags;
 }
 
 /*----------------------------------------------------------------
@@ -315,7 +315,7 @@ int16 CFE_TIME_GetLeapSeconds(void)
     */
     CFE_TIME_GetReference(&Reference);
 
-    return (Reference.AtToneLeapSeconds);
+    return Reference.AtToneLeapSeconds;
 }
 
 /*----------------------------------------------------------------
@@ -340,7 +340,7 @@ CFE_TIME_SysTime_t CFE_TIME_GetSTCF(void)
     */
     CFE_TIME_GetReference(&Reference);
 
-    return (Reference.AtToneSTCF);
+    return Reference.AtToneSTCF;
 }
 
 /*----------------------------------------------------------------
@@ -365,7 +365,7 @@ CFE_TIME_SysTime_t CFE_TIME_GetMET(void)
     */
     CFE_TIME_GetReference(&Reference);
 
-    return (Reference.CurrentMET);
+    return Reference.CurrentMET;
 }
 
 /*----------------------------------------------------------------
@@ -390,7 +390,7 @@ uint32 CFE_TIME_GetMETseconds(void)
     */
     CFE_TIME_GetReference(&Reference);
 
-    return (Reference.CurrentMET.Seconds);
+    return Reference.CurrentMET.Seconds;
 }
 
 /*----------------------------------------------------------------
@@ -415,7 +415,7 @@ uint32 CFE_TIME_GetMETsubsecs(void)
     */
     CFE_TIME_GetReference(&Reference);
 
-    return (Reference.CurrentMET.Subseconds);
+    return Reference.CurrentMET.Subseconds;
 }
 
 /*----------------------------------------------------------------
@@ -444,7 +444,7 @@ CFE_TIME_SysTime_t CFE_TIME_Add(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Tim
         Result.Seconds = Time1.Seconds + Time2.Seconds;
     }
 
-    return (Result);
+    return Result;
 }
 
 /*----------------------------------------------------------------
@@ -470,7 +470,7 @@ CFE_TIME_SysTime_t CFE_TIME_Subtract(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_
         Result.Seconds = Time1.Seconds - Time2.Seconds;
     }
 
-    return (Result);
+    return Result;
 }
 
 /*----------------------------------------------------------------
@@ -532,7 +532,7 @@ CFE_TIME_Compare_t CFE_TIME_Compare(CFE_TIME_SysTime_t TimeA, CFE_TIME_SysTime_t
         }
     }
 
-    return (Result);
+    return Result;
 }
 
 /*----------------------------------------------------------------
@@ -587,7 +587,7 @@ uint32 CFE_TIME_Micro2SubSecs(uint32 MicroSeconds)
         SubSeconds = OS_TimeGetSubsecondsPart(tm);
     }
 
-    return (SubSeconds);
+    return SubSeconds;
 }
 
 /*----------------------------------------------------------------

--- a/modules/time/fsw/src/cfe_time_task.c
+++ b/modules/time/fsw/src/cfe_time_task.c
@@ -54,7 +54,7 @@ int32 CFE_TIME_EarlyInit(void)
     */
     CFE_TIME_InitData();
 
-    return (CFE_SUCCESS);
+    return CFE_SUCCESS;
 }
 
 /*----------------------------------------------------------------
@@ -346,7 +346,7 @@ bool CFE_TIME_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
         ++CFE_TIME_Global.CommandErrorCounter;
     }
 
-    return (result);
+    return result;
 }
 
 /*----------------------------------------------------------------

--- a/modules/time/fsw/src/cfe_time_tone.c
+++ b/modules/time/fsw/src/cfe_time_tone.c
@@ -292,7 +292,7 @@ int32 CFE_TIME_ToneSendMET(CFE_TIME_SysTime_t NewMET)
 
     /* Exit performance monitoring */
     CFE_ES_PerfLogExit(CFE_MISSION_TIME_SENDMET_PERF_ID);
-    return (Result);
+    return Result;
 }
 #endif /* CFE_PLATFORM_TIME_CFG_SRC_MET */
 
@@ -432,7 +432,7 @@ int32 CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps)
         }
     }
 
-    return (Result);
+    return Result;
 }
 #endif /* CFE_PLATFORM_TIME_CFG_SRC_GPS */
 
@@ -574,7 +574,7 @@ int32 CFE_TIME_ToneSendTime(CFE_TIME_SysTime_t NewTime)
         }
     }
 
-    return (Result);
+    return Result;
 }
 #endif /* CFE_PLATFORM_TIME_CFG_SRC_TIME */
 

--- a/modules/time/fsw/src/cfe_time_utils.c
+++ b/modules/time/fsw/src/cfe_time_utils.c
@@ -99,7 +99,7 @@ CFE_TIME_SysTime_t CFE_TIME_LatchClock(void)
     LatchTime.Seconds    = OS_TimeGetTotalSeconds(LocalTime);
     LatchTime.Subseconds = OS_TimeGetSubsecondsPart(LocalTime);
 
-    return (LatchTime);
+    return LatchTime;
 }
 
 /*----------------------------------------------------------------
@@ -699,7 +699,7 @@ CFE_TIME_SysTime_t CFE_TIME_CalculateTAI(const CFE_TIME_Reference_t *Reference)
 
     TimeAsTAI = CFE_TIME_Add(Reference->CurrentMET, Reference->AtToneSTCF);
 
-    return (TimeAsTAI);
+    return TimeAsTAI;
 }
 
 /*----------------------------------------------------------------
@@ -717,7 +717,7 @@ CFE_TIME_SysTime_t CFE_TIME_CalculateUTC(const CFE_TIME_Reference_t *Reference)
     TimeAsUTC = CFE_TIME_Add(Reference->CurrentMET, Reference->AtToneSTCF);
     TimeAsUTC.Seconds -= Reference->AtToneLeapSeconds;
 
-    return (TimeAsUTC);
+    return TimeAsUTC;
 }
 
 /*----------------------------------------------------------------
@@ -771,7 +771,7 @@ CFE_TIME_ClockState_Enum_t CFE_TIME_CalculateState(const CFE_TIME_Reference_t *R
         ClockState = CFE_TIME_ClockState_INVALID;
     }
 
-    return (ClockState);
+    return ClockState;
 }
 
 /*----------------------------------------------------------------


### PR DESCRIPTION
**Checklist (Please check before submitting)**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #2153 
Removes parentheses in return statements in cFE that return a single value/term.
This is aligns these return statements with the predominant style of cFS.

**Testing performed**
None, prior to submission of the pull request.

**Expected behavior changes**
No impact on behavior.

**Contributor Info - All information REQUIRED for consideration of pull request**
@thnkslprpt 