### PR TITLE
Fix #1540, Remove 'return;' from last line of void functions.

### DIFF
--- a/modules/cfe_testcase/src/es_task_test.c
+++ b/modules/cfe_testcase/src/es_task_test.c
@@ -36,7 +36,6 @@ void TaskFunction(void)
         CFE_FT_Global.Count += 1;
         OS_TaskDelay(100);
     }
-    return;
 }
 
 /* A task function that verifies the behavior of other APIs when those are called from a child task */
@@ -89,7 +88,6 @@ void TaskExitFunction(void)
         CFE_FT_Global.Count += 1;
         CFE_ES_ExitChildTask();
     }
-    return;
 }
 
 void TestCreateChild(void)

--- a/modules/es/fsw/src/cfe_es_api.c
+++ b/modules/es/fsw/src/cfe_es_api.c
@@ -2255,8 +2255,6 @@ void CFE_ES_LockSharedData(const char *FunctionName, int32 LineNumber)
                                   FunctionName, (int)LineNumber);
 
     } /* end if */
-
-    return;
 }
 
 /*----------------------------------------------------------------
@@ -2282,8 +2280,6 @@ void CFE_ES_UnlockSharedData(const char *FunctionName, int32 LineNumber)
                                   FunctionName, (int)LineNumber);
 
     } /* end if */
-
-    return;
 }
 
 /*----------------------------------------------------------------

--- a/modules/es/fsw/src/cfe_es_cds.c
+++ b/modules/es/fsw/src/cfe_es_cds.c
@@ -688,8 +688,6 @@ void CFE_ES_FormCDSName(char *FullCDSName, const char *CDSName, CFE_ES_AppId_t T
 
     /* Complete formation of processor specific table name */
     sprintf(FullCDSName, "%s.%s", AppName, CDSName);
-
-    return;
 }
 
 /*----------------------------------------------------------------

--- a/modules/evs/fsw/src/cfe_evs_log.c
+++ b/modules/evs/fsw/src/cfe_evs_log.c
@@ -84,8 +84,6 @@ void EVS_AddLog(CFE_EVS_LongEventTlm_t *EVS_PktPtr)
     }
 
     OS_MutSemGive(CFE_EVS_Global.EVS_SharedDataMutexID);
-
-    return;
 }
 
 /*----------------------------------------------------------------
@@ -111,8 +109,6 @@ void EVS_ClearLog(void)
     memset(CFE_EVS_Global.EVS_LogPtr->LogEntry, 0, sizeof(CFE_EVS_Global.EVS_LogPtr->LogEntry));
 
     OS_MutSemGive(CFE_EVS_Global.EVS_SharedDataMutexID);
-
-    return;
 }
 
 /*----------------------------------------------------------------

--- a/modules/evs/fsw/src/cfe_evs_task.c
+++ b/modules/evs/fsw/src/cfe_evs_task.c
@@ -349,8 +349,6 @@ void CFE_EVS_ProcessCommandPacket(CFE_SB_Buffer_t *SBBufPtr)
                           (unsigned int)CFE_SB_MsgIdToValue(MessageID));
             break;
     }
-
-    return;
 }
 
 /*----------------------------------------------------------------
@@ -560,8 +558,6 @@ void CFE_EVS_ProcessGroundCommand(CFE_SB_Buffer_t *SBBufPtr, CFE_SB_MsgId_t MsgI
     {
         CFE_EVS_Global.EVS_TlmPkt.Payload.CommandErrorCounter++;
     }
-
-    return;
 }
 
 /*----------------------------------------------------------------

--- a/modules/fs/fsw/src/cfe_fs_priv.c
+++ b/modules/fs/fsw/src/cfe_fs_priv.c
@@ -85,8 +85,6 @@ void CFE_FS_LockSharedData(const char *FunctionName)
                              CFE_RESOURCEID_TO_ULONG(AppId), FunctionName);
 
     } /* end if */
-
-    return;
 }
 
 /*----------------------------------------------------------------
@@ -110,5 +108,4 @@ void CFE_FS_UnlockSharedData(const char *FunctionName)
                              CFE_RESOURCEID_TO_ULONG(AppId), FunctionName);
 
     } /* end if */
-    return;
 }

--- a/modules/sb/fsw/src/cfe_sb_priv.c
+++ b/modules/sb/fsw/src/cfe_sb_priv.c
@@ -143,8 +143,6 @@ void CFE_SB_LockSharedData(const char *FuncName, int32 LineNumber)
                              (long)OsStatus, CFE_RESOURCEID_TO_ULONG(AppId), FuncName, (int)LineNumber);
 
     } /* end if */
-
-    return;
 }
 
 /*----------------------------------------------------------------
@@ -168,8 +166,6 @@ void CFE_SB_UnlockSharedData(const char *FuncName, int32 LineNumber)
                              (long)OsStatus, CFE_RESOURCEID_TO_ULONG(AppId), FuncName, (int)LineNumber);
 
     } /* end if */
-
-    return;
 }
 
 /*----------------------------------------------------------------

--- a/modules/tbl/fsw/src/cfe_tbl_internal.c
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.c
@@ -602,8 +602,6 @@ void CFE_TBL_FormTableName(char *FullTblName, const char *TblName, CFE_ES_AppId_
 
     /* Complete formation of application specific table name */
     sprintf(FullTblName, "%s.%s", AppName, TblName);
-
-    return;
 }
 
 /*----------------------------------------------------------------

--- a/modules/tbl/fsw/src/cfe_tbl_task.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task.c
@@ -323,8 +323,6 @@ void CFE_TBL_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
             */
         }
     }
-
-    return;
 }
 
 /*----------------------------------------------------------------

--- a/modules/time/fsw/src/cfe_time_api.c
+++ b/modules/time/fsw/src/cfe_time_api.c
@@ -742,8 +742,6 @@ void CFE_TIME_Print(char *PrintBuffer, CFE_TIME_SysTime_t TimeToPrint)
     *PrintBuffer++ = '0' + (char)(NumberOfMicros / 10);
     *PrintBuffer++ = '0' + (char)(NumberOfMicros % 10);
     *PrintBuffer++ = '\0';
-
-    return;
 }
 
 /*----------------------------------------------------------------
@@ -760,8 +758,6 @@ void CFE_TIME_ExternalTone(void)
     ** Call tone signal ISR (OK if called from non-ISR context)...
     */
     CFE_TIME_Tone1HzISR();
-
-    return;
 }
 
 /*----------------------------------------------------------------
@@ -863,8 +859,6 @@ void CFE_TIME_ExternalMET(CFE_TIME_SysTime_t NewMET)
     ** Process external MET data...
     */
     CFE_TIME_ToneSendMET(NewMET);
-
-    return;
 }
 #endif /* CFE_PLATFORM_TIME_CFG_SRC_MET  */
 
@@ -883,8 +877,6 @@ void CFE_TIME_ExternalGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps)
     ** Process external GPS time data...
     */
     CFE_TIME_ToneSendGPS(NewTime, NewLeaps);
-
-    return;
 }
 #endif /* CFE_PLATFORM_TIME_CFG_SRC_GPS */
 
@@ -903,7 +895,5 @@ void CFE_TIME_ExternalTime(CFE_TIME_SysTime_t NewTime)
     ** Process external time data...
     */
     CFE_TIME_ToneSendTime(NewTime);
-
-    return;
 }
 #endif /* CFE_PLATFORM_TIME_CFG_SRC_TIME */

--- a/modules/time/fsw/src/cfe_time_task.c
+++ b/modules/time/fsw/src/cfe_time_task.c
@@ -550,8 +550,6 @@ void CFE_TIME_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
             break;
 
     } /* switch (message ID) */
-
-    return;
 }
 
 /*----------------------------------------------------------------

--- a/modules/time/fsw/src/cfe_time_tone.c
+++ b/modules/time/fsw/src/cfe_time_tone.c
@@ -158,8 +158,6 @@ void CFE_TIME_ToneSend(void)
     ** Count of "time at the tone" commands sent with internal data...
     */
     CFE_TIME_Global.InternalCount++;
-
-    return;
 }
 #endif /* CFE_PLATFORM_TIME_CFG_SERVER */
 
@@ -646,8 +644,6 @@ void CFE_TIME_ToneData(const CFE_TIME_ToneDataCmd_Payload_t *ToneDataCmd)
     ** Maintain a count of tone data packets...
     */
     CFE_TIME_Global.ToneDataCounter++;
-
-    return;
 }
 
 /*----------------------------------------------------------------
@@ -689,8 +685,6 @@ void CFE_TIME_ToneSignal(void)
     ** Maintain a count of tone signal packets...
     */
     CFE_TIME_Global.ToneSignalCounter++;
-
-    return;
 }
 
 /*----------------------------------------------------------------
@@ -774,8 +768,6 @@ void CFE_TIME_ToneVerify(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2)
 
     PrevTime1 = Time1;
     PrevTime2 = Time2;
-
-    return;
 }
 
 /*----------------------------------------------------------------
@@ -965,8 +957,6 @@ void CFE_TIME_ToneUpdate(void)
     {
         CFE_EVS_SendEvent(CFE_TIME_FLY_OFF_EID, CFE_EVS_EventType_INFORMATION, "Stop FLYWHEEL");
     }
-
-    return;
 }
 
 /*----------------------------------------------------------------
@@ -1087,8 +1077,6 @@ void CFE_TIME_Tone1HzISR(void)
 
     /* Exit performance monitoring */
     CFE_ES_PerfLogExit(CFE_MISSION_TIME_TONE1HZISR_PERF_ID);
-
-    return;
 }
 
 /*----------------------------------------------------------------
@@ -1147,7 +1135,6 @@ void CFE_TIME_Tone1HzTask(void)
     ** This should never happen - but during development we
     **    had an error in the creation of the semaphore.
     */
-    return;
 }
 
 /*----------------------------------------------------------------
@@ -1285,8 +1272,6 @@ void CFE_TIME_Local1HzISR(void)
     ** Enable 1Hz task (we can't send a SB message from here)...
     */
     OS_BinSemGive(CFE_TIME_Global.LocalSemaphore);
-
-    return;
 }
 
 /*----------------------------------------------------------------
@@ -1346,7 +1331,6 @@ void CFE_TIME_Local1HzTask(void)
     ** This should never happen - but during development we had an
     **    error in the creation of the semaphore.
     */
-    return;
 }
 
 /*----------------------------------------------------------------
@@ -1380,6 +1364,4 @@ void CFE_TIME_NotifyTimeSynchApps(void)
             }
         }
     }
-
-    return;
 }

--- a/modules/time/fsw/src/cfe_time_utils.c
+++ b/modules/time/fsw/src/cfe_time_utils.c
@@ -188,8 +188,6 @@ void CFE_TIME_QueryResetVars(void)
     }
 
     CFE_TIME_FinishReferenceUpdate(RefState);
-
-    return;
 }
 
 /*----------------------------------------------------------------
@@ -232,8 +230,6 @@ void CFE_TIME_UpdateResetVars(const CFE_TIME_Reference_t *Reference)
             CFE_TIME_ResetDataPtr->TimeResetVars = LocalResetVars;
         }
     }
-
-    return;
 }
 
 /*----------------------------------------------------------------
@@ -369,8 +365,6 @@ void CFE_TIME_InitData(void)
     */
     CFE_MSG_Init(CFE_MSG_PTR(CFE_TIME_Global.Local1HzCmd.CommandHeader), CFE_SB_ValueToMsgId(CFE_TIME_1HZ_CMD_MID),
                  sizeof(CFE_TIME_Global.Local1HzCmd));
-
-    return;
 }
 
 /*----------------------------------------------------------------
@@ -429,8 +423,6 @@ void CFE_TIME_GetHkData(const CFE_TIME_Reference_t *Reference)
     CFE_TIME_Global.HkPacket.Payload.SecondsDelay = Reference->AtToneDelay.Seconds;
     CFE_TIME_Global.HkPacket.Payload.SubsecsDelay = Reference->AtToneDelay.Subseconds;
 #endif
-
-    return;
 }
 
 /*----------------------------------------------------------------
@@ -551,8 +543,6 @@ void CFE_TIME_GetDiagData(void)
     ** Reset Area access status...
     */
     CFE_TIME_Global.DiagPacket.Payload.DataStoreStatus = CFE_TIME_Global.DataStoreStatus;
-
-    return;
 }
 
 /*----------------------------------------------------------------
@@ -681,8 +671,6 @@ void CFE_TIME_GetReference(CFE_TIME_Reference_t *Reference)
 #endif
 
     Reference->CurrentMET = CurrentMET;
-
-    return;
 }
 
 /*----------------------------------------------------------------
@@ -816,8 +804,6 @@ void CFE_TIME_SetState(CFE_TIME_ClockState_Enum_t NewState)
     ** Time has changed, force anyone reading time to retry...
     */
     CFE_TIME_FinishReferenceUpdate(RefState);
-
-    return;
 }
 
 /*----------------------------------------------------------------
@@ -875,8 +861,6 @@ void CFE_TIME_SetDelay(CFE_TIME_SysTime_t NewDelay, int16 Direction)
     ** Time has changed, force anyone reading time to retry...
     */
     CFE_TIME_FinishReferenceUpdate(RefState);
-
-    return;
 }
 #endif /* CFE_PLATFORM_TIME_CFG_CLIENT */
 
@@ -926,8 +910,6 @@ void CFE_TIME_SetTime(CFE_TIME_SysTime_t NewTime)
     ** Time has changed, force anyone reading time to retry...
     */
     CFE_TIME_FinishReferenceUpdate(RefState);
-
-    return;
 }
 #endif /* CFE_PLATFORM_TIME_CFG_SERVER */
 
@@ -964,8 +946,6 @@ void CFE_TIME_SetMET(CFE_TIME_SysTime_t NewMET)
     ** Time has changed, force anyone reading time to retry...
     */
     CFE_TIME_FinishReferenceUpdate(RefState);
-
-    return;
 }
 #endif /* CFE_PLATFORM_TIME_CFG_SERVER */
 
@@ -990,8 +970,6 @@ void CFE_TIME_SetSTCF(CFE_TIME_SysTime_t NewSTCF)
     ** Time has changed, force anyone reading time to retry...
     */
     CFE_TIME_FinishReferenceUpdate(RefState);
-
-    return;
 }
 #endif /* CFE_PLATFORM_TIME_CFG_SERVER */
 
@@ -1016,8 +994,6 @@ void CFE_TIME_SetLeapSeconds(int16 NewLeaps)
     ** Time has changed, force anyone reading time to retry...
     */
     CFE_TIME_FinishReferenceUpdate(RefState);
-
-    return;
 }
 #endif /* CFE_PLATFORM_TIME_CFG_SERVER */
 
@@ -1055,8 +1031,6 @@ void CFE_TIME_SetAdjust(CFE_TIME_SysTime_t NewAdjust, int16 Direction)
     ** Time has changed, force anyone reading time to retry...
     */
     CFE_TIME_FinishReferenceUpdate(RefState);
-
-    return;
 }
 #endif /* CFE_PLATFORM_TIME_CFG_SERVER */
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #1540
Removes all cases of redundant "return;" statements on the last line of void functions.

**Testing performed**
None, prior to submission.

**Expected behavior changes**
No impact on behavior.

**Contributor Info**
@thnkslprpt 