### PR TITLE
Fix #2162, Remove redundant/inconsistent comments (/* end of function */, /* end if */ etc.) and clean up empty lines.

### DIFF
--- a/cmake/target/inc/target_config.h
+++ b/cmake/target/inc/target_config.h
@@ -132,7 +132,6 @@ typedef const struct
      * File name of startup script
      */
     const char *NonvolStartupFile;
-
 } Target_CfeConfigData;
 
 /**
@@ -197,7 +196,6 @@ typedef const struct
     CFE_ConfigName_t *    CoreModuleList;    /**< List of CFE core support module names that are statically linked */
     CFE_ConfigName_t
         *StaticAppList; /**< List of additional CFS Applications that are statically linked into this binary */
-
 } Target_ConfigData;
 
 /**

--- a/docs/cFE Application Developers Guide.md
+++ b/docs/cFE Application Developers Guide.md
@@ -790,7 +790,6 @@ uint32 ConvertSecs2Ticks(uint32 Seconds)
 		( (Seconds * 1000000) + TickDurationInMicroSec - 1 ) / TickDurationInMicroSec;
 
 	return(NumOfTicks);
-
 }
 ```
 ## 5.7 OS Queues, Semaphores and Mutexes
@@ -1282,7 +1281,7 @@ void SAMPLE_TaskMain(void)
     }
     CFE_EVS_SendEvent(CFE_TBL_EXIT_ERR_EID, CFE_EVS_ERROR,
                       "SAMPLE Task terminating, err = 0x%X", Status);
-} /* End of SAMPLE_TaskMain() */
+}
 ```
 
 ### 5.10.4	Standard CRC Calculations
@@ -1821,7 +1820,6 @@ typedef struct
   */
   uint8          CmdCounter;
   uint8          ErrCounter;
-
 } SAMPLE_HkPacket_t;
 
 
@@ -1884,14 +1882,12 @@ containing just a CFE_MSG_Message_t is invalid per the CCSDS standard.
 ```c
 typedef struct
 {
-
     uint8 FunctionCode; /**< \brief Command Function Code */
                         /* bits shift ---------description-------- */
                         /* 0x7F  0    Command function code        */
                         /* 0x80  7    Reserved                     */
 
     uint8 Checksum; /**< \brief Command checksum  (all bits, 0xFF)      */
-
 } CFE_MSG_CommandSecondaryHeader_t;
 
 /**
@@ -1899,9 +1895,7 @@ typedef struct
  */
 typedef struct
 {
-
     uint8 Time[6]; /**< \brief Time, big endian: 4 byte seconds, 2 byte subseconds */
-
 } CFE_MSG_TelemetrySecondaryHeader_t;
 ```
 
@@ -2131,7 +2125,6 @@ typedef struct
   ** Task command interface counters...
   */
   uint8          Data[SAMPLE_BIGPKT_DATALEN];
-
 } SAMPLE_BigPkt_t;
 
 typedef union
@@ -3123,7 +3116,6 @@ typedef struct
     uint32  TimeSubSeconds;        /* File creation timestamp (sub-seconds) */
 
     char    Description[32];       /* File description */
-
 } CFE_FS_Header_t;
 ```
 

--- a/modules/cfe_assert/src/cfe_assert_priv.h
+++ b/modules/cfe_assert/src/cfe_assert_priv.h
@@ -148,7 +148,6 @@ typedef struct
      * Line number of source file that produced "StoredStatus"
      */
     uint32 StoredLine;
-
 } CFE_Assert_Global_t;
 
 extern CFE_Assert_Global_t CFE_Assert_Global;

--- a/modules/cfe_testcase/src/cfe_test_table.c
+++ b/modules/cfe_testcase/src/cfe_test_table.c
@@ -32,7 +32,6 @@
 /* Setup function to register a table */
 void RegisterTestTable(void)
 {
-
     UtAssert_INT32_EQ(CFE_TBL_Register(&CFE_FT_Global.TblHandle, CFE_FT_Global.TblName, sizeof(TBL_TEST_Table_t),
                                        CFE_TBL_OPT_DEFAULT, NULL),
                       CFE_SUCCESS);

--- a/modules/cfe_testcase/src/time_arithmetic_test.c
+++ b/modules/cfe_testcase/src/time_arithmetic_test.c
@@ -108,7 +108,7 @@ void TestTimeCompare(void)
     UtAssert_UINT32_EQ(CFE_TIME_Compare(time1, time2), CFE_TIME_EQUAL);
     UtAssert_UINT32_EQ(CFE_TIME_Compare(time2, time1), CFE_TIME_EQUAL);
 
-    // time1 > time2 here due to the roll over handling of the comparison
+    /* time1 > time2 here due to the roll over handling of the comparison */
     time1.Seconds    = 1;
     time1.Subseconds = 1;
     time2.Seconds    = UINT32_MAX;

--- a/modules/config/fsw/src/cfe_config_get.c
+++ b/modules/config/fsw/src/cfe_config_get.c
@@ -34,8 +34,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_Config_GetValue
- *
  * Defined per public API
  * See description in header file for argument/return detail
  *
@@ -54,8 +52,6 @@ uint32 CFE_Config_GetValue(CFE_ConfigId_t ConfigId)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_Config_GetObjPointer
  *
  * Defined per public API
  * See description in header file for argument/return detail
@@ -76,8 +72,6 @@ const void *CFE_Config_GetObjPointer(CFE_ConfigId_t ConfigId)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_Config_GetObjPointer
- *
  * Defined per public API
  * See description in header file for argument/return detail
  *
@@ -96,8 +90,6 @@ const char *CFE_Config_GetString(CFE_ConfigId_t ConfigId)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_Config_GetName
  *
  * Defined per public API
  * See description in header file for argument/return detail
@@ -118,8 +110,6 @@ const char *CFE_Config_GetName(CFE_ConfigId_t ConfigId)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_Config_GetIdByName
  *
  * Defined per public API
  * See description in header file for argument/return detail
@@ -149,8 +139,6 @@ CFE_ConfigId_t CFE_Config_GetIdByName(const char *Name)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_Config_GetIdByName
  *
  * Defined per public API
  * See description in header file for argument/return detail

--- a/modules/config/fsw/src/cfe_config_init.c
+++ b/modules/config/fsw/src/cfe_config_init.c
@@ -53,8 +53,6 @@ bool CFE_Config_StrCaseEq(const char *c1, const char *c2)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_Config_FindTargetKeyValue
- *
  * Internal helper routine only, not part of API.
  *
  * Find value for given config key
@@ -200,8 +198,6 @@ void CFE_Config_SetupBasicBuildInfo(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_Config_Init
  *
  * CFE core internal function
  * See description in header file for argument/return detail

--- a/modules/config/fsw/src/cfe_config_lookup.c
+++ b/modules/config/fsw/src/cfe_config_lookup.c
@@ -46,8 +46,6 @@ CFE_Config_Global_t CFE_Config_Global;
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_Config_LocateConfigRecordByID
- *
  * Application scope internal function
  * See description in header file for argument/return detail
  *

--- a/modules/config/fsw/src/cfe_config_set.c
+++ b/modules/config/fsw/src/cfe_config_set.c
@@ -31,8 +31,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_Config_SetValue
- *
  * CFE core internal function
  * See description in header file for argument/return detail
  *
@@ -51,8 +49,6 @@ void CFE_Config_SetValue(CFE_ConfigId_t ConfigId, uint32 Value)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_Config_SetObjPointer
- *
  * CFE core internal function
  * See description in header file for argument/return detail
  *
@@ -70,8 +66,6 @@ void CFE_Config_SetObjPointer(CFE_ConfigId_t ConfigId, const void *Ptr)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_Config_SetString
  *
  * CFE core internal function
  * See description in header file for argument/return detail

--- a/modules/core_api/fsw/inc/cfe_es_extern_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_es_extern_typedefs.h
@@ -44,7 +44,6 @@
  */
 enum CFE_ES_LogMode
 {
-
     /**
      * @brief Overwrite Log Mode
      */
@@ -68,7 +67,6 @@ typedef uint8 CFE_ES_LogMode_Enum_t;
  */
 enum CFE_ES_ExceptionAction
 {
-
     /**
      * @brief Restart application if exception occurs
      */
@@ -92,7 +90,6 @@ typedef uint8 CFE_ES_ExceptionAction_Enum_t;
  */
 enum CFE_ES_AppType
 {
-
     /**
      * @brief CFE core application
      */
@@ -175,7 +172,6 @@ enum CFE_ES_RunStatus
      * @brief Reserved value, marker for the maximum state
      */
     CFE_ES_RunStatus_MAX
-
 };
 
 /**
@@ -190,7 +186,6 @@ typedef uint32 CFE_ES_RunStatus_Enum_t;
  */
 enum CFE_ES_SystemState
 {
-
     /**
      * @brief reserved
      */
@@ -248,7 +243,6 @@ typedef uint32 CFE_ES_SystemState_Enum_t;
  */
 enum CFE_ES_LogEntryType
 {
-
     /**
      * @brief Log entry from a core subsystem
      */
@@ -272,7 +266,6 @@ typedef uint8 CFE_ES_LogEntryType_Enum_t;
  */
 enum CFE_ES_AppState
 {
-
     /**
      * @brief Initial state before app thread is started
      */
@@ -484,7 +477,6 @@ typedef struct CFE_ES_AppInfo
                                                         \brief The Application's Main Task ID */
     uint32 NumOfChildTasks;                        /**< \cfetlmmnemonic \ES_CHILDTASKS
                                                         \brief Number of Child tasks for an App */
-
 } CFE_ES_AppInfo_t;
 
 /**

--- a/modules/core_api/fsw/inc/cfe_evs_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_evs_api_typedefs.h
@@ -61,7 +61,6 @@ typedef struct CFE_EVS_BinFilter
 {
     uint16 EventID; /**< \brief Numerical event identifier */
     uint16 Mask;    /**< \brief Binary filter mask value */
-
 } CFE_EVS_BinFilter_t;
 
 #endif /* CFE_EVS_API_TYPEDEFS_H */

--- a/modules/core_api/fsw/inc/cfe_evs_extern_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_evs_extern_typedefs.h
@@ -42,7 +42,6 @@
  */
 enum CFE_EVS_MsgFormat
 {
-
     /**
      * @brief Short Format Messages
      */
@@ -66,7 +65,6 @@ typedef uint8 CFE_EVS_MsgFormat_Enum_t;
  */
 enum CFE_EVS_LogMode
 {
-
     /**
      * @brief Overwrite Log Mode
      */
@@ -90,7 +88,6 @@ typedef uint8 CFE_EVS_LogMode_Enum_t;
  */
 enum CFE_EVS_EventType
 {
-
     /**
      * @brief Events that are intended only for debugging, not nominal operations
      */
@@ -124,7 +121,6 @@ typedef uint16 CFE_EVS_EventType_Enum_t;
  */
 enum CFE_EVS_EventFilter
 {
-
     /**
      * @brief Binary event filter
      */
@@ -143,7 +139,6 @@ typedef uint8 CFE_EVS_EventFilter_Enum_t;
  */
 enum CFE_EVS_EventOutput
 {
-
     /**
      * @brief Output Port 1
      */

--- a/modules/core_api/fsw/inc/cfe_fs_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_fs_api_typedefs.h
@@ -75,7 +75,6 @@ typedef enum
     CFE_FS_FileWriteEvent_RECORD_WRITE_ERROR, /**< Unable to write data record */
 
     CFE_FS_FileWriteEvent_MAX /* placeholder, no-op, keep last */
-
 } CFE_FS_FileWriteEvent_t;
 
 /**
@@ -133,7 +132,6 @@ typedef struct CFE_FS_FileWriteMetaData
 
     CFE_FS_FileWriteGetData_t GetData; /**< Application callback to get a data record */
     CFE_FS_FileWriteOnEvent_t OnEvent; /**< Application callback for abstract event processing */
-
 } CFE_FS_FileWriteMetaData_t;
 
 #endif /* CFE_FS_API_TYPEDEFS_H */

--- a/modules/core_api/fsw/inc/cfe_fs_extern_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_fs_extern_typedefs.h
@@ -60,7 +60,6 @@
  */
 enum CFE_FS_SubType
 {
-
     /**
      * @brief Executive Services Exception/Reset Log Type
      *
@@ -216,7 +215,6 @@ typedef struct CFE_FS_Header
     uint32 TimeSubSeconds; /**< \brief File creation timestamp (sub-seconds) */
 
     char Description[CFE_FS_HDR_DESC_MAX_LEN]; /**< \brief File description */
-
 } CFE_FS_Header_t;
 
 #endif /* CFE_EDS_ENABLED_BUILD */

--- a/modules/core_api/fsw/inc/cfe_sb_extern_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_sb_extern_typedefs.h
@@ -46,7 +46,6 @@
  */
 enum CFE_SB_QosPriority
 {
-
     /**
      * @brief Normal priority level
      */
@@ -70,7 +69,6 @@ typedef uint8 CFE_SB_QosPriority_Enum_t;
  */
 enum CFE_SB_QosReliability
 {
-
     /**
      * @brief Normal (best-effort) reliability
      */

--- a/modules/core_api/fsw/inc/cfe_tbl_extern_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_tbl_extern_typedefs.h
@@ -44,7 +44,6 @@
  */
 enum CFE_TBL_BufferSelect
 {
-
     /**
      * @brief Select the Inactive buffer for validate or dump
      */

--- a/modules/core_api/fsw/inc/cfe_time_extern_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_time_extern_typedefs.h
@@ -59,7 +59,6 @@ typedef struct CFE_TIME_SysTime
  */
 enum CFE_TIME_FlagBit
 {
-
     /**
      * @brief The spacecraft time has been set
      */
@@ -128,7 +127,6 @@ typedef uint8 CFE_TIME_FlagBit_Enum_t;
  */
 enum CFE_TIME_ClockState
 {
-
     /**
      *
      * The spacecraft time has not been set since the last clock
@@ -181,7 +179,6 @@ typedef int16 CFE_TIME_ClockState_Enum_t;
  */
 enum CFE_TIME_SourceSelect
 {
-
     /**
      * @brief Use Internal Source
      */
@@ -205,7 +202,6 @@ typedef uint8 CFE_TIME_SourceSelect_Enum_t;
  */
 enum CFE_TIME_ToneSignalSelect
 {
-
     /**
      * @brief Primary Source
      */
@@ -229,7 +225,6 @@ typedef uint8 CFE_TIME_ToneSignalSelect_Enum_t;
  */
 enum CFE_TIME_AdjustDirection
 {
-
     /**
      * @brief Add time adjustment
      */
@@ -253,7 +248,6 @@ typedef uint8 CFE_TIME_AdjustDirection_Enum_t;
  */
 enum CFE_TIME_FlywheelState
 {
-
     /**
      * @brief Not in flywheel state
      */
@@ -277,7 +271,6 @@ typedef uint8 CFE_TIME_FlywheelState_Enum_t;
  */
 enum CFE_TIME_SetState
 {
-
     /**
      * @brief Spacecraft time has not been set
      */

--- a/modules/core_api/ut-stubs/src/cfe_es_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_es_stubs.c
@@ -69,7 +69,6 @@ CFE_Status_t CFE_ES_AppID_ToIndex(CFE_ES_AppId_t AppID, uint32 *Idx)
  */
 void CFE_ES_BackgroundWakeup(void)
 {
-
     UT_GenStub_Execute(CFE_ES_BackgroundWakeup, Basic, NULL);
 }
 
@@ -217,7 +216,6 @@ void CFE_ES_ExitApp(uint32 ExitStatus)
  */
 void CFE_ES_ExitChildTask(void)
 {
-
     UT_GenStub_Execute(CFE_ES_ExitChildTask, Basic, NULL);
 }
 
@@ -604,7 +602,6 @@ CFE_Status_t CFE_ES_IncrementGenCounter(CFE_ES_CounterId_t CounterId)
  */
 void CFE_ES_IncrementTaskCounter(void)
 {
-
     UT_GenStub_Execute(CFE_ES_IncrementTaskCounter, Basic, NULL);
 }
 
@@ -734,7 +731,6 @@ int32 CFE_ES_PoolDelete(CFE_ES_MemHandle_t PoolID)
  */
 void CFE_ES_ProcessAsyncEvent(void)
 {
-
     UT_GenStub_Execute(CFE_ES_ProcessAsyncEvent, Basic, NULL);
 }
 

--- a/modules/core_api/ut-stubs/src/cfe_sb_handlers.c
+++ b/modules/core_api/ut-stubs/src/cfe_sb_handlers.c
@@ -43,7 +43,6 @@ typedef struct
     uint32             TotalLength;
     uint16             CommandCode;
     CFE_TIME_SysTime_t TimeStamp;
-
 } CFE_SB_StubMsg_MetaData_t;
 
 static CFE_SB_StubMsg_MetaData_t *CFE_SB_StubMsg_GetMetaData(const CFE_MSG_Message_t *MsgPtr)
@@ -256,7 +255,6 @@ void UT_DefaultHandler_CFE_SB_TransmitBuffer(void *UserObj, UT_EntryKey_t FuncKe
  *------------------------------------------------------------*/
 void UT_DefaultHandler_CFE_SB_MessageStringGet(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
-
     char *      DestStringPtr   = UT_Hook_GetArgValueByName(Context, "DestStringPtr", char *);
     const char *SourceStringPtr = UT_Hook_GetArgValueByName(Context, "SourceStringPtr", const char *);
     const char *DefaultString   = UT_Hook_GetArgValueByName(Context, "DefaultString", const char *);
@@ -303,7 +301,6 @@ void UT_DefaultHandler_CFE_SB_MessageStringGet(void *UserObj, UT_EntryKey_t Func
  *------------------------------------------------------------*/
 void UT_DefaultHandler_CFE_SB_MessageStringSet(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
-
     char *      DestStringPtr   = UT_Hook_GetArgValueByName(Context, "DestStringPtr", char *);
     const char *SourceStringPtr = UT_Hook_GetArgValueByName(Context, "SourceStringPtr", const char *);
     size_t      DestMaxSize     = UT_Hook_GetArgValueByName(Context, "DestMaxSize", size_t);

--- a/modules/core_api/ut-stubs/src/cfe_time_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_time_stubs.c
@@ -113,7 +113,6 @@ void CFE_TIME_ExternalTime(CFE_TIME_SysTime_t NewTime)
  */
 void CFE_TIME_ExternalTone(void)
 {
-
     UT_GenStub_Execute(CFE_TIME_ExternalTone, Basic, NULL);
 }
 
@@ -264,7 +263,6 @@ CFE_TIME_SysTime_t CFE_TIME_GetUTC(void)
  */
 void CFE_TIME_Local1HzISR(void)
 {
-
     UT_GenStub_Execute(CFE_TIME_Local1HzISR, Basic, NULL);
 }
 

--- a/modules/core_private/fsw/inc/cfe_es_erlog_typedef.h
+++ b/modules/core_private/fsw/inc/cfe_es_erlog_typedef.h
@@ -43,7 +43,6 @@ typedef struct
     uint32 WatchdogWriteFlag;
     uint32 PrintfEnabledFlag;
     uint32 LastAppId;
-
 } CFE_ES_DebugVariables_t;
 
 /*

--- a/modules/core_private/fsw/inc/cfe_es_resetdata_typedef.h
+++ b/modules/core_private/fsw/inc/cfe_es_resetdata_typedef.h
@@ -91,7 +91,6 @@ typedef struct
     ** EVS Log and associated variables. This needs to be preserved on a processor reset.
     */
     CFE_EVS_Log_t EVS_Log;
-
 } CFE_ES_ResetData_t;
 
 #endif /* CFE_ES_RESETDATA_TYPEDEF_H */

--- a/modules/core_private/fsw/inc/cfe_evs_log_typedef.h
+++ b/modules/core_private/fsw/inc/cfe_evs_log_typedef.h
@@ -43,7 +43,6 @@ typedef struct
     uint8                  LogMode;            /**< \brief Local Event Logging mode (overwrite/discard) */
     uint16                 LogOverflowCounter; /**< \brief Local Event Log overflow counter */
     CFE_EVS_LongEventTlm_t LogEntry[CFE_PLATFORM_EVS_LOG_MAX]; /**< \brief The actual Local Event Log entry */
-
 } CFE_EVS_Log_t;
 
 #endif /* CFE_EVS_LOG_TYPEDEF_H */

--- a/modules/core_private/fsw/inc/cfe_time_resetvars_typedef.h
+++ b/modules/core_private/fsw/inc/cfe_time_resetvars_typedef.h
@@ -49,7 +49,6 @@ typedef struct CFE_TIME_ResetVars
     CFE_TIME_SysTime_t CurrentMET;   /**< \brief Current Mission Elapsed Time (MET) */
     CFE_TIME_SysTime_t CurrentSTCF;  /**< \brief Current Spacecraft Time Correlation Factor (STCF) */
     CFE_TIME_SysTime_t CurrentDelay; /**< \brief Current time client delay value */
-
 } CFE_TIME_ResetVars_t;
 
 #endif /* CFE_TIME_RESETVARS_TYPEDEF_H */

--- a/modules/core_private/ut-stubs/inc/ut_support.h
+++ b/modules/core_private/ut-stubs/inc/ut_support.h
@@ -133,7 +133,6 @@ typedef struct
      * set to zero in this case).
      */
     CFE_MSG_FcnCode_t CommandCode;
-
 } UT_TaskPipeDispatchId_t;
 
 /*

--- a/modules/core_private/ut-stubs/src/cfe_es_core_internal_stubs.c
+++ b/modules/core_private/ut-stubs/src/cfe_es_core_internal_stubs.c
@@ -84,6 +84,5 @@ int32 CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr, size_t UserBlockSize, 
  */
 void CFE_ES_TaskMain(void)
 {
-
     UT_GenStub_Execute(CFE_ES_TaskMain, Basic, NULL);
 }

--- a/modules/core_private/ut-stubs/src/cfe_evs_core_internal_stubs.c
+++ b/modules/core_private/ut-stubs/src/cfe_evs_core_internal_stubs.c
@@ -62,6 +62,5 @@ int32 CFE_EVS_EarlyInit(void)
  */
 void CFE_EVS_TaskMain(void)
 {
-
     UT_GenStub_Execute(CFE_EVS_TaskMain, Basic, NULL);
 }

--- a/modules/core_private/ut-stubs/src/cfe_sb_core_internal_stubs.c
+++ b/modules/core_private/ut-stubs/src/cfe_sb_core_internal_stubs.c
@@ -62,6 +62,5 @@ int32 CFE_SB_EarlyInit(void)
  */
 void CFE_SB_TaskMain(void)
 {
-
     UT_GenStub_Execute(CFE_SB_TaskMain, Basic, NULL);
 }

--- a/modules/core_private/ut-stubs/src/cfe_tbl_core_internal_stubs.c
+++ b/modules/core_private/ut-stubs/src/cfe_tbl_core_internal_stubs.c
@@ -62,6 +62,5 @@ int32 CFE_TBL_EarlyInit(void)
  */
 void CFE_TBL_TaskMain(void)
 {
-
     UT_GenStub_Execute(CFE_TBL_TaskMain, Basic, NULL);
 }

--- a/modules/core_private/ut-stubs/src/cfe_time_core_internal_stubs.c
+++ b/modules/core_private/ut-stubs/src/cfe_time_core_internal_stubs.c
@@ -62,6 +62,5 @@ int32 CFE_TIME_EarlyInit(void)
  */
 void CFE_TIME_TaskMain(void)
 {
-
     UT_GenStub_Execute(CFE_TIME_TaskMain, Basic, NULL);
 }

--- a/modules/es/fsw/inc/cfe_es_msg.h
+++ b/modules/es/fsw/inc/cfe_es_msg.h
@@ -1137,7 +1137,6 @@ typedef struct CFE_ES_OverWriteSysLogCmd_Payload
 {
     uint32 Mode; /**< \brief #CFE_ES_LogMode_DISCARD=Throw away most recent messages,
                              #CFE_ES_LogMode_OVERWRITE=Overwrite oldest with most recent */
-
 } CFE_ES_OverWriteSysLogCmd_Payload_t;
 
 /**
@@ -1169,7 +1168,6 @@ typedef struct CFE_ES_StartAppCmd_Payload
                                                        #CFE_ES_ExceptionAction_PROC_RESTART=On exception,
                                                        perform a Processor Reset */
     CFE_ES_TaskPriority_Atom_t Priority;           /**< \brief The new Applications runtime priority. */
-
 } CFE_ES_StartAppCmd_Payload_t;
 
 /**
@@ -1263,7 +1261,6 @@ typedef struct CFE_ES_DeleteCDSCmd_Payload
 {
     char
         CdsName[CFE_MISSION_ES_CDS_MAX_FULL_NAME_LEN]; /**< \brief ASCII text string containing name of CDS to delete */
-
 } CFE_ES_DeleteCDSCmd_Payload_t;
 
 /**
@@ -1326,7 +1323,6 @@ typedef struct CFE_ES_SetPerfFilterMaskCmd_Payload
 {
     uint32 FilterMaskNum; /**< \brief Index into array of Filter Masks */
     uint32 FilterMask;    /**< \brief New Mask for specified entry in array of Filter Masks */
-
 } CFE_ES_SetPerfFilterMaskCmd_Payload_t;
 
 /**
@@ -1348,7 +1344,6 @@ typedef struct CFE_ES_SetPerfTrigMaskCmd_Payload
 {
     uint32 TriggerMaskNum; /**< \brief Index into array of Trigger Masks */
     uint32 TriggerMask;    /**< \brief New Mask for specified entry in array of Trigger Masks */
-
 } CFE_ES_SetPerfTrigMaskCmd_Payload_t;
 
 /**
@@ -1370,7 +1365,6 @@ typedef struct CFE_ES_SendMemPoolStatsCmd_Payload
 {
     char               Application[CFE_MISSION_MAX_API_LEN]; /**< \brief - RESERVED - should be all zeroes */
     CFE_ES_MemHandle_t PoolHandle; /**< \brief Handle of Pool whose statistics are to be telemetered */
-
 } CFE_ES_SendMemPoolStatsCmd_Payload_t;
 
 /**
@@ -1418,7 +1412,6 @@ typedef struct CFE_ES_DumpCDSRegistryCmd
 typedef struct CFE_ES_OneAppTlm_Payload
 {
     CFE_ES_AppInfo_t AppInfo; /**< \brief For more information, see #CFE_ES_AppInfo_t */
-
 } CFE_ES_OneAppTlm_Payload_t;
 
 typedef struct CFE_ES_OneAppTlm
@@ -1549,7 +1542,6 @@ typedef struct CFE_ES_HousekeepingTlm
 {
     CFE_MSG_TelemetryHeader_t        TelemetryHeader; /**< \brief Telemetry header */
     CFE_ES_HousekeepingTlm_Payload_t Payload;         /**< \brief Telemetry payload */
-
 } CFE_ES_HousekeepingTlm_t;
 
 #endif /* CFE_ES_MSG_H */

--- a/modules/es/fsw/src/cfe_es_api.c
+++ b/modules/es/fsw/src/cfe_es_api.c
@@ -42,8 +42,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_GetResetType
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -59,8 +57,6 @@ int32 CFE_ES_GetResetType(uint32 *ResetSubtypePtr)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_ResetCFE
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -115,8 +111,7 @@ CFE_Status_t CFE_ES_ResetCFE(uint32 ResetType)
             ** Call the BSP reset routine
             */
             CFE_PSP_Restart(CFE_PSP_RST_TYPE_PROCESSOR);
-
-        } /* end if */
+        }
 
         /*
         ** If the BSP routine is not implemented,
@@ -157,8 +152,6 @@ CFE_Status_t CFE_ES_ResetCFE(uint32 ResetType)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_RestartApp
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -172,7 +165,6 @@ CFE_Status_t CFE_ES_RestartApp(CFE_ES_AppId_t AppID)
     AppRecPtr = CFE_ES_LocateAppRecordByID(AppID);
     if (AppRecPtr != NULL)
     {
-
         CFE_ES_LockSharedData(__func__, __LINE__);
 
         /*
@@ -218,15 +210,12 @@ CFE_Status_t CFE_ES_RestartApp(CFE_ES_AppId_t AppID)
 
         CFE_ES_WriteToSysLog("%s: Invalid Application ID received, AppID = %lu\n", __func__,
                              CFE_RESOURCEID_TO_ULONG(AppID));
-
-    } /* end if */
+    }
 
     return ReturnCode;
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_ReloadApp
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -240,7 +229,6 @@ CFE_Status_t CFE_ES_ReloadApp(CFE_ES_AppId_t AppID, const char *AppFileName)
 
     if (AppRecPtr != NULL)
     {
-
         CFE_ES_LockSharedData(__func__, __LINE__);
 
         /*
@@ -295,8 +283,6 @@ CFE_Status_t CFE_ES_ReloadApp(CFE_ES_AppId_t AppID, const char *AppFileName)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_DeleteApp
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -308,7 +294,6 @@ CFE_Status_t CFE_ES_DeleteApp(CFE_ES_AppId_t AppID)
 
     if (AppRecPtr != NULL)
     {
-
         CFE_ES_LockSharedData(__func__, __LINE__);
 
         /*
@@ -347,8 +332,6 @@ CFE_Status_t CFE_ES_DeleteApp(CFE_ES_AppId_t AppID)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_ExitApp
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -453,7 +436,6 @@ void CFE_ES_ExitApp(uint32 ExitStatus)
         }
         else /* It is an external App */
         {
-
             CFE_ES_SysLogWrite_Unsync("%s: Application %s called CFE_ES_ExitApp\n", __func__,
                                       CFE_ES_AppRecordGetName(AppRecPtr));
 
@@ -472,8 +454,7 @@ void CFE_ES_ExitApp(uint32 ExitStatus)
             {
                 OS_TaskDelay(500);
             }
-
-        } /* end if */
+        }
 
     } /* end if ReturnCode == CFE_SUCCESS */
 
@@ -481,8 +462,6 @@ void CFE_ES_ExitApp(uint32 ExitStatus)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_RunLoop
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -572,8 +551,6 @@ bool CFE_ES_RunLoop(uint32 *RunStatus)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_WaitForSystemState
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -677,8 +654,6 @@ CFE_Status_t CFE_ES_WaitForSystemState(uint32 MinSystemState, uint32 TimeOutMill
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_WaitForStartupSync
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -689,8 +664,6 @@ void CFE_ES_WaitForStartupSync(uint32 TimeOutMilliseconds)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GetAppIDByName
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -731,8 +704,6 @@ CFE_Status_t CFE_ES_GetAppIDByName(CFE_ES_AppId_t *AppIdPtr, const char *AppName
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_GetLibIDByName
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -772,8 +743,6 @@ CFE_Status_t CFE_ES_GetLibIDByName(CFE_ES_LibId_t *LibIdPtr, const char *LibName
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_GetTaskIDByName
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -806,8 +775,6 @@ CFE_Status_t CFE_ES_GetTaskIDByName(CFE_ES_TaskId_t *TaskIdPtr, const char *Task
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GetAppID
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -845,8 +812,6 @@ CFE_Status_t CFE_ES_GetAppID(CFE_ES_AppId_t *AppIdPtr)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_GetTaskID
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -878,8 +843,6 @@ CFE_Status_t CFE_ES_GetTaskID(CFE_ES_TaskId_t *TaskIdPtr)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GetAppName
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -925,8 +888,6 @@ CFE_Status_t CFE_ES_GetAppName(char *AppName, CFE_ES_AppId_t AppId, size_t Buffe
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_GetLibName
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -970,8 +931,6 @@ CFE_Status_t CFE_ES_GetLibName(char *LibName, CFE_ES_LibId_t LibId, size_t Buffe
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GetTaskName
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -1019,8 +978,6 @@ CFE_Status_t CFE_ES_GetTaskName(char *TaskName, CFE_ES_TaskId_t TaskId, size_t B
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GetAppInfo
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -1117,8 +1074,6 @@ CFE_Status_t CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, CFE_ES_AppId_t AppId)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_GetLibInfo
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -1181,8 +1136,6 @@ int32 CFE_ES_GetLibInfo(CFE_ES_AppInfo_t *LibInfo, CFE_ES_LibId_t LibId)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_GetModuleInfo
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -1214,8 +1167,6 @@ int32 CFE_ES_GetModuleInfo(CFE_ES_AppInfo_t *ModuleInfo, CFE_ResourceId_t Resour
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_GetTaskInfo
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -1246,7 +1197,6 @@ CFE_Status_t CFE_ES_GetTaskInfo(CFE_ES_TaskInfo_t *TaskInfo, CFE_ES_TaskId_t Tas
     }
     else
     {
-
         /*
         ** Get the Application ID and Task Name
         */
@@ -1289,8 +1239,6 @@ CFE_Status_t CFE_ES_GetTaskInfo(CFE_ES_TaskInfo_t *TaskInfo, CFE_ES_TaskId_t Tas
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_CreateChildTask
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -1386,8 +1334,6 @@ CFE_Status_t CFE_ES_CreateChildTask(CFE_ES_TaskId_t *TaskIdPtr, const char *Task
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_IncrementTaskCounter
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -1417,8 +1363,6 @@ void CFE_ES_IncrementTaskCounter(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_DeleteChildTask
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -1464,10 +1408,10 @@ CFE_Status_t CFE_ES_DeleteChildTask(CFE_ES_TaskId_t TaskId)
                         */
                         TaskIsMain = true;
                         break;
-                    } /* end if */
-                }     /* end if */
+                    }
+                }
                 ++AppRecPtr;
-            } /* end for */
+            }
 
             if (TaskIsMain == false)
             {
@@ -1515,8 +1459,7 @@ CFE_Status_t CFE_ES_DeleteChildTask(CFE_ES_TaskId_t TaskId)
             CFE_ES_SysLogWrite_Unsync("%s: Error: Task ID is not active: %lu\n", __func__,
                                       CFE_RESOURCEID_TO_ULONG(TaskId));
             ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
-
-        } /* end if */
+        }
 
         CFE_ES_UnlockSharedData(__func__, __LINE__);
     }
@@ -1532,8 +1475,6 @@ CFE_Status_t CFE_ES_DeleteChildTask(CFE_ES_TaskId_t TaskId)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_ExitChildTask
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -1591,8 +1532,6 @@ void CFE_ES_ExitChildTask(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_WriteToSysLog
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1627,8 +1566,6 @@ CFE_Status_t CFE_ES_WriteToSysLog(const char *SpecStringPtr, ...)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_CalculateCRC
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -1705,8 +1642,6 @@ uint32 CFE_ES_CalculateCRC(const void *DataPtr, size_t DataLength, uint32 InputC
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_RegisterCDS
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -1789,8 +1724,6 @@ CFE_Status_t CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *CDSHandlePtr, size_t BlockSi
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_GetCDSBlockIDByName
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -1830,8 +1763,6 @@ CFE_Status_t CFE_ES_GetCDSBlockIDByName(CFE_ES_CDSHandle_t *BlockIdPtr, const ch
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GetCDSBlockName
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -1874,8 +1805,6 @@ CFE_Status_t CFE_ES_GetCDSBlockName(char *BlockName, CFE_ES_CDSHandle_t BlockId,
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_CopyToCDS
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -1892,8 +1821,6 @@ CFE_Status_t CFE_ES_CopyToCDS(CFE_ES_CDSHandle_t Handle, const void *DataToCopy)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_RestoreFromCDS
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -1909,8 +1836,6 @@ CFE_Status_t CFE_ES_RestoreFromCDS(void *RestoreToMemory, CFE_ES_CDSHandle_t Han
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_RegisterGenCounter
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -1975,8 +1900,6 @@ CFE_Status_t CFE_ES_RegisterGenCounter(CFE_ES_CounterId_t *CounterIdPtr, const c
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_DeleteGenCounter
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -2004,8 +1927,6 @@ CFE_Status_t CFE_ES_DeleteGenCounter(CFE_ES_CounterId_t CounterId)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_IncrementGenCounter
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -2025,8 +1946,6 @@ CFE_Status_t CFE_ES_IncrementGenCounter(CFE_ES_CounterId_t CounterId)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_SetGenCount
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -2048,8 +1967,6 @@ CFE_Status_t CFE_ES_SetGenCount(CFE_ES_CounterId_t CounterId, uint32 Count)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_GetGenCount
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -2069,8 +1986,6 @@ CFE_Status_t CFE_ES_GetGenCount(CFE_ES_CounterId_t CounterId, uint32 *Count)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GetGenCounterIDByName
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -2114,8 +2029,6 @@ CFE_Status_t CFE_ES_GetGenCounterIDByName(CFE_ES_CounterId_t *CounterIdPtr, cons
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_GetGenCounterName
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -2153,8 +2066,6 @@ CFE_Status_t CFE_ES_GetGenCounterName(char *CounterName, CFE_ES_CounterId_t Coun
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_AppID_ToIndex
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -2167,8 +2078,6 @@ CFE_Status_t CFE_ES_AppID_ToIndex(CFE_ES_AppId_t AppID, uint32 *Idx)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_LibID_ToIndex
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -2179,8 +2088,6 @@ int32 CFE_ES_LibID_ToIndex(CFE_ES_LibId_t LibId, uint32 *Idx)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_TaskID_ToIndex
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -2216,8 +2123,6 @@ CFE_Status_t CFE_ES_TaskID_ToIndex(CFE_ES_TaskId_t TaskID, uint32 *Idx)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_CounterID_ToIndex
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -2233,8 +2138,6 @@ CFE_Status_t CFE_ES_CounterID_ToIndex(CFE_ES_CounterId_t CounterId, uint32 *Idx)
 */
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_LockSharedData
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -2253,13 +2156,10 @@ void CFE_ES_LockSharedData(const char *FunctionName, int32 LineNumber)
          */
         CFE_ES_SysLogWrite_Unsync("%s: SharedData Mutex Take Err Stat=%ld,Func=%s,Line=%d\n", __func__, (long)OsStatus,
                                   FunctionName, (int)LineNumber);
-
-    } /* end if */
+    }
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_UnlockSharedData
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -2278,13 +2178,10 @@ void CFE_ES_UnlockSharedData(const char *FunctionName, int32 LineNumber)
          */
         CFE_ES_SysLogWrite_Unsync("%s: SharedData Mutex Give Err Stat=%ld,Func=%s,Line=%d\n", __func__, (long)OsStatus,
                                   FunctionName, (int)LineNumber);
-
-    } /* end if */
+    }
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_ProcessAsyncEvent
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -2297,8 +2194,6 @@ void CFE_ES_ProcessAsyncEvent(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_StatusToString
  *
  * Implemented per public API
  * See description in header file for argument/return detail

--- a/modules/es/fsw/src/cfe_es_apps.c
+++ b/modules/es/fsw/src/cfe_es_apps.c
@@ -64,8 +64,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_StartApplications
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -116,8 +114,7 @@ void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath)
             CFE_ES_WriteToSysLog("%s: CFE_FS_ParseInputFileName() RC=%08x parsing volatile script file name.\n",
                                  __func__, (unsigned int)Status);
         }
-
-    } /* end if */
+    }
 
     /*
     ** This if block covers two cases: A Power on reset, and a Processor reset when
@@ -281,8 +278,6 @@ void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_ParseFileEntry
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -392,8 +387,6 @@ int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_LoadModule
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -494,8 +487,6 @@ int32 CFE_ES_LoadModule(CFE_ResourceId_t ParentResourceId, const char *ModuleNam
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_GetTaskFunction
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -550,8 +541,6 @@ int32 CFE_ES_GetTaskFunction(CFE_ES_TaskEntryFuncPtr_t *FuncPtr)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_TaskEntryPoint
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -579,8 +568,6 @@ void CFE_ES_TaskEntryPoint(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_StartAppTask
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -659,8 +646,6 @@ int32 CFE_ES_StartAppTask(CFE_ES_TaskId_t *TaskIdPtr, const char *TaskName, CFE_
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_AppCreate
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -825,8 +810,6 @@ int32 CFE_ES_AppCreate(CFE_ES_AppId_t *ApplicationIdPtr, const char *AppName, co
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_LoadLibrary
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -981,8 +964,6 @@ int32 CFE_ES_LoadLibrary(CFE_ES_LibId_t *LibraryIdPtr, const char *LibName, cons
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_RunAppTableScan
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1071,8 +1052,7 @@ bool CFE_ES_RunAppTableScan(uint32 ElapsedTime, void *Arg)
                 AppPtr->AppState                = CFE_ES_AppState_WAITING;
                 AppPtr->ControlReq.AppTimerMsec = CFE_PLATFORM_ES_APP_KILL_TIMEOUT * CFE_PLATFORM_ES_APP_SCAN_RATE;
             }
-
-        } /* end if */
+        }
 
         ++AppPtr;
 
@@ -1103,8 +1083,6 @@ bool CFE_ES_RunAppTableScan(uint32 ElapsedTime, void *Arg)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_ProcessControlRequest
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1330,8 +1308,6 @@ void CFE_ES_ProcessControlRequest(CFE_ES_AppId_t AppId)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_CleanUpApp
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1401,7 +1377,7 @@ int32 CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId)
             }
 
             ++TaskRecPtr;
-        } /* end for */
+        }
 
         CFE_ES_Global.RegisteredTasks -= NumTasks;
 
@@ -1419,7 +1395,7 @@ int32 CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId)
             }
 
             ++MemPoolRecPtr;
-        } /* end for */
+        }
 
         /*
          * Set the record to RESERVED.
@@ -1575,8 +1551,6 @@ typedef struct
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_CleanupObjectCallback
- *
  * Internal helper routine only, not part of API.
  *
  * Purpose: clean up all objects.
@@ -1676,8 +1650,6 @@ void CFE_ES_CleanupObjectCallback(osal_id_t ObjectId, void *arg)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_CleanupTaskResources
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1744,8 +1716,6 @@ int32 CFE_ES_CleanupTaskResources(CFE_ES_TaskId_t TaskId)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_CopyModuleBasicInfo
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1761,8 +1731,6 @@ void CFE_ES_CopyModuleBasicInfo(const CFE_ES_ModuleLoadParams_t *ParamsPtr, CFE_
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_CopyModuleStatusInfo
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1773,8 +1741,6 @@ void CFE_ES_CopyModuleStatusInfo(const CFE_ES_ModuleLoadStatus_t *StatusPtr, CFE
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_CopyModuleAddressInfo
  *
  * Application-scope internal function
  * See description in header file for argument/return detail

--- a/modules/es/fsw/src/cfe_es_apps.h
+++ b/modules/es/fsw/src/cfe_es_apps.h
@@ -58,7 +58,6 @@ typedef struct
 {
     uint32 AppControlRequest; /* What the App should be doing next */
     int32  AppTimerMsec;      /* Countdown timer for killing an app, in milliseconds */
-
 } CFE_ES_ControlReq_t;
 
 /*
@@ -76,7 +75,6 @@ typedef struct
 {
     char InitSymbolName[OS_MAX_API_NAME];
     char FileName[OS_MAX_PATH_LEN];
-
 } CFE_ES_ModuleLoadParams_t;
 
 /*
@@ -90,7 +88,6 @@ typedef struct
 {
     osal_id_t ModuleId;
     cpuaddr   InitSymbolAddress;
-
 } CFE_ES_ModuleLoadStatus_t;
 
 /*
@@ -103,7 +100,6 @@ typedef struct
 {
     size_t                     StackSize;
     CFE_ES_TaskPriority_Atom_t Priority;
-
 } CFE_ES_TaskStartParams_t;
 
 /*
@@ -122,7 +118,6 @@ typedef struct
 
     CFE_ES_TaskStartParams_t      MainTaskInfo;
     CFE_ES_ExceptionAction_Enum_t ExceptionAction;
-
 } CFE_ES_AppStartParams_t;
 
 /*
@@ -139,7 +134,6 @@ typedef struct
     CFE_ES_ModuleLoadStatus_t LoadStatus;               /* Runtime module information */
     CFE_ES_ControlReq_t       ControlReq;               /* The Control Request Record for External cFE Apps */
     CFE_ES_TaskId_t           MainTaskId;               /* The Application's Main Task ID */
-
 } CFE_ES_AppRecord_t;
 
 /*
@@ -154,7 +148,6 @@ typedef struct
     CFE_ES_TaskStartParams_t  StartParams;               /* The start parameters for the task */
     CFE_ES_TaskEntryFuncPtr_t EntryFunc;                 /* Task entry function */
     uint32                    ExecutionCounter;          /* The execution counter for the task */
-
 } CFE_ES_TaskRecord_t;
 
 /*
@@ -167,7 +160,6 @@ typedef struct
     char                      LibName[OS_MAX_API_NAME]; /* Library Name */
     CFE_ES_ModuleLoadParams_t LoadParams;               /* Basic (static) information about the module */
     CFE_ES_ModuleLoadStatus_t LoadStatus;               /* Runtime information about the module */
-
 } CFE_ES_LibRecord_t;
 
 /*

--- a/modules/es/fsw/src/cfe_es_backgroundtask.c
+++ b/modules/es/fsw/src/cfe_es_backgroundtask.c
@@ -89,8 +89,6 @@ const CFE_ES_BackgroundJobEntry_t CFE_ES_BACKGROUND_JOB_TABLE[] = {
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_BackgroundTask
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -166,8 +164,6 @@ void CFE_ES_BackgroundTask(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_BackgroundInit
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -201,8 +197,6 @@ int32 CFE_ES_BackgroundInit(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_BackgroundCleanup
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -217,8 +211,6 @@ void CFE_ES_BackgroundCleanup(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_BackgroundWakeup
  *
  * Implemented per public API
  * See description in header file for argument/return detail

--- a/modules/es/fsw/src/cfe_es_cds.c
+++ b/modules/es/fsw/src/cfe_es_cds.c
@@ -44,8 +44,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_CDS_EarlyInit
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -149,8 +147,6 @@ int32 CFE_ES_CDS_EarlyInit(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_CDSHandle_ToIndex
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -162,8 +158,6 @@ int32 CFE_ES_CDSHandle_ToIndex(CFE_ES_CDSHandle_t BlockID, uint32 *Idx)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_CheckCDSHandleSlotUsed
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -182,8 +176,6 @@ bool CFE_ES_CheckCDSHandleSlotUsed(CFE_ResourceId_t CheckId)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_LocateCDSBlockRecordByID
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -208,8 +200,6 @@ CFE_ES_CDS_RegRec_t *CFE_ES_LocateCDSBlockRecordByID(CFE_ES_CDSHandle_t BlockID)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_CDS_CacheFetch
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -244,8 +234,6 @@ int32 CFE_ES_CDS_CacheFetch(CFE_ES_CDS_AccessCache_t *Cache, size_t Offset, size
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_CDS_CacheFlush
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -276,8 +264,6 @@ int32 CFE_ES_CDS_CacheFlush(CFE_ES_CDS_AccessCache_t *Cache)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_CDS_CachePreload
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -312,8 +298,6 @@ int32 CFE_ES_CDS_CachePreload(CFE_ES_CDS_AccessCache_t *Cache, const void *Sourc
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_RegisterCDSEx
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -473,8 +457,6 @@ int32 CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr, size_t UserBlockSize, 
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_ValidateCDS
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -524,8 +506,6 @@ int32 CFE_ES_ValidateCDS(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_ClearCDS
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -571,8 +551,6 @@ int32 CFE_ES_ClearCDS(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_InitCDSSignatures
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -612,8 +590,6 @@ int32 CFE_ES_InitCDSSignatures(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_InitCDSRegistry
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -646,8 +622,6 @@ int32 CFE_ES_InitCDSRegistry(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_UpdateCDSRegistry
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -671,8 +645,6 @@ int32 CFE_ES_UpdateCDSRegistry(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_FormCDSName
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -691,8 +663,6 @@ void CFE_ES_FormCDSName(char *FullCDSName, const char *CDSName, CFE_ES_AppId_t T
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_LockCDS
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -721,8 +691,6 @@ int32 CFE_ES_LockCDS(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_UnlockCDS
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -749,8 +717,6 @@ int32 CFE_ES_UnlockCDS(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_LocateCDSBlockRecordByName
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -790,8 +756,6 @@ CFE_ES_CDS_RegRec_t *CFE_ES_LocateCDSBlockRecordByName(const char *CDSName)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_RebuildCDS
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -840,8 +804,6 @@ int32 CFE_ES_RebuildCDS(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_DeleteCDS
  *
  * Implemented per public API
  * See description in header file for argument/return detail

--- a/modules/es/fsw/src/cfe_es_cds_mempool.c
+++ b/modules/es/fsw/src/cfe_es_cds_mempool.c
@@ -63,8 +63,6 @@ const size_t CFE_ES_CDSMemPoolDefSize[CFE_ES_CDS_NUM_BLOCK_SIZES] = {
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_CDS_PoolRetrieve
- *
  * Internal helper routine only, not part of API.
  *
  * Obtains a block descriptor from CDS storage.
@@ -82,8 +80,6 @@ int32 CFE_ES_CDS_PoolRetrieve(CFE_ES_GenPoolRecord_t *GenPoolRecPtr, size_t Offs
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_CDS_PoolCommit
- *
  * Internal helper routine only, not part of API.
  *
  * Writes a block descriptor to CDS storage.
@@ -100,8 +96,6 @@ int32 CFE_ES_CDS_PoolCommit(CFE_ES_GenPoolRecord_t *GenPoolRecPtr, size_t Offset
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_CreateCDSPool
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -136,8 +130,6 @@ int32 CFE_ES_CreateCDSPool(size_t CDSPoolSize, size_t StartOffset)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_RebuildCDSPool
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -169,8 +161,6 @@ int32 CFE_ES_RebuildCDSPool(size_t CDSPoolSize, size_t StartOffset)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_CDSBlockWrite
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -268,8 +258,6 @@ int32 CFE_ES_CDSBlockWrite(CFE_ES_CDSHandle_t Handle, const void *DataToWrite)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_CDSBlockRead
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -356,8 +344,6 @@ int32 CFE_ES_CDSBlockRead(void *DataRead, CFE_ES_CDSHandle_t Handle)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_CDSReqdMinSize
  *
  * Application-scope internal function
  * See description in header file for argument/return detail

--- a/modules/es/fsw/src/cfe_es_erlog.c
+++ b/modules/es/fsw/src/cfe_es_erlog.c
@@ -44,8 +44,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_WriteToERLogWithContext
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -147,8 +145,6 @@ int32 CFE_ES_WriteToERLogWithContext(CFE_ES_LogEntryType_Enum_t EntryType, uint3
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_WriteToERLog
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -162,8 +158,6 @@ int32 CFE_ES_WriteToERLog(CFE_ES_LogEntryType_Enum_t EntryType, uint32 ResetType
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_BackgroundERLogFileDataGetter
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -230,8 +224,6 @@ bool CFE_ES_BackgroundERLogFileDataGetter(void *Meta, uint32 RecordNum, void **B
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_BackgroundERLogFileEventHandler
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -271,8 +263,6 @@ void CFE_ES_BackgroundERLogFileEventHandler(void *Meta, CFE_FS_FileWriteEvent_t 
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_RunExceptionScan
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -309,7 +299,7 @@ bool CFE_ES_RunExceptionScan(uint32 ElapsedTime, void *Arg)
                  (long)PspStatus);
         PspContextId    = 0;
         ExceptionTaskID = OS_OBJECT_ID_UNDEFINED;
-    } /* end if */
+    }
 
     /*
      * Note that writes to the ES ER log actually do not get propagated to the debug console.

--- a/modules/es/fsw/src/cfe_es_generic_pool.c
+++ b/modules/es/fsw/src/cfe_es_generic_pool.c
@@ -45,8 +45,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_GenPoolFindBucket
- *
  * Internal helper routine only, not part of API.
  *
  * Find the appropriate bucket given a requested block size
@@ -74,8 +72,6 @@ uint16 CFE_ES_GenPoolFindBucket(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t ReqSi
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_GenPoolGetBucketState
- *
  * Internal helper routine only, not part of API.
  *
  * Obtain a pointer to the state structure associated with a given bucket ID
@@ -95,8 +91,6 @@ CFE_ES_GenPoolBucket_t *CFE_ES_GenPoolGetBucketState(CFE_ES_GenPoolRecord_t *Poo
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GenPoolRecyclePoolBlock
  *
  * Internal helper routine only, not part of API.
  *
@@ -157,8 +151,6 @@ int32 CFE_ES_GenPoolRecyclePoolBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GenPoolCreatePoolBlock
  *
  * Internal helper routine only, not part of API.
  *
@@ -234,8 +226,6 @@ int32 CFE_ES_GenPoolCreatePoolBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 B
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GenPoolInitialize
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -331,8 +321,6 @@ int32 CFE_ES_GenPoolInitialize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t StartO
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_GenPoolCalcMinSize
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -362,8 +350,6 @@ size_t CFE_ES_GenPoolCalcMinSize(uint16 NumBlockSizes, const size_t *BlockSizeLi
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GenPoolGetBlock
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -395,8 +381,6 @@ int32 CFE_ES_GenPoolGetBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockOf
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GenPoolGetBlockSize
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -440,8 +424,6 @@ int32 CFE_ES_GenPoolGetBlockSize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *Blo
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GenPoolPutBlock
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -495,8 +477,6 @@ int32 CFE_ES_GenPoolPutBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockSi
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GenPoolRebuild
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -608,8 +588,6 @@ int32 CFE_ES_GenPoolRebuild(CFE_ES_GenPoolRecord_t *PoolRecPtr)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_GenPoolValidateState
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -621,8 +599,6 @@ bool CFE_ES_GenPoolValidateState(const CFE_ES_GenPoolRecord_t *PoolRecPtr)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GenPoolGetUsage
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -642,8 +618,6 @@ void CFE_ES_GenPoolGetUsage(CFE_ES_GenPoolRecord_t *PoolRecPtr, CFE_ES_MemOffset
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GenPoolGetCounts
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -667,8 +641,6 @@ void CFE_ES_GenPoolGetCounts(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 *NumBuck
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GenPoolGetBucketUsage
  *
  * Application-scope internal function
  * See description in header file for argument/return detail

--- a/modules/es/fsw/src/cfe_es_global.h
+++ b/modules/es/fsw/src/cfe_es_global.h
@@ -121,7 +121,6 @@ typedef struct
     ** ES Task operational data (not reported in housekeeping)
     */
     CFE_SB_PipeId_t CmdPipe;
-
 } CFE_ES_TaskData_t;
 
 /*
@@ -220,7 +219,6 @@ typedef struct
      * Pointer to the Reset data that is preserved on a processor reset
      */
     CFE_ES_ResetData_t *ResetDataPtr;
-
 } CFE_ES_Global_t;
 
 /*

--- a/modules/es/fsw/src/cfe_es_mempool.c
+++ b/modules/es/fsw/src/cfe_es_mempool.c
@@ -73,8 +73,6 @@ const size_t CFE_ES_MemPoolDefSize[CFE_PLATFORM_ES_POOL_MAX_BUCKETS] = {
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_MemPoolDirectRetrieve
- *
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
@@ -91,8 +89,6 @@ int32 CFE_ES_MemPoolDirectRetrieve(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Of
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_MemPoolDirectCommit
- *
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
@@ -102,8 +98,6 @@ int32 CFE_ES_MemPoolDirectCommit(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offs
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_MemPoolID_ToIndex
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -116,8 +110,6 @@ int32 CFE_ES_MemPoolID_ToIndex(CFE_ES_MemHandle_t PoolID, uint32 *Idx)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_CheckMemPoolSlotUsed
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -136,8 +128,6 @@ bool CFE_ES_CheckMemPoolSlotUsed(CFE_ResourceId_t CheckId)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_LocateMemPoolRecordByID
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -162,8 +152,6 @@ CFE_ES_MemPoolRecord_t *CFE_ES_LocateMemPoolRecordByID(CFE_ES_MemHandle_t PoolID
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_PoolCreateNoSem
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -176,8 +164,6 @@ CFE_Status_t CFE_ES_PoolCreateNoSem(CFE_ES_MemHandle_t *PoolID, void *MemPtr, si
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_PoolCreate
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -189,8 +175,6 @@ CFE_Status_t CFE_ES_PoolCreate(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_t 
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_PoolCreateEx
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -360,8 +344,6 @@ CFE_Status_t CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_PoolDelete
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -414,8 +396,6 @@ int32 CFE_ES_PoolDelete(CFE_ES_MemHandle_t PoolID)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GetPoolBuf
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -484,8 +464,6 @@ int32 CFE_ES_GetPoolBuf(CFE_ES_MemPoolBuf_t *BufPtr, CFE_ES_MemHandle_t Handle, 
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_GetPoolBufInfo
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -545,8 +523,6 @@ CFE_Status_t CFE_ES_GetPoolBufInfo(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_PutPoolBuf
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -627,8 +603,6 @@ int32 CFE_ES_PutPoolBuf(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_t BufPtr)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_GetMemPoolStats
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -698,8 +672,6 @@ CFE_Status_t CFE_ES_GetMemPoolStats(CFE_ES_MemPoolStats_t *BufPtr, CFE_ES_MemHan
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_ValidateHandle
  *
  * Application-scope internal function
  * See description in header file for argument/return detail

--- a/modules/es/fsw/src/cfe_es_objtab.c
+++ b/modules/es/fsw/src/cfe_es_objtab.c
@@ -133,6 +133,4 @@ CFE_ES_ObjectTable_t CFE_ES_ObjectTable[CFE_PLATFORM_ES_OBJECT_TABLE_SIZE] = {
     {.ObjectType = CFE_ES_NULL_ENTRY},
     {.ObjectType = CFE_ES_NULL_ENTRY},
     {.ObjectType = CFE_ES_NULL_ENTRY},
-    {.ObjectType = CFE_ES_NULL_ENTRY}
-
-};
+    {.ObjectType = CFE_ES_NULL_ENTRY}};

--- a/modules/es/fsw/src/cfe_es_perf.c
+++ b/modules/es/fsw/src/cfe_es_perf.c
@@ -33,8 +33,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_SetupPerfVariables
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -69,7 +67,6 @@ void CFE_ES_SetupPerfVariables(uint32 ResetType)
     }
     else
     {
-
         Perf->MetaData.Version             = 1;
         Perf->MetaData.Endian              = EndianCheck.Endian;
         Perf->MetaData.TimerTicksPerSecond = CFE_PSP_GetTimerTicksPerSecond();
@@ -94,8 +91,6 @@ void CFE_ES_SetupPerfVariables(uint32 ResetType)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GetPerfLogDumpRemaining
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -140,8 +135,6 @@ uint32 CFE_ES_GetPerfLogDumpRemaining(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_StartPerfDataCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -165,7 +158,6 @@ int32 CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfDataCmd_t *data)
         /* cppcheck-suppress unsignedPositive */
         if ((CmdPtr->TriggerMode >= CFE_ES_PERF_TRIGGER_START) && (CmdPtr->TriggerMode < CFE_ES_PERF_MAX_MODES))
         {
-
             CFE_ES_Global.TaskData.CommandCounter++;
 
             /* Taking lock here as this might be changing states from one active mode to another.
@@ -190,21 +182,19 @@ int32 CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfDataCmd_t *data)
             CFE_EVS_SendEvent(CFE_ES_PERF_STARTCMD_TRIG_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Cannot start collecting performance data, trigger mode (%d) out of range (%d to %d)",
                               (int)CmdPtr->TriggerMode, (int)CFE_ES_PERF_TRIGGER_START, (int)CFE_ES_PERF_TRIGGER_END);
-        } /* end if */
+        }
     }
     else
     {
         CFE_ES_Global.TaskData.CommandErrorCounter++;
         CFE_EVS_SendEvent(CFE_ES_PERF_STARTCMD_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Cannot start collecting performance data,perf data write in progress");
-    } /* end if */
+    }
 
     return CFE_SUCCESS;
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_StopPerfDataCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -259,18 +249,15 @@ int32 CFE_ES_StopPerfDataCmd(const CFE_ES_StopPerfDataCmd_t *data)
     } /* if data to write == 0 */
     else
     {
-
         CFE_ES_Global.TaskData.CommandErrorCounter++;
         CFE_EVS_SendEvent(CFE_ES_PERF_STOPCMD_ERR2_EID, CFE_EVS_EventType_ERROR,
                           "Stop performance data cmd ignored,perf data write in progress");
-    } /* end if */
+    }
 
     return CFE_SUCCESS;
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_RunPerfLogDump
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -413,7 +400,7 @@ bool CFE_ES_RunPerfLogDump(uint32 ElapsedTime, void *Arg)
                     if (!OS_ObjectIdDefined(State->FileDesc))
                     {
                         State->PendingState = CFE_ES_PerfDumpState_IDLE;
-                    } /* end if */
+                    }
                     break;
 
                 case CFE_ES_PerfDumpState_WRITE_PERF_ENTRIES:
@@ -499,8 +486,6 @@ bool CFE_ES_RunPerfLogDump(uint32 ElapsedTime, void *Arg)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_SetPerfFilterMaskCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -517,7 +502,6 @@ int32 CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMaskCmd_t *data)
 
     if (cmd->FilterMaskNum < CFE_ES_PERF_32BIT_WORDS_IN_MASK)
     {
-
         Perf->MetaData.FilterMask[cmd->FilterMaskNum] = cmd->FilterMask;
 
         CFE_EVS_SendEvent(CFE_ES_PERF_FILTMSKCMD_EID, CFE_EVS_EventType_DEBUG,
@@ -540,8 +524,6 @@ int32 CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMaskCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_SetPerfTriggerMaskCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -558,7 +540,6 @@ int32 CFE_ES_SetPerfTriggerMaskCmd(const CFE_ES_SetPerfTriggerMaskCmd_t *data)
 
     if (cmd->TriggerMaskNum < CFE_ES_PERF_32BIT_WORDS_IN_MASK)
     {
-
         Perf->MetaData.TriggerMask[cmd->TriggerMaskNum] = cmd->TriggerMask;
 
         CFE_EVS_SendEvent(CFE_ES_PERF_TRIGMSKCMD_EID, CFE_EVS_EventType_DEBUG,
@@ -580,8 +561,6 @@ int32 CFE_ES_SetPerfTriggerMaskCmd(const CFE_ES_SetPerfTriggerMaskCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_PerfLogAdd
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -615,10 +594,10 @@ void CFE_ES_PerfLogAdd(uint32 Marker, uint32 EntryExit)
             CFE_ES_WriteToSysLog("%s: Invalid performance marker %d,max is %d\n", __func__, (unsigned int)Marker,
                                  (CFE_MISSION_ES_PERF_MAX_IDS - 1));
             Perf->MetaData.InvalidMarkerReported = true;
-        } /* end if */
+        }
 
         return;
-    } /* end if */
+    }
 
     /*
      * check if this ID is filtered.

--- a/modules/es/fsw/src/cfe_es_resource.c
+++ b/modules/es/fsw/src/cfe_es_resource.c
@@ -39,8 +39,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_TaskId_ToOSAL
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -58,8 +56,6 @@ osal_id_t CFE_ES_TaskId_ToOSAL(CFE_ES_TaskId_t id)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_TaskId_FromOSAL
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -76,8 +72,6 @@ CFE_ES_TaskId_t CFE_ES_TaskId_FromOSAL(osal_id_t id)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_LocateAppRecordByName
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -114,8 +108,6 @@ CFE_ES_AppRecord_t *CFE_ES_LocateAppRecordByName(const char *Name)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_LocateLibRecordByName
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -150,8 +142,6 @@ CFE_ES_LibRecord_t *CFE_ES_LocateLibRecordByName(const char *Name)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_LocateCounterRecordByName
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -188,8 +178,6 @@ CFE_ES_GenCounterRecord_t *CFE_ES_LocateCounterRecordByName(const char *Name)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_LocateAppRecordByID
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -212,8 +200,6 @@ CFE_ES_AppRecord_t *CFE_ES_LocateAppRecordByID(CFE_ES_AppId_t AppID)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_LocateLibRecordByID
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -238,8 +224,6 @@ CFE_ES_LibRecord_t *CFE_ES_LocateLibRecordByID(CFE_ES_LibId_t LibID)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_LocateTaskRecordByID
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -263,8 +247,6 @@ CFE_ES_TaskRecord_t *CFE_ES_LocateTaskRecordByID(CFE_ES_TaskId_t TaskID)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_LocateCounterRecordByID
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -287,8 +269,6 @@ CFE_ES_GenCounterRecord_t *CFE_ES_LocateCounterRecordByID(CFE_ES_CounterId_t Cou
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GetTaskRecordByContext
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -320,8 +300,6 @@ CFE_ES_TaskRecord_t *CFE_ES_GetTaskRecordByContext(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GetAppRecordByContext
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -364,8 +342,6 @@ CFE_ES_AppRecord_t *CFE_ES_GetAppRecordByContext(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_CheckCounterIdSlotUsed
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -384,8 +360,6 @@ bool CFE_ES_CheckCounterIdSlotUsed(CFE_ResourceId_t CheckId)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_CheckAppIdSlotUsed
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -403,8 +377,6 @@ bool CFE_ES_CheckAppIdSlotUsed(CFE_ResourceId_t CheckId)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_CheckLibIdSlotUsed
  *
  * Application-scope internal function
  * See description in header file for argument/return detail

--- a/modules/es/fsw/src/cfe_es_start.c
+++ b/modules/es/fsw/src/cfe_es_start.c
@@ -65,8 +65,6 @@ CFE_ES_Global_t CFE_ES_Global;
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_Main
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -111,7 +109,7 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const cha
          * Normally CFE_PSP_Panic() will not return but it will under UT
          */
         return;
-    } /* end if */
+    }
 
     /*
     ** Initialize the Reset variables. This call is required
@@ -235,8 +233,6 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const cha
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_SetupResetVariables
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -436,8 +432,7 @@ void CFE_ES_SetupResetVariables(uint32 StartType, uint32 StartSubtype, uint32 Bo
                     CFE_ES_WriteToERLog(CFE_ES_LogEntryType_CORE, CFE_PSP_RST_TYPE_PROCESSOR, StartSubtype,
                                         "PROCESSOR RESET due to Watchdog (Watchdog).");
                 }
-
-            } /* end if */
+            }
         }
         /*
         ** If a processor reset is due to a command or exception, the reset has already been logged.
@@ -464,8 +459,6 @@ void CFE_ES_SetupResetVariables(uint32 StartType, uint32 StartSubtype, uint32 Bo
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_InitializeFileSystems
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -603,14 +596,12 @@ void CFE_ES_InitializeFileSystems(uint32 StartType)
                 OsStatus = OS_unmount(CFE_PLATFORM_ES_RAM_DISK_MOUNT_STRING);
                 if (OsStatus == OS_SUCCESS)
                 {
-
                     /*
                     ** Remove the file system from the OSAL
                     */
                     OsStatus = OS_rmfs("/ramdev0");
                     if (OsStatus == OS_SUCCESS)
                     {
-
                         /*
                         ** Next, make a new file system on the disk
                         */
@@ -640,7 +631,6 @@ void CFE_ES_InitializeFileSystems(uint32 StartType)
                         }
                         else
                         {
-
                             CFE_ES_WriteToSysLog("%s: Error Re-Formatting Volatile(RAM) Volume. EC = %ld\n", __func__,
                                                  (long)OsStatus);
                             /*
@@ -657,7 +647,6 @@ void CFE_ES_InitializeFileSystems(uint32 StartType)
                     }
                     else /* could not Remove File system */
                     {
-
                         CFE_ES_WriteToSysLog("%s: Error Removing Volatile(RAM) Volume. EC = %ld\n", __func__,
                                              (long)OsStatus);
                         /*
@@ -710,8 +699,6 @@ void CFE_ES_InitializeFileSystems(uint32 StartType)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_CreateObjects
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -864,8 +851,7 @@ void CFE_ES_CreateObjects(void)
                         ** cFE Cannot continue to start up.
                         */
                         CFE_PSP_Panic(CFE_PSP_PANIC_CORE_APP);
-
-                    } /* end if */
+                    }
                 }
                 else
                 {
@@ -885,8 +871,6 @@ void CFE_ES_CreateObjects(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_MainTaskSyncDelay
  *
  * Internal helper routine only, not part of API.
  *

--- a/modules/es/fsw/src/cfe_es_start.h
+++ b/modules/es/fsw/src/cfe_es_start.h
@@ -73,7 +73,6 @@ typedef struct
     uint32                ObjectPriority;              /* object priority */
     uint32                ObjectSize;                  /* size used for stack, queue size, etc. */
     uint32                ObjectFlags;                 /* extra flags to pass */
-
 } CFE_ES_ObjectTable_t;
 
 /*

--- a/modules/es/fsw/src/cfe_es_syslog.c
+++ b/modules/es/fsw/src/cfe_es_syslog.c
@@ -71,8 +71,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_SysLogClear_Unsync
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -90,8 +88,6 @@ void CFE_ES_SysLogClear_Unsync(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_SysLogReadStart_Unsync
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -128,8 +124,6 @@ void CFE_ES_SysLogReadStart_Unsync(CFE_ES_SysLogReadBuffer_t *Buffer)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_SysLogAppend_Unsync
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -253,8 +247,6 @@ int32 CFE_ES_SysLogAppend_Unsync(const char *LogString)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_SysLogWrite_Unsync
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -287,8 +279,6 @@ int32 CFE_ES_SysLogWrite_Unsync(const char *SpecStringPtr, ...)
  *******************************************************************/
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_SysLogReadData
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -338,8 +328,6 @@ void CFE_ES_SysLogReadData(CFE_ES_SysLogReadBuffer_t *Buffer)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_SysLogSetMode
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -362,8 +350,6 @@ int32 CFE_ES_SysLogSetMode(CFE_ES_LogMode_Enum_t Mode)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_SysLog_vsnprintf
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -442,8 +428,6 @@ void CFE_ES_SysLog_vsnprintf(char *Buffer, size_t BufferSize, const char *SpecSt
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_SysLogDump
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -468,7 +452,7 @@ int32 CFE_ES_SysLogDump(const char *Filename)
         CFE_EVS_SendEvent(CFE_ES_SYSLOG2_ERR_EID, CFE_EVS_EventType_ERROR, "Error creating file %s, RC = %ld", Filename,
                           (long)OsStatus);
         return CFE_ES_FILE_IO_ERR;
-    } /* end if */
+    }
 
     CFE_FS_InitHeader(&Buffer.FileHdr, CFE_ES_SYS_LOG_DESC, CFE_FS_SubType_ES_SYSLOG);
 
@@ -501,7 +485,7 @@ int32 CFE_ES_SysLogDump(const char *Filename)
                 if (OsStatus <= 0)
                 {
                     break;
-                } /* end if */
+                }
 
                 WritePos += (long)OsStatus;
                 TotalSize += (long)OsStatus;

--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -69,8 +69,6 @@ CFE_ES_TaskData_t CFE_ES_TaskData;
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_TaskMain
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -101,8 +99,7 @@ void CFE_ES_TaskMain(void)
         ** Allow Core App to Exit
         */
         AppRunStatus = CFE_ES_RunStatus_CORE_APP_INIT_ERROR;
-
-    } /* end if */
+    }
 
     /*
      * Wait for other apps to start.
@@ -164,8 +161,7 @@ void CFE_ES_TaskMain(void)
             ** Allow Core App to Exit
             */
             AppRunStatus = CFE_ES_RunStatus_CORE_APP_RUNTIME_ERROR;
-
-        } /* end if */
+        }
 
     } /* end while */
 
@@ -181,8 +177,6 @@ void CFE_ES_TaskMain(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GenerateSingleVersionEvent
  *
  * Internal helper routine only, not part of API.
  *
@@ -205,8 +199,6 @@ int32 CFE_ES_GenerateSingleVersionEvent(const char *ModuleType, const char *Modu
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_ModSrcVerCallback
- *
  * Internal helper routine only, not part of API.
  *
  * Callback for iterating all configuration keys
@@ -223,8 +215,6 @@ void CFE_ES_ModSrcVerCallback(void *Arg, CFE_ConfigId_t Id, const char *Name)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GenerateVersionEvents
  *
  * Internal helper routine only, not part of API.
  *
@@ -248,8 +238,6 @@ void CFE_ES_GenerateVersionEvents(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_GenerateBuildInfoEvents
  *
  * Internal helper routine only, not part of API.
  *
@@ -277,8 +265,6 @@ void CFE_ES_GenerateBuildInfoEvents(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_TaskInit
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -449,8 +435,6 @@ int32 CFE_ES_TaskInit(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_TaskPipe
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -667,8 +651,6 @@ void CFE_ES_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_HousekeepingCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -782,8 +764,6 @@ int32 CFE_ES_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_NoopCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -811,8 +791,6 @@ int32 CFE_ES_NoopCmd(const CFE_ES_NoopCmd_t *Cmd)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_ResetCountersCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -831,8 +809,6 @@ int32 CFE_ES_ResetCountersCmd(const CFE_ES_ResetCountersCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_RestartCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -860,8 +836,6 @@ int32 CFE_ES_RestartCmd(const CFE_ES_RestartCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_StartAppCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -966,8 +940,6 @@ int32 CFE_ES_StartAppCmd(const CFE_ES_StartAppCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_StopAppCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1017,8 +989,6 @@ int32 CFE_ES_StopAppCmd(const CFE_ES_StopAppCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_RestartAppCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1066,8 +1036,6 @@ int32 CFE_ES_RestartAppCmd(const CFE_ES_RestartAppCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_ReloadAppCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1125,8 +1093,6 @@ int32 CFE_ES_ReloadAppCmd(const CFE_ES_ReloadAppCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_QueryOneCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1192,8 +1158,6 @@ int32 CFE_ES_QueryOneCmd(const CFE_ES_QueryOneCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_QueryAllCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1297,7 +1261,7 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAllCmd_t *data)
              * the full extent of the error recovery has been done
              */
             return CFE_SUCCESS;
-        } /* end if */
+        }
 
         /*
         ** Maintain statistics of amount of data written to file
@@ -1331,7 +1295,7 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAllCmd_t *data)
                      * the full extent of the error recovery has been done
                      */
                     return CFE_SUCCESS;
-                } /* end if */
+                }
 
                 FileSize += sizeof(CFE_ES_AppInfo_t);
                 EntryCount++;
@@ -1354,8 +1318,6 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAllCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_QueryAllTasksCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1451,7 +1413,7 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasksCmd_t *data)
              * the full extent of the error recovery has been done
              */
             return CFE_SUCCESS;
-        } /* end if */
+        }
 
         /*
         ** Maintain statistics of amount of data written to file
@@ -1485,7 +1447,7 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasksCmd_t *data)
                      * the full extent of the error recovery has been done
                      */
                     return CFE_SUCCESS;
-                } /* end if */
+                }
 
                 FileSize += sizeof(CFE_ES_TaskInfo_t);
                 EntryCount++;
@@ -1508,8 +1470,6 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasksCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_ClearSysLogCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1535,8 +1495,6 @@ int32 CFE_ES_ClearSysLogCmd(const CFE_ES_ClearSysLogCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_OverWriteSysLogCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1568,8 +1526,6 @@ int32 CFE_ES_OverWriteSysLogCmd(const CFE_ES_OverWriteSysLogCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_WriteSysLogCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1609,14 +1565,12 @@ int32 CFE_ES_WriteSysLogCmd(const CFE_ES_WriteSysLogCmd_t *data)
     else
     {
         CFE_ES_Global.TaskData.CommandErrorCounter++;
-    } /* end if */
+    }
 
     return CFE_SUCCESS;
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_ClearERLogCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1651,8 +1605,6 @@ int32 CFE_ES_ClearERLogCmd(const CFE_ES_ClearERLogCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_WriteERLogCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1729,8 +1681,6 @@ int32 CFE_ES_WriteERLogCmd(const CFE_ES_WriteERLogCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_VerifyCmdLength
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1765,8 +1715,6 @@ bool CFE_ES_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_ResetPRCountCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1789,8 +1737,6 @@ int32 CFE_ES_ResetPRCountCmd(const CFE_ES_ResetPRCountCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_SetMaxPRCountCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1817,8 +1763,6 @@ int32 CFE_ES_SetMaxPRCountCmd(const CFE_ES_SetMaxPRCountCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_DeleteCDSCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1876,8 +1820,6 @@ int32 CFE_ES_DeleteCDSCmd(const CFE_ES_DeleteCDSCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_SendMemPoolStatsCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1925,8 +1867,6 @@ int32 CFE_ES_SendMemPoolStatsCmd(const CFE_ES_SendMemPoolStatsCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ES_DumpCDSRegistryCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -2054,15 +1994,12 @@ int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistryCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ES_FileWriteByteCntErr
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_FileWriteByteCntErr(const char *Filename, size_t Requested, int32 Status)
 {
-
     CFE_EVS_SendEvent(CFE_ES_FILEWRITE_ERR_EID, CFE_EVS_EventType_ERROR,
                       "File write,byte cnt err,file %s,request=%u,status=0x%08x", Filename, (unsigned int)Requested,
                       (unsigned int)Status);

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -664,8 +664,7 @@ void ES_ResetUnitTest(void)
      * so it must be re-initialized here every time CFE_ES_Global is reset.
      */
     CFE_ES_Global.ResetDataPtr = ES_UT_PersistentResetData;
-
-} /* end ES_ResetUnitTest() */
+}
 
 void TestInit(void)
 {
@@ -1100,7 +1099,6 @@ static void ES_UT_SetPerfIdle(void *UserObj, UT_EntryKey_t FuncKey, const UT_Stu
 
 static void ES_UT_ForEachObjectIncrease(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
-
     OS_ArgCallback_t callback_ptr = UT_Hook_GetArgValueByName(Context, "callback_ptr", OS_ArgCallback_t);
     void *           callback_arg = UT_Hook_GetArgValueByName(Context, "callback_arg", void *);
     int *            count        = (int *)UserObj;
@@ -1118,7 +1116,6 @@ static void ES_UT_ForEachObjectIncrease(void *UserObj, UT_EntryKey_t FuncKey, co
 
 static void ES_UT_ForEachObjectFail(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
-
     OS_ArgCallback_t callback_ptr = UT_Hook_GetArgValueByName(Context, "callback_ptr", OS_ArgCallback_t);
     void *           callback_arg = UT_Hook_GetArgValueByName(Context, "callback_arg", void *);
     osal_id_t        id           = OS_OBJECT_ID_UNDEFINED;
@@ -3521,8 +3518,7 @@ void TestTask(void)
     UT_SetHandlerFunction(UT_KEY(CFE_Config_IterateAll), ES_UT_Config_IterateAll, NULL);
     UtAssert_VOIDCALL(CFE_ES_TaskInit());
     CFE_UtAssert_PRINTF("Error sending mission version event");
-
-} /* end TestTask */
+}
 
 void TestPerf(void)
 {
@@ -5018,8 +5014,7 @@ void TestCDS()
     CFE_ES_Global.CDSIsAvailable = false;
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockIDByName(&CDSHandle, "NotNULL"), CFE_ES_NOT_IMPLEMENTED);
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockName(CDSName, CDSHandle, sizeof(CDSName)), CFE_ES_NOT_IMPLEMENTED);
-
-} /* End TestCDS */
+}
 
 void TestCDSMempool(void)
 {

--- a/modules/evs/fsw/inc/cfe_evs_msg.h
+++ b/modules/evs/fsw/inc/cfe_evs_msg.h
@@ -1165,7 +1165,6 @@ typedef struct CFE_EVS_AppTlmData
                                            \brief Application event service enable status */
     uint8 AppMessageSquelchedCounter; /**< \cfetlmmnemonic \EVS_SQUELCHEDC
                                        \brief Number of events squelched */
-
 } CFE_EVS_AppTlmData_t;
 
 /**
@@ -1207,7 +1206,6 @@ typedef struct CFE_EVS_HousekeepingTlm_Payload
 
     CFE_EVS_AppTlmData_t AppData[CFE_MISSION_ES_MAX_APPLICATIONS]; /**< \cfetlmmnemonic \EVS_APP
                                                                 \brief Array of registered application table data */
-
 } CFE_EVS_HousekeepingTlm_Payload_t;
 
 typedef struct CFE_EVS_HousekeepingTlm
@@ -1230,7 +1228,6 @@ typedef struct CFE_EVS_PacketID
                                                 \brief Spacecraft identifier */
     uint32 ProcessorID;                    /**< \cfetlmmnemonic \EVS_PROCESSORID
                                                 \brief Numerical processor identifier */
-
 } CFE_EVS_PacketID_t;
 
 /**
@@ -1253,21 +1250,18 @@ typedef struct CFE_EVS_LongEventTlm_Payload
 typedef struct CFE_EVS_ShortEventTlm_Payload
 {
     CFE_EVS_PacketID_t PacketID; /**< \brief Event packet information */
-
 } CFE_EVS_ShortEventTlm_Payload_t;
 
 typedef struct CFE_EVS_LongEventTlm
 {
     CFE_MSG_TelemetryHeader_t      TelemetryHeader; /**< \brief Telemetry header */
     CFE_EVS_LongEventTlm_Payload_t Payload;         /**< \brief Telemetry payload */
-
 } CFE_EVS_LongEventTlm_t;
 
 typedef struct CFE_EVS_ShortEventTlm
 {
     CFE_MSG_TelemetryHeader_t       TelemetryHeader; /**< \brief Telemetry header */
     CFE_EVS_ShortEventTlm_Payload_t Payload;         /**< \brief Telemetry payload */
-
 } CFE_EVS_ShortEventTlm_t;
 
 #endif /* CFE_EVS_MSG_H */

--- a/modules/evs/fsw/src/cfe_evs.c
+++ b/modules/evs/fsw/src/cfe_evs.c
@@ -35,8 +35,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_EVS_Register
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -114,8 +112,6 @@ CFE_Status_t CFE_EVS_Register(const void *Filters, uint16 NumEventFilters, uint1
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_EVS_SendEvent
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -166,8 +162,6 @@ CFE_Status_t CFE_EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spe
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_EVS_SendEventWithAppID
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -217,8 +211,6 @@ CFE_Status_t CFE_EVS_SendEventWithAppID(uint16 EventID, uint16 EventType, CFE_ES
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_EVS_SendTimedEvent
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -265,8 +257,6 @@ CFE_Status_t CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time, uint16 EventID, uin
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_EVS_ResetFilter
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -305,8 +295,6 @@ int32 CFE_EVS_ResetFilter(uint16 EventID)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_EVS_ResetAllFilters
  *
  * Implemented per public API
  * See description in header file for argument/return detail

--- a/modules/evs/fsw/src/cfe_evs_log.c
+++ b/modules/evs/fsw/src/cfe_evs_log.c
@@ -33,15 +33,12 @@
 
 /*----------------------------------------------------------------
  *
- * Function: EVS_AddLog
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void EVS_AddLog(CFE_EVS_LongEventTlm_t *EVS_PktPtr)
 {
-
     /* Serialize access to event log control variables */
     OS_MutSemTake(CFE_EVS_Global.EVS_SharedDataMutexID);
 
@@ -88,15 +85,12 @@ void EVS_AddLog(CFE_EVS_LongEventTlm_t *EVS_PktPtr)
 
 /*----------------------------------------------------------------
  *
- * Function: EVS_ClearLog
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void EVS_ClearLog(void)
 {
-
     /* Serialize access to event log control variables */
     OS_MutSemTake(CFE_EVS_Global.EVS_SharedDataMutexID);
 
@@ -112,8 +106,6 @@ void EVS_ClearLog(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_EVS_WriteLogDataFileCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -232,8 +224,6 @@ int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFileCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_EVS_SetLogModeCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail

--- a/modules/evs/fsw/src/cfe_evs_task.c
+++ b/modules/evs/fsw/src/cfe_evs_task.c
@@ -52,8 +52,6 @@ bool CFE_EVS_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength);
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_EVS_EarlyInit
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -169,8 +167,6 @@ int32 CFE_EVS_EarlyInit(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_EVS_CleanUpApp
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -196,8 +192,6 @@ int32 CFE_EVS_CleanUpApp(CFE_ES_AppId_t AppID)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_EVS_TaskMain
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -217,7 +211,7 @@ void CFE_EVS_TaskMain(void)
         CFE_ES_PerfLogExit(CFE_MISSION_EVS_MAIN_PERF_ID);
         /* Note: CFE_ES_ExitApp will not return */
         CFE_ES_ExitApp(CFE_ES_RunStatus_CORE_APP_INIT_ERROR);
-    } /* end if */
+    }
 
     /*
      * Wait for other apps to start.
@@ -248,7 +242,7 @@ void CFE_EVS_TaskMain(void)
         else
         {
             CFE_ES_WriteToSysLog("%s: Error reading cmd pipe,RC=0x%08X\n", __func__, (unsigned int)Status);
-        } /* end if */
+        }
 
     } /* end while */
 
@@ -257,8 +251,6 @@ void CFE_EVS_TaskMain(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_EVS_TaskInit
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -317,8 +309,6 @@ int32 CFE_EVS_TaskInit(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_EVS_ProcessCommandPacket
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -352,8 +342,6 @@ void CFE_EVS_ProcessCommandPacket(CFE_SB_Buffer_t *SBBufPtr)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_EVS_ProcessGroundCommand
  *
  * Internal helper routine only, not part of API.
  *
@@ -562,8 +550,6 @@ void CFE_EVS_ProcessGroundCommand(CFE_SB_Buffer_t *SBBufPtr, CFE_SB_MsgId_t MsgI
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_EVS_VerifyCmdLength
- *
  * Internal helper routine only, not part of API.
  *
  * This function validates the length of a command structure, and
@@ -599,8 +585,6 @@ bool CFE_EVS_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_EVS_NoopCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -613,8 +597,6 @@ int32 CFE_EVS_NoopCmd(const CFE_EVS_NoopCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_EVS_ClearLogCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -626,8 +608,6 @@ int32 CFE_EVS_ClearLogCmd(const CFE_EVS_ClearLogCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_EVS_ReportHousekeepingCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -680,8 +660,6 @@ int32 CFE_EVS_ReportHousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_EVS_ResetCountersCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -705,8 +683,6 @@ int32 CFE_EVS_ResetCountersCmd(const CFE_EVS_ResetCountersCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_EVS_SetFilterCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -771,8 +747,6 @@ int32 CFE_EVS_SetFilterCmd(const CFE_EVS_SetFilterCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_EVS_EnablePortsCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -792,7 +766,6 @@ int32 CFE_EVS_EnablePortsCmd(const CFE_EVS_EnablePortsCmd_t *data)
     }
     else
     {
-
         /* Process command data */
         if (((CmdPtr->BitMask & CFE_EVS_PORT1_BIT) >> 0) == true)
         {
@@ -821,8 +794,6 @@ int32 CFE_EVS_EnablePortsCmd(const CFE_EVS_EnablePortsCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_EVS_DisablePortsCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -842,7 +813,6 @@ int32 CFE_EVS_DisablePortsCmd(const CFE_EVS_DisablePortsCmd_t *data)
     }
     else
     {
-
         /* Process command data */
         if (((CmdPtr->BitMask & CFE_EVS_PORT1_BIT) >> 0) == true)
         {
@@ -871,8 +841,6 @@ int32 CFE_EVS_DisablePortsCmd(const CFE_EVS_DisablePortsCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_EVS_EnableEventTypeCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -917,8 +885,6 @@ int32 CFE_EVS_EnableEventTypeCmd(const CFE_EVS_EnableEventTypeCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_EVS_DisableEventTypeCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -965,8 +931,6 @@ int32 CFE_EVS_DisableEventTypeCmd(const CFE_EVS_DisableEventTypeCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_EVS_SetEventFormatModeCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -997,8 +961,6 @@ int32 CFE_EVS_SetEventFormatModeCmd(const CFE_EVS_SetEventFormatModeCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_EVS_EnableAppEventTypeCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1018,7 +980,6 @@ int32 CFE_EVS_EnableAppEventTypeCmd(const CFE_EVS_EnableAppEventTypeCmd_t *data)
 
     if (Status == CFE_SUCCESS)
     {
-
         /* Need to check for an out of range bitmask, since our bit masks are only 4 bits */
         if (CmdPtr->BitMask == 0x0 || CmdPtr->BitMask > 0x0F)
         {
@@ -1062,8 +1023,6 @@ int32 CFE_EVS_EnableAppEventTypeCmd(const CFE_EVS_EnableAppEventTypeCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_EVS_DisableAppEventTypeCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1083,7 +1042,6 @@ int32 CFE_EVS_DisableAppEventTypeCmd(const CFE_EVS_DisableAppEventTypeCmd_t *dat
 
     if (Status == CFE_SUCCESS)
     {
-
         /* Need to check for an out of range bitmask, since our bit masks are only 4 bits */
         if (CmdPtr->BitMask == 0x0 || CmdPtr->BitMask > 0x0F)
         {
@@ -1126,8 +1084,6 @@ int32 CFE_EVS_DisableAppEventTypeCmd(const CFE_EVS_DisableAppEventTypeCmd_t *dat
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_EVS_EnableAppEventsCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1176,8 +1132,6 @@ int32 CFE_EVS_EnableAppEventsCmd(const CFE_EVS_EnableAppEventsCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_EVS_DisableAppEventsCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1224,8 +1178,6 @@ int32 CFE_EVS_DisableAppEventsCmd(const CFE_EVS_DisableAppEventsCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_EVS_ResetAppCounterCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1274,8 +1226,6 @@ int32 CFE_EVS_ResetAppCounterCmd(const CFE_EVS_ResetAppCounterCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_EVS_ResetFilterCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1339,8 +1289,6 @@ int32 CFE_EVS_ResetFilterCmd(const CFE_EVS_ResetFilterCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_EVS_ResetAllFiltersCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1391,8 +1339,6 @@ int32 CFE_EVS_ResetAllFiltersCmd(const CFE_EVS_ResetAllFiltersCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_EVS_AddEventFilterCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1476,8 +1422,6 @@ int32 CFE_EVS_AddEventFilterCmd(const CFE_EVS_AddEventFilterCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_EVS_DeleteEventFilterCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1541,8 +1485,6 @@ int32 CFE_EVS_DeleteEventFilterCmd(const CFE_EVS_DeleteEventFilterCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_EVS_WriteAppDataFileCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail

--- a/modules/evs/fsw/src/cfe_evs_task.h
+++ b/modules/evs/fsw/src/cfe_evs_task.h
@@ -78,7 +78,6 @@ typedef struct
     uint16 Mask;    /* Binary filter mask */
     uint16 Count;   /* Binary filter counter */
     uint16 Padding; /* Structure padding */
-
 } EVS_BinFilter_t;
 
 typedef struct
@@ -94,7 +93,6 @@ typedef struct
     OS_time_t LastSquelchCreditableTime; /* Time of last squelch token return */
     int32     SquelchTokens;             /* Application event squelch token counter */
     uint8     SquelchedCount;            /* Application events squelched counter */
-
 } EVS_AppData_t;
 
 typedef struct
@@ -106,7 +104,6 @@ typedef struct
     uint8           SquelchedCount;           /* Application events squelched counter */
     uint8           Spare[3];
     EVS_BinFilter_t Filters[CFE_PLATFORM_EVS_MAX_EVENT_FILTERS]; /* Application event filters */
-
 } CFE_EVS_AppDataFile_t;
 
 /* Global data structure */

--- a/modules/evs/fsw/src/cfe_evs_utils.c
+++ b/modules/evs/fsw/src/cfe_evs_utils.c
@@ -44,8 +44,6 @@ void EVS_OutputPort4(char *Message);
 
 /*----------------------------------------------------------------
  *
- * Function: EVS_GetAppDataByID
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -68,8 +66,6 @@ EVS_AppData_t *EVS_GetAppDataByID(CFE_ES_AppId_t AppID)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: EVS_GetCurrentContext
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -112,8 +108,6 @@ int32 EVS_GetCurrentContext(EVS_AppData_t **AppDataOut, CFE_ES_AppId_t *AppIDOut
 
 /*----------------------------------------------------------------
  *
- * Function: EVS_GetApplicationInfo
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -155,8 +149,6 @@ int32 EVS_GetApplicationInfo(EVS_AppData_t **AppDataOut, const char *pAppName)
 
 /*----------------------------------------------------------------
  *
- * Function: EVS_NotRegistered
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -190,8 +182,6 @@ int32 EVS_NotRegistered(EVS_AppData_t *AppDataPtr, CFE_ES_AppId_t CallerID)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: EVS_IsFiltered
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -291,8 +281,6 @@ bool EVS_IsFiltered(EVS_AppData_t *AppDataPtr, uint16 EventID, uint16 EventType)
 
 /*----------------------------------------------------------------
  *
- * Function: EVS_CheckAndIncrementSquelchTokens
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -380,7 +368,7 @@ bool EVS_CheckAndIncrementSquelchTokens(EVS_AppData_t *AppDataPtr)
              */
             if (AppDataPtr->SquelchTokens > -EVENT_COST && CreditCount < EVENT_COST)
             {
-                // Set flag and send event later, since we still own mutex
+                /* Set flag and send event later, since we still own mutex */
                 SendSquelchEvent = true;
             }
         }
@@ -411,8 +399,6 @@ bool EVS_CheckAndIncrementSquelchTokens(EVS_AppData_t *AppDataPtr)
 
 /*----------------------------------------------------------------
  *
- * Function: EVS_FindEventID
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -434,8 +420,6 @@ EVS_BinFilter_t *EVS_FindEventID(uint16 EventID, EVS_BinFilter_t *FilterArray)
 
 /*----------------------------------------------------------------
  *
- * Function: EVS_EnableTypes
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -450,8 +434,6 @@ void EVS_EnableTypes(EVS_AppData_t *AppDataPtr, uint8 BitMask)
 
 /*----------------------------------------------------------------
  *
- * Function: EVS_DisableTypes
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -465,8 +447,6 @@ void EVS_DisableTypes(EVS_AppData_t *AppDataPtr, uint8 BitMask)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: EVS_GenerateEventTelemetry
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -553,8 +533,6 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint1
 
 /*----------------------------------------------------------------
  *
- * Function: EVS_SendViaPorts
- *
  * Internal helper routine only, not part of API.
  *
  * This routine sends a string event message out all enabled
@@ -612,8 +590,6 @@ void EVS_SendViaPorts(CFE_EVS_LongEventTlm_t *EVS_PktPtr)
 
 /*----------------------------------------------------------------
  *
- * Function: EVS_OutputPort1
- *
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
@@ -623,8 +599,6 @@ void EVS_OutputPort1(char *Message)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: EVS_OutputPort2
  *
  * Internal helper routine only, not part of API.
  *
@@ -636,8 +610,6 @@ void EVS_OutputPort2(char *Message)
 
 /*----------------------------------------------------------------
  *
- * Function: EVS_OutputPort3
- *
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
@@ -648,8 +620,6 @@ void EVS_OutputPort3(char *Message)
 
 /*----------------------------------------------------------------
  *
- * Function: EVS_OutputPort4
- *
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
@@ -659,8 +629,6 @@ void EVS_OutputPort4(char *Message)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: EVS_SendEvent
  *
  * Application-scope internal function
  * See description in header file for argument/return detail

--- a/modules/fs/fsw/src/cfe_fs_api.c
+++ b/modules/fs/fsw/src/cfe_fs_api.c
@@ -46,8 +46,6 @@ const char CFE_FS_DEFAULT_LOG_FILE_EXTENSION[]  = ".log";
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_FS_GetDefaultMountPoint
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -78,8 +76,6 @@ const char *CFE_FS_GetDefaultMountPoint(CFE_FS_FileCategory_t FileCategory)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_FS_GetDefaultExtension
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -114,8 +110,6 @@ const char *CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_t FileCategory)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_FS_ReadHeader
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -168,8 +162,6 @@ CFE_Status_t CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, osal_id_t FileDes)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_FS_InitHeader
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -189,8 +181,6 @@ void CFE_FS_InitHeader(CFE_FS_Header_t *Hdr, const char *Description, uint32 Sub
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_FS_WriteHeader
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -279,8 +269,6 @@ CFE_Status_t CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_FS_SetTimestamp
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -334,8 +322,6 @@ CFE_Status_t CFE_FS_SetTimestamp(osal_id_t FileDes, CFE_TIME_SysTime_t NewTimest
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_FS_ByteSwapCFEHeader
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -354,8 +340,6 @@ void CFE_FS_ByteSwapCFEHeader(CFE_FS_Header_t *Hdr)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_FS_ByteSwapUint32
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -373,8 +357,6 @@ void CFE_FS_ByteSwapUint32(uint32 *Uint32ToSwapPtr)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_FS_ParseInputFileNameEx
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -589,8 +571,6 @@ int32 CFE_FS_ParseInputFileNameEx(char *OutputBuffer, const char *InputBuffer, s
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_FS_ParseInputFileName
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -604,8 +584,6 @@ int32 CFE_FS_ParseInputFileName(char *OutputBuffer, const char *InputName, size_
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_FS_ExtractFilenameFromPath
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -624,7 +602,6 @@ CFE_Status_t CFE_FS_ExtractFilenameFromPath(const char *OriginalPath, char *File
     }
     else
     {
-
         /*
         ** Get the string length of the original file path
         */
@@ -684,8 +661,6 @@ CFE_Status_t CFE_FS_ExtractFilenameFromPath(const char *OriginalPath, char *File
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_FS_RunBackgroundFileDump
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -810,8 +785,7 @@ bool CFE_FS_RunBackgroundFileDump(uint32 ElapsedTime, void *Arg)
         }
 
         ++State->RecordNum;
-
-    } /* end if */
+    }
 
     /* On normal EOF close the file and generate the complete event */
     if (IsEOF)
@@ -839,15 +813,12 @@ bool CFE_FS_RunBackgroundFileDump(uint32 ElapsedTime, void *Arg)
         Meta->IsPending = false;
 
         CFE_FS_UnlockSharedData(__func__);
-
-    } /* end if */
+    }
 
     return !IsEOF;
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_FS_BackgroundFileDumpRequest
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -934,8 +905,6 @@ int32 CFE_FS_BackgroundFileDumpRequest(CFE_FS_FileWriteMetaData_t *Meta)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_FS_BackgroundFileDumpIsPending
  *
  * Implemented per public API
  * See description in header file for argument/return detail

--- a/modules/fs/fsw/src/cfe_fs_priv.c
+++ b/modules/fs/fsw/src/cfe_fs_priv.c
@@ -42,8 +42,6 @@ CFE_FS_Global_t CFE_FS_Global;
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_FS_EarlyInit
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -59,14 +57,12 @@ int32 CFE_FS_EarlyInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Shared Data Mutex creation failed! RC=%ld\n", __func__, (long)OsStatus);
         return CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
-    } /* end if */
+    }
 
     return CFE_SUCCESS;
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_FS_LockSharedData
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -83,13 +79,10 @@ void CFE_FS_LockSharedData(const char *FunctionName)
         CFE_ES_GetAppID(&AppId);
         CFE_ES_WriteToSysLog("%s: SharedData Mutex Take Err Stat=%ld,App=%lu,Function=%s\n", __func__, (long)OsStatus,
                              CFE_RESOURCEID_TO_ULONG(AppId), FunctionName);
-
-    } /* end if */
+    }
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_FS_UnlockSharedData
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -106,6 +99,5 @@ void CFE_FS_UnlockSharedData(const char *FunctionName)
         CFE_ES_GetAppID(&AppId);
         CFE_ES_WriteToSysLog("%s: SharedData Mutex Give Err Stat=%ld,App=%lu,Function=%s\n", __func__, (long)OsStatus,
                              CFE_RESOURCEID_TO_ULONG(AppId), FunctionName);
-
-    } /* end if */
+    }
 }

--- a/modules/fs/fsw/src/cfe_fs_priv.h
+++ b/modules/fs/fsw/src/cfe_fs_priv.h
@@ -123,7 +123,6 @@ typedef struct
      * (reused for each file)
      */
     CFE_FS_CurrentFileState_t Current;
-
 } CFE_FS_BackgroundFileDumpState_t;
 
 /******************************************************************************
@@ -137,7 +136,6 @@ typedef struct
     osal_id_t SharedDataMutexId;
 
     CFE_FS_BackgroundFileDumpState_t FileDump;
-
 } CFE_FS_Global_t;
 
 extern CFE_FS_Global_t CFE_FS_Global;

--- a/modules/msg/fsw/inc/ccsds_hdr.h
+++ b/modules/msg/fsw/inc/ccsds_hdr.h
@@ -50,7 +50,6 @@
  */
 typedef struct CCSDS_PrimaryHeader
 {
-
     uint8 StreamId[2]; /**< \brief packet identifier word (stream ID) */
                        /*  bits  shift   ------------ description ---------------- */
                        /* 0x07FF    0  : application ID                            */
@@ -66,7 +65,6 @@ typedef struct CCSDS_PrimaryHeader
     uint8 Length[2]; /**< \brief packet length word */
                      /*  bits  shift   ------------ description ---------------- */
                      /* 0xFFFF    0  : (total packet length) - 7                 */
-
 } CCSDS_PrimaryHeader_t;
 
 /**
@@ -74,7 +72,6 @@ typedef struct CCSDS_PrimaryHeader
  */
 typedef struct CCSDS_ExtendedHeader
 {
-
     uint8 Subsystem[2]; /**< \brief subsystem qualifier */
                         /*  bits  shift   ------------ description ---------------- */
                         /* 0x01FF   0  : Subsystem Id  mission defined              */
@@ -84,7 +81,6 @@ typedef struct CCSDS_ExtendedHeader
 
     uint8 SystemId[2]; /**< \brief system qualifier */
                        /* 0xFFFF   0  : System Id      mission defined             */
-
 } CCSDS_ExtendedHeader_t;
 
 #endif /* CCSDS_HDR_H */

--- a/modules/msg/fsw/src/cfe_msg_ccsdsext.c
+++ b/modules/msg/fsw/src/cfe_msg_ccsdsext.c
@@ -34,15 +34,12 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_SetDefaultCCSDSExt
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_MSG_SetDefaultCCSDSExt(CFE_MSG_Message_t *MsgPtr)
 {
-
     CFE_MSG_SetEDSVersion(MsgPtr, (CFE_MSG_EDSVersion_t)CFE_PLATFORM_EDSVER);
 
 #if (CFE_PLATFORM_ENDIAN == CCSDS_LITTLE_ENDIAN)
@@ -58,15 +55,12 @@ void CFE_MSG_SetDefaultCCSDSExt(CFE_MSG_Message_t *MsgPtr)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_GetEDSVersion
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetEDSVersion(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_EDSVersion_t *Version)
 {
-
     if (MsgPtr == NULL || Version == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
@@ -79,8 +73,6 @@ CFE_Status_t CFE_MSG_GetEDSVersion(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_EDSV
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_MSG_SetEDSVersion
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -100,15 +92,12 @@ CFE_Status_t CFE_MSG_SetEDSVersion(CFE_MSG_Message_t *MsgPtr, CFE_MSG_EDSVersion
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_GetEndian
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetEndian(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Endian_t *Endian)
 {
-
     if (MsgPtr == NULL || Endian == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
@@ -127,8 +116,6 @@ CFE_Status_t CFE_MSG_GetEndian(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Endian_t
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_MSG_SetEndian
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -161,15 +148,12 @@ CFE_Status_t CFE_MSG_SetEndian(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Endian_t Endia
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_GetPlaybackFlag
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetPlaybackFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_PlaybackFlag_t *PlayFlag)
 {
-
     if (MsgPtr == NULL || PlayFlag == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
@@ -188,8 +172,6 @@ CFE_Status_t CFE_MSG_GetPlaybackFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Pl
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_MSG_SetPlaybackFlag
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -222,15 +204,12 @@ CFE_Status_t CFE_MSG_SetPlaybackFlag(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Playback
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_GetSubsystem
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetSubsystem(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Subsystem_t *Subsystem)
 {
-
     if (MsgPtr == NULL || Subsystem == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
@@ -242,8 +221,6 @@ CFE_Status_t CFE_MSG_GetSubsystem(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Subsy
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_MSG_SetSubsystem
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -263,15 +240,12 @@ CFE_Status_t CFE_MSG_SetSubsystem(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Subsystem_t
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_GetSystem
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetSystem(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_System_t *System)
 {
-
     if (MsgPtr == NULL || System == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
@@ -283,8 +257,6 @@ CFE_Status_t CFE_MSG_GetSystem(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_System_t
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_MSG_SetSystem
  *
  * Implemented per public API
  * See description in header file for argument/return detail

--- a/modules/msg/fsw/src/cfe_msg_ccsdspri.c
+++ b/modules/msg/fsw/src/cfe_msg_ccsdspri.c
@@ -40,15 +40,12 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_SetDefaultCCSDSPri
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_MSG_SetDefaultCCSDSPri(CFE_MSG_Message_t *MsgPtr)
 {
-
     /* cFS standard is for secondary header to be present */
     CFE_MSG_SetHasSecondaryHeader(MsgPtr, true);
 
@@ -64,15 +61,12 @@ void CFE_MSG_SetDefaultCCSDSPri(CFE_MSG_Message_t *MsgPtr)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_GetHeaderVersion
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetHeaderVersion(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_HeaderVersion_t *Version)
 {
-
     if (MsgPtr == NULL || Version == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
@@ -85,8 +79,6 @@ CFE_Status_t CFE_MSG_GetHeaderVersion(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_H
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_MSG_SetHeaderVersion
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -106,15 +98,12 @@ CFE_Status_t CFE_MSG_SetHeaderVersion(CFE_MSG_Message_t *MsgPtr, CFE_MSG_HeaderV
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_GetType
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetType(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t *Type)
 {
-
     if (MsgPtr == NULL || Type == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
@@ -133,8 +122,6 @@ CFE_Status_t CFE_MSG_GetType(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t *Ty
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_MSG_SetType
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -167,15 +154,12 @@ CFE_Status_t CFE_MSG_SetType(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t Type)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_GetHasSecondaryHeader
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetHasSecondaryHeader(const CFE_MSG_Message_t *MsgPtr, bool *HasSecondary)
 {
-
     if (MsgPtr == NULL || HasSecondary == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
@@ -187,8 +171,6 @@ CFE_Status_t CFE_MSG_GetHasSecondaryHeader(const CFE_MSG_Message_t *MsgPtr, bool
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_MSG_SetHasSecondaryHeader
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -215,15 +197,12 @@ CFE_Status_t CFE_MSG_SetHasSecondaryHeader(CFE_MSG_Message_t *MsgPtr, bool HasSe
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_GetApId
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetApId(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t *ApId)
 {
-
     if (MsgPtr == NULL || ApId == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
@@ -235,8 +214,6 @@ CFE_Status_t CFE_MSG_GetApId(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t *Ap
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_MSG_SetApId
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -256,15 +233,12 @@ CFE_Status_t CFE_MSG_SetApId(CFE_MSG_Message_t *MsgPtr, CFE_MSG_ApId_t ApId)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_GetSegmentationFlag
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetSegmentationFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_SegmentationFlag_t *SegFlag)
 {
-
     uint16 rawval;
 
     if (MsgPtr == NULL || SegFlag == NULL)
@@ -294,8 +268,6 @@ CFE_Status_t CFE_MSG_GetSegmentationFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MS
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_MSG_SetSegmentationFlag
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -340,15 +312,12 @@ CFE_Status_t CFE_MSG_SetSegmentationFlag(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Segm
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_GetSequenceCount
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetSequenceCount(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_SequenceCount_t *SeqCnt)
 {
-
     if (MsgPtr == NULL || SeqCnt == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
@@ -360,8 +329,6 @@ CFE_Status_t CFE_MSG_GetSequenceCount(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_S
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_MSG_SetSequenceCount
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -381,8 +348,6 @@ CFE_Status_t CFE_MSG_SetSequenceCount(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Sequenc
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_GetNextSequenceCount
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -401,15 +366,12 @@ CFE_MSG_SequenceCount_t CFE_MSG_GetNextSequenceCount(CFE_MSG_SequenceCount_t Seq
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_GetSize
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetSize(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t *Size)
 {
-
     if (MsgPtr == NULL || Size == NULL)
     {
         return CFE_MSG_BAD_ARGUMENT;
@@ -421,8 +383,6 @@ CFE_Status_t CFE_MSG_GetSize(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t *Si
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_MSG_SetSize
  *
  * Implemented per public API
  * See description in header file for argument/return detail

--- a/modules/msg/fsw/src/cfe_msg_init.c
+++ b/modules/msg/fsw/src/cfe_msg_init.c
@@ -26,15 +26,12 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_Init
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_MSG_Size_t Size)
 {
-
     int32 status;
 
     if (MsgPtr == NULL)

--- a/modules/msg/fsw/src/cfe_msg_initdefaulthdr_pri.c
+++ b/modules/msg/fsw/src/cfe_msg_initdefaulthdr_pri.c
@@ -25,8 +25,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_InitDefaultHdr
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *

--- a/modules/msg/fsw/src/cfe_msg_initdefaulthdr_priext.c
+++ b/modules/msg/fsw/src/cfe_msg_initdefaulthdr_priext.c
@@ -25,8 +25,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_InitDefaultHdr
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *

--- a/modules/msg/fsw/src/cfe_msg_msgid_shared.c
+++ b/modules/msg/fsw/src/cfe_msg_msgid_shared.c
@@ -25,8 +25,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_GetTypeFromMsgId
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *

--- a/modules/msg/fsw/src/cfe_msg_msgid_v1.c
+++ b/modules/msg/fsw/src/cfe_msg_msgid_v1.c
@@ -27,15 +27,12 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_GetMsgId
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetMsgId(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgId)
 {
-
     CFE_SB_MsgId_Atom_t msgidval;
 
     if (MsgPtr == NULL || MsgId == NULL)
@@ -51,15 +48,12 @@ CFE_Status_t CFE_MSG_GetMsgId(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *M
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_SetMsgId
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_SetMsgId(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId)
 {
-
     CFE_SB_MsgId_Atom_t msgidval = CFE_SB_MsgIdToValue(MsgId);
 
     if (MsgPtr == NULL || msgidval > CFE_PLATFORM_SB_HIGHEST_VALID_MSGID)

--- a/modules/msg/fsw/src/cfe_msg_msgid_v2.c
+++ b/modules/msg/fsw/src/cfe_msg_msgid_v2.c
@@ -48,15 +48,12 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_GetMsgId
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetMsgId(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgId)
 {
-
     CFE_SB_MsgId_Atom_t msgidval;
     CFE_MSG_Type_t      type;
 
@@ -83,15 +80,12 @@ CFE_Status_t CFE_MSG_GetMsgId(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *M
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_SetMsgId
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_SetMsgId(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId)
 {
-
     CFE_SB_MsgId_Atom_t msgidval = CFE_SB_MsgIdToValue(MsgId);
 
     if (MsgPtr == NULL || msgidval > CFE_PLATFORM_SB_HIGHEST_VALID_MSGID)

--- a/modules/msg/fsw/src/cfe_msg_sechdr_checksum.c
+++ b/modules/msg/fsw/src/cfe_msg_sechdr_checksum.c
@@ -24,8 +24,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_ComputeCheckSum
- *
  * Internal helper routine only, not part of API.
  *
  * Computes checksum -
@@ -35,7 +33,6 @@
  *-----------------------------------------------------------------*/
 CFE_MSG_Checksum_t CFE_MSG_ComputeCheckSum(const CFE_MSG_Message_t *MsgPtr)
 {
-
     CFE_MSG_Size_t     PktLen  = 0;
     const uint8 *      BytePtr = MsgPtr->Byte;
     CFE_MSG_Checksum_t chksum  = 0xFF;
@@ -52,8 +49,6 @@ CFE_MSG_Checksum_t CFE_MSG_ComputeCheckSum(const CFE_MSG_Message_t *MsgPtr)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_MSG_GenerateChecksum
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -92,15 +87,12 @@ CFE_Status_t CFE_MSG_GenerateChecksum(CFE_MSG_Message_t *MsgPtr)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_ValidateChecksum
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_ValidateChecksum(const CFE_MSG_Message_t *MsgPtr, bool *IsValid)
 {
-
     CFE_Status_t   status;
     CFE_MSG_Type_t type;
     bool           hassechdr = false;

--- a/modules/msg/fsw/src/cfe_msg_sechdr_fc.c
+++ b/modules/msg/fsw/src/cfe_msg_sechdr_fc.c
@@ -26,8 +26,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_GetFcnCode
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -60,8 +58,6 @@ CFE_Status_t CFE_MSG_GetFcnCode(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_FcnCode
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_MSG_SetFcnCode
  *
  * Implemented per public API
  * See description in header file for argument/return detail

--- a/modules/msg/fsw/src/cfe_msg_sechdr_time.c
+++ b/modules/msg/fsw/src/cfe_msg_sechdr_time.c
@@ -27,15 +27,12 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_SetMsgTime
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_SetMsgTime(CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t NewTime)
 {
-
     CFE_Status_t               status;
     CFE_MSG_Type_t             type;
     bool                       hassechdr = false;
@@ -68,15 +65,12 @@ CFE_Status_t CFE_MSG_SetMsgTime(CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t Ne
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_MSG_GetMsgTime
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_GetMsgTime(const CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTime_t *Time)
 {
-
     CFE_Status_t               status;
     CFE_MSG_Type_t             type;
     bool                       hassechdr = false;

--- a/modules/msg/option_inc/default_cfe_msg_sechdr.h
+++ b/modules/msg/option_inc/default_cfe_msg_sechdr.h
@@ -59,14 +59,12 @@
  */
 typedef struct
 {
-
     uint8 FunctionCode; /**< \brief Command Function Code */
                         /* bits shift ---------description-------- */
                         /* 0x7F  0    Command function code        */
                         /* 0x80  7    Reserved                     */
 
     uint8 Checksum; /**< \brief Command checksum  (all bits, 0xFF)      */
-
 } CFE_MSG_CommandSecondaryHeader_t;
 
 /**
@@ -74,9 +72,7 @@ typedef struct
  */
 typedef struct
 {
-
     uint8 Time[6]; /**< \brief Time, big endian: 4 byte seconds, 2 byte subseconds */
-
 } CFE_MSG_TelemetrySecondaryHeader_t;
 
 #endif /* DEFAULT_CFE_MSG_SECHDR_H */

--- a/modules/msg/ut-coverage/test_cfe_msg_init.c
+++ b/modules/msg/ut-coverage/test_cfe_msg_init.c
@@ -40,7 +40,6 @@
  */
 void Test_MSG_Init(void)
 {
-
     CFE_MSG_CommandHeader_t    cmd;
     CFE_MSG_Size_t             size;
     CFE_SB_MsgId_Atom_t        msgidval_exp;

--- a/modules/resourceid/fsw/inc/cfe_core_resourceid_basevalues.h
+++ b/modules/resourceid/fsw/inc/cfe_core_resourceid_basevalues.h
@@ -70,7 +70,6 @@ enum
 
     /* configuration registry */
     CFE_RESOURCEID_CONFIGID_BASE_OFFSET = OS_OBJECT_TYPE_USER + 7,
-
 };
 
 /*

--- a/modules/resourceid/fsw/src/cfe_resourceid_api.c
+++ b/modules/resourceid/fsw/src/cfe_resourceid_api.c
@@ -50,8 +50,6 @@ CompileTimeAssert(((CFE_RESOURCEID_MAX + 1) & CFE_RESOURCEID_MAX) == 0, CFE_RESO
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ResourceId_GetBase
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -63,8 +61,6 @@ uint32 CFE_ResourceId_GetBase(CFE_ResourceId_t ResourceId)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_ResourceId_GetSerial
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -75,8 +71,6 @@ uint32 CFE_ResourceId_GetSerial(CFE_ResourceId_t ResourceId)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ResourceId_ToIndex
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -103,8 +97,6 @@ int32 CFE_ResourceId_ToIndex(CFE_ResourceId_t Id, uint32 BaseValue, uint32 Table
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_ResourceId_FindNext
  *
  * Implemented per public API
  * See description in header file for argument/return detail

--- a/modules/sb/fsw/inc/cfe_sb_msg.h
+++ b/modules/sb/fsw/inc/cfe_sb_msg.h
@@ -523,7 +523,6 @@ typedef CFE_SB_WriteFileInfoCmd_t CFE_SB_WriteMapInfoCmd_t;
 */
 typedef struct CFE_SB_RouteCmd_Payload
 {
-
     CFE_SB_MsgId_t  MsgId; /**< \brief Message ID of route to be enabled or disabled #CFE_SB_MsgId_t */
     CFE_SB_PipeId_t Pipe;  /**< \brief Pipe ID of route to be enabled or disabled #CFE_SB_PipeId_t */
     uint8           Spare; /**<\brief Spare byte to make command even number of bytes */
@@ -553,7 +552,6 @@ typedef CFE_SB_RouteCmd_t CFE_SB_DisableRouteCmd_t;
 */
 typedef struct CFE_SB_HousekeepingTlm_Payload
 {
-
     uint8 CommandCounter;       /**< \cfetlmmnemonic \SB_CMDPC
                                  \brief Count of valid commands received */
     uint8 CommandErrorCounter;  /**< \cfetlmmnemonic \SB_CMDEC
@@ -608,7 +606,6 @@ typedef struct CFE_SB_HousekeepingTlm
 */
 typedef struct CFE_SB_PipeDepthStats
 {
-
     CFE_SB_PipeId_t PipeId;   /**< \cfetlmmnemonic \SB_PDPIPEID
                                    \brief Pipe Id associated with the stats below */
     uint16 MaxQueueDepth;     /**< \cfetlmmnemonic \SB_PDDEPTH
@@ -619,7 +616,6 @@ typedef struct CFE_SB_PipeDepthStats
                               \brief Peak number of messages that have been on the pipe */
     uint16 Spare;             /**< \cfetlmmnemonic \SB_PDSPARE
                                    \brief Spare word to ensure alignment */
-
 } CFE_SB_PipeDepthStats_t;
 
 /**
@@ -649,7 +645,6 @@ typedef struct CFE_SB_PipeInfoEntry
     uint16          SendErrors;                        /**< Number of errors when writing to this pipe */
     uint8           Opts;                              /**< Pipe options set (bitmask) */
     uint8           Spare[3];                          /**< Padding to make this structure a multiple of 4 bytes */
-
 } CFE_SB_PipeInfoEntry_t;
 
 /**
@@ -659,7 +654,6 @@ typedef struct CFE_SB_PipeInfoEntry
 */
 typedef struct CFE_SB_StatsTlm_Payload
 {
-
     uint32 MsgIdsInUse;      /**< \cfetlmmnemonic \SB_SMMIDIU
                                   \brief Current number of MsgIds with a destination */
     uint32 PeakMsgIdsInUse;  /**< \cfetlmmnemonic \SB_SMPMIDIU
@@ -745,12 +739,10 @@ typedef struct CFE_SB_MsgMapFileEntry
 */
 typedef struct CFE_SB_SingleSubscriptionTlm_Payload
 {
-
     uint8           SubType; /**< \brief Subscription or Unsubscription */
     CFE_SB_MsgId_t  MsgId;   /**< \brief MsgId subscribed or unsubscribe to */
     CFE_SB_Qos_t    Qos;     /**< \brief Quality of Service, used only for interprocessor communication */
     CFE_SB_PipeId_t Pipe;    /**< \brief Destination pipe id to send above msg id  */
-
 } CFE_SB_SingleSubscriptionTlm_Payload_t;
 
 typedef struct CFE_SB_SingleSubscriptionTlm
@@ -769,11 +761,9 @@ typedef struct CFE_SB_SingleSubscriptionTlm
 */
 typedef struct CFE_SB_SubEntries
 {
-
     CFE_SB_MsgId_t  MsgId; /**< \brief MsgId portion of the subscription */
     CFE_SB_Qos_t    Qos;   /**< \brief Qos portion of the subscription */
     CFE_SB_PipeId_t Pipe;  /**< \brief PipeId portion of the subscription */
-
 } CFE_SB_SubEntries_t;
 
 /**
@@ -787,7 +777,6 @@ typedef struct CFE_SB_SubEntries
 */
 typedef struct CFE_SB_AllSubscriptionsTlm_Payload
 {
-
     uint32              PktSegment;    /**< \brief Pkt number(starts at 1) in the series */
     uint32              TotalSegments; /**< \brief Total number of pkts needed to complete the request */
     uint32              Entries;       /**< \brief Number of entries in the pkt */

--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -77,8 +77,6 @@ typedef struct
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_PipeId_ToIndex
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -89,8 +87,6 @@ CFE_Status_t CFE_SB_PipeId_ToIndex(CFE_SB_PipeId_t PipeID, uint32 *Idx)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_CreatePipe
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -207,7 +203,7 @@ CFE_Status_t CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16 Depth, const c
         if (CFE_SB_Global.StatTlmMsg.Payload.PipesInUse > CFE_SB_Global.StatTlmMsg.Payload.PeakPipesInUse)
         {
             CFE_SB_Global.StatTlmMsg.Payload.PeakPipesInUse = CFE_SB_Global.StatTlmMsg.Payload.PipesInUse;
-        } /* end if */
+        }
     }
     else
     {
@@ -277,8 +273,6 @@ CFE_Status_t CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16 Depth, const c
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_DeletePipe
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -298,8 +292,6 @@ CFE_Status_t CFE_SB_DeletePipe(CFE_SB_PipeId_t PipeId)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_DeletePipeWithAppId
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -314,8 +306,6 @@ int32 CFE_SB_DeletePipeWithAppId(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_RemovePipeFromRoute
  *
  * Internal helper routine only, not part of API.
  *
@@ -338,8 +328,6 @@ void CFE_SB_RemovePipeFromRoute(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_DeletePipeFull
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -488,8 +476,6 @@ int32 CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_SetPipeOpts
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -577,8 +563,6 @@ CFE_Status_t CFE_SB_SetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 Opts)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_GetPipeOpts
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -653,8 +637,6 @@ CFE_Status_t CFE_SB_GetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 *OptsPtr)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_GetPipeName
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -749,8 +731,6 @@ CFE_Status_t CFE_SB_GetPipeName(char *PipeNameBuf, size_t PipeNameSize, CFE_SB_P
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_GetPipeIdByName
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -809,7 +789,7 @@ CFE_Status_t CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *Pipe
                 /* grab the ID before we release the lock */
                 *PipeIdPtr = CFE_SB_PipeDescGetID(PipeDscPtr);
                 break;
-            } /* end if */
+            }
 
             --Idx;
             ++PipeDscPtr;
@@ -855,8 +835,6 @@ CFE_Status_t CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *Pipe
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_SubscribeEx
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -867,8 +845,6 @@ CFE_Status_t CFE_SB_SubscribeEx(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CF
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_SubscribeLocal
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -881,8 +857,6 @@ CFE_Status_t CFE_SB_SubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId,
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_Subscribe
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -894,8 +868,6 @@ CFE_Status_t CFE_SB_Subscribe(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_SubscribeFull
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -972,7 +944,7 @@ int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_
                 if (CFE_SB_Global.StatTlmMsg.Payload.MsgIdsInUse > CFE_SB_Global.StatTlmMsg.Payload.PeakMsgIdsInUse)
                 {
                     CFE_SB_Global.StatTlmMsg.Payload.PeakMsgIdsInUse = CFE_SB_Global.StatTlmMsg.Payload.MsgIdsInUse;
-                } /* end if */
+                }
             }
         }
     }
@@ -1136,8 +1108,6 @@ int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_Unsubscribe
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -1156,8 +1126,6 @@ CFE_Status_t CFE_SB_Unsubscribe(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_UnsubscribeLocal
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -1178,8 +1146,6 @@ CFE_Status_t CFE_SB_UnsubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeI
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_UnsubscribeWithAppId
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1194,8 +1160,6 @@ int32 CFE_SB_UnsubscribeWithAppId(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, 
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_UnsubscribeFull
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1267,7 +1231,7 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint8
                 PendingEventID = CFE_SB_UNSUB_NO_SUBS_EID;
             }
         }
-    } /* end if */
+    }
 
     CFE_SB_UnlockSharedData(__func__, __LINE__);
 
@@ -1318,8 +1282,6 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint8
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_TransmitMsg
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -1426,8 +1388,6 @@ CFE_Status_t CFE_SB_TransmitMsg(const CFE_MSG_Message_t *MsgPtr, bool IncrementS
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_TransmitMsgValidate
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1471,7 +1431,7 @@ int32 CFE_SB_TransmitMsgValidate(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t
         {
             PendingEventID = CFE_SB_MSG_TOO_BIG_EID;
             Status         = CFE_SB_MSG_TOO_BIG;
-        } /* end if */
+        }
     }
 
     if (Status == CFE_SUCCESS)
@@ -1550,18 +1510,15 @@ int32 CFE_SB_TransmitMsgValidate(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t
 
                     /* clear the bit so the task may send this event again */
                     CFE_SB_FinishSendEvent(TskId, CFE_SB_SEND_NO_SUBS_EID_BIT);
-                } /* end if */
+                }
                 break;
         }
-
-    } /* end if */
+    }
 
     return Status;
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_BroadcastBufferToRoute
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1624,7 +1581,7 @@ void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_
                 CFE_RESOURCEID_TEST_EQUAL(PipeDscPtr->AppId, AppId))
             {
                 continue;
-            } /* end if */
+            }
 
             /* if Msg limit exceeded, log event, increment counter */
             /* and go to next destination */
@@ -1637,7 +1594,7 @@ void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_
                 PipeDscPtr->SendErrors++;
 
                 continue;
-            } /* end if */
+            }
 
             /*
             ** Write the buffer descriptor to the queue of the pipe.  If the write
@@ -1721,11 +1678,9 @@ void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_
     {
         if (SBSndErr.EvtBuf[i].EventId == CFE_SB_MSGID_LIM_ERR_EID)
         {
-
             /* Determine if event can be sent without causing recursive event problem */
             if (CFE_SB_RequestToSendEvent(TskId, CFE_SB_MSGID_LIM_ERR_EID_BIT) == CFE_SB_GRANTED)
             {
-
                 CFE_SB_GetPipeName(PipeName, sizeof(PipeName), SBSndErr.EvtBuf[i].PipeId);
 
                 CFE_ES_PerfLogEntry(CFE_MISSION_SB_MSG_LIM_PERF_ID);
@@ -1738,15 +1693,13 @@ void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_
 
                 /* clear the bit so the task may send this event again */
                 CFE_SB_FinishSendEvent(TskId, CFE_SB_MSGID_LIM_ERR_EID_BIT);
-            } /* end if */
+            }
         }
         else if (SBSndErr.EvtBuf[i].EventId == CFE_SB_Q_FULL_ERR_EID)
         {
-
             /* Determine if event can be sent without causing recursive event problem */
             if (CFE_SB_RequestToSendEvent(TskId, CFE_SB_Q_FULL_ERR_EID_BIT) == CFE_SB_GRANTED)
             {
-
                 CFE_SB_GetPipeName(PipeName, sizeof(PipeName), SBSndErr.EvtBuf[i].PipeId);
 
                 CFE_ES_PerfLogEntry(CFE_MISSION_SB_PIPE_OFLOW_PERF_ID);
@@ -1759,15 +1712,13 @@ void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_
 
                 /* clear the bit so the task may send this event again */
                 CFE_SB_FinishSendEvent(TskId, CFE_SB_Q_FULL_ERR_EID_BIT);
-            } /* end if */
+            }
         }
         else
         {
-
             /* Determine if event can be sent without causing recursive event problem */
             if (CFE_SB_RequestToSendEvent(TskId, CFE_SB_Q_WR_ERR_EID_BIT) == CFE_SB_GRANTED)
             {
-
                 CFE_SB_GetPipeName(PipeName, sizeof(PipeName), SBSndErr.EvtBuf[i].PipeId);
 
                 CFE_EVS_SendEventWithAppID(CFE_SB_Q_WR_ERR_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
@@ -1777,15 +1728,12 @@ void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_
 
                 /* clear the bit so the task may send this event again */
                 CFE_SB_FinishSendEvent(TskId, CFE_SB_Q_WR_ERR_EID_BIT);
-            } /* end if */
-
-        } /* end if */
+            }
+        }
     }
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_ReceiveBuffer
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -2042,8 +1990,6 @@ CFE_Status_t CFE_SB_ReceiveBuffer(CFE_SB_Buffer_t **BufPtr, CFE_SB_PipeId_t Pipe
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_AllocateMessageBuffer
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -2102,8 +2048,6 @@ CFE_SB_Buffer_t *CFE_SB_AllocateMessageBuffer(size_t MsgSize)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_ZeroCopyBufferValidate
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -2141,8 +2085,6 @@ int32 CFE_SB_ZeroCopyBufferValidate(CFE_SB_Buffer_t *BufPtr, CFE_SB_BufferD_t **
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_ReleaseMessageBuffer
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -2169,8 +2111,6 @@ CFE_Status_t CFE_SB_ReleaseMessageBuffer(CFE_SB_Buffer_t *BufPtr)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_TransmitBuffer
  *
  * Implemented per public API
  * See description in header file for argument/return detail

--- a/modules/sb/fsw/src/cfe_sb_buf.c
+++ b/modules/sb/fsw/src/cfe_sb_buf.c
@@ -42,8 +42,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_TrackingListReset
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -56,8 +54,6 @@ void CFE_SB_TrackingListReset(CFE_SB_BufferLink_t *Link)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_TrackingListRemove
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -75,8 +71,6 @@ void CFE_SB_TrackingListRemove(CFE_SB_BufferLink_t *Node)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_TrackingListAdd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -93,8 +87,6 @@ void CFE_SB_TrackingListAdd(CFE_SB_BufferLink_t *List, CFE_SB_BufferLink_t *Node
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_GetBufferFromPool
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -122,7 +114,7 @@ CFE_SB_BufferD_t *CFE_SB_GetBufferFromPool(size_t MaxMsgSize)
     if (CFE_SB_Global.StatTlmMsg.Payload.SBBuffersInUse > CFE_SB_Global.StatTlmMsg.Payload.PeakSBBuffersInUse)
     {
         CFE_SB_Global.StatTlmMsg.Payload.PeakSBBuffersInUse = CFE_SB_Global.StatTlmMsg.Payload.SBBuffersInUse;
-    } /* end if */
+    }
 
     /* Add the size of the actual buffer to the memory-in-use ctr and */
     /* adjust the high water mark if needed */
@@ -130,7 +122,7 @@ CFE_SB_BufferD_t *CFE_SB_GetBufferFromPool(size_t MaxMsgSize)
     if (CFE_SB_Global.StatTlmMsg.Payload.MemInUse > CFE_SB_Global.StatTlmMsg.Payload.PeakMemInUse)
     {
         CFE_SB_Global.StatTlmMsg.Payload.PeakMemInUse = CFE_SB_Global.StatTlmMsg.Payload.MemInUse;
-    } /* end if */
+    }
 
     /* Initialize the buffer descriptor structure. */
     bd = (CFE_SB_BufferD_t *)addr;
@@ -146,8 +138,6 @@ CFE_SB_BufferD_t *CFE_SB_GetBufferFromPool(size_t MaxMsgSize)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_ReturnBufferToPool
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -167,8 +157,6 @@ void CFE_SB_ReturnBufferToPool(CFE_SB_BufferD_t *bd)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_IncrBufUseCnt
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -183,8 +171,6 @@ void CFE_SB_IncrBufUseCnt(CFE_SB_BufferD_t *bd)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_DecrBufUseCnt
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -205,8 +191,6 @@ void CFE_SB_DecrBufUseCnt(CFE_SB_BufferD_t *bd)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_GetDestinationBlk
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -230,14 +214,12 @@ CFE_SB_DestinationD_t *CFE_SB_GetDestinationBlk(void)
     if (CFE_SB_Global.StatTlmMsg.Payload.MemInUse > CFE_SB_Global.StatTlmMsg.Payload.PeakMemInUse)
     {
         CFE_SB_Global.StatTlmMsg.Payload.PeakMemInUse = CFE_SB_Global.StatTlmMsg.Payload.MemInUse;
-    } /* end if */
+    }
 
     return (CFE_SB_DestinationD_t *)addr;
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_PutDestinationBlk
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -250,7 +232,7 @@ int32 CFE_SB_PutDestinationBlk(CFE_SB_DestinationD_t *Dest)
     if (Dest == NULL)
     {
         return CFE_SB_BAD_ARGUMENT;
-    } /* end if */
+    }
 
     /* give the destination block back to the SB memory pool */
     Stat = CFE_ES_PutPoolBuf(CFE_SB_Global.Mem.PoolHdl, Dest);
@@ -258,7 +240,7 @@ int32 CFE_SB_PutDestinationBlk(CFE_SB_DestinationD_t *Dest)
     {
         /* Subtract the size of the destination block from the Memory in use ctr */
         CFE_SB_Global.StatTlmMsg.Payload.MemInUse -= Stat;
-    } /* end if */
+    }
 
     return CFE_SUCCESS;
 }

--- a/modules/sb/fsw/src/cfe_sb_init.c
+++ b/modules/sb/fsw/src/cfe_sb_init.c
@@ -48,8 +48,6 @@ const size_t CFE_SB_MemPoolDefSize[CFE_PLATFORM_ES_POOL_MAX_BUCKETS] = {
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_EarlyInit
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -67,7 +65,7 @@ int32 CFE_SB_EarlyInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Shared data mutex creation failed! RC=%ld\n", __func__, (long)OsStatus);
         return CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
-    } /* end if */
+    }
 
     /* Initialize the state of subscription reporting */
     CFE_SB_Global.SubscriptionReporting = CFE_SB_DISABLE;
@@ -78,7 +76,7 @@ int32 CFE_SB_EarlyInit(void)
     {
         /* error reported in CFE_SB_InitBuffers */
         return Stat;
-    } /* end if */
+    }
 
     /* Initialize the pipe table. */
     CFE_SB_InitPipeTbl();
@@ -95,15 +93,12 @@ int32 CFE_SB_EarlyInit(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_InitBuffers
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_InitBuffers(void)
 {
-
     int32 Stat = 0;
 
     Stat = CFE_ES_PoolCreateEx(&CFE_SB_Global.Mem.PoolHdl, CFE_SB_Global.Mem.Partition.Data,
@@ -128,8 +123,6 @@ int32 CFE_SB_InitBuffers(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_InitPipeTbl
  *
  * Application-scope internal function
  * See description in header file for argument/return detail

--- a/modules/sb/fsw/src/cfe_sb_msg_id_util.c
+++ b/modules/sb/fsw/src/cfe_sb_msg_id_util.c
@@ -28,8 +28,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_IsValidMsgId
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *

--- a/modules/sb/fsw/src/cfe_sb_priv.c
+++ b/modules/sb/fsw/src/cfe_sb_priv.c
@@ -80,8 +80,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_CleanUpApp
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -124,8 +122,6 @@ int32 CFE_SB_CleanUpApp(CFE_ES_AppId_t AppId)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_LockSharedData
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -141,13 +137,10 @@ void CFE_SB_LockSharedData(const char *FuncName, int32 LineNumber)
         CFE_ES_GetAppID(&AppId);
         CFE_ES_WriteToSysLog("%s: SharedData Mutex Take Err Stat=%ld,App=%lu,Func=%s,Line=%d\n", __func__,
                              (long)OsStatus, CFE_RESOURCEID_TO_ULONG(AppId), FuncName, (int)LineNumber);
-
-    } /* end if */
+    }
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_UnlockSharedData
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -164,13 +157,10 @@ void CFE_SB_UnlockSharedData(const char *FuncName, int32 LineNumber)
         CFE_ES_GetAppID(&AppId);
         CFE_ES_WriteToSysLog("%s: SharedData Mutex Give Err Stat=%ld,App=%lu,Func=%s,Line=%d\n", __func__,
                              (long)OsStatus, CFE_RESOURCEID_TO_ULONG(AppId), FuncName, (int)LineNumber);
-
-    } /* end if */
+    }
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_GetDestPtr
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -197,15 +187,12 @@ CFE_SB_DestinationD_t *CFE_SB_GetDestPtr(CFE_SBR_RouteId_t RouteId, CFE_SB_PipeI
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_ValidateMsgId
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_ValidateMsgId(CFE_SB_MsgId_t MsgId)
 {
-
     if (!CFE_SB_IsValidMsgId(MsgId))
     {
         return CFE_SB_FAILED;
@@ -213,14 +200,12 @@ int32 CFE_SB_ValidateMsgId(CFE_SB_MsgId_t MsgId)
     else
     {
         return CFE_SUCCESS;
-    } /* end if */
+    }
 }
 
 /*********************************************************************/
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_LocatePipeDescByID
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -245,8 +230,6 @@ CFE_SB_PipeD_t *CFE_SB_LocatePipeDescByID(CFE_SB_PipeId_t PipeId)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_CheckPipeDescSlotUsed
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -265,15 +248,12 @@ bool CFE_SB_CheckPipeDescSlotUsed(CFE_ResourceId_t CheckId)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_GetAppTskName
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 char *CFE_SB_GetAppTskName(CFE_ES_TaskId_t TaskId, char *FullName)
 {
-
     CFE_ES_TaskInfo_t  TaskInfo;
     CFE_ES_TaskInfo_t *ptr = &TaskInfo;
     char               AppName[OS_MAX_API_NAME];
@@ -281,21 +261,18 @@ char *CFE_SB_GetAppTskName(CFE_ES_TaskId_t TaskId, char *FullName)
 
     if (CFE_ES_GetTaskInfo(ptr, TaskId) != CFE_SUCCESS)
     {
-
         /* unlikely, but possible if TaskId is bogus */
         strncpy(FullName, "Unknown", OS_MAX_API_NAME - 1);
         FullName[OS_MAX_API_NAME - 1] = '\0';
     }
     else if (strncmp((char *)ptr->AppName, (char *)ptr->TaskName, sizeof(ptr->AppName)) == 0)
     {
-
         /* if app name and task name are the same */
         strncpy(FullName, (char *)ptr->AppName, OS_MAX_API_NAME - 1);
         FullName[OS_MAX_API_NAME - 1] = '\0';
     }
     else
     {
-
         /* AppName and TskName buffers and strncpy are needed to limit string sizes */
         strncpy(AppName, (char *)ptr->AppName, sizeof(AppName) - 1);
         AppName[sizeof(AppName) - 1] = '\0';
@@ -303,15 +280,12 @@ char *CFE_SB_GetAppTskName(CFE_ES_TaskId_t TaskId, char *FullName)
         TskName[sizeof(TskName) - 1] = '\0';
 
         sprintf(FullName, "%s.%s", AppName, TskName);
-
-    } /* end if */
+    }
 
     return FullName;
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_RequestToSendEvent
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -319,7 +293,6 @@ char *CFE_SB_GetAppTskName(CFE_ES_TaskId_t TaskId, char *FullName)
  *-----------------------------------------------------------------*/
 uint32 CFE_SB_RequestToSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit)
 {
-
     uint32 Indx;
 
     if (CFE_ES_TaskID_ToIndex(TaskId, &Indx) != CFE_SUCCESS)
@@ -330,21 +303,16 @@ uint32 CFE_SB_RequestToSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit)
     /* if bit is set... */
     if (CFE_TST(CFE_SB_Global.StopRecurseFlags[Indx], Bit))
     {
-
         return CFE_SB_DENIED;
     }
     else
     {
-
         CFE_SET(CFE_SB_Global.StopRecurseFlags[Indx], Bit);
         return CFE_SB_GRANTED;
-
-    } /* end if */
+    }
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_FinishSendEvent
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -352,7 +320,6 @@ uint32 CFE_SB_RequestToSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit)
  *-----------------------------------------------------------------*/
 void CFE_SB_FinishSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit)
 {
-
     uint32 Indx;
 
     if (CFE_ES_TaskID_ToIndex(TaskId, &Indx) != CFE_SUCCESS)
@@ -366,15 +333,12 @@ void CFE_SB_FinishSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_AddDestNode
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_AddDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *NewNode)
 {
-
     CFE_SB_DestinationD_t *WBS; /* Will Be Second (WBS) node */
     CFE_SB_DestinationD_t *listheadptr;
 
@@ -407,8 +371,6 @@ int32 CFE_SB_AddDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *NewNo
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_RemoveDest
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -421,8 +383,6 @@ void CFE_SB_RemoveDest(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *DestPtr
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_RemoveDestNode
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -447,7 +407,6 @@ void CFE_SB_RemoveDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *Nod
     }
     else if (NodeToRemove->Next == NULL)
     {
-
         /* Last in the list, remove previous pointer */
         PrevNode       = NodeToRemove->Prev;
         PrevNode->Next = NULL;
@@ -467,8 +426,6 @@ void CFE_SB_RemoveDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *Nod
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_ZeroCopyReleaseAppId
  *
  * Application-scope internal function
  * See description in header file for argument/return detail

--- a/modules/sb/fsw/src/cfe_sb_priv.h
+++ b/modules/sb/fsw/src/cfe_sb_priv.h
@@ -107,7 +107,6 @@ typedef struct CFE_SB_BufferLink
 {
     struct CFE_SB_BufferLink *Next;
     struct CFE_SB_BufferLink *Prev;
-
 } CFE_SB_BufferLink_t;
 
 /******************************************************************************
@@ -156,7 +155,6 @@ typedef struct CFE_SB_BufferD
     uint16 UseCount; /**< Number of active references to this buffer in the system */
 
     CFE_SB_Buffer_t Content; /* Variably sized content field, Keep last */
-
 } CFE_SB_BufferD_t;
 
 /******************************************************************************
@@ -189,10 +187,8 @@ typedef struct
 */
 typedef struct
 {
-
     CFE_ES_MemHandle_t PoolHdl;
     CFE_ES_STATIC_POOL_TYPE(CFE_PLATFORM_SB_BUF_MEMORY_BYTES) Partition;
-
 } CFE_SB_MemParams_t;
 
 /*******************************************************************************/
@@ -260,7 +256,6 @@ typedef struct
 
     /* A list of buffers currently issued to apps for zero-copy */
     CFE_SB_BufferLink_t ZeroCopyList;
-
 } CFE_SB_Global_t;
 
 /******************************************************************************

--- a/modules/sb/fsw/src/cfe_sb_task.c
+++ b/modules/sb/fsw/src/cfe_sb_task.c
@@ -50,8 +50,6 @@ typedef struct
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_TaskMain
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -71,7 +69,7 @@ void CFE_SB_TaskMain(void)
         CFE_ES_PerfLogExit(CFE_MISSION_SB_MAIN_PERF_ID);
         /* Note: CFE_ES_ExitApp will not return */
         CFE_ES_ExitApp(CFE_ES_RunStatus_CORE_APP_INIT_ERROR);
-    } /* end if */
+    }
 
     /*
      * Wait for other apps to start.
@@ -102,7 +100,7 @@ void CFE_SB_TaskMain(void)
         else
         {
             CFE_ES_WriteToSysLog("%s: Error reading cmd pipe,RC=0x%08X\n", __func__, (unsigned int)Status);
-        } /* end if */
+        }
 
     } /* end while */
 
@@ -112,15 +110,12 @@ void CFE_SB_TaskMain(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_AppInit
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_SB_AppInit(void)
 {
-
     uint32              CfgFileEventsToFilter = 0;
     CFE_ES_MemPoolBuf_t TmpPtr;
     int32               Status;
@@ -134,63 +129,63 @@ int32 CFE_SB_AppInit(void)
         CFE_SB_Global.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT1;
         CFE_SB_Global.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK1;
         CfgFileEventsToFilter++;
-    } /* end if */
+    }
 
     if (CFE_PLATFORM_SB_FILTERED_EVENT2 != 0)
     {
         CFE_SB_Global.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT2;
         CFE_SB_Global.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK2;
         CfgFileEventsToFilter++;
-    } /* end if */
+    }
 
     if (CFE_PLATFORM_SB_FILTERED_EVENT3 != 0)
     {
         CFE_SB_Global.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT3;
         CFE_SB_Global.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK3;
         CfgFileEventsToFilter++;
-    } /* end if */
+    }
 
     if (CFE_PLATFORM_SB_FILTERED_EVENT4 != 0)
     {
         CFE_SB_Global.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT4;
         CFE_SB_Global.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK4;
         CfgFileEventsToFilter++;
-    } /* end if */
+    }
 
     if (CFE_PLATFORM_SB_FILTERED_EVENT5 != 0)
     {
         CFE_SB_Global.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT5;
         CFE_SB_Global.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK5;
         CfgFileEventsToFilter++;
-    } /* end if */
+    }
 
     if (CFE_PLATFORM_SB_FILTERED_EVENT6 != 0)
     {
         CFE_SB_Global.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT6;
         CFE_SB_Global.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK6;
         CfgFileEventsToFilter++;
-    } /* end if */
+    }
 
     if (CFE_PLATFORM_SB_FILTERED_EVENT7 != 0)
     {
         CFE_SB_Global.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT7;
         CFE_SB_Global.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK7;
         CfgFileEventsToFilter++;
-    } /* end if */
+    }
 
     if (CFE_PLATFORM_SB_FILTERED_EVENT8 != 0)
     {
         CFE_SB_Global.EventFilters[CfgFileEventsToFilter].EventID = CFE_PLATFORM_SB_FILTERED_EVENT8;
         CFE_SB_Global.EventFilters[CfgFileEventsToFilter].Mask    = CFE_PLATFORM_SB_FILTER_MASK8;
         CfgFileEventsToFilter++;
-    } /* end if */
+    }
 
     /* Be sure the number of events to register for filtering
     ** does not exceed CFE_PLATFORM_EVS_MAX_EVENT_FILTERS */
     if (CFE_PLATFORM_EVS_MAX_EVENT_FILTERS < CfgFileEventsToFilter)
     {
         CfgFileEventsToFilter = CFE_PLATFORM_EVS_MAX_EVENT_FILTERS;
-    } /* end if */
+    }
 
     /* Register event filter table... */
     Status = CFE_EVS_Register(CFE_SB_Global.EventFilters, CfgFileEventsToFilter, CFE_EVS_EventFilter_BINARY);
@@ -198,7 +193,7 @@ int32 CFE_SB_AppInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Call to CFE_EVS_Register Failed:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
     CFE_ES_WriteToSysLog("%s: Registered %d events for filtering\n", __func__, (int)CfgFileEventsToFilter);
 
@@ -224,7 +219,7 @@ int32 CFE_SB_AppInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Call to CFE_SB_CreatePipe Failed:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
     Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_SB_CMD_MID), CFE_SB_Global.CmdPipe);
 
@@ -232,7 +227,7 @@ int32 CFE_SB_AppInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Subscribe to Cmds Failed:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
     Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_SB_SEND_HK_MID), CFE_SB_Global.CmdPipe);
 
@@ -240,7 +235,7 @@ int32 CFE_SB_AppInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Subscribe to HK Request Failed:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
     Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_SB_SUB_RPT_CTRL_MID), CFE_SB_Global.CmdPipe);
 
@@ -249,7 +244,7 @@ int32 CFE_SB_AppInit(void)
         CFE_ES_WriteToSysLog("%s: Subscribe to Subscription Report Request Failed:RC=0x%08X\n", __func__,
                              (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
     /* Ensure a ground commanded reset does not get blocked if SB mem pool  */
     /* becomes fully configured (DCR6772) */
@@ -259,7 +254,7 @@ int32 CFE_SB_AppInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Init error, GetPool Failed:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
     /* Return mem block used on previous call,the actual memory is not needed.*/
     /* The SB mem pool is now configured with a block size for the reset cmd. */
@@ -269,7 +264,7 @@ int32 CFE_SB_AppInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Init error, PutPool Failed:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
     Status =
         CFE_EVS_SendEvent(CFE_SB_INIT_EID, CFE_EVS_EventType_INFORMATION, "cFE SB Initialized: %s", CFE_VERSION_STRING);
@@ -277,14 +272,12 @@ int32 CFE_SB_AppInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Error sending init event:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
     return CFE_SUCCESS;
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_VerifyCmdLength
  *
  * Internal helper routine only, not part of API.
  *
@@ -321,8 +314,6 @@ bool CFE_SB_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_ProcessCmdPipePkt
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -336,7 +327,6 @@ void CFE_SB_ProcessCmdPipePkt(CFE_SB_Buffer_t *SBBufPtr)
 
     switch (CFE_SB_MsgIdToValue(MessageID))
     {
-
         case CFE_SB_SEND_HK_MID:
             /* Note: Command counter not incremented for this command */
             CFE_SB_SendHKTlmCmd((CFE_MSG_CommandHeader_t *)SBBufPtr);
@@ -456,8 +446,6 @@ void CFE_SB_ProcessCmdPipePkt(CFE_SB_Buffer_t *SBBufPtr)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_NoopCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -471,8 +459,6 @@ int32 CFE_SB_NoopCmd(const CFE_SB_NoopCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_ResetCountersCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -489,8 +475,6 @@ int32 CFE_SB_ResetCountersCmd(const CFE_SB_ResetCountersCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_EnableSubReportingCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -503,8 +487,6 @@ int32 CFE_SB_EnableSubReportingCmd(const CFE_SB_EnableSubReportingCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_DisableSubReportingCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -516,8 +498,6 @@ int32 CFE_SB_DisableSubReportingCmd(const CFE_SB_DisableSubReportingCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_SendHKTlmCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -541,15 +521,12 @@ int32 CFE_SB_SendHKTlmCmd(const CFE_MSG_CommandHeader_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_ResetCounters
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_ResetCounters(void)
 {
-
     CFE_SB_Global.HKTlmMsg.Payload.CommandCounter                = 0;
     CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter           = 0;
     CFE_SB_Global.HKTlmMsg.Payload.NoSubscribersCounter          = 0;
@@ -564,8 +541,6 @@ void CFE_SB_ResetCounters(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_EnableRouteCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -607,8 +582,7 @@ int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data)
             PendingEventID  = CFE_SB_ENBL_RTE2_EID;
             CFE_SB_Global.HKTlmMsg.Payload.CommandCounter++;
         }
-
-    } /* end if */
+    }
 
     CFE_SB_UnlockSharedData(__func__, __LINE__);
 
@@ -634,8 +608,6 @@ int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_DisableRouteCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -677,8 +649,7 @@ int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data)
             PendingEventID  = CFE_SB_DSBL_RTE2_EID;
             CFE_SB_Global.HKTlmMsg.Payload.CommandCounter++;
         }
-
-    } /* end if */
+    }
 
     CFE_SB_UnlockSharedData(__func__, __LINE__);
 
@@ -704,8 +675,6 @@ int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_SendStatsCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -766,8 +735,6 @@ int32 CFE_SB_SendStatsCmd(const CFE_SB_SendSbStatsCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_CollectRouteInfo
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -848,8 +815,6 @@ void CFE_SB_CollectRouteInfo(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_SendSubscriptionReport
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -883,8 +848,6 @@ int32 CFE_SB_SendSubscriptionReport(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_WriteRouteInfoDataGetter
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -916,8 +879,6 @@ bool CFE_SB_WriteRouteInfoDataGetter(void *Meta, uint32 RecordNum, void **Buffer
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_BackgroundFileEventHandler
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -964,8 +925,6 @@ void CFE_SB_BackgroundFileEventHandler(void *Meta, CFE_FS_FileWriteEvent_t Event
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_WriteRoutingInfoCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1027,8 +986,6 @@ int32 CFE_SB_WriteRoutingInfoCmd(const CFE_SB_WriteRoutingInfoCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_WritePipeInfoDataGetter
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1108,8 +1065,6 @@ bool CFE_SB_WritePipeInfoDataGetter(void *Meta, uint32 RecordNum, void **Buffer,
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_WritePipeInfoCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1171,8 +1126,6 @@ int32 CFE_SB_WritePipeInfoCmd(const CFE_SB_WritePipeInfoCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_CollectMsgMapInfo
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1195,8 +1148,6 @@ void CFE_SB_CollectMsgMapInfo(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_WriteMsgMapInfoDataGetter
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1237,8 +1188,6 @@ bool CFE_SB_WriteMsgMapInfoDataGetter(void *Meta, uint32 RecordNum, void **Buffe
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_WriteMapInfoCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1301,8 +1250,6 @@ int32 CFE_SB_WriteMapInfoCmd(const CFE_SB_WriteMapInfoCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_SendRouteSub
- *
  * Internal helper routine only, not part of API.
  *
  * Callback for sending route subscriptions
@@ -1318,10 +1265,8 @@ void CFE_SB_SendRouteSub(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
     /* Loop through destinations */
     while (destptr != NULL)
     {
-
         if (destptr->Scope == CFE_SB_MSG_GLOBAL)
         {
-
             /* ...add entry into pkt */
             CFE_SB_Global.PrevSubMsg.Payload.Entry[CFE_SB_Global.PrevSubMsg.Payload.Entries].MsgId =
                 CFE_SBR_GetMsgId(RouteId);
@@ -1359,8 +1304,6 @@ void CFE_SB_SendRouteSub(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_SendPrevSubsCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1396,15 +1339,12 @@ int32 CFE_SB_SendPrevSubsCmd(const CFE_SB_SendPrevSubsCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_IncrCmdCtr
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_SB_IncrCmdCtr(int32 status)
 {
-
     if (status == CFE_SUCCESS)
     {
         CFE_SB_Global.HKTlmMsg.Payload.CommandCounter++;
@@ -1412,12 +1352,10 @@ void CFE_SB_IncrCmdCtr(int32 status)
     else
     {
         CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter++;
-    } /* end if */
+    }
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_SetSubscriptionReporting
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1425,6 +1363,5 @@ void CFE_SB_IncrCmdCtr(int32 status)
  *-----------------------------------------------------------------*/
 void CFE_SB_SetSubscriptionReporting(uint32 state)
 {
-
     CFE_SB_Global.SubscriptionReporting = state;
 }

--- a/modules/sb/fsw/src/cfe_sb_util.c
+++ b/modules/sb/fsw/src/cfe_sb_util.c
@@ -37,8 +37,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_MsgHdrSize
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -77,8 +75,6 @@ size_t CFE_SB_MsgHdrSize(const CFE_MSG_Message_t *MsgPtr)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_GetUserData
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -102,8 +98,6 @@ void *CFE_SB_GetUserData(CFE_MSG_Message_t *MsgPtr)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_GetUserDataLength
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -125,8 +119,6 @@ size_t CFE_SB_GetUserDataLength(const CFE_MSG_Message_t *MsgPtr)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_SetUserDataLength
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -159,8 +151,6 @@ void CFE_SB_SetUserDataLength(CFE_MSG_Message_t *MsgPtr, size_t DataLength)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SB_TimeStampMsg
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -171,8 +161,6 @@ void CFE_SB_TimeStampMsg(CFE_MSG_Message_t *MsgPtr)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_MessageStringGet
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -228,8 +216,6 @@ int32 CFE_SB_MessageStringGet(char *DestStringPtr, const char *SourceStringPtr, 
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SB_MessageStringSet
  *
  * Implemented per public API
  * See description in header file for argument/return detail

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -211,8 +211,7 @@ void UtTest_Setup(void)
     Test_SB_Utils();
 
     Test_SB_SpecialCases();
-
-} /* end main */
+}
 
 /*
 ** Reset variable values and sockets prior to a test
@@ -221,7 +220,7 @@ void SB_ResetUnitTest(void)
 {
     UT_InitData();
     CFE_SB_EarlyInit();
-} /* end SB_ResetUnitTest */
+}
 
 /*
 ** Function for calling SB application initialization
@@ -237,7 +236,7 @@ void Test_SB_AppInit(void)
     SB_UT_ADD_SUBTEST(Test_SB_AppInit_Sub3Fail);
     SB_UT_ADD_SUBTEST(Test_SB_AppInit_GetPoolFail);
     SB_UT_ADD_SUBTEST(Test_SB_AppInit_PutPoolFail);
-} /* end Test_SB_AppInit */
+}
 
 /*
 ** Test task init with EVS_Register returning error
@@ -250,8 +249,7 @@ void Test_SB_AppInit_EVSRegFail(void)
     UtAssert_INT32_EQ(CFE_SB_AppInit(), ForcedRtnVal);
 
     CFE_UtAssert_EVENTCOUNT(0);
-
-} /* end Test_SB_AppInit_EVSRegFail */
+}
 
 /*
 ** Test task init with EVS_SendEvent returning error on task init event
@@ -279,8 +277,7 @@ void Test_SB_AppInit_EVSSendEvtFail(void)
     CFE_UtAssert_EVENTCOUNT(4);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(CFE_SB_Global.CmdPipe));
-
-} /* end Test_SB_AppInit_EVSSendEvtFail */
+}
 
 /*
 ** Test task init with pipe create failure
@@ -296,8 +293,7 @@ void Test_SB_AppInit_CrPipeFail(void)
     CFE_UtAssert_EVENTCOUNT(1);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_CR_PIPE_ERR_EID);
-
-} /* end Test_SB_AppInit_CrPipeFail */
+}
 
 /*
 ** Test task init with a failure on first subscription request
@@ -312,8 +308,7 @@ void Test_SB_AppInit_Sub1Fail(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_DEST_BLK_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(CFE_SB_Global.CmdPipe));
-
-} /* end Test_SB_AppInit_Sub1Fail */
+}
 
 /*
 ** Test task init with a failure on second subscription request
@@ -328,8 +323,7 @@ void Test_SB_AppInit_Sub2Fail(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_DEST_BLK_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(CFE_SB_Global.CmdPipe));
-
-} /* end Test_SB_AppInit_Sub2Fail */
+}
 
 /*
 ** Test task init with a failure on second subscription request
@@ -344,8 +338,7 @@ void Test_SB_AppInit_Sub3Fail(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_DEST_BLK_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(CFE_SB_Global.CmdPipe));
-
-} /* end Test_SB_AppInit_Sub3Fail */
+}
 
 /*
 ** Test task init with a GetPool failure
@@ -361,8 +354,7 @@ void Test_SB_AppInit_GetPoolFail(void)
     CFE_UtAssert_EVENTCOUNT(4);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(CFE_SB_Global.CmdPipe));
-
-} /* end Test_SB_AppInit_GetPoolFail */
+}
 
 /*
 ** Test task init with a PutPool failure
@@ -378,8 +370,7 @@ void Test_SB_AppInit_PutPoolFail(void)
     CFE_UtAssert_EVENTCOUNT(4);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(CFE_SB_Global.CmdPipe));
-
-} /* end Test_SB_AppInit_PutPoolFail */
+}
 
 /*
 ** Function for calling SB main task test functions
@@ -389,7 +380,7 @@ void Test_SB_MainRoutine(void)
     SB_UT_ADD_SUBTEST(Test_SB_Main_RcvErr);
     SB_UT_ADD_SUBTEST(Test_SB_Main_InitErr);
     SB_UT_ADD_SUBTEST(Test_SB_Main_Nominal);
-} /* end Test_SB_MainRoutine */
+}
 
 /*
 ** Test main task with a packet receive error
@@ -406,8 +397,7 @@ void Test_SB_Main_RcvErr(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_Q_RD_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(CFE_SB_Global.CmdPipe));
-
-} /* end Test_SB_Main_RcvErr */
+}
 
 static void SB_UT_PipeGetHandler(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
@@ -459,8 +449,7 @@ void Test_SB_Main_Nominal(void)
     /* remove the handler so the pipe can be deleted */
     UT_SetHandlerFunction(UT_KEY(OS_QueueGet), NULL, NULL);
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(CFE_SB_Global.CmdPipe));
-
-} /* end Test_SB_Main_RcvErr */
+}
 
 /*
 ** Test main task with an application initialization error
@@ -473,8 +462,7 @@ void Test_SB_Main_InitErr(void)
     CFE_UtAssert_EVENTCOUNT(4);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(CFE_SB_Global.CmdPipe));
-
-} /* end Test_SB_Main_InitErr */
+}
 
 /*
 ** Function for calling SB command test functions
@@ -511,7 +499,7 @@ void Test_SB_Cmds(void)
     SB_UT_ADD_SUBTEST(Test_SB_Cmds_CmdUnexpCmdCode);
     SB_UT_ADD_SUBTEST(Test_SB_Cmds_BadCmdLength);
     SB_UT_ADD_SUBTEST(Test_SB_Cmds_UnexpMsgId);
-} /* end Test_SB_Cmds */
+}
 
 /*
 ** Test no-op command
@@ -534,8 +522,7 @@ void Test_SB_Cmds_Noop(void)
 
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &Noop.SBBuf.Msg, 0, UT_TPID_CFE_SB_CMD_NOOP_CC);
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
-
-} /* end Test_SB_Cmds_Noop */
+}
 
 /*
 ** Test reset counters command
@@ -559,7 +546,6 @@ void Test_SB_Cmds_RstCtrs(void)
 
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &ResetCounters.SBBuf.Msg, 0, UT_TPID_CFE_SB_CMD_RESET_COUNTERS_CC);
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
-
 } /* Test_SB_Cmds_RstCtrs */
 
 /*
@@ -607,8 +593,7 @@ void Test_SB_Cmds_Stats(void)
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId2));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId3));
-
-} /* end Test_SB_Cmds_Stats */
+}
 
 /*
 ** Test write routing information command using the default file name
@@ -646,8 +631,7 @@ void Test_SB_Cmds_RoutingInfoDef(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(CFE_SB_Global.CmdPipe));
-
-} /* end Test_SB_Cmds_RoutingInfoDef */
+}
 
 /*
 ** Test write routing information command with request already pending
@@ -673,8 +657,7 @@ void Test_SB_Cmds_RoutingInfoAlreadyPending(void)
     CFE_UtAssert_EVENTCOUNT(1);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_SND_RTG_ERR1_EID);
-
-} /* end Test_SB_Cmds_RoutingInfoSpec */
+}
 
 /*
 **  Test send routing information command data getter
@@ -751,7 +734,7 @@ void Test_SB_Cmds_RoutingInfoDataGetter(void)
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId2));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId3));
-} /* end Test_SB_Cmds_RoutingInfoDataGetter */
+}
 
 /*
 ** Test send pipe information command default / nominal path
@@ -794,8 +777,7 @@ void Test_SB_Cmds_PipeInfoDef(void)
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId2));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId3));
-
-} /* end Test_SB_Cmds_PipeInfoDef */
+}
 
 /*
 ** Test write pipe information command when already pending
@@ -821,8 +803,7 @@ void Test_SB_Cmds_PipeInfoAlreadyPending(void)
     CFE_UtAssert_EVENTCOUNT(1);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_SND_RTG_ERR1_EID);
-
-} /* end Test_SB_Cmds_PipeInfoAlreadyPending */
+}
 
 /*
 ** Test write pipe information data getter
@@ -863,7 +844,7 @@ void Test_SB_Cmds_PipeInfoDataGetter(void)
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId2));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId3));
-} /* end Test_SB_Cmds_PipeInfoDataGetter */
+}
 
 /*
 ** Test background file write event generator
@@ -942,7 +923,7 @@ void Test_SB_Cmds_MapInfoDataGetter(void)
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId2));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId3));
-} /* end Test_SB_MapInfoDataGetter */
+}
 
 /*
 ** Test write map information command nominal path
@@ -1001,8 +982,7 @@ void Test_SB_Cmds_MapInfoDef(void)
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId2));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId3));
-
-} /* end Test_SB_Cmds_MapInfoDef */
+}
 
 /*
 ** Test write map information command when already pending
@@ -1028,15 +1008,13 @@ void Test_SB_Cmds_MapInfoAlreadyPending(void)
     CFE_UtAssert_EVENTCOUNT(1);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_SND_RTG_ERR1_EID);
-
-} /* end Test_SB_Cmds_MapInfoSpec */
+}
 
 /*
 ** Test command to enable a specific route using a valid route
 */
 void Test_SB_Cmds_EnRouteValParam(void)
 {
-
     union
     {
         CFE_SB_Buffer_t         SBBuf;
@@ -1069,8 +1047,7 @@ void Test_SB_Cmds_EnRouteValParam(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_SB_Cmds_EnRouteValParam */
+}
 
 /*
 ** Test command to enable a specific route using a non-existent route
@@ -1106,8 +1083,7 @@ void Test_SB_Cmds_EnRouteNonExist(void)
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId2));
-
-} /* end Test_SB_Cmds_EnRouteNonExist */
+}
 
 /*
 ** Test command to enable a specific route using an invalid pipe ID
@@ -1131,8 +1107,7 @@ void Test_SB_Cmds_EnRouteInvParam(void)
     CFE_UtAssert_EVENTCOUNT(1);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_ENBL_RTE3_EID);
-
-} /* end Test_SB_Cmds_EnRouteInvParam */
+}
 
 /*
 ** Test command to enable a specific route using an invalid message ID
@@ -1156,8 +1131,7 @@ void Test_SB_Cmds_EnRouteInvParam2(void)
     CFE_UtAssert_EVENTCOUNT(1);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_ENBL_RTE3_EID);
-
-} /* end Test_SB_Cmds_EnRouteInvParam2 */
+}
 
 /*
 ** Test command to enable a specific route using a message ID greater
@@ -1182,8 +1156,7 @@ void Test_SB_Cmds_EnRouteInvParam3(void)
     CFE_UtAssert_EVENTCOUNT(1);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_ENBL_RTE3_EID);
-
-} /* end Test_SB_Cmds_EnRouteInvParam3 */
+}
 
 /*
 **  Test command to disable a specific route using a valid route
@@ -1222,8 +1195,7 @@ void Test_SB_Cmds_DisRouteValParam(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_SB_Cmds_DisRouteValParam */
+}
 
 /*
 ** Test command to disable a specific route using an invalid pipe ID
@@ -1259,8 +1231,7 @@ void Test_SB_Cmds_DisRouteNonExist(void)
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId2));
-
-} /* end Test_SB_Cmds_DisRouteNonExist */
+}
 
 /*
 ** Test command to disable a specific route using an invalid pipe ID
@@ -1284,8 +1255,7 @@ void Test_SB_Cmds_DisRouteInvParam(void)
     CFE_UtAssert_EVENTCOUNT(1);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_DSBL_RTE3_EID);
-
-} /* end Test_SB_Cmds_DisRouteInvParam */
+}
 
 /*
 ** Test command to disable a specific route using an invalid message ID
@@ -1309,8 +1279,7 @@ void Test_SB_Cmds_DisRouteInvParam2(void)
     CFE_UtAssert_EVENTCOUNT(1);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_DSBL_RTE3_EID);
-
-} /* end Test_SB_Cmds_DisRouteInvParam2 */
+}
 
 /*
 ** Test command to disable a specific route using a message ID greater
@@ -1335,8 +1304,7 @@ void Test_SB_Cmds_DisRouteInvParam3(void)
     CFE_UtAssert_EVENTCOUNT(1);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_DSBL_RTE3_EID);
-
-} /* end Test_SB_Cmds_DisRouteInvParam3 */
+}
 
 /*
 ** Test send housekeeping information command
@@ -1367,8 +1335,7 @@ void Test_SB_Cmds_SendHK(void)
     CFE_UtAssert_EVENTCOUNT(1);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_SEND_NO_SUBS_EID);
-
-} /* end Test_SB_Cmds_SendHK */
+}
 
 /*
 ** Test command to build and send a SB packet containing a complete
@@ -1498,8 +1465,7 @@ void Test_SB_Cmds_SendPrevSubs(void)
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId2));
-
-} /* end Test_SB_Cmds_SendPrevSubs */
+}
 
 /*
 ** Test command to enable subscription reporting
@@ -1527,8 +1493,7 @@ void Test_SB_Cmds_SubRptOn(void)
                     UT_TPID_CFE_SB_SUB_RPT_CTL_ENABLE_SUB_REPORTING_CC);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
-
-} /* end Test_SB_Cmds_SubRptOn */
+}
 
 /*
 ** Test command to disable subscription reporting
@@ -1556,8 +1521,7 @@ void Test_SB_Cmds_SubRptOff(void)
                     UT_TPID_CFE_SB_SUB_RPT_CTL_DISABLE_SUB_REPORTING_CC);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
-
-} /* end Test_SB_Cmds_SubRptOff */
+}
 
 /*
 ** Test command handler response to an invalid command code
@@ -1571,8 +1535,7 @@ void Test_SB_Cmds_CmdUnexpCmdCode(void)
 
     UT_SetupBasicMsgDispatch(&UT_TPID_CFE_SB_SUB_RPT_CTRL_BAD_FCNCODE, sizeof(CFE_MSG_CommandHeader_t), true);
     CFE_SB_ProcessCmdPipePkt((CFE_SB_Buffer_t *)NULL);
-
-} /* end Test_SB_Cmds_UnexpCmdCode */
+}
 
 /*
 ** Test command handler response to an incorrect length
@@ -1594,8 +1557,7 @@ void Test_SB_Cmds_BadCmdLength(void)
     CFE_UtAssert_EVENTCOUNT(1);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
-
-} /* end Test_SB_Cmds_BadCmdLength */
+}
 
 /*
 ** Test command handler response to an invalid message ID
@@ -1608,8 +1570,7 @@ void Test_SB_Cmds_UnexpMsgId(void)
     CFE_UtAssert_EVENTCOUNT(1);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_BAD_MSGID_EID);
-
-} /* end Test_SB_Cmds_UnexpMsgId */
+}
 
 /*
 ** Function for calling early initialization tests
@@ -1619,7 +1580,7 @@ void Test_SB_EarlyInit(void)
     SB_UT_ADD_SUBTEST(Test_SB_EarlyInit_SemCreateError);
     SB_UT_ADD_SUBTEST(Test_SB_EarlyInit_PoolCreateError);
     SB_UT_ADD_SUBTEST(Test_SB_EarlyInit_NoErrors);
-} /* end Test_SB_EarlyInit */
+}
 
 /*
 ** Test early initialization response to a semaphore create failure
@@ -1628,7 +1589,7 @@ void Test_SB_EarlyInit_SemCreateError(void)
 {
     UT_SetDeferredRetcode(UT_KEY(OS_MutSemCreate), 1, OS_ERR_NO_FREE_IDS);
     UtAssert_INT32_EQ(CFE_SB_EarlyInit(), CFE_STATUS_EXTERNAL_RESOURCE_FAIL);
-} /* end Test_SB_EarlyInit_SemCreateError */
+}
 
 /*
 ** Test early initialization response to a pool create ex failure
@@ -1637,7 +1598,7 @@ void Test_SB_EarlyInit_PoolCreateError(void)
 {
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_PoolCreateEx), 1, CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_SB_EarlyInit(), CFE_ES_BAD_ARGUMENT);
-} /* end Test_SB_EarlyInit_PoolCreateError */
+}
 
 /*
 ** Test successful early initialization
@@ -1672,8 +1633,7 @@ void Test_SB_EarlyInit_NoErrors(void)
     UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.PeakSubscriptionsInUse);
     UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.SBBuffersInUse);
     UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.PeakSBBuffersInUse);
-
-} /* end Test_SB_EarlyInit_NoErrors */
+}
 
 /*
 ** Function for calling SB create pipe API test functions
@@ -1685,7 +1645,7 @@ void Test_CreatePipe_API(void)
     SB_UT_ADD_SUBTEST(Test_CreatePipe_InvalPipeDepth);
     SB_UT_ADD_SUBTEST(Test_CreatePipe_MaxPipes);
     SB_UT_ADD_SUBTEST(Test_CreatePipe_SamePipeName);
-} /* end Test_CreatePipe_API */
+}
 
 /*
 ** Test create pipe response to a null pipe ID pointer
@@ -1703,8 +1663,7 @@ void Test_CreatePipe_NullPtr(void)
     CFE_UtAssert_EVENTCOUNT(1);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_CR_PIPE_BAD_ARG_EID);
-
-} /* end Test_CreatePipe_NullPtr */
+}
 
 /*
 ** Test create pipe response to valid pipe depths
@@ -1722,8 +1681,7 @@ void Test_CreatePipe_ValPipeDepth(void)
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeIdReturned[0]));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeIdReturned[1]));
-
-} /* end Test_CreatePipe_ValPipeDepth */
+}
 
 /*
 ** Test create pipe response to invalid pipe depths
@@ -1743,8 +1701,7 @@ void Test_CreatePipe_InvalPipeDepth(void)
     CFE_UtAssert_EVENTCOUNT(3);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_CR_PIPE_BAD_ARG_EID);
-
-} /* end Test_CreatePipe_InvalPipeDepth */
+}
 
 /*
 ** Test create pipe response to too many pipes
@@ -1807,8 +1764,7 @@ void Test_CreatePipe_MaxPipes(void)
     UtAssert_BOOL_FALSE(CFE_SB_CheckPipeDescSlotUsed(UT_SB_MakePipeIdForIndex(2)));
     UT_SetDeferredRetcode(UT_KEY(CFE_ResourceId_ToIndex), 1, -1);
     UtAssert_BOOL_TRUE(CFE_SB_CheckPipeDescSlotUsed(UT_SB_MakePipeIdForIndex(1)));
-
-} /* end Test_CreatePipe_MaxPipes */
+}
 
 /*
 ** Test create pipe response to duplicate pipe names
@@ -1852,7 +1808,7 @@ void Test_DeletePipe_API(void)
     SB_UT_ADD_SUBTEST(Test_DeletePipe_InvalidPipeId);
     SB_UT_ADD_SUBTEST(Test_DeletePipe_InvalidPipeOwner);
     SB_UT_ADD_SUBTEST(Test_DeletePipe_WithAppid);
-} /* end Test_DeletePipe_API */
+}
 
 /*
 ** Test delete pipe response to deleting a pipe with no subscriptions
@@ -1869,8 +1825,7 @@ void Test_DeletePipe_NoSubs(void)
 
     CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
     CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_DELETED_EID);
-
-} /* end Test_DeletePipe_NoSubs */
+}
 
 /*
 ** Test delete pipe response to deleting a pipe with subscriptions
@@ -1895,8 +1850,7 @@ void Test_DeletePipe_WithSubs(void)
 
     CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
     CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_DELETED_EID);
-
-} /* end Test_DeletePipe_WithSubs */
+}
 
 /*
 ** Test delete pipe response to an invalid pipe ID
@@ -1910,8 +1864,7 @@ void Test_DeletePipe_InvalidPipeId(void)
     CFE_UtAssert_EVENTCOUNT(1);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_DEL_PIPE_ERR1_EID);
-
-} /* end Test_DeletePipe_InvalidPipeId */
+}
 
 /*
 ** Test delete pipe response to an invalid pipe owner
@@ -1940,8 +1893,7 @@ void Test_DeletePipe_InvalidPipeOwner(void)
     /* Restore owner id and delete pipe since test is complete */
     PipeDscPtr->AppId = RealOwner;
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipedId));
-
-} /* end Test_DeletePipe_InvalidPipeId */
+}
 
 /*
 ** Test successful pipe delete with app ID
@@ -1962,8 +1914,7 @@ void Test_DeletePipe_WithAppid(void)
     CFE_UtAssert_SUCCESS(CFE_SB_DeletePipeWithAppId(PipedId, AppId));
 
     CFE_UtAssert_EVENTCOUNT(6);
-
-} /* end Test_DeletePipe_WithAppid */
+}
 
 /*
 ** Function for calling SB set pipe opts API test functions
@@ -1976,7 +1927,7 @@ void Test_PipeOpts_API(void)
     SB_UT_ADD_SUBTEST(Test_GetPipeOpts_BadID);
     SB_UT_ADD_SUBTEST(Test_GetPipeOpts_BadPtr);
     SB_UT_ADD_SUBTEST(Test_GetPipeOpts);
-} /* end Test_PipeOpts_API */
+}
 
 /*
 ** Function for calling SB get pipe name by id API test functions
@@ -1986,7 +1937,7 @@ void Test_GetPipeName_API(void)
     SB_UT_ADD_SUBTEST(Test_GetPipeName_NullPtr);
     SB_UT_ADD_SUBTEST(Test_GetPipeName_InvalidId);
     SB_UT_ADD_SUBTEST(Test_GetPipeName);
-} /* end Test_GetGetPipeName_API */
+}
 
 /*
 ** Call GetPipeName with null pointer.
@@ -2005,8 +1956,7 @@ void Test_GetPipeName_NullPtr(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_GETPIPENAME_NULL_PTR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_GetPipeName_NullPtr */
+}
 
 /*
 ** Call to GetPipeName with an invalid pipe id.
@@ -2024,8 +1974,7 @@ void Test_GetPipeName_InvalidId(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_GETPIPENAME_ID_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_GetPipeName_InvalidId */
+}
 
 /*
 ** Successful call to GetPipeName
@@ -2046,8 +1995,7 @@ void Test_GetPipeName(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_GETPIPENAME_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_GetPipeName */
+}
 
 /*
 ** Function for calling SB get pipe id by name API test functions
@@ -2057,7 +2005,7 @@ void Test_GetPipeIdByName_API(void)
     SB_UT_ADD_SUBTEST(Test_GetPipeIdByName_NullPtrs);
     SB_UT_ADD_SUBTEST(Test_GetPipeIdByName_InvalidName);
     SB_UT_ADD_SUBTEST(Test_GetPipeIdByName);
-} /* end Test_GetPipeIdByName_API */
+}
 
 /*
 ** Call GetPipeIdByName with null pointers.
@@ -2073,8 +2021,7 @@ void Test_GetPipeIdByName_NullPtrs(void)
     UtAssert_INT32_EQ(CFE_SB_GetPipeIdByName(NULL, "invalid"), CFE_SB_BAD_ARGUMENT);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_GETPIPEIDBYNAME_NULL_ERR_EID);
-
-} /* end Test_GetPipeIdByName_NullPtrs */
+}
 
 /*
 ** Call to GetPipeId with an invalid pipe name.
@@ -2098,8 +2045,7 @@ void Test_GetPipeIdByName_InvalidName(void)
     UtAssert_INT32_EQ(CFE_SB_GetPipeIdByName(&PipeIdOut, "nonsb"), CFE_SB_BAD_ARGUMENT);
     CFE_UtAssert_EVENTSENT(CFE_SB_GETPIPEIDBYNAME_NAME_ERR_EID);
     CFE_UtAssert_TEARDOWN(OS_QueueDelete(OtherQueueId));
-
-} /* end Test_GetPipeIdByName_InvalidName */
+}
 
 /*
 ** Successful call to GetPipeIdByName
@@ -2118,8 +2064,7 @@ void Test_GetPipeIdByName(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_GETPIPEIDBYNAME_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_GetPipeIdByName */
+}
 
 /*
 ** Try setting pipe options on an invalid pipe ID
@@ -2129,8 +2074,7 @@ void Test_SetPipeOpts_BadID(void)
     UtAssert_INT32_EQ(CFE_SB_SetPipeOpts(SB_UT_ALTERNATE_INVALID_PIPEID, 0), CFE_SB_BAD_ARGUMENT);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_SETPIPEOPTS_ID_ERR_EID);
-
-} /* end Test_SetPipeOpts_BadID */
+}
 
 /*
 ** Try setting pipe options when not pipe owner
@@ -2155,8 +2099,7 @@ void Test_SetPipeOpts_NotOwner(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_SETPIPEOPTS_OWNER_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeID));
-
-} /* end Test_SetPipeOpts_NotOwner */
+}
 
 /*
 ** Set pipe options
@@ -2175,8 +2118,7 @@ void Test_SetPipeOpts(void)
     UtAssert_INT32_EQ(CFE_SB_SetPipeOpts(PipeID, 0), CFE_ES_ERR_RESOURCEID_NOT_VALID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeID));
-
-} /* end Test_SetPipeOpts */
+}
 
 /*
 ** Try getting pipe options on an invalid pipe ID
@@ -2188,8 +2130,7 @@ void Test_GetPipeOpts_BadID(void)
     UtAssert_INT32_EQ(CFE_SB_GetPipeOpts(SB_UT_ALTERNATE_INVALID_PIPEID, &Opts), CFE_SB_BAD_ARGUMENT);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_GETPIPEOPTS_ID_ERR_EID);
-
-} /* end Test_GetPipeOpts_BadID */
+}
 
 /*
 ** Try getting pipe options with a bad pointer
@@ -2205,8 +2146,7 @@ void Test_GetPipeOpts_BadPtr(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_GETPIPEOPTS_PTR_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeID));
-
-} /* end Test_GetPipeOpts_BadPtr */
+}
 
 /*
 ** Successful call to GetPipeOpts
@@ -2223,8 +2163,7 @@ void Test_GetPipeOpts(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_GETPIPEOPTS_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeID));
-
-} /* end Test_GetPipeOpts */
+}
 
 /*
 ** Function for calling SB subscribe API test functions
@@ -2243,7 +2182,7 @@ void Test_Subscribe_API(void)
     SB_UT_ADD_SUBTEST(Test_Subscribe_PipeNonexistent);
     SB_UT_ADD_SUBTEST(Test_Subscribe_SubscriptionReporting);
     SB_UT_ADD_SUBTEST(Test_Subscribe_InvalidPipeOwner);
-} /* end Test_Subscribe_API */
+}
 
 /*
 ** Test API to globally subscribe to a message
@@ -2266,8 +2205,7 @@ void Test_Subscribe_SubscribeEx(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_Subscribe_SubscribeEx */
+}
 
 /*
 ** Test message subscription response to an invalid pipe ID
@@ -2282,8 +2220,7 @@ void Test_Subscribe_InvalidPipeId(void)
     CFE_UtAssert_EVENTCOUNT(2);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_SUB_INV_PIPE_EID);
-
-} /* end Test_Subscribe_InvalidPipeId */
+}
 
 /*
 ** Test message subscription response to an invalid message ID
@@ -2303,8 +2240,7 @@ void Test_Subscribe_InvalidMsgId(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_SUB_ARG_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_Subscribe_InvalidMsgId */
+}
 
 /*
 ** Test message subscription response to the maximum message limit
@@ -2327,8 +2263,7 @@ void Test_Subscribe_MaxMsgLim(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_Subscribe_MaxMsgLim */
+}
 
 /*
 ** Test message subscription response to a duplicate subscription
@@ -2350,8 +2285,7 @@ void Test_Subscribe_DuplicateSubscription(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_DUP_SUBSCRIP_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_Subscribe_DuplicateSubscription */
+}
 
 /*
 ** Test API to locally subscribe to a message
@@ -2379,8 +2313,7 @@ void Test_Subscribe_LocalSubscription(void)
     UtAssert_INT32_EQ(CFE_SB_SubscribeLocal(MsgId, PipeId, UINT16_MAX), CFE_SUCCESS);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_Subscribe_LocalSubscription */
+}
 
 /*
 ** Test message subscription response to reaching the maximum destination count
@@ -2423,8 +2356,7 @@ void Test_Subscribe_MaxDestCount(void)
     {
         CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId[i]));
     }
-
-} /* end Test_Subscribe_MaxDestCount */
+}
 
 /*
 ** Test message subscription response to reaching the maximum message ID count
@@ -2465,8 +2397,7 @@ void Test_Subscribe_MaxMsgIdCount(void)
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId0));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId2));
-
-} /* end Test_Subscribe_MaxMsgIdCount */
+}
 
 /*
 ** Test obtaining the list of current message subscriptions
@@ -2514,8 +2445,7 @@ void Test_Subscribe_SendPrevSubs(void)
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId0));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId2));
-
-} /* end Test_Subscribe_SendPrevSubs */
+}
 
 /*
 ** Test message subscription response to nonexistent pipe
@@ -2530,8 +2460,7 @@ void Test_Subscribe_PipeNonexistent(void)
     CFE_UtAssert_EVENTCOUNT(2);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_SUB_INV_PIPE_EID);
-
-} /* end Test_Subscribe_PipeNonexistent */
+}
 
 /*
 ** Test enabling and disabling subscription reporting
@@ -2574,8 +2503,7 @@ void Test_Subscribe_SubscriptionReporting(void)
     CFE_SB_SetSubscriptionReporting(CFE_SB_DISABLE);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_Subscribe_SubscriptionReporting */
+}
 
 /*
 ** Test message subscription response to an invalid pipe owner
@@ -2605,8 +2533,7 @@ void Test_Subscribe_InvalidPipeOwner(void)
     /* Restore owner id and delete pipe since test is complete */
     PipeDscPtr->AppId = RealOwner;
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_Subscribe_InvalidPipeOwner */
+}
 
 /*
 ** Function for calling SB unsubscribe API test functions
@@ -2623,7 +2550,7 @@ void Test_Unsubscribe_API(void)
     SB_UT_ADD_SUBTEST(Test_Unsubscribe_FirstDestWithMany);
     SB_UT_ADD_SUBTEST(Test_Unsubscribe_MiddleDestWithMany);
     SB_UT_ADD_SUBTEST(Test_Unsubscribe_GetDestPtr);
-} /* end Test_Unsubscribe_API */
+}
 
 /*
 ** Test API used to unsubscribe to a message (successful)
@@ -2650,8 +2577,7 @@ void Test_Unsubscribe_Basic(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_UNSUB_NO_SUBS_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe));
-
-} /* end Test_Unsubscribe_Basic */
+}
 
 /*
 ** Test API used to unsubscribe to a message with a specific AppId
@@ -2675,8 +2601,7 @@ void Test_Unsubscribe_AppId(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe));
-
-} /* end Test_Unsubscribe_AppId */
+}
 
 /*
 ** Test CFE internal API used to locally unsubscribe to a message (successful)
@@ -2697,8 +2622,7 @@ void Test_Unsubscribe_Local(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe));
-
-} /* end Test_Unsubscribe_Local */
+}
 
 /*
 ** Test message unsubscription response to an invalid message ID
@@ -2742,8 +2666,7 @@ void Test_Unsubscribe_InvalParam(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_UNSUB_INV_PIPE_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe));
-
-} /* end Test_Unsubscribe_InvalParam */
+}
 
 /*
 ** Test message unsubscription response to a message ID that is not subscribed
@@ -2770,8 +2693,7 @@ void Test_Unsubscribe_NoMatch(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_UNSUB_NO_SUBS_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe));
-
-} /* end Test_Unsubscribe_NoMatch */
+}
 
 /*
 ** Test message unsubscription response to an invalid pipe ID
@@ -2792,8 +2714,7 @@ void Test_Unsubscribe_InvalidPipe(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_UNSUB_INV_PIPE_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe));
-
-} /* end Test_Unsubscribe_InvalidPipe */
+}
 
 /*
 ** Test message unsubscription response to an invalid pipe owner
@@ -2825,8 +2746,7 @@ void Test_Unsubscribe_InvalidPipeOwner(void)
     PipeDscPtr->AppId = RealOwner;
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_Unsubscribe_InvalidPipeOwner */
+}
 
 /*
 ** Test message unsubscription response to the first pipe destination when
@@ -2857,8 +2777,7 @@ void Test_Unsubscribe_FirstDestWithMany(void)
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe2));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe3));
-
-} /* end Test_Unsubscribe_FirstDestWithMany */
+}
 
 /*
 ** Test message unsubscription response to a middle pipe destination when
@@ -2889,8 +2808,7 @@ void Test_Unsubscribe_MiddleDestWithMany(void)
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe2));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe3));
-
-} /* end Test_Unsubscribe_MiddleDestWithMany */
+}
 
 /*
 ** Test message unsubscription by verifying the message destination pointer no
@@ -2921,8 +2839,7 @@ void Test_Unsubscribe_GetDestPtr(void)
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe2));
-
-} /* end Test_Unsubscribe_GetDestPtr */
+}
 
 /*
 ** Function for calling SB send message API test functions
@@ -2948,7 +2865,7 @@ void Test_TransmitMsg_API(void)
     SB_UT_ADD_SUBTEST(Test_TransmitMsgValidate_InvalidMsgId);
     SB_UT_ADD_SUBTEST(Test_AllocateMessageBuffer);
     SB_UT_ADD_SUBTEST(Test_ReleaseMessageBuffer);
-} /* end Test_TransmitMsg_API */
+}
 
 /*
 ** Test response to sending a null message on the software bus
@@ -2960,8 +2877,7 @@ void Test_TransmitMsg_NullPtr(void)
     CFE_UtAssert_EVENTCOUNT(1);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_SEND_BAD_ARG_EID);
-
-} /* end Test_TransmitMsg_NullPtr */
+}
 
 /*
 ** Test response to sending a message which has no subscribers
@@ -2982,8 +2898,7 @@ void Test_TransmitMsg_NoSubscribers(void)
     CFE_UtAssert_EVENTCOUNT(1);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_SEND_NO_SUBS_EID);
-
-} /* end Test_TransmitMsg_NoSubscribers */
+}
 
 /*
 ** Test response to sending a message with the message size larger than allowed
@@ -3006,8 +2921,7 @@ void Test_TransmitMsg_MaxMsgSizePlusOne(void)
 
     CFE_UtAssert_EVENTSENT(CFE_SB_MSG_TOO_BIG_EID);
     UtAssert_INT32_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter, 1);
-
-} /* end Test_TransmitMsg_MaxMsgSizePlusOne */
+}
 
 /*
 ** Test successfully sending a message on the software bus
@@ -3034,8 +2948,7 @@ void Test_TransmitMsg_BasicSend(void)
     CFE_UtAssert_EVENTCOUNT(2);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_TransmitMsg_BasicSend */
+}
 
 /* Set sequence count hook */
 static int32 UT_CheckSetSequenceCount(void *UserObj, int32 StubRetcode, uint32 CallCount,
@@ -3128,8 +3041,7 @@ void Test_TransmitMsg_SequenceCount(void)
     UtAssert_STUB_COUNT(CFE_MSG_GetNextSequenceCount, 4);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_TransmitMsg_SequenceCount */
+}
 
 /*
 ** Test send message response to a socket queue 'put' error
@@ -3159,8 +3071,7 @@ void Test_TransmitMsg_QueuePutError(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_Q_WR_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId4Error));
-
-} /* end Test_TransmitMsg_QueuePutError */
+}
 
 /*
 ** Test send message response when the socket queue is full
@@ -3200,8 +3111,7 @@ void Test_TransmitMsg_PipeFull(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_Q_FULL_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_TransmitMsg_PipeFull */
+}
 
 /*
 ** Test send message response to too many messages sent to the pipe
@@ -3243,8 +3153,7 @@ void Test_TransmitMsg_MsgLimitExceeded(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_MSGID_LIM_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_TransmitMsg_MsgLimitExceeded */
+}
 
 /*
 ** Test send message response to a buffer descriptor allocation failure
@@ -3285,8 +3194,7 @@ void Test_TransmitMsg_GetPoolBufErr(void)
     CFE_UtAssert_EVENTCOUNT(3);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_TransmitMsg_GetPoolBufErr */
+}
 
 /*
 ** Test getting a pointer to a buffer for zero copy mode with buffer
@@ -3330,8 +3238,7 @@ void Test_AllocateMessageBuffer(void)
                       CFE_SB_Global.StatTlmMsg.Payload.SBBuffersInUse + 1);
 
     CFE_UtAssert_EVENTCOUNT(0);
-
-} /* end Test_AllocateMessageBuffer */
+}
 
 void Test_TransmitMsg_ZeroCopyBufferValidate(void)
 {
@@ -3511,8 +3418,7 @@ void Test_ReleaseMessageBuffer(void)
     CFE_UtAssert_SUCCESS(CFE_SB_ReleaseMessageBuffer(ZeroCpyMsgPtr1));
 
     CFE_UtAssert_EVENTCOUNT(0);
-
-} /* end Test_TransmitMsg_ZeroCopyReleasePtr */
+}
 
 /*
 ** Test send message response with the destination disabled
@@ -3550,8 +3456,7 @@ void Test_TransmitMsg_DisabledDestination(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_TransmitMsg_DisabledDestination */
+}
 
 /*
 ** Test successful CFE_SB_BroadcastBufferToRoute
@@ -3584,8 +3489,7 @@ void Test_BroadcastBufferToRoute(void)
     CFE_SB_BroadcastBufferToRoute(&SBBufD, CFE_SBR_INVALID_ROUTE_ID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_BroadcastBufferToRoute */
+}
 
 /*
 ** Test response to sending a message with the message size larger than allowed
@@ -3675,7 +3579,7 @@ void Test_ReceiveBuffer_API(void)
     SB_UT_ADD_SUBTEST(Test_ReceiveBuffer_PipeReadError);
     SB_UT_ADD_SUBTEST(Test_ReceiveBuffer_PendForever);
     SB_UT_ADD_SUBTEST(Test_ReceiveBuffer_InvalidBufferPtr);
-} /* end Test_ReceiveBuffer_API */
+}
 
 static void SB_UT_PipeIdModifyHandler(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
@@ -3757,8 +3661,7 @@ void Test_ReceiveBuffer_InvalidPipeId(void)
     PipeDscPtr->PipeId = PipeId;
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_ReceiveBuffer_InvalidPipeId */
+}
 
 /*
 ** Test receiving a message response to invalid timeout value (< -1)
@@ -3781,8 +3684,7 @@ void Test_ReceiveBuffer_InvalidTimeout(void)
     UtAssert_UINT8_EQ(CFE_SB_Global.HKTlmMsg.Payload.InternalErrorCounter, 0);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_ReceiveBuffer_InvalidTimeout */
+}
 
 /*
 ** Test receiving a message response when there is no message on the queue
@@ -3804,8 +3706,7 @@ void Test_ReceiveBuffer_Poll(void)
     UtAssert_UINT8_EQ(CFE_SB_Global.HKTlmMsg.Payload.InternalErrorCounter, 0);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_ReceiveBuffer_Poll */
+}
 
 /*
 ** Test receiving a message response to a timeout
@@ -3829,8 +3730,7 @@ void Test_ReceiveBuffer_Timeout(void)
     UtAssert_UINT8_EQ(CFE_SB_Global.HKTlmMsg.Payload.InternalErrorCounter, 0);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_ReceiveBuffer_Timeout */
+}
 
 /*
 ** Test receiving a message response to a pipe read error
@@ -3860,8 +3760,7 @@ void Test_ReceiveBuffer_PipeReadError(void)
     UtAssert_UINT8_EQ(CFE_SB_Global.HKTlmMsg.Payload.InternalErrorCounter, 3);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_ReceiveBuffer_PipeReadError */
+}
 
 /*
 ** Test receiving a message response to a "pend forever" timeout
@@ -3902,8 +3801,7 @@ void Test_ReceiveBuffer_PendForever(void)
     UtAssert_UINT8_EQ(CFE_SB_Global.HKTlmMsg.Payload.InternalErrorCounter, 0);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_ReceiveBuffer_PendForever */
+}
 
 /*
 ** Test releasing zero copy buffers for all pipes owned by a given app ID
@@ -3964,8 +3862,7 @@ void Test_CleanupApp_API(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_DELETED_EID);
-
-} /* end Test_CleanupApp_API */
+}
 
 /*
 ** Test receiving a message response to invalid buffer pointer (null)
@@ -3984,8 +3881,7 @@ void Test_ReceiveBuffer_InvalidBufferPtr(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_RCV_BAD_ARG_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_ReceiveBuffer_InvalidBufferPtr */
+}
 
 /*
 ** Test SB Utility APIs
@@ -3997,7 +3893,7 @@ void Test_SB_Utils(void)
     SB_UT_ADD_SUBTEST(Test_CFE_SB_SetGetUserDataLength);
     SB_UT_ADD_SUBTEST(Test_CFE_SB_ValidateMsgId);
     SB_UT_ADD_SUBTEST(Test_CFE_SB_ZeroCopyReleaseAppId);
-} /* end Test_SB_Utils */
+}
 
 /*
 ** Test getting the size of a command/telemetry message header
@@ -4046,8 +3942,7 @@ void Test_CFE_SB_MsgHdrSize(void)
      * due to this mismatch.
      */
     UtAssert_VOIDCALL(CFE_SB_MsgHdrSize(NULL));
-
-} /* end Test_CFE_SB_MsgHdrSize */
+}
 
 /*
 ** Test getting a pointer to the user data portion of a message
@@ -4151,8 +4046,7 @@ void Test_CFE_SB_GetUserData(void)
 
     /* Bad inputs */
     UtAssert_NULL(CFE_SB_GetUserData(NULL));
-
-} /* end Test_CFE_SB_GetUserData */
+}
 
 /*
 ** Test setting and getting the user data length of a message
@@ -4190,8 +4084,7 @@ void Test_CFE_SB_SetGetUserDataLength(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetHasSecondaryHeader), &hassec, sizeof(hassec), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &type, sizeof(type), false);
     UtAssert_VOIDCALL(CFE_SB_SetUserDataLength(&msg, CFE_MISSION_SB_MAX_SB_MSG_SIZE + 1));
-
-} /* end Util_CFE_SB_SetGetUserDataLength */
+}
 
 /*
 ** Test validating a msg id
@@ -4254,7 +4147,7 @@ void Test_SB_SpecialCases(void)
     SB_UT_ADD_SUBTEST(Test_SB_TransmitMsgPaths_IgnoreOpt);
     SB_UT_ADD_SUBTEST(Test_ReceiveBuffer_UnsubResubPath);
     SB_UT_ADD_SUBTEST(Test_MessageString);
-} /* end Test_SB_SpecialCases */
+}
 
 /*
  * Test the use count rollover prevetion
@@ -4291,8 +4184,7 @@ void Test_OS_MutSem_ErrLogic(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_OS_MutSemTake_ErrLogic */
+}
 
 /*
 ** Test successful recursive event prevention
@@ -4321,8 +4213,7 @@ void Test_ReqToSendEvent_ErrLogic(void)
     UT_ClearDefaultReturnValue(UT_KEY(CFE_ES_TaskID_ToIndex));
 
     CFE_UtAssert_EVENTCOUNT(0);
-
-} /* end Test_ReqToSendEvent_ErrLogic */
+}
 
 /*
 ** Test getting a destination descriptor to the SB memory pool using a null
@@ -4333,8 +4224,7 @@ void Test_PutDestBlk_ErrLogic(void)
     UtAssert_INT32_EQ(CFE_SB_PutDestinationBlk(NULL), CFE_SB_BAD_ARGUMENT);
 
     CFE_UtAssert_EVENTCOUNT(0);
-
-} /* end Test_PutDestBlk_ErrLogic */
+}
 
 /*
 ** Test functions that involve a buffer in the SB buffer pool
@@ -4390,8 +4280,7 @@ void Test_CFE_SB_Buffers(void)
     UtAssert_ZERO(CFE_SB_Global.StatTlmMsg.Payload.MemInUse);
 
     CFE_UtAssert_EVENTCOUNT(0);
-
-} /* end Test_CFE_SB_Buffers */
+}
 
 /*
 ** Test internal function to get the pipe table index for the given pipe ID
@@ -4423,8 +4312,7 @@ void Test_CFE_SB_BadPipeInfo(void)
     CFE_UtAssert_EVENTCOUNT(4);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_CFE_SB_BadPipeInfo */
+}
 
 /*
 ** Test send housekeeping information command
@@ -4536,7 +4424,7 @@ void Test_SB_TransmitMsgPaths_Nominal(void)
     UtAssert_UINT32_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter, 1);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-} /* end Test_SB_TransmitMsgPaths */
+}
 
 void Test_SB_TransmitMsgPaths_LimitErr(void)
 {
@@ -4574,8 +4462,7 @@ void Test_SB_TransmitMsgPaths_LimitErr(void)
     CFE_UtAssert_EVENTNOTSENT(CFE_SB_MSGID_LIM_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_SB_TransmitMsgPaths */
+}
 
 void Test_SB_TransmitMsgPaths_FullErr(void)
 {
@@ -4615,7 +4502,7 @@ void Test_SB_TransmitMsgPaths_FullErr(void)
     CFE_UtAssert_EVENTCOUNT(2);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-} /* end Test_SB_TransmitMsgPaths */
+}
 
 void Test_SB_TransmitMsgPaths_WriteErr(void)
 {
@@ -4653,8 +4540,7 @@ void Test_SB_TransmitMsgPaths_WriteErr(void)
     CFE_UtAssert_EVENTNOTSENT(CFE_SB_Q_WR_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_SB_TransmitMsgPaths */
+}
 
 void Test_SB_TransmitMsgPaths_IgnoreOpt(void)
 {
@@ -4701,8 +4587,7 @@ void Test_SB_TransmitMsgPaths_IgnoreOpt(void)
 
     CFE_UtAssert_TEARDOWN(CFE_SB_SetPipeOpts(PipeId, 0));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_SB_TransmitMsgPaths */
+}
 
 /*
 ** Test receiving a message response to an unsubscribing to message, then
@@ -4739,8 +4624,7 @@ void Test_ReceiveBuffer_UnsubResubPath(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_REMOVED_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-
-} /* end Test_ReceiveBuffer_UnsubResubPath */
+}
 
 /*
 ** Test the paths through the MessageStringSet and MessageStringGet functions
@@ -4812,4 +4696,4 @@ void Test_MessageString(void)
     memset(DestString, 'q', sizeof(DestString));
     CFE_SB_MessageStringGet(DestString, SrcString, DefString, 4, sizeof(SrcString));
     UtAssert_STRINGBUF_EQ(DestString, 4, SrcString, 3);
-} /* end Test_MessageString */
+}

--- a/modules/sbr/fsw/src/cfe_sbr_map_direct.c
+++ b/modules/sbr/fsw/src/cfe_sbr_map_direct.c
@@ -56,8 +56,6 @@ CFE_SBR_RouteId_t CFE_SBR_MSGMAP[CFE_SBR_MSG_MAP_SIZE];
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SBR_Init_Map
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -69,8 +67,6 @@ void CFE_SBR_Init_Map(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SBR_SetRouteId
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -88,8 +84,6 @@ uint32 CFE_SBR_SetRouteId(CFE_SB_MsgId_t MsgId, CFE_SBR_RouteId_t RouteId)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SBR_GetRouteId
  *
  * Internal helper routine only, not part of API.
  *

--- a/modules/sbr/fsw/src/cfe_sbr_map_hash.c
+++ b/modules/sbr/fsw/src/cfe_sbr_map_hash.c
@@ -74,8 +74,6 @@ CFE_SBR_RouteId_t CFE_SBR_MSGMAP[CFE_SBR_MSG_MAP_SIZE];
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SBR_MsgIdHash
- *
  * Internal helper routine only, not part of API.
  *
  * Hashes the message id
@@ -102,8 +100,6 @@ CFE_SB_MsgId_Atom_t CFE_SBR_MsgIdHash(CFE_SB_MsgId_t MsgId)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SBR_Init_Map
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -115,8 +111,6 @@ void CFE_SBR_Init_Map(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SBR_SetRouteId
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -150,8 +144,6 @@ uint32 CFE_SBR_SetRouteId(CFE_SB_MsgId_t MsgId, CFE_SBR_RouteId_t RouteId)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SBR_GetRouteId
  *
  * Internal helper routine only, not part of API.
  *

--- a/modules/sbr/fsw/src/cfe_sbr_route_unsorted.c
+++ b/modules/sbr/fsw/src/cfe_sbr_route_unsorted.c
@@ -66,8 +66,6 @@ cfe_sbr_route_data_t CFE_SBR_RDATA;
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SBR_Init
- *
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
@@ -89,8 +87,6 @@ void CFE_SBR_Init(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SBR_AddRoute
  *
  * Internal helper routine only, not part of API.
  *
@@ -119,8 +115,6 @@ CFE_SBR_RouteId_t CFE_SBR_AddRoute(CFE_SB_MsgId_t MsgId, uint32 *CollisionsPtr)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SBR_GetMsgId
- *
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
@@ -138,14 +132,11 @@ CFE_SB_MsgId_t CFE_SBR_GetMsgId(CFE_SBR_RouteId_t RouteId)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SBR_GetDestListHeadPtr
- *
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
 CFE_SB_DestinationD_t *CFE_SBR_GetDestListHeadPtr(CFE_SBR_RouteId_t RouteId)
 {
-
     CFE_SB_DestinationD_t *destptr = NULL;
 
     if (CFE_SBR_IsValidRouteId(RouteId))
@@ -158,14 +149,11 @@ CFE_SB_DestinationD_t *CFE_SBR_GetDestListHeadPtr(CFE_SBR_RouteId_t RouteId)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SBR_SetDestListHeadPtr
- *
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
 void CFE_SBR_SetDestListHeadPtr(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *DestPtr)
 {
-
     if (CFE_SBR_IsValidRouteId(RouteId))
     {
         CFE_SBR_RDATA.RoutingTbl[CFE_SBR_RouteIdToValue(RouteId)].ListHeadPtr = DestPtr;
@@ -173,8 +161,6 @@ void CFE_SBR_SetDestListHeadPtr(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SBR_IncrementSequenceCounter
  *
  * Internal helper routine only, not part of API.
  *
@@ -192,8 +178,6 @@ void CFE_SBR_IncrementSequenceCounter(CFE_SBR_RouteId_t RouteId)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_SBR_GetSequenceCounter
- *
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
@@ -210,8 +194,6 @@ CFE_MSG_SequenceCount_t CFE_SBR_GetSequenceCounter(CFE_SBR_RouteId_t RouteId)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_SBR_ForEachRouteId
  *
  * Internal helper routine only, not part of API.
  *

--- a/modules/sbr/ut-coverage/test_cfe_sbr_map_direct.c
+++ b/modules/sbr/ut-coverage/test_cfe_sbr_map_direct.c
@@ -37,7 +37,6 @@
 
 void Test_SBR_Map_Direct(void)
 {
-
     CFE_SB_MsgId_Atom_t msgidx;
     CFE_SB_MsgId_Atom_t msgid_limit;
     CFE_SBR_RouteId_t   routeid;

--- a/modules/sbr/ut-coverage/test_cfe_sbr_map_hash.c
+++ b/modules/sbr/ut-coverage/test_cfe_sbr_map_hash.c
@@ -46,7 +46,6 @@
  */
 CFE_SB_MsgId_t Test_SBR_Unhash(CFE_SB_MsgId_Atom_t Hash)
 {
-
     Hash = ((Hash >> 16) ^ Hash) * CFE_SBR_UNHASH_MAGIC;
     Hash = ((Hash >> 16) ^ Hash) * CFE_SBR_UNHASH_MAGIC;
     Hash = (Hash >> 16) ^ Hash;
@@ -56,7 +55,6 @@ CFE_SB_MsgId_t Test_SBR_Unhash(CFE_SB_MsgId_Atom_t Hash)
 
 void Test_SBR_Map_Hash(void)
 {
-
     CFE_SB_MsgId_Atom_t msgidx;
     CFE_SB_MsgId_Atom_t msgid_limit;
     CFE_SBR_RouteId_t   routeid[3];

--- a/modules/sbr/ut-coverage/test_cfe_sbr_route_unsorted.c
+++ b/modules/sbr/ut-coverage/test_cfe_sbr_route_unsorted.c
@@ -38,7 +38,6 @@ void Test_SBR_Callback(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
 
 void Test_SBR_Route_Unsort_General(void)
 {
-
     CFE_SBR_RouteId_t  routeid;
     CFE_SB_MsgId_t     msgid;
     uint32             collisions;
@@ -112,7 +111,6 @@ void Test_SBR_Route_Unsort_General(void)
 
 void Test_SBR_Route_Unsort_GetSet(void)
 {
-
     CFE_SB_RouteId_Atom_t   routeidx;
     CFE_SB_MsgId_t          msgid[3];
     CFE_SBR_RouteId_t       routeid[3];

--- a/modules/tbl/fsw/src/cfe_tbl_api.c
+++ b/modules/tbl/fsw/src/cfe_tbl_api.c
@@ -40,8 +40,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_Register
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -501,8 +499,6 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_Share
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -604,8 +600,6 @@ CFE_Status_t CFE_TBL_Share(CFE_TBL_Handle_t *TblHandlePtr, const char *TblName)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_Unregister
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -668,8 +662,6 @@ CFE_Status_t CFE_TBL_Unregister(CFE_TBL_Handle_t TblHandle)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_Load
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -900,8 +892,6 @@ CFE_Status_t CFE_TBL_Load(CFE_TBL_Handle_t TblHandle, CFE_TBL_SrcEnum_t SrcType,
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_Update
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -977,8 +967,6 @@ CFE_Status_t CFE_TBL_Update(CFE_TBL_Handle_t TblHandle)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_GetAddress
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -1017,8 +1005,6 @@ CFE_Status_t CFE_TBL_GetAddress(void **TblPtr, CFE_TBL_Handle_t TblHandle)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_ReleaseAddress
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -1053,8 +1039,6 @@ CFE_Status_t CFE_TBL_ReleaseAddress(CFE_TBL_Handle_t TblHandle)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_GetAddresses
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -1107,8 +1091,6 @@ CFE_Status_t CFE_TBL_GetAddresses(void **TblPtrs[], uint16 NumTables, const CFE_
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_ReleaseAddresses
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -1142,8 +1124,6 @@ CFE_Status_t CFE_TBL_ReleaseAddresses(uint16 NumTables, const CFE_TBL_Handle_t T
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_Validate
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -1291,8 +1271,6 @@ CFE_Status_t CFE_TBL_Validate(CFE_TBL_Handle_t TblHandle)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_Manage
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -1351,8 +1329,6 @@ CFE_Status_t CFE_TBL_Manage(CFE_TBL_Handle_t TblHandle)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_GetStatus
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -1398,8 +1374,6 @@ CFE_Status_t CFE_TBL_GetStatus(CFE_TBL_Handle_t TblHandle)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_GetInfo
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -1463,8 +1437,6 @@ CFE_Status_t CFE_TBL_GetInfo(CFE_TBL_Info_t *TblInfoPtr, const char *TblName)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_DumpToBuffer
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -1506,8 +1478,6 @@ CFE_Status_t CFE_TBL_DumpToBuffer(CFE_TBL_Handle_t TblHandle)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_Modified
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -1577,8 +1547,6 @@ CFE_Status_t CFE_TBL_Modified(CFE_TBL_Handle_t TblHandle)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_NotifyByMessage
  *
  * Implemented per public API
  * See description in header file for argument/return detail

--- a/modules/tbl/fsw/src/cfe_tbl_internal.c
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.c
@@ -37,8 +37,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_EarlyInit
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -92,7 +90,7 @@ int32 CFE_TBL_EarlyInit(void)
     if (OsStatus != OS_SUCCESS)
     {
         return CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
-    } /* end if */
+    }
 
     /*
     ** Create working buffer access mutex
@@ -101,7 +99,7 @@ int32 CFE_TBL_EarlyInit(void)
     if (OsStatus != OS_SUCCESS)
     {
         return CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
-    } /* end if */
+    }
 
     /* Initialize memory partition and allocate shared table buffers. */
     Status = CFE_ES_PoolCreate(&CFE_TBL_Global.Buf.PoolHdl, CFE_TBL_Global.Buf.Partition.Data,
@@ -193,8 +191,6 @@ int32 CFE_TBL_EarlyInit(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_InitRegistryRecord
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -214,8 +210,6 @@ void CFE_TBL_InitRegistryRecord(CFE_TBL_RegistryRec_t *RegRecPtr)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_ValidateHandle
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -240,8 +234,6 @@ int32 CFE_TBL_ValidateHandle(CFE_TBL_Handle_t TblHandle)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_ValidateAccess
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -274,8 +266,6 @@ int32 CFE_TBL_ValidateAccess(CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t *AppIdPt
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_CheckAccessRights
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -298,8 +288,6 @@ int32 CFE_TBL_CheckAccessRights(CFE_TBL_Handle_t TblHandle, CFE_ES_AppId_t ThisA
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_RemoveAccessLink
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -393,8 +381,6 @@ int32 CFE_TBL_RemoveAccessLink(CFE_TBL_Handle_t TblHandle)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_GetAddressInternal
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -465,8 +451,6 @@ int32 CFE_TBL_GetAddressInternal(void **TblPtr, CFE_TBL_Handle_t TblHandle, CFE_
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_GetNextNotification
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -492,8 +476,6 @@ int32 CFE_TBL_GetNextNotification(CFE_TBL_Handle_t TblHandle)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_FindTableInRegistry
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -526,8 +508,6 @@ int16 CFE_TBL_FindTableInRegistry(const char *TblName)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_FindFreeRegistryEntry
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -557,8 +537,6 @@ int16 CFE_TBL_FindFreeRegistryEntry(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_FindFreeHandle
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -585,8 +563,6 @@ CFE_TBL_Handle_t CFE_TBL_FindFreeHandle(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_FormTableName
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -605,8 +581,6 @@ void CFE_TBL_FormTableName(char *FullTblName, const char *TblName, CFE_ES_AppId_
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_LockRegistry
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -633,8 +607,6 @@ int32 CFE_TBL_LockRegistry(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_UnlockRegistry
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -659,8 +631,6 @@ int32 CFE_TBL_UnlockRegistry(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_GetWorkingBuffer
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -796,8 +766,6 @@ int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr, CFE_TBL_Re
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_LoadFromFile
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -941,8 +909,6 @@ int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBuffe
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_UpdateInternal
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1045,8 +1011,6 @@ int32 CFE_TBL_UpdateInternal(CFE_TBL_Handle_t TblHandle, CFE_TBL_RegistryRec_t *
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_NotifyTblUsersOfUpdate
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1072,8 +1036,6 @@ void CFE_TBL_NotifyTblUsersOfUpdate(CFE_TBL_RegistryRec_t *RegRecPtr)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_ReadHeaders
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1222,8 +1184,6 @@ int32 CFE_TBL_ReadHeaders(osal_id_t FileDescriptor, CFE_FS_Header_t *StdFileHead
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_ByteSwapTblHeader
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1236,8 +1196,6 @@ void CFE_TBL_ByteSwapTblHeader(CFE_TBL_File_Hdr_t *HdrPtr)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_ByteSwapUint32
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1256,8 +1214,6 @@ void CFE_TBL_ByteSwapUint32(uint32 *Uint32ToSwapPtr)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_CleanUpApp
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -1324,8 +1280,6 @@ int32 CFE_TBL_CleanUpApp(CFE_ES_AppId_t AppId)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_FindCriticalTblInfo
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1348,8 +1302,6 @@ void CFE_TBL_FindCriticalTblInfo(CFE_TBL_CritRegRec_t **CritRegRecPtr, CFE_ES_CD
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_UpdateCriticalTblCDS
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1404,8 +1356,6 @@ void CFE_TBL_UpdateCriticalTblCDS(CFE_TBL_RegistryRec_t *RegRecPtr)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_SendNotificationMsg
  *
  * Application-scope internal function
  * See description in header file for argument/return detail

--- a/modules/tbl/fsw/src/cfe_tbl_task.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task.c
@@ -86,8 +86,6 @@ const CFE_TBL_CmdHandlerTblRec_t CFE_TBL_CmdHandlerTbl[] = {
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_TaskMain
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -107,7 +105,7 @@ void CFE_TBL_TaskMain(void)
         CFE_ES_PerfLogExit(CFE_MISSION_TBL_MAIN_PERF_ID);
         /* Note: CFE_ES_ExitApp will not return */
         CFE_ES_ExitApp(CFE_ES_RunStatus_CORE_APP_INIT_ERROR);
-    } /* end if */
+    }
 
     /*
      * Wait for other apps to start.
@@ -138,7 +136,7 @@ void CFE_TBL_TaskMain(void)
         else
         {
             CFE_ES_WriteToSysLog("%s: Error reading cmd pipe,RC=0x%08X\n", __func__, (unsigned int)Status);
-        } /* end if */
+        }
 
     } /* end while */
 
@@ -147,8 +145,6 @@ void CFE_TBL_TaskMain(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_TaskInit
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -172,7 +168,7 @@ int32 CFE_TBL_TaskInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Call to CFE_EVS_Register Failed:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
     /*
     ** Create Software Bus message pipe
@@ -182,7 +178,7 @@ int32 CFE_TBL_TaskInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Error creating cmd pipe:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
     /*
     ** Subscribe to Housekeeping request commands
@@ -193,7 +189,7 @@ int32 CFE_TBL_TaskInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Error subscribing to HK Request:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
     /*
     ** Subscribe to Table task ground command packets
@@ -204,7 +200,7 @@ int32 CFE_TBL_TaskInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Error subscribing to gnd cmds:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
     /*
     ** Task startup event message
@@ -216,14 +212,12 @@ int32 CFE_TBL_TaskInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Error sending init event:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
     return CFE_SUCCESS;
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_InitData
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -231,7 +225,6 @@ int32 CFE_TBL_TaskInit(void)
  *-----------------------------------------------------------------*/
 void CFE_TBL_InitData(void)
 {
-
     /* Get the assigned Application ID for the Table Services Task */
     CFE_ES_GetAppID(&CFE_TBL_Global.TableTaskAppId);
 
@@ -248,8 +241,6 @@ void CFE_TBL_InitData(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_TaskPipe
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -326,8 +317,6 @@ void CFE_TBL_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_SearchCmdHndlrTbl
  *
  * Application-scope internal function
  * See description in header file for argument/return detail

--- a/modules/tbl/fsw/src/cfe_tbl_task.h
+++ b/modules/tbl/fsw/src/cfe_tbl_task.h
@@ -339,7 +339,6 @@ typedef struct
      * Registry dump state info (background job)
      */
     CFE_TBL_RegDumpStateInfo_t RegDumpState;
-
 } CFE_TBL_Global_t;
 
 /*************************************************************************/

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
@@ -37,8 +37,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_HousekeepingCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -135,8 +133,6 @@ int32 CFE_TBL_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_GetHkData
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -250,8 +246,6 @@ void CFE_TBL_GetHkData(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_GetTblRegData
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -310,8 +304,6 @@ void CFE_TBL_GetTblRegData(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_NoopCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -325,8 +317,6 @@ int32 CFE_TBL_NoopCmd(const CFE_TBL_NoopCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_ResetCountersCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -347,8 +337,6 @@ int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCountersCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_LoadCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -539,8 +527,6 @@ int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_DumpCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -685,8 +671,6 @@ int32 CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_DumpToFile
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -810,8 +794,6 @@ CFE_TBL_CmdProcRet_t CFE_TBL_DumpToFile(const char *DumpFilename, const char *Ta
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_ValidateCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -954,8 +936,6 @@ int32 CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_ActivateCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1033,8 +1013,6 @@ int32 CFE_TBL_ActivateCmd(const CFE_TBL_ActivateCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_DumpRegistryGetter
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1154,8 +1132,6 @@ bool CFE_TBL_DumpRegistryGetter(void *Meta, uint32 RecordNum, void **Buffer, siz
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_DumpRegistryEventHandler
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1218,8 +1194,6 @@ void CFE_TBL_DumpRegistryEventHandler(void *Meta, CFE_FS_FileWriteEvent_t Event,
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_DumpRegistryCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1281,8 +1255,6 @@ int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_SendRegistryCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1321,8 +1293,6 @@ int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_DeleteCDSCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1412,8 +1382,6 @@ int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TBL_AbortLoadCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1463,8 +1431,6 @@ int32 CFE_TBL_AbortLoadCmd(const CFE_TBL_AbortLoadCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TBL_AbortLoad
  *
  * Application-scope internal function
  * See description in header file for argument/return detail

--- a/modules/tbl/ut-coverage/tbl_UT.c
+++ b/modules/tbl/ut-coverage/tbl_UT.c
@@ -757,7 +757,6 @@ void Test_CFE_TBL_ValidateCmd(void)
 */
 void Test_CFE_TBL_NoopCmd(void)
 {
-
     UtPrintf("Begin Test No-Op Command");
 
     /* Test run through function (there are no additional paths) */
@@ -1386,7 +1385,6 @@ void Test_CFE_TBL_HousekeepingCmd(void)
 */
 void Test_CFE_TBL_ApiInit(void)
 {
-
     UT_ResetCDS();
 
     /* Provide a big enough pool for the load buffers */

--- a/modules/time/fsw/inc/cfe_time_msg.h
+++ b/modules/time/fsw/inc/cfe_time_msg.h
@@ -729,7 +729,6 @@
 typedef struct CFE_TIME_NoArgsCmd
 {
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
-
 } CFE_TIME_NoArgsCmd_t;
 
 /*
@@ -858,7 +857,6 @@ typedef struct CFE_TIME_OneHzAdjustmentCmd_Payload
 {
     uint32 Seconds;
     uint32 Subseconds;
-
 } CFE_TIME_OneHzAdjustmentCmd_Payload_t;
 
 /**
@@ -959,7 +957,6 @@ typedef struct CFE_TIME_HousekeepingTlm_Payload
     uint32 SubsecsDelay; /**< \cfetlmmnemonic \TIME_1HZDLYSSECS
                               \brief Current 1 Hz SCTF Delay (sub-seconds) */
 #endif
-
 } CFE_TIME_HousekeepingTlm_Payload_t;
 
 typedef struct CFE_TIME_HousekeepingTlm

--- a/modules/time/fsw/src/cfe_time_api.c
+++ b/modules/time/fsw/src/cfe_time_api.c
@@ -36,8 +36,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_GetTime
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -60,8 +58,6 @@ CFE_TIME_SysTime_t CFE_TIME_GetTime(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_GetTAI
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -92,8 +88,6 @@ CFE_TIME_SysTime_t CFE_TIME_GetTAI(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_GetUTC
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -122,15 +116,12 @@ CFE_TIME_SysTime_t CFE_TIME_GetUTC(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_MET2SCTime
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 CFE_TIME_SysTime_t CFE_TIME_MET2SCTime(CFE_TIME_SysTime_t METTime)
 {
-
     CFE_TIME_SysTime_t STCF;
     CFE_TIME_SysTime_t TIATime;
     CFE_TIME_SysTime_t ReturnTime;
@@ -163,8 +154,6 @@ CFE_TIME_SysTime_t CFE_TIME_MET2SCTime(CFE_TIME_SysTime_t METTime)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_GetClockState
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -192,8 +181,6 @@ CFE_TIME_ClockState_Enum_t CFE_TIME_GetClockState(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_GetClockInfo
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -295,8 +282,6 @@ uint16 CFE_TIME_GetClockInfo(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_GetLeapSeconds
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -319,8 +304,6 @@ int16 CFE_TIME_GetLeapSeconds(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_GetSTCF
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -345,8 +328,6 @@ CFE_TIME_SysTime_t CFE_TIME_GetSTCF(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_GetMET
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -369,8 +350,6 @@ CFE_TIME_SysTime_t CFE_TIME_GetMET(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_GetMETseconds
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -395,8 +374,6 @@ uint32 CFE_TIME_GetMETseconds(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_GetMETsubsecs
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -419,8 +396,6 @@ uint32 CFE_TIME_GetMETsubsecs(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_Add
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -449,8 +424,6 @@ CFE_TIME_SysTime_t CFE_TIME_Add(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Tim
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_Subtract
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -474,8 +447,6 @@ CFE_TIME_SysTime_t CFE_TIME_Subtract(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_Compare
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -537,8 +508,6 @@ CFE_TIME_Compare_t CFE_TIME_Compare(CFE_TIME_SysTime_t TimeA, CFE_TIME_SysTime_t
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_Sub2MicroSecs
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -558,8 +527,6 @@ uint32 CFE_TIME_Sub2MicroSecs(uint32 SubSeconds)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_Micro2SubSecs
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -591,8 +558,6 @@ uint32 CFE_TIME_Micro2SubSecs(uint32 MicroSeconds)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_Print
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -746,8 +711,6 @@ void CFE_TIME_Print(char *PrintBuffer, CFE_TIME_SysTime_t TimeToPrint)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_ExternalTone
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -761,8 +724,6 @@ void CFE_TIME_ExternalTone(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_RegisterSynchCallback
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -786,7 +747,6 @@ CFE_Status_t CFE_TIME_RegisterSynchCallback(CFE_TIME_SynchCallbackPtr_t Callback
 
         if (Status == CFE_SUCCESS)
         {
-
             if (AppIndex >= (sizeof(CFE_TIME_Global.SynchCallback) / sizeof(CFE_TIME_Global.SynchCallback[0])) ||
                 CFE_TIME_Global.SynchCallback[AppIndex].Ptr != NULL)
             {
@@ -803,8 +763,6 @@ CFE_Status_t CFE_TIME_RegisterSynchCallback(CFE_TIME_SynchCallbackPtr_t Callback
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_UnregisterSynchCallback
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -828,7 +786,6 @@ CFE_Status_t CFE_TIME_UnregisterSynchCallback(CFE_TIME_SynchCallbackPtr_t Callba
 
         if (Status == CFE_SUCCESS)
         {
-
             if (AppIndex >= (sizeof(CFE_TIME_Global.SynchCallback) / sizeof(CFE_TIME_Global.SynchCallback[0])) ||
                 CFE_TIME_Global.SynchCallback[AppIndex].Ptr != CallbackFuncPtr)
             {
@@ -846,8 +803,6 @@ CFE_Status_t CFE_TIME_UnregisterSynchCallback(CFE_TIME_SynchCallbackPtr_t Callba
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_ExternalMET
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -864,8 +819,6 @@ void CFE_TIME_ExternalMET(CFE_TIME_SysTime_t NewMET)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_ExternalGPS
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -881,8 +834,6 @@ void CFE_TIME_ExternalGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps)
 #endif /* CFE_PLATFORM_TIME_CFG_SRC_GPS */
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_ExternalTime
  *
  * Implemented per public API
  * See description in header file for argument/return detail

--- a/modules/time/fsw/src/cfe_time_task.c
+++ b/modules/time/fsw/src/cfe_time_task.c
@@ -41,8 +41,6 @@ CFE_TIME_Global_t CFE_TIME_Global;
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_EarlyInit
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
@@ -58,8 +56,6 @@ int32 CFE_TIME_EarlyInit(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_TaskMain
  *
  * Implemented per public API
  * See description in header file for argument/return detail
@@ -80,7 +76,7 @@ void CFE_TIME_TaskMain(void)
         CFE_ES_PerfLogExit(CFE_MISSION_TIME_MAIN_PERF_ID);
         /* Note: CFE_ES_ExitApp will not return */
         CFE_ES_ExitApp(CFE_ES_RunStatus_CORE_APP_INIT_ERROR);
-    } /* end if */
+    }
 
     /*
      * Wait for other apps to start.
@@ -93,7 +89,6 @@ void CFE_TIME_TaskMain(void)
     /* Main loop */
     while (Status == CFE_SUCCESS)
     {
-
         /* Increment the Main task Execution Counter */
         CFE_ES_IncrementTaskCounter();
 
@@ -112,7 +107,7 @@ void CFE_TIME_TaskMain(void)
         else
         {
             CFE_ES_WriteToSysLog("%s: Error reading cmd pipe,RC=0x%08X\n", __func__, (unsigned int)Status);
-        } /* end if */
+        }
 
     } /* end while */
 
@@ -121,8 +116,6 @@ void CFE_TIME_TaskMain(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_TaskInit
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -140,7 +133,7 @@ int32 CFE_TIME_TaskInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Call to CFE_EVS_Register Failed:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
     OsStatus = OS_BinSemCreate(&CFE_TIME_Global.ToneSemaphore, CFE_TIME_SEM_TONE_NAME, CFE_TIME_SEM_VALUE,
                                CFE_TIME_SEM_OPTIONS);
@@ -148,7 +141,7 @@ int32 CFE_TIME_TaskInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Error creating tone semaphore:RC=%ld\n", __func__, (long)OsStatus);
         return CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
-    } /* end if */
+    }
 
     OsStatus = OS_BinSemCreate(&CFE_TIME_Global.LocalSemaphore, CFE_TIME_SEM_1HZ_NAME, CFE_TIME_SEM_VALUE,
                                CFE_TIME_SEM_OPTIONS);
@@ -156,7 +149,7 @@ int32 CFE_TIME_TaskInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Error creating local semaphore:RC=%ld\n", __func__, (long)OsStatus);
         return CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
-    } /* end if */
+    }
 
     Status = CFE_ES_CreateChildTask(&CFE_TIME_Global.ToneTaskID, CFE_TIME_TASK_TONE_NAME, CFE_TIME_Tone1HzTask,
                                     CFE_TIME_TASK_STACK_PTR, CFE_PLATFORM_TIME_TONE_TASK_STACK_SIZE,
@@ -165,7 +158,7 @@ int32 CFE_TIME_TaskInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Error creating tone 1Hz child task:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
     Status = CFE_ES_CreateChildTask(&CFE_TIME_Global.LocalTaskID, CFE_TIME_TASK_1HZ_NAME, CFE_TIME_Local1HzTask,
                                     CFE_TIME_TASK_STACK_PTR, CFE_PLATFORM_TIME_1HZ_TASK_STACK_SIZE,
@@ -174,21 +167,21 @@ int32 CFE_TIME_TaskInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Error creating local 1Hz child task:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
     Status = CFE_SB_CreatePipe(&CFE_TIME_Global.CmdPipe, CFE_TIME_TASK_PIPE_DEPTH, CFE_TIME_TASK_PIPE_NAME);
     if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s: Error creating cmd pipe:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
     Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_TIME_SEND_HK_MID), CFE_TIME_Global.CmdPipe);
     if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s: Error subscribing to HK Request:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
 /*
 ** Subscribe to time at the tone "signal" commands...
@@ -205,7 +198,7 @@ int32 CFE_TIME_TaskInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Error subscribing to tone cmd:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
 /*
 ** Subscribe to time at the tone "data" commands...
@@ -222,7 +215,7 @@ int32 CFE_TIME_TaskInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Error subscribing to time data cmd:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
 /*
 ** Subscribe to 1Hz signal commands...
@@ -241,7 +234,7 @@ int32 CFE_TIME_TaskInit(void)
         CFE_ES_WriteToSysLog("%s: Error subscribing to fake tone signal cmds:RC=0x%08X\n", __func__,
                              (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
 /*
 ** Subscribe to time at the tone "request data" commands...
@@ -253,7 +246,7 @@ int32 CFE_TIME_TaskInit(void)
         CFE_ES_WriteToSysLog("%s: Error subscribing to time at the tone request data cmds:RC=0x%08X\n", __func__,
                              (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 #endif
 
     /*
@@ -264,7 +257,7 @@ int32 CFE_TIME_TaskInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Error subscribing to time task gnd cmds:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
     Status = CFE_EVS_SendEvent(CFE_TIME_INIT_EID, CFE_EVS_EventType_INFORMATION, "cFE TIME Initialized: %s",
                                CFE_VERSION_STRING);
@@ -272,7 +265,7 @@ int32 CFE_TIME_TaskInit(void)
     {
         CFE_ES_WriteToSysLog("%s: Error sending init event:RC=0x%08X\n", __func__, (unsigned int)Status);
         return Status;
-    } /* end if */
+    }
 
 /*
 ** Select primary vs redundant tone interrupt signal...
@@ -314,8 +307,6 @@ int32 CFE_TIME_TaskInit(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_VerifyCmdLength
- *
  * Internal helper routine only, not part of API.
  *
  * Function to verify the length of incoming TIME command packets
@@ -350,8 +341,6 @@ bool CFE_TIME_VerifyCmdLength(CFE_MSG_Message_t *MsgPtr, size_t ExpectedLength)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_TaskPipe
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -554,8 +543,6 @@ void CFE_TIME_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_HousekeepingCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -594,8 +581,6 @@ int32 CFE_TIME_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_ToneSignalCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -616,8 +601,6 @@ int32 CFE_TIME_ToneSignalCmd(const CFE_TIME_ToneSignalCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_ToneDataCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -637,8 +620,6 @@ int32 CFE_TIME_ToneDataCmd(const CFE_TIME_ToneDataCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_OneHzCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -670,8 +651,6 @@ int32 CFE_TIME_OneHzCmd(const CFE_TIME_1HzCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_ToneSendCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -694,15 +673,12 @@ int32 CFE_TIME_ToneSendCmd(const CFE_TIME_FakeToneCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_NoopCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_NoopCmd(const CFE_TIME_NoopCmd_t *data)
 {
-
     CFE_TIME_Global.CommandCounter++;
 
     CFE_EVS_SendEvent(CFE_TIME_NOOP_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", CFE_VERSION_STRING);
@@ -712,15 +688,12 @@ int32 CFE_TIME_NoopCmd(const CFE_TIME_NoopCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_ResetCountersCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_ResetCountersCmd(const CFE_TIME_ResetCountersCmd_t *data)
 {
-
     CFE_TIME_Global.CommandCounter      = 0;
     CFE_TIME_Global.CommandErrorCounter = 0;
 
@@ -753,8 +726,6 @@ int32 CFE_TIME_ResetCountersCmd(const CFE_TIME_ResetCountersCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_SendDiagnosticTlm
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -780,8 +751,6 @@ int32 CFE_TIME_SendDiagnosticTlm(const CFE_TIME_SendDiagnosticCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_SetStateCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -831,8 +800,6 @@ int32 CFE_TIME_SetStateCmd(const CFE_TIME_SetStateCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_SetSourceCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -901,8 +868,6 @@ int32 CFE_TIME_SetSourceCmd(const CFE_TIME_SetSourceCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_SetSignalCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -970,8 +935,6 @@ int32 CFE_TIME_SetSignalCmd(const CFE_TIME_SetSignalCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_SetDelayImpl
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1020,8 +983,6 @@ void CFE_TIME_SetDelayImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIM
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_AddDelayCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1034,8 +995,6 @@ int32 CFE_TIME_AddDelayCmd(const CFE_TIME_AddDelayCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_SubDelayCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1047,8 +1006,6 @@ int32 CFE_TIME_SubDelayCmd(const CFE_TIME_SubDelayCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_SetTimeCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1101,8 +1058,6 @@ int32 CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_SetMETCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1153,8 +1108,6 @@ int32 CFE_TIME_SetMETCmd(const CFE_TIME_SetMETCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_SetSTCFCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1207,8 +1160,6 @@ int32 CFE_TIME_SetSTCFCmd(const CFE_TIME_SetSTCFCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_SetLeapSecondsCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1244,8 +1195,6 @@ int32 CFE_TIME_SetLeapSecondsCmd(const CFE_TIME_SetLeapSecondsCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_AdjustImpl
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1295,8 +1244,6 @@ void CFE_TIME_AdjustImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_AddAdjustCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1309,8 +1256,6 @@ int32 CFE_TIME_AddAdjustCmd(const CFE_TIME_AddAdjustCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_SubAdjustCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1322,8 +1267,6 @@ int32 CFE_TIME_SubAdjustCmd(const CFE_TIME_SubAdjustCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_1HzAdjImpl
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1362,8 +1305,6 @@ void CFE_TIME_1HzAdjImpl(const CFE_TIME_OneHzAdjustmentCmd_Payload_t *CommandPtr
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_Add1HZAdjustmentCmd
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1375,8 +1316,6 @@ int32 CFE_TIME_Add1HZAdjustmentCmd(const CFE_TIME_Add1HZAdjustmentCmd_t *data)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_Sub1HZAdjustmentCmd
  *
  * Application-scope internal function
  * See description in header file for argument/return detail

--- a/modules/time/fsw/src/cfe_time_tone.c
+++ b/modules/time/fsw/src/cfe_time_tone.c
@@ -43,8 +43,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_ToneSend
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -162,8 +160,6 @@ void CFE_TIME_ToneSend(void)
 #endif /* CFE_PLATFORM_TIME_CFG_SERVER */
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_ToneSendMET
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -295,8 +291,6 @@ int32 CFE_TIME_ToneSendMET(CFE_TIME_SysTime_t NewMET)
 #endif /* CFE_PLATFORM_TIME_CFG_SRC_MET */
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_ToneSendGPS
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -435,8 +429,6 @@ int32 CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps)
 #endif /* CFE_PLATFORM_TIME_CFG_SRC_GPS */
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_ToneSendTime
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -578,8 +570,6 @@ int32 CFE_TIME_ToneSendTime(CFE_TIME_SysTime_t NewTime)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_ToneData
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -648,8 +638,6 @@ void CFE_TIME_ToneData(const CFE_TIME_ToneDataCmd_Payload_t *ToneDataCmd)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_ToneSignal
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -688,8 +676,6 @@ void CFE_TIME_ToneSignal(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_ToneVerify
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -771,8 +757,6 @@ void CFE_TIME_ToneVerify(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_ToneUpdate
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -961,8 +945,6 @@ void CFE_TIME_ToneUpdate(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_Local1HzTimerCallback
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -974,15 +956,12 @@ void CFE_TIME_Local1HzTimerCallback(osal_id_t TimerId, void *Arg)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_Tone1HzISR
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_Tone1HzISR(void)
 {
-
     CFE_TIME_SysTime_t ToneSignalLatch;
     CFE_TIME_SysTime_t Elapsed;
     CFE_TIME_Compare_t Result;
@@ -1081,8 +1060,6 @@ void CFE_TIME_Tone1HzISR(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_Tone1HzTask
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1139,15 +1116,12 @@ void CFE_TIME_Tone1HzTask(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_Local1HzStateMachine
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_Local1HzStateMachine(void)
 {
-
     CFE_TIME_Reference_t                Reference;
     volatile CFE_TIME_ReferenceState_t *NextState;
 
@@ -1257,15 +1231,12 @@ void CFE_TIME_Local1HzStateMachine(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_Local1HzISR
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_Local1HzISR(void)
 {
-
     CFE_TIME_Global.LocalIntCounter++;
 
     /*
@@ -1275,8 +1246,6 @@ void CFE_TIME_Local1HzISR(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_Local1HzTask
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1288,7 +1257,6 @@ void CFE_TIME_Local1HzTask(void)
 
     while (true)
     {
-
         /* Increment the Main task Execution Counter */
         CFE_ES_IncrementTaskCounter();
 
@@ -1334,8 +1302,6 @@ void CFE_TIME_Local1HzTask(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_NotifyTimeSynchApps
  *
  * Application-scope internal function
  * See description in header file for argument/return detail

--- a/modules/time/fsw/src/cfe_time_utils.c
+++ b/modules/time/fsw/src/cfe_time_utils.c
@@ -42,8 +42,6 @@
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_StartReferenceUpdate
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -75,8 +73,6 @@ volatile CFE_TIME_ReferenceState_t *CFE_TIME_StartReferenceUpdate(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_LatchClock
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -104,15 +100,12 @@ CFE_TIME_SysTime_t CFE_TIME_LatchClock(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_QueryResetVars
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_QueryResetVars(void)
 {
-
     CFE_TIME_ResetVars_t                LocalResetVars;
     uint32                              DefSubsMET;
     uint32                              DefSubsSTCF;
@@ -192,8 +185,6 @@ void CFE_TIME_QueryResetVars(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_UpdateResetVars
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -209,7 +200,6 @@ void CFE_TIME_UpdateResetVars(const CFE_TIME_Reference_t *Reference)
     */
     if (CFE_TIME_Global.DataStoreStatus != CFE_TIME_RESET_AREA_ERROR)
     {
-
         /* Store all of our critical variables to a ResetVars_t
          * then copy that to the Reset Area */
         LocalResetVars.Signature = CFE_TIME_RESET_SIGNATURE;
@@ -233,8 +223,6 @@ void CFE_TIME_UpdateResetVars(const CFE_TIME_Reference_t *Reference)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_InitData
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -369,15 +357,12 @@ void CFE_TIME_InitData(void)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_GetHkData
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_TIME_GetHkData(const CFE_TIME_Reference_t *Reference)
 {
-
     /*
     ** Get command execution counters...
     */
@@ -426,8 +411,6 @@ void CFE_TIME_GetHkData(const CFE_TIME_Reference_t *Reference)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_GetDiagData
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -546,8 +529,6 @@ void CFE_TIME_GetDiagData(void)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_GetReference
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -675,8 +656,6 @@ void CFE_TIME_GetReference(CFE_TIME_Reference_t *Reference)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_CalculateTAI
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -691,8 +670,6 @@ CFE_TIME_SysTime_t CFE_TIME_CalculateTAI(const CFE_TIME_Reference_t *Reference)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_CalculateUTC
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -709,8 +686,6 @@ CFE_TIME_SysTime_t CFE_TIME_CalculateUTC(const CFE_TIME_Reference_t *Reference)
 }
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_CalculateState
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -764,8 +739,6 @@ CFE_TIME_ClockState_Enum_t CFE_TIME_CalculateState(const CFE_TIME_Reference_t *R
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_SetState
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -808,8 +781,6 @@ void CFE_TIME_SetState(CFE_TIME_ClockState_Enum_t NewState)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_SetSource
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -822,8 +793,6 @@ void CFE_TIME_SetSource(int16 NewSource)
 #endif /* CFE_PLATFORM_TIME_CFG_SOURCE */
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_SetSignal
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -840,8 +809,6 @@ void CFE_TIME_SetSignal(int16 NewSignal)
 #endif /* CFE_PLATFORM_TIME_CFG_SIGNAL */
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_SetDelay
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -865,8 +832,6 @@ void CFE_TIME_SetDelay(CFE_TIME_SysTime_t NewDelay, int16 Direction)
 #endif /* CFE_PLATFORM_TIME_CFG_CLIENT */
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_SetTime
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -915,8 +880,6 @@ void CFE_TIME_SetTime(CFE_TIME_SysTime_t NewTime)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_SetMET
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -951,8 +914,6 @@ void CFE_TIME_SetMET(CFE_TIME_SysTime_t NewMET)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_SetSTCF
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -975,8 +936,6 @@ void CFE_TIME_SetSTCF(CFE_TIME_SysTime_t NewSTCF)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_SetLeapSeconds
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -998,8 +957,6 @@ void CFE_TIME_SetLeapSeconds(int16 NewLeaps)
 #endif /* CFE_PLATFORM_TIME_CFG_SERVER */
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_SetAdjust
  *
  * Application-scope internal function
  * See description in header file for argument/return detail
@@ -1036,8 +993,6 @@ void CFE_TIME_SetAdjust(CFE_TIME_SysTime_t NewAdjust, int16 Direction)
 
 /*----------------------------------------------------------------
  *
- * Function: CFE_TIME_Set1HzAdj
- *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
@@ -1054,8 +1009,6 @@ void CFE_TIME_Set1HzAdj(CFE_TIME_SysTime_t NewAdjust, int16 Direction)
 #endif /* CFE_PLATFORM_TIME_CFG_SERVER */
 
 /*----------------------------------------------------------------
- *
- * Function: CFE_TIME_CleanUpApp
  *
  * Implemented per public API
  * See description in header file for argument/return detail

--- a/modules/time/fsw/src/cfe_time_utils.h
+++ b/modules/time/fsw/src/cfe_time_utils.h
@@ -104,7 +104,6 @@
 */
 typedef struct
 {
-
     CFE_TIME_SysTime_t AtToneMET;         /* MET at time of tone */
     CFE_TIME_SysTime_t AtToneSTCF;        /* STCF at time of tone */
     int16              AtToneLeapSeconds; /* Leap Seconds at time of tone */
@@ -116,7 +115,6 @@ typedef struct
     CFE_TIME_SysTime_t CurrentLatch;      /* Local clock latched just "now" */
     CFE_TIME_SysTime_t TimeSinceTone;     /* Time elapsed since the tone */
     CFE_TIME_SysTime_t CurrentMET;        /* MET at this instant */
-
 } CFE_TIME_Reference_t;
 
 /*
@@ -147,7 +145,6 @@ typedef struct
     CFE_TIME_SysTime_t AtToneSTCF;
     CFE_TIME_SysTime_t AtToneDelay;
     CFE_TIME_SysTime_t AtToneLatch;
-
 } CFE_TIME_ReferenceState_t;
 
 /*************************************************************************/
@@ -315,7 +312,6 @@ typedef struct
     ** One callback per app is allowed
     */
     CFE_TIME_SynchCallbackRegEntry_t SynchCallback[CFE_PLATFORM_ES_MAX_APPLICATIONS];
-
 } CFE_TIME_Global_t;
 
 /*


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #2162
Removes redundant and inconsistent comments (incl. `/* end of function */`, `/* end if */`, function name in function header comments).
There were also a few cases of unnecessary empty lines (e.g. on the last line before the closing brace of a function) and also missing empty lines (e.g. between functions) which were corrected. Some of these empty lines trigger the CI format checks.
I've left the commits separated for now to make life easier for whoever reviews this. I can squash them if/when this is ready for merge.

**Testing performed**
None (comment and whitespace changes only).

**Expected behavior changes**
No impact on behavior.
These updates will reduce clutter and inconsistency in the code, improving readability.

**Contributor Info**
@thnkslprpt 