### PR TITLE
Fix #2169, Update CI_LAB entry point in cfe_es_startup.scr

### DIFF
--- a/cmake/sample_defs/cpu1_cfe_es_startup.scr
+++ b/cmake/sample_defs/cpu1_cfe_es_startup.scr
@@ -1,7 +1,7 @@
 CFE_LIB, cfe_assert,  CFE_Assert_LibInit, ASSERT_LIB,    0,   0,     0x0, 0;
 CFE_LIB, sample_lib,  SAMPLE_LIB_Init,    SAMPLE_LIB,    0,   0,     0x0, 0;
 CFE_APP, sample_app,  SAMPLE_APP_Main,    SAMPLE_APP,   50,   16384, 0x0, 0;
-CFE_APP, ci_lab,      CI_Lab_AppMain,     CI_LAB_APP,   60,   16384, 0x0, 0;
+CFE_APP, ci_lab,      CI_LAB_AppMain,     CI_LAB_APP,   60,   16384, 0x0, 0;
 CFE_APP, to_lab,      TO_LAB_AppMain,     TO_LAB_APP,   70,   16384, 0x0, 0;
 CFE_APP, sch_lab,     SCH_Lab_AppMain,    SCH_LAB_APP,  80,   16384, 0x0, 0;
 !


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2169 
  - Updates CI_LAB entry point in cfe_es_startup.scr

Part of changes to the [ci-lab app](https://github.com/nasa/ci_lab/pull/126) and [GroundSystem](https://github.com/nasa/cFS-GroundSystem/pull/230)
Aim is to standardize naming of CI_LAB functions to match the predominant cFS style.

**Testing performed**
Only the GitHub CI workflow actions.

**Expected behavior changes**
No impact on behavior.

**Contributor Info**
Avi Weiss @thnkslprpt 