### PR TITLE
Fix #2172, Remove last few uses of sprintf()

### DIFF
--- a/modules/cfe_testcase/src/tbl_content_access_test.c
+++ b/modules/cfe_testcase/src/tbl_content_access_test.c
@@ -118,7 +118,7 @@ void TestGetReleaseAddresses(void)
     TblPtrs[0]    = TblPtrsList;
     for (int i = 1; i < numValidTbls + 1; i++)
     {
-        sprintf(TblName, "%d", i);
+        snprintf(TblName, sizeof(TblName), "%d", i);
         UtAssert_INT32_EQ(
             CFE_TBL_Register(&TblHandles[i], TblName, sizeof(TBL_TEST_Table_t), CFE_TBL_OPT_DEFAULT, NULL),
             CFE_SUCCESS);


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2172 
  - Use of sprintf() swapped for snprintf() removing a source of potential buffer overruns.

2 other cases already have their own issues open with further changes being considered, and have not been updated with this PR at this stage (https://github.com/nasa/cFE/issues/1465 and https://github.com/nasa/cFE/issues/1511).


**Testing performed**
Standard cFS build tests (covered the fsw change but not test code change).

**Expected behavior changes**
No impact on behavior expected.

**System(s) tested on**
Intel(R) Celeron(R) N4100 CPU @ 1.10GHz x86_64
Debian GNU/Linux 11 (bullseye)
cFE v7.0.0-rc4+dev193

**Contributor Info**
Avi Weiss @thnkslprpt