### PR TITLE
Fix #2175, Apply consistent Event ID names to common events

### DIFF
--- a/docs/src/cfe_es.dox
+++ b/docs/src/cfe_es.dox
@@ -728,7 +728,7 @@
   message length embedded within the header (from `CFE_MSG_GetSize()`) matches the expected
   length of that message, based on the size of the C structure defining that command.
   If there is any discrepancy between the expected and actual message size, ES will generate
-  the #CFE_ES_LEN_ERR_EID event, increment the command error counter (\ES_CMDEC), and the
+  the #CFE_ES_CMD_LEN_ERR_EID event, increment the command error counter (\ES_CMDEC), and the
   command will _not_ be accepted for processing.
 
   The following is a list of commands that are processed by the cFE Executive Services Task.

--- a/docs/src/cfe_evs.dox
+++ b/docs/src/cfe_evs.dox
@@ -492,7 +492,7 @@
 **  message length embedded within the header (from `CFE_MSG_GetSize()`) matches the expected
 **  length of that message, based on the size of the C structure defining that command.
 **  If there is any discrepancy between the expected and actual message size, EVS will generate
-**  the #CFE_EVS_LEN_ERR_EID event, increment the command error counter (\EVS_CMDEC), and the
+**  the #CFE_EVS_CMD_LEN_ERR_EID event, increment the command error counter (\EVS_CMDEC), and the
 **  command will _not_ be accepted for processing.
 **
 **  The following is a list of commands that are processed by the cFE Event Services Task.

--- a/docs/src/cfe_sb.dox
+++ b/docs/src/cfe_sb.dox
@@ -530,7 +530,7 @@
 **  message length embedded within the header (from `CFE_MSG_GetSize()`) matches the expected
 **  length of that message, based on the size of the C structure defining that command.
 **  If there is any discrepancy between the expected and actual message size, SB will generate
-**  the #CFE_SB_LEN_ERR_EID event, increment the command error counter (\SB_CMDEC), and the
+**  the #CFE_SB_CMD_LEN_ERR_EID event, increment the command error counter (\SB_CMDEC), and the
 **  command will _not_ be accepted for processing.
 **
 **  The following is a list of commands that are processed by the cFE Software Bus Task.

--- a/docs/src/cfe_tbl.dox
+++ b/docs/src/cfe_tbl.dox
@@ -377,7 +377,7 @@
 **  message length embedded within the header (from `CFE_MSG_GetSize()`) matches the expected
 **  length of that message, based on the size of the C structure defining that command.
 **  If there is any discrepancy between the expected and actual message size, TBL will generate
-**  the #CFE_TBL_LEN_ERR_EID event, increment the command error counter (\TBL_CMDEC), and the
+**  the #CFE_TBL_CMD_LEN_ERR_EID event, increment the command error counter (\TBL_CMDEC), and the
 **  command will _not_ be accepted for processing.
 **
 **  The following is a list of commands that are processed by the cFE Table Services Task.

--- a/docs/src/cfe_time.dox
+++ b/docs/src/cfe_time.dox
@@ -706,7 +706,7 @@
 **  message length embedded within the header (from `CFE_MSG_GetSize()`) matches the expected
 **  length of that message, based on the size of the C structure defining that command.
 **  If there is any discrepancy between the expected and actual message size, TIME will generate
-**  the #CFE_TIME_LEN_ERR_EID event, increment the command error counter (\TIME_CMDEC), and the
+**  the #CFE_TIME_CMD_LEN_ERR_EID event, increment the command error counter (\TIME_CMDEC), and the
 **  command will _not_ be accepted for processing.
 **
 **  The following is a list of commands that are processed by the cFE Time Services Task.

--- a/modules/es/config/default_cfe_es_fcncodes.h
+++ b/modules/es/config/default_cfe_es_fcncodes.h
@@ -63,7 +63,7 @@
 **
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \ES_CMDEC - command error counter will increment
-**       - the #CFE_ES_LEN_ERR_EID error event message will be generated
+**       - the #CFE_ES_CMD_LEN_ERR_EID error event message will be generated
 **
 **  \par Criticality
 **       None

--- a/modules/es/eds/cfe_es.xml
+++ b/modules/es/eds/cfe_es.xml
@@ -815,7 +815,7 @@
 
           Evidence of failure may be found in the following telemetry:
           - \b \c \ES_CMDEC - command error counter will increment
-          - the #CFE_ES_LEN_ERR_EID error event message will be generated
+          - the #CFE_ES_CMD_LEN_ERR_EID error event message will be generated
 
           \par  Criticality
           None
@@ -856,7 +856,7 @@
 
           Evidence of failure may be found in the following telemetry:
           - \b \c \ES_CMDEC - command error counter will increment
-          - the #CFE_ES_LEN_ERR_EID error event message will be generated
+          - the #CFE_ES_CMD_LEN_ERR_EID error event message will be generated
 
           \par  Criticality
 

--- a/modules/es/fsw/inc/cfe_es_eventids.h
+++ b/modules/es/fsw/inc/cfe_es_eventids.h
@@ -269,7 +269,7 @@
  *
  *  Invalid command code for message ID #CFE_ES_CMD_MID received on the ES message pipe.
  */
-#define CFE_ES_CC1_ERR_EID 22
+#define CFE_ES_CC_ERR_EID 22
 
 /**
  * \brief ES Invalid Command Length Event ID
@@ -280,7 +280,7 @@
  *
  *  Invalid length for the command code in message ID #CFE_ES_CMD_MID received on the ES message pipe.
  */
-#define CFE_ES_LEN_ERR_EID 23
+#define CFE_ES_CMD_LEN_ERR_EID 23
 
 /**
  * \brief ES Restart Command Invalid Restart Type Event ID

--- a/modules/es/fsw/src/cfe_es_dispatch.c
+++ b/modules/es/fsw/src/cfe_es_dispatch.c
@@ -58,7 +58,7 @@ bool CFE_ES_VerifyCmdLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLeng
         CFE_MSG_GetMsgId(MsgPtr, &MsgId);
         CFE_MSG_GetFcnCode(MsgPtr, &FcnCode);
 
-        CFE_EVS_SendEvent(CFE_ES_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CFE_ES_CMD_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Invalid msg length: ID = 0x%X,  CC = %u, Len = %u, Expected = %u",
                           (unsigned int)CFE_SB_MsgIdToValue(MsgId), (unsigned int)FcnCode, (unsigned int)ActualLength,
                           (unsigned int)ExpectedLength);
@@ -267,7 +267,7 @@ void CFE_ES_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
                     break;
 
                 default:
-                    CFE_EVS_SendEvent(CFE_ES_CC1_ERR_EID, CFE_EVS_EventType_ERROR,
+                    CFE_EVS_SendEvent(CFE_ES_CC_ERR_EID, CFE_EVS_EventType_ERROR,
                                       "Invalid ground command code: ID = 0x%X, CC = %d",
                                       (unsigned int)CFE_SB_MsgIdToValue(MessageID), (int)CommandCode);
                     CFE_ES_Global.TaskData.CommandErrorCounter++;

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -3259,7 +3259,7 @@ void TestTask(void)
      */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_INVALID_LENGTH);
-    CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_CMD_LEN_ERR_EID);
 
     /* Test resetting and setting the max for the processor reset count */
     ES_ResetUnitTest();
@@ -3380,22 +3380,22 @@ void TestTask(void)
     /* Test the command pipe message process with an invalid command */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.NoopCmd), UT_TPID_CFE_ES_CMD_INVALID_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_CC1_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_CC_ERR_EID);
 
     /* Test sending a no-op command with an invalid command length */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_NOOP_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_CMD_LEN_ERR_EID);
 
     /* Test sending a reset counters command with an invalid command length */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_RESET_COUNTERS_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_CMD_LEN_ERR_EID);
 
     /* Test sending a cFE restart command with an invalid command length */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_RESTART_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_CMD_LEN_ERR_EID);
 
     /* Test cFE restart with a power on reset */
     ES_ResetUnitTest();
@@ -3409,7 +3409,7 @@ void TestTask(void)
      */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_START_APP_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_CMD_LEN_ERR_EID);
 
     /* Test start application command with a processor restart on application
      * exception
@@ -3434,63 +3434,63 @@ void TestTask(void)
      */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_STOP_APP_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_CMD_LEN_ERR_EID);
 
     /* Test sending a restart application command with an invalid command
      * length
      */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_RESTART_APP_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_CMD_LEN_ERR_EID);
 
     /* Test sending a reload application command with an invalid command
      * length
      */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_RELOAD_APP_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_CMD_LEN_ERR_EID);
 
     /* Test sending a write request for a single application with an
      * invalid command length
      */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_QUERY_ONE_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_CMD_LEN_ERR_EID);
 
     /* Test sending a write request for all applications with an
      * invalid command length
      */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_QUERY_ALL_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_CMD_LEN_ERR_EID);
 
     /* Test sending a write request for all tasks with an
      * invalid command length
      */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_QUERY_ALL_TASKS_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_CMD_LEN_ERR_EID);
 
     /* Test sending a request to clear the system log with an
      * invalid command length
      */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_CLEAR_SYS_LOG_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_CMD_LEN_ERR_EID);
 
     /* Test sending a request to overwrite the system log with an
      * invalid command length
      */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_OVER_WRITE_SYS_LOG_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_CMD_LEN_ERR_EID);
 
     /* Test sending a request to write the system log with an
      * invalid command length
      */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_WRITE_SYS_LOG_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_CMD_LEN_ERR_EID);
 
     /* Test successful overwriting of the system log using overwrite mode */
     ES_ResetUnitTest();
@@ -3505,35 +3505,35 @@ void TestTask(void)
      */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_WRITE_ER_LOG_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_CMD_LEN_ERR_EID);
 
     /* Test sending a request to reset the processor reset count with an
      * invalid command length
      */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_RESET_PR_COUNT_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_CMD_LEN_ERR_EID);
 
     /* Test sending a request to set the maximum processor reset count with
      * an invalid command length
      */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_SET_MAX_PR_COUNT_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_CMD_LEN_ERR_EID);
 
     /* Test sending a request to delete the CDS with an invalid command
      * length
      */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_DELETE_CDS_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_CMD_LEN_ERR_EID);
 
     /* Test sending a telemetry pool statistics retrieval command with an
      * invalid command length
      */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_SEND_MEM_POOL_STATS_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_CMD_LEN_ERR_EID);
 
     /* Test successful dump of CDS to file using a specified dump file name */
     ES_ResetUnitTest();
@@ -3550,7 +3550,7 @@ void TestTask(void)
     /* Dump CDS command with invalid length */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_DUMP_CDS_REGISTRY_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_CMD_LEN_ERR_EID);
 
     /* Test error when sending Build Info event */
     ES_ResetUnitTest();

--- a/modules/evs/config/default_cfe_evs_fcncodes.h
+++ b/modules/evs/config/default_cfe_evs_fcncodes.h
@@ -48,7 +48,7 @@
 **       following telemetry:
 **       - \b \c \EVS_CMDPC - command execution counter will
 **         increment
-**       - The #CFE_EVS_NOOP_EID informational event message will
+**       - The #CFE_EVS_NOOP_INF_EID informational event message will
 **         be generated
 **
 **  \par Error Conditions
@@ -84,7 +84,7 @@
 **         will be reset to 0
 **       - \b \c \EVS_CMDEC - command error counter
 **         will be reset to 0
-**       - The #CFE_EVS_RSTCNT_EID debug event message will be
+**       - The #CFE_EVS_RESET_INF_EID debug event message will be
 **         generated
 **
 **  \par Error Conditions

--- a/modules/evs/eds/cfe_evs.xml
+++ b/modules/evs/eds/cfe_evs.xml
@@ -349,7 +349,7 @@
           \par  Command Verification
           Successful execution of this command may be verified with the following telemetry:
           - \b \c \EVS_CMDPC - command execution counter will increment
-          - The #CFE_EVS_NOOP_EID informational event message will be generated
+          - The #CFE_EVS_NOOP_INF_EID informational event message will be generated
 
           \par  Error Conditions
           There are no error conditions for this command. If the Event
@@ -384,7 +384,7 @@
           the following telemetry:
           - \b \c \EVS_CMDPC - command execution counter will
           increment
-          - The #CFE_EVS_RSTCNT_EID debug event message will be
+          - The #CFE_EVS_RESET_INF_EID debug event message will be
           generated
 
           \par  Error Conditions

--- a/modules/evs/fsw/inc/cfe_evs_eventids.h
+++ b/modules/evs/fsw/inc/cfe_evs_eventids.h
@@ -39,7 +39,7 @@
  *
  *  \link #CFE_EVS_NOOP_CC EVS NO-OP command \endlink success.
  */
-#define CFE_EVS_NOOP_EID 0
+#define CFE_EVS_NOOP_INF_EID 0
 
 /**
  * \brief EVS Initialization Event ID
@@ -50,7 +50,7 @@
  *
  *  Event Services Task initialization complete.
  */
-#define CFE_EVS_STARTUP_EID 1
+#define CFE_EVS_INIT_INF_EID 1
 
 /**
  * \brief EVS Write Event Log Command File Write Entry Failed Event ID
@@ -85,7 +85,7 @@
  *
  *  Invalid message ID received on the EVS message pipe.
  */
-#define CFE_EVS_ERR_MSGID_EID 5
+#define CFE_EVS_MID_ERR_EID 5
 
 /**
  * \brief EVS Command Event Not Registered For Filtering Event ID
@@ -199,7 +199,7 @@
  *
  *  Invalid command code for message ID #CFE_EVS_CMD_MID received on the EVS message pipe.
  */
-#define CFE_EVS_ERR_CC_EID 15
+#define CFE_EVS_CC_ERR_EID 15
 
 /**
  * \brief EVS Reset Counters Command Success Event ID
@@ -210,7 +210,7 @@
  *
  *  \link #CFE_EVS_RESET_COUNTERS_CC EVS Reset Counters Command \endlink success.
  */
-#define CFE_EVS_RSTCNT_EID 16
+#define CFE_EVS_RESET_INF_EID 16
 
 /**
  * \brief EVS Set Filter Command Success Event ID
@@ -476,7 +476,7 @@
  *
  *  Invalid length for the command code in message ID #CFE_EVS_CMD_MID received on the EVS message pipe.
  */
-#define CFE_EVS_LEN_ERR_EID 43
+#define CFE_EVS_CMD_LEN_ERR_EID 43
 
 /**
  * \brief EVS Events Squelched Error Event ID

--- a/modules/evs/fsw/src/cfe_evs_dispatch.c
+++ b/modules/evs/fsw/src/cfe_evs_dispatch.c
@@ -61,7 +61,7 @@ void CFE_EVS_ProcessCommandPacket(const CFE_SB_Buffer_t *SBBufPtr)
         default:
             /* Unknown command -- should never occur */
             CFE_EVS_Global.EVS_TlmPkt.Payload.CommandErrorCounter++;
-            EVS_SendEvent(CFE_EVS_ERR_MSGID_EID, CFE_EVS_EventType_ERROR, "Invalid command packet, Message ID = 0x%08X",
+            EVS_SendEvent(CFE_EVS_MID_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid command packet, Message ID = 0x%08X",
                           (unsigned int)CFE_SB_MsgIdToValue(MessageID));
             break;
     }
@@ -257,7 +257,7 @@ void CFE_EVS_ProcessGroundCommand(const CFE_SB_Buffer_t *SBBufPtr, CFE_SB_MsgId_
         /* default is a bad command code as it was not found above */
         default:
 
-            EVS_SendEvent(CFE_EVS_ERR_CC_EID, CFE_EVS_EventType_ERROR, "Invalid command code -- ID = 0x%08x, CC = %u",
+            EVS_SendEvent(CFE_EVS_CC_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid command code -- ID = 0x%08x, CC = %u",
                           (unsigned int)CFE_SB_MsgIdToValue(MsgId), (unsigned int)FcnCode);
             Status = CFE_STATUS_BAD_COMMAND_CODE;
 
@@ -299,7 +299,7 @@ bool CFE_EVS_VerifyCmdLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLen
         CFE_MSG_GetMsgId(MsgPtr, &MsgId);
         CFE_MSG_GetFcnCode(MsgPtr, &FcnCode);
 
-        EVS_SendEvent(CFE_EVS_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+        EVS_SendEvent(CFE_EVS_CMD_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
                       "Invalid msg length: ID = 0x%X,  CC = %u, Len = %u, Expected = %u",
                       (unsigned int)CFE_SB_MsgIdToValue(MsgId), (unsigned int)FcnCode, (unsigned int)ActualLength,
                       (unsigned int)ExpectedLength);

--- a/modules/evs/fsw/src/cfe_evs_task.c
+++ b/modules/evs/fsw/src/cfe_evs_task.c
@@ -300,7 +300,7 @@ int32 CFE_EVS_TaskInit(void)
     CFE_EVS_Global.EVS_AppID = AppID;
     CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE", CFE_SRC_VERSION, CFE_BUILD_CODENAME,
                                 CFE_LAST_OFFICIAL);
-    EVS_SendEvent(CFE_EVS_STARTUP_EID, CFE_EVS_EventType_INFORMATION, "cFE EVS Initialized: %s", VersionString);
+    EVS_SendEvent(CFE_EVS_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "cFE EVS Initialized: %s", VersionString);
 
     return CFE_SUCCESS;
 }
@@ -316,7 +316,7 @@ int32 CFE_EVS_NoopCmd(const CFE_EVS_NoopCmd_t *data)
     char VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
     CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE", CFE_SRC_VERSION, CFE_BUILD_CODENAME,
                                 CFE_LAST_OFFICIAL);
-    EVS_SendEvent(CFE_EVS_NOOP_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", VersionString);
+    EVS_SendEvent(CFE_EVS_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", VersionString);
     return CFE_SUCCESS;
 }
 
@@ -400,7 +400,7 @@ int32 CFE_EVS_ResetCountersCmd(const CFE_EVS_ResetCountersCmd_t *data)
     CFE_EVS_Global.EVS_TlmPkt.Payload.MessageTruncCounter    = 0;
     CFE_EVS_Global.EVS_TlmPkt.Payload.UnregisteredAppCounter = 0;
 
-    EVS_SendEvent(CFE_EVS_RSTCNT_EID, CFE_EVS_EventType_DEBUG, "Reset Counters Command Received");
+    EVS_SendEvent(CFE_EVS_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "Reset Counters Command Received");
 
     /* NOTE: Historically the reset counters command does _NOT_ increment the command counter */
 

--- a/modules/evs/ut-coverage/evs_UT.c
+++ b/modules/evs/ut-coverage/evs_UT.c
@@ -324,7 +324,7 @@ void Test_Init(void)
 
     UT_EVS_DoGenericCheckEvents(CFE_EVS_TaskMain, &UT_EVS_EventBuf);
     CFE_UtAssert_SYSLOG(EVS_SYSLOG_MSGS[8]);
-    UtAssert_INT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ERR_MSGID_EID);
+    UtAssert_INT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_MID_ERR_EID);
 
     /* Test early initialization with a get reset area failure */
     UT_InitData_EVS();
@@ -1010,7 +1010,7 @@ void Test_Logging(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_EVS_DoDispatchCheckEvents(&CmdBuf.noopcmd, sizeof(CmdBuf.noopcmd), UT_TPID_CFE_EVS_CMD_NOOP_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_NOOP_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_NOOP_INF_EID);
 
     /* Clear log for next test */
     UT_InitData_EVS();
@@ -1114,7 +1114,7 @@ void Test_WriteApp(void)
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&CmdBuf.ResetCountersCmd, sizeof(CmdBuf.ResetCountersCmd),
                                  UT_TPID_CFE_EVS_CMD_RESET_COUNTERS_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_RSTCNT_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_RESET_INF_EID);
 
     /* Test writing application data with a create failure using default
      * file name
@@ -1781,122 +1781,122 @@ void Test_InvalidCmd(void)
     /* Test invalid msg id event */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&cmd, sizeof(cmd), UT_TPID_CFE_EVS_INVALID_MID, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ERR_MSGID_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_MID_ERR_EID);
 
     /* Test invalid command code event */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&cmd, sizeof(cmd), UT_TPID_CFE_EVS_CMD_INVALID_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ERR_CC_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_CC_ERR_EID);
 
     /* Test invalid command length event */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&cmd, 0, UT_TPID_CFE_EVS_CMD_NOOP_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LEN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_CMD_LEN_ERR_EID);
 
     /* Test invalid command length with reset counters command */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&cmd, 0, UT_TPID_CFE_EVS_CMD_RESET_COUNTERS_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LEN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_CMD_LEN_ERR_EID);
 
     /* Test invalid command length with enable event type command */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&cmd, 0, UT_TPID_CFE_EVS_CMD_ENABLE_EVENT_TYPE_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LEN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_CMD_LEN_ERR_EID);
 
     /* Test invalid command length with disable event type command */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&cmd, 0, UT_TPID_CFE_EVS_CMD_DISABLE_EVENT_TYPE_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LEN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_CMD_LEN_ERR_EID);
 
     /* Test invalid command length with set event format mode command */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&cmd, 0, UT_TPID_CFE_EVS_CMD_SET_EVENT_FORMAT_MODE_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LEN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_CMD_LEN_ERR_EID);
 
     /* Test invalid command length with enable application event
      * type command
      */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&cmd, 0, UT_TPID_CFE_EVS_CMD_ENABLE_APP_EVENT_TYPE_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LEN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_CMD_LEN_ERR_EID);
 
     /* Test invalid command length with disable application event
      * type command
      */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&cmd, 0, UT_TPID_CFE_EVS_CMD_DISABLE_APP_EVENT_TYPE_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LEN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_CMD_LEN_ERR_EID);
 
     /* Test invalid command length with enable application events command */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&cmd, 0, UT_TPID_CFE_EVS_CMD_ENABLE_APP_EVENTS_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LEN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_CMD_LEN_ERR_EID);
 
     /* Test invalid command length with disable application events command */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&cmd, 0, UT_TPID_CFE_EVS_CMD_DISABLE_APP_EVENTS_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LEN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_CMD_LEN_ERR_EID);
 
     /* Test invalid command length with reset application counter command */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&cmd, 0, UT_TPID_CFE_EVS_CMD_RESET_APP_COUNTER_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LEN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_CMD_LEN_ERR_EID);
 
     /* Test invalid command length with set filter command */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&cmd, 0, UT_TPID_CFE_EVS_CMD_SET_FILTER_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LEN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_CMD_LEN_ERR_EID);
 
     /* Test invalid command length with enable ports command */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&cmd, 0, UT_TPID_CFE_EVS_CMD_ENABLE_PORTS_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LEN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_CMD_LEN_ERR_EID);
 
     /* Test invalid command length with disable ports command */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&cmd, 0, UT_TPID_CFE_EVS_CMD_DISABLE_PORTS_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LEN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_CMD_LEN_ERR_EID);
 
     /* Test invalid command length with reset filter command */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&cmd, 0, UT_TPID_CFE_EVS_CMD_RESET_FILTER_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LEN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_CMD_LEN_ERR_EID);
 
     /* Test invalid command length with reset all filters command */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&cmd, 0, UT_TPID_CFE_EVS_CMD_RESET_ALL_FILTERS_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LEN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_CMD_LEN_ERR_EID);
 
     /* Test invalid command length with add event filter command */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&cmd, 0, UT_TPID_CFE_EVS_CMD_ADD_EVENT_FILTER_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LEN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_CMD_LEN_ERR_EID);
 
     /* Test invalid command length with delete event filter command */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&cmd, 0, UT_TPID_CFE_EVS_CMD_DELETE_EVENT_FILTER_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LEN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_CMD_LEN_ERR_EID);
 
     /* Test invalid command length with write application data command */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&cmd, 0, UT_TPID_CFE_EVS_CMD_WRITE_APP_DATA_FILE_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LEN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_CMD_LEN_ERR_EID);
 
     /* Test invalid command length with write log data command */
     UT_InitData_EVS();
     CFE_EVS_Global.EVS_TlmPkt.Payload.LogEnabled = true;
     UT_EVS_DoDispatchCheckEvents(&cmd, 0, UT_TPID_CFE_EVS_CMD_WRITE_LOG_DATA_FILE_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LEN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_CMD_LEN_ERR_EID);
 
     /* Test invalid command length with set log mode command */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&cmd, 0, UT_TPID_CFE_EVS_CMD_SET_LOG_MODE_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LEN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_CMD_LEN_ERR_EID);
 
     /* Test invalid command length with clear log command */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&cmd, 0, UT_TPID_CFE_EVS_CMD_CLEAR_LOG_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LEN_ERR_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_CMD_LEN_ERR_EID);
 }
 
 /*

--- a/modules/sb/config/default_cfe_sb_fcncodes.h
+++ b/modules/sb/config/default_cfe_sb_fcncodes.h
@@ -49,7 +49,7 @@
 **       following telemetry:
 **       - \b \c \SB_CMDPC - command execution counter will
 **         increment
-**       - The #CFE_SB_CMD0_RCVD_EID informational event message will
+**       - The #CFE_SB_NOOP_INF_EID informational event message will
 **         be generated
 **
 **  \par Error Conditions
@@ -93,7 +93,7 @@
 **       - \b \c \SB_CMDPC - command execution counter will
 **         be reset to 0
 **       - All other counters listed in description will be reset to 0
-**       - The #CFE_SB_CMD1_RCVD_EID informational event message will
+**       - The #CFE_SB_RESET_INF_EID informational event message will
 **         be generated
 **
 **  \par Error Conditions

--- a/modules/sb/eds/cfe_sb.xml
+++ b/modules/sb/eds/cfe_sb.xml
@@ -475,7 +475,7 @@
           Successful execution of this command may be verified with the
           following telemetry:
           - \b \c \SB_CMDPC - command execution counter will increment
-          - The #CFE_SB_CMD0_RCVD_EID informational event message will be generated
+          - The #CFE_SB_NOOP_INF_EID informational event message will be generated
 
           \par  Error Conditions
           There are no error conditions for this command. If the Software
@@ -509,7 +509,7 @@
           Successful execution of this command may be verified with the
           following telemetry:
           - \b \c \SB_CMDPC - command execution counter will increment
-          - The #CFE_SB_CMD1_RCVD_EID informational event message will be generated
+          - The #CFE_SB_RESET_INF_EID informational event message will be generated
 
           \par  Error Conditions
           There are no error conditions for this command. If the Software

--- a/modules/sb/fsw/inc/cfe_sb_eventids.h
+++ b/modules/sb/fsw/inc/cfe_sb_eventids.h
@@ -39,7 +39,7 @@
  *
  *  Software Bus Services Task initialization complete.
  */
-#define CFE_SB_INIT_EID 1
+#define CFE_SB_INIT_INF_EID 1
 
 /**
  * \brief SB Create Pipe API Bad Argument Event ID
@@ -332,7 +332,7 @@
  *
  *  \link #CFE_SB_NOOP_CC SB NO-OP Command \endlink success.
  */
-#define CFE_SB_CMD0_RCVD_EID 28
+#define CFE_SB_NOOP_INF_EID 28
 
 /**
  * \brief SB Reset Counters Command Success Event ID
@@ -343,7 +343,7 @@
  *
  *  \link #CFE_SB_RESET_COUNTERS_CC SB Reset Counters Command \endlink success.
  */
-#define CFE_SB_CMD1_RCVD_EID 29
+#define CFE_SB_RESET_INF_EID 29
 
 /**
  * \brief SB Send Statistics Command Success Event ID
@@ -458,7 +458,7 @@
  *  Invalid command code for message ID #CFE_SB_CMD_MID or #CFE_SB_SUB_RPT_CTRL_MID received
  *  on the SB message pipe. OVERLOADED
  */
-#define CFE_SB_BAD_CMD_CODE_EID 42
+#define CFE_SB_CC_ERR_EID 42
 
 /**
  * \brief SB Invalid Message ID Received Event ID
@@ -469,7 +469,7 @@
  *
  *  Invalid message ID received on the SB message pipe.
  */
-#define CFE_SB_BAD_MSGID_EID 43
+#define CFE_SB_MID_ERR_EID 43
 
 /**
  * \brief SB Send Previous Subscriptions Command Full Packet Sent Event ID
@@ -736,7 +736,7 @@
  *  Invalid length for the command code in message ID #CFE_SB_CMD_MID or #CFE_SB_SUB_RPT_CTRL_MID
  *  received on the SB message pipe.
  */
-#define CFE_SB_LEN_ERR_EID 68
+#define CFE_SB_CMD_LEN_ERR_EID 68
 
 /**
  * \brief SB Create Pipe API Name Taken Event ID

--- a/modules/sb/fsw/src/cfe_sb_dispatch.c
+++ b/modules/sb/fsw/src/cfe_sb_dispatch.c
@@ -56,7 +56,7 @@ bool CFE_SB_VerifyCmdLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLeng
         CFE_MSG_GetMsgId(MsgPtr, &MsgId);
         CFE_MSG_GetFcnCode(MsgPtr, &FcnCode);
 
-        CFE_EVS_SendEvent(CFE_SB_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CFE_SB_CMD_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Invalid msg length: ID = 0x%X,  CC = %u, Len = %u, Expected = %u",
                           (unsigned int)CFE_SB_MsgIdToValue(MsgId), (unsigned int)FcnCode, (unsigned int)ActualLength,
                           (unsigned int)ExpectedLength);
@@ -114,7 +114,7 @@ void CFE_SB_ProcessCmdPipePkt(const CFE_SB_Buffer_t *SBBufPtr)
                     break;
 
                 default:
-                    CFE_EVS_SendEvent(CFE_SB_BAD_CMD_CODE_EID, CFE_EVS_EventType_ERROR,
+                    CFE_EVS_SendEvent(CFE_SB_CC_ERR_EID, CFE_EVS_EventType_ERROR,
                                       "Invalid Cmd, Unexpected Command Code %u", (unsigned int)FcnCode);
                     CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter++;
                     break;
@@ -183,7 +183,7 @@ void CFE_SB_ProcessCmdPipePkt(const CFE_SB_Buffer_t *SBBufPtr)
                     break;
 
                 default:
-                    CFE_EVS_SendEvent(CFE_SB_BAD_CMD_CODE_EID, CFE_EVS_EventType_ERROR,
+                    CFE_EVS_SendEvent(CFE_SB_CC_ERR_EID, CFE_EVS_EventType_ERROR,
                                       "Invalid Cmd, Unexpected Command Code %u", FcnCode);
                     CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter++;
                     break;
@@ -191,7 +191,7 @@ void CFE_SB_ProcessCmdPipePkt(const CFE_SB_Buffer_t *SBBufPtr)
             break;
 
         default:
-            CFE_EVS_SendEvent(CFE_SB_BAD_MSGID_EID, CFE_EVS_EventType_ERROR, "Invalid Cmd, Unexpected Msg Id: 0x%x",
+            CFE_EVS_SendEvent(CFE_SB_MID_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid Cmd, Unexpected Msg Id: 0x%x",
                               (unsigned int)CFE_SB_MsgIdToValue(MessageID));
             CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter++;
             break;

--- a/modules/sb/fsw/src/cfe_sb_task.c
+++ b/modules/sb/fsw/src/cfe_sb_task.c
@@ -271,7 +271,7 @@ int32 CFE_SB_AppInit(void)
     CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE",
         CFE_SRC_VERSION, CFE_BUILD_CODENAME, CFE_LAST_OFFICIAL);
     Status =
-        CFE_EVS_SendEvent(CFE_SB_INIT_EID, CFE_EVS_EventType_INFORMATION, "cFE SB Initialized: %s", VersionString);
+        CFE_EVS_SendEvent(CFE_SB_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "cFE SB Initialized: %s", VersionString);
     if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s: Error sending init event:RC=0x%08X\n", __func__, (unsigned int)Status);
@@ -292,7 +292,7 @@ int32 CFE_SB_NoopCmd(const CFE_SB_NoopCmd_t *data)
     char VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
     CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE",
         CFE_SRC_VERSION, CFE_BUILD_CODENAME, CFE_LAST_OFFICIAL);
-    CFE_EVS_SendEvent(CFE_SB_CMD0_RCVD_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", VersionString);
+    CFE_EVS_SendEvent(CFE_SB_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", VersionString);
     CFE_SB_Global.HKTlmMsg.Payload.CommandCounter++;
 
     return CFE_SUCCESS;
@@ -306,7 +306,7 @@ int32 CFE_SB_NoopCmd(const CFE_SB_NoopCmd_t *data)
  *-----------------------------------------------------------------*/
 int32 CFE_SB_ResetCountersCmd(const CFE_SB_ResetCountersCmd_t *data)
 {
-    CFE_EVS_SendEvent(CFE_SB_CMD1_RCVD_EID, CFE_EVS_EventType_DEBUG, "Reset Counters Cmd Rcvd");
+    CFE_EVS_SendEvent(CFE_SB_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "Reset Counters Cmd Rcvd");
 
     CFE_SB_ResetCounters();
 

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -392,7 +392,7 @@ void Test_SB_Main_RcvErr(void)
 
     CFE_UtAssert_EVENTCOUNT(6);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_INIT_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_INIT_INF_EID);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_Q_RD_ERR_EID);
 
@@ -443,8 +443,8 @@ void Test_SB_Main_Nominal(void)
 
     CFE_UtAssert_EVENTCOUNT(6);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_INIT_EID);
-    CFE_UtAssert_EVENTSENT(CFE_SB_CMD0_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_INIT_INF_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_NOOP_INF_EID);
 
     /* remove the handler so the pipe can be deleted */
     UT_SetHandlerFunction(UT_KEY(OS_QueueGet), NULL, NULL);
@@ -518,10 +518,10 @@ void Test_SB_Cmds_Noop(void)
 
     CFE_UtAssert_EVENTCOUNT(1);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_CMD0_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_NOOP_INF_EID);
 
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, CFE_MSG_PTR(Noop.SBBuf), 0, UT_TPID_CFE_SB_CMD_NOOP_CC);
-    CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_CMD_LEN_ERR_EID);
 }
 
 /*
@@ -542,11 +542,11 @@ void Test_SB_Cmds_RstCtrs(void)
 
     CFE_UtAssert_EVENTCOUNT(1);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_CMD1_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_RESET_INF_EID);
 
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, CFE_MSG_PTR(ResetCounters.SBBuf), 0,
                     UT_TPID_CFE_SB_CMD_RESET_COUNTERS_CC);
-    CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_CMD_LEN_ERR_EID);
 } /* Test_SB_Cmds_RstCtrs */
 
 /*
@@ -589,7 +589,7 @@ void Test_SB_Cmds_Stats(void)
     CFE_UtAssert_EVENTSENT(CFE_SB_SND_STATS_EID);
 
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, CFE_MSG_PTR(SendSbStats.SBBuf), 0, UT_TPID_CFE_SB_CMD_SEND_SB_STATS_CC);
-    CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_CMD_LEN_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId2));
@@ -617,7 +617,7 @@ void Test_SB_Cmds_RoutingInfoDef(void)
 
     CFE_UtAssert_EVENTCOUNT(5);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_INIT_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_INIT_INF_EID);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
@@ -630,7 +630,7 @@ void Test_SB_Cmds_RoutingInfoDef(void)
 
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, CFE_MSG_PTR(WriteRoutingInfo.SBBuf), 0,
                     UT_TPID_CFE_SB_CMD_WRITE_ROUTING_INFO_CC);
-    CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_CMD_LEN_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(CFE_SB_Global.CmdPipe));
 }
@@ -775,7 +775,7 @@ void Test_SB_Cmds_PipeInfoDef(void)
 
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, CFE_MSG_PTR(WritePipeInfo.SBBuf), 0,
                     UT_TPID_CFE_SB_CMD_WRITE_PIPE_INFO_CC);
-    CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_CMD_LEN_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId2));
@@ -980,7 +980,7 @@ void Test_SB_Cmds_MapInfoDef(void)
 
     /* Bad Size */
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, CFE_MSG_PTR(WriteMapInfo.SBBuf), 0, UT_TPID_CFE_SB_CMD_WRITE_MAP_INFO_CC);
-    CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_CMD_LEN_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId2));
@@ -1047,7 +1047,7 @@ void Test_SB_Cmds_EnRouteValParam(void)
 
     /* Bad Size */
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, CFE_MSG_PTR(EnableRoute.SBBuf), 0, UT_TPID_CFE_SB_CMD_ENABLE_ROUTE_CC);
-    CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_CMD_LEN_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
 }
@@ -1195,7 +1195,7 @@ void Test_SB_Cmds_DisRouteValParam(void)
 
     /* Bad Size */
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, CFE_MSG_PTR(DisableRoute.SBBuf), 0, UT_TPID_CFE_SB_CMD_DISABLE_ROUTE_CC);
-    CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_CMD_LEN_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
 }
@@ -1465,7 +1465,7 @@ void Test_SB_Cmds_SendPrevSubs(void)
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, CFE_MSG_PTR(SendPrevSubs.SBBuf), 0,
                     UT_TPID_CFE_SB_SUB_RPT_CTL_SEND_PREV_SUBS_CC);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_CMD_LEN_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId2));
@@ -1496,7 +1496,7 @@ void Test_SB_Cmds_SubRptOn(void)
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, CFE_MSG_PTR(EnableSubReporting.SBBuf), 0,
                     UT_TPID_CFE_SB_SUB_RPT_CTL_ENABLE_SUB_REPORTING_CC);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_CMD_LEN_ERR_EID);
 }
 
 /*
@@ -1524,7 +1524,7 @@ void Test_SB_Cmds_SubRptOff(void)
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, CFE_MSG_PTR(DisableSubReporting.SBBuf), 0,
                     UT_TPID_CFE_SB_SUB_RPT_CTL_DISABLE_SUB_REPORTING_CC);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_CMD_LEN_ERR_EID);
 }
 
 /*
@@ -1535,7 +1535,7 @@ void Test_SB_Cmds_CmdUnexpCmdCode(void)
     UT_SetupBasicMsgDispatch(&UT_TPID_CFE_SB_CMD_BAD_FCNCODE, sizeof(CFE_MSG_CommandHeader_t), true);
     CFE_SB_ProcessCmdPipePkt((CFE_SB_Buffer_t *)NULL);
     CFE_UtAssert_EVENTCOUNT(1);
-    CFE_UtAssert_EVENTSENT(CFE_SB_BAD_CMD_CODE_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_CC_ERR_EID);
 
     UT_SetupBasicMsgDispatch(&UT_TPID_CFE_SB_SUB_RPT_CTRL_BAD_FCNCODE, sizeof(CFE_MSG_CommandHeader_t), true);
     CFE_SB_ProcessCmdPipePkt((CFE_SB_Buffer_t *)NULL);
@@ -1560,7 +1560,7 @@ void Test_SB_Cmds_BadCmdLength(void)
 
     CFE_UtAssert_EVENTCOUNT(1);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_CMD_LEN_ERR_EID);
 }
 
 /*
@@ -1573,7 +1573,7 @@ void Test_SB_Cmds_UnexpMsgId(void)
 
     CFE_UtAssert_EVENTCOUNT(1);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_BAD_MSGID_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_MID_ERR_EID);
 }
 
 /*

--- a/modules/tbl/fsw/inc/cfe_tbl_eventids.h
+++ b/modules/tbl/fsw/inc/cfe_tbl_eventids.h
@@ -243,7 +243,7 @@
  *
  *  Invalid command code for message ID #CFE_TBL_CMD_MID received on the TBL message pipe.
  */
-#define CFE_TBL_CC1_ERR_EID 51
+#define CFE_TBL_CC_ERR_EID 51
 
 /**
  * \brief TBL Invalid Command Length Event ID
@@ -254,7 +254,7 @@
  *
  *  Invalid length for the message ID and command code received on the TBL message pipe.
  */
-#define CFE_TBL_LEN_ERR_EID 52
+#define CFE_TBL_CMD_LEN_ERR_EID 52
 
 /**
  * \brief TBL Load Table File Open Failure Event ID

--- a/modules/tbl/fsw/src/cfe_tbl_dispatch.c
+++ b/modules/tbl/fsw/src/cfe_tbl_dispatch.c
@@ -117,7 +117,7 @@ void CFE_TBL_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
         }
         else /* Bad Message Length */
         {
-            CFE_EVS_SendEvent(CFE_TBL_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+            CFE_EVS_SendEvent(CFE_TBL_CMD_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Invalid msg length -- ID = 0x%X, CC = %u, Len = %u, Expected = %u",
                               (unsigned int)CFE_SB_MsgIdToValue(MessageID), (unsigned int)CommandCode,
                               (unsigned int)ActualLength, (unsigned int)CFE_TBL_CmdHandlerTbl[CmdIndx].ExpectedLength);
@@ -142,8 +142,7 @@ void CFE_TBL_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
         /* "Bad Command Code" or "Bad Message ID"    */
         if (CmdIndx == CFE_TBL_BAD_CMD_CODE)
         {
-            CFE_EVS_SendEvent(CFE_TBL_CC1_ERR_EID, CFE_EVS_EventType_ERROR,
-                              "Invalid command code -- ID = 0x%X, CC = %u",
+            CFE_EVS_SendEvent(CFE_TBL_CC_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid command code -- ID = 0x%X, CC = %u",
                               (unsigned int)CFE_SB_MsgIdToValue(MessageID), (unsigned int)CommandCode);
 
             /* Update the command error counter */

--- a/modules/tbl/ut-coverage/tbl_UT.c
+++ b/modules/tbl/ut-coverage/tbl_UT.c
@@ -322,14 +322,14 @@ void Test_CFE_TBL_TaskInit(void)
      */
     UT_InitData();
     UT_CallTaskPipe(CFE_TBL_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.NoopCmd) - 1, UT_TPID_CFE_TBL_CMD_NOOP_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TBL_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TBL_CMD_LEN_ERR_EID);
 
     /* Test command pipe messages handler response to an invalid
      * command code
      */
     UT_InitData();
     UT_CallTaskPipe(CFE_TBL_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.NoopCmd), UT_TPID_CFE_TBL_CMD_INVALID_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TBL_CC1_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TBL_CC_ERR_EID);
 
     /* Test command pipe messages handler response to other errors */
     UT_InitData();

--- a/modules/time/config/default_cfe_time_fcncodes.h
+++ b/modules/time/config/default_cfe_time_fcncodes.h
@@ -50,7 +50,7 @@
 **       Successful execution of this command may be verified with the
 **       following telemetry:
 **       - \b \c \TIME_CMDPC - command execution counter will increment
-**       - The #CFE_TIME_NOOP_EID informational event message will be generated
+**       - The #CFE_TIME_NOOP_INF_EID informational event message will be generated
 **
 **  \par Error Conditions
 **       There are no error conditions for this command. If the Time
@@ -95,7 +95,7 @@
 **       following telemetry:
 **       - \b \c \TIME_CMDPC - command execution counter will reset to 0
 **       - \b \c \TIME_CMDEC - command error counter will reset to 0
-**       - The #CFE_TIME_RESET_EID informational event message will be generated
+**       - The #CFE_TIME_RESET_INF_EID informational event message will be generated
 **
 **  \par Error Conditions
 **       There are no error conditions for this command. If the Time

--- a/modules/time/eds/cfe_time.xml
+++ b/modules/time/eds/cfe_time.xml
@@ -495,7 +495,7 @@
           Successful execution of this command may be verified with the
           following telemetry:
           - \b \c \TIME_CMDPC - command execution counter will increment
-          - The #CFE_TIME_NOOP_EID informational event message will be generated
+          - The #CFE_TIME_NOOP_INF_EID informational event message will be generated
 
           \par  Error Conditions
           There are no error conditions for this command. If the Time
@@ -541,7 +541,7 @@
           Successful execution of this command may be verified with the
           following telemetry:
           - \b \c \TIME_CMDPC - command execution counter will increment
-          - The #CFE_TIME_RESET_EID informational event message will be generated
+          - The #CFE_TIME_RESET_INF_EID informational event message will be generated
 
           \par  Error Conditions
           There are no error conditions for this command. If the Time

--- a/modules/time/fsw/inc/cfe_time_eventids.h
+++ b/modules/time/fsw/inc/cfe_time_eventids.h
@@ -39,7 +39,7 @@
  *
  *  Time Services Task Initialization complete.
  */
-#define CFE_TIME_INIT_EID 1
+#define CFE_TIME_INIT_INF_EID 1
 
 /**
  * \brief TIME No-op Command Success Event ID
@@ -50,7 +50,7 @@
  *
  *  \link #CFE_TIME_NOOP_CC TIME NO-OP Command \endlink success.
  */
-#define CFE_TIME_NOOP_EID 4
+#define CFE_TIME_NOOP_INF_EID 4
 
 /**
  * \brief TIME Reset Counters Command Success Event ID
@@ -61,7 +61,7 @@
  *
  *  \link #CFE_TIME_RESET_COUNTERS_CC TIME Reset Counters Command \endlink success.
  */
-#define CFE_TIME_RESET_EID 5
+#define CFE_TIME_RESET_INF_EID 5
 
 /**
  * \brief TIME Request Diagnostics Command Success Event ID
@@ -218,7 +218,7 @@
  *
  *  Invalid message ID received on the TIME message pipe.
  */
-#define CFE_TIME_ID_ERR_EID 26
+#define CFE_TIME_MID_ERR_EID 26
 
 /**
  * \brief TIME Invalid Command Code Received Event ID
@@ -447,7 +447,7 @@
  *  Invalid length for the command code in message ID #CFE_TIME_CMD_MID received on the TIME
  *  message pipe.
  */
-#define CFE_TIME_LEN_ERR_EID 49
+#define CFE_TIME_CMD_LEN_ERR_EID 49
 /**\}*/
 
 #endif /* CFE_TIME_EVENTS_H */

--- a/modules/time/fsw/src/cfe_time_dispatch.c
+++ b/modules/time/fsw/src/cfe_time_dispatch.c
@@ -51,7 +51,7 @@ bool CFE_TIME_VerifyCmdLength(const CFE_MSG_Message_t *MsgPtr, size_t ExpectedLe
         CFE_MSG_GetMsgId(MsgPtr, &MsgId);
         CFE_MSG_GetFcnCode(MsgPtr, &FcnCode);
 
-        CFE_EVS_SendEvent(CFE_TIME_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
+        CFE_EVS_SendEvent(CFE_TIME_CMD_LEN_ERR_EID, CFE_EVS_EventType_ERROR,
                           "Invalid msg length: ID = 0x%X,  CC = %u, Len = %u, Expected = %u",
                           (unsigned int)CFE_SB_MsgIdToValue(MsgId), (unsigned int)FcnCode, (unsigned int)ActualLength,
                           (unsigned int)ExpectedLength);
@@ -256,7 +256,7 @@ void CFE_TIME_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
             ** Note: we only increment the command error counter when
             **    processing CFE_TIME_CMD_MID commands...
             */
-            CFE_EVS_SendEvent(CFE_TIME_ID_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid message ID -- ID = 0x%X",
+            CFE_EVS_SendEvent(CFE_TIME_MID_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid message ID -- ID = 0x%X",
                               (unsigned int)CFE_SB_MsgIdToValue(MessageID));
             break;
 

--- a/modules/time/fsw/src/cfe_time_task.c
+++ b/modules/time/fsw/src/cfe_time_task.c
@@ -263,8 +263,8 @@ int32 CFE_TIME_TaskInit(void)
 
     CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE", CFE_SRC_VERSION, CFE_BUILD_CODENAME,
                                 CFE_LAST_OFFICIAL);
-    Status =
-        CFE_EVS_SendEvent(CFE_TIME_INIT_EID, CFE_EVS_EventType_INFORMATION, "cFE TIME Initialized: %s", VersionString);
+    Status = CFE_EVS_SendEvent(CFE_TIME_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "cFE TIME Initialized: %s",
+                               VersionString);
     if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s: Error sending init event:RC=0x%08X\n", __func__, (unsigned int)Status);
@@ -453,7 +453,7 @@ int32 CFE_TIME_NoopCmd(const CFE_TIME_NoopCmd_t *data)
 
     CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE", CFE_SRC_VERSION, CFE_BUILD_CODENAME,
                                 CFE_LAST_OFFICIAL);
-    CFE_EVS_SendEvent(CFE_TIME_NOOP_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", VersionString);
+    CFE_EVS_SendEvent(CFE_TIME_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", VersionString);
 
     return CFE_SUCCESS;
 }
@@ -491,7 +491,7 @@ int32 CFE_TIME_ResetCountersCmd(const CFE_TIME_ResetCountersCmd_t *data)
     CFE_TIME_Global.InternalCount = 0;
     CFE_TIME_Global.ExternalCount = 0;
 
-    CFE_EVS_SendEvent(CFE_TIME_RESET_EID, CFE_EVS_EventType_DEBUG, "Reset Counters command");
+    CFE_EVS_SendEvent(CFE_TIME_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "Reset Counters command");
 
     return CFE_SUCCESS;
 }

--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -1400,16 +1400,16 @@ void Test_PipeCmds(void)
 
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
     UtAssert_UINT32_EQ(CFE_TIME_Global.InternalCount, count + 1);
-    CFE_UtAssert_EVENTNOTSENT(CFE_TIME_ID_ERR_EID);
+    CFE_UtAssert_EVENTNOTSENT(CFE_TIME_MID_ERR_EID);
 #else
-    CFE_UtAssert_EVENTSENT(CFE_TIME_ID_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_MID_ERR_EID);
 #endif
 
     /* Test sending the no-op command */
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.noopcmd), UT_TPID_CFE_TIME_CMD_NOOP_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TIME_NOOP_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_NOOP_INF_EID);
 
     /* Noop with bad size */
     UT_InitData();
@@ -1417,7 +1417,7 @@ void Test_PipeCmds(void)
     CFE_TIME_Global.CommandCounter      = 0;
     CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_NOOP_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_CMD_LEN_ERR_EID);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
@@ -1432,10 +1432,9 @@ void Test_PipeCmds(void)
     CFE_TIME_Global.ToneTaskCounter       = 1;
     CFE_TIME_Global.LocalIntCounter       = 1;
     CFE_TIME_Global.LocalTaskCounter      = 1;
-    memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.resetcounterscmd),
                     UT_TPID_CFE_TIME_CMD_RESET_COUNTERS_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TIME_RESET_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_RESET_INF_EID);
 
     /* Confirm error counters get reset to help cover requirements that are difficult operationally */
     UtAssert_ZERO(CFE_TIME_Global.ToneMatchCounter);
@@ -1454,7 +1453,7 @@ void Test_PipeCmds(void)
     CFE_TIME_Global.CommandCounter      = 0;
     CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_RESET_COUNTERS_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_CMD_LEN_ERR_EID);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
@@ -1471,7 +1470,7 @@ void Test_PipeCmds(void)
     CFE_TIME_Global.CommandCounter      = 0;
     CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_SEND_DIAGNOSTIC_TLM_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_CMD_LEN_ERR_EID);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
@@ -1511,7 +1510,7 @@ void Test_PipeCmds(void)
     CFE_TIME_Global.CommandCounter      = 0;
     CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_SET_STATE_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_CMD_LEN_ERR_EID);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
@@ -1554,7 +1553,7 @@ void Test_PipeCmds(void)
     CFE_TIME_Global.CommandCounter      = 0;
     CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_SET_SOURCE_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_CMD_LEN_ERR_EID);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
@@ -1611,7 +1610,7 @@ void Test_PipeCmds(void)
     CFE_TIME_Global.CommandCounter      = 0;
     CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_SET_SIGNAL_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_CMD_LEN_ERR_EID);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
@@ -1640,7 +1639,7 @@ void Test_PipeCmds(void)
     CFE_TIME_Global.CommandCounter      = 0;
     CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_ADD_DELAY_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_CMD_LEN_ERR_EID);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
@@ -1667,7 +1666,7 @@ void Test_PipeCmds(void)
     CFE_TIME_Global.CommandCounter      = 0;
     CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_SUB_DELAY_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_CMD_LEN_ERR_EID);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
@@ -1694,7 +1693,7 @@ void Test_PipeCmds(void)
     CFE_TIME_Global.CommandCounter      = 0;
     CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_SET_TIME_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_CMD_LEN_ERR_EID);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
@@ -1721,7 +1720,7 @@ void Test_PipeCmds(void)
     CFE_TIME_Global.CommandCounter      = 0;
     CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_SET_MET_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_CMD_LEN_ERR_EID);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
@@ -1748,7 +1747,7 @@ void Test_PipeCmds(void)
     CFE_TIME_Global.CommandCounter      = 0;
     CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_SET_STCF_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_CMD_LEN_ERR_EID);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
@@ -1775,7 +1774,7 @@ void Test_PipeCmds(void)
     CFE_TIME_Global.CommandCounter      = 0;
     CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_ADD_ADJUST_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_CMD_LEN_ERR_EID);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
@@ -1802,7 +1801,7 @@ void Test_PipeCmds(void)
     CFE_TIME_Global.CommandCounter      = 0;
     CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_SUB_ADJUST_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_CMD_LEN_ERR_EID);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
@@ -1830,7 +1829,7 @@ void Test_PipeCmds(void)
     CFE_TIME_Global.CommandCounter      = 0;
     CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_ADD_ONEHZ_ADJUSTMENT_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_CMD_LEN_ERR_EID);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
@@ -1858,7 +1857,7 @@ void Test_PipeCmds(void)
     CFE_TIME_Global.CommandCounter      = 0;
     CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_SUB_ONEHZ_ADJUSTMENT_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_CMD_LEN_ERR_EID);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
@@ -1922,7 +1921,7 @@ void Test_PipeCmds(void)
     CFE_TIME_Global.CommandCounter      = 0;
     CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_SET_LEAP_SECONDS_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_CMD_LEN_ERR_EID);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
     UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
@@ -1936,7 +1935,7 @@ void Test_PipeCmds(void)
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.noopcmd), UT_TPID_CFE_TIME_INVALID_MID);
-    CFE_UtAssert_EVENTSENT(CFE_TIME_ID_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_MID_ERR_EID);
 
     /* Call the Task Pipe with the 1Hz command. */
     /* In the 1Hz state machine it should call PSP GetTime as part,


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2175
  - Consistent event IDs have been applied to the inconsistent cases to align them with a common Event ID naming convention.

**Testing performed**
Only GitHub CI actions.

**Expected behavior changes**
No impact on code behavior (no logic changes).
Consistent Event ID names for the events which are common to all/most cFS components and apps will improve consistency and ease make code review/debugging easier.

**Contributor Info**
Avi Weiss @thnkslprpt