### PR TITLE
Fix #2004, Update deprecated binary filter constant in Dev Guide

### DIFF
--- a/docs/cFE Application Developers Guide.md
+++ b/docs/cFE Application Developers Guide.md
@@ -2402,7 +2402,7 @@ where a filter mask is logically "anded" with a counter value in order
 to generate a filter value. When the filter value is greater than zero
 the message is filtered. When the filter value is equal to zero the
 message is sent. This filtering scheme is specified during Application
-registration with the `CFE_EVS_BINARY_FILTER` parameter.
+registration with the `CFE_EVS_EventFilter_BINARY` parameter.
 
 The EVS binary filter structure type, shown below, contains an Event ID
 along with a hexadecimal bit mask. The Event ID is a numeric literal
@@ -2428,7 +2428,7 @@ Several common bit masks are defined within the EVS. These include:
 
 Applications may also create and use their own hexadecimal bit masks.
 When applications register event filters with the
-`CFE_EVS_BINARY_FILTER` scheme a filter counter is created for each
+`CFE_EVS_EventFilter_BINARY` scheme a filter counter is created for each
 Event ID contained in the binary filter structure. The binary event
 filtering is accomplished by "anding" the hexadecimal bit mask with the
 current value of the event filter counter. When the result is zero the
@@ -2497,7 +2497,7 @@ SAMPLE_AppData_t  SAMPLE_AppData;  /* Instantiate Task Data */
     */
     CFE_EVS_Register(SAMPLE_AppData.EventFilters,
                      SAMPLE_EVT_COUNT,
-                     CFE_EVS_BINARY_FILTER);
+                     CFE_EVS_EventFilter_BINARY);
 
    ...
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2004 
  - Updates the Development Guide to refer to `CFE_EVS_EventFilter_BINARY` rather than the deprecated `CFE_EVS_BINARY_FILTER`.

**Expected behavior changes**
No impact on behavior (doc changes only).

**Contributor Info**
Avi Weiss @thnkslprpt