### PR TITLE
Fix #1506, Align Table Name reporting in CFE_TBL_Register()

### DIFF
--- a/modules/tbl/fsw/src/cfe_tbl_api.c
+++ b/modules/tbl/fsw/src/cfe_tbl_api.c
@@ -165,8 +165,8 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
                 }
                 else if (Status != CFE_TBL_INFO_RECOVERED_TBL)
                 {
-                    CFE_ES_WriteToSysLog("%s: Failed to register '%s.%s' as a CDS (ErrCode=0x%08X)\n", __func__,
-                                         AppName, Name, (unsigned int)Status);
+                    CFE_ES_WriteToSysLog("%s: Failed to register Table '%s' as a CDS (ErrCode=0x%08X)\n", __func__,
+                                         TblName, (unsigned int)Status);
 
                     /* Notify caller that although they asked for it to be critical, it isn't */
                     Status = CFE_TBL_WARN_NOT_CRITICAL;

--- a/modules/tbl/fsw/src/cfe_tbl_internal.c
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.c
@@ -1379,7 +1379,7 @@ void CFE_TBL_RegisterWithCriticalTableRegistry(CFE_TBL_CritRegRec_t *CritRegRecP
     }
     else
     {
-        CFE_ES_WriteToSysLog("%s: Failed to find a free Crit Tbl Reg Rec for '%s'\n", __func__, RegRecPtr->Name);
+        CFE_ES_WriteToSysLog("%s: Failed to find a free Crit Tbl Reg Rec for '%s'\n", __func__, TblName);
     }
 
     /* Mark the table as critical for future reference */


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1506
  - Updates/standardizes use of `TblName` in syslog reports in `CFE_TBL_Register()`.

**Testing performed**
Only GitHub actions.

**Expected behavior changes**
No impact on behavior.

**Contributor Info**
Avi Weiss @thnkslprpt