### PR TITLE
Fix #1472, Replace while loop with single memset

### DIFF
--- a/modules/sb/fsw/src/cfe_sb_task.c
+++ b/modules/sb/fsw/src/cfe_sb_task.c
@@ -716,13 +716,7 @@ int32 CFE_SB_SendStatsCmd(const CFE_SB_SendSbStatsCmd_t *data)
 
     CFE_SB_UnlockSharedData(__FILE__, __LINE__);
 
-    while (PipeStatCount > 0)
-    {
-        memset(PipeStatPtr, 0, sizeof(*PipeStatPtr));
-
-        ++PipeStatPtr;
-        --PipeStatCount;
-    }
+    memset(PipeStatPtr, 0, sizeof(*PipeStatPtr) * PipeStatCount);
 
     CFE_SB_TimeStampMsg(CFE_MSG_PTR(CFE_SB_Global.StatTlmMsg.TelemetryHeader));
     CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_SB_Global.StatTlmMsg.TelemetryHeader), true);


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1472
  - Removes unnecessary while loop in `CFE_SB_SendStatsCmd()` and sets entire block of memory pointed to by `PipeStatPtr` to `0` in a single memset (sized by remaining value of `PipeStatCount`).

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
Achieves same result without going through the loop.

**Contributor Info**
Avi Weiss @thnkslprpt