### PR TITLE
Fix #2183, use osal_public_api header targets in doc

### DIFF
--- a/cmake/mission_build.cmake
+++ b/cmake/mission_build.cmake
@@ -322,11 +322,11 @@ function(prepare)
     WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/docs/cfe-usersguide")
 
   # OSAL API GUIDE include PUBLIC API
-  set(OSAL_API_INCLUDE_DIRECTORIES
-    "${osal_MISSION_DIR}/src/os/inc"
-    "${CMAKE_BINARY_DIR}/docs"
-  )
+  add_subdirectory(${osal_MISSION_DIR} osal_public_api)
   add_subdirectory(${osal_MISSION_DIR}/docs/src ${CMAKE_BINARY_DIR}/docs/osal-apiguide)
+
+  add_dependencies(cfe-usersguide osal_public_api_headerlist)
+  add_dependencies(mission-doc osal_public_api_headerlist)
 
   # Pull in any application-specific mission-scope configuration
   # This may include user configuration files such as cfe_mission_cfg.h,


### PR DESCRIPTION

**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Ensure that `osal_public_api_headerlist` is a dependency of all the doc builds.  Also adds the OSAL top level directory to the mission build which will define the `osal_public_api` target, and thus not require the path to be repeated.

Fixes #2183

**Testing performed**
Build documentation from clean build area

**Expected behavior changes**
Order of operations with doc targets does not matter anymore, as the file gets generated correctly no matter which target is built first.

**System(s) tested on**
Ubuntu

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.