### PR TITLE
Fix #1450, Remove duplicate status check

### DIFF
--- a/modules/evs/fsw/src/cfe_evs_task.c
+++ b/modules/evs/fsw/src/cfe_evs_task.c
@@ -686,6 +686,10 @@ int32 CFE_EVS_EnableAppEventTypeCmd(const CFE_EVS_EnableAppEventTypeCmd_t *data)
         else
         {
             EVS_EnableTypes(AppDataPtr, CmdPtr->BitMask);
+
+            EVS_SendEvent(CFE_EVS_ENAAPPEVTTYPE_EID, CFE_EVS_EventType_DEBUG,
+                          "Enable App Event Type Command Received with AppName = %s, EventType Bit Mask = 0x%02x",
+                          LocalName, CmdPtr->BitMask);
         }
     }
     else if (Status == CFE_EVS_APP_NOT_REGISTERED)
@@ -704,13 +708,6 @@ int32 CFE_EVS_EnableAppEventTypeCmd(const CFE_EVS_EnableAppEventTypeCmd_t *data)
         EVS_SendEvent(CFE_EVS_ERR_NOAPPIDFOUND_EID, CFE_EVS_EventType_ERROR,
                       "Unable to retrieve application ID for %s: CC = %lu", LocalName,
                       (long unsigned int)CFE_EVS_ENABLE_APP_EVENT_TYPE_CC);
-    }
-
-    if (Status == CFE_SUCCESS)
-    {
-        EVS_SendEvent(CFE_EVS_ENAAPPEVTTYPE_EID, CFE_EVS_EventType_DEBUG,
-                      "Enable App Event Type Command Received with AppName = %s, EventType Bit Mask = 0x%02x",
-                      LocalName, CmdPtr->BitMask);
     }
 
     return Status;
@@ -748,6 +745,10 @@ int32 CFE_EVS_DisableAppEventTypeCmd(const CFE_EVS_DisableAppEventTypeCmd_t *dat
         else
         {
             EVS_DisableTypes(AppDataPtr, CmdPtr->BitMask);
+
+            EVS_SendEvent(CFE_EVS_DISAPPENTTYPE_EID, CFE_EVS_EventType_DEBUG,
+                          "Disable App Event Type Command Received with AppName = %s, EventType Bit Mask = 0x%02x",
+                          LocalName, (unsigned int)CmdPtr->BitMask);
         }
     }
     else if (Status == CFE_EVS_APP_NOT_REGISTERED)
@@ -766,13 +767,6 @@ int32 CFE_EVS_DisableAppEventTypeCmd(const CFE_EVS_DisableAppEventTypeCmd_t *dat
         EVS_SendEvent(CFE_EVS_ERR_NOAPPIDFOUND_EID, CFE_EVS_EventType_ERROR,
                       "Unable to retrieve application ID for %s: CC = %lu", LocalName,
                       (long unsigned int)CFE_EVS_DISABLE_APP_EVENT_TYPE_CC);
-    }
-
-    if (Status == CFE_SUCCESS)
-    {
-        EVS_SendEvent(CFE_EVS_DISAPPENTTYPE_EID, CFE_EVS_EventType_DEBUG,
-                      "Disable App Event Type Command Received with AppName = %s, EventType Bit Mask = 0x%02x",
-                      LocalName, (unsigned int)CmdPtr->BitMask);
     }
 
     return Status;


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1450
  - Removes duplicate (unnecessary) status check (for `Status == CFE_SUCCESS`) and moves event report (`EVS_SendEvent(CFE_EVS_ENAAPPEVTTYPE_EID...`) to earlier in function.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No impact on behavior.
Logic does not change as the event is still sent in first `if (Status == CFE_SUCCESS)`.

**Contributor Info**
Avi Weiss @thnkslprpt