### PR TITLE
Fix #1411, Make EVS_PktPtr parameter in EVS_AddLog() const

### DIFF
--- a/modules/evs/fsw/src/cfe_evs_log.c
+++ b/modules/evs/fsw/src/cfe_evs_log.c
@@ -37,7 +37,7 @@
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-void EVS_AddLog(CFE_EVS_LongEventTlm_t *EVS_PktPtr)
+void EVS_AddLog(const CFE_EVS_LongEventTlm_t *EVS_PktPtr)
 {
     /* Serialize access to event log control variables */
     OS_MutSemTake(CFE_EVS_Global.EVS_SharedDataMutexID);

--- a/modules/evs/fsw/src/cfe_evs_log.h
+++ b/modules/evs/fsw/src/cfe_evs_log.h
@@ -54,7 +54,7 @@
 /**
  * @brief This routine adds an event packet to the internal event log.
  */
-void EVS_AddLog(CFE_EVS_LongEventTlm_t *EVS_PktPtr);
+void EVS_AddLog(const CFE_EVS_LongEventTlm_t *EVS_PktPtr);
 
 /*---------------------------------------------------------------------------------------*/
 /**


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1411
  - Changes `EVS_PktPtr` parameter in `EVS_AddLog()` to `const`.
    - Parameter is not modified, so should be `const` to better show intent and improve type safety.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No impact on behavior.

**Contributor Info**
Avi Weiss @thnkslprpt