### PR TITLE
Fix #1471, Rename confusing SB ENBL/DSBL Route Commands

### DIFF
--- a/modules/sb/config/default_cfe_sb_fcncodes.h
+++ b/modules/sb/config/default_cfe_sb_fcncodes.h
@@ -211,7 +211,7 @@
 **       - \b \c \SB_CMDPC - command execution counter will increment
 **       - View routing information #CFE_SB_WRITE_ROUTING_INFO_CC to verify
 **         enable/disable state change
-**       - The #CFE_SB_ENBL_RTE2_EID debug event message will be generated
+**       - The #CFE_SB_ENBL_RTE_EID debug event message will be generated
 **       - Destination will begin receiving messages
 **
 **  \par Error Conditions
@@ -222,7 +222,7 @@
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \SB_CMDEC - command error counter will increment
 **       - A command specific error event message is issued for all error
-**         cases. See #CFE_SB_ENBL_RTE1_EID or #CFE_SB_ENBL_RTE3_EID
+**         cases. See #CFE_SB_ENBL_RTE_MID_SUB_ERR_EID or #CFE_SB_ENBL_RTE_MID_PIPE_ERR_EID
 **
 **  \par Criticality
 **       This command is not inherently dangerous.
@@ -247,7 +247,7 @@
 **       - \b \c \SB_CMDPC - command execution counter will increment
 **       - View routing information #CFE_SB_WRITE_ROUTING_INFO_CC to verify
 **         enable/disable state change
-**       - The #CFE_SB_DSBL_RTE2_EID debug event message will be generated
+**       - The #CFE_SB_DSBL_RTE_EID debug event message will be generated
 **       - Destination will stop receiving messages
 **
 **  \par Error Conditions
@@ -258,7 +258,7 @@
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \SB_CMDEC - command error counter will increment
 **       - A command specific error event message is issued for all error
-**         cases. See #CFE_SB_DSBL_RTE1_EID or #CFE_SB_DSBL_RTE3_EID
+**         cases. See #CFE_SB_DSBL_RTE_MID_SUB_ERR_EID or #CFE_SB_DSBL_RTE_MID_PIPE_ERR_EID
 **
 **  \par Criticality
 **       This command is not intended to be used in nominal conditions. It is

--- a/modules/sb/eds/cfe_sb.xml
+++ b/modules/sb/eds/cfe_sb.xml
@@ -637,7 +637,7 @@
           - \b \c \SB_CMDPC - command execution counter will increment
           - View routing information #CFE_SB_SEND_ROUTING_INFO_CC to verify
           enable/disable state change
-          - The #CFE_SB_ENBL_RTE2_EID debug event message will be generated. All
+          - The #CFE_SB_ENBL_RTE_EID debug event message will be generated. All
           debug events are filtered by default.
           - Destination will begin receiving messages.
 
@@ -647,7 +647,7 @@
           Evidence of failure may be found in the following telemetry:
           - \b \c \SB_CMDEC - command error counter will increment
           - A command specific error event message is issued for all error
-          cases. See #CFE_SB_ENBL_RTE1_EID or #CFE_SB_ENBL_RTE3_EID
+          cases. See #CFE_SB_ENBL_RTE_MID_SUB_ERR_EID or #CFE_SB_ENBL_RTE_MID_PIPE_ERR_EID
 
           \par  Criticality
           This command is not inherently dangerous.
@@ -681,7 +681,7 @@
           - \b \c \SB_CMDPC - command execution counter will increment
           - View routing information #CFE_SB_SEND_ROUTING_INFO_CC to verify
           enable/disable state change
-          - The #CFE_SB_DSBL_RTE2_EID debug event message will be generated. All
+          - The #CFE_SB_DSBL_RTE_EID debug event message will be generated. All
           debug events are filtered by default.
           - Destination will stop receiving messages.
 
@@ -691,7 +691,7 @@
           Evidence of failure may be found in the following telemetry:
           - \b \c \SB_CMDEC - command error counter will increment
           - A command specific error event message is issued for all error
-          cases. See #CFE_SB_DSBL_RTE1_EID or #CFE_SB_DSBL_RTE3_EID
+          cases. See #CFE_SB_DSBL_RTE_MID_SUB_ERR_EID or #CFE_SB_DSBL_RTE_MID_PIPE_ERR_EID
 
           \par  Criticality
           This command is not intended to be used in nominal conditions. It is

--- a/modules/sb/fsw/inc/cfe_sb_eventids.h
+++ b/modules/sb/fsw/inc/cfe_sb_eventids.h
@@ -366,7 +366,7 @@
  *  \link #CFE_SB_ENABLE_ROUTE_CC SB Enable Route Command \endlink failure due
  *  to the Message ID not being subscribed to the pipe.
  */
-#define CFE_SB_ENBL_RTE1_EID 33
+#define CFE_SB_ENBL_RTE_MID_SUB_ERR_EID 33
 
 /**
  * \brief SB Enable Route Command Success Event ID
@@ -377,7 +377,7 @@
  *
  *  \link #CFE_SB_ENABLE_ROUTE_CC SB Enable Route Command \endlink success.
  */
-#define CFE_SB_ENBL_RTE2_EID 34
+#define CFE_SB_ENBL_RTE_EID 34
 
 /**
  * \brief SB Enable Route Command Invalid MsgId or Pipe Event ID
@@ -389,7 +389,7 @@
  *  \link #CFE_SB_ENABLE_ROUTE_CC SB Enable Route Command \endlink failure due
  *  to an invalid MsgId or Pipe.
  */
-#define CFE_SB_ENBL_RTE3_EID 35
+#define CFE_SB_ENBL_RTE_MID_PIPE_ERR_EID 35
 
 /**
  * \brief SB Disable Route Command Invalid MsgId/PipeId Pair Event ID
@@ -401,7 +401,7 @@
  *  \link #CFE_SB_DISABLE_ROUTE_CC SB Disable Route Command \endlink failure due
  *  to the Message ID not being subscribed to the pipe.
  */
-#define CFE_SB_DSBL_RTE1_EID 36
+#define CFE_SB_DSBL_RTE_MID_SUB_ERR_EID 36
 
 /**
  * \brief SB Disable Route Command Success Event ID
@@ -412,7 +412,7 @@
  *
  *  \link #CFE_SB_DISABLE_ROUTE_CC SB Disable Route Command \endlink success.
  */
-#define CFE_SB_DSBL_RTE2_EID 37
+#define CFE_SB_DSBL_RTE_EID 37
 
 /**
  * \brief SB Disable Route Command Invalid MsgId or Pipe Event ID
@@ -424,7 +424,7 @@
  *  \link #CFE_SB_DISABLE_ROUTE_CC SB Disable Route Command \endlink failure due
  *  to an invalid MsgId or Pipe.
  */
-#define CFE_SB_DSBL_RTE3_EID 38
+#define CFE_SB_DSBL_RTE_MID_PIPE_ERR_EID 38
 
 /**
  * \brief SB File Write Success Event ID

--- a/modules/sb/fsw/src/cfe_sb_task.c
+++ b/modules/sb/fsw/src/cfe_sb_task.c
@@ -398,7 +398,7 @@ int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data)
     PipeDscPtr = CFE_SB_LocatePipeDescByID(CmdPtr->Pipe);
     if (!CFE_SB_IsValidMsgId(MsgId) || !CFE_SB_PipeDescIsMatch(PipeDscPtr, CmdPtr->Pipe))
     {
-        PendingEventID = CFE_SB_ENBL_RTE3_EID;
+        PendingEventID = CFE_SB_ENBL_RTE_MID_PIPE_ERR_EID;
         CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter++;
     }
     else
@@ -406,13 +406,13 @@ int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data)
         DestPtr = CFE_SB_GetDestPtr(CFE_SBR_GetRouteId(MsgId), CmdPtr->Pipe);
         if (DestPtr == NULL)
         {
-            PendingEventID = CFE_SB_ENBL_RTE1_EID;
+            PendingEventID = CFE_SB_ENBL_RTE_MID_SUB_ERR_EID;
             CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter++;
         }
         else
         {
             DestPtr->Active = CFE_SB_ACTIVE;
-            PendingEventID  = CFE_SB_ENBL_RTE2_EID;
+            PendingEventID  = CFE_SB_ENBL_RTE_EID;
             CFE_SB_Global.HKTlmMsg.Payload.CommandCounter++;
         }
     }
@@ -421,18 +421,18 @@ int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data)
 
     switch (PendingEventID)
     {
-        case CFE_SB_ENBL_RTE1_EID:
-            CFE_EVS_SendEvent(CFE_SB_ENBL_RTE1_EID, CFE_EVS_EventType_ERROR,
+        case CFE_SB_ENBL_RTE_MID_SUB_ERR_EID:
+            CFE_EVS_SendEvent(CFE_SB_ENBL_RTE_MID_SUB_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Enbl Route Cmd:Route does not exist.Msg 0x%x,Pipe %lu",
                               (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(CmdPtr->Pipe));
             break;
-        case CFE_SB_ENBL_RTE3_EID:
-            CFE_EVS_SendEvent(CFE_SB_ENBL_RTE3_EID, CFE_EVS_EventType_ERROR,
+        case CFE_SB_ENBL_RTE_MID_PIPE_ERR_EID:
+            CFE_EVS_SendEvent(CFE_SB_ENBL_RTE_MID_PIPE_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Enbl Route Cmd:Invalid Param.Msg 0x%x,Pipe %lu",
                               (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(CmdPtr->Pipe));
             break;
-        case CFE_SB_ENBL_RTE2_EID:
-            CFE_EVS_SendEvent(CFE_SB_ENBL_RTE2_EID, CFE_EVS_EventType_DEBUG, "Enabling Route,Msg 0x%x,Pipe %lu",
+        case CFE_SB_ENBL_RTE_EID:
+            CFE_EVS_SendEvent(CFE_SB_ENBL_RTE_EID, CFE_EVS_EventType_DEBUG, "Enabling Route,Msg 0x%x,Pipe %lu",
                               (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(CmdPtr->Pipe));
             break;
     }
@@ -465,7 +465,7 @@ int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data)
     PipeDscPtr = CFE_SB_LocatePipeDescByID(CmdPtr->Pipe);
     if (!CFE_SB_IsValidMsgId(MsgId) || !CFE_SB_PipeDescIsMatch(PipeDscPtr, CmdPtr->Pipe))
     {
-        PendingEventID = CFE_SB_DSBL_RTE3_EID;
+        PendingEventID = CFE_SB_DSBL_RTE_MID_PIPE_ERR_EID;
         CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter++;
     }
     else
@@ -473,13 +473,13 @@ int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data)
         DestPtr = CFE_SB_GetDestPtr(CFE_SBR_GetRouteId(MsgId), CmdPtr->Pipe);
         if (DestPtr == NULL)
         {
-            PendingEventID = CFE_SB_DSBL_RTE1_EID;
+            PendingEventID = CFE_SB_DSBL_RTE_MID_SUB_ERR_EID;
             CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter++;
         }
         else
         {
             DestPtr->Active = CFE_SB_INACTIVE;
-            PendingEventID  = CFE_SB_DSBL_RTE2_EID;
+            PendingEventID  = CFE_SB_DSBL_RTE_EID;
             CFE_SB_Global.HKTlmMsg.Payload.CommandCounter++;
         }
     }
@@ -488,18 +488,18 @@ int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data)
 
     switch (PendingEventID)
     {
-        case CFE_SB_DSBL_RTE1_EID:
-            CFE_EVS_SendEvent(CFE_SB_DSBL_RTE1_EID, CFE_EVS_EventType_ERROR,
+        case CFE_SB_DSBL_RTE_MID_SUB_ERR_EID:
+            CFE_EVS_SendEvent(CFE_SB_DSBL_RTE_MID_SUB_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Disable Route Cmd:Route does not exist,Msg 0x%x,Pipe %lu",
                               (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(CmdPtr->Pipe));
             break;
-        case CFE_SB_DSBL_RTE3_EID:
-            CFE_EVS_SendEvent(CFE_SB_DSBL_RTE3_EID, CFE_EVS_EventType_ERROR,
+        case CFE_SB_DSBL_RTE_MID_PIPE_ERR_EID:
+            CFE_EVS_SendEvent(CFE_SB_DSBL_RTE_MID_PIPE_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Disable Route Cmd:Invalid Param.Msg 0x%x,Pipe %lu",
                               (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(CmdPtr->Pipe));
             break;
-        case CFE_SB_DSBL_RTE2_EID:
-            CFE_EVS_SendEvent(CFE_SB_DSBL_RTE2_EID, CFE_EVS_EventType_DEBUG, "Route Disabled,Msg 0x%x,Pipe %lu",
+        case CFE_SB_DSBL_RTE_EID:
+            CFE_EVS_SendEvent(CFE_SB_DSBL_RTE_EID, CFE_EVS_EventType_DEBUG, "Route Disabled,Msg 0x%x,Pipe %lu",
                               (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(CmdPtr->Pipe));
             break;
     }

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -1040,7 +1040,7 @@ void Test_SB_Cmds_EnRouteValParam(void)
 
     CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_ENBL_RTE2_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_ENBL_RTE_EID);
 
     /* Bad Size */
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &EnableRoute.SBBuf.Msg, 0, UT_TPID_CFE_SB_CMD_ENABLE_ROUTE_CC);
@@ -1079,7 +1079,7 @@ void Test_SB_Cmds_EnRouteNonExist(void)
 
     CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
     CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
-    CFE_UtAssert_EVENTSENT(CFE_SB_ENBL_RTE1_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_ENBL_RTE_MID_SUB_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId2));
@@ -1106,7 +1106,7 @@ void Test_SB_Cmds_EnRouteInvParam(void)
 
     CFE_UtAssert_EVENTCOUNT(1);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_ENBL_RTE3_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_ENBL_RTE_MID_PIPE_ERR_EID);
 }
 
 /*
@@ -1130,7 +1130,7 @@ void Test_SB_Cmds_EnRouteInvParam2(void)
 
     CFE_UtAssert_EVENTCOUNT(1);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_ENBL_RTE3_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_ENBL_RTE_MID_PIPE_ERR_EID);
 }
 
 /*
@@ -1155,7 +1155,7 @@ void Test_SB_Cmds_EnRouteInvParam3(void)
 
     CFE_UtAssert_EVENTCOUNT(1);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_ENBL_RTE3_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_ENBL_RTE_MID_PIPE_ERR_EID);
 }
 
 /*
@@ -1188,7 +1188,7 @@ void Test_SB_Cmds_DisRouteValParam(void)
 
     CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_DSBL_RTE2_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_DSBL_RTE_EID);
 
     /* Bad Size */
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &DisableRoute.SBBuf.Msg, 0, UT_TPID_CFE_SB_CMD_DISABLE_ROUTE_CC);
@@ -1227,7 +1227,7 @@ void Test_SB_Cmds_DisRouteNonExist(void)
 
     CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
     CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
-    CFE_UtAssert_EVENTSENT(CFE_SB_DSBL_RTE1_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_DSBL_RTE_MID_SUB_ERR_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId2));
@@ -1254,7 +1254,7 @@ void Test_SB_Cmds_DisRouteInvParam(void)
 
     CFE_UtAssert_EVENTCOUNT(1);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_DSBL_RTE3_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_DSBL_RTE_MID_PIPE_ERR_EID);
 }
 
 /*
@@ -1278,7 +1278,7 @@ void Test_SB_Cmds_DisRouteInvParam2(void)
 
     CFE_UtAssert_EVENTCOUNT(1);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_DSBL_RTE3_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_DSBL_RTE_MID_PIPE_ERR_EID);
 }
 
 /*
@@ -1303,7 +1303,7 @@ void Test_SB_Cmds_DisRouteInvParam3(void)
 
     CFE_UtAssert_EVENTCOUNT(1);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_DSBL_RTE3_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_DSBL_RTE_MID_PIPE_ERR_EID);
 }
 
 /*


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1471
  - EID Enable/Disable Route commands have been improved to add information and better differentiate between similar EIDs.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No impact on behavior (no logic changes).
Better-differentiated EID names will improve code clarity.

**Contributor Info**
Avi Weiss @thnkslprpt