### PR TITLE
Fix #2174, Move CRC types and convert to enum

### DIFF
--- a/cmake/sample_defs/sample_mission_cfg.h
+++ b/cmake/sample_defs/sample_mission_cfg.h
@@ -258,14 +258,16 @@
 */
 #define CFE_MISSION_EVS_MAX_MESSAGE_LENGTH 122
 
+#ifndef CFE_OMIT_DEPRECATED_6_8
+/* These names have been converted to an enum in cfe_es_api_typedefs.h */
+
 /** \name Checksum/CRC algorithm identifiers */
-/** \{ */
-#define CFE_MISSION_ES_CRC_8  1 /**< \brief CRC ( 8 bit additive - returns 32 bit total) (Currently not implemented) */
-#define CFE_MISSION_ES_CRC_16 2 /**< \brief CRC (16 bit additive - returns 32 bit total) */
-#define CFE_MISSION_ES_CRC_32                                                              \
-    3 /**< \brief CRC (32 bit additive - returns 32 bit total) (Currently not implemented) \
-       */
-/** \} */
+
+#define CFE_MISSION_ES_CRC_8  CFE_ES_CrcType_CRC_8  /* 1 */
+#define CFE_MISSION_ES_CRC_16 CFE_ES_CrcType_CRC_16 /* 2 */
+#define CFE_MISSION_ES_CRC_32 CFE_ES_CrcType_CRC_32 /* 3 */
+
+#endif
 
 /**
 **  \cfeescfg Mission Default CRC algorithm
@@ -276,9 +278,10 @@
 **      Table Image data integrity values.
 **
 **  \par Limits
-**      Currently only CFE_MISSION_ES_CRC_16 is supported (see #CFE_MISSION_ES_CRC_16)
+**      Currently only CFE_ES_CrcType_CRC_16 is supported (see brief in CFE_ES_CrcType_Enum
+**      definition in cfe_es_api_typedefs.h)
 */
-#define CFE_MISSION_ES_DEFAULT_CRC CFE_MISSION_ES_CRC_16
+#define CFE_MISSION_ES_DEFAULT_CRC CFE_ES_CrcType_CRC_16
 
 /**
 **  \cfetblcfg Maximum Table Name Length

--- a/docs/cFE Application Developers Guide.md
+++ b/docs/cFE Application Developers Guide.md
@@ -1293,24 +1293,28 @@ an API for a CRC calculation that can be used by all Applications on a mission.
 This function looks like the following:
 
 ```c
-uint32 CFE_ES_CalculateCRC(void *pData, uint32 DataLength, uint32 InputCRC, uint32 TypeCRC);
+uint32 CFE_ES_CalculateCRC(const void *DataPtr, size_t DataLength, uint32 InputCRC, CFE_ES_CrcType_Enum_t TypeCRC);
 ```
 
-where pData points to the first byte of an array of bytes that are to have
+where DataPtr points to the first byte of an array of bytes that are to have
 the CRC calculated on, DataLength specifies the number of sequential bytes to
 include in the calculation, InputCRC is the initial value of the CRC and
 TypeCRC identifies which of the standard CRC polynomials to be used.  Currently,
 there are the following types available:
 
 ```
-CFE_MISSION_ES_CRC_8 – an 8-bit additive checksum calculation that returns a 32-bit value
-CFE_MISSION_ES_CRC_16 – a 16-bit additive checksum calculation that returns a 32-bit value
-CFE_MISSION_ES_CRC_32 – a 32-bit additive checksum calculation that returns a 32-bit value
-CFE_MISSION_ES_DEFAULT_CRC – the mission specified default CRC calculation
+CFE_ES_CrcType_CRC_8 – an 8-bit additive checksum calculation that returns a 32-bit value
+CFE_ES_CrcType_CRC_16 – a 16-bit additive checksum calculation that returns a 32-bit value
+CFE_ES_CrcType_CRC_32 – a 32-bit additive checksum calculation that returns a 32-bit value
+CFE_MISSION_ES_DEFAULT_CRC – the mission specified default CRC calculation (currently
+                             this is set to CFE_ES_CrcType_CRC_16 in sample_mission_cfg.h)
 ```
 
-Unless there is a specific interface with a specified CRC calculation,
-Applications must use the CFE_MISSION_ES_DEFAULT_CRC type.
+Unless there is a specific interface with a specified CRC calculation, applications
+must use the CFE_MISSION_ES_DEFAULT_CRC type.
+
+Currently only CFE_ES_CrcType_CRC_16 is supported. CFE_ES_CrcType_CRC_8 and CFE_ES_CrcType_CRC_32 are yet
+to be implemented.
 
 ## 5.11 File System Functions
 

--- a/modules/cfe_testcase/src/es_misc_test.c
+++ b/modules/cfe_testcase/src/es_misc_test.c
@@ -41,19 +41,19 @@ void TestCalculateCRC(void)
     UtAssert_VOIDCALL(Result = CFE_ES_CalculateCRC(Data, sizeof(Data), 0, CFE_MISSION_ES_DEFAULT_CRC));
     UtAssert_MIR("Confirm mission default CRC of \"%s\" is %lu", Data, (unsigned long)Result);
 
-    UtAssert_VOIDCALL(Result = CFE_ES_CalculateCRC(Data, sizeof(Data), inputCrc, CFE_MISSION_ES_CRC_16));
+    UtAssert_VOIDCALL(Result = CFE_ES_CalculateCRC(Data, sizeof(Data), inputCrc, CFE_ES_CrcType_CRC_16));
     UtAssert_MIR("Confirm CRC16 of \"%s\" with input CRC of %lu is %lu", Data, (unsigned long)inputCrc,
                  (unsigned long)Result);
 
-    UtAssert_VOIDCALL(Result = CFE_ES_CalculateCRC(Data, sizeof(Data), 0, CFE_MISSION_ES_CRC_8));
+    UtAssert_VOIDCALL(Result = CFE_ES_CalculateCRC(Data, sizeof(Data), 0, CFE_ES_CrcType_CRC_8));
     UtAssert_MIR("Confirm CRC8 of \"%s\" is %lu", Data, (unsigned long)Result);
 
-    UtAssert_VOIDCALL(Result = CFE_ES_CalculateCRC(Data, sizeof(Data), 0, CFE_MISSION_ES_CRC_32));
+    UtAssert_VOIDCALL(Result = CFE_ES_CalculateCRC(Data, sizeof(Data), 0, CFE_ES_CrcType_CRC_32));
     UtAssert_MIR("Confirm CRC32 of \"%s\" is %lu", Data, (unsigned long)Result);
 
     /* NULL input or 0 size returns input crc */
-    UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(NULL, sizeof(Data), inputCrc, CFE_MISSION_ES_CRC_16), inputCrc);
-    UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(Data, 0, inputCrc, CFE_MISSION_ES_CRC_16), inputCrc);
+    UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(NULL, sizeof(Data), inputCrc, CFE_ES_CrcType_CRC_16), inputCrc);
+    UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(Data, 0, inputCrc, CFE_ES_CrcType_CRC_16), inputCrc);
 }
 
 void TestWriteToSysLog(void)

--- a/modules/core_api/fsw/inc/cfe_es.h
+++ b/modules/core_api/fsw/inc/cfe_es.h
@@ -999,20 +999,20 @@ CFE_Status_t CFE_ES_WriteToSysLog(const char *SpecStringPtr, ...) OS_PRINTF(1, 2
 **                          a single value.  Nominally, the user should set this value to zero.
 **
 ** \param[in]   TypeCRC     One of the following CRC algorithm selections:
-**                          \arg \c CFE_MISSION_ES_CRC_8 -  (Not currently implemented)
-**                          \arg \c CFE_MISSION_ES_CRC_16 - CRC-16/ARC <BR>
+**                          \arg \c CFE_ES_CrcType_CRC_8 -  (Not currently implemented)
+**                          \arg \c CFE_ES_CrcType_CRC_16 - CRC-16/ARC <BR>
 **                                  Polynomial: 0x8005 <BR>
 **                                  Initialization: 0x0000 <BR>
 **                                  Reflect Input/Output: true <BR>
 **                                  XorOut: 0x0000
-**                          \arg \c CFE_MISSION_ES_CRC_32 - (not currently implemented)
+**                          \arg \c CFE_ES_CrcType_CRC_32 - (not currently implemented)
 **
 ** \return The result of the CRC calculation on the specified memory block.
 **         If the TypeCRC is unimplemented will return 0.
 **         If DataPtr is null or DataLength is 0, will return InputCRC
 **
 ******************************************************************************/
-uint32 CFE_ES_CalculateCRC(const void *DataPtr, size_t DataLength, uint32 InputCRC, uint32 TypeCRC);
+uint32 CFE_ES_CalculateCRC(const void *DataPtr, size_t DataLength, uint32 InputCRC, CFE_ES_CrcType_Enum_t TypeCRC);
 
 /*****************************************************************************/
 /**

--- a/modules/core_api/fsw/inc/cfe_es_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_es_api_typedefs.h
@@ -84,6 +84,18 @@ typedef CFE_ES_TaskEntryFuncPtr_t CFE_ES_ChildTaskMainFuncPtr_t;
 typedef void *CFE_ES_StackPointer_t; /* aka osal_stackptr_t in proposed OSAL change */
 
 /**
+ * \brief Checksum/CRC algorithm identifiers
+ *
+ * Currently only CFE_ES_CrcType_CRC_16 is supported.
+ */
+typedef enum CFE_ES_CrcType_Enum
+{
+    CFE_ES_CrcType_CRC_8  = 1, /**< \brief CRC ( 8 bit additive - returns 32 bit total) (Not currently implemented) */
+    CFE_ES_CrcType_CRC_16 = 2, /**< \brief CRC (16 bit additive - returns 32 bit total) */
+    CFE_ES_CrcType_CRC_32 = 3  /**< \brief CRC (32 bit additive - returns 32 bit total) (Not currently implemented) */
+} CFE_ES_CrcType_Enum_t;
+
+/**
  * \brief Pool Alignment
  *
  * Union that can be used for minimum memory alignment of ES memory pools on the target.

--- a/modules/core_api/ut-stubs/src/cfe_es_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_es_stubs.c
@@ -77,14 +77,14 @@ void CFE_ES_BackgroundWakeup(void)
  * Generated stub function for CFE_ES_CalculateCRC()
  * ----------------------------------------------------
  */
-uint32 CFE_ES_CalculateCRC(const void *DataPtr, size_t DataLength, uint32 InputCRC, uint32 TypeCRC)
+uint32 CFE_ES_CalculateCRC(const void *DataPtr, size_t DataLength, uint32 InputCRC, CFE_ES_CrcType_Enum_t TypeCRC)
 {
     UT_GenStub_SetupReturnBuffer(CFE_ES_CalculateCRC, uint32);
 
     UT_GenStub_AddParam(CFE_ES_CalculateCRC, const void *, DataPtr);
     UT_GenStub_AddParam(CFE_ES_CalculateCRC, size_t, DataLength);
     UT_GenStub_AddParam(CFE_ES_CalculateCRC, uint32, InputCRC);
-    UT_GenStub_AddParam(CFE_ES_CalculateCRC, uint32, TypeCRC);
+    UT_GenStub_AddParam(CFE_ES_CalculateCRC, CFE_ES_CrcType_Enum_t, TypeCRC);
 
     UT_GenStub_Execute(CFE_ES_CalculateCRC, Basic, NULL);
 

--- a/modules/es/fsw/src/cfe_es_api.c
+++ b/modules/es/fsw/src/cfe_es_api.c
@@ -1571,7 +1571,7 @@ CFE_Status_t CFE_ES_WriteToSysLog(const char *SpecStringPtr, ...)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-uint32 CFE_ES_CalculateCRC(const void *DataPtr, size_t DataLength, uint32 InputCRC, uint32 TypeCRC)
+uint32 CFE_ES_CalculateCRC(const void *DataPtr, size_t DataLength, uint32 InputCRC, CFE_ES_CrcType_Enum_t TypeCRC)
 {
     uint32       i;
     int16        Index;
@@ -1610,11 +1610,11 @@ uint32 CFE_ES_CalculateCRC(const void *DataPtr, size_t DataLength, uint32 InputC
 
     switch (TypeCRC)
     {
-        case CFE_MISSION_ES_CRC_32:
+        case CFE_ES_CrcType_CRC_32:
             CFE_ES_WriteToSysLog("%s: Calculate CRC32 not Implemented\n", __func__);
             break;
 
-        case CFE_MISSION_ES_CRC_16:
+        case CFE_ES_CrcType_CRC_16:
             Crc    = (int16)(0xFFFF & InputCRC);
             BufPtr = (const uint8 *)DataPtr;
 
@@ -1631,7 +1631,7 @@ uint32 CFE_ES_CalculateCRC(const void *DataPtr, size_t DataLength, uint32 InputC
             }
             break;
 
-        case CFE_MISSION_ES_CRC_8:
+        case CFE_ES_CrcType_CRC_8:
             CFE_ES_WriteToSysLog("%s: Calculate CRC8 not Implemented\n", __func__);
             break;
 

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -4386,17 +4386,17 @@ void TestAPI(void)
      */
     memset(Data, 1, sizeof(Data));
     ES_ResetUnitTest();
-    UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(&Data, 12, 345353, CFE_MISSION_ES_CRC_8), 0);
+    UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(&Data, 12, 345353, CFE_ES_CrcType_CRC_8), 0);
 
     /* Test calculating a CRC on a range of memory using CRC type 16 */
     ES_ResetUnitTest();
-    UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(&Data, 12, 345353, CFE_MISSION_ES_CRC_16), 2688);
+    UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(&Data, 12, 345353, CFE_ES_CrcType_CRC_16), 2688);
 
     /* Test calculating a CRC on a range of memory using CRC type 32
      * NOTE: This capability is not currently implemented in cFE
      */
     ES_ResetUnitTest();
-    UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(&Data, 12, 345353, CFE_MISSION_ES_CRC_32), 0);
+    UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(&Data, 12, 345353, CFE_ES_CrcType_CRC_32), 0);
 
     /* Test calculating a CRC on a range of memory using an invalid CRC type
      */
@@ -4405,8 +4405,8 @@ void TestAPI(void)
 
     /* Test NULL and zero size */
     ES_ResetUnitTest();
-    UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(NULL, 12, 345353, CFE_MISSION_ES_CRC_16), 345353);
-    UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(&Data, 0, 345353, CFE_MISSION_ES_CRC_16), 345353);
+    UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(NULL, 12, 345353, CFE_ES_CrcType_CRC_16), 345353);
+    UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(&Data, 0, 345353, CFE_ES_CrcType_CRC_16), 345353);
 
     /* Test shared mutex take with a take error */
     ES_ResetUnitTest();


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #2174 
The macro definitions of the CRC types (8, 16, and 32-bit CRC polynomials) have been moved to `cfe_es_api_typedefs.h` and turned into a typedef'd `enum`.
The previous `#define`'s have been left in with deprecation directives added around them, due to dependencies of the FM app.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
Essentially no change to logic.

Note - Two new issues will need to be opened if/when this is merged:
FM: directly references the types that have been changed here.
CS: refers to (in comments only) `CFE_MISSION_ES_CRC_16`

**Contributor Info**
Avi Weiss @thnkslprpt