### PR TITLE
Fix #1545, Refactor CFE_TIME_CalculateUTC to utilize CFE_TIME_CalculateTAI

### DIFF
--- a/modules/time/fsw/src/cfe_time_utils.c
+++ b/modules/time/fsw/src/cfe_time_utils.c
@@ -679,7 +679,14 @@ CFE_TIME_SysTime_t CFE_TIME_CalculateUTC(const CFE_TIME_Reference_t *Reference)
 {
     CFE_TIME_SysTime_t TimeAsUTC;
 
-    TimeAsUTC = CFE_TIME_Add(Reference->CurrentMET, Reference->AtToneSTCF);
+    /*
+    ** Get preliminary UTC time using TAI (not accounting for leap seconds)
+    */
+    TimeAsUTC = CFE_TIME_CalculateTAI(Reference);
+
+    /*
+    ** Adjust UTC time by deducting leap seconds from TAI
+    */
     TimeAsUTC.Seconds -= Reference->AtToneLeapSeconds;
 
     return TimeAsUTC;


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1545
  - Removes (a small amount) of duplicate logic in `CFE_TIME_CalculateUTC()` by utilizing `CFE_TIME_CalculateTAI()`.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No impact on behavior.

**Contributor Info**
Avi @thnkslprpt