### PR TITLE
Fix #1461, Move data lock to inside of if block

### DIFF
--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -1458,17 +1458,18 @@ CFE_Status_t CFE_SB_ReleaseMessageBuffer(CFE_SB_Buffer_t *BufPtr)
         return CFE_SB_BAD_ARGUMENT;
     }
 
-    CFE_SB_LockSharedData(__func__, __LINE__);
-
     Status = CFE_SB_ZeroCopyBufferValidate(BufPtr, &BufDscPtr);
+
     if (Status == CFE_SUCCESS)
     {
+        CFE_SB_LockSharedData(__func__, __LINE__);
+
         /* Clear the ownership app ID and decrement use count (may also free) */
         BufDscPtr->AppId = CFE_ES_APPID_UNDEFINED;
         CFE_SB_DecrBufUseCnt(BufDscPtr);
-    }
 
-    CFE_SB_UnlockSharedData(__func__, __LINE__);
+        CFE_SB_UnlockSharedData(__func__, __LINE__);
+    }
 
     return Status;
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1461
  - Data lock moved inside the `if` block (lock is not needed if the `if` block condition doesn't evaluate to `true`).

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
Data lock will not occur in the (unexpected) case of an error return from `CFE_SB_ZeroCopyBufferValidate()`, which is fine as no data would be accessed/amended in that case anyway.

**Contributor Info**
Avi @thnkslprpt