### PR TITLE
Fix #1458, Factor out construction of FullName to reduce code duplication

### DIFF
--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -122,6 +122,9 @@ CFE_Status_t CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16 Depth, const c
     /* get callers TaskId */
     CFE_ES_GetTaskID(&TskId);
 
+    /* Construct full app.task name */
+    CFE_SB_GetAppTskName(TskId, FullName);
+
     /* check input parameters */
     if ((PipeIdPtr == NULL) || (Depth > OS_QUEUE_MAX_DEPTH) || (Depth == 0) ||
         (PipeName != NULL && PipeName[0] == '\0'))
@@ -230,7 +233,7 @@ CFE_Status_t CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16 Depth, const c
         /* send debug event */
         CFE_EVS_SendEventWithAppID(CFE_SB_PIPE_ADDED_EID, CFE_EVS_EventType_DEBUG, CFE_SB_Global.AppId,
                                    "Pipe Created:name %s,id %d,app %s", PipeName,
-                                   (int)CFE_ResourceId_ToInteger(PendingPipeId), CFE_SB_GetAppTskName(TskId, FullName));
+                                   (int)CFE_ResourceId_ToInteger(PendingPipeId), FullName);
 
         /* give the pipe handle to the caller */
         *PipeIdPtr = CFE_SB_PIPEID_C(PendingPipeId);
@@ -242,29 +245,27 @@ CFE_Status_t CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16 Depth, const c
             case CFE_SB_CR_PIPE_BAD_ARG_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_CR_PIPE_BAD_ARG_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                            "CreatePipeErr:Bad Input Arg:app=%s,ptr=0x%lx,depth=%d,maxdepth=%d",
-                                           CFE_SB_GetAppTskName(TskId, FullName), (unsigned long)PipeIdPtr, (int)Depth,
-                                           OS_QUEUE_MAX_DEPTH);
+                                           FullName, (unsigned long)PipeIdPtr, (int)Depth, OS_QUEUE_MAX_DEPTH);
                 break;
 
             case CFE_SB_MAX_PIPES_MET_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_MAX_PIPES_MET_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                            "CreatePipeErr:Max Pipes(%d)In Use.app %s", CFE_PLATFORM_SB_MAX_PIPES,
-                                           CFE_SB_GetAppTskName(TskId, FullName));
+                                           FullName);
                 break;
             case CFE_SB_CR_PIPE_NAME_TAKEN_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_CR_PIPE_NAME_TAKEN_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                            "CreatePipeErr:OS_QueueCreate failed, name taken (app=%s, name=%s)",
-                                           CFE_SB_GetAppTskName(TskId, FullName), PipeName);
+                                           FullName, PipeName);
                 break;
             case CFE_SB_CR_PIPE_NO_FREE_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_CR_PIPE_NO_FREE_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
-                                           "CreatePipeErr:OS_QueueCreate failed, no free id's (app=%s)",
-                                           CFE_SB_GetAppTskName(TskId, FullName));
+                                           "CreatePipeErr:OS_QueueCreate failed, no free id's (app=%s)", FullName);
                 break;
             case CFE_SB_CR_PIPE_ERR_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_CR_PIPE_ERR_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                            "CreatePipeErr:OS_QueueCreate returned %ld,app %s", (long)OsStatus,
-                                           CFE_SB_GetAppTskName(TskId, FullName));
+                                           FullName);
                 break;
         }
     }
@@ -543,18 +544,21 @@ CFE_Status_t CFE_SB_SetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 Opts)
         /* get TaskId of caller for events */
         CFE_ES_GetTaskID(&TskId);
 
+        /* Construct full app.task name */
+        CFE_SB_GetAppTskName(TskId, FullName);
+
         switch (PendingEventID)
         {
             case CFE_SB_SETPIPEOPTS_ID_ERR_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_SETPIPEOPTS_ID_ERR_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                            "Pipe Opts Error:Bad Argument,PipedId %lu,Requestor %s",
-                                           CFE_RESOURCEID_TO_ULONG(PipeId), CFE_SB_GetAppTskName(TskId, FullName));
+                                           CFE_RESOURCEID_TO_ULONG(PipeId), FullName);
                 break;
             case CFE_SB_SETPIPEOPTS_OWNER_ERR_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_SETPIPEOPTS_OWNER_ERR_EID, CFE_EVS_EventType_ERROR,
                                            CFE_SB_Global.AppId,
-                                           "Pipe Opts Set Error: Caller(%s) is not the owner of pipe %lu",
-                                           CFE_SB_GetAppTskName(TskId, FullName), CFE_RESOURCEID_TO_ULONG(PipeId));
+                                           "Pipe Opts Set Error: Caller(%s) is not the owner of pipe %lu", FullName,
+                                           CFE_RESOURCEID_TO_ULONG(PipeId));
                 break;
         }
     }
@@ -619,17 +623,19 @@ CFE_Status_t CFE_SB_GetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 *OptsPtr)
         /* get TaskId of caller for events */
         CFE_ES_GetTaskID(&TskId);
 
+        /* Construct full app.task name */
+        CFE_SB_GetAppTskName(TskId, FullName);
+
         switch (PendingEventID)
         {
             case CFE_SB_GETPIPEOPTS_PTR_ERR_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPEOPTS_PTR_ERR_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
-                                           "Pipe Opts Error:Bad Argument,Requestor %s",
-                                           CFE_SB_GetAppTskName(TskId, FullName));
+                                           "Pipe Opts Error:Bad Argument,Requestor %s", FullName);
                 break;
             case CFE_SB_GETPIPEOPTS_ID_ERR_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPEOPTS_ID_ERR_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                            "Pipe Opts Error:Bad Argument,PipedId %lu,Requestor %s",
-                                           CFE_RESOURCEID_TO_ULONG(PipeId), CFE_SB_GetAppTskName(TskId, FullName));
+                                           CFE_RESOURCEID_TO_ULONG(PipeId), FullName);
                 break;
         }
     }
@@ -707,17 +713,19 @@ CFE_Status_t CFE_SB_GetPipeName(char *PipeNameBuf, size_t PipeNameSize, CFE_SB_P
     {
         CFE_ES_GetTaskID(&TskId);
 
+        /* Construct full app.task name */
+        CFE_SB_GetAppTskName(TskId, FullName);
+
         switch (PendingEventID)
         {
             case CFE_SB_GETPIPENAME_NULL_PTR_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPENAME_NULL_PTR_EID, CFE_EVS_EventType_ERROR,
-                                           CFE_SB_Global.AppId, "Pipe Name Error:NullPtr,Requestor %s",
-                                           CFE_SB_GetAppTskName(TskId, FullName));
+                                           CFE_SB_Global.AppId, "Pipe Name Error:NullPtr,Requestor %s", FullName);
                 break;
             case CFE_SB_GETPIPENAME_ID_ERR_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPENAME_ID_ERR_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                            "Pipe Id Error:Bad Argument,Id=%lu,Requestor %s",
-                                           CFE_RESOURCEID_TO_ULONG(PipeId), CFE_SB_GetAppTskName(TskId, FullName));
+                                           CFE_RESOURCEID_TO_ULONG(PipeId), FullName);
                 break;
         }
 
@@ -815,18 +823,21 @@ CFE_Status_t CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *Pipe
         /* get TaskId of caller for events */
         CFE_ES_GetTaskID(&TskId);
 
+        /* Construct full app.task name */
+        CFE_SB_GetAppTskName(TskId, FullName);
+
         switch (PendingEventID)
         {
             case CFE_SB_GETPIPEIDBYNAME_NULL_ERR_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPEIDBYNAME_NULL_ERR_EID, CFE_EVS_EventType_ERROR,
                                            CFE_SB_Global.AppId, "Pipe ID By Name Error:Bad Argument,Requestor %s",
-                                           CFE_SB_GetAppTskName(TskId, FullName));
+                                           FullName);
                 break;
 
             case CFE_SB_GETPIPEIDBYNAME_NAME_ERR_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPEIDBYNAME_NAME_ERR_EID, CFE_EVS_EventType_ERROR,
                                            CFE_SB_Global.AppId, "Pipe ID By Name Error:Bad Argument,Requestor %s",
-                                           CFE_SB_GetAppTskName(TskId, FullName));
+                                           FullName);
                 break;
         }
     }
@@ -899,6 +910,9 @@ int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_
 
     /* get TaskId of caller for events */
     CFE_ES_GetTaskID(&TskId);
+
+    /* Construct full app.task name */
+    CFE_SB_GetAppTskName(TskId, FullName);
 
     /* take semaphore to prevent a task switch during this call */
     CFE_SB_LockSharedData(__func__, __LINE__);
@@ -1037,22 +1051,20 @@ int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_
             case CFE_SB_DUP_SUBSCRIP_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_DUP_SUBSCRIP_EID, CFE_EVS_EventType_INFORMATION, CFE_SB_Global.AppId,
                                            "Duplicate Subscription,MsgId 0x%x on %s pipe,app %s",
-                                           (unsigned int)CFE_SB_MsgIdToValue(MsgId), PipeName,
-                                           CFE_SB_GetAppTskName(TskId, FullName));
+                                           (unsigned int)CFE_SB_MsgIdToValue(MsgId), PipeName, FullName);
                 break;
 
             case CFE_SB_SUB_INV_CALLER_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_SUB_INV_CALLER_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
-                                           "Subscribe Err:Caller(%s) is not the owner of pipe %lu,Msg=0x%x",
-                                           CFE_SB_GetAppTskName(TskId, FullName), CFE_RESOURCEID_TO_ULONG(PipeId),
-                                           (unsigned int)CFE_SB_MsgIdToValue(MsgId));
+                                           "Subscribe Err:Caller(%s) is not the owner of pipe %lu,Msg=0x%x", FullName,
+                                           CFE_RESOURCEID_TO_ULONG(PipeId), (unsigned int)CFE_SB_MsgIdToValue(MsgId));
                 break;
 
             case CFE_SB_SUB_INV_PIPE_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_SUB_INV_PIPE_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                            "Subscribe Err:Invalid Pipe Id,Msg=0x%x,PipeId=%lu,App %s",
                                            (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(PipeId),
-                                           CFE_SB_GetAppTskName(TskId, FullName));
+                                           FullName);
                 break;
 
             case CFE_SB_DEST_BLK_ERR_EID:
@@ -1065,21 +1077,21 @@ int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_
                 CFE_EVS_SendEventWithAppID(CFE_SB_MAX_DESTS_MET_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                            "Subscribe Err:Max Dests(%d)In Use For Msg 0x%x,pipe %s,app %s",
                                            CFE_PLATFORM_SB_MAX_DEST_PER_PKT, (unsigned int)CFE_SB_MsgIdToValue(MsgId),
-                                           PipeName, CFE_SB_GetAppTskName(TskId, FullName));
+                                           PipeName, FullName);
                 break;
 
             case CFE_SB_MAX_MSGS_MET_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_MAX_MSGS_MET_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                            "Subscribe Err:Max Msgs(%d)In Use,MsgId 0x%x,pipe %s,app %s",
                                            CFE_PLATFORM_SB_MAX_MSG_IDS, (unsigned int)CFE_SB_MsgIdToValue(MsgId),
-                                           PipeName, CFE_SB_GetAppTskName(TskId, FullName));
+                                           PipeName, FullName);
                 break;
 
             case CFE_SB_SUB_ARG_ERR_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_SUB_ARG_ERR_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                            "Subscribe Err:Bad Arg,MsgId 0x%x,PipeId %lu,app %s,scope %d",
                                            (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(PipeId),
-                                           CFE_SB_GetAppTskName(TskId, FullName), Scope);
+                                           FullName, Scope);
                 break;
         }
     }
@@ -1088,8 +1100,7 @@ int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_
         /* If no other event pending, send a debug event indicating success */
         CFE_EVS_SendEventWithAppID(CFE_SB_SUBSCRIPTION_RCVD_EID, CFE_EVS_EventType_DEBUG, CFE_SB_Global.AppId,
                                    "Subscription Rcvd:MsgId 0x%x on PipeId %lu,app %s",
-                                   (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(PipeId),
-                                   CFE_SB_GetAppTskName(TskId, FullName));
+                                   (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(PipeId), FullName);
     }
 
     if (Status == CFE_SUCCESS && Scope == CFE_SB_MSG_GLOBAL)
@@ -1184,6 +1195,9 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint8
     /* get TaskId of caller for events */
     CFE_ES_GetTaskID(&TskId);
 
+    /* Construct full app.task name */
+    CFE_SB_GetAppTskName(TskId, FullName);
+
     /* take semaphore to prevent a task switch during this call */
     CFE_SB_LockSharedData(__func__, __LINE__);
 
@@ -1244,29 +1258,27 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint8
                 CFE_SB_GetPipeName(PipeName, sizeof(PipeName), PipeId);
                 CFE_EVS_SendEventWithAppID(CFE_SB_UNSUB_NO_SUBS_EID, CFE_EVS_EventType_INFORMATION, CFE_SB_Global.AppId,
                                            "Unsubscribe Err:No subs for Msg 0x%x on %s,app %s",
-                                           (unsigned int)CFE_SB_MsgIdToValue(MsgId), PipeName,
-                                           CFE_SB_GetAppTskName(TskId, FullName));
+                                           (unsigned int)CFE_SB_MsgIdToValue(MsgId), PipeName, FullName);
                 break;
 
             case CFE_SB_UNSUB_INV_PIPE_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_UNSUB_INV_PIPE_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                            "Unsubscribe Err:Invalid Pipe Id Msg=0x%x,Pipe=%lu,app=%s",
                                            (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(PipeId),
-                                           CFE_SB_GetAppTskName(TskId, FullName));
+                                           FullName);
                 break;
 
             case CFE_SB_UNSUB_INV_CALLER_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_UNSUB_INV_CALLER_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
-                                           "Unsubscribe Err:Caller(%s) is not the owner of pipe %lu,Msg=0x%x",
-                                           CFE_SB_GetAppTskName(TskId, FullName), CFE_RESOURCEID_TO_ULONG(PipeId),
-                                           (unsigned int)CFE_SB_MsgIdToValue(MsgId));
+                                           "Unsubscribe Err:Caller(%s) is not the owner of pipe %lu,Msg=0x%x", FullName,
+                                           CFE_RESOURCEID_TO_ULONG(PipeId), (unsigned int)CFE_SB_MsgIdToValue(MsgId));
                 break;
 
             case CFE_SB_UNSUB_ARG_ERR_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_UNSUB_ARG_ERR_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                            "Unsubscribe Err:Bad Arg,MsgId 0x%x,PipeId %lu,app %s,scope %d",
                                            (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(PipeId),
-                                           CFE_SB_GetAppTskName(TskId, FullName), (int)Scope);
+                                           FullName, (int)Scope);
                 break;
         }
     }
@@ -1275,8 +1287,7 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint8
         /* if no other event pending, send a debug event for successful unsubscribe */
         CFE_EVS_SendEventWithAppID(CFE_SB_SUBSCRIPTION_REMOVED_EID, CFE_EVS_EventType_DEBUG, CFE_SB_Global.AppId,
                                    "Subscription Removed:Msg 0x%x on pipe %lu,app %s",
-                                   (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(PipeId),
-                                   CFE_SB_GetAppTskName(TskId, FullName));
+                                   (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(PipeId), FullName);
     }
 
     return Status;
@@ -1459,6 +1470,9 @@ int32 CFE_SB_TransmitMsgValidate(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t
         /* get task id for events */
         CFE_ES_GetTaskID(&TskId);
 
+        /* Construct full app.task name */
+        CFE_SB_GetAppTskName(TskId, FullName);
+
         switch (PendingEventID)
         {
             case CFE_SB_SEND_BAD_ARG_EID:
@@ -1466,7 +1480,7 @@ int32 CFE_SB_TransmitMsgValidate(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t
                 {
                     CFE_EVS_SendEventWithAppID(CFE_SB_SEND_BAD_ARG_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                                "Send Err:Bad input argument,Arg 0x%lx,App %s", (unsigned long)MsgPtr,
-                                               CFE_SB_GetAppTskName(TskId, FullName));
+                                               FullName);
 
                     /* clear the bit so the task may send this event again */
                     CFE_SB_FinishSendEvent(TskId, CFE_SB_SEND_BAD_ARG_EID_BIT);
@@ -1478,8 +1492,7 @@ int32 CFE_SB_TransmitMsgValidate(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t
                 {
                     CFE_EVS_SendEventWithAppID(CFE_SB_SEND_INV_MSGID_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                                "Send Err:Invalid MsgId(0x%x)in msg,App %s",
-                                               (unsigned int)CFE_SB_MsgIdToValue(*MsgIdPtr),
-                                               CFE_SB_GetAppTskName(TskId, FullName));
+                                               (unsigned int)CFE_SB_MsgIdToValue(*MsgIdPtr), FullName);
 
                     /* clear the bit so the task may send this event again */
                     CFE_SB_FinishSendEvent(TskId, CFE_SB_SEND_INV_MSGID_EID_BIT);
@@ -1491,8 +1504,7 @@ int32 CFE_SB_TransmitMsgValidate(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t
                 {
                     CFE_EVS_SendEventWithAppID(CFE_SB_MSG_TOO_BIG_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                                "Send Err:Msg Too Big MsgId=0x%x,app=%s,size=%d,MaxSz=%d",
-                                               (unsigned int)CFE_SB_MsgIdToValue(*MsgIdPtr),
-                                               CFE_SB_GetAppTskName(TskId, FullName), (int)*SizePtr,
+                                               (unsigned int)CFE_SB_MsgIdToValue(*MsgIdPtr), FullName, (int)*SizePtr,
                                                CFE_MISSION_SB_MAX_SB_MSG_SIZE);
 
                     /* clear the bit so the task may send this event again */
@@ -1506,8 +1518,7 @@ int32 CFE_SB_TransmitMsgValidate(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t
                 {
                     CFE_EVS_SendEventWithAppID(CFE_SB_SEND_NO_SUBS_EID, CFE_EVS_EventType_INFORMATION,
                                                CFE_SB_Global.AppId, "No subscribers for MsgId 0x%x,sender %s",
-                                               (unsigned int)CFE_SB_MsgIdToValue(*MsgIdPtr),
-                                               CFE_SB_GetAppTskName(TskId, FullName));
+                                               (unsigned int)CFE_SB_MsgIdToValue(*MsgIdPtr), FullName);
 
                     /* clear the bit so the task may send this event again */
                     CFE_SB_FinishSendEvent(TskId, CFE_SB_SEND_NO_SUBS_EID_BIT);
@@ -1546,6 +1557,9 @@ void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_
 
     /* get task id for events and Sender Info*/
     CFE_ES_GetTaskID(&TskId);
+
+    /* Construct full app.task name */
+    CFE_SB_GetAppTskName(TskId, FullName);
 
     /* take semaphore to prevent a task switch during processing */
     CFE_SB_LockSharedData(__func__, __LINE__);
@@ -1695,8 +1709,7 @@ void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_
 
                 CFE_EVS_SendEventWithAppID(CFE_SB_MSGID_LIM_ERR_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                            "Msg Limit Err,MsgId 0x%x,pipe %s,sender %s",
-                                           (unsigned int)CFE_SB_MsgIdToValue(BufDscPtr->MsgId), PipeName,
-                                           CFE_SB_GetAppTskName(TskId, FullName));
+                                           (unsigned int)CFE_SB_MsgIdToValue(BufDscPtr->MsgId), PipeName, FullName);
 
                 /* clear the bit so the task may send this event again */
                 CFE_SB_FinishSendEvent(TskId, CFE_SB_MSGID_LIM_ERR_EID_BIT);
@@ -1714,8 +1727,7 @@ void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_
 
                 CFE_EVS_SendEventWithAppID(CFE_SB_Q_FULL_ERR_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                            "Pipe Overflow,MsgId 0x%x,pipe %s,sender %s",
-                                           (unsigned int)CFE_SB_MsgIdToValue(BufDscPtr->MsgId), PipeName,
-                                           CFE_SB_GetAppTskName(TskId, FullName));
+                                           (unsigned int)CFE_SB_MsgIdToValue(BufDscPtr->MsgId), PipeName, FullName);
 
                 /* clear the bit so the task may send this event again */
                 CFE_SB_FinishSendEvent(TskId, CFE_SB_Q_FULL_ERR_EID_BIT);
@@ -1730,8 +1742,8 @@ void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_
 
                 CFE_EVS_SendEventWithAppID(CFE_SB_Q_WR_ERR_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                            "Pipe Write Err,MsgId 0x%x,pipe %s,sender %s,stat %ld",
-                                           (unsigned int)CFE_SB_MsgIdToValue(BufDscPtr->MsgId), PipeName,
-                                           CFE_SB_GetAppTskName(TskId, FullName), (long)(SBSndErr.EvtBuf[i].OsStatus));
+                                           (unsigned int)CFE_SB_MsgIdToValue(BufDscPtr->MsgId), PipeName, FullName,
+                                           (long)(SBSndErr.EvtBuf[i].OsStatus));
 
                 /* clear the bit so the task may send this event again */
                 CFE_SB_FinishSendEvent(TskId, CFE_SB_Q_WR_ERR_EID_BIT);
@@ -1965,23 +1977,26 @@ CFE_Status_t CFE_SB_ReceiveBuffer(CFE_SB_Buffer_t **BufPtr, CFE_SB_PipeId_t Pipe
         /* get task id for events */
         CFE_ES_GetTaskID(&TskId);
 
+        /* Construct full app.task name */
+        CFE_SB_GetAppTskName(TskId, FullName);
+
         switch (PendingEventID)
         {
             case CFE_SB_Q_RD_ERR_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_Q_RD_ERR_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                            "Pipe Read Err,pipe %lu,app %s,stat %ld", CFE_RESOURCEID_TO_ULONG(PipeId),
-                                           CFE_SB_GetAppTskName(TskId, FullName), (long)OsStatus);
+                                           FullName, (long)OsStatus);
                 break;
             case CFE_SB_RCV_BAD_ARG_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_RCV_BAD_ARG_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                            "Rcv Err:Bad Input Arg:BufPtr 0x%lx,pipe %lu,t/o %d,app %s",
                                            (unsigned long)BufPtr, CFE_RESOURCEID_TO_ULONG(PipeId), (int)TimeOut,
-                                           CFE_SB_GetAppTskName(TskId, FullName));
+                                           FullName);
                 break;
             case CFE_SB_BAD_PIPEID_EID:
                 CFE_EVS_SendEventWithAppID(CFE_SB_BAD_PIPEID_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                            "Rcv Err:PipeId %lu does not exist,app %s", CFE_RESOURCEID_TO_ULONG(PipeId),
-                                           CFE_SB_GetAppTskName(TskId, FullName));
+                                           FullName);
                 break;
         }
     }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1458
  - Construction of `FullName` (using `CFE_SB_GetAppTskName()`) has been moved out of the `switch` statements, so as to only be included once in each function, instead of 2-6 times. This reduces code duplication.

**Testing performed**
GitHub CI actions (incl. Build + Run, Functional Tests etc.) all passing successfully.

**Expected behavior changes**
No impact on behavior.

**Contributor Info**
Avi Weiss @thnkslprpt