### PR TITLE
Fix #2120, Support clang for whole archive flags

### DIFF
--- a/cmake/sample_defs/toolchain-i686-linux-clang.cmake
+++ b/cmake/sample_defs/toolchain-i686-linux-clang.cmake
@@ -1,0 +1,23 @@
+# This example toolchain file describes the cross compiler to use for
+# the target architecture indicated in the configuration file.
+
+# Basic cross system configuration
+SET(CMAKE_SYSTEM_NAME           Linux)
+SET(CMAKE_SYSTEM_VERSION        1)
+SET(CMAKE_SYSTEM_PROCESSOR      i686)
+
+# Specify the cross compiler executables
+# Typically these would be installed in a home directory or somewhere
+# in /opt.  However in this example the system compiler is used.
+SET(CMAKE_C_COMPILER            "/usr/bin/clang")
+SET(CMAKE_CXX_COMPILER          "/usr/bin/clang++")
+
+# Configure the find commands
+SET(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM   NEVER)
+SET(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY   NEVER)
+SET(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE   NEVER)
+
+# These variable settings are specific to cFE/OSAL and determines which 
+# abstraction layers are built when using this toolchain
+SET(CFE_SYSTEM_PSPNAME      "pc-linux")
+SET(OSAL_SYSTEM_OSTYPE      "posix")

--- a/cmake/target/CMakeLists.txt
+++ b/cmake/target/CMakeLists.txt
@@ -156,7 +156,7 @@ if (${TGTNAME}_APPLIST)
 
   set_target_properties(core-${TGTNAME} PROPERTIES ENABLE_EXPORTS TRUE)
 
-  if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+  if (("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU") OR ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang"))
     # The option pair for GNU gcc/ld tools
     set(START_WHOLE_ARCHIVE "--whole-archive")
     set(STOP_WHOLE_ARCHIVE  "--no-whole-archive")
@@ -165,6 +165,7 @@ if (${TGTNAME}_APPLIST)
     set(COMPILER_LINKER_OPTION_PREFIX "-Wl,")
   else()
     # Other toolchain options may be added here
+    message(WARNING "Unmatched compiler id, WHOLE_ARCHIVE flags not automatically set and may need custom config")
   endif()
 
   # Determine if a pass-through prefix is needed for a linker option.


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #2120 
- Adds a toolchain file for clang to make testing simple

**Testing performed**
W/ Clang 10 installed, performed the following changes in sample_defs:
- Removed unsupported flags
- Compiled permissive to confirm it worked w/ standard user privilages
- Explicitly set cpu1 to use the clang toolchain

```
diff sample_defs/arch_build_custom.cmake cfe/cmake/sample_defs/arch_build_custom.cmake
36a37,38
>     -Wno-format-truncation      # Inhibit printf-style format truncation warnings
>     -Wno-stringop-truncation    # Inhibit string operation truncation warnings
diff sample_defs/default_osconfig.cmake cfe/cmake/sample_defs/default_osconfig.cmake
36d35
< set(OSAL_CONFIG_DEBUG_PERMISSIVE_MODE TRUE)
diff sample_defs/targets.cmake cfe/cmake/sample_defs/targets.cmake
107d106
< SET(cpu1_SYSTEM i686-linux-clang)
```

**Expected behavior changes**
Properly sets the whole archive flags for clang, warns if compiler is unmatched

**System(s) tested on**
CI shows no impact to base system
Steps above to prove Clang works

**Additional context**
Could add to CI if someone wanted to maintain support, might be overcome if there's a target added to CI that uses clang.
Clang build does depend on nasa/sample_lib#92 being merged, but doesn't impact current CI

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC