### PR TITLE
Fix #2205, Enforce strict cast alignment on arch

### DIFF
--- a/cmake/sample_defs/arch_build_custom.cmake
+++ b/cmake/sample_defs/arch_build_custom.cmake
@@ -32,7 +32,7 @@ add_compile_options(
     -Wstrict-prototypes         # Warn about missing prototypes
     -Wwrite-strings             # Warn if not treating string literals as "const"
     -Wpointer-arith             # Warn about suspicious pointer operations
-    -Wcast-align                # Warn about casts that increase alignment requirements
+    -Wcast-align=strict         # Warn about casts that increase alignment requirements
     -Werror                     # Treat warnings as errors (code should be clean)
     -Wno-format-truncation      # Inhibit printf-style format truncation warnings
     -Wno-stringop-truncation    # Inhibit string operation truncation warnings

--- a/cmake/sample_defs/arch_build_custom.cmake
+++ b/cmake/sample_defs/arch_build_custom.cmake
@@ -32,7 +32,6 @@ add_compile_options(
     -Wstrict-prototypes         # Warn about missing prototypes
     -Wwrite-strings             # Warn if not treating string literals as "const"
     -Wpointer-arith             # Warn about suspicious pointer operations
-    -Wcast-align=strict         # Warn about casts that increase alignment requirements
     -Werror                     # Treat warnings as errors (code should be clean)
     -Wno-format-truncation      # Inhibit printf-style format truncation warnings
     -Wno-stringop-truncation    # Inhibit string operation truncation warnings

--- a/cmake/sample_defs/arch_build_custom_native.cmake
+++ b/cmake/sample_defs/arch_build_custom_native.cmake
@@ -1,0 +1,11 @@
+#
+# Example arch_build_custom.cmake
+# -------------------------------
+#
+# On native builds only, add strict cast alignment warnings
+# This requires a newer version of gcc
+#
+add_compile_options(
+    -Wcast-align=strict         # Warn about casts that increase alignment requirements
+)
+


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #2205 

**Testing performed**
CI

**Expected behavior changes**
None, just enforces strict alignment and currently compliant

**System(s) tested on**
CI

**Additional context**
Note this strict option isn't supported by clang so would need to be removed along with `-Wno-format-truncation` and `-Wno-stringop-truncation`

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC