### PR TITLE
Fix #2210, Move variables declared mid-function to the top

### DIFF
--- a/modules/cfe_testcase/src/tbl_content_access_test.c
+++ b/modules/cfe_testcase/src/tbl_content_access_test.c
@@ -106,6 +106,7 @@ void TestReleaseAddress(void)
 
 void TestGetReleaseAddresses(void)
 {
+    int                  i;
     int                  numValidTbls = 5;
     char                 TblName[10];
     CFE_TBL_Handle_t     TblHandles[numValidTbls + 1];
@@ -116,7 +117,7 @@ void TestGetReleaseAddresses(void)
     /* Put an invalid handle at the start*/
     TblHandles[0] = CFE_TBL_BAD_TABLE_HANDLE;
     TblPtrs[0]    = TblPtrsList;
-    for (int i = 1; i < numValidTbls + 1; i++)
+    for (i = 1; i < numValidTbls + 1; i++)
     {
         sprintf(TblName, "%d", i);
         UtAssert_INT32_EQ(
@@ -132,7 +133,7 @@ void TestGetReleaseAddresses(void)
     UtAssert_INT32_EQ(CFE_TBL_GetAddresses((void ***)&TblPtrs, numValidTbls, TblHandles + 1), CFE_TBL_ERR_NEVER_LOADED);
 
     /* Load data and then get addresses */
-    for (int i = 1; i < numValidTbls + 1; i++)
+    for (i = 1; i < numValidTbls + 1; i++)
     {
         if (CFE_TBL_Load(TblHandles[i], CFE_TBL_SRC_ADDRESS, &TestTable) != CFE_SUCCESS)
         {
@@ -149,7 +150,7 @@ void TestGetReleaseAddresses(void)
     UtAssert_INT32_EQ(CFE_TBL_ReleaseAddresses(numValidTbls, TblHandles + 1), CFE_SUCCESS);
 
     /* Unregister all tables */
-    for (int i = 1; i < numValidTbls + 1; i++)
+    for (i = 1; i < numValidTbls + 1; i++)
     {
         if (CFE_TBL_Unregister(TblHandles[i]) != CFE_SUCCESS)
         {

--- a/modules/cfe_testcase/src/tbl_information_test.c
+++ b/modules/cfe_testcase/src/tbl_information_test.c
@@ -46,7 +46,14 @@ void TestGetStatus(void)
 void TestGetInfo(void)
 {
     CFE_TBL_Info_t TblInfo;
-    const char *   BadTblName = "BadTable";
+    const char *   BadTblName          = "BadTable";
+    size_t         expectedSize        = sizeof(CFE_TEST_TestTable_t);
+    uint32         expectedNumUsers    = 1;
+    bool           expectedTableLoaded = false;
+    bool           expectedDumpOnly    = false;
+    bool           expectedDoubleBuf   = false;
+    bool           expectedUserDefAddr = false;
+    bool           expectedCritical    = false;
 
     memset(&TblInfo, 0, sizeof(TblInfo));
 
@@ -57,14 +64,6 @@ void TestGetInfo(void)
     UtAssert_INT32_EQ(CFE_TBL_GetInfo(&TblInfo, BadTblName), CFE_TBL_ERR_INVALID_NAME);
     UtAssert_INT32_EQ(CFE_TBL_GetInfo(&TblInfo, NULL), CFE_TBL_BAD_ARGUMENT);
 
-    /* This is only checking some parts of the TblInfo struct */
-    size_t expectedSize        = sizeof(CFE_TEST_TestTable_t);
-    uint32 expectedNumUsers    = 1;
-    bool   expectedTableLoaded = false;
-    bool   expectedDumpOnly    = false;
-    bool   expectedDoubleBuf   = false;
-    bool   expectedUserDefAddr = false;
-    bool   expectedCritical    = false;
     UtAssert_UINT32_EQ(TblInfo.Size, expectedSize);
     UtAssert_UINT32_EQ(TblInfo.NumUsers, expectedNumUsers);
     UtAssert_INT32_EQ(TblInfo.TableLoadedOnce, expectedTableLoaded);


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2210
  - A couple of stray variables that were declared mid-function were moved to the top of their respective functions.

**Testing performed**
GitHub CI actions all passing successfully.

**Expected behavior changes**
All variables declared top of function as per cFS conventions/guidelines.

**Contributor Info**
Avi Weiss @thnkslprpt