### PR TITLE
Fix #2214, add abstract documentation dependency target

### DIFF
--- a/cmake/mission_build.cmake
+++ b/cmake/mission_build.cmake
@@ -180,6 +180,7 @@ function(prepare)
   add_custom_target(mission-install COMMAND $(MAKE) install)
   add_custom_target(mission-clean COMMAND $(MAKE) clean)
   add_custom_target(mission-prebuild)
+  add_custom_target(doc-prebuild)
 
   # Locate the source location for all the apps found within the target file
   # This is done by searching through the list of paths to find a matching name
@@ -325,8 +326,8 @@ function(prepare)
   add_subdirectory(${osal_MISSION_DIR} osal_public_api)
   add_subdirectory(${osal_MISSION_DIR}/docs/src ${CMAKE_BINARY_DIR}/docs/osal-apiguide)
 
-  add_dependencies(cfe-usersguide osal_public_api_headerlist)
-  add_dependencies(mission-doc osal_public_api_headerlist)
+  add_dependencies(cfe-usersguide doc-prebuild)
+  add_dependencies(mission-doc doc-prebuild)
 
   # Pull in any application-specific mission-scope configuration
   # This may include user configuration files such as cfe_mission_cfg.h,
@@ -484,5 +485,3 @@ function(process_arch TARGETSYSTEM)
   add_dependencies(mission-install ${TARGETSYSTEM}-install)
 
 endfunction(process_arch TARGETSYSTEM)
-
-


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Adds a top level target called "doc-prebuild" which in turn can be made to depend on any other files that need to exist before documentation can be built.

Fixes #2214

**Testing performed**
Build documentation

**Expected behavior changes**
Abstract dependency target now provided

**System(s) tested on**
Ubuntu 22.04

**Additional context**
needs to be merged with nasa/osal#1341 to work correctly.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
