### PR TITLE
Fix #2218, add -fno-common to arch build flags

### DIFF
--- a/cmake/sample_defs/arch_build_custom_native.cmake
+++ b/cmake/sample_defs/arch_build_custom_native.cmake
@@ -7,5 +7,6 @@
 #
 add_compile_options(
     -Wcast-align=strict         # Warn about casts that increase alignment requirements
+    -fno-common                 # Do not use a common section for globals
 )
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Add -fno-common to arch_build_custom_native.cmake so the CI workflows will all build with this option.  This is not the default in the version of gcc/binutils used in ubuntu 20.04 on which the workflows run.

Fixes nasa/cfe#2218

**Testing performed**
Build and run all tests

**Expected behavior changes**
Duplicate global symbol names will trigger errors, rather than being silently merged on some versions of the tools (consistent behavior).

**System(s) tested on**
Ubuntu 22.04 and 20.04  (workflows)

**Additional context**
no-common is the default in newer versions of the tools, but was not the default in the versions used in 20.04.  The CFE/CFS builds should not require/rely on the use of a common section.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
