### PR TITLE
Fix #2220, Replace CFE_MSG_CommandHeader_t w/ CFE_TBL_NoArgsCmd_t

### DIFF
--- a/modules/tbl/fsw/src/cfe_tbl_task.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task.c
@@ -45,29 +45,35 @@ CFE_TBL_Global_t CFE_TBL_Global;
  * Macros to assist in building the CFE_TBL_CmdHandlerTbl -
  *  For command handler entries, which have a command code, payload type, and a handler function
  */
-#define CFE_TBL_ENTRY(mid, ccode, paramtype, handlerfunc, msgtype)                                                       \
-    {                                                                                                              \
-        CFE_SB_MSGID_WRAP_VALUE(mid), ccode, sizeof(paramtype), (CFE_TBL_MsgProcFuncPtr_t)handlerfunc, \
-            msgtype                                                                                    \
+#define CFE_TBL_ENTRY(mid, ccode, paramtype, handlerfunc, msgtype)                                             \
+    {                                                                                                          \
+        CFE_SB_MSGID_WRAP_VALUE(mid), ccode, sizeof(paramtype), (CFE_TBL_MsgProcFuncPtr_t)handlerfunc, msgtype \
     }
 
 /* Constant Data */
 
 const CFE_TBL_CmdHandlerTblRec_t CFE_TBL_CmdHandlerTbl[] = {
     /* SEND_HK Entry */
-    CFE_TBL_ENTRY(CFE_TBL_SEND_HK_MID, 0, CFE_MSG_CommandHeader_t, CFE_TBL_HousekeepingCmd, CFE_TBL_MSG_MSGTYPE),
+    CFE_TBL_ENTRY(CFE_TBL_SEND_HK_MID, 0, CFE_TBL_NoArgsCmd_t, CFE_TBL_HousekeepingCmd, CFE_TBL_MSG_MSGTYPE),
 
     /* Everything else */
     CFE_TBL_ENTRY(CFE_TBL_CMD_MID, CFE_TBL_NOOP_CC, CFE_TBL_NoopCmd_t, CFE_TBL_NoopCmd, CFE_TBL_CMD_MSGTYPE),
-    CFE_TBL_ENTRY(CFE_TBL_CMD_MID, CFE_TBL_RESET_COUNTERS_CC, CFE_TBL_ResetCountersCmd_t, CFE_TBL_ResetCountersCmd, CFE_TBL_CMD_MSGTYPE),
+    CFE_TBL_ENTRY(CFE_TBL_CMD_MID, CFE_TBL_RESET_COUNTERS_CC, CFE_TBL_ResetCountersCmd_t, CFE_TBL_ResetCountersCmd,
+                  CFE_TBL_CMD_MSGTYPE),
     CFE_TBL_ENTRY(CFE_TBL_CMD_MID, CFE_TBL_LOAD_CC, CFE_TBL_LoadCmd_t, CFE_TBL_LoadCmd, CFE_TBL_CMD_MSGTYPE),
     CFE_TBL_ENTRY(CFE_TBL_CMD_MID, CFE_TBL_DUMP_CC, CFE_TBL_DumpCmd_t, CFE_TBL_DumpCmd, CFE_TBL_CMD_MSGTYPE),
-    CFE_TBL_ENTRY(CFE_TBL_CMD_MID, CFE_TBL_VALIDATE_CC, CFE_TBL_ValidateCmd_t, CFE_TBL_ValidateCmd, CFE_TBL_CMD_MSGTYPE),
-    CFE_TBL_ENTRY(CFE_TBL_CMD_MID, CFE_TBL_ACTIVATE_CC, CFE_TBL_ActivateCmd_t, CFE_TBL_ActivateCmd, CFE_TBL_CMD_MSGTYPE),
-    CFE_TBL_ENTRY(CFE_TBL_CMD_MID, CFE_TBL_DUMP_REGISTRY_CC, CFE_TBL_DumpRegistryCmd_t, CFE_TBL_DumpRegistryCmd, CFE_TBL_CMD_MSGTYPE),
-    CFE_TBL_ENTRY(CFE_TBL_CMD_MID, CFE_TBL_SEND_REGISTRY_CC, CFE_TBL_SendRegistryCmd_t, CFE_TBL_SendRegistryCmd, CFE_TBL_CMD_MSGTYPE),
-    CFE_TBL_ENTRY(CFE_TBL_CMD_MID, CFE_TBL_DELETE_CDS_CC, CFE_TBL_DeleteCDSCmd_t, CFE_TBL_DeleteCDSCmd, CFE_TBL_CMD_MSGTYPE),
-    CFE_TBL_ENTRY(CFE_TBL_CMD_MID, CFE_TBL_ABORT_LOAD_CC, CFE_TBL_AbortLoadCmd_t, CFE_TBL_AbortLoadCmd, CFE_TBL_CMD_MSGTYPE),
+    CFE_TBL_ENTRY(CFE_TBL_CMD_MID, CFE_TBL_VALIDATE_CC, CFE_TBL_ValidateCmd_t, CFE_TBL_ValidateCmd,
+                  CFE_TBL_CMD_MSGTYPE),
+    CFE_TBL_ENTRY(CFE_TBL_CMD_MID, CFE_TBL_ACTIVATE_CC, CFE_TBL_ActivateCmd_t, CFE_TBL_ActivateCmd,
+                  CFE_TBL_CMD_MSGTYPE),
+    CFE_TBL_ENTRY(CFE_TBL_CMD_MID, CFE_TBL_DUMP_REGISTRY_CC, CFE_TBL_DumpRegistryCmd_t, CFE_TBL_DumpRegistryCmd,
+                  CFE_TBL_CMD_MSGTYPE),
+    CFE_TBL_ENTRY(CFE_TBL_CMD_MID, CFE_TBL_SEND_REGISTRY_CC, CFE_TBL_SendRegistryCmd_t, CFE_TBL_SendRegistryCmd,
+                  CFE_TBL_CMD_MSGTYPE),
+    CFE_TBL_ENTRY(CFE_TBL_CMD_MID, CFE_TBL_DELETE_CDS_CC, CFE_TBL_DeleteCDSCmd_t, CFE_TBL_DeleteCDSCmd,
+                  CFE_TBL_CMD_MSGTYPE),
+    CFE_TBL_ENTRY(CFE_TBL_CMD_MID, CFE_TBL_ABORT_LOAD_CC, CFE_TBL_AbortLoadCmd_t, CFE_TBL_AbortLoadCmd,
+                  CFE_TBL_CMD_MSGTYPE),
 
     /* list terminator (keep last) */
     {CFE_SB_MSGID_RESERVED, 0, 0, NULL, CFE_TBL_TERM_MSGTYPE}};


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x ] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Replaces CFE_MSG_CommandHeader_t w/ CFE_TBL_NoArgsCmd_t & runs clang-format. [Fixes #2220 ]

**Testing performed**
Build and run all tests

**Expected behavior changes**
None

**System(s) tested on**
Ubuntu 22.04 and 20.04 (workflows)

**Contributor Info - All information REQUIRED for consideration of pull request**
Dan Knutsen
NASA Goddard 
