### PR TITLE
Fix #2228, Update UTs to use correct cmd types

### DIFF
--- a/modules/es/fsw/inc/cfe_es_msg.h
+++ b/modules/es/fsw/inc/cfe_es_msg.h
@@ -1073,6 +1073,7 @@ typedef CFE_ES_NoArgsCmd_t CFE_ES_ResetCountersCmd_t;
 typedef CFE_ES_NoArgsCmd_t CFE_ES_ClearSysLogCmd_t;
 typedef CFE_ES_NoArgsCmd_t CFE_ES_ClearERLogCmd_t;
 typedef CFE_ES_NoArgsCmd_t CFE_ES_ResetPRCountCmd_t;
+typedef CFE_ES_NoArgsCmd_t CFE_ES_SendHkCmd_t;
 
 /**
 ** \brief Restart cFE Command Payload

--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -452,7 +452,7 @@ void CFE_ES_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
         ** Housekeeping telemetry request
         */
         case CFE_ES_SEND_HK_MID:
-            CFE_ES_HousekeepingCmd((CFE_MSG_CommandHeader_t *)SBBufPtr);
+            CFE_ES_HousekeepingCmd((CFE_ES_SendHkCmd_t *)SBBufPtr);
             break;
 
         /*
@@ -655,7 +655,7 @@ void CFE_ES_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
+int32 CFE_ES_HousekeepingCmd(const CFE_ES_SendHkCmd_t *data)
 {
     OS_heap_prop_t HeapProp;
     int32          OsStatus;

--- a/modules/es/fsw/src/cfe_es_task.h
+++ b/modules/es/fsw/src/cfe_es_task.h
@@ -128,7 +128,7 @@ void CFE_ES_BackgroundCleanup(void);
 /*
 ** ES Task message dispatch functions
 */
-int32 CFE_ES_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data);
+int32 CFE_ES_HousekeepingCmd(const CFE_ES_SendHkCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -2466,7 +2466,9 @@ void TestTask(void)
     union
     {
         CFE_MSG_Message_t            Msg;
-        CFE_ES_NoArgsCmd_t           NoArgsCmd;
+        CFE_ES_SendHkCmd_t           SendHkCmd;
+        CFE_ES_NoopCmd_t             NoopCmd;
+        CFE_ES_ResetCountersCmd_t    ResetCountersCmd;
         CFE_ES_ClearSysLogCmd_t      ClearSysLogCmd;
         CFE_ES_ClearERLogCmd_t       ClearERLogCmd;
         CFE_ES_ResetPRCountCmd_t     ResetPRCountCmd;
@@ -2587,23 +2589,24 @@ void TestTask(void)
 
     /* Test a successful HK request */
     ES_ResetUnitTest();
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.NoArgsCmd), UT_TPID_CFE_ES_SEND_HK);
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.SendHkCmd), UT_TPID_CFE_ES_SEND_HK);
     UtAssert_NONZERO(CFE_ES_Global.TaskData.HkPacket.Payload.HeapBytesFree);
 
     /* Test the HK request with a get heap failure */
     ES_ResetUnitTest();
     UT_SetDeferredRetcode(UT_KEY(OS_HeapGetInfo), 1, -1);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.NoArgsCmd), UT_TPID_CFE_ES_SEND_HK);
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.SendHkCmd), UT_TPID_CFE_ES_SEND_HK);
     UtAssert_ZERO(CFE_ES_Global.TaskData.HkPacket.Payload.HeapBytesFree);
 
     /* Test successful no-op command */
     ES_ResetUnitTest();
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.NoArgsCmd), UT_TPID_CFE_ES_CMD_NOOP_CC);
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.NoopCmd), UT_TPID_CFE_ES_CMD_NOOP_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_NOOP_INF_EID);
 
     /* Test successful reset counters command */
     ES_ResetUnitTest();
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.NoArgsCmd), UT_TPID_CFE_ES_CMD_RESET_COUNTERS_CC);
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.ResetCountersCmd),
+                    UT_TPID_CFE_ES_CMD_RESET_COUNTERS_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_RESET_INF_EID);
 
     /* Test successful cFE restart */
@@ -3328,7 +3331,7 @@ void TestTask(void)
 
     /* Test the command pipe message process with an invalid command */
     ES_ResetUnitTest();
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.NoArgsCmd), UT_TPID_CFE_ES_CMD_INVALID_CC);
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.NoopCmd), UT_TPID_CFE_ES_CMD_INVALID_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_CC1_ERR_EID);
 
     /* Test sending a no-op command with an invalid command length */
@@ -3504,7 +3507,7 @@ void TestTask(void)
     /* Test error when sending Build Info event */
     ES_ResetUnitTest();
     UT_SetDeferredRetcode(UT_KEY(CFE_EVS_SendEvent), 1, CFE_EVS_INVALID_PARAMETER);
-    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.NoArgsCmd), UT_TPID_CFE_ES_CMD_NOOP_CC);
+    UT_CallTaskPipe(CFE_ES_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.NoopCmd), UT_TPID_CFE_ES_CMD_NOOP_CC);
     CFE_UtAssert_PRINTF("Error sending build info event");
 
     /*

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -664,7 +664,7 @@ void ES_ResetUnitTest(void)
      * so it must be re-initialized here every time CFE_ES_Global is reset.
      */
     CFE_ES_Global.ResetDataPtr = ES_UT_PersistentResetData;
-}
+} /* end ES_ResetUnitTest() */
 
 void TestInit(void)
 {
@@ -2466,7 +2466,7 @@ void TestTask(void)
     union
     {
         CFE_MSG_Message_t            Msg;
-        CFE_MSG_CommandHeader_t      NoArgsCmd;
+        CFE_ES_NoArgsCmd_t           NoArgsCmd;
         CFE_ES_ClearSysLogCmd_t      ClearSysLogCmd;
         CFE_ES_ClearERLogCmd_t       ClearERLogCmd;
         CFE_ES_ResetPRCountCmd_t     ResetPRCountCmd;
@@ -3518,7 +3518,7 @@ void TestTask(void)
     UT_SetHandlerFunction(UT_KEY(CFE_Config_IterateAll), ES_UT_Config_IterateAll, NULL);
     UtAssert_VOIDCALL(CFE_ES_TaskInit());
     CFE_UtAssert_PRINTF("Error sending mission version event");
-}
+} /* end TestTask */
 
 void TestPerf(void)
 {
@@ -5014,7 +5014,7 @@ void TestCDS()
     CFE_ES_Global.CDSIsAvailable = false;
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockIDByName(&CDSHandle, "NotNULL"), CFE_ES_NOT_IMPLEMENTED);
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockName(CDSName, CDSHandle, sizeof(CDSName)), CFE_ES_NOT_IMPLEMENTED);
-}
+} /* End TestCDS */
 
 void TestCDSMempool(void)
 {

--- a/modules/evs/fsw/inc/cfe_evs_msg.h
+++ b/modules/evs/fsw/inc/cfe_evs_msg.h
@@ -915,6 +915,7 @@ typedef struct CFE_EVS_NoArgsCmd
 typedef CFE_EVS_NoArgsCmd_t CFE_EVS_NoopCmd_t;
 typedef CFE_EVS_NoArgsCmd_t CFE_EVS_ResetCountersCmd_t;
 typedef CFE_EVS_NoArgsCmd_t CFE_EVS_ClearLogCmd_t;
+typedef CFE_EVS_NoArgsCmd_t CFE_EVS_SendHkCmd_t;
 
 /**
 ** \brief Write Event Log to File Command Payload

--- a/modules/evs/fsw/src/cfe_evs_task.c
+++ b/modules/evs/fsw/src/cfe_evs_task.c
@@ -329,7 +329,7 @@ void CFE_EVS_ProcessCommandPacket(CFE_SB_Buffer_t *SBBufPtr)
 
         case CFE_EVS_SEND_HK_MID:
             /* Housekeeping request */
-            CFE_EVS_ReportHousekeepingCmd((CFE_MSG_CommandHeader_t *)SBBufPtr);
+            CFE_EVS_ReportHousekeepingCmd((CFE_EVS_SendHkCmd_t *)SBBufPtr);
             break;
 
         default:
@@ -613,7 +613,7 @@ int32 CFE_EVS_ClearLogCmd(const CFE_EVS_ClearLogCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_ReportHousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
+int32 CFE_EVS_ReportHousekeepingCmd(const CFE_EVS_SendHkCmd_t *data)
 {
     uint32                i, j;
     EVS_AppData_t *       AppDataPtr;

--- a/modules/evs/fsw/src/cfe_evs_task.h
+++ b/modules/evs/fsw/src/cfe_evs_task.h
@@ -161,7 +161,7 @@ void CFE_EVS_ProcessCommandPacket(CFE_SB_Buffer_t *SBBufPtr);
  *
  * Request for housekeeping status telemetry packet.
  */
-int32 CFE_EVS_ReportHousekeepingCmd(const CFE_MSG_CommandHeader_t *data);
+int32 CFE_EVS_ReportHousekeepingCmd(const CFE_EVS_SendHkCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**

--- a/modules/evs/ut-coverage/evs_UT.c
+++ b/modules/evs/ut-coverage/evs_UT.c
@@ -906,7 +906,7 @@ void Test_Logging(void)
     char   tmpString[100];
     union
     {
-        CFE_MSG_CommandHeader_t       cmd;
+        CFE_EVS_NoopCmd_t             cmd;
         CFE_EVS_SetLogModeCmd_t       modecmd;
         CFE_EVS_WriteLogDataFileCmd_t logfilecmd;
     } CmdBuf;
@@ -1056,7 +1056,7 @@ void Test_WriteApp(void)
 {
     union
     {
-        CFE_MSG_CommandHeader_t       cmd;
+        CFE_EVS_ResetCountersCmd_t    cmd;
         CFE_EVS_WriteAppDataFileCmd_t AppDataCmd;
         CFE_EVS_AppNameBitMaskCmd_t   appbitcmd;
     } CmdBuf;
@@ -1993,7 +1993,7 @@ void Test_Misc(void)
     union
     {
         CFE_MSG_Message_t             msg;
-        CFE_MSG_CommandHeader_t       cmd;
+        CFE_EVS_NoArgsCmd_t           cmd;
         CFE_EVS_SetLogModeCmd_t       modecmd;
         CFE_EVS_WriteLogDataFileCmd_t writelogdatacmd;
     } PktBuf;

--- a/modules/evs/ut-coverage/evs_UT.c
+++ b/modules/evs/ut-coverage/evs_UT.c
@@ -906,7 +906,8 @@ void Test_Logging(void)
     char   tmpString[100];
     union
     {
-        CFE_EVS_NoopCmd_t             cmd;
+        CFE_EVS_NoopCmd_t             noopcmd;
+        CFE_EVS_ClearLogCmd_t         clearlogcmd;
         CFE_EVS_SetLogModeCmd_t       modecmd;
         CFE_EVS_WriteLogDataFileCmd_t logfilecmd;
     } CmdBuf;
@@ -976,13 +977,15 @@ void Test_Logging(void)
     /* Test sending a no op command */
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    UT_EVS_DoDispatchCheckEvents(&CmdBuf.cmd, sizeof(CmdBuf.cmd), UT_TPID_CFE_EVS_CMD_NOOP_CC, &UT_EVS_EventBuf);
+    UT_EVS_DoDispatchCheckEvents(&CmdBuf.noopcmd, sizeof(CmdBuf.noopcmd), UT_TPID_CFE_EVS_CMD_NOOP_CC,
+                                 &UT_EVS_EventBuf);
     UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_NOOP_EID);
 
     /* Clear log for next test */
     UT_InitData();
     CFE_EVS_Global.EVS_TlmPkt.Payload.LogEnabled = true;
-    UT_EVS_DoDispatchCheckEvents(&CmdBuf.cmd, sizeof(CmdBuf.cmd), UT_TPID_CFE_EVS_CMD_CLEAR_LOG_CC, &UT_EVS_EventBuf);
+    UT_EVS_DoDispatchCheckEvents(&CmdBuf.clearlogcmd, sizeof(CmdBuf.clearlogcmd), UT_TPID_CFE_EVS_CMD_CLEAR_LOG_CC,
+                                 &UT_EVS_EventBuf);
     UtAssert_BOOL_FALSE(CFE_EVS_Global.EVS_LogPtr->LogFullFlag);
     UtAssert_UINT32_EQ(CFE_EVS_Global.EVS_LogPtr->LogOverflowCounter, 0);
 
@@ -1056,7 +1059,7 @@ void Test_WriteApp(void)
 {
     union
     {
-        CFE_EVS_ResetCountersCmd_t    cmd;
+        CFE_EVS_ResetCountersCmd_t    ResetCountersCmd;
         CFE_EVS_WriteAppDataFileCmd_t AppDataCmd;
         CFE_EVS_AppNameBitMaskCmd_t   appbitcmd;
     } CmdBuf;
@@ -1078,8 +1081,8 @@ void Test_WriteApp(void)
 
     /* Test resetting counters */
     UT_InitData();
-    UT_EVS_DoDispatchCheckEvents(&CmdBuf.cmd, sizeof(CmdBuf.cmd), UT_TPID_CFE_EVS_CMD_RESET_COUNTERS_CC,
-                                 &UT_EVS_EventBuf);
+    UT_EVS_DoDispatchCheckEvents(&CmdBuf.ResetCountersCmd, sizeof(CmdBuf.ResetCountersCmd),
+                                 UT_TPID_CFE_EVS_CMD_RESET_COUNTERS_CC, &UT_EVS_EventBuf);
     UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_RSTCNT_EID);
 
     /* Test writing application data with a create failure using default
@@ -1993,7 +1996,7 @@ void Test_Misc(void)
     union
     {
         CFE_MSG_Message_t             msg;
-        CFE_EVS_NoArgsCmd_t           cmd;
+        CFE_EVS_SendHkCmd_t           sendhkcmd;
         CFE_EVS_SetLogModeCmd_t       modecmd;
         CFE_EVS_WriteLogDataFileCmd_t writelogdatacmd;
     } PktBuf;
@@ -2051,7 +2054,7 @@ void Test_Misc(void)
     CFE_EVS_Global.EVS_TlmPkt.Payload.LogEnabled = true;
     HK_SnapshotData.Count                        = 0;
     UT_SetHookFunction(UT_KEY(CFE_SB_TransmitMsg), UT_SoftwareBusSnapshotHook, &HK_SnapshotData);
-    UT_CallTaskPipe(CFE_EVS_ProcessCommandPacket, &PktBuf.msg, sizeof(PktBuf.cmd), UT_TPID_CFE_EVS_SEND_HK);
+    UT_CallTaskPipe(CFE_EVS_ProcessCommandPacket, &PktBuf.msg, sizeof(PktBuf.sendhkcmd), UT_TPID_CFE_EVS_SEND_HK);
     UtAssert_UINT32_EQ(HK_SnapshotData.Count, 1);
 
     /* Test successful application cleanup */
@@ -2067,7 +2070,7 @@ void Test_Misc(void)
     CFE_EVS_Global.EVS_TlmPkt.Payload.LogEnabled = false;
     HK_SnapshotData.Count                        = 0;
     UT_SetHookFunction(UT_KEY(CFE_SB_TransmitMsg), UT_SoftwareBusSnapshotHook, &HK_SnapshotData);
-    UT_CallTaskPipe(CFE_EVS_ProcessCommandPacket, &PktBuf.msg, sizeof(PktBuf.cmd), UT_TPID_CFE_EVS_SEND_HK);
+    UT_CallTaskPipe(CFE_EVS_ProcessCommandPacket, &PktBuf.msg, sizeof(PktBuf.sendhkcmd), UT_TPID_CFE_EVS_SEND_HK);
     UtAssert_UINT32_EQ(HK_SnapshotData.Count, 1);
 
     /* Test sending a packet with the message counter and the event counter

--- a/modules/sb/fsw/inc/cfe_sb_msg.h
+++ b/modules/sb/fsw/inc/cfe_sb_msg.h
@@ -486,6 +486,7 @@ typedef CFE_MSG_CommandHeader_t CFE_SB_EnableSubReportingCmd_t;
 typedef CFE_MSG_CommandHeader_t CFE_SB_DisableSubReportingCmd_t;
 typedef CFE_MSG_CommandHeader_t CFE_SB_SendSbStatsCmd_t;
 typedef CFE_MSG_CommandHeader_t CFE_SB_SendPrevSubsCmd_t;
+typedef CFE_MSG_CommandHeader_t CFE_SB_SendHkCmd_t;
 
 /**
 **  \brief Write File Info Command Payload

--- a/modules/sb/fsw/src/cfe_sb_priv.h
+++ b/modules/sb/fsw/src/cfe_sb_priv.h
@@ -802,7 +802,7 @@ int32 CFE_SB_DisableSubReportingCmd(const CFE_SB_DisableSubReportingCmd_t *data)
  * \param[in] data Pointer to command structure
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_SendHKTlmCmd(const CFE_MSG_CommandHeader_t *data);
+int32 CFE_SB_SendHKTlmCmd(const CFE_SB_SendHkCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**

--- a/modules/sb/fsw/src/cfe_sb_task.c
+++ b/modules/sb/fsw/src/cfe_sb_task.c
@@ -503,7 +503,7 @@ int32 CFE_SB_DisableSubReportingCmd(const CFE_SB_DisableSubReportingCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_SendHKTlmCmd(const CFE_MSG_CommandHeader_t *data)
+int32 CFE_SB_SendHKTlmCmd(const CFE_SB_SendHkCmd_t *data)
 {
     CFE_SB_LockSharedData(__FILE__, __LINE__);
 

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -4321,8 +4321,8 @@ void Test_SB_TransmitMsgPaths_Nominal(void)
 {
     union
     {
-        CFE_SB_Buffer_t         SBBuf;
-        CFE_MSG_CommandHeader_t Cmd;
+        CFE_SB_Buffer_t    SBBuf;
+        CFE_SB_SendHkCmd_t SendHkCmd;
     } Housekeeping;
     CFE_SB_MsgId_t   MsgId;
     CFE_SB_PipeId_t  PipeId = CFE_SB_INVALID_PIPE;
@@ -4335,7 +4335,7 @@ void Test_SB_TransmitMsgPaths_Nominal(void)
     memset(&TlmPkt, 0, sizeof(TlmPkt));
 
     /* Set up for dispatch FIRST */
-    UT_SetupBasicMsgDispatch(&UT_TPID_CFE_SB_SEND_HK, sizeof(Housekeeping.Cmd), false);
+    UT_SetupBasicMsgDispatch(&UT_TPID_CFE_SB_SEND_HK, sizeof(Housekeeping.SendHkCmd), false);
 
     /* For internal send message call */
     MsgId = CFE_SB_ValueToMsgId(CFE_SB_HK_TLM_MID);
@@ -4357,7 +4357,7 @@ void Test_SB_TransmitMsgPaths_Nominal(void)
     CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_GET_BUF_ERR_EID_BIT);
 
     /* Set up for dispatch FIRST */
-    UT_SetupBasicMsgDispatch(&UT_TPID_CFE_SB_SEND_HK, sizeof(Housekeeping.Cmd), false);
+    UT_SetupBasicMsgDispatch(&UT_TPID_CFE_SB_SEND_HK, sizeof(Housekeeping.SendHkCmd), false);
 
     /* For internal send message call */
     MsgId = CFE_SB_ValueToMsgId(CFE_SB_HK_TLM_MID);

--- a/modules/tbl/fsw/inc/cfe_tbl_msg.h
+++ b/modules/tbl/fsw/inc/cfe_tbl_msg.h
@@ -499,6 +499,7 @@ typedef struct CFE_TBL_NoArgsCmd
  */
 typedef CFE_TBL_NoArgsCmd_t CFE_TBL_NoopCmd_t;
 typedef CFE_TBL_NoArgsCmd_t CFE_TBL_ResetCountersCmd_t;
+typedef CFE_TBL_NoArgsCmd_t CFE_TBL_SendHkCmd_t;
 
 /**
 ** \brief Load Table Command Payload

--- a/modules/tbl/ut-coverage/tbl_UT.c
+++ b/modules/tbl/ut-coverage/tbl_UT.c
@@ -227,8 +227,10 @@ void Test_CFE_TBL_TaskInit(void)
     uint32 ExitCode;
     union
     {
-        CFE_TBL_NoArgsCmd_t NoArgsCmd;
-        CFE_MSG_Message_t   Msg;
+        CFE_TBL_NoopCmd_t          NoopCmd;
+        CFE_TBL_SendHkCmd_t        SendHkCmd;
+        CFE_TBL_ResetCountersCmd_t ResetCountersCmd;
+        CFE_MSG_Message_t          Msg;
     } CmdBuf;
     CFE_SB_MsgId_t    MsgId   = CFE_SB_INVALID_MSG_ID;
     CFE_MSG_FcnCode_t FcnCode = 0;
@@ -298,28 +300,28 @@ void Test_CFE_TBL_TaskInit(void)
 
     /* Test command pipe messages handler response to a valid command */
     UT_InitData();
-    UT_CallTaskPipe(CFE_TBL_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.NoArgsCmd), UT_TPID_CFE_TBL_CMD_NOOP_CC);
+    UT_CallTaskPipe(CFE_TBL_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.NoopCmd), UT_TPID_CFE_TBL_CMD_NOOP_CC);
     CFE_UtAssert_EVENTSENT(CFE_TBL_NOOP_INF_EID);
 
     /* Test command pipe messages handler response to an invalid
      * message length
      */
     UT_InitData();
-    UT_CallTaskPipe(CFE_TBL_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.NoArgsCmd) - 1, UT_TPID_CFE_TBL_CMD_NOOP_CC);
+    UT_CallTaskPipe(CFE_TBL_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.NoopCmd) - 1, UT_TPID_CFE_TBL_CMD_NOOP_CC);
     CFE_UtAssert_EVENTSENT(CFE_TBL_LEN_ERR_EID);
 
     /* Test command pipe messages handler response to an invalid
      * command code
      */
     UT_InitData();
-    UT_CallTaskPipe(CFE_TBL_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.NoArgsCmd), UT_TPID_CFE_TBL_CMD_INVALID_CC);
+    UT_CallTaskPipe(CFE_TBL_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.NoopCmd), UT_TPID_CFE_TBL_CMD_INVALID_CC);
     CFE_UtAssert_EVENTSENT(CFE_TBL_CC1_ERR_EID);
 
     /* Test command pipe messages handler response to other errors */
     UT_InitData();
     CFE_TBL_Global.CommandCounter      = 0;
     CFE_TBL_Global.CommandErrorCounter = 0;
-    UT_CallTaskPipe(CFE_TBL_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.NoArgsCmd), UT_TPID_CFE_TBL_INVALID_MID);
+    UT_CallTaskPipe(CFE_TBL_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.NoopCmd), UT_TPID_CFE_TBL_INVALID_MID);
     CFE_UtAssert_EVENTSENT(CFE_TBL_MID_ERR_EID);
     UtAssert_ZERO(CFE_TBL_Global.CommandCounter);
     UtAssert_ZERO(CFE_TBL_Global.CommandErrorCounter);
@@ -328,13 +330,14 @@ void Test_CFE_TBL_TaskInit(void)
     UT_InitData();
     CFE_TBL_Global.CommandCounter      = 0;
     CFE_TBL_Global.CommandErrorCounter = 0;
-    UT_CallTaskPipe(CFE_TBL_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.NoArgsCmd), UT_TPID_CFE_TBL_MSG_HK);
+    UT_CallTaskPipe(CFE_TBL_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.SendHkCmd), UT_TPID_CFE_TBL_MSG_HK);
     UtAssert_ZERO(CFE_TBL_Global.CommandCounter);
     UtAssert_ZERO(CFE_TBL_Global.CommandErrorCounter);
 
     /* Test command pipe messages handler response to "command type" message */
     UT_InitData();
-    UT_CallTaskPipe(CFE_TBL_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.NoArgsCmd), UT_TPID_CFE_TBL_CMD_RESET_COUNTERS_CC);
+    UT_CallTaskPipe(CFE_TBL_TaskPipe, &CmdBuf.Msg, sizeof(CmdBuf.ResetCountersCmd),
+                    UT_TPID_CFE_TBL_CMD_RESET_COUNTERS_CC);
     CFE_UtAssert_EVENTSENT(CFE_TBL_RESET_INF_EID);
     UtAssert_ZERO(CFE_TBL_Global.CommandCounter);
     UtAssert_ZERO(CFE_TBL_Global.CommandErrorCounter);

--- a/modules/tbl/ut-coverage/tbl_UT.c
+++ b/modules/tbl/ut-coverage/tbl_UT.c
@@ -227,8 +227,8 @@ void Test_CFE_TBL_TaskInit(void)
     uint32 ExitCode;
     union
     {
-        CFE_MSG_CommandHeader_t NoArgsCmd;
-        CFE_MSG_Message_t       Msg;
+        CFE_TBL_NoArgsCmd_t NoArgsCmd;
+        CFE_MSG_Message_t   Msg;
     } CmdBuf;
     CFE_SB_MsgId_t    MsgId   = CFE_SB_INVALID_MSG_ID;
     CFE_MSG_FcnCode_t FcnCode = 0;

--- a/modules/time/fsw/inc/cfe_time_msg.h
+++ b/modules/time/fsw/inc/cfe_time_msg.h
@@ -742,6 +742,7 @@ typedef CFE_TIME_NoArgsCmd_t CFE_TIME_SendDiagnosticCmd_t;
 typedef CFE_TIME_NoArgsCmd_t CFE_TIME_1HzCmd_t;
 typedef CFE_TIME_NoArgsCmd_t CFE_TIME_ToneSignalCmd_t;
 typedef CFE_TIME_NoArgsCmd_t CFE_TIME_FakeToneCmd_t;
+typedef CFE_TIME_NoArgsCmd_t CFE_TIME_SendHkCmd_t;
 
 /**
  * \brief Set leap seconds command payload

--- a/modules/time/fsw/src/cfe_time_task.c
+++ b/modules/time/fsw/src/cfe_time_task.c
@@ -359,7 +359,7 @@ void CFE_TIME_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
         ** Housekeeping telemetry request...
         */
         case CFE_TIME_SEND_HK_MID:
-            CFE_TIME_HousekeepingCmd((CFE_MSG_CommandHeader_t *)SBBufPtr);
+            CFE_TIME_HousekeepingCmd((CFE_TIME_SendHkCmd_t *)SBBufPtr);
             break;
 
         /*
@@ -547,7 +547,7 @@ void CFE_TIME_TaskPipe(CFE_SB_Buffer_t *SBBufPtr)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data)
+int32 CFE_TIME_HousekeepingCmd(const CFE_TIME_SendHkCmd_t *data)
 {
     CFE_TIME_Reference_t Reference;
 

--- a/modules/time/fsw/src/cfe_time_utils.h
+++ b/modules/time/fsw/src/cfe_time_utils.h
@@ -672,7 +672,7 @@ void CFE_TIME_Local1HzTimerCallback(osal_id_t TimerId, void *Arg);
 /**
  * @brief  Onboard command (HK request)
  */
-int32 CFE_TIME_HousekeepingCmd(const CFE_MSG_CommandHeader_t *data);
+int32 CFE_TIME_HousekeepingCmd(const CFE_TIME_SendHkCmd_t *data);
 
 /*
 ** Command handler for "tone signal detected"...

--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -1312,10 +1312,13 @@ void Test_PipeCmds(void)
     union
     {
         CFE_MSG_Message_t              message;
-        CFE_MSG_CommandHeader_t        cmd;
         CFE_TIME_ToneDataCmd_t         tonedatacmd;
+        CFE_TIME_ToneSignalCmd_t       tonesignalcmd;
+        CFE_TIME_FakeToneCmd_t         timesendcmd;
+        CFE_TIME_SendHkCmd_t           sendhkcmd;
+        CFE_TIME_1HzCmd_t              onehzcmd;
         CFE_TIME_NoopCmd_t             noopcmd;
-        CFE_TIME_ResetCountersCmd_t    resetcountercmd;
+        CFE_TIME_ResetCountersCmd_t    resetcounterscmd;
         CFE_TIME_SendDiagnosticCmd_t   diagtlmcmd;
         CFE_TIME_SetStateCmd_t         statecmd;
         CFE_TIME_SetSourceCmd_t        sourcecmd;
@@ -1344,14 +1347,14 @@ void Test_PipeCmds(void)
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_SetHookFunction(UT_KEY(CFE_SB_TransmitMsg), UT_SoftwareBusSnapshotHook, &LocalSnapshotData);
-    UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.cmd), UT_TPID_CFE_TIME_SEND_HK);
+    UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.sendhkcmd), UT_TPID_CFE_TIME_SEND_HK);
     UtAssert_INT32_EQ(LocalSnapshotData.Count, 1);
 
     /* Test sending the time at the tone "signal" command */
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CFE_TIME_Global.ToneSignalCounter = 0;
-    UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.cmd), UT_TPID_CFE_TIME_TONE_CMD);
+    UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.tonesignalcmd), UT_TPID_CFE_TIME_TONE_CMD);
     UtAssert_INT32_EQ(CFE_TIME_Global.ToneSignalCounter, 1);
 
     /* Test sending the time at the tone "data" command */
@@ -1379,7 +1382,7 @@ void Test_PipeCmds(void)
     count = CFE_TIME_Global.InternalCount;
 #endif
 
-    UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.cmd), UT_TPID_CFE_TIME_SEND_CMD);
+    UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.timesendcmd), UT_TPID_CFE_TIME_SEND_CMD);
 
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
     UtAssert_UINT32_EQ(CFE_TIME_Global.InternalCount, count + 1);
@@ -1416,7 +1419,7 @@ void Test_PipeCmds(void)
     CFE_TIME_Global.LocalIntCounter       = 1;
     CFE_TIME_Global.LocalTaskCounter      = 1;
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.resetcountercmd),
+    UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.resetcounterscmd),
                     UT_TPID_CFE_TIME_CMD_RESET_COUNTERS_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_RESET_EID);
 
@@ -1912,20 +1915,20 @@ void Test_PipeCmds(void)
     /* Test response to sending an invalid command */
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.cmd), UT_TPID_CFE_TIME_CMD_INVALID_CC);
+    UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.noopcmd), UT_TPID_CFE_TIME_CMD_INVALID_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_CC_ERR_EID);
 
     /* Test response to sending a command using an invalid message ID */
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.cmd), UT_TPID_CFE_TIME_INVALID_MID);
+    UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.noopcmd), UT_TPID_CFE_TIME_INVALID_MID);
     CFE_UtAssert_EVENTSENT(CFE_TIME_ID_ERR_EID);
 
     /* Call the Task Pipe with the 1Hz command. */
     /* In the 1Hz state machine it should call PSP GetTime as part,
         of latching the clock.  This is tested only to see that the latch executed. */
     UT_InitData();
-    UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.cmd), UT_TPID_CFE_TIME_1HZ_CMD);
+    UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.onehzcmd), UT_TPID_CFE_TIME_1HZ_CMD);
     UtAssert_NONZERO(UT_GetStubCount(UT_KEY(CFE_PSP_GetTime)));
 }
 

--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -1391,7 +1391,7 @@ void Test_PipeCmds(void)
     /* Test sending the no-op command */
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.cmd), UT_TPID_CFE_TIME_CMD_NOOP_CC);
+    UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.noopcmd), UT_TPID_CFE_TIME_CMD_NOOP_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_NOOP_EID);
 
     /* Noop with bad size */
@@ -1416,7 +1416,8 @@ void Test_PipeCmds(void)
     CFE_TIME_Global.LocalIntCounter       = 1;
     CFE_TIME_Global.LocalTaskCounter      = 1;
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.cmd), UT_TPID_CFE_TIME_CMD_RESET_COUNTERS_CC);
+    UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.resetcountercmd),
+                    UT_TPID_CFE_TIME_CMD_RESET_COUNTERS_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_RESET_EID);
 
     /* Confirm error counters get reset to help cover requirements that are difficult operationally */
@@ -1443,7 +1444,7 @@ void Test_PipeCmds(void)
     /* Test sending the request diagnostics command */
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.cmd),
+    UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.diagtlmcmd),
                     UT_TPID_CFE_TIME_CMD_SEND_DIAGNOSTIC_TLM_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_DIAG_EID);
 


### PR DESCRIPTION
Fix #2228, Update UTs to use correct cmd types

**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
These are the unit test updates requested by @shion-ito-nasa, and are associated with #2228 
The requested change originated from #2220

**Testing performed**
Build and run all tests'

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
Ubuntu 22.04 and 20.04 (workflows)

**Contributor Info - All information REQUIRED for consideration of pull request**
Dan Knutsen
NASA/Goddard
