### PR TITLE
Fix #1117, Rename unclear FileWrite EIDs

### DIFF
--- a/cmake/sample_defs/toolchain-i686-rtems4.11.cmake
+++ b/cmake/sample_defs/toolchain-i686-rtems4.11.cmake
@@ -29,7 +29,7 @@ ADD_DEFINITIONS(-DOS_RTEMS_4_DEPRECATED)
 # RTEMS_DYNAMIC_LOAD definition:
 # - Set to FALSE for platforms that create a RTEMS executable and link it
 #   to the cFE core.
-# - Set to TRUE for platforms that expect the cFE core to to be dynamically
+# - Set to TRUE for platforms that expect the cFE core to be dynamically
 #   loaded into an existing runtime image.
 # This is tied to the OSAL-BSP and PSP implementation so generally cannot
 # be switched on a specific OSAL/PSP platform without modifications.

--- a/cmake/sample_defs/toolchain-i686-rtems5.cmake
+++ b/cmake/sample_defs/toolchain-i686-rtems5.cmake
@@ -29,7 +29,7 @@ ADD_DEFINITIONS(-DOS_RTEMS_5)
 # RTEMS_DYNAMIC_LOAD definition:
 # - Set to FALSE for platforms that create a RTEMS executable and link it
 #   to the cFE core.
-# - Set to TRUE for platforms that expect the cFE core to to be dynamically
+# - Set to TRUE for platforms that expect the cFE core to be dynamically
 #   loaded into an existing runtime image.
 # This is tied to the OSAL-BSP and PSP implementation so generally cannot
 # be switched on a specific OSAL/PSP platform without modifications.

--- a/cmake/sample_defs/toolchain-i686-rtems6.cmake
+++ b/cmake/sample_defs/toolchain-i686-rtems6.cmake
@@ -29,7 +29,7 @@ ADD_DEFINITIONS(-DOS_RTEMS_6)
 # RTEMS_DYNAMIC_LOAD definition:
 # - Set to FALSE for platforms that create a RTEMS executable and link it
 #   to the cFE core.
-# - Set to TRUE for platforms that expect the cFE core to to be dynamically
+# - Set to TRUE for platforms that expect the cFE core to be dynamically
 #   loaded into an existing runtime image.
 # This is tied to the OSAL-BSP and PSP implementation so generally cannot
 # be switched on a specific OSAL/PSP platform without modifications.

--- a/modules/sb/config/default_cfe_sb_fcncodes.h
+++ b/modules/sb/config/default_cfe_sb_fcncodes.h
@@ -172,7 +172,7 @@
 **       - The file specified in the command (or the default specified
 **         by the #CFE_PLATFORM_SB_DEFAULT_ROUTING_FILENAME configuration parameter) will be
 **         updated with the latest information.
-**       - The #CFE_SB_SND_RTG_EID debug event message will be generated
+**       - The #CFE_SB_FILE_WRITE_EID debug event message will be generated
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):
@@ -182,7 +182,7 @@
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \SB_CMDEC - command error counter will increment
 **       - A command specific error event message is issued for all error
-**         cases. See #CFE_SB_SND_RTG_ERR1_EID and #CFE_SB_FILEWRITE_ERR_EID
+**         cases. See #CFE_SB_FILE_WRITE_CR_ERR_EID and #CFE_SB_FILE_WRITE_ERR_EID
 **
 **  \par Criticality
 **       This command is not inherently dangerous.  It will create a new
@@ -296,7 +296,7 @@
 **       - The file specified in the command (or the default specified
 **         by the #CFE_PLATFORM_SB_DEFAULT_PIPE_FILENAME configuration parameter) will be
 **         updated with the latest information.
-**       - The #CFE_SB_SND_RTG_EID debug event message will be generated
+**       - The #CFE_SB_FILE_WRITE_EID debug event message will be generated
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):
@@ -306,7 +306,7 @@
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \SB_CMDEC - command error counter will increment
 **       - A command specific error event message is issued for all error
-**         cases. See #CFE_SB_SND_RTG_ERR1_EID and #CFE_SB_FILEWRITE_ERR_EID
+**         cases. See #CFE_SB_FILE_WRITE_CR_ERR_EID and #CFE_SB_FILE_WRITE_ERR_EID
 **
 **  \par Criticality
 **       This command is not inherently dangerous.  It will create a new
@@ -342,7 +342,7 @@
 **       - The file specified in the command (or the default specified
 **         by the #CFE_PLATFORM_SB_DEFAULT_MAP_FILENAME configuration parameter) will be
 **         updated with the latest information.
-**       - The #CFE_SB_SND_RTG_EID debug event message will be generated
+**       - The #CFE_SB_FILE_WRITE_EID debug event message will be generated
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):
@@ -352,7 +352,7 @@
 **       Evidence of failure may be found in the following telemetry:
 **       - \b \c \SB_CMDEC - command error counter will increment
 **       - A command specific error event message is issued for all error
-**         cases. See #CFE_SB_SND_RTG_ERR1_EID and #CFE_SB_FILEWRITE_ERR_EID
+**         cases. See #CFE_SB_FILE_WRITE_CR_ERR_EID and #CFE_SB_FILE_WRITE_ERR_EID
 **
 **  \par Criticality
 **       This command is not inherently dangerous.  It will create a new

--- a/modules/sb/eds/cfe_sb.xml
+++ b/modules/sb/eds/cfe_sb.xml
@@ -589,7 +589,7 @@
           following telemetry:
           - \b \c \SB_CMDPC - command execution counter will increment.
           - Specified filename created at specified location. See description.
-          - The #CFE_SB_SND_RTG_EID debug event message will be generated. All
+          - The #CFE_SB_FILE_WRITE_EID debug event message will be generated. All
           debug events are filtered by default.
 
           \par  Error Conditions
@@ -599,7 +599,7 @@
           Evidence of failure may be found in the following telemetry:
           - \b \c \SB_CMDEC - command error counter will increment
           - A command specific error event message is issued for all error
-          cases. See #CFE_SB_SND_RTG_ERR1_EID and #CFE_SB_FILEWRITE_ERR_EID
+          cases. See #CFE_SB_FILE_WRITE_CR_ERR_EID and #CFE_SB_FILE_WRITE_ERR_EID
 
           \par  Criticality
           This command is not inherently dangerous.  It will create a new
@@ -734,7 +734,7 @@
           following telemetry:
           - \b \c \SB_CMDPC - command execution counter will increment.
           - Specified filename created at specified location. See description.
-          - The #CFE_SB_SND_RTG_EID debug event message will be generated. All
+          - The #CFE_SB_FILE_WRITE_EID debug event message will be generated. All
           debug events are filtered by default.
 
           \par  Error Conditions
@@ -744,7 +744,7 @@
           Evidence of failure may be found in the following telemetry:
           - \b \c \SB_CMDEC - command error counter will increment
           - A command specific error event message is issued for all error
-          cases. See #CFE_SB_SND_RTG_ERR1_EID and #CFE_SB_FILEWRITE_ERR_EID
+          cases. See #CFE_SB_FILE_WRITE_CR_ERR_EID and #CFE_SB_FILE_WRITE_ERR_EID
 
           \par  Criticality
           This command is not inherently dangerous.  It will create a new
@@ -785,7 +785,7 @@
           following telemetry:
           - \b \c \SB_CMDPC - command execution counter will increment.
           - Specified filename created at specified location. See description.
-          - The #CFE_SB_SND_RTG_EID debug event message will be generated. All
+          - The #CFE_SB_FILE_WRITE_EID debug event message will be generated. All
           debug events are filtered by default.
 
           \par  Error Conditions
@@ -795,7 +795,7 @@
           Evidence of failure may be found in the following telemetry:
           - \b \c \SB_CMDEC - command error counter will increment
           - A command specific error event message is issued for all error
-          cases. See #CFE_SB_SND_RTG_ERR1_EID and #CFE_SB_FILEWRITE_ERR_EID
+          cases. See #CFE_SB_FILE_WRITE_CR_ERR_EID and #CFE_SB_FILE_WRITE_ERR_EID
 
           \par  Criticality
           This command is not inherently dangerous.  It will create a new

--- a/modules/sb/fsw/inc/cfe_sb_eventids.h
+++ b/modules/sb/fsw/inc/cfe_sb_eventids.h
@@ -435,7 +435,7 @@
  *
  *  An SB file write successfully completed. OVERLOADED
  */
-#define CFE_SB_SND_RTG_EID 39
+#define CFE_SB_FILE_WRITE_EID 39
 
 /**
  * \brief SB File Write Create File Failure Event ID
@@ -446,7 +446,7 @@
  *
  *  An SB file write failure due to file creation error. OVERLOADED
  */
-#define CFE_SB_SND_RTG_ERR1_EID 40
+#define CFE_SB_FILE_WRITE_CR_ERR_EID 40
 
 /**
  * \brief SB Invalid Command Code Received Event ID
@@ -537,7 +537,7 @@
  *
  *  An SB file write failure encountered when writing to the file.
  */
-#define CFE_SB_FILEWRITE_ERR_EID 49
+#define CFE_SB_FILE_WRITE_ERR_EID 49
 
 /**
  * \brief SB Subscribe API Invalid Pipe Event ID

--- a/modules/sb/fsw/src/cfe_sb_task.c
+++ b/modules/sb/fsw/src/cfe_sb_task.c
@@ -734,20 +734,20 @@ void CFE_SB_BackgroundFileEventHandler(void *Meta, CFE_FS_FileWriteEvent_t Event
     switch (Event)
     {
         case CFE_FS_FileWriteEvent_COMPLETE:
-            CFE_EVS_SendEventWithAppID(CFE_SB_SND_RTG_EID, CFE_EVS_EventType_DEBUG, CFE_SB_Global.AppId,
+            CFE_EVS_SendEventWithAppID(CFE_SB_FILE_WRITE_EID, CFE_EVS_EventType_DEBUG, CFE_SB_Global.AppId,
                                        "%s written:Size=%d,Entries=%d", BgFilePtr->FileWrite.FileName, (int)Position,
                                        (int)RecordNum);
             break;
 
         case CFE_FS_FileWriteEvent_HEADER_WRITE_ERROR:
         case CFE_FS_FileWriteEvent_RECORD_WRITE_ERROR:
-            CFE_EVS_SendEventWithAppID(CFE_SB_FILEWRITE_ERR_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
+            CFE_EVS_SendEventWithAppID(CFE_SB_FILE_WRITE_ERR_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                        "File write,byte cnt err,file %s,request=%d,actual=%d",
                                        BgFilePtr->FileWrite.FileName, (int)BlockSize, (int)Status);
             break;
 
         case CFE_FS_FileWriteEvent_CREATE_ERROR:
-            CFE_EVS_SendEventWithAppID(CFE_SB_SND_RTG_ERR1_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
+            CFE_EVS_SendEventWithAppID(CFE_SB_FILE_WRITE_CR_ERR_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                        "Error creating file %s, stat=0x%x", BgFilePtr->FileWrite.FileName, (int)Status);
             break;
 

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -620,12 +620,12 @@ void Test_SB_Cmds_RoutingInfoDef(void)
 
     CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
-    /* Also test with a bad file name - should generate CFE_SB_SND_RTG_ERR1_EID */
+    /* Also test with a bad file name - should generate CFE_SB_FILE_WRITE_CR_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_ParseInputFileNameEx), 1, CFE_FS_INVALID_PATH);
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &WriteRoutingInfo.SBBuf.Msg, sizeof(WriteRoutingInfo.Cmd),
                     UT_TPID_CFE_SB_CMD_WRITE_ROUTING_INFO_CC);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_SND_RTG_ERR1_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_FILE_WRITE_CR_ERR_EID);
 
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &WriteRoutingInfo.SBBuf.Msg, 0, UT_TPID_CFE_SB_CMD_WRITE_ROUTING_INFO_CC);
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
@@ -656,7 +656,7 @@ void Test_SB_Cmds_RoutingInfoAlreadyPending(void)
 
     CFE_UtAssert_EVENTCOUNT(1);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_SND_RTG_ERR1_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_FILE_WRITE_CR_ERR_EID);
 }
 
 /*
@@ -765,11 +765,11 @@ void Test_SB_Cmds_PipeInfoDef(void)
 
     CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
 
-    /* Also test with a bad file name - should generate CFE_SB_SND_RTG_ERR1_EID */
+    /* Also test with a bad file name - should generate CFE_SB_FILE_WRITE_CR_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_ParseInputFileNameEx), 1, CFE_FS_INVALID_PATH);
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &WritePipeInfo.SBBuf.Msg, sizeof(WritePipeInfo.Cmd),
                     UT_TPID_CFE_SB_CMD_WRITE_PIPE_INFO_CC);
-    CFE_UtAssert_EVENTSENT(CFE_SB_SND_RTG_ERR1_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_FILE_WRITE_CR_ERR_EID);
 
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &WritePipeInfo.SBBuf.Msg, 0, UT_TPID_CFE_SB_CMD_WRITE_PIPE_INFO_CC);
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
@@ -802,7 +802,7 @@ void Test_SB_Cmds_PipeInfoAlreadyPending(void)
 
     CFE_UtAssert_EVENTCOUNT(1);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_SND_RTG_ERR1_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_FILE_WRITE_CR_ERR_EID);
 }
 
 /*
@@ -857,19 +857,19 @@ void Test_SB_Cmds_BackgroundFileWriteEvents(void)
 
     UT_ClearEventHistory();
     CFE_SB_BackgroundFileEventHandler(&State, CFE_FS_FileWriteEvent_COMPLETE, CFE_SUCCESS, 10, 0, 1000);
-    CFE_UtAssert_EVENTSENT(CFE_SB_SND_RTG_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_FILE_WRITE_EID);
 
     UT_ClearEventHistory();
     CFE_SB_BackgroundFileEventHandler(&State, CFE_FS_FileWriteEvent_RECORD_WRITE_ERROR, CFE_SUCCESS, 10, 10, 1000);
-    CFE_UtAssert_EVENTSENT(CFE_SB_FILEWRITE_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_FILE_WRITE_ERR_EID);
 
     UT_ClearEventHistory();
     CFE_SB_BackgroundFileEventHandler(&State, CFE_FS_FileWriteEvent_HEADER_WRITE_ERROR, CFE_SUCCESS, 10, 10, 1000);
-    CFE_UtAssert_EVENTSENT(CFE_SB_FILEWRITE_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_FILE_WRITE_ERR_EID);
 
     UT_ClearEventHistory();
     CFE_SB_BackgroundFileEventHandler(&State, CFE_FS_FileWriteEvent_CREATE_ERROR, OS_ERROR, 10, 0, 0);
-    CFE_UtAssert_EVENTSENT(CFE_SB_SND_RTG_ERR1_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_FILE_WRITE_CR_ERR_EID);
 
     UT_ClearEventHistory();
     CFE_SB_BackgroundFileEventHandler(&State, CFE_FS_FileWriteEvent_UNDEFINED, OS_ERROR, 0, 0, 0);
@@ -969,11 +969,11 @@ void Test_SB_Cmds_MapInfoDef(void)
 
     CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
-    /* Also test with a bad file name - should generate CFE_SB_SND_RTG_ERR1_EID */
+    /* Also test with a bad file name - should generate CFE_SB_FILE_WRITE_CR_ERR_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_ParseInputFileNameEx), 1, CFE_FS_INVALID_PATH);
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &WriteMapInfo.SBBuf.Msg, sizeof(WriteMapInfo.Cmd),
                     UT_TPID_CFE_SB_CMD_WRITE_MAP_INFO_CC);
-    CFE_UtAssert_EVENTSENT(CFE_SB_SND_RTG_ERR1_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_FILE_WRITE_CR_ERR_EID);
 
     /* Bad Size */
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, &WriteMapInfo.SBBuf.Msg, 0, UT_TPID_CFE_SB_CMD_WRITE_MAP_INFO_CC);
@@ -1007,7 +1007,7 @@ void Test_SB_Cmds_MapInfoAlreadyPending(void)
 
     CFE_UtAssert_EVENTCOUNT(1);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_SND_RTG_ERR1_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_FILE_WRITE_CR_ERR_EID);
 }
 
 /*


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1117 
  - Replaces misnamed/unclear FileWrite EIDs:
    - `CFE_SB_SND_RTG_EID` replaced with: `CFE_SB_FILE_WRITE_EID`
    - `CFE_SB_FILEWRITE_ERR_EID` replaced with: `CFE_SB_FILE_WRITE_ERR_EID` (minor change, purely for format consistency)
    - `CFE_SB_SND_RTG_ERR1_EID` replaced with: `CFE_SB_FILE_WRITE_CR_ERR_EID`

These EIDs are still overloaded. The aim to eventually make them unique is still open in issue https://github.com/nasa/cFE/issues/1588

Note: unrelated minor typo piggy-backed onto this PR (to to).

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No change to code behavior.
Future maintainability and ease-of-use improved due to clearer EID names.

**Contributor Info**
Avi Weiss @thnkslprpt