### PR TITLE
Fix #1332, Resolve compiler warnings re. signedness comparisons

### DIFF
--- a/modules/es/fsw/src/cfe_es_api.c
+++ b/modules/es/fsw/src/cfe_es_api.c
@@ -627,7 +627,7 @@ CFE_Status_t CFE_ES_WaitForSystemState(uint32 MinSystemState, uint32 TimeOutMill
      * to be at least the state requested.
      */
     WaitRemaining = TimeOutMilliseconds;
-    while (CFE_ES_Global.SystemState < MinSystemState)
+    while (CFE_ES_Global.SystemState < (int)MinSystemState)
     {
         /* TBD: Very Crude timing here, but not sure if it matters,
          * as this is only done during startup, not real work */

--- a/modules/es/fsw/src/cfe_es_apps.c
+++ b/modules/es/fsw/src/cfe_es_apps.c
@@ -1033,7 +1033,7 @@ bool CFE_ES_RunAppTableScan(uint32 ElapsedTime, void *Arg)
                  * Decrement the wait timer, if active.
                  * When the timeout value becomes zero, take the action to delete/restart/reload the app
                  */
-                if (AppPtr->ControlReq.AppTimerMsec > ElapsedTime)
+                if (AppPtr->ControlReq.AppTimerMsec > (int64_t)ElapsedTime)
                 {
                     AppPtr->ControlReq.AppTimerMsec -= ElapsedTime;
                 }

--- a/modules/es/fsw/src/cfe_es_perf.c
+++ b/modules/es/fsw/src/cfe_es_perf.c
@@ -457,7 +457,7 @@ bool CFE_ES_RunPerfLogDump(uint32 ElapsedTime, void *Arg)
 
             if (BlockSize != 0)
             {
-                if (Status != BlockSize)
+                if (Status != (int)BlockSize)
                 {
                     CFE_ES_FileWriteByteCntErr(State->DataFileName, BlockSize, Status);
 

--- a/modules/fs/fsw/src/cfe_fs_api.c
+++ b/modules/fs/fsw/src/cfe_fs_api.c
@@ -596,7 +596,7 @@ int32 CFE_FS_ParseInputFileName(char *OutputBuffer, const char *InputName, size_
 CFE_Status_t CFE_FS_ExtractFilenameFromPath(const char *OriginalPath, char *FileNameOnly)
 {
     uint32 i, j;
-    int    StringLength;
+    size_t StringLength;
     int    DirMarkIdx;
     int32  ReturnCode;
 
@@ -770,7 +770,7 @@ bool CFE_FS_RunBackgroundFileDump(uint32 ElapsedTime, void *Arg)
              */
             OsStatus = OS_write(State->Fd, RecordPtr, RecordSize);
 
-            if (OsStatus != RecordSize)
+            if (OsStatus != (int64_t)RecordSize)
             {
                 /* end the file early (cannot set "IsEOF" as this would cause the complete event to be generated too) */
                 OS_close(State->Fd);

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
@@ -735,7 +735,7 @@ CFE_TBL_CmdProcRet_t CFE_TBL_DumpToFile(const char *DumpFilename, const char *Ta
                 /* Output the active table image data to the dump file */
                 OsStatus = OS_write(FileDescriptor, DumpDataAddr, TblSizeInBytes);
 
-                if ((long)OsStatus == TblSizeInBytes)
+                if ((long)OsStatus == (int64_t)TblSizeInBytes)
                 {
                     if (FileExistedPrev)
                     {


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Partially fixes #1332 - only flight code was amended. Warnings for test code still exist.
  - `MinSystemState` represents `CFE_ES_SystemState` values. Seems safe (and future-proof) to cast to a simple `int` given the possible range of these values.
  - `ElapsedTime` casted to `int64_t` instead of `int`/`int32` to guarantee no conceivable chance of overflow even with (very) large msec time values.
  - `BlockSize` used to represent the size of various structures - fine to cast to standard `int`.
  - `StringLength` type changed to `size_t` (more correct given it's usage, and avoids 2 signedness comparison warnings).
  - `RecordSize` represents number of bytes - maybe safest with `int64_t`.
  - `TblSizeInBytes` represents number of bytes (safest with `int64_t`)

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.
Tested locally with `-Wsign-compare` flag enabled - no warnings issued for cFE.

**Expected behavior changes**
No change to behavior.

**Contributor Info**
Avi Weiss @thnkslprpt