### PR TITLE
Fix #1449, Factor out common code for bitmask check

### DIFF
--- a/modules/evs/fsw/src/cfe_evs_task.c
+++ b/modules/evs/fsw/src/cfe_evs_task.c
@@ -481,22 +481,15 @@ int32 CFE_EVS_EnablePortsCmd(const CFE_EVS_EnablePortsCmd_t *data)
     const CFE_EVS_BitMaskCmd_Payload_t *CmdPtr = &data->Payload;
     int32                               ReturnCode;
 
-    /* Need to check for an out of range bitmask, since oue bit masks are only 4 bits */
-    if (CmdPtr->BitMask == 0x0 || CmdPtr->BitMask > 0x0F)
-    {
-        EVS_SendEvent(CFE_EVS_ERR_INVALID_BITMASK_EID, CFE_EVS_EventType_ERROR,
-                      "Bit Mask = 0x%08x out of range: CC = %lu", (unsigned int)CmdPtr->BitMask,
-                      (long unsigned int)CFE_EVS_ENABLE_PORTS_CC);
-        ReturnCode = CFE_EVS_INVALID_PARAMETER;
-    }
-    else
+    ReturnCode = CFE_EVS_CheckBitmaskInRange(CmdPtr, CFE_EVS_ENABLE_PORTS_CC);
+
+    if (ReturnCode == CFE_SUCCESS)
     {
         /* Process command data */
         CFE_EVS_Global.EVS_TlmPkt.Payload.OutputPort |= CmdPtr->BitMask;
 
         EVS_SendEvent(CFE_EVS_ENAPORT_EID, CFE_EVS_EventType_DEBUG,
                       "Enable Ports Command Received with Port Bit Mask = 0x%02x", (unsigned int)CmdPtr->BitMask);
-        ReturnCode = CFE_SUCCESS;
     }
 
     return ReturnCode;
@@ -513,23 +506,15 @@ int32 CFE_EVS_DisablePortsCmd(const CFE_EVS_DisablePortsCmd_t *data)
     const CFE_EVS_BitMaskCmd_Payload_t *CmdPtr = &data->Payload;
     int32                               ReturnCode;
 
-    /* Need to check for an out of range bitmask, since oue bit masks are only 4 bits */
-    if (CmdPtr->BitMask == 0x0 || CmdPtr->BitMask > 0x0F)
-    {
-        EVS_SendEvent(CFE_EVS_ERR_INVALID_BITMASK_EID, CFE_EVS_EventType_ERROR,
-                      "Bit Mask = 0x%08x out of range: CC = %lu", (unsigned int)CmdPtr->BitMask,
-                      (long unsigned int)CFE_EVS_DISABLE_PORTS_CC);
-        ReturnCode = CFE_EVS_INVALID_PARAMETER;
-    }
-    else
+    ReturnCode = CFE_EVS_CheckBitmaskInRange(CmdPtr, CFE_EVS_DISABLE_PORTS_CC);
+
+    if (ReturnCode == CFE_SUCCESS)
     {
         /* Process command data */
         CFE_EVS_Global.EVS_TlmPkt.Payload.OutputPort &= ~CmdPtr->BitMask;
 
         EVS_SendEvent(CFE_EVS_DISPORT_EID, CFE_EVS_EventType_DEBUG,
                       "Disable Ports Command Received with Port Bit Mask = 0x%02x", (unsigned int)CmdPtr->BitMask);
-
-        ReturnCode = CFE_SUCCESS;
     }
 
     return ReturnCode;
@@ -548,15 +533,9 @@ int32 CFE_EVS_EnableEventTypeCmd(const CFE_EVS_EnableEventTypeCmd_t *data)
     int32                               ReturnCode;
     EVS_AppData_t *                     AppDataPtr;
 
-    /* Need to check for an out of range bitmask, since our bit masks are only 4 bits */
-    if (CmdPtr->BitMask == 0x0 || CmdPtr->BitMask > 0x0F)
-    {
-        EVS_SendEvent(CFE_EVS_ERR_INVALID_BITMASK_EID, CFE_EVS_EventType_ERROR,
-                      "Bit Mask = 0x%08x out of range: CC = %lu", (unsigned int)CmdPtr->BitMask,
-                      (long unsigned int)CFE_EVS_ENABLE_EVENT_TYPE_CC);
-        ReturnCode = CFE_EVS_INVALID_PARAMETER;
-    }
-    else
+    ReturnCode = CFE_EVS_CheckBitmaskInRange(CmdPtr, CFE_EVS_ENABLE_EVENT_TYPE_CC);
+
+    if (ReturnCode == CFE_SUCCESS)
     {
         AppDataPtr = CFE_EVS_Global.AppData;
         for (i = 0; i < CFE_PLATFORM_ES_MAX_APPLICATIONS; i++)
@@ -572,8 +551,6 @@ int32 CFE_EVS_EnableEventTypeCmd(const CFE_EVS_EnableEventTypeCmd_t *data)
         EVS_SendEvent(CFE_EVS_ENAEVTTYPE_EID, CFE_EVS_EventType_DEBUG,
                       "Enable Event Type Command Received with Event Type Bit Mask = 0x%02x",
                       (unsigned int)CmdPtr->BitMask);
-
-        ReturnCode = CFE_SUCCESS;
     }
 
     return ReturnCode;
@@ -592,16 +569,9 @@ int32 CFE_EVS_DisableEventTypeCmd(const CFE_EVS_DisableEventTypeCmd_t *data)
     int32                               ReturnCode;
     EVS_AppData_t *                     AppDataPtr;
 
-    /* Need to check for an out of range bitmask, since our bit masks are only 4 bits */
-    if (CmdPtr->BitMask == 0x0 || CmdPtr->BitMask > 0x0F)
-    {
-        EVS_SendEvent(CFE_EVS_ERR_INVALID_BITMASK_EID, CFE_EVS_EventType_ERROR,
-                      "Bit Mask = 0x%08x out of range: CC = %lu", (unsigned int)CmdPtr->BitMask,
-                      (long unsigned int)CFE_EVS_DISABLE_EVENT_TYPE_CC);
-        ReturnCode = CFE_EVS_INVALID_PARAMETER;
-    }
+    ReturnCode = CFE_EVS_CheckBitmaskInRange(CmdPtr, CFE_EVS_DISABLE_EVENT_TYPE_CC);
 
-    else
+    if (ReturnCode == CFE_SUCCESS)
     {
         AppDataPtr = CFE_EVS_Global.AppData;
         for (i = 0; i < CFE_PLATFORM_ES_MAX_APPLICATIONS; i++)
@@ -617,8 +587,6 @@ int32 CFE_EVS_DisableEventTypeCmd(const CFE_EVS_DisableEventTypeCmd_t *data)
         EVS_SendEvent(CFE_EVS_DISEVTTYPE_EID, CFE_EVS_EventType_DEBUG,
                       "Disable Event Type Command Received with Event Type Bit Mask = 0x%02x",
                       (unsigned int)CmdPtr->BitMask);
-
-        ReturnCode = CFE_SUCCESS;
     }
 
     return ReturnCode;
@@ -1291,4 +1259,25 @@ int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFileCmd_t *data)
     }
 
     return Result;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+CFE_Status_t CFE_EVS_CheckBitmaskInRange(const CFE_EVS_BitMaskCmd_Payload_t *CmdPtr, uint16 CommandCode)
+{
+    CFE_Status_t status = CFE_SUCCESS;
+
+    if (CmdPtr->BitMask == 0x0 || CmdPtr->BitMask > 0x0F)
+    {
+        EVS_SendEvent(CFE_EVS_ERR_INVALID_BITMASK_EID, CFE_EVS_EventType_ERROR,
+                      "Bit Mask = 0x%08x out of range: CC = %lu", (unsigned int)CmdPtr->BitMask,
+                      (long unsigned int)CommandCode);
+        status = CFE_EVS_INVALID_PARAMETER;
+    }
+
+    return status;
 }

--- a/modules/evs/fsw/src/cfe_evs_task.h
+++ b/modules/evs/fsw/src/cfe_evs_task.h
@@ -323,4 +323,14 @@ int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFileCmd_t *data);
  */
 int32 CFE_EVS_ResetAllFiltersCmd(const CFE_EVS_ResetAllFiltersCmd_t *data);
 
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Internal helper function to check if command bitmask is in range
+ *
+ * This routine checks if the given command bitmask is zero, or out of range (> 4 bits).
+ *
+ * @returns CFE_EVS_INVALID_PARAMETER if out of range, CFE_SUCCESS if within valid range
+ */
+CFE_Status_t CFE_EVS_CheckBitmaskInRange(const CFE_EVS_BitMaskCmd_Payload_t *CmdPtr, uint16 CommandCode);
+
 #endif /* CFE_EVS_TASK_H */


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1449
  - Duplication reduced from 4 bitmask checks to 1 in the helper function.

Could also add another (almost identical) helper to factor out the bitmask check from `CFE_EVS_EnableAppEventTypeCmd()` and `CFE_EVS_DisableAppEventTypeCmd()`. They weren't included here as they use a different structure to hold the bitmask (they use `CFE_EVS_AppNameBitMaskCmd_Payload_t`)

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No change to behavior or return values.

**Contributor Info**
Avi Weiss @thnkslprpt