### PR TITLE
Fix #2258, add more generic status codes

### DIFF
--- a/modules/core_api/fsw/inc/cfe_error.h
+++ b/modules/core_api/fsw/inc/cfe_error.h
@@ -203,6 +203,30 @@ char *CFE_ES_StatusToString(CFE_Status_t status, CFE_StatusString_t *status_stri
 #define CFE_STATUS_REQUEST_ALREADY_PENDING ((int32)0xc8000006)
 
 /**
+ * @brief Request or input value failed basic structural validation
+ *
+ * A message or table input was not in the proper format to be understood
+ * and processed by an application, and was rejected.
+ */
+#define CFE_STATUS_VALIDATION_FAILURE ((int32)0xc8000007)
+
+/**
+ * @brief Request or input value is out of range
+ *
+ * A message, table, or function call input contained a value that was outside
+ * the acceptable range, and the request was rejected.
+ */
+#define CFE_STATUS_RANGE_ERROR ((int32)0xc8000008)
+
+/**
+ * @brief Cannot process request at this time
+ *
+ * The system is not currently in the correct state to accept the request at
+ * this time.
+ */
+#define CFE_STATUS_INCORRECT_STATE ((int32)0xc8000009)
+
+/**
  * @brief Not Implemented
  *
  *  Current version does not have the function or the feature


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Adds several more generic CFE_STATUS_ codes to be used for common validation and input processing conditions.

Fixes #2258

**Testing performed**
Build and run CFE, run all tests

**Expected behavior changes**
None - just defines some new status codes that are not (yet) used anywhere, does not change any existing status code.

**System(s) tested on**
Debian

**Additional context**
Apps can use these codes to make input validation a bit more consistent.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
