### PR TITLE
Fix #2260, Convert CFE_TBL_INFO_TABLE_LOCKED into a negative error code

### DIFF
--- a/modules/cfe_testcase/src/tbl_content_access_test.c
+++ b/modules/cfe_testcase/src/tbl_content_access_test.c
@@ -90,7 +90,7 @@ void TestReleaseAddress(void)
     /* Attempt to load while address is locked */
     LoadTable(&TestTable, CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_TBL_GetAddress(&TblPtr, CFE_FT_Global.TblHandle), CFE_TBL_INFO_UPDATED);
-    LoadTable(&TestTable, CFE_TBL_INFO_TABLE_LOCKED);
+    LoadTable(&TestTable, CFE_TBL_ERR_TABLE_LOCKED);
 
     /* Release and try again */
     UtAssert_INT32_EQ(CFE_TBL_ReleaseAddress(CFE_FT_Global.TblHandle), CFE_SUCCESS);

--- a/modules/core_api/fsw/inc/cfe_error.h
+++ b/modules/core_api/fsw/inc/cfe_error.h
@@ -1053,7 +1053,7 @@ char *CFE_ES_StatusToString(CFE_Status_t status, CFE_StatusString_t *status_stri
  *  The calling Application tried to update a table that is locked by another user.
  *
  */
-#define CFE_TBL_INFO_TABLE_LOCKED ((CFE_Status_t)0x4c000018)
+#define CFE_TBL_ERR_TABLE_LOCKED ((CFE_Status_t)0xcc000018)
 
 /**
  * Validation Pending

--- a/modules/tbl/fsw/src/cfe_tbl_internal.c
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.c
@@ -961,7 +961,7 @@ int32 CFE_TBL_UpdateInternal(CFE_TBL_Handle_t TblHandle, CFE_TBL_RegistryRec_t *
 
             if (LockStatus)
             {
-                Status = CFE_TBL_INFO_TABLE_LOCKED;
+                Status = CFE_TBL_ERR_TABLE_LOCKED;
 
                 CFE_ES_WriteToSysLog("%s: Unable to update locked table Handle=%d\n", __func__, TblHandle);
             }

--- a/modules/tbl/ut-coverage/tbl_UT.c
+++ b/modules/tbl/ut-coverage/tbl_UT.c
@@ -2243,7 +2243,7 @@ void Test_CFE_TBL_Load(void)
     /* c. Perform test */
     UT_InitData();
     UT_SetAppID(UT_TBL_APPID_1);
-    UtAssert_INT32_EQ(CFE_TBL_Load(App1TblHandle1, CFE_TBL_SRC_ADDRESS, &TestTable1), CFE_TBL_INFO_TABLE_LOCKED);
+    UtAssert_INT32_EQ(CFE_TBL_Load(App1TblHandle1, CFE_TBL_SRC_ADDRESS, &TestTable1), CFE_TBL_ERR_TABLE_LOCKED);
     CFE_UtAssert_EVENTCOUNT(1);
 
     /* d. Test cleanup */
@@ -2725,8 +2725,8 @@ void Test_CFE_TBL_Manage(void)
 
     /* Configure table for update */
     RegRecPtr->LoadPending = true;
-    UtAssert_INT32_EQ(CFE_TBL_Manage(App1TblHandle1), CFE_TBL_INFO_TABLE_LOCKED);
-    CFE_UtAssert_EVENTCOUNT(0);
+    UtAssert_INT32_EQ(CFE_TBL_Manage(App1TblHandle1), CFE_TBL_ERR_TABLE_LOCKED);
+    CFE_UtAssert_EVENTCOUNT(1);
 
     /* Save the previous table's information for a subsequent test */
     AccessDescPtr  = &CFE_TBL_Global.Handles[App1TblHandle1];


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2260 (one of the cases of multiple 'success' return codes identified in https://github.com/nasa/cFE/issues/483).
  - `CFE_TBL_INFO_TABLE_LOCKED` in `CFE_TBL_UpdateInternal()` converted into a negative error return code. Not updating the table is a clear failure, and it should not be represented by a positive return value, giving an impression of success.

**Testing performed**
GitHub CI actions (incl. Code Coverage Analysis, Functional Test etc.) all passing successfully.

`CFE_TBL_Update()` (which calls `CFE_TBL_UpdateInternal()`) tests for `(Status < 0)` which is now triggered by `CFE_TBL_INFO_TABLE_LOCKED` as well, and the branch for a non-NULL `RegRecPtr` was not previously covered. With these changes, that branch is now executed by the existing tests. This results in an increase in coverage of 2 lines and 1 branch:
```
Prior to the changes:
  lines......: 98.1% (13074 of 13326 lines)
  functions..: 97.0% (1041 of 1073 functions)
  branches...: 97.1% (5870 of 6047 branches)
  
With the changes:
  lines......: 98.1% (13076 of 13326 lines)
  functions..: 97.0% (1041 of 1073 functions)
  branches...: 97.1% (5871 of 6047 branches)
```

**Expected behavior changes**
Behavior of the function is the same. Only the return code in the case of trying to update a locked table is changing from positive to negative.

The only use of `CFE_TBL_Update()` from other apps where the return value is checked (e.g. in HK) use `== CFE_SUCCESS`, so will not be affected by this change. Other (non-public) users who were checking the return of `CFE_TBL_Update()` and testing less precisely for `return >= 0` (or similar equivalents) will see a change, but it seems unlikely that they would consider a non-update as success anyway.

**System(s) tested on**
Intel(R) Celeron(R) N4100 CPU @ 1.10GHz x86_64
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS.

**Contributor Info**
Avi Weiss @thnkslprpt