### PR TITLE
Fix #921, Update remaining cFE source/tests to use CFE_Status_t

### DIFF
--- a/docs/cFE Application Developers Guide.md
+++ b/docs/cFE Application Developers Guide.md
@@ -930,20 +930,20 @@ the newly-created resource.  This ID is used in all other functions that use
 the binary semaphore.
 
 ```c
-int32 OS_BinSemCreate(uint32 *xxx_SEM_ID, const char *xxx_SEM_NAME,
+CFE_Status_t OS_BinSemCreate(uint32 *xxx_SEM_ID, const char *xxx_SEM_NAME,
  			       uint32 sem_initial_value, uint32 options);
 ```
 
 There are two options for pending on a binary semaphore:
 
 ```c
-int32 OS_BinSemTake( uint32 xxx_SEM_ID );
+CFE_Status_t OS_BinSemTake( uint32 xxx_SEM_ID );
 ```
 
 which waits indefinitely for a semaphore to become available, and
 
 ```c
-int32 OS_BinSemTimedWait( uint32 xxx_SEM_ID , uint32 timeout_in_milliseconds );
+CFE_Status_t OS_BinSemTimedWait( uint32 xxx_SEM_ID , uint32 timeout_in_milliseconds );
 ```
 
 which waits for a specified timeout period and quits if the semaphore
@@ -952,7 +952,7 @@ has not become available.
 A binary semaphore is given by using this function:
 
 ```c
-int32 OS_BinSemGive( uint32 xxx_SEM_ID );
+CFE_Status_t OS_BinSemGive( uint32 xxx_SEM_ID );
 ```
 
 For more detail on these functions (including arguments and return codes, refer
@@ -977,26 +977,26 @@ ID of the newly-created resource. This ID is used in all other functions that
 use the binary semaphore.
 
 ```c
-int32 OS_CountSemCreate(uint32 *xxx_SEM_ID, const char *xxx_SEM_NAME,
+CFE_Status_t OS_CountSemCreate(uint32 *xxx_SEM_ID, const char *xxx_SEM_NAME,
  			       uint32 sem_initial_value, uint32 options);
 ```
 
 There are two options for pending on a counting semaphore:
 
 ```c
-int32 OS_CountSemTake( uint32 xxx_SEM_ID );
+CFE_Status_t OS_CountSemTake( uint32 xxx_SEM_ID );
 ```
 
 which waits indefinitely for a semaphore to become available, and
 
 ```c
-int32 OS_CountSemTimedWait( uint32 xxx_SEM_ID , uint32 timeout_in_milliseconds );
+CFE_Status_t OS_CountSemTimedWait( uint32 xxx_SEM_ID , uint32 timeout_in_milliseconds );
 ```
 
 A counting semaphore is given by using this function:
 
 ```c
-int32 OS_CountSemGive( uint32 xxx_SEM_ID );
+CFE_Status_t OS_CountSemGive( uint32 xxx_SEM_ID );
 ```
 
 For more detail on these functions (including arguments and return codes, refer
@@ -1032,12 +1032,12 @@ have the same level of indentation, and there should be exactly one
 entry point and one exit point to the protected region.
 
 ```c
-int32 OS_MutSemTake( uint32 xxx_MUT_ID );
+CFE_Status_t OS_MutSemTake( uint32 xxx_MUT_ID );
 
    /* protected region */
    Use the resource...
 
-int32 OS_MutSemGive( uint32 xxx_MUT_ID );
+CFE_Status_t OS_MutSemGive( uint32 xxx_MUT_ID );
 ```
 
 The code in the protected region should be kept as short as possible;
@@ -1057,25 +1057,25 @@ of the entire system.
 An application creates a mutex by calling:
 
 ```c
-int32 OS_MutSemCreate (uint32 *sem_id, const char *sem_name, uint32 options);
+CFE_Status_t OS_MutSemCreate (uint32 *sem_id, const char *sem_name, uint32 options);
 ```
 
 and deletes it by calling:
 
 ```c
-int32 OS_MutSemDelete (uint32 sem_id);
+CFE_Status_t OS_MutSemDelete (uint32 sem_id);
 ```
 
 An application takes a mutex by calling:
 
 ```c
-int32 OS_MutSemTake( uint32 xxx_MUT_ID );
+CFE_Status_t OS_MutSemTake( uint32 xxx_MUT_ID );
 ```
 
 and gives it by calling:
 
 ```c
-int32 OS_MutSemGive( uint32 xxx_MUT_ID );
+CFE_Status_t OS_MutSemGive( uint32 xxx_MUT_ID );
 ```
 
 There is no function for taking a mutex with a timeout limit since
@@ -1297,8 +1297,8 @@ SAMPLE_TaskData_t SAMPLE_TaskData;
 
 int32 SAMPLE_TaskInit(void)
 {
-    int32  Status = CFE_SUCCESS;
-    uint32 CDSCrc;
+    CFE_Status_t Status = CFE_SUCCESS;
+    uint32       CDSCrc;
 
     /* Create the Critical Data Store */
     Status = CFE_ES_RegisterCDS(&SAMPLE_TaskData.MyCDSHandle,
@@ -1345,7 +1345,7 @@ int32 SAMPLE_TaskInit(void)
 
 void SAMPLE_TaskMain(void)
 {
-    int32 Status = CFE_SUCCESS;
+    CFE_Status_t Status = CFE_SUCCESS;
 
     ...
 
@@ -1471,7 +1471,7 @@ function, then the Developer can use the `CFE_ES_WriteToSysLog`
 function. This function has the following prototype:
 
 ```c
-int32 CFE_ES_WriteToSysLog(const char *pSpecString, ...);
+CFE_Status_t CFE_ES_WriteToSysLog(const char *pSpecString, ...);
 ```
 
 The function acts just like a standard 'C' printf function and records
@@ -1500,9 +1500,9 @@ FILE: xx_app.c
 
 void XX_AppMain(void)
 {
-    uint32 RunStatus = CFE_ES_RunStatus_APP_RUN;
+    uint32           RunStatus = CFE_ES_RunStatus_APP_RUN;
     CFE_SB_Buffer_t *SBBufPtr;
-    int32  Result = CFE_SUCCESS;
+    CFE_Status_t     Result = CFE_SUCCESS;
 
     /* Performance Log (start time counter) */
     CFE_ES_PerfLogEntry(XX_APPMAIN_PERF_ID);
@@ -1735,7 +1735,7 @@ SAMPLE_AppData_t;  SAMPLE_AppData;
 ...
 
 {
-   int32 Status;
+   CFE_Status_t Status;
 
    ...
    Status = CFE_SB_CreatePipe( &SAMPLE_AppData.SAMPLE_Pipe_1, /* Variable to hold Pipe ID */
@@ -1775,7 +1775,7 @@ follows:
 FILE: sample_app.c
 
 {
-   int32 Status;
+   CFE_Status_t Status;
 
    ...
    Status = CFE_SB_DeletePipe(SAMPLE_Pipe_1); /* Delete pipe created earlier */
@@ -1830,7 +1830,7 @@ SAMPLE_AppData_t SAMPLE_AppData;
 
 ...
 {
-   int32 Status;
+   CFE_Status_t Status;
 
    ...
    Status = CFE_SB_SubscribeEX(SAMPLE_CMDID_1,               /* Msg Id to Receive */
@@ -1878,7 +1878,7 @@ Message IDs. The following is a sample of the API to accomplish this:
 
 ```c
 {
-   int32 Status;
+   CFE_Status_t Status;
 
    ...
    Status = CFE_SB_Unsubscribe(SAMPLE_CMDID_1,                 /* Msg Id to Not Receive */
@@ -1946,7 +1946,7 @@ SAMPLE_AppData_t  SAMPLE_AppData;  /* Instantiate Task Data */
 
 ...
 {
-   int32 Status;
+   CFE_Status_t Status;
 
    ...
    Status = CFE_MSG_Init(CFE_MSG_PTR(SAMPLE_AppData.HkPacket.TelemetryHeader), /* Location of SB Message Data Buffer */
@@ -2473,7 +2473,7 @@ SAMPLE_AppData_t  SAMPLE_AppData;  /* Instantiate Task Data */
 
 ...
 {
-   int32 Status;
+   CFE_Status_t Status;
 
    ...
     /*
@@ -2516,7 +2516,7 @@ resetting a specific Event ID filter counter is shown below:
 FILE: sample_app.c
 
 {
-   int32 Status;
+   CFE_Status_t Status;
 
    ...
    Status = CFE_EVS_ResetFilter(SAMPLE_MID_ERR_EID); /* Reset filter for command pkt errors */
@@ -2748,7 +2748,7 @@ CFE_TBL_Handle_t  MyTableHandle;  /* Handle to MyTable */
 
 ...
 {
-   int32 Status;
+   CFE_Status_t Status;
 
    ...
     /*
@@ -2778,7 +2778,7 @@ of this is shown in Section 8.5.1.
 
 ```c
 {
-   int32 Status = CFE_SUCCESS;
+   CFE_Status_t      Status = CFE_SUCCESS;
    SAMPLE_MyTable_t *MyTblPtr;
 
    ...
@@ -2871,8 +2871,8 @@ Table Validation Request has been made as shown below:
 
 ```c
 {
-    int32   Status = CFE_SUCCESS;
-    boolean FinishedManaging = FALSE;
+    CFE_Status_t Status           = CFE_SUCCESS;
+    boolean      FinishedManaging = FALSE;
 
     while (!FinishedManaging)
     {
@@ -2926,7 +2926,7 @@ CFE_TBL_Handle_t  MyTableHandle  /* Handle to MyTable */
 SAMPLE_MyTable_t MyTblInitData = { 0x1234, 0x5678, { 2, 3, 4, ... }, ...};
 ...
 {
-   int32 Status;
+   CFE_Status_t Status;
 
    ...
     /*
@@ -2946,7 +2946,7 @@ memory image, the code would look something like the following:
 
 ```c
 {
-   int32 Status;
+   CFE_Status_t Status;
 
    ...
     /*
@@ -3074,7 +3074,7 @@ FILE: xx_tbl.c
 
 int32 XX_TableInit(void)
 {
-   int32 Status = CFE_SUCCESS;
+   CFE_Status_t Status = CFE_SUCCESS;
 
    ...
     /*
@@ -3111,8 +3111,8 @@ int32 XX_TableInit(void)
 int32 XX_ValidateTable(void *TableData)
 {
     /* Default to successful validation */
-    int32 Status = CFE_SUCCESS;
-    int32 i = 0;
+    CFE_Status_t Status = CFE_SUCCESS;
+    int32        i      = 0;
 
     XX_MyTable_t *MyTblPtr = (XX_MyTable_t *)TblPtr;
 

--- a/modules/cfe_assert/inc/cfe_assert.h
+++ b/modules/cfe_assert/inc/cfe_assert.h
@@ -255,7 +255,7 @@ typedef void (*CFE_Assert_StatusCallback_t)(uint8 MessageType, const char *Prefi
 **  \return #CFE_SUCCESS if successful, or error code
 **
 *************************************************************************/
-int32 CFE_Assert_LibInit(CFE_ES_LibId_t LibId);
+CFE_Status_t CFE_Assert_LibInit(CFE_ES_LibId_t LibId);
 
 /************************************************************************/
 /** \brief Start Test
@@ -268,7 +268,7 @@ int32 CFE_Assert_LibInit(CFE_ES_LibId_t LibId);
 **  \return #CFE_SUCCESS if successful, or error code
 **
 *************************************************************************/
-int32 CFE_Assert_RegisterTest(const char *TestName);
+CFE_Status_t CFE_Assert_RegisterTest(const char *TestName);
 
 /************************************************************************/
 /** \brief Execute Test and Exit
@@ -315,7 +315,7 @@ void CFE_Assert_RegisterCallback(CFE_Assert_StatusCallback_t Callback);
  * \retval #CFE_SUCCESS if file was opened successfully
  *
  */
-int32 CFE_Assert_OpenLogFile(const char *Filename);
+CFE_Status_t CFE_Assert_OpenLogFile(const char *Filename);
 
 /************************************************************************/
 /** \brief Complete a test log file

--- a/modules/cfe_assert/src/cfe_assert_init.c
+++ b/modules/cfe_assert/src/cfe_assert_init.c
@@ -43,7 +43,7 @@ void CFE_Assert_RegisterCallback(CFE_Assert_StatusCallback_t Callback)
 /*
  * Opens a log file to "tee" the test output to
  */
-int32 CFE_Assert_OpenLogFile(const char *Filename)
+CFE_Status_t CFE_Assert_OpenLogFile(const char *Filename)
 {
     int32  OsStatus;
     char * Ext;
@@ -104,7 +104,7 @@ void CFE_Assert_CloseLogFile(void)
 /*
  * Initialization Function for this library
  */
-int32 CFE_Assert_LibInit(CFE_ES_LibId_t LibId)
+CFE_Status_t CFE_Assert_LibInit(CFE_ES_LibId_t LibId)
 {
     int32 OsStatus;
 

--- a/modules/cfe_assert/src/cfe_assert_runner.c
+++ b/modules/cfe_assert/src/cfe_assert_runner.c
@@ -183,9 +183,9 @@ void CFE_Assert_StatusReport(uint8 MessageType, const char *Prefix, const char *
     CFE_EVS_SendEvent(MessageType, EventType, "[%5s] %s", Prefix, OutputMessage);
 }
 
-int32 CFE_Assert_RegisterTest(const char *TestName)
+CFE_Status_t CFE_Assert_RegisterTest(const char *TestName)
 {
-    int32          rc;
+    CFE_Status_t   rc;
     char           SetupSegmentName[64];
     CFE_ES_AppId_t SelfId;
 
@@ -280,7 +280,7 @@ int32 CFE_Assert_RegisterTest(const char *TestName)
 
 void CFE_Assert_ExecuteTest(void)
 {
-    int32          rc;
+    CFE_Status_t   rc;
     CFE_ES_AppId_t AppId;
 
     /*

--- a/modules/cfe_testcase/src/message_id_test.c
+++ b/modules/cfe_testcase/src/message_id_test.c
@@ -65,7 +65,7 @@ void TestGetTypeFromMsgId(void)
     UtPrintf("Testing: CFE_MSG_GetTypeFromMsgId");
     CFE_SB_MsgId_t msgid = CFE_SB_INVALID_MSG_ID;
     CFE_MSG_Type_t msgtype;
-    int32          status;
+    CFE_Status_t   status;
 
     /*
      * Response not verified because msgid 0 could be out of range based on implementation and

--- a/modules/cfe_testcase/src/time_external_test.c
+++ b/modules/cfe_testcase/src/time_external_test.c
@@ -29,13 +29,13 @@
 
 #include "cfe_test.h"
 
-int32 TestCallbackFunction(void)
+CFE_Status_t TestCallbackFunction(void)
 {
     CFE_FT_Global.Count += 1;
     return CFE_SUCCESS;
 }
 
-int32 TestCallbackFunction2(void)
+CFE_Status_t TestCallbackFunction2(void)
 {
     CFE_FT_Global.Count = 0;
     return CFE_SUCCESS;

--- a/modules/config/fsw/src/cfe_config_init.c
+++ b/modules/config/fsw/src/cfe_config_init.c
@@ -210,7 +210,7 @@ void CFE_Config_SetupBasicBuildInfo(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_Config_Init(void)
+CFE_Status_t CFE_Config_Init(void)
 {
     /* Clear the table, just in case it was not already cleared from initial program loading */
     memset(&CFE_Config_Global, 0, sizeof(CFE_Config_Global));

--- a/modules/config/ut-coverage/test_cfe_config.c
+++ b/modules/config/ut-coverage/test_cfe_config.c
@@ -240,7 +240,7 @@ void Test_CFE_Config_Init(void)
 {
     /*
      * Test case for:
-     * int32 CFE_Config_Init(void)
+     * CFE_Status_t CFE_Config_Init(void)
      */
     UtAssert_INT32_EQ(CFE_Config_Init(), CFE_SUCCESS);
 }

--- a/modules/core_api/fsw/inc/cfe_es.h
+++ b/modules/core_api/fsw/inc/cfe_es.h
@@ -118,7 +118,7 @@ CFE_Status_t CFE_ES_AppID_ToIndex(CFE_ES_AppId_t AppID, uint32 *Idx);
  * @retval #CFE_SUCCESS                      @copybrief CFE_SUCCESS
  * @retval #CFE_ES_ERR_RESOURCEID_NOT_VALID  @copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID
  */
-int32 CFE_ES_LibID_ToIndex(CFE_ES_LibId_t LibId, uint32 *Idx);
+CFE_Status_t CFE_ES_LibID_ToIndex(CFE_ES_LibId_t LibId, uint32 *Idx);
 
 /**
  * @brief Obtain an index value correlating to an ES Task ID
@@ -748,7 +748,7 @@ CFE_Status_t CFE_ES_GetTaskInfo(CFE_ES_TaskInfo_t *TaskInfo, CFE_ES_TaskId_t Tas
 ** \sa #CFE_ES_GetLibIDByName, #CFE_ES_GetLibName
 **
 ******************************************************************************/
-int32 CFE_ES_GetLibInfo(CFE_ES_AppInfo_t *LibInfo, CFE_ES_LibId_t LibId);
+CFE_Status_t CFE_ES_GetLibInfo(CFE_ES_AppInfo_t *LibInfo, CFE_ES_LibId_t LibId);
 
 /*****************************************************************************/
 /**
@@ -780,7 +780,7 @@ int32 CFE_ES_GetLibInfo(CFE_ES_AppInfo_t *LibInfo, CFE_ES_LibId_t LibId);
 ** \sa #CFE_ES_GetLibInfo, #CFE_ES_GetAppInfo
 **
 ******************************************************************************/
-int32 CFE_ES_GetModuleInfo(CFE_ES_AppInfo_t *ModuleInfo, CFE_ResourceId_t ResourceId);
+CFE_Status_t CFE_ES_GetModuleInfo(CFE_ES_AppInfo_t *ModuleInfo, CFE_ResourceId_t ResourceId);
 
 /**@}*/
 
@@ -1330,7 +1330,7 @@ CFE_Status_t CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_
 ** \sa #CFE_ES_PoolCreate, #CFE_ES_PoolCreateNoSem, #CFE_ES_GetPoolBuf, #CFE_ES_PutPoolBuf, #CFE_ES_GetMemPoolStats
 **
 ******************************************************************************/
-int32 CFE_ES_PoolDelete(CFE_ES_MemHandle_t PoolID);
+CFE_Status_t CFE_ES_PoolDelete(CFE_ES_MemHandle_t PoolID);
 
 /*****************************************************************************/
 /**
@@ -1358,7 +1358,7 @@ int32 CFE_ES_PoolDelete(CFE_ES_MemHandle_t PoolID);
 *#CFE_ES_GetPoolBufInfo
 **
 ******************************************************************************/
-int32 CFE_ES_GetPoolBuf(CFE_ES_MemPoolBuf_t *BufPtr, CFE_ES_MemHandle_t Handle, size_t Size);
+CFE_Status_t CFE_ES_GetPoolBuf(CFE_ES_MemPoolBuf_t *BufPtr, CFE_ES_MemHandle_t Handle, size_t Size);
 
 /*****************************************************************************/
 /**
@@ -1409,7 +1409,7 @@ CFE_Status_t CFE_ES_GetPoolBufInfo(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_
 *#CFE_ES_GetPoolBufInfo
 **
 ******************************************************************************/
-int32 CFE_ES_PutPoolBuf(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_t BufPtr);
+CFE_Status_t CFE_ES_PutPoolBuf(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_t BufPtr);
 
 /*****************************************************************************/
 /**

--- a/modules/core_api/fsw/inc/cfe_fs.h
+++ b/modules/core_api/fsw/inc/cfe_fs.h
@@ -254,9 +254,9 @@ const char *CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_t FileCategory);
 ** \retval #CFE_SUCCESS            \copybrief CFE_SUCCESS
 **
 ******************************************************************************/
-int32 CFE_FS_ParseInputFileNameEx(char *OutputBuffer, const char *InputBuffer, size_t OutputBufSize,
-                                  size_t InputBufSize, const char *DefaultInput, const char *DefaultPath,
-                                  const char *DefaultExtension);
+CFE_Status_t CFE_FS_ParseInputFileNameEx(char *OutputBuffer, const char *InputBuffer, size_t OutputBufSize,
+                                         size_t InputBufSize, const char *DefaultInput, const char *DefaultPath,
+                                         const char *DefaultExtension);
 
 /*****************************************************************************/
 /**
@@ -284,8 +284,8 @@ int32 CFE_FS_ParseInputFileNameEx(char *OutputBuffer, const char *InputBuffer, s
 **
 **---------------------------------------------------------------------------------------
 */
-int32 CFE_FS_ParseInputFileName(char *OutputBuffer, const char *InputName, size_t OutputBufSize,
-                                CFE_FS_FileCategory_t FileCategory);
+CFE_Status_t CFE_FS_ParseInputFileName(char *OutputBuffer, const char *InputName, size_t OutputBufSize,
+                                       CFE_FS_FileCategory_t FileCategory);
 
 /*****************************************************************************/
 /**
@@ -334,7 +334,7 @@ CFE_Status_t CFE_FS_ExtractFilenameFromPath(const char *OriginalPath, char *File
 ** \retval #CFE_SUCCESS                         \copybrief CFE_SUCCESS
 **
 ******************************************************************************/
-int32 CFE_FS_BackgroundFileDumpRequest(CFE_FS_FileWriteMetaData_t *Meta);
+CFE_Status_t CFE_FS_BackgroundFileDumpRequest(CFE_FS_FileWriteMetaData_t *Meta);
 
 /*****************************************************************************/
 /**

--- a/modules/core_api/fsw/inc/cfe_resourceid.h
+++ b/modules/core_api/fsw/inc/cfe_resourceid.h
@@ -37,6 +37,8 @@
 #ifndef CFE_RESOURCEID_H
 #define CFE_RESOURCEID_H
 
+#include "cfe_error.h"
+
 /*
  * The basic resource ID API definitions
  */
@@ -216,6 +218,6 @@ CFE_ResourceId_t CFE_ResourceId_FindNext(CFE_ResourceId_t StartId, uint32 TableS
  * @retval #CFE_ES_BAD_ARGUMENT             @copybrief CFE_ES_BAD_ARGUMENT
  * @retval #CFE_ES_ERR_RESOURCEID_NOT_VALID @copybrief CFE_ES_ERR_RESOURCEID_NOT_VALID
  */
-int32 CFE_ResourceId_ToIndex(CFE_ResourceId_t Id, uint32 BaseValue, uint32 TableSize, uint32 *Idx);
+CFE_Status_t CFE_ResourceId_ToIndex(CFE_ResourceId_t Id, uint32 BaseValue, uint32 TableSize, uint32 *Idx);
 
 #endif /* CFE_RESOURCEID_H */

--- a/modules/core_api/fsw/inc/cfe_sb.h
+++ b/modules/core_api/fsw/inc/cfe_sb.h
@@ -669,8 +669,8 @@ void CFE_SB_TimeStampMsg(CFE_MSG_Message_t *MsgPtr);
 ** \retval #CFE_SB_BAD_ARGUMENT  \copybrief CFE_SB_BAD_ARGUMENT
 **
 */
-int32 CFE_SB_MessageStringSet(char *DestStringPtr, const char *SourceStringPtr, size_t DestMaxSize,
-                              size_t SourceMaxSize);
+CFE_Status_t CFE_SB_MessageStringSet(char *DestStringPtr, const char *SourceStringPtr, size_t DestMaxSize,
+                                     size_t SourceMaxSize);
 
 /*****************************************************************************/
 /**
@@ -749,8 +749,8 @@ size_t CFE_SB_GetUserDataLength(const CFE_MSG_Message_t *MsgPtr);
 ** \retval #CFE_SB_BAD_ARGUMENT  \copybrief CFE_SB_BAD_ARGUMENT
 **
 */
-int32 CFE_SB_MessageStringGet(char *DestStringPtr, const char *SourceStringPtr, const char *DefaultString,
-                              size_t DestMaxSize, size_t SourceMaxSize);
+CFE_Status_t CFE_SB_MessageStringGet(char *DestStringPtr, const char *SourceStringPtr, const char *DefaultString,
+                                     size_t DestMaxSize, size_t SourceMaxSize);
 /** @} */
 
 /** @defgroup CFEAPISBMessageID cFE Message ID APIs

--- a/modules/core_api/ut-stubs/src/cfe_es_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_es_stubs.c
@@ -398,16 +398,16 @@ CFE_Status_t CFE_ES_GetLibIDByName(CFE_ES_LibId_t *LibIdPtr, const char *LibName
  * Generated stub function for CFE_ES_GetLibInfo()
  * ----------------------------------------------------
  */
-int32 CFE_ES_GetLibInfo(CFE_ES_AppInfo_t *LibInfo, CFE_ES_LibId_t LibId)
+CFE_Status_t CFE_ES_GetLibInfo(CFE_ES_AppInfo_t *LibInfo, CFE_ES_LibId_t LibId)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_ES_GetLibInfo, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_ES_GetLibInfo, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_ES_GetLibInfo, CFE_ES_AppInfo_t *, LibInfo);
     UT_GenStub_AddParam(CFE_ES_GetLibInfo, CFE_ES_LibId_t, LibId);
 
     UT_GenStub_Execute(CFE_ES_GetLibInfo, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CFE_ES_GetLibInfo, int32);
+    return UT_GenStub_GetReturnValue(CFE_ES_GetLibInfo, CFE_Status_t);
 }
 
 /*
@@ -450,16 +450,16 @@ CFE_Status_t CFE_ES_GetMemPoolStats(CFE_ES_MemPoolStats_t *BufPtr, CFE_ES_MemHan
  * Generated stub function for CFE_ES_GetModuleInfo()
  * ----------------------------------------------------
  */
-int32 CFE_ES_GetModuleInfo(CFE_ES_AppInfo_t *ModuleInfo, CFE_ResourceId_t ResourceId)
+CFE_Status_t CFE_ES_GetModuleInfo(CFE_ES_AppInfo_t *ModuleInfo, CFE_ResourceId_t ResourceId)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_ES_GetModuleInfo, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_ES_GetModuleInfo, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_ES_GetModuleInfo, CFE_ES_AppInfo_t *, ModuleInfo);
     UT_GenStub_AddParam(CFE_ES_GetModuleInfo, CFE_ResourceId_t, ResourceId);
 
     UT_GenStub_Execute(CFE_ES_GetModuleInfo, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CFE_ES_GetModuleInfo, int32);
+    return UT_GenStub_GetReturnValue(CFE_ES_GetModuleInfo, CFE_Status_t);
 }
 
 /*
@@ -467,9 +467,9 @@ int32 CFE_ES_GetModuleInfo(CFE_ES_AppInfo_t *ModuleInfo, CFE_ResourceId_t Resour
  * Generated stub function for CFE_ES_GetPoolBuf()
  * ----------------------------------------------------
  */
-int32 CFE_ES_GetPoolBuf(CFE_ES_MemPoolBuf_t *BufPtr, CFE_ES_MemHandle_t Handle, size_t Size)
+CFE_Status_t CFE_ES_GetPoolBuf(CFE_ES_MemPoolBuf_t *BufPtr, CFE_ES_MemHandle_t Handle, size_t Size)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_ES_GetPoolBuf, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_ES_GetPoolBuf, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_ES_GetPoolBuf, CFE_ES_MemPoolBuf_t *, BufPtr);
     UT_GenStub_AddParam(CFE_ES_GetPoolBuf, CFE_ES_MemHandle_t, Handle);
@@ -477,7 +477,7 @@ int32 CFE_ES_GetPoolBuf(CFE_ES_MemPoolBuf_t *BufPtr, CFE_ES_MemHandle_t Handle, 
 
     UT_GenStub_Execute(CFE_ES_GetPoolBuf, Basic, UT_DefaultHandler_CFE_ES_GetPoolBuf);
 
-    return UT_GenStub_GetReturnValue(CFE_ES_GetPoolBuf, int32);
+    return UT_GenStub_GetReturnValue(CFE_ES_GetPoolBuf, CFE_Status_t);
 }
 
 /*
@@ -613,16 +613,16 @@ void CFE_ES_IncrementTaskCounter(void)
  * Generated stub function for CFE_ES_LibID_ToIndex()
  * ----------------------------------------------------
  */
-int32 CFE_ES_LibID_ToIndex(CFE_ES_LibId_t LibId, uint32 *Idx)
+CFE_Status_t CFE_ES_LibID_ToIndex(CFE_ES_LibId_t LibId, uint32 *Idx)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_ES_LibID_ToIndex, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_ES_LibID_ToIndex, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_ES_LibID_ToIndex, CFE_ES_LibId_t, LibId);
     UT_GenStub_AddParam(CFE_ES_LibID_ToIndex, uint32 *, Idx);
 
     UT_GenStub_Execute(CFE_ES_LibID_ToIndex, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CFE_ES_LibID_ToIndex, int32);
+    return UT_GenStub_GetReturnValue(CFE_ES_LibID_ToIndex, CFE_Status_t);
 }
 
 /*
@@ -716,15 +716,15 @@ CFE_Status_t CFE_ES_PoolCreateNoSem(CFE_ES_MemHandle_t *PoolID, void *MemPtr, si
  * Generated stub function for CFE_ES_PoolDelete()
  * ----------------------------------------------------
  */
-int32 CFE_ES_PoolDelete(CFE_ES_MemHandle_t PoolID)
+CFE_Status_t CFE_ES_PoolDelete(CFE_ES_MemHandle_t PoolID)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_ES_PoolDelete, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_ES_PoolDelete, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_ES_PoolDelete, CFE_ES_MemHandle_t, PoolID);
 
     UT_GenStub_Execute(CFE_ES_PoolDelete, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CFE_ES_PoolDelete, int32);
+    return UT_GenStub_GetReturnValue(CFE_ES_PoolDelete, CFE_Status_t);
 }
 
 /*
@@ -743,16 +743,16 @@ void CFE_ES_ProcessAsyncEvent(void)
  * Generated stub function for CFE_ES_PutPoolBuf()
  * ----------------------------------------------------
  */
-int32 CFE_ES_PutPoolBuf(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_t BufPtr)
+CFE_Status_t CFE_ES_PutPoolBuf(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_t BufPtr)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_ES_PutPoolBuf, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_ES_PutPoolBuf, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_ES_PutPoolBuf, CFE_ES_MemHandle_t, Handle);
     UT_GenStub_AddParam(CFE_ES_PutPoolBuf, CFE_ES_MemPoolBuf_t, BufPtr);
 
     UT_GenStub_Execute(CFE_ES_PutPoolBuf, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CFE_ES_PutPoolBuf, int32);
+    return UT_GenStub_GetReturnValue(CFE_ES_PutPoolBuf, CFE_Status_t);
 }
 
 /*

--- a/modules/core_api/ut-stubs/src/cfe_fs_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_fs_stubs.c
@@ -56,15 +56,15 @@ bool CFE_FS_BackgroundFileDumpIsPending(const CFE_FS_FileWriteMetaData_t *Meta)
  * Generated stub function for CFE_FS_BackgroundFileDumpRequest()
  * ----------------------------------------------------
  */
-int32 CFE_FS_BackgroundFileDumpRequest(CFE_FS_FileWriteMetaData_t *Meta)
+CFE_Status_t CFE_FS_BackgroundFileDumpRequest(CFE_FS_FileWriteMetaData_t *Meta)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_FS_BackgroundFileDumpRequest, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_FS_BackgroundFileDumpRequest, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_FS_BackgroundFileDumpRequest, CFE_FS_FileWriteMetaData_t *, Meta);
 
     UT_GenStub_Execute(CFE_FS_BackgroundFileDumpRequest, Basic, UT_DefaultHandler_CFE_FS_BackgroundFileDumpRequest);
 
-    return UT_GenStub_GetReturnValue(CFE_FS_BackgroundFileDumpRequest, int32);
+    return UT_GenStub_GetReturnValue(CFE_FS_BackgroundFileDumpRequest, CFE_Status_t);
 }
 
 /*
@@ -135,10 +135,10 @@ void CFE_FS_InitHeader(CFE_FS_Header_t *Hdr, const char *Description, uint32 Sub
  * Generated stub function for CFE_FS_ParseInputFileName()
  * ----------------------------------------------------
  */
-int32 CFE_FS_ParseInputFileName(char *OutputBuffer, const char *InputName, size_t OutputBufSize,
-                                CFE_FS_FileCategory_t FileCategory)
+CFE_Status_t CFE_FS_ParseInputFileName(char *OutputBuffer, const char *InputName, size_t OutputBufSize,
+                                       CFE_FS_FileCategory_t FileCategory)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_FS_ParseInputFileName, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_FS_ParseInputFileName, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_FS_ParseInputFileName, char *, OutputBuffer);
     UT_GenStub_AddParam(CFE_FS_ParseInputFileName, const char *, InputName);
@@ -147,7 +147,7 @@ int32 CFE_FS_ParseInputFileName(char *OutputBuffer, const char *InputName, size_
 
     UT_GenStub_Execute(CFE_FS_ParseInputFileName, Basic, UT_DefaultHandler_CFE_FS_ParseInputFileName);
 
-    return UT_GenStub_GetReturnValue(CFE_FS_ParseInputFileName, int32);
+    return UT_GenStub_GetReturnValue(CFE_FS_ParseInputFileName, CFE_Status_t);
 }
 
 /*
@@ -155,11 +155,11 @@ int32 CFE_FS_ParseInputFileName(char *OutputBuffer, const char *InputName, size_
  * Generated stub function for CFE_FS_ParseInputFileNameEx()
  * ----------------------------------------------------
  */
-int32 CFE_FS_ParseInputFileNameEx(char *OutputBuffer, const char *InputBuffer, size_t OutputBufSize,
-                                  size_t InputBufSize, const char *DefaultInput, const char *DefaultPath,
-                                  const char *DefaultExtension)
+CFE_Status_t CFE_FS_ParseInputFileNameEx(char *OutputBuffer, const char *InputBuffer, size_t OutputBufSize,
+                                         size_t InputBufSize, const char *DefaultInput, const char *DefaultPath,
+                                         const char *DefaultExtension)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_FS_ParseInputFileNameEx, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_FS_ParseInputFileNameEx, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_FS_ParseInputFileNameEx, char *, OutputBuffer);
     UT_GenStub_AddParam(CFE_FS_ParseInputFileNameEx, const char *, InputBuffer);
@@ -171,7 +171,7 @@ int32 CFE_FS_ParseInputFileNameEx(char *OutputBuffer, const char *InputBuffer, s
 
     UT_GenStub_Execute(CFE_FS_ParseInputFileNameEx, Basic, UT_DefaultHandler_CFE_FS_ParseInputFileNameEx);
 
-    return UT_GenStub_GetReturnValue(CFE_FS_ParseInputFileNameEx, int32);
+    return UT_GenStub_GetReturnValue(CFE_FS_ParseInputFileNameEx, CFE_Status_t);
 }
 
 /*

--- a/modules/core_api/ut-stubs/src/cfe_resourceid_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_resourceid_stubs.c
@@ -85,9 +85,9 @@ uint32 CFE_ResourceId_GetSerial(CFE_ResourceId_t ResourceId)
  * Generated stub function for CFE_ResourceId_ToIndex()
  * ----------------------------------------------------
  */
-int32 CFE_ResourceId_ToIndex(CFE_ResourceId_t Id, uint32 BaseValue, uint32 TableSize, uint32 *Idx)
+CFE_Status_t CFE_ResourceId_ToIndex(CFE_ResourceId_t Id, uint32 BaseValue, uint32 TableSize, uint32 *Idx)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_ResourceId_ToIndex, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_ResourceId_ToIndex, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_ResourceId_ToIndex, CFE_ResourceId_t, Id);
     UT_GenStub_AddParam(CFE_ResourceId_ToIndex, uint32, BaseValue);
@@ -96,5 +96,5 @@ int32 CFE_ResourceId_ToIndex(CFE_ResourceId_t Id, uint32 BaseValue, uint32 Table
 
     UT_GenStub_Execute(CFE_ResourceId_ToIndex, Basic, UT_DefaultHandler_CFE_ResourceId_ToIndex);
 
-    return UT_GenStub_GetReturnValue(CFE_ResourceId_ToIndex, int32);
+    return UT_GenStub_GetReturnValue(CFE_ResourceId_ToIndex, CFE_Status_t);
 }

--- a/modules/core_api/ut-stubs/src/cfe_sb_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_sb_stubs.c
@@ -283,10 +283,10 @@ CFE_SB_MsgId_Atom_t CFE_SB_LocalTlmTopicIdToMsgId(uint16 TopicId)
  * Generated stub function for CFE_SB_MessageStringGet()
  * ----------------------------------------------------
  */
-int32 CFE_SB_MessageStringGet(char *DestStringPtr, const char *SourceStringPtr, const char *DefaultString,
-                              size_t DestMaxSize, size_t SourceMaxSize)
+CFE_Status_t CFE_SB_MessageStringGet(char *DestStringPtr, const char *SourceStringPtr, const char *DefaultString,
+                                     size_t DestMaxSize, size_t SourceMaxSize)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_SB_MessageStringGet, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_SB_MessageStringGet, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_SB_MessageStringGet, char *, DestStringPtr);
     UT_GenStub_AddParam(CFE_SB_MessageStringGet, const char *, SourceStringPtr);
@@ -296,7 +296,7 @@ int32 CFE_SB_MessageStringGet(char *DestStringPtr, const char *SourceStringPtr, 
 
     UT_GenStub_Execute(CFE_SB_MessageStringGet, Basic, UT_DefaultHandler_CFE_SB_MessageStringGet);
 
-    return UT_GenStub_GetReturnValue(CFE_SB_MessageStringGet, int32);
+    return UT_GenStub_GetReturnValue(CFE_SB_MessageStringGet, CFE_Status_t);
 }
 
 /*
@@ -304,10 +304,10 @@ int32 CFE_SB_MessageStringGet(char *DestStringPtr, const char *SourceStringPtr, 
  * Generated stub function for CFE_SB_MessageStringSet()
  * ----------------------------------------------------
  */
-int32 CFE_SB_MessageStringSet(char *DestStringPtr, const char *SourceStringPtr, size_t DestMaxSize,
-                              size_t SourceMaxSize)
+CFE_Status_t CFE_SB_MessageStringSet(char *DestStringPtr, const char *SourceStringPtr, size_t DestMaxSize,
+                                     size_t SourceMaxSize)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_SB_MessageStringSet, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_SB_MessageStringSet, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_SB_MessageStringSet, char *, DestStringPtr);
     UT_GenStub_AddParam(CFE_SB_MessageStringSet, const char *, SourceStringPtr);
@@ -316,7 +316,7 @@ int32 CFE_SB_MessageStringSet(char *DestStringPtr, const char *SourceStringPtr, 
 
     UT_GenStub_Execute(CFE_SB_MessageStringSet, Basic, UT_DefaultHandler_CFE_SB_MessageStringSet);
 
-    return UT_GenStub_GetReturnValue(CFE_SB_MessageStringSet, int32);
+    return UT_GenStub_GetReturnValue(CFE_SB_MessageStringSet, CFE_Status_t);
 }
 
 /*

--- a/modules/core_private/fsw/inc/cfe_config_core_internal.h
+++ b/modules/core_private/fsw/inc/cfe_config_core_internal.h
@@ -32,12 +32,13 @@
 #include "cfe_config_api_typedefs.h"
 
 #include "common_types.h"
+#include "cfe_error.h"
 
 /** @defgroup CFEAPIConfigCoreInternal cFE Internal configuration APIs, internal to CFE core
  * @{
  */
 
-int32 CFE_Config_Init(void);
+CFE_Status_t CFE_Config_Init(void);
 
 /*
  * The "Set" API is only used during init phase

--- a/modules/core_private/fsw/inc/cfe_es_core_internal.h
+++ b/modules/core_private/fsw/inc/cfe_es_core_internal.h
@@ -35,6 +35,7 @@
 
 #include "common_types.h"
 #include "cfe_es_extern_typedefs.h"
+#include "cfe_error.h"
 
 /*
  * The internal APIs prototyped within this block are only intended to be invoked from
@@ -70,7 +71,7 @@ void CFE_ES_TaskMain(void);
 **        -# This function MUST be called before any module API's are called.
 **
 ******************************************************************************/
-int32 CFE_ES_CDS_EarlyInit(void);
+CFE_Status_t CFE_ES_CDS_EarlyInit(void);
 
 /*****************************************************************************/
 /**
@@ -100,7 +101,8 @@ int32 CFE_ES_CDS_EarlyInit(void);
 ** \return See return codes for #CFE_ES_RegisterCDS
 **
 ******************************************************************************/
-int32 CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr, size_t UserBlockSize, const char *Name, bool CriticalTbl);
+CFE_Status_t CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr, size_t UserBlockSize, const char *Name,
+                                  bool CriticalTbl);
 
 /*****************************************************************************/
 /**
@@ -133,7 +135,7 @@ int32 CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr, size_t UserBlockSize, 
 ** \return Any of the return values from CFE_ES_GenPoolPutBlock
 **
 ******************************************************************************/
-int32 CFE_ES_DeleteCDS(const char *CDSName, bool CalledByTblServices);
+CFE_Status_t CFE_ES_DeleteCDS(const char *CDSName, bool CalledByTblServices);
 
 /**@}*/
 

--- a/modules/core_private/fsw/inc/cfe_evs_core_internal.h
+++ b/modules/core_private/fsw/inc/cfe_evs_core_internal.h
@@ -35,6 +35,7 @@
 
 #include "common_types.h"
 #include "cfe_es_extern_typedefs.h"
+#include "cfe_error.h"
 
 /*
  * The internal APIs prototyped within this block are only intended to be invoked from
@@ -70,7 +71,7 @@ void CFE_EVS_TaskMain(void);
 **        -# This function MUST be called before any module API's are called.
 **
 ******************************************************************************/
-int32 CFE_EVS_EarlyInit(void);
+CFE_Status_t CFE_EVS_EarlyInit(void);
 
 /*****************************************************************************/
 /**
@@ -82,7 +83,7 @@ int32 CFE_EVS_EarlyInit(void);
 **        that have been allocated to the specified Application.
 **
 ******************************************************************************/
-int32 CFE_EVS_CleanUpApp(CFE_ES_AppId_t AppId);
+CFE_Status_t CFE_EVS_CleanUpApp(CFE_ES_AppId_t AppId);
 
 /**@}*/
 

--- a/modules/core_private/fsw/inc/cfe_fs_core_internal.h
+++ b/modules/core_private/fsw/inc/cfe_fs_core_internal.h
@@ -29,6 +29,7 @@
 #define CFE_FS_CORE_INTERNAL_H
 
 #include "common_types.h"
+#include "cfe_error.h"
 
 /*
  * The internal APIs prototyped within this block are only intended to be invoked from
@@ -51,7 +52,7 @@
 **        -# This function MUST be called before any module API's are called.
 **
 ******************************************************************************/
-int32 CFE_FS_EarlyInit(void);
+CFE_Status_t CFE_FS_EarlyInit(void);
 
 /*****************************************************************************/
 /**

--- a/modules/core_private/fsw/inc/cfe_sb_core_internal.h
+++ b/modules/core_private/fsw/inc/cfe_sb_core_internal.h
@@ -32,6 +32,7 @@
 
 #include "common_types.h"
 #include "cfe_es_extern_typedefs.h"
+#include "cfe_error.h"
 
 /*
  * The internal APIs prototyped within this block are only intended to be invoked from
@@ -67,7 +68,7 @@ void CFE_SB_TaskMain(void);
 **        -# This function MUST be called before any module API's are called.
 **
 ******************************************************************************/
-int32 CFE_SB_EarlyInit(void);
+CFE_Status_t CFE_SB_EarlyInit(void);
 
 /*****************************************************************************/
 /**
@@ -79,7 +80,7 @@ int32 CFE_SB_EarlyInit(void);
 **        that have been allocated to the specified Application.
 **
 ******************************************************************************/
-int32 CFE_SB_CleanUpApp(CFE_ES_AppId_t AppId);
+CFE_Status_t CFE_SB_CleanUpApp(CFE_ES_AppId_t AppId);
 
 /**@}*/
 

--- a/modules/core_private/fsw/inc/cfe_tbl_core_internal.h
+++ b/modules/core_private/fsw/inc/cfe_tbl_core_internal.h
@@ -38,6 +38,7 @@
 
 #include "common_types.h"
 #include "cfe_es_extern_typedefs.h"
+#include "cfe_error.h"
 
 /*
  * The internal APIs prototyped within this block are only intended to be invoked from
@@ -75,7 +76,7 @@ void CFE_TBL_TaskMain(void);
 **        -# This function MUST be called before any TBL API's are called.
 **
 ******************************************************************************/
-int32 CFE_TBL_EarlyInit(void);
+CFE_Status_t CFE_TBL_EarlyInit(void);
 
 /*****************************************************************************/
 /**
@@ -91,7 +92,7 @@ int32 CFE_TBL_EarlyInit(void);
 **           the specified application from the Critical Data Store.
 **
 ******************************************************************************/
-int32 CFE_TBL_CleanUpApp(CFE_ES_AppId_t AppId);
+CFE_Status_t CFE_TBL_CleanUpApp(CFE_ES_AppId_t AppId);
 
 /**@}*/
 

--- a/modules/core_private/fsw/inc/cfe_time_core_internal.h
+++ b/modules/core_private/fsw/inc/cfe_time_core_internal.h
@@ -32,6 +32,7 @@
 
 #include "common_types.h"
 #include "cfe_es_extern_typedefs.h"
+#include "cfe_error.h"
 
 /*
  * The internal APIs prototyped within this block are only intended to be invoked from
@@ -67,7 +68,7 @@ void CFE_TIME_TaskMain(void);
 **        -# This function MUST be called before any module API's are called.
 **
 ******************************************************************************/
-int32 CFE_TIME_EarlyInit(void);
+CFE_Status_t CFE_TIME_EarlyInit(void);
 
 /*****************************************************************************/
 /**
@@ -79,7 +80,7 @@ int32 CFE_TIME_EarlyInit(void);
 **        that have been allocated to the specified Application.
 **
 ******************************************************************************/
-int32 CFE_TIME_CleanUpApp(CFE_ES_AppId_t AppId);
+CFE_Status_t CFE_TIME_CleanUpApp(CFE_ES_AppId_t AppId);
 
 /**@}*/
 

--- a/modules/core_private/ut-stubs/inc/ut_support.h
+++ b/modules/core_private/ut-stubs/inc/ut_support.h
@@ -330,7 +330,8 @@ void UT_CallTaskPipe(void (*TaskPipeFunc)(const CFE_SB_Buffer_t *), const CFE_MS
 **        Passes through the return code from the handler
 **
 ******************************************************************************/
-int32 UT_SoftwareBusSnapshotHook(void *UserObj, int32 StubRetcode, uint32 CallCount, const UT_StubContext_t *Context);
+int32 UT_SoftwareBusSnapshotHook(void *UserObj, int32 StubRetcode, uint32 CallCount,
+                                        const UT_StubContext_t *Context);
 
 /*****************************************************************************/
 /**

--- a/modules/core_private/ut-stubs/src/cfe_config_core_internal_stubs.c
+++ b/modules/core_private/ut-stubs/src/cfe_config_core_internal_stubs.c
@@ -30,13 +30,13 @@
  * Generated stub function for CFE_Config_Init()
  * ----------------------------------------------------
  */
-int32 CFE_Config_Init(void)
+CFE_Status_t CFE_Config_Init(void)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_Config_Init, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_Config_Init, CFE_Status_t);
 
     UT_GenStub_Execute(CFE_Config_Init, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CFE_Config_Init, int32);
+    return UT_GenStub_GetReturnValue(CFE_Config_Init, CFE_Status_t);
 }
 
 /*

--- a/modules/core_private/ut-stubs/src/cfe_es_core_internal_stubs.c
+++ b/modules/core_private/ut-stubs/src/cfe_es_core_internal_stubs.c
@@ -32,13 +32,13 @@ void UT_DefaultHandler_CFE_ES_RegisterCDSEx(void *, UT_EntryKey_t, const UT_Stub
  * Generated stub function for CFE_ES_CDS_EarlyInit()
  * ----------------------------------------------------
  */
-int32 CFE_ES_CDS_EarlyInit(void)
+CFE_Status_t CFE_ES_CDS_EarlyInit(void)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_ES_CDS_EarlyInit, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_ES_CDS_EarlyInit, CFE_Status_t);
 
     UT_GenStub_Execute(CFE_ES_CDS_EarlyInit, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CFE_ES_CDS_EarlyInit, int32);
+    return UT_GenStub_GetReturnValue(CFE_ES_CDS_EarlyInit, CFE_Status_t);
 }
 
 /*
@@ -46,16 +46,16 @@ int32 CFE_ES_CDS_EarlyInit(void)
  * Generated stub function for CFE_ES_DeleteCDS()
  * ----------------------------------------------------
  */
-int32 CFE_ES_DeleteCDS(const char *CDSName, bool CalledByTblServices)
+CFE_Status_t CFE_ES_DeleteCDS(const char *CDSName, bool CalledByTblServices)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_ES_DeleteCDS, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_ES_DeleteCDS, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_ES_DeleteCDS, const char *, CDSName);
     UT_GenStub_AddParam(CFE_ES_DeleteCDS, bool, CalledByTblServices);
 
     UT_GenStub_Execute(CFE_ES_DeleteCDS, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CFE_ES_DeleteCDS, int32);
+    return UT_GenStub_GetReturnValue(CFE_ES_DeleteCDS, CFE_Status_t);
 }
 
 /*
@@ -63,9 +63,10 @@ int32 CFE_ES_DeleteCDS(const char *CDSName, bool CalledByTblServices)
  * Generated stub function for CFE_ES_RegisterCDSEx()
  * ----------------------------------------------------
  */
-int32 CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr, size_t UserBlockSize, const char *Name, bool CriticalTbl)
+CFE_Status_t CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr, size_t UserBlockSize, const char *Name,
+                                  bool CriticalTbl)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_ES_RegisterCDSEx, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_ES_RegisterCDSEx, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_ES_RegisterCDSEx, CFE_ES_CDSHandle_t *, HandlePtr);
     UT_GenStub_AddParam(CFE_ES_RegisterCDSEx, size_t, UserBlockSize);
@@ -74,7 +75,7 @@ int32 CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr, size_t UserBlockSize, 
 
     UT_GenStub_Execute(CFE_ES_RegisterCDSEx, Basic, UT_DefaultHandler_CFE_ES_RegisterCDSEx);
 
-    return UT_GenStub_GetReturnValue(CFE_ES_RegisterCDSEx, int32);
+    return UT_GenStub_GetReturnValue(CFE_ES_RegisterCDSEx, CFE_Status_t);
 }
 
 /*

--- a/modules/core_private/ut-stubs/src/cfe_evs_core_internal_stubs.c
+++ b/modules/core_private/ut-stubs/src/cfe_evs_core_internal_stubs.c
@@ -30,15 +30,15 @@
  * Generated stub function for CFE_EVS_CleanUpApp()
  * ----------------------------------------------------
  */
-int32 CFE_EVS_CleanUpApp(CFE_ES_AppId_t AppId)
+CFE_Status_t CFE_EVS_CleanUpApp(CFE_ES_AppId_t AppId)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_EVS_CleanUpApp, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_EVS_CleanUpApp, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_EVS_CleanUpApp, CFE_ES_AppId_t, AppId);
 
     UT_GenStub_Execute(CFE_EVS_CleanUpApp, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CFE_EVS_CleanUpApp, int32);
+    return UT_GenStub_GetReturnValue(CFE_EVS_CleanUpApp, CFE_Status_t);
 }
 
 /*
@@ -46,13 +46,13 @@ int32 CFE_EVS_CleanUpApp(CFE_ES_AppId_t AppId)
  * Generated stub function for CFE_EVS_EarlyInit()
  * ----------------------------------------------------
  */
-int32 CFE_EVS_EarlyInit(void)
+CFE_Status_t CFE_EVS_EarlyInit(void)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_EVS_EarlyInit, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_EVS_EarlyInit, CFE_Status_t);
 
     UT_GenStub_Execute(CFE_EVS_EarlyInit, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CFE_EVS_EarlyInit, int32);
+    return UT_GenStub_GetReturnValue(CFE_EVS_EarlyInit, CFE_Status_t);
 }
 
 /*

--- a/modules/core_private/ut-stubs/src/cfe_fs_core_internal_stubs.c
+++ b/modules/core_private/ut-stubs/src/cfe_fs_core_internal_stubs.c
@@ -32,13 +32,13 @@ void UT_DefaultHandler_CFE_FS_RunBackgroundFileDump(void *, UT_EntryKey_t, const
  * Generated stub function for CFE_FS_EarlyInit()
  * ----------------------------------------------------
  */
-int32 CFE_FS_EarlyInit(void)
+CFE_Status_t CFE_FS_EarlyInit(void)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_FS_EarlyInit, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_FS_EarlyInit, CFE_Status_t);
 
     UT_GenStub_Execute(CFE_FS_EarlyInit, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CFE_FS_EarlyInit, int32);
+    return UT_GenStub_GetReturnValue(CFE_FS_EarlyInit, CFE_Status_t);
 }
 
 /*

--- a/modules/core_private/ut-stubs/src/cfe_sb_core_internal_stubs.c
+++ b/modules/core_private/ut-stubs/src/cfe_sb_core_internal_stubs.c
@@ -30,15 +30,15 @@
  * Generated stub function for CFE_SB_CleanUpApp()
  * ----------------------------------------------------
  */
-int32 CFE_SB_CleanUpApp(CFE_ES_AppId_t AppId)
+CFE_Status_t CFE_SB_CleanUpApp(CFE_ES_AppId_t AppId)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_SB_CleanUpApp, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_SB_CleanUpApp, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_SB_CleanUpApp, CFE_ES_AppId_t, AppId);
 
     UT_GenStub_Execute(CFE_SB_CleanUpApp, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CFE_SB_CleanUpApp, int32);
+    return UT_GenStub_GetReturnValue(CFE_SB_CleanUpApp, CFE_Status_t);
 }
 
 /*
@@ -46,13 +46,13 @@ int32 CFE_SB_CleanUpApp(CFE_ES_AppId_t AppId)
  * Generated stub function for CFE_SB_EarlyInit()
  * ----------------------------------------------------
  */
-int32 CFE_SB_EarlyInit(void)
+CFE_Status_t CFE_SB_EarlyInit(void)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_SB_EarlyInit, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_SB_EarlyInit, CFE_Status_t);
 
     UT_GenStub_Execute(CFE_SB_EarlyInit, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CFE_SB_EarlyInit, int32);
+    return UT_GenStub_GetReturnValue(CFE_SB_EarlyInit, CFE_Status_t);
 }
 
 /*

--- a/modules/core_private/ut-stubs/src/cfe_tbl_core_internal_stubs.c
+++ b/modules/core_private/ut-stubs/src/cfe_tbl_core_internal_stubs.c
@@ -30,15 +30,15 @@
  * Generated stub function for CFE_TBL_CleanUpApp()
  * ----------------------------------------------------
  */
-int32 CFE_TBL_CleanUpApp(CFE_ES_AppId_t AppId)
+CFE_Status_t CFE_TBL_CleanUpApp(CFE_ES_AppId_t AppId)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_TBL_CleanUpApp, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_TBL_CleanUpApp, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_TBL_CleanUpApp, CFE_ES_AppId_t, AppId);
 
     UT_GenStub_Execute(CFE_TBL_CleanUpApp, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CFE_TBL_CleanUpApp, int32);
+    return UT_GenStub_GetReturnValue(CFE_TBL_CleanUpApp, CFE_Status_t);
 }
 
 /*
@@ -46,13 +46,13 @@ int32 CFE_TBL_CleanUpApp(CFE_ES_AppId_t AppId)
  * Generated stub function for CFE_TBL_EarlyInit()
  * ----------------------------------------------------
  */
-int32 CFE_TBL_EarlyInit(void)
+CFE_Status_t CFE_TBL_EarlyInit(void)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_TBL_EarlyInit, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_TBL_EarlyInit, CFE_Status_t);
 
     UT_GenStub_Execute(CFE_TBL_EarlyInit, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CFE_TBL_EarlyInit, int32);
+    return UT_GenStub_GetReturnValue(CFE_TBL_EarlyInit, CFE_Status_t);
 }
 
 /*

--- a/modules/core_private/ut-stubs/src/cfe_time_core_internal_stubs.c
+++ b/modules/core_private/ut-stubs/src/cfe_time_core_internal_stubs.c
@@ -30,15 +30,15 @@
  * Generated stub function for CFE_TIME_CleanUpApp()
  * ----------------------------------------------------
  */
-int32 CFE_TIME_CleanUpApp(CFE_ES_AppId_t AppId)
+CFE_Status_t CFE_TIME_CleanUpApp(CFE_ES_AppId_t AppId)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_TIME_CleanUpApp, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_TIME_CleanUpApp, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_TIME_CleanUpApp, CFE_ES_AppId_t, AppId);
 
     UT_GenStub_Execute(CFE_TIME_CleanUpApp, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CFE_TIME_CleanUpApp, int32);
+    return UT_GenStub_GetReturnValue(CFE_TIME_CleanUpApp, CFE_Status_t);
 }
 
 /*
@@ -46,13 +46,13 @@ int32 CFE_TIME_CleanUpApp(CFE_ES_AppId_t AppId)
  * Generated stub function for CFE_TIME_EarlyInit()
  * ----------------------------------------------------
  */
-int32 CFE_TIME_EarlyInit(void)
+CFE_Status_t CFE_TIME_EarlyInit(void)
 {
-    UT_GenStub_SetupReturnBuffer(CFE_TIME_EarlyInit, int32);
+    UT_GenStub_SetupReturnBuffer(CFE_TIME_EarlyInit, CFE_Status_t);
 
     UT_GenStub_Execute(CFE_TIME_EarlyInit, Basic, NULL);
 
-    return UT_GenStub_GetReturnValue(CFE_TIME_EarlyInit, int32);
+    return UT_GenStub_GetReturnValue(CFE_TIME_EarlyInit, CFE_Status_t);
 }
 
 /*

--- a/modules/core_private/ut-stubs/src/ut_support.c
+++ b/modules/core_private/ut-stubs/src/ut_support.c
@@ -338,7 +338,8 @@ void UT_CallTaskPipe(void (*TaskPipeFunc)(const CFE_SB_Buffer_t *), const CFE_MS
     UT_SetupBasicMsgDispatch(NULL, 0, false);
 }
 
-int32 UT_SoftwareBusSnapshotHook(void *UserObj, int32 StubRetcode, uint32 CallCount, const UT_StubContext_t *Context)
+int32 UT_SoftwareBusSnapshotHook(void *UserObj, int32 StubRetcode, uint32 CallCount,
+                                        const UT_StubContext_t *Context)
 {
     UT_SoftwareBusSnapshot_Entry_t *Snapshot = UserObj;
     const CFE_MSG_Message_t *       MsgPtr   = UT_Hook_GetArgValueByName(Context, "MsgPtr", CFE_MSG_Message_t *);

--- a/modules/es/fsw/src/cfe_es_api.c
+++ b/modules/es/fsw/src/cfe_es_api.c
@@ -64,7 +64,7 @@ int32 CFE_ES_GetResetType(uint32 *ResetSubtypePtr)
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_ResetCFE(uint32 ResetType)
 {
-    int32 ReturnCode;
+    CFE_Status_t ReturnCode;
 
     if (ResetType == CFE_PSP_RST_TYPE_PROCESSOR)
     {
@@ -158,7 +158,7 @@ CFE_Status_t CFE_ES_ResetCFE(uint32 ResetType)
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_RestartApp(CFE_ES_AppId_t AppID)
 {
-    int32               ReturnCode = CFE_SUCCESS;
+    CFE_Status_t        ReturnCode = CFE_SUCCESS;
     os_fstat_t          FileStatus;
     CFE_ES_AppRecord_t *AppRecPtr;
 
@@ -223,7 +223,7 @@ CFE_Status_t CFE_ES_RestartApp(CFE_ES_AppId_t AppID)
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_ReloadApp(CFE_ES_AppId_t AppID, const char *AppFileName)
 {
-    int32               ReturnCode = CFE_SUCCESS;
+    CFE_Status_t        ReturnCode = CFE_SUCCESS;
     os_fstat_t          FileStatus;
     CFE_ES_AppRecord_t *AppRecPtr = CFE_ES_LocateAppRecordByID(AppID);
 
@@ -289,7 +289,7 @@ CFE_Status_t CFE_ES_ReloadApp(CFE_ES_AppId_t AppID, const char *AppFileName)
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_DeleteApp(CFE_ES_AppId_t AppID)
 {
-    int32               ReturnCode = CFE_SUCCESS;
+    CFE_Status_t        ReturnCode = CFE_SUCCESS;
     CFE_ES_AppRecord_t *AppRecPtr  = CFE_ES_LocateAppRecordByID(AppID);
 
     if (AppRecPtr != NULL)
@@ -339,7 +339,7 @@ CFE_Status_t CFE_ES_DeleteApp(CFE_ES_AppId_t AppID)
  *-----------------------------------------------------------------*/
 void CFE_ES_ExitApp(uint32 ExitStatus)
 {
-    int32               ReturnCode;
+    CFE_Status_t        ReturnCode;
     CFE_ES_AppRecord_t *AppRecPtr;
 
     CFE_ES_LockSharedData(__func__, __LINE__);
@@ -558,7 +558,7 @@ bool CFE_ES_RunLoop(uint32 *RunStatus)
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_WaitForSystemState(uint32 MinSystemState, uint32 TimeOutMilliseconds)
 {
-    int32               Status = CFE_SUCCESS;
+    CFE_Status_t        Status = CFE_SUCCESS;
     CFE_ES_AppRecord_t *AppRecPtr;
     uint32              RequiredAppState;
     uint32              WaitTime;
@@ -672,7 +672,7 @@ void CFE_ES_WaitForStartupSync(uint32 TimeOutMilliseconds)
 CFE_Status_t CFE_ES_GetAppIDByName(CFE_ES_AppId_t *AppIdPtr, const char *AppName)
 {
     CFE_ES_AppRecord_t *AppRecPtr;
-    int32               Result;
+    CFE_Status_t        Result;
 
     if (AppName == NULL || AppIdPtr == NULL)
     {
@@ -711,7 +711,7 @@ CFE_Status_t CFE_ES_GetAppIDByName(CFE_ES_AppId_t *AppIdPtr, const char *AppName
 CFE_Status_t CFE_ES_GetLibIDByName(CFE_ES_LibId_t *LibIdPtr, const char *LibName)
 {
     CFE_ES_LibRecord_t *LibRecPtr;
-    int32               Result;
+    CFE_Status_t        Result;
 
     if (LibName == NULL || LibIdPtr == NULL)
     {
@@ -783,7 +783,7 @@ CFE_Status_t CFE_ES_GetTaskIDByName(CFE_ES_TaskId_t *TaskIdPtr, const char *Task
 CFE_Status_t CFE_ES_GetAppID(CFE_ES_AppId_t *AppIdPtr)
 {
     CFE_ES_AppRecord_t *AppRecPtr;
-    int32               Result;
+    CFE_Status_t        Result;
 
     if (AppIdPtr == NULL)
     {
@@ -818,7 +818,7 @@ CFE_Status_t CFE_ES_GetAppID(CFE_ES_AppId_t *AppIdPtr)
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_GetTaskID(CFE_ES_TaskId_t *TaskIdPtr)
 {
-    int32                Result;
+    CFE_Status_t         Result;
     CFE_ES_TaskRecord_t *TaskRecPtr;
 
     if (TaskIdPtr == NULL)
@@ -850,7 +850,7 @@ CFE_Status_t CFE_ES_GetTaskID(CFE_ES_TaskId_t *TaskIdPtr)
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_GetAppName(char *AppName, CFE_ES_AppId_t AppId, size_t BufferLength)
 {
-    int32               Result;
+    CFE_Status_t        Result;
     CFE_ES_AppRecord_t *AppRecPtr;
 
     if (BufferLength == 0 || AppName == NULL)
@@ -894,7 +894,7 @@ CFE_Status_t CFE_ES_GetAppName(char *AppName, CFE_ES_AppId_t AppId, size_t Buffe
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_GetLibName(char *LibName, CFE_ES_LibId_t LibId, size_t BufferLength)
 {
-    int32               Result;
+    CFE_Status_t        Result;
     CFE_ES_LibRecord_t *LibRecPtr;
 
     if (BufferLength == 0 || LibName == NULL)
@@ -985,9 +985,9 @@ CFE_Status_t CFE_ES_GetTaskName(char *TaskName, CFE_ES_TaskId_t TaskId, size_t B
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, CFE_ES_AppId_t AppId)
 {
-    CFE_ES_AppRecord_t * AppRecPtr;
+    CFE_ES_AppRecord_t  *AppRecPtr;
     CFE_ES_TaskRecord_t *TaskRecPtr;
-    int32                Status;
+    CFE_Status_t         Status;
     osal_id_t            ModuleId;
     uint32               i;
 
@@ -1078,9 +1078,9 @@ CFE_Status_t CFE_ES_GetAppInfo(CFE_ES_AppInfo_t *AppInfo, CFE_ES_AppId_t AppId)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_GetLibInfo(CFE_ES_AppInfo_t *LibInfo, CFE_ES_LibId_t LibId)
+CFE_Status_t CFE_ES_GetLibInfo(CFE_ES_AppInfo_t *LibInfo, CFE_ES_LibId_t LibId)
 {
-    int32               Status;
+    CFE_Status_t        Status;
     CFE_ES_LibRecord_t *LibRecPtr;
     osal_id_t           ModuleId;
 
@@ -1140,9 +1140,9 @@ int32 CFE_ES_GetLibInfo(CFE_ES_AppInfo_t *LibInfo, CFE_ES_LibId_t LibId)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_GetModuleInfo(CFE_ES_AppInfo_t *ModuleInfo, CFE_ResourceId_t ResourceId)
+CFE_Status_t CFE_ES_GetModuleInfo(CFE_ES_AppInfo_t *ModuleInfo, CFE_ResourceId_t ResourceId)
 {
-    int32 Status;
+    CFE_Status_t Status;
 
     /* Note - ModuleInfo NULL pointer check is performed by CFE_ES_GetAppInfo or CFE_ES_GetLibInfo */
     switch (CFE_ResourceId_GetBase(ResourceId))
@@ -1174,8 +1174,8 @@ int32 CFE_ES_GetModuleInfo(CFE_ES_AppInfo_t *ModuleInfo, CFE_ResourceId_t Resour
 CFE_Status_t CFE_ES_GetTaskInfo(CFE_ES_TaskInfo_t *TaskInfo, CFE_ES_TaskId_t TaskId)
 {
     CFE_ES_TaskRecord_t *TaskRecPtr;
-    CFE_ES_AppRecord_t * AppRecPtr;
-    int32                Status;
+    CFE_ES_AppRecord_t  *AppRecPtr;
+    CFE_Status_t         Status;
 
     if (TaskInfo == NULL)
     {
@@ -1248,8 +1248,8 @@ CFE_Status_t CFE_ES_CreateChildTask(CFE_ES_TaskId_t *TaskIdPtr, const char *Task
                                     CFE_ES_ChildTaskMainFuncPtr_t FunctionPtr, CFE_ES_StackPointer_t StackPtr,
                                     size_t StackSize, CFE_ES_TaskPriority_Atom_t Priority, uint32 Flags)
 {
-    int32                    ReturnCode;
-    CFE_ES_AppRecord_t *     AppRecPtr;
+    CFE_Status_t             ReturnCode;
+    CFE_ES_AppRecord_t      *AppRecPtr;
     CFE_ES_AppId_t           ParentAppId;
     CFE_ES_TaskId_t          SelfTaskId;
     CFE_ES_TaskStartParams_t Params;
@@ -1372,10 +1372,10 @@ void CFE_ES_IncrementTaskCounter(void)
 CFE_Status_t CFE_ES_DeleteChildTask(CFE_ES_TaskId_t TaskId)
 {
     CFE_ES_TaskRecord_t *TaskRecPtr;
-    CFE_ES_AppRecord_t * AppRecPtr;
+    CFE_ES_AppRecord_t  *AppRecPtr;
     uint32               i;
     bool                 TaskIsMain;
-    int32                ReturnCode = CFE_SUCCESS;
+    CFE_Status_t         ReturnCode = CFE_SUCCESS;
     int32                OsStatus;
     osal_id_t            OsalId;
 
@@ -1483,7 +1483,7 @@ CFE_Status_t CFE_ES_DeleteChildTask(CFE_ES_TaskId_t TaskId)
  *-----------------------------------------------------------------*/
 void CFE_ES_ExitChildTask(void)
 {
-    CFE_ES_AppRecord_t * AppRecPtr;
+    CFE_ES_AppRecord_t  *AppRecPtr;
     CFE_ES_TaskRecord_t *TaskRecPtr;
 
     CFE_ES_LockSharedData(__func__, __LINE__);
@@ -1539,9 +1539,9 @@ void CFE_ES_ExitChildTask(void)
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_WriteToSysLog(const char *SpecStringPtr, ...)
 {
-    char    TmpString[CFE_ES_MAX_SYSLOG_MSG_SIZE];
-    int32   ReturnCode;
-    va_list ArgPtr;
+    char         TmpString[CFE_ES_MAX_SYSLOG_MSG_SIZE];
+    CFE_Status_t ReturnCode;
+    va_list      ArgPtr;
 
     if (SpecStringPtr == NULL)
     {
@@ -1600,7 +1600,7 @@ uint32 CFE_ES_CalculateCRC(const void *DataPtr, size_t DataLength, uint32 InputC
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *CDSHandlePtr, size_t BlockSize, const char *Name)
 {
-    int32          Status;
+    CFE_Status_t   Status;
     size_t         NameLen;
     CFE_ES_AppId_t ThisAppId;
 
@@ -1796,7 +1796,7 @@ CFE_Status_t CFE_ES_RegisterGenCounter(CFE_ES_CounterId_t *CounterIdPtr, const c
 {
     CFE_ES_GenCounterRecord_t *CountRecPtr;
     CFE_ResourceId_t           PendingResourceId;
-    int32                      Status;
+    CFE_Status_t               Status;
 
     if (CounterName == NULL || CounterIdPtr == NULL)
     {
@@ -1858,7 +1858,7 @@ CFE_Status_t CFE_ES_RegisterGenCounter(CFE_ES_CounterId_t *CounterIdPtr, const c
 CFE_Status_t CFE_ES_DeleteGenCounter(CFE_ES_CounterId_t CounterId)
 {
     CFE_ES_GenCounterRecord_t *CountRecPtr;
-    int32                      Status = CFE_ES_BAD_ARGUMENT;
+    CFE_Status_t               Status = CFE_ES_BAD_ARGUMENT;
 
     CountRecPtr = CFE_ES_LocateCounterRecordByID(CounterId);
     if (CountRecPtr != NULL)
@@ -1884,7 +1884,7 @@ CFE_Status_t CFE_ES_DeleteGenCounter(CFE_ES_CounterId_t CounterId)
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_IncrementGenCounter(CFE_ES_CounterId_t CounterId)
 {
-    int32                      Status = CFE_ES_BAD_ARGUMENT;
+    CFE_Status_t               Status = CFE_ES_BAD_ARGUMENT;
     CFE_ES_GenCounterRecord_t *CountRecPtr;
 
     CountRecPtr = CFE_ES_LocateCounterRecordByID(CounterId);
@@ -1904,7 +1904,7 @@ CFE_Status_t CFE_ES_IncrementGenCounter(CFE_ES_CounterId_t CounterId)
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_SetGenCount(CFE_ES_CounterId_t CounterId, uint32 Count)
 {
-    int32                      Status = CFE_ES_BAD_ARGUMENT;
+    CFE_Status_t               Status = CFE_ES_BAD_ARGUMENT;
     CFE_ES_GenCounterRecord_t *CountRecPtr;
 
     CountRecPtr = CFE_ES_LocateCounterRecordByID(CounterId);
@@ -1924,7 +1924,7 @@ CFE_Status_t CFE_ES_SetGenCount(CFE_ES_CounterId_t CounterId, uint32 Count)
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_GetGenCount(CFE_ES_CounterId_t CounterId, uint32 *Count)
 {
-    int32                      Status = CFE_ES_BAD_ARGUMENT;
+    CFE_Status_t               Status = CFE_ES_BAD_ARGUMENT;
     CFE_ES_GenCounterRecord_t *CountRecPtr;
 
     CountRecPtr = CFE_ES_LocateCounterRecordByID(CounterId);
@@ -1945,7 +1945,7 @@ CFE_Status_t CFE_ES_GetGenCount(CFE_ES_CounterId_t CounterId, uint32 *Count)
 CFE_Status_t CFE_ES_GetGenCounterIDByName(CFE_ES_CounterId_t *CounterIdPtr, const char *CounterName)
 {
     CFE_ES_GenCounterRecord_t *CounterRecPtr;
-    int32                      Result;
+    CFE_Status_t               Result;
 
     if (CounterName == NULL || CounterIdPtr == NULL)
     {
@@ -2033,7 +2033,7 @@ CFE_Status_t CFE_ES_AppID_ToIndex(CFE_ES_AppId_t AppID, uint32 *Idx)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_LibID_ToIndex(CFE_ES_LibId_t LibId, uint32 *Idx)
+CFE_Status_t CFE_ES_LibID_ToIndex(CFE_ES_LibId_t LibId, uint32 *Idx)
 {
     return CFE_ResourceId_ToIndex(CFE_RESOURCEID_UNWRAP(LibId), CFE_ES_LIBID_BASE, CFE_PLATFORM_ES_MAX_LIBRARIES, Idx);
 }

--- a/modules/es/fsw/src/cfe_es_apps.c
+++ b/modules/es/fsw/src/cfe_es_apps.c
@@ -77,7 +77,7 @@ void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath)
     uint32      NumLines;
     uint32      BuffLen; /* Length of the current buffer */
     osal_id_t   AppFile = OS_OBJECT_ID_UNDEFINED;
-    int32       Status;
+    CFE_Status_t Status;
     int32       OsStatus;
     char        c           = 0;
     bool        LineTooLong = false;
@@ -282,7 +282,7 @@ void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens)
+CFE_Status_t CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens)
 {
     const char *  ModuleName;
     const char *  EntryType;
@@ -292,7 +292,7 @@ int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens)
         CFE_ES_AppId_t AppId;
         CFE_ES_LibId_t LibId;
     } IdBuf;
-    int32                   Status;
+    CFE_Status_t            Status;
     CFE_ES_AppStartParams_t ParamBuf;
 
     memset(&ParamBuf, 0, sizeof(ParamBuf));
@@ -393,14 +393,14 @@ int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_LoadModule(CFE_ResourceId_t ParentResourceId, const char *ModuleName,
-                        const CFE_ES_ModuleLoadParams_t *LoadParams, CFE_ES_ModuleLoadStatus_t *LoadStatus)
+CFE_Status_t CFE_ES_LoadModule(CFE_ResourceId_t ParentResourceId, const char *ModuleName,
+                               const CFE_ES_ModuleLoadParams_t *LoadParams, CFE_ES_ModuleLoadStatus_t *LoadStatus)
 {
-    osal_id_t ModuleId = OS_OBJECT_ID_UNDEFINED;
-    cpuaddr   InitSymbolAddress;
-    int32     ReturnCode;
-    int32     OsStatus;
-    uint32    LoadFlags;
+    osal_id_t    ModuleId = OS_OBJECT_ID_UNDEFINED;
+    cpuaddr      InitSymbolAddress;
+    CFE_Status_t ReturnCode;
+    int32        OsStatus;
+    uint32       LoadFlags;
 
     LoadFlags         = 0;
     InitSymbolAddress = 0;
@@ -493,11 +493,11 @@ int32 CFE_ES_LoadModule(CFE_ResourceId_t ParentResourceId, const char *ModuleNam
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_GetTaskFunction(CFE_ES_TaskEntryFuncPtr_t *FuncPtr)
+CFE_Status_t CFE_ES_GetTaskFunction(CFE_ES_TaskEntryFuncPtr_t *FuncPtr)
 {
     CFE_ES_TaskRecord_t *     TaskRecPtr;
     CFE_ES_TaskEntryFuncPtr_t EntryFunc;
-    int32                     ReturnCode;
+    CFE_Status_t              ReturnCode;
     int32                     Timeout;
 
     /*
@@ -575,14 +575,14 @@ void CFE_ES_TaskEntryPoint(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_StartAppTask(CFE_ES_TaskId_t *TaskIdPtr, const char *TaskName, CFE_ES_TaskEntryFuncPtr_t EntryFunc,
-                          const CFE_ES_TaskStartParams_t *Params, CFE_ES_AppId_t ParentAppId)
+CFE_Status_t CFE_ES_StartAppTask(CFE_ES_TaskId_t *TaskIdPtr, const char *TaskName, CFE_ES_TaskEntryFuncPtr_t EntryFunc,
+                                 const CFE_ES_TaskStartParams_t *Params, CFE_ES_AppId_t ParentAppId)
 {
     CFE_ES_TaskRecord_t *TaskRecPtr;
     osal_id_t            OsalTaskId = OS_OBJECT_ID_UNDEFINED;
     CFE_ES_TaskId_t      LocalTaskId;
     int32                OsStatus;
-    int32                ReturnCode;
+    CFE_Status_t         ReturnCode;
 
     /*
      * Create the primary task for the newly loaded task
@@ -653,7 +653,8 @@ int32 CFE_ES_StartAppTask(CFE_ES_TaskId_t *TaskIdPtr, const char *TaskName, CFE_
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_AppCreate(CFE_ES_AppId_t *ApplicationIdPtr, const char *AppName, const CFE_ES_AppStartParams_t *Params)
+CFE_Status_t CFE_ES_AppCreate(CFE_ES_AppId_t *ApplicationIdPtr, const char *AppName,
+                              const CFE_ES_AppStartParams_t *Params)
 {
     CFE_Status_t        Status;
     CFE_ES_AppRecord_t *AppRecPtr;
@@ -816,11 +817,12 @@ int32 CFE_ES_AppCreate(CFE_ES_AppId_t *ApplicationIdPtr, const char *AppName, co
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_LoadLibrary(CFE_ES_LibId_t *LibraryIdPtr, const char *LibName, const CFE_ES_ModuleLoadParams_t *Params)
+CFE_Status_t CFE_ES_LoadLibrary(CFE_ES_LibId_t *LibraryIdPtr, const char *LibName,
+                                const CFE_ES_ModuleLoadParams_t *Params)
 {
     CFE_ES_LibraryEntryFuncPtr_t FunctionPointer;
     CFE_ES_LibRecord_t *         LibSlotPtr;
-    int32                        Status;
+    CFE_Status_t                 Status;
     CFE_ResourceId_t             PendingResourceId;
 
     /*
@@ -1314,12 +1316,12 @@ void CFE_ES_ProcessControlRequest(CFE_ES_AppId_t AppId)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId)
+CFE_Status_t CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId)
 {
     uint32                  i;
     int32                   OsStatus;
-    int32                   Status;
-    int32                   ReturnCode;
+    CFE_Status_t            Status;
+    CFE_Status_t            ReturnCode;
     CFE_ES_TaskId_t         TaskList[OS_MAX_TASKS];
     CFE_ES_MemHandle_t      PoolList[CFE_PLATFORM_ES_MAX_MEMORY_POOLS];
     osal_id_t               ModuleId;
@@ -1656,11 +1658,11 @@ void CFE_ES_CleanupObjectCallback(osal_id_t ObjectId, void *arg)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_CleanupTaskResources(CFE_ES_TaskId_t TaskId)
+CFE_Status_t CFE_ES_CleanupTaskResources(CFE_ES_TaskId_t TaskId)
 {
     CFE_ES_CleanupState_t CleanState;
     int32                 OsStatus;
-    int32                 Result;
+    CFE_Status_t          Result;
     osal_id_t             OsalId;
 
     /* Get the Task ID for calling OSAL APIs (convert type) */

--- a/modules/es/fsw/src/cfe_es_apps.h
+++ b/modules/es/fsw/src/cfe_es_apps.h
@@ -189,7 +189,7 @@ void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath);
 /**
  * This function parses the startup file line for an individual cFE application.
  */
-int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens);
+CFE_Status_t CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -200,8 +200,8 @@ int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens);
  * This only loads the code and looks up relevant runtime information.
  * It does not start any tasks.
  */
-int32 CFE_ES_LoadModule(CFE_ResourceId_t ParentResourceId, const char *ModuleName,
-                        const CFE_ES_ModuleLoadParams_t *LoadParams, CFE_ES_ModuleLoadStatus_t *LoadStatus);
+CFE_Status_t CFE_ES_LoadModule(CFE_ResourceId_t ParentResourceId, const char *ModuleName,
+                               const CFE_ES_ModuleLoadParams_t *LoadParams, CFE_ES_ModuleLoadStatus_t *LoadStatus);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -210,7 +210,7 @@ int32 CFE_ES_LoadModule(CFE_ResourceId_t ParentResourceId, const char *ModuleNam
  * If the app isn't fully registered in the global app table, then this delays until
  * the app is completely configured and the entry point is confirmed to be valid.
  */
-int32 CFE_ES_GetTaskFunction(CFE_ES_TaskEntryFuncPtr_t *FuncPtr);
+CFE_Status_t CFE_ES_GetTaskFunction(CFE_ES_TaskEntryFuncPtr_t *FuncPtr);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -234,8 +234,8 @@ void CFE_ES_TaskEntryPoint(void);
  * Therefore this calls a dedicated CFE_ES_AppEntryPoint which then will wait until
  * the task is fully registered in the global, before calling the actual app entry point.
  */
-int32 CFE_ES_StartAppTask(CFE_ES_TaskId_t *TaskIdPtr, const char *TaskName, CFE_ES_TaskEntryFuncPtr_t EntryFunc,
-                          const CFE_ES_TaskStartParams_t *Params, CFE_ES_AppId_t ParentAppId);
+CFE_Status_t CFE_ES_StartAppTask(CFE_ES_TaskId_t *TaskIdPtr, const char *TaskName, CFE_ES_TaskEntryFuncPtr_t EntryFunc,
+                                 const CFE_ES_TaskStartParams_t *Params, CFE_ES_AppId_t ParentAppId);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -245,13 +245,15 @@ int32 CFE_ES_StartAppTask(CFE_ES_TaskId_t *TaskIdPtr, const char *TaskName, CFE_
  * loads the cFE Applications from the disk using the startup script, or it
  * can be called when the ES Start Application command is executed.
  */
-int32 CFE_ES_AppCreate(CFE_ES_AppId_t *ApplicationIdPtr, const char *AppName, const CFE_ES_AppStartParams_t *Params);
+CFE_Status_t CFE_ES_AppCreate(CFE_ES_AppId_t *ApplicationIdPtr, const char *AppName,
+                              const CFE_ES_AppStartParams_t *Params);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * This function loads and initializes a cFE Shared Library.
  */
-int32 CFE_ES_LoadLibrary(CFE_ES_LibId_t *LibraryIdPtr, const char *LibName, const CFE_ES_ModuleLoadParams_t *Params);
+CFE_Status_t CFE_ES_LoadLibrary(CFE_ES_LibId_t *LibraryIdPtr, const char *LibName,
+                                const CFE_ES_ModuleLoadParams_t *Params);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -300,7 +302,7 @@ void CFE_ES_ProcessControlRequest(CFE_ES_AppId_t AppId);
 /**
  * Clean up all app resources and delete it
  */
-int32 CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId);
+CFE_Status_t CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -311,7 +313,7 @@ int32 CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId);
  * Note: This is called when the ES global is UNLOCKED  so it should not touch
  * any ES global data structures.  It should only clean up at the OSAL level.
  */
-int32 CFE_ES_CleanupTaskResources(CFE_ES_TaskId_t TaskId);
+CFE_Status_t CFE_ES_CleanupTaskResources(CFE_ES_TaskId_t TaskId);
 
 /*---------------------------------------------------------------------------------------*/
 /**

--- a/modules/es/fsw/src/cfe_es_backgroundtask.c
+++ b/modules/es/fsw/src/cfe_es_backgroundtask.c
@@ -168,10 +168,10 @@ void CFE_ES_BackgroundTask(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_BackgroundInit(void)
+CFE_Status_t CFE_ES_BackgroundInit(void)
 {
-    int32 status;
-    int32 OsStatus;
+    CFE_Status_t status;
+    int32        OsStatus;
 
     OsStatus = OS_BinSemCreate(&CFE_ES_Global.BackgroundTask.WorkSem, CFE_ES_BACKGROUND_SEM_NAME, 0, 0);
     if (OsStatus != OS_SUCCESS)

--- a/modules/es/fsw/src/cfe_es_cds.c
+++ b/modules/es/fsw/src/cfe_es_cds.c
@@ -48,13 +48,13 @@
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_CDS_EarlyInit(void)
+CFE_Status_t CFE_ES_CDS_EarlyInit(void)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
     uint32                 PlatformSize;
     size_t                 MinRequiredSize;
     int32                  OsStatus;
-    int32                  Status;
+    CFE_Status_t           Status;
     int32                  PspStatus;
 
     CFE_ES_Global.CDSIsAvailable = false;
@@ -151,7 +151,7 @@ int32 CFE_ES_CDS_EarlyInit(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_CDSHandle_ToIndex(CFE_ES_CDSHandle_t BlockID, uint32 *Idx)
+CFE_Status_t CFE_ES_CDSHandle_ToIndex(CFE_ES_CDSHandle_t BlockID, uint32 *Idx)
 {
     return CFE_ResourceId_ToIndex(CFE_RESOURCEID_UNWRAP(BlockID), CFE_ES_CDSBLOCKID_BASE,
                                   CFE_PLATFORM_ES_CDS_MAX_NUM_ENTRIES, Idx);
@@ -205,9 +205,9 @@ CFE_ES_CDS_RegRec_t *CFE_ES_LocateCDSBlockRecordByID(CFE_ES_CDSHandle_t BlockID)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_CDS_CacheFetch(CFE_ES_CDS_AccessCache_t *Cache, size_t Offset, size_t Size)
+CFE_Status_t CFE_ES_CDS_CacheFetch(CFE_ES_CDS_AccessCache_t *Cache, size_t Offset, size_t Size)
 {
-    int32 Status;
+    CFE_Status_t Status;
 
     if (Size > 0 && Size <= sizeof(Cache->Data))
     {
@@ -238,9 +238,9 @@ int32 CFE_ES_CDS_CacheFetch(CFE_ES_CDS_AccessCache_t *Cache, size_t Offset, size
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_CDS_CacheFlush(CFE_ES_CDS_AccessCache_t *Cache)
+CFE_Status_t CFE_ES_CDS_CacheFlush(CFE_ES_CDS_AccessCache_t *Cache)
 {
-    int32 Status;
+    CFE_Status_t Status;
 
     if (Cache->Size > 0 && Cache->Size <= sizeof(Cache->Data))
     {
@@ -269,9 +269,9 @@ int32 CFE_ES_CDS_CacheFlush(CFE_ES_CDS_AccessCache_t *Cache)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_CDS_CachePreload(CFE_ES_CDS_AccessCache_t *Cache, const void *Source, size_t Offset, size_t Size)
+CFE_Status_t CFE_ES_CDS_CachePreload(CFE_ES_CDS_AccessCache_t *Cache, const void *Source, size_t Offset, size_t Size)
 {
-    int32 Status;
+    CFE_Status_t Status;
 
     if (Size > 0 && Size <= sizeof(Cache->Data))
     {
@@ -303,11 +303,12 @@ int32 CFE_ES_CDS_CachePreload(CFE_ES_CDS_AccessCache_t *Cache, const void *Sourc
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr, size_t UserBlockSize, const char *Name, bool CriticalTbl)
+CFE_Status_t CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr, size_t UserBlockSize, const char *Name,
+                                  bool CriticalTbl)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
-    int32                  Status;
-    int32                  RegUpdateStatus;
+    CFE_Status_t           Status;
+    CFE_Status_t           RegUpdateStatus;
     CFE_ES_CDS_RegRec_t *  RegRecPtr;
     size_t                 BlockOffset;
     size_t                 OldBlockSize;
@@ -461,12 +462,12 @@ int32 CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr, size_t UserBlockSize, 
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_ValidateCDS(void)
+CFE_Status_t CFE_ES_ValidateCDS(void)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
     size_t                 TrailerOffset;
     const size_t           SIG_CDS_SIZE = {CFE_ES_CDS_SIGNATURE_LEN};
-    int32                  Status;
+    CFE_Status_t           Status;
 
     /* Perform 2 checks to validate the CDS Memory Pool */
     /* First, determine if the first validity check field is correct */
@@ -510,11 +511,11 @@ int32 CFE_ES_ValidateCDS(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_ClearCDS(void)
+CFE_Status_t CFE_ES_ClearCDS(void)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
     size_t                 RemainSize;
-    int32                  Status;
+    CFE_Status_t           Status;
 
     Status = CFE_SUCCESS;
 
@@ -555,11 +556,11 @@ int32 CFE_ES_ClearCDS(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_InitCDSSignatures(void)
+CFE_Status_t CFE_ES_InitCDSSignatures(void)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
     size_t                 SigOffset;
-    int32                  Status;
+    CFE_Status_t           Status;
 
     /* Initialize the Validity Check strings */
     SigOffset = 0;
@@ -594,10 +595,10 @@ int32 CFE_ES_InitCDSSignatures(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_InitCDSRegistry(void)
+CFE_Status_t CFE_ES_InitCDSRegistry(void)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
-    int32                  Status;
+    CFE_Status_t           Status;
     uint32                 RegSize;
 
     /* Initialize the local CDS Registry */
@@ -626,7 +627,7 @@ int32 CFE_ES_InitCDSRegistry(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_UpdateCDSRegistry(void)
+CFE_Status_t CFE_ES_UpdateCDSRegistry(void)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
     int32                  PspStatus;
@@ -668,11 +669,11 @@ void CFE_ES_FormCDSName(char *FullCDSName, const char *CDSName, CFE_ES_AppId_t T
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_LockCDS(void)
+CFE_Status_t CFE_ES_LockCDS(void)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
     int32                  OsStatus;
-    int32                  Status;
+    CFE_Status_t           Status;
 
     OsStatus = OS_MutSemTake(CDS->GenMutex);
 
@@ -695,11 +696,11 @@ int32 CFE_ES_LockCDS(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_UnlockCDS(void)
+CFE_Status_t CFE_ES_UnlockCDS(void)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
     int32                  OsStatus;
-    int32                  Status;
+    CFE_Status_t           Status;
 
     OsStatus = OS_MutSemGive(CDS->GenMutex);
 
@@ -761,10 +762,10 @@ CFE_ES_CDS_RegRec_t *CFE_ES_LocateCDSBlockRecordByName(const char *CDSName)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_RebuildCDS(void)
+CFE_Status_t CFE_ES_RebuildCDS(void)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
-    int32                  Status;
+    CFE_Status_t           Status;
     int32                  PspStatus;
 
     /* First, determine if the CDS registry stored in the CDS is smaller or equal */
@@ -809,10 +810,10 @@ int32 CFE_ES_RebuildCDS(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_DeleteCDS(const char *CDSName, bool CalledByTblServices)
+CFE_Status_t CFE_ES_DeleteCDS(const char *CDSName, bool CalledByTblServices)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
-    int32                  Status;
+    CFE_Status_t           Status;
     CFE_ES_CDS_RegRec_t *  RegRecPtr;
     char                   OwnerName[OS_MAX_API_NAME];
     CFE_ES_AppId_t         AppId;

--- a/modules/es/fsw/src/cfe_es_cds.h
+++ b/modules/es/fsw/src/cfe_es_cds.h
@@ -208,7 +208,7 @@ typedef struct CFE_ES_CDS_PersistentTrailer
  * @param[in]    Size   the CDS data size to fetch
  * @returns #CFE_SUCCESS on success, or appropriate error code.
  */
-int32 CFE_ES_CDS_CacheFetch(CFE_ES_CDS_AccessCache_t *Cache, size_t Offset, size_t Size);
+CFE_Status_t CFE_ES_CDS_CacheFetch(CFE_ES_CDS_AccessCache_t *Cache, size_t Offset, size_t Size);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -225,7 +225,7 @@ int32 CFE_ES_CDS_CacheFetch(CFE_ES_CDS_AccessCache_t *Cache, size_t Offset, size
  * @param[inout] Cache  the global CDS cache buffer
  * @returns #CFE_SUCCESS on success, or appropriate error code.
  */
-int32 CFE_ES_CDS_CacheFlush(CFE_ES_CDS_AccessCache_t *Cache);
+CFE_Status_t CFE_ES_CDS_CacheFlush(CFE_ES_CDS_AccessCache_t *Cache);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -250,7 +250,7 @@ int32 CFE_ES_CDS_CacheFlush(CFE_ES_CDS_AccessCache_t *Cache);
  * @param[in]    Size   the CDS data size to fetch
  * @returns #CFE_SUCCESS on success, or appropriate error code.
  */
-int32 CFE_ES_CDS_CachePreload(CFE_ES_CDS_AccessCache_t *Cache, const void *Source, size_t Offset, size_t Size);
+CFE_Status_t CFE_ES_CDS_CachePreload(CFE_ES_CDS_AccessCache_t *Cache, const void *Source, size_t Offset, size_t Size);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -264,7 +264,7 @@ int32 CFE_ES_CDS_CachePreload(CFE_ES_CDS_AccessCache_t *Cache, const void *Sourc
  * @returns    #CFE_SUCCESS if conversion successful. @copydoc CFE_SUCCESS
  *             #CFE_ES_ERR_RESOURCEID_NOT_VALID if block ID is outside valid range
  */
-int32 CFE_ES_CDSHandle_ToIndex(CFE_ES_CDSHandle_t BlockID, uint32 *Idx);
+CFE_Status_t CFE_ES_CDSHandle_ToIndex(CFE_ES_CDSHandle_t BlockID, uint32 *Idx);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -451,7 +451,7 @@ bool CFE_ES_CheckCDSHandleSlotUsed(CFE_ResourceId_t CheckId);
 ** \return None
 **
 ******************************************************************************/
-int32 CFE_ES_CDS_EarlyInit(void);
+CFE_Status_t CFE_ES_CDS_EarlyInit(void);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -470,7 +470,7 @@ int32 CFE_ES_CDS_EarlyInit(void);
 ** \return Any of the return values from #CFE_PSP_ReadFromCDS
 **
 ******************************************************************************/
-int32 CFE_ES_ValidateCDS(void);
+CFE_Status_t CFE_ES_ValidateCDS(void);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -486,7 +486,7 @@ int32 CFE_ES_ValidateCDS(void);
 ** \retval #CFE_SUCCESS         \copydoc CFE_SUCCESS
 **
 ******************************************************************************/
-int32 CFE_ES_InitCDSRegistry(void);
+CFE_Status_t CFE_ES_InitCDSRegistry(void);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -503,7 +503,7 @@ int32 CFE_ES_InitCDSRegistry(void);
 ** \return Any of the return values from #CFE_PSP_ReadFromCDS
 **
 ******************************************************************************/
-int32 CFE_ES_RebuildCDS(void);
+CFE_Status_t CFE_ES_RebuildCDS(void);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -519,7 +519,7 @@ int32 CFE_ES_RebuildCDS(void);
 ** \return Any of the return values from #CFE_PSP_WriteToCDS
 **
 ******************************************************************************/
-int32 CFE_ES_UpdateCDSRegistry(void);
+CFE_Status_t CFE_ES_UpdateCDSRegistry(void);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -579,7 +579,7 @@ CFE_ES_CDS_RegRec_t *CFE_ES_LocateCDSBlockRecordByName(const char *CDSName);
 **
 ** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
 ******************************************************************************/
-int32 CFE_ES_LockCDS(void);
+CFE_Status_t CFE_ES_LockCDS(void);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -595,7 +595,7 @@ int32 CFE_ES_LockCDS(void);
 ** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
 **
 ******************************************************************************/
-int32 CFE_ES_UnlockCDS(void);
+CFE_Status_t CFE_ES_UnlockCDS(void);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -612,7 +612,7 @@ int32 CFE_ES_UnlockCDS(void);
 ** \return Any of the return values from #CFE_PSP_ReadFromCDS
 **
 ******************************************************************************/
-int32 CFE_ES_RebuildCDS(void);
+CFE_Status_t CFE_ES_RebuildCDS(void);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -628,7 +628,7 @@ int32 CFE_ES_RebuildCDS(void);
 ** \retval #CFE_SUCCESS         \copydoc CFE_SUCCESS
 **
 ******************************************************************************/
-int32 CFE_ES_InitCDSRegistry(void);
+CFE_Status_t CFE_ES_InitCDSRegistry(void);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -647,7 +647,7 @@ int32 CFE_ES_InitCDSRegistry(void);
 ** \return Any of the return values from #CFE_PSP_ReadFromCDS
 **
 ******************************************************************************/
-int32 CFE_ES_ValidateCDS(void);
+CFE_Status_t CFE_ES_ValidateCDS(void);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -666,7 +666,7 @@ int32 CFE_ES_ValidateCDS(void);
 ** \return Any of the return values from #CFE_ES_CDS_CacheFlush
 **
 ******************************************************************************/
-int32 CFE_ES_ClearCDS(void);
+CFE_Status_t CFE_ES_ClearCDS(void);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -683,6 +683,6 @@ int32 CFE_ES_ClearCDS(void);
 ** \return Any of the return values from #CFE_ES_CDS_CacheFlush
 **
 ******************************************************************************/
-int32 CFE_ES_InitCDSSignatures(void);
+CFE_Status_t CFE_ES_InitCDSSignatures(void);
 
 #endif /* CFE_ES_CDS_H */

--- a/modules/es/fsw/src/cfe_es_cds_mempool.c
+++ b/modules/es/fsw/src/cfe_es_cds_mempool.c
@@ -69,7 +69,7 @@ const size_t CFE_ES_CDSMemPoolDefSize[CFE_ES_CDS_NUM_BLOCK_SIZES] = {
  * This is a bridge between the generic pool implementation and the CDS cache.
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_CDS_PoolRetrieve(CFE_ES_GenPoolRecord_t *GenPoolRecPtr, size_t Offset, CFE_ES_GenPoolBD_t **BdPtr)
+CFE_Status_t CFE_ES_CDS_PoolRetrieve(CFE_ES_GenPoolRecord_t *GenPoolRecPtr, size_t Offset, CFE_ES_GenPoolBD_t **BdPtr)
 {
     CFE_ES_CDS_Instance_t *CDS = (CFE_ES_CDS_Instance_t *)GenPoolRecPtr;
 
@@ -86,7 +86,8 @@ int32 CFE_ES_CDS_PoolRetrieve(CFE_ES_GenPoolRecord_t *GenPoolRecPtr, size_t Offs
  * This is a bridge between the generic pool implementation and the CDS cache.
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_CDS_PoolCommit(CFE_ES_GenPoolRecord_t *GenPoolRecPtr, size_t Offset, const CFE_ES_GenPoolBD_t *BdPtr)
+CFE_Status_t CFE_ES_CDS_PoolCommit(CFE_ES_GenPoolRecord_t *GenPoolRecPtr, size_t Offset,
+                                   const CFE_ES_GenPoolBD_t *BdPtr)
 {
     CFE_ES_CDS_Instance_t *CDS = (CFE_ES_CDS_Instance_t *)GenPoolRecPtr;
 
@@ -101,10 +102,10 @@ int32 CFE_ES_CDS_PoolCommit(CFE_ES_GenPoolRecord_t *GenPoolRecPtr, size_t Offset
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_CreateCDSPool(size_t CDSPoolSize, size_t StartOffset)
+CFE_Status_t CFE_ES_CreateCDSPool(size_t CDSPoolSize, size_t StartOffset)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
-    int32                  Status;
+    CFE_Status_t           Status;
     size_t                 SizeCheck;
     size_t                 ActualSize;
 
@@ -134,10 +135,10 @@ int32 CFE_ES_CreateCDSPool(size_t CDSPoolSize, size_t StartOffset)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_RebuildCDSPool(size_t CDSPoolSize, size_t StartOffset)
+CFE_Status_t CFE_ES_RebuildCDSPool(size_t CDSPoolSize, size_t StartOffset)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
-    int32                  Status;
+    CFE_Status_t           Status;
 
     /*
      * Start by creating the pool in a clean state, as it would be in a non-rebuild.
@@ -166,11 +167,11 @@ int32 CFE_ES_RebuildCDSPool(size_t CDSPoolSize, size_t StartOffset)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_CDSBlockWrite(CFE_ES_CDSHandle_t Handle, const void *DataToWrite)
+CFE_Status_t CFE_ES_CDSBlockWrite(CFE_ES_CDSHandle_t Handle, const void *DataToWrite)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
     char                   LogMessage[CFE_ES_MAX_SYSLOG_MSG_SIZE];
-    int32                  Status;
+    CFE_Status_t           Status;
     int32                  PspStatus;
     size_t                 BlockSize;
     size_t                 UserDataSize;
@@ -262,10 +263,10 @@ int32 CFE_ES_CDSBlockWrite(CFE_ES_CDSHandle_t Handle, const void *DataToWrite)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_CDSBlockRead(void *DataRead, CFE_ES_CDSHandle_t Handle)
+CFE_Status_t CFE_ES_CDSBlockRead(void *DataRead, CFE_ES_CDSHandle_t Handle)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
-    int32                  Status;
+    CFE_Status_t           Status;
     int32                  PspStatus;
     uint32                 CrcOfCDSData;
     size_t                 BlockSize;

--- a/modules/es/fsw/src/cfe_es_cds_mempool.h
+++ b/modules/es/fsw/src/cfe_es_cds_mempool.h
@@ -63,7 +63,7 @@
 ** \return #CFE_SUCCESS                     \copydoc CFE_SUCCESS
 **
 ******************************************************************************/
-int32 CFE_ES_CreateCDSPool(size_t CDSPoolSize, size_t StartOffset);
+CFE_Status_t CFE_ES_CreateCDSPool(size_t CDSPoolSize, size_t StartOffset);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -77,19 +77,19 @@ int32 CFE_ES_CreateCDSPool(size_t CDSPoolSize, size_t StartOffset);
  *
  * \return #CFE_SUCCESS                     \copydoc CFE_SUCCESS
  */
-int32 CFE_ES_RebuildCDSPool(size_t CDSPoolSize, size_t StartOffset);
+CFE_Status_t CFE_ES_RebuildCDSPool(size_t CDSPoolSize, size_t StartOffset);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * @brief Writes a block of data to CDS
  */
-int32 CFE_ES_CDSBlockWrite(CFE_ES_CDSHandle_t Handle, const void *DataToWrite);
+CFE_Status_t CFE_ES_CDSBlockWrite(CFE_ES_CDSHandle_t Handle, const void *DataToWrite);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * @brief Reads a block of data from CDS
  */
-int32 CFE_ES_CDSBlockRead(void *DataRead, CFE_ES_CDSHandle_t Handle);
+CFE_Status_t CFE_ES_CDSBlockRead(void *DataRead, CFE_ES_CDSHandle_t Handle);
 
 /*---------------------------------------------------------------------------------------*/
 /**

--- a/modules/es/fsw/src/cfe_es_erlog.c
+++ b/modules/es/fsw/src/cfe_es_erlog.c
@@ -48,8 +48,8 @@
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_WriteToERLogWithContext(CFE_ES_LogEntryType_Enum_t EntryType, uint32 ResetType, uint32 ResetSubtype,
-                                     const char *Description, CFE_ES_AppId_t AppId, uint32 PspContextId)
+CFE_Status_t CFE_ES_WriteToERLogWithContext(CFE_ES_LogEntryType_Enum_t EntryType, uint32 ResetType, uint32 ResetSubtype,
+                                            const char *Description, CFE_ES_AppId_t AppId, uint32 PspContextId)
 {
     uint32                   LogIdx;
     CFE_ES_ERLog_MetaData_t *EntryPtr;
@@ -149,8 +149,8 @@ int32 CFE_ES_WriteToERLogWithContext(CFE_ES_LogEntryType_Enum_t EntryType, uint3
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_WriteToERLog(CFE_ES_LogEntryType_Enum_t EntryType, uint32 ResetType, uint32 ResetSubtype,
-                          const char *Description)
+CFE_Status_t CFE_ES_WriteToERLog(CFE_ES_LogEntryType_Enum_t EntryType, uint32 ResetType, uint32 ResetSubtype,
+                                 const char *Description)
 {
     /* passing 0xFFFFFFFF as the appid avoids confusion with actual appid 0 */
     return CFE_ES_WriteToERLogWithContext(EntryType, ResetType, ResetSubtype, Description, CFE_ES_APPID_UNDEFINED,
@@ -269,7 +269,7 @@ void CFE_ES_BackgroundERLogFileEventHandler(void *Meta, CFE_FS_FileWriteEvent_t 
  *-----------------------------------------------------------------*/
 bool CFE_ES_RunExceptionScan(uint32 ElapsedTime, void *Arg)
 {
-    int32                      Status;
+    CFE_Status_t               Status;
     int32                      PspStatus;
     uint32                     PspContextId;
     char                       ReasonString[CFE_ES_ERLOG_DESCRIPTION_MAX_LENGTH];

--- a/modules/es/fsw/src/cfe_es_generic_pool.c
+++ b/modules/es/fsw/src/cfe_es_generic_pool.c
@@ -97,8 +97,8 @@ CFE_ES_GenPoolBucket_t *CFE_ES_GenPoolGetBucketState(CFE_ES_GenPoolRecord_t *Poo
  * Find and re-allocate a previously returned block
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_GenPoolRecyclePoolBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 BucketId, size_t NewSize,
-                                     size_t *BlockOffsetPtr)
+CFE_Status_t CFE_ES_GenPoolRecyclePoolBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 BucketId, size_t NewSize,
+                                            size_t *BlockOffsetPtr)
 {
     CFE_ES_GenPoolBucket_t *BucketPtr;
     size_t                  DescOffset;
@@ -106,7 +106,7 @@ int32 CFE_ES_GenPoolRecyclePoolBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 
     size_t                  NextOffset;
     CFE_ES_GenPoolBD_t *    BdPtr;
     uint16                  RecycleBucketId;
-    int32                   Status;
+    CFE_Status_t            Status;
 
     BucketPtr = CFE_ES_GenPoolGetBucketState(PoolRecPtr, BucketId);
     if (BucketPtr == NULL || BucketPtr->RecycleCount == BucketPtr->ReleaseCount || BucketPtr->FirstOffset == 0)
@@ -157,15 +157,15 @@ int32 CFE_ES_GenPoolRecyclePoolBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 
  * Create a new block of the given size
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_GenPoolCreatePoolBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 BucketId, size_t NewSize,
-                                    size_t *BlockOffsetPtr)
+CFE_Status_t CFE_ES_GenPoolCreatePoolBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 BucketId, size_t NewSize,
+                                           size_t *BlockOffsetPtr)
 {
     CFE_ES_GenPoolBucket_t *BucketPtr;
     size_t                  DescOffset;
     size_t                  BlockOffset;
     size_t                  NextTailPosition;
     CFE_ES_GenPoolBD_t *    BdPtr;
-    int32                   Status;
+    CFE_Status_t            Status;
 
     BucketPtr = CFE_ES_GenPoolGetBucketState(PoolRecPtr, BucketId);
     if (BucketPtr == NULL)
@@ -231,9 +231,9 @@ int32 CFE_ES_GenPoolCreatePoolBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 B
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_GenPoolInitialize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t StartOffset, size_t PoolSize,
-                               size_t AlignSize, uint16 NumBlockSizes, const size_t *BlockSizeList,
-                               CFE_ES_PoolRetrieve_Func_t RetrieveFunc, CFE_ES_PoolCommit_Func_t CommitFunc)
+CFE_Status_t CFE_ES_GenPoolInitialize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t StartOffset, size_t PoolSize,
+                                      size_t AlignSize, uint16 NumBlockSizes, const size_t *BlockSizeList,
+                                      CFE_ES_PoolRetrieve_Func_t RetrieveFunc, CFE_ES_PoolCommit_Func_t CommitFunc)
 {
     cpuaddr                 AlignMask;
     uint32                  i;
@@ -355,10 +355,10 @@ size_t CFE_ES_GenPoolCalcMinSize(uint16 NumBlockSizes, const size_t *BlockSizeLi
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_GenPoolGetBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockOffsetPtr, size_t ReqSize)
+CFE_Status_t CFE_ES_GenPoolGetBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockOffsetPtr, size_t ReqSize)
 {
-    int32  Status;
-    uint16 BucketId;
+    CFE_Status_t Status;
+    uint16       BucketId;
 
     /* Find the bucket which can accommodate the requested size. */
     BucketId = CFE_ES_GenPoolFindBucket(PoolRecPtr, ReqSize);
@@ -386,12 +386,12 @@ int32 CFE_ES_GenPoolGetBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockOf
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_GenPoolGetBlockSize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockSizePtr, size_t BlockOffset)
+CFE_Status_t CFE_ES_GenPoolGetBlockSize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockSizePtr, size_t BlockOffset)
 {
     size_t                  DescOffset;
     CFE_ES_GenPoolBucket_t *BucketPtr;
     CFE_ES_GenPoolBD_t *    BdPtr;
-    int32                   Status;
+    CFE_Status_t            Status;
     uint16                  BucketId;
 
     if (BlockOffset >= PoolRecPtr->TailPosition || BlockOffset < CFE_ES_GENERIC_POOL_DESCRIPTOR_SIZE)
@@ -429,12 +429,12 @@ int32 CFE_ES_GenPoolGetBlockSize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *Blo
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_GenPoolPutBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockSizePtr, size_t BlockOffset)
+CFE_Status_t CFE_ES_GenPoolPutBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockSizePtr, size_t BlockOffset)
 {
     size_t                  DescOffset;
     CFE_ES_GenPoolBucket_t *BucketPtr;
     CFE_ES_GenPoolBD_t *    BdPtr;
-    int32                   Status;
+    CFE_Status_t            Status;
     uint16                  BucketId;
 
     if (BlockOffset >= PoolRecPtr->TailPosition || BlockOffset < CFE_ES_GENERIC_POOL_DESCRIPTOR_SIZE)
@@ -482,9 +482,9 @@ int32 CFE_ES_GenPoolPutBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockSi
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_GenPoolRebuild(CFE_ES_GenPoolRecord_t *PoolRecPtr)
+CFE_Status_t CFE_ES_GenPoolRebuild(CFE_ES_GenPoolRecord_t *PoolRecPtr)
 {
-    int32                   Status;
+    CFE_Status_t            Status;
     size_t                  DescOffset;
     size_t                  BlockOffset;
     CFE_ES_GenPoolBucket_t *BucketPtr;

--- a/modules/es/fsw/src/cfe_es_generic_pool.h
+++ b/modules/es/fsw/src/cfe_es_generic_pool.h
@@ -139,9 +139,9 @@ struct CFE_ES_GenPoolRecord
  *
  * \return #CFE_SUCCESS, or error code \ref CFEReturnCodes
  */
-int32 CFE_ES_GenPoolInitialize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t StartOffset, size_t PoolSize,
-                               size_t AlignSize, uint16 NumBlockSizes, const size_t *BlockSizeList,
-                               CFE_ES_PoolRetrieve_Func_t RetrieveFunc, CFE_ES_PoolCommit_Func_t CommitFunc);
+CFE_Status_t CFE_ES_GenPoolInitialize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t StartOffset, size_t PoolSize,
+                                      size_t AlignSize, uint16 NumBlockSizes, const size_t *BlockSizeList,
+                                      CFE_ES_PoolRetrieve_Func_t RetrieveFunc, CFE_ES_PoolCommit_Func_t CommitFunc);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -156,7 +156,7 @@ int32 CFE_ES_GenPoolInitialize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t StartO
  *
  * \return #CFE_SUCCESS, or error code \ref CFEReturnCodes
  */
-int32 CFE_ES_GenPoolGetBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockOffsetPtr, size_t ReqSize);
+CFE_Status_t CFE_ES_GenPoolGetBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockOffsetPtr, size_t ReqSize);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -167,13 +167,13 @@ int32 CFE_ES_GenPoolGetBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockOf
  * \param[inout] PoolRecPtr      Pointer to pool structure
  * \param[in]    BucketId        Bucket ID
  * \param[in]    NewSize         Size of block
- * \param[out]   BlockOffsetPtr  Location to output new block offset 
+ * \param[out]   BlockOffsetPtr  Location to output new block offset
  *
  * \return #CFE_SUCCESS, or error code #CFE_ES_BUFFER_NOT_IN_POOL #CFE_ES_ERR_MEM_BLOCK_SIZE
  *         \ref CFEReturnCodes
  */
-int32 CFE_ES_GenPoolCreatePoolBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 BucketId, size_t NewSize, 
-                                    size_t *BlockOffsetPtr);
+CFE_Status_t CFE_ES_GenPoolCreatePoolBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 BucketId, size_t NewSize,
+                                           size_t *BlockOffsetPtr);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -184,12 +184,12 @@ int32 CFE_ES_GenPoolCreatePoolBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 B
  * \param[inout] PoolRecPtr      Pointer to pool structure
  * \param[in]    BucketId        Bucket ID
  * \param[in]    NewSize         Size of block
- * \param[out]   BlockOffsetPtr  Location to output new block offset 
+ * \param[out]   BlockOffsetPtr  Location to output new block offset
  *
  * \return #CFE_SUCCESS, or error code #CFE_ES_BUFFER_NOT_IN_POOL \ref CFEReturnCodes
  */
-int32 CFE_ES_GenPoolRecyclePoolBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 BucketId, size_t NewSize,
-                                     size_t *BlockOffsetPtr);
+CFE_Status_t CFE_ES_GenPoolRecyclePoolBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 BucketId, size_t NewSize,
+                                            size_t *BlockOffsetPtr);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -204,7 +204,7 @@ int32 CFE_ES_GenPoolRecyclePoolBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 
  *
  * \return #CFE_SUCCESS, or error code \ref CFEReturnCodes
  */
-int32 CFE_ES_GenPoolPutBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockSizePtr, size_t BlockOffset);
+CFE_Status_t CFE_ES_GenPoolPutBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockSizePtr, size_t BlockOffset);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -225,7 +225,7 @@ int32 CFE_ES_GenPoolPutBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockSi
  *
  * \return #CFE_SUCCESS, or error code \ref CFEReturnCodes
  */
-int32 CFE_ES_GenPoolRebuild(CFE_ES_GenPoolRecord_t *PoolRecPtr);
+CFE_Status_t CFE_ES_GenPoolRebuild(CFE_ES_GenPoolRecord_t *PoolRecPtr);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -240,7 +240,7 @@ int32 CFE_ES_GenPoolRebuild(CFE_ES_GenPoolRecord_t *PoolRecPtr);
  *
  * \return #CFE_SUCCESS, or error code \ref CFEReturnCodes
  */
-int32 CFE_ES_GenPoolGetBlockSize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockSizePtr, size_t BlockOffset);
+CFE_Status_t CFE_ES_GenPoolGetBlockSize(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockSizePtr, size_t BlockOffset);
 
 /*---------------------------------------------------------------------------------------*/
 /**

--- a/modules/es/fsw/src/cfe_es_log.h
+++ b/modules/es/fsw/src/cfe_es_log.h
@@ -167,7 +167,7 @@ void CFE_ES_SysLogReadStart_Unsync(CFE_ES_SysLogReadBuffer_t *Buffer);
  *
  * \note This function requires external thread synchronization
  */
-int32 CFE_ES_SysLogWrite_Unsync(const char *SpecStringPtr, ...);
+CFE_Status_t CFE_ES_SysLogWrite_Unsync(const char *SpecStringPtr, ...);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -188,7 +188,7 @@ int32 CFE_ES_SysLogWrite_Unsync(const char *SpecStringPtr, ...);
  * \note This function requires external thread synchronization
  * \sa CFE_ES_SysLogSetMode()
  */
-int32 CFE_ES_SysLogAppend_Unsync(const char *LogString);
+CFE_Status_t CFE_ES_SysLogAppend_Unsync(const char *LogString);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -235,7 +235,7 @@ void CFE_ES_SysLogReadData(CFE_ES_SysLogReadBuffer_t *Buffer);
  * \param Mode   The desired operating mode
  * \return CFE_SUCCESS if set successfully
  */
-int32 CFE_ES_SysLogSetMode(CFE_ES_LogMode_Enum_t Mode);
+CFE_Status_t CFE_ES_SysLogSetMode(CFE_ES_LogMode_Enum_t Mode);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -287,7 +287,7 @@ void CFE_ES_SysLog_vsnprintf(char *Buffer, size_t BufferSize, const char *SpecSt
  * \sa CFE_ES_SYSLOG_READ_BUFFER_SIZE
  *
  */
-int32 CFE_ES_SysLogDump(const char *Filename);
+CFE_Status_t CFE_ES_SysLogDump(const char *Filename);
 
 /*
 ** Exception and Reset Log API
@@ -307,8 +307,8 @@ int32 CFE_ES_SysLogDump(const char *Filename);
  *
  * \return CFE_SUCCESS if successful, or an appropriate error code from cfe_error.h
  */
-int32 CFE_ES_WriteToERLog(CFE_ES_LogEntryType_Enum_t EntryType, uint32 ResetType, uint32 ResetSubtype,
-                          const char *Description);
+CFE_Status_t CFE_ES_WriteToERLog(CFE_ES_LogEntryType_Enum_t EntryType, uint32 ResetType, uint32 ResetSubtype,
+                                 const char *Description);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -321,7 +321,7 @@ int32 CFE_ES_WriteToERLog(CFE_ES_LogEntryType_Enum_t EntryType, uint32 ResetType
  * \param AppId The Application ID associated with the task that caused the exception
  * \param PspContextId Identifier of extended context info stored in the PSP (if available)
  */
-int32 CFE_ES_WriteToERLogWithContext(CFE_ES_LogEntryType_Enum_t EntryType, uint32 ResetType, uint32 ResetSubtype,
-                                     const char *Description, CFE_ES_AppId_t AppId, uint32 PspContextId);
+CFE_Status_t CFE_ES_WriteToERLogWithContext(CFE_ES_LogEntryType_Enum_t EntryType, uint32 ResetType, uint32 ResetSubtype,
+                                            const char *Description, CFE_ES_AppId_t AppId, uint32 PspContextId);
 
 #endif /* CFE_ES_LOG_H */

--- a/modules/es/fsw/src/cfe_es_mempool.c
+++ b/modules/es/fsw/src/cfe_es_mempool.c
@@ -76,7 +76,7 @@ const size_t CFE_ES_MemPoolDefSize[CFE_PLATFORM_ES_POOL_MAX_BUCKETS] = {
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_MemPoolDirectRetrieve(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset, CFE_ES_GenPoolBD_t **BdPtr)
+CFE_Status_t CFE_ES_MemPoolDirectRetrieve(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset, CFE_ES_GenPoolBD_t **BdPtr)
 {
     cpuaddr                 DataAddress;
     CFE_ES_MemPoolRecord_t *MemPoolRecPtr = (CFE_ES_MemPoolRecord_t *)PoolRecPtr;
@@ -92,7 +92,8 @@ int32 CFE_ES_MemPoolDirectRetrieve(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Of
  * Internal helper routine only, not part of API.
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_MemPoolDirectCommit(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset, const CFE_ES_GenPoolBD_t *BdPtr)
+CFE_Status_t CFE_ES_MemPoolDirectCommit(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset,
+                                        const CFE_ES_GenPoolBD_t *BdPtr)
 {
     return CFE_SUCCESS;
 }
@@ -103,7 +104,7 @@ int32 CFE_ES_MemPoolDirectCommit(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offs
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_MemPoolID_ToIndex(CFE_ES_MemHandle_t PoolID, uint32 *Idx)
+CFE_Status_t CFE_ES_MemPoolID_ToIndex(CFE_ES_MemHandle_t PoolID, uint32 *Idx)
 {
     return CFE_ResourceId_ToIndex(CFE_RESOURCEID_UNWRAP(PoolID), CFE_ES_POOLID_BASE, CFE_PLATFORM_ES_MAX_MEMORY_POOLS,
                                   Idx);
@@ -184,7 +185,7 @@ CFE_Status_t CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_
                                  const size_t *BlockSizes, bool UseMutex)
 {
     int32                   OsStatus;
-    int32                   Status;
+    CFE_Status_t            Status;
     CFE_ResourceId_t        PendingID;
     CFE_ES_MemPoolRecord_t *PoolRecPtr;
     size_t                  Alignment;
@@ -348,11 +349,11 @@ CFE_Status_t CFE_ES_PoolCreateEx(CFE_ES_MemHandle_t *PoolID, void *MemPtr, size_
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_PoolDelete(CFE_ES_MemHandle_t PoolID)
+CFE_Status_t CFE_ES_PoolDelete(CFE_ES_MemHandle_t PoolID)
 {
     CFE_ES_MemPoolRecord_t *PoolRecPtr;
     osal_id_t               MutexId;
-    int32                   Status;
+    CFE_Status_t            Status;
     int32                   OsStatus;
 
     PoolRecPtr = CFE_ES_LocateMemPoolRecordByID(PoolID);
@@ -401,9 +402,9 @@ int32 CFE_ES_PoolDelete(CFE_ES_MemHandle_t PoolID)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_GetPoolBuf(CFE_ES_MemPoolBuf_t *BufPtr, CFE_ES_MemHandle_t Handle, size_t Size)
+CFE_Status_t CFE_ES_GetPoolBuf(CFE_ES_MemPoolBuf_t *BufPtr, CFE_ES_MemHandle_t Handle, size_t Size)
 {
-    int32                   Status;
+    CFE_Status_t            Status;
     CFE_ES_AppId_t          AppId;
     CFE_ES_MemPoolRecord_t *PoolRecPtr;
     size_t                  DataOffset;
@@ -470,7 +471,7 @@ int32 CFE_ES_GetPoolBuf(CFE_ES_MemPoolBuf_t *BufPtr, CFE_ES_MemHandle_t Handle, 
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_ES_GetPoolBufInfo(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_t BufPtr)
 {
-    int32                   Status;
+    CFE_Status_t            Status;
     CFE_ES_MemPoolRecord_t *PoolRecPtr;
     size_t                  DataOffset;
     size_t                  DataSize;
@@ -528,12 +529,12 @@ CFE_Status_t CFE_ES_GetPoolBufInfo(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_PutPoolBuf(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_t BufPtr)
+CFE_Status_t CFE_ES_PutPoolBuf(CFE_ES_MemHandle_t Handle, CFE_ES_MemPoolBuf_t BufPtr)
 {
     CFE_ES_MemPoolRecord_t *PoolRecPtr;
     size_t                  DataSize;
     size_t                  DataOffset;
-    int32                   Status;
+    CFE_Status_t            Status;
 
     if (BufPtr == NULL)
     {

--- a/modules/es/fsw/src/cfe_es_mempool.h
+++ b/modules/es/fsw/src/cfe_es_mempool.h
@@ -94,7 +94,7 @@ typedef struct
  * @return Execution status, see @ref CFEReturnCodes
  * @retval #CFE_SUCCESS                 @copybrief CFE_SUCCESS
  */
-int32 CFE_ES_MemPoolID_ToIndex(CFE_ES_MemHandle_t PoolID, uint32 *Idx);
+CFE_Status_t CFE_ES_MemPoolID_ToIndex(CFE_ES_MemHandle_t PoolID, uint32 *Idx);
 
 /*---------------------------------------------------------------------------------------*/
 /**

--- a/modules/es/fsw/src/cfe_es_perf.c
+++ b/modules/es/fsw/src/cfe_es_perf.c
@@ -139,7 +139,7 @@ uint32 CFE_ES_GetPerfLogDumpRemaining(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfDataCmd_t *data)
+CFE_Status_t CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfDataCmd_t *data)
 {
     const CFE_ES_StartPerfCmd_Payload_t *CmdPtr        = &data->Payload;
     CFE_ES_PerfDumpGlobal_t *            PerfDumpState = &CFE_ES_Global.BackgroundPerfDumpState;
@@ -199,12 +199,12 @@ int32 CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfDataCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_StopPerfDataCmd(const CFE_ES_StopPerfDataCmd_t *data)
+CFE_Status_t CFE_ES_StopPerfDataCmd(const CFE_ES_StopPerfDataCmd_t *data)
 {
     const CFE_ES_StopPerfCmd_Payload_t *CmdPtr        = &data->Payload;
     CFE_ES_PerfDumpGlobal_t *           PerfDumpState = &CFE_ES_Global.BackgroundPerfDumpState;
     CFE_ES_PerfData_t *                 Perf;
-    int32                               Status;
+    CFE_Status_t                        Status;
 
     /*
     ** Set the pointer to the data area
@@ -266,7 +266,7 @@ bool CFE_ES_RunPerfLogDump(uint32 ElapsedTime, void *Arg)
 {
     CFE_ES_PerfDumpGlobal_t *State = (CFE_ES_PerfDumpGlobal_t *)Arg;
     int32                    OsStatus;
-    int32                    Status;
+    CFE_Status_t             Status;
     CFE_FS_Header_t          FileHdr;
     size_t                   BlockSize;
     CFE_ES_PerfData_t *      Perf;
@@ -485,7 +485,7 @@ bool CFE_ES_RunPerfLogDump(uint32 ElapsedTime, void *Arg)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMaskCmd_t *data)
+CFE_Status_t CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMaskCmd_t *data)
 {
     const CFE_ES_SetPerfFilterMaskCmd_Payload_t *cmd = &data->Payload;
     CFE_ES_PerfData_t *                          Perf;
@@ -523,7 +523,7 @@ int32 CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMaskCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_SetPerfTriggerMaskCmd(const CFE_ES_SetPerfTriggerMaskCmd_t *data)
+CFE_Status_t CFE_ES_SetPerfTriggerMaskCmd(const CFE_ES_SetPerfTriggerMaskCmd_t *data)
 {
     const CFE_ES_SetPerfTrigMaskCmd_Payload_t *cmd = &data->Payload;
     CFE_ES_PerfData_t *                        Perf;

--- a/modules/es/fsw/src/cfe_es_start.c
+++ b/modules/es/fsw/src/cfe_es_start.c
@@ -706,7 +706,7 @@ void CFE_ES_InitializeFileSystems(uint32 StartType)
  *-----------------------------------------------------------------*/
 void CFE_ES_CreateObjects(void)
 {
-    int32               ReturnCode;
+    CFE_Status_t        ReturnCode;
     uint16              i;
     CFE_ES_AppRecord_t *AppRecPtr;
     CFE_ResourceId_t    PendingAppId;
@@ -878,9 +878,9 @@ void CFE_ES_CreateObjects(void)
  * reach the indicated state, by polling the app counters in a delay loop.
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_MainTaskSyncDelay(uint32 AppStateId, uint32 TimeOutMilliseconds)
+CFE_Status_t CFE_ES_MainTaskSyncDelay(uint32 AppStateId, uint32 TimeOutMilliseconds)
 {
-    int32               Status;
+    CFE_Status_t        Status;
     uint32              i;
     uint32              WaitTime;
     uint32              WaitRemaining;

--- a/modules/es/fsw/src/cfe_es_syslog.c
+++ b/modules/es/fsw/src/cfe_es_syslog.c
@@ -129,12 +129,12 @@ void CFE_ES_SysLogReadStart_Unsync(CFE_ES_SysLogReadBuffer_t *Buffer)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_SysLogAppend_Unsync(const char *LogString)
+CFE_Status_t CFE_ES_SysLogAppend_Unsync(const char *LogString)
 {
-    int32  ReturnCode;
-    size_t MessageLen;
-    size_t WriteIdx;
-    size_t EndIdx;
+    CFE_Status_t ReturnCode;
+    size_t       MessageLen;
+    size_t       WriteIdx;
+    size_t       EndIdx;
 
     /*
      * Sanity check - Make sure the message length is actually reasonable
@@ -251,7 +251,7 @@ int32 CFE_ES_SysLogAppend_Unsync(const char *LogString)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_SysLogWrite_Unsync(const char *SpecStringPtr, ...)
+CFE_Status_t CFE_ES_SysLogWrite_Unsync(const char *SpecStringPtr, ...)
 {
     char    TmpString[CFE_ES_MAX_SYSLOG_MSG_SIZE];
     va_list ArgPtr;
@@ -332,9 +332,9 @@ void CFE_ES_SysLogReadData(CFE_ES_SysLogReadBuffer_t *Buffer)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_SysLogSetMode(CFE_ES_LogMode_Enum_t Mode)
+CFE_Status_t CFE_ES_SysLogSetMode(CFE_ES_LogMode_Enum_t Mode)
 {
-    int32 Status;
+    CFE_Status_t Status;
 
     if ((Mode == CFE_ES_LogMode_OVERWRITE) || (Mode == CFE_ES_LogMode_DISCARD))
     {
@@ -432,14 +432,14 @@ void CFE_ES_SysLog_vsnprintf(char *Buffer, size_t BufferSize, const char *SpecSt
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_SysLogDump(const char *Filename)
+CFE_Status_t CFE_ES_SysLogDump(const char *Filename)
 {
-    osal_id_t fd = OS_OBJECT_ID_UNDEFINED;
-    int32     OsStatus;
-    int32     Status;
-    size_t    WritePos;
-    size_t    TotalSize;
-    size_t    LastReqSize;
+    osal_id_t    fd = OS_OBJECT_ID_UNDEFINED;
+    int32        OsStatus;
+    CFE_Status_t Status;
+    size_t       WritePos;
+    size_t       TotalSize;
+    size_t       LastReqSize;
     union
     {
         CFE_ES_SysLogReadBuffer_t LogData;

--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -75,7 +75,7 @@ CFE_ES_TaskData_t CFE_ES_TaskData;
  *-----------------------------------------------------------------*/
 void CFE_ES_TaskMain(void)
 {
-    int32            Status;
+    CFE_Status_t     Status;
     uint32           AppRunStatus = CFE_ES_RunStatus_APP_RUN;
     CFE_SB_Buffer_t *SBBufPtr;
 
@@ -183,9 +183,9 @@ void CFE_ES_TaskMain(void)
  * Send a single CFE_ES_VERSION_INF_EID event for a component/module
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_GenerateSingleVersionEvent(const char *ModuleType, const char *ModuleName, CFE_ConfigId_t Id)
+CFE_Status_t CFE_ES_GenerateSingleVersionEvent(const char *ModuleType, const char *ModuleName, CFE_ConfigId_t Id)
 {
-    int32 Status;
+    CFE_Status_t Status;
 
     /*
      * Advertise the mission version information
@@ -223,7 +223,7 @@ void CFE_ES_ModSrcVerCallback(void *Arg, CFE_ConfigId_t Id, const char *Name)
  *-----------------------------------------------------------------*/
 void CFE_ES_GenerateVersionEvents(void)
 {
-    int32 Status;
+    CFE_Status_t Status;
 
     /*
      * Advertise the mission version information
@@ -246,7 +246,7 @@ void CFE_ES_GenerateVersionEvents(void)
  *-----------------------------------------------------------------*/
 void CFE_ES_GenerateBuildInfoEvents(void)
 {
-    int32       Status;
+    CFE_Status_t Status;
     const char *BuildDate;
     const char *BuildUser;
     const char *BuildHost;
@@ -270,14 +270,14 @@ void CFE_ES_GenerateBuildInfoEvents(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_TaskInit(void)
+CFE_Status_t CFE_ES_TaskInit(void)
 {
-    int32   Status;
-    int32   PspStatus;
-    uint32  SizeofCfeSegment;
-    cpuaddr CfeSegmentAddr;
-    uint8   VersionNumber[4];
-    char    VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
+    CFE_Status_t Status;
+    int32        PspStatus;
+    uint32       SizeofCfeSegment;
+    cpuaddr      CfeSegmentAddr;
+    uint8        VersionNumber[4];
+    char         VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
 
     /*
     ** Initialize task command execution counters
@@ -443,7 +443,7 @@ int32 CFE_ES_TaskInit(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_SendHkCmd(const CFE_ES_SendHkCmd_t *data)
+CFE_Status_t CFE_ES_SendHkCmd(const CFE_ES_SendHkCmd_t *data)
 {
     OS_heap_prop_t HeapProp;
     int32          OsStatus;
@@ -556,7 +556,7 @@ int32 CFE_ES_SendHkCmd(const CFE_ES_SendHkCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_NoopCmd(const CFE_ES_NoopCmd_t *Cmd)
+CFE_Status_t CFE_ES_NoopCmd(const CFE_ES_NoopCmd_t *Cmd)
 {
     /*
     ** Advertise the build and version information with the no-op command
@@ -583,7 +583,7 @@ int32 CFE_ES_NoopCmd(const CFE_ES_NoopCmd_t *Cmd)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_ResetCountersCmd(const CFE_ES_ResetCountersCmd_t *data)
+CFE_Status_t CFE_ES_ResetCountersCmd(const CFE_ES_ResetCountersCmd_t *data)
 {
     CFE_ES_Global.TaskData.CommandCounter      = 0;
     CFE_ES_Global.TaskData.CommandErrorCounter = 0;
@@ -602,7 +602,7 @@ int32 CFE_ES_ResetCountersCmd(const CFE_ES_ResetCountersCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_RestartCmd(const CFE_ES_RestartCmd_t *data)
+CFE_Status_t CFE_ES_RestartCmd(const CFE_ES_RestartCmd_t *data)
 {
     const CFE_ES_RestartCmd_Payload_t *cmd = &data->Payload;
 
@@ -629,11 +629,11 @@ int32 CFE_ES_RestartCmd(const CFE_ES_RestartCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_StartAppCmd(const CFE_ES_StartAppCmd_t *data)
+CFE_Status_t CFE_ES_StartAppCmd(const CFE_ES_StartAppCmd_t *data)
 {
     const CFE_ES_StartAppCmd_Payload_t *cmd = &data->Payload;
     CFE_ES_AppId_t                      AppID;
-    int32                               Result;
+    CFE_Status_t                        Result;
     int32                               AppEntryLen;
     int32                               AppNameLen;
     char                                LocalAppName[OS_MAX_API_NAME];
@@ -731,12 +731,12 @@ int32 CFE_ES_StartAppCmd(const CFE_ES_StartAppCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_StopAppCmd(const CFE_ES_StopAppCmd_t *data)
+CFE_Status_t CFE_ES_StopAppCmd(const CFE_ES_StopAppCmd_t *data)
 {
     const CFE_ES_AppNameCmd_Payload_t *cmd = &data->Payload;
     char                               LocalApp[OS_MAX_API_NAME];
     CFE_ES_AppId_t                     AppID;
-    int32                              Result;
+    CFE_Status_t                       Result;
 
     CFE_SB_MessageStringGet(LocalApp, (char *)cmd->Application, NULL, sizeof(LocalApp), sizeof(cmd->Application));
 
@@ -780,12 +780,12 @@ int32 CFE_ES_StopAppCmd(const CFE_ES_StopAppCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_RestartAppCmd(const CFE_ES_RestartAppCmd_t *data)
+CFE_Status_t CFE_ES_RestartAppCmd(const CFE_ES_RestartAppCmd_t *data)
 {
     const CFE_ES_AppNameCmd_Payload_t *cmd = &data->Payload;
     char                               LocalApp[OS_MAX_API_NAME];
     CFE_ES_AppId_t                     AppID;
-    int32                              Result;
+    CFE_Status_t                       Result;
 
     CFE_SB_MessageStringGet(LocalApp, (char *)cmd->Application, NULL, sizeof(LocalApp), sizeof(cmd->Application));
 
@@ -828,13 +828,13 @@ int32 CFE_ES_RestartAppCmd(const CFE_ES_RestartAppCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_ReloadAppCmd(const CFE_ES_ReloadAppCmd_t *data)
+CFE_Status_t CFE_ES_ReloadAppCmd(const CFE_ES_ReloadAppCmd_t *data)
 {
     const CFE_ES_AppReloadCmd_Payload_t *cmd = &data->Payload;
     char                                 LocalApp[OS_MAX_API_NAME];
     char                                 LocalFileName[OS_MAX_PATH_LEN];
     CFE_ES_AppId_t                       AppID;
-    int32                                Result;
+    CFE_Status_t                         Result;
 
     CFE_SB_MessageStringGet(LocalApp, (char *)cmd->Application, NULL, sizeof(LocalApp), sizeof(cmd->Application));
 
@@ -885,7 +885,7 @@ int32 CFE_ES_ReloadAppCmd(const CFE_ES_ReloadAppCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_QueryOneCmd(const CFE_ES_QueryOneCmd_t *data)
+CFE_Status_t CFE_ES_QueryOneCmd(const CFE_ES_QueryOneCmd_t *data)
 {
     const CFE_ES_AppNameCmd_Payload_t *cmd = &data->Payload;
     char                               LocalApp[OS_MAX_API_NAME];
@@ -895,7 +895,7 @@ int32 CFE_ES_QueryOneCmd(const CFE_ES_QueryOneCmd_t *data)
         CFE_ES_LibId_t   LibId;
         CFE_ResourceId_t ResourceID;
     } IdBuf;
-    int32 Result;
+    CFE_Status_t Result;
 
     CFE_SB_MessageStringGet(LocalApp, (char *)cmd->Application, NULL, sizeof(LocalApp), sizeof(cmd->Application));
 
@@ -950,7 +950,7 @@ int32 CFE_ES_QueryOneCmd(const CFE_ES_QueryOneCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAllCmd_t *data)
+CFE_Status_t CFE_ES_QueryAllCmd(const CFE_ES_QueryAllCmd_t *data)
 {
     CFE_FS_Header_t                     FileHeader;
     osal_id_t                           FileDescriptor = OS_OBJECT_ID_UNDEFINED;
@@ -958,14 +958,14 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAllCmd_t *data)
     uint32                              EntryCount = 0;
     uint32                              FileSize   = 0;
     int32                               OsStatus;
-    int32                               Result;
+    CFE_Status_t                        Result;
     CFE_ES_AppInfo_t                    AppInfo;
     const CFE_ES_FileNameCmd_Payload_t *CmdPtr = &data->Payload;
     char                                QueryAllFilename[OS_MAX_PATH_LEN];
     CFE_ResourceId_t                    ResourceList[CFE_ES_QUERY_ALL_MAX_ENTRIES];
     uint32                              NumResources;
-    CFE_ES_AppRecord_t *                AppRecPtr;
-    CFE_ES_LibRecord_t *                LibRecPtr;
+    CFE_ES_AppRecord_t                 *AppRecPtr;
+    CFE_ES_LibRecord_t                 *LibRecPtr;
 
     /*
      * Collect list of active resource IDs.
@@ -1110,7 +1110,7 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAllCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasksCmd_t *data)
+CFE_Status_t CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasksCmd_t *data)
 {
     CFE_FS_Header_t                     FileHeader;
     osal_id_t                           FileDescriptor = OS_OBJECT_ID_UNDEFINED;
@@ -1118,13 +1118,13 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasksCmd_t *data)
     uint32                              EntryCount = 0;
     uint32                              FileSize   = 0;
     int32                               OsStatus;
-    int32                               Result;
+    CFE_Status_t                        Result;
     CFE_ES_TaskInfo_t                   TaskInfo;
     const CFE_ES_FileNameCmd_Payload_t *CmdPtr = &data->Payload;
     char                                QueryAllFilename[OS_MAX_PATH_LEN];
     CFE_ES_TaskId_t                     TaskList[OS_MAX_TASKS];
     uint32                              NumTasks;
-    CFE_ES_TaskRecord_t *               TaskRecPtr;
+    CFE_ES_TaskRecord_t                *TaskRecPtr;
 
     /*
      * Collect list of active task IDs.
@@ -1262,7 +1262,7 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasksCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_ClearSysLogCmd(const CFE_ES_ClearSysLogCmd_t *data)
+CFE_Status_t CFE_ES_ClearSysLogCmd(const CFE_ES_ClearSysLogCmd_t *data)
 {
     /*
     ** Clear syslog index and memory area
@@ -1287,9 +1287,9 @@ int32 CFE_ES_ClearSysLogCmd(const CFE_ES_ClearSysLogCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_OverWriteSysLogCmd(const CFE_ES_OverWriteSysLogCmd_t *data)
+CFE_Status_t CFE_ES_OverWriteSysLogCmd(const CFE_ES_OverWriteSysLogCmd_t *data)
 {
-    int32                                      Status;
+    CFE_Status_t                               Status;
     const CFE_ES_OverWriteSysLogCmd_Payload_t *CmdPtr = &data->Payload;
 
     Status = CFE_ES_SysLogSetMode(CmdPtr->Mode);
@@ -1318,10 +1318,10 @@ int32 CFE_ES_OverWriteSysLogCmd(const CFE_ES_OverWriteSysLogCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_WriteSysLogCmd(const CFE_ES_WriteSysLogCmd_t *data)
+CFE_Status_t CFE_ES_WriteSysLogCmd(const CFE_ES_WriteSysLogCmd_t *data)
 {
     const CFE_ES_FileNameCmd_Payload_t *CmdPtr = &data->Payload;
-    int32                               Stat;
+    CFE_Status_t                        Stat;
     char                                LogFilename[OS_MAX_PATH_LEN];
 
     /*
@@ -1363,7 +1363,7 @@ int32 CFE_ES_WriteSysLogCmd(const CFE_ES_WriteSysLogCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_ClearERLogCmd(const CFE_ES_ClearERLogCmd_t *data)
+CFE_Status_t CFE_ES_ClearERLogCmd(const CFE_ES_ClearERLogCmd_t *data)
 {
     /*
     ** Clear ER log data buffer
@@ -1397,11 +1397,11 @@ int32 CFE_ES_ClearERLogCmd(const CFE_ES_ClearERLogCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_WriteERLogCmd(const CFE_ES_WriteERLogCmd_t *data)
+CFE_Status_t CFE_ES_WriteERLogCmd(const CFE_ES_WriteERLogCmd_t *data)
 {
     const CFE_ES_FileNameCmd_Payload_t *CmdPtr = &data->Payload;
-    CFE_ES_BackgroundLogDumpGlobal_t *  StatePtr;
-    int32                               Status;
+    CFE_ES_BackgroundLogDumpGlobal_t   *StatePtr;
+    CFE_Status_t                        Status;
 
     StatePtr = &CFE_ES_Global.BackgroundERLogDumpState;
 
@@ -1472,7 +1472,7 @@ int32 CFE_ES_WriteERLogCmd(const CFE_ES_WriteERLogCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_ResetPRCountCmd(const CFE_ES_ResetPRCountCmd_t *data)
+CFE_Status_t CFE_ES_ResetPRCountCmd(const CFE_ES_ResetPRCountCmd_t *data)
 {
     /*
     ** Reset the processor reset count
@@ -1495,7 +1495,7 @@ int32 CFE_ES_ResetPRCountCmd(const CFE_ES_ResetPRCountCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_SetMaxPRCountCmd(const CFE_ES_SetMaxPRCountCmd_t *data)
+CFE_Status_t CFE_ES_SetMaxPRCountCmd(const CFE_ES_SetMaxPRCountCmd_t *data)
 {
     const CFE_ES_SetMaxPRCountCmd_Payload_t *cmd = &data->Payload;
 
@@ -1521,9 +1521,9 @@ int32 CFE_ES_SetMaxPRCountCmd(const CFE_ES_SetMaxPRCountCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_DeleteCDSCmd(const CFE_ES_DeleteCDSCmd_t *data)
+CFE_Status_t CFE_ES_DeleteCDSCmd(const CFE_ES_DeleteCDSCmd_t *data)
 {
-    int32                                Status;
+    CFE_Status_t                         Status;
     const CFE_ES_DeleteCDSCmd_Payload_t *cmd = &data->Payload;
     char                                 LocalCdsName[CFE_MISSION_ES_CDS_MAX_FULL_NAME_LEN];
 
@@ -1577,7 +1577,7 @@ int32 CFE_ES_DeleteCDSCmd(const CFE_ES_DeleteCDSCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_SendMemPoolStatsCmd(const CFE_ES_SendMemPoolStatsCmd_t *data)
+CFE_Status_t CFE_ES_SendMemPoolStatsCmd(const CFE_ES_SendMemPoolStatsCmd_t *data)
 {
     const CFE_ES_SendMemPoolStatsCmd_Payload_t *Cmd;
     CFE_ES_MemHandle_t                          MemHandle;
@@ -1625,16 +1625,16 @@ int32 CFE_ES_SendMemPoolStatsCmd(const CFE_ES_SendMemPoolStatsCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistryCmd_t *data)
+CFE_Status_t CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistryCmd_t *data)
 {
     CFE_FS_Header_t                            StdFileHeader;
     osal_id_t                                  FileDescriptor = OS_OBJECT_ID_UNDEFINED;
     int32                                      OsStatus;
-    int32                                      Status;
+    CFE_Status_t                               Status;
     int16                                      RegIndex = 0;
     const CFE_ES_DumpCDSRegistryCmd_Payload_t *CmdPtr   = &data->Payload;
     char                                       DumpFilename[OS_MAX_PATH_LEN];
-    CFE_ES_CDS_RegRec_t *                      RegRecPtr;
+    CFE_ES_CDS_RegRec_t                       *RegRecPtr;
     CFE_ES_CDSRegDumpRec_t                     DumpRecord;
     int32                                      FileSize   = 0;
     int32                                      NumEntries = 0;

--- a/modules/es/fsw/src/cfe_es_task.h
+++ b/modules/es/fsw/src/cfe_es_task.h
@@ -87,7 +87,7 @@ void CFE_ES_TaskMain(void);
 /**
  * \brief Initialization of executive services global state
  */
-int32 CFE_ES_TaskInit(void);
+CFE_Status_t CFE_ES_TaskInit(void);
 
 /*
  * Functions related to the ES background helper task for low-priority tasks
@@ -97,7 +97,7 @@ int32 CFE_ES_TaskInit(void);
 /**
  * \brief Initializes the ES background task state
  */
-int32 CFE_ES_BackgroundInit(void);
+CFE_Status_t CFE_ES_BackgroundInit(void);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -122,150 +122,150 @@ void CFE_ES_BackgroundCleanup(void);
 /*
 ** ES Task message dispatch functions
 */
-int32 CFE_ES_SendHkCmd(const CFE_ES_SendHkCmd_t *data);
+CFE_Status_t CFE_ES_SendHkCmd(const CFE_ES_SendHkCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief ES task ground command (NO-OP)
  */
-int32 CFE_ES_NoopCmd(const CFE_ES_NoopCmd_t *Cmd);
+CFE_Status_t CFE_ES_NoopCmd(const CFE_ES_NoopCmd_t *Cmd);
 
 /*---------------------------------------------------------------------------------------*/
 /** \brief  ES task ground command (reset counters)
  */
-int32 CFE_ES_ResetCountersCmd(const CFE_ES_ResetCountersCmd_t *data);
+CFE_Status_t CFE_ES_ResetCountersCmd(const CFE_ES_ResetCountersCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief  Restart cFE (may reset processor)
  */
-int32 CFE_ES_RestartCmd(const CFE_ES_RestartCmd_t *data);
+CFE_Status_t CFE_ES_RestartCmd(const CFE_ES_RestartCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief  Load (and start) single application
  */
-int32 CFE_ES_StartAppCmd(const CFE_ES_StartAppCmd_t *data);
+CFE_Status_t CFE_ES_StartAppCmd(const CFE_ES_StartAppCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief  Stop single application
  */
-int32 CFE_ES_StopAppCmd(const CFE_ES_StopAppCmd_t *data);
+CFE_Status_t CFE_ES_StopAppCmd(const CFE_ES_StopAppCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief  Restart a single application
  */
-int32 CFE_ES_RestartAppCmd(const CFE_ES_RestartAppCmd_t *data);
+CFE_Status_t CFE_ES_RestartAppCmd(const CFE_ES_RestartAppCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief  Reload a single application
  */
-int32 CFE_ES_ReloadAppCmd(const CFE_ES_ReloadAppCmd_t *data);
+CFE_Status_t CFE_ES_ReloadAppCmd(const CFE_ES_ReloadAppCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief  Request tlm packet with single app data
  */
-int32 CFE_ES_QueryOneCmd(const CFE_ES_QueryOneCmd_t *data);
+CFE_Status_t CFE_ES_QueryOneCmd(const CFE_ES_QueryOneCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief  Write all app data to file
  */
-int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAllCmd_t *data);
+CFE_Status_t CFE_ES_QueryAllCmd(const CFE_ES_QueryAllCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief  Write all Task Data to a file
  */
-int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasksCmd_t *data);
+CFE_Status_t CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasksCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief  Clear executive services system log
  */
-int32 CFE_ES_ClearSysLogCmd(const CFE_ES_ClearSysLogCmd_t *data);
+CFE_Status_t CFE_ES_ClearSysLogCmd(const CFE_ES_ClearSysLogCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief  set syslog mode
  */
-int32 CFE_ES_OverWriteSysLogCmd(const CFE_ES_OverWriteSysLogCmd_t *data);
+CFE_Status_t CFE_ES_OverWriteSysLogCmd(const CFE_ES_OverWriteSysLogCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief  Process Cmd to write ES System Log to file
  */
-int32 CFE_ES_WriteSysLogCmd(const CFE_ES_WriteSysLogCmd_t *data);
+CFE_Status_t CFE_ES_WriteSysLogCmd(const CFE_ES_WriteSysLogCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief  Clear The exception and reset log.
  */
-int32 CFE_ES_ClearERLogCmd(const CFE_ES_ClearERLogCmd_t *data);
+CFE_Status_t CFE_ES_ClearERLogCmd(const CFE_ES_ClearERLogCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief  Process Cmd to write exception & reset log to a file.
  */
-int32 CFE_ES_WriteERLogCmd(const CFE_ES_WriteERLogCmd_t *data);
+CFE_Status_t CFE_ES_WriteERLogCmd(const CFE_ES_WriteERLogCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief  Processor Reset Count
  */
-int32 CFE_ES_ResetPRCountCmd(const CFE_ES_ResetPRCountCmd_t *data);
+CFE_Status_t CFE_ES_ResetPRCountCmd(const CFE_ES_ResetPRCountCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief  Set Maximum Processor reset count
  */
-int32 CFE_ES_SetMaxPRCountCmd(const CFE_ES_SetMaxPRCountCmd_t *data);
+CFE_Status_t CFE_ES_SetMaxPRCountCmd(const CFE_ES_SetMaxPRCountCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief  Delete Specified Critical Data Store
  */
-int32 CFE_ES_DeleteCDSCmd(const CFE_ES_DeleteCDSCmd_t *data);
+CFE_Status_t CFE_ES_DeleteCDSCmd(const CFE_ES_DeleteCDSCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief  Command handler to start collecting performance data
  */
-int32 CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfDataCmd_t *data);
+CFE_Status_t CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfDataCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief  Command handler to stop collecting performance data
  */
-int32 CFE_ES_StopPerfDataCmd(const CFE_ES_StopPerfDataCmd_t *data);
+CFE_Status_t CFE_ES_StopPerfDataCmd(const CFE_ES_StopPerfDataCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief  Command handler to set perf ID filter mask
  */
-int32 CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMaskCmd_t *data);
+CFE_Status_t CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMaskCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief  Command handler to set perf ID trigger mask
  */
-int32 CFE_ES_SetPerfTriggerMaskCmd(const CFE_ES_SetPerfTriggerMaskCmd_t *data);
+CFE_Status_t CFE_ES_SetPerfTriggerMaskCmd(const CFE_ES_SetPerfTriggerMaskCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief  Telemeter Memory Pool Statistics
  */
-int32 CFE_ES_SendMemPoolStatsCmd(const CFE_ES_SendMemPoolStatsCmd_t *data);
+CFE_Status_t CFE_ES_SendMemPoolStatsCmd(const CFE_ES_SendMemPoolStatsCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief  Dump CDS Registry to a file
  */
-int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistryCmd_t *data);
+CFE_Status_t CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistryCmd_t *data);
 
 /*
 ** Message Handler Helper Functions

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -393,31 +393,32 @@ void ES_UT_SetupSingleLibId(const char *LibName, CFE_ES_LibRecord_t **OutLibRec)
     ++CFE_ES_Global.RegisteredLibs;
 }
 
-int32 ES_UT_PoolDirectRetrieve(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset, CFE_ES_GenPoolBD_t **BdPtr)
+CFE_Status_t ES_UT_PoolDirectRetrieve(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset, CFE_ES_GenPoolBD_t **BdPtr)
 {
     *BdPtr = (CFE_ES_GenPoolBD_t *)((void *)&UT_MemPoolDirectBuffer.Data[Offset]);
     return CFE_SUCCESS;
 }
 
-int32 ES_UT_PoolDirectCommit(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset, const CFE_ES_GenPoolBD_t *BdPtr)
+CFE_Status_t ES_UT_PoolDirectCommit(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset, const CFE_ES_GenPoolBD_t *BdPtr)
 {
     return CFE_SUCCESS;
 }
 
-int32 ES_UT_PoolIndirectRetrieve(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset, CFE_ES_GenPoolBD_t **BdPtr)
+CFE_Status_t ES_UT_PoolIndirectRetrieve(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset, CFE_ES_GenPoolBD_t **BdPtr)
 {
     memcpy(&UT_MemPoolIndirectBuffer.BD, &UT_MemPoolIndirectBuffer.Data[Offset], sizeof(CFE_ES_GenPoolBD_t));
     *BdPtr = &UT_MemPoolIndirectBuffer.BD;
     return CFE_SUCCESS;
 }
 
-int32 ES_UT_PoolIndirectCommit(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset, const CFE_ES_GenPoolBD_t *BdPtr)
+CFE_Status_t ES_UT_PoolIndirectCommit(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset,
+                                      const CFE_ES_GenPoolBD_t *BdPtr)
 {
     memcpy(&UT_MemPoolIndirectBuffer.Data[Offset], BdPtr, sizeof(CFE_ES_GenPoolBD_t));
     return CFE_SUCCESS;
 }
 
-int32 ES_UT_CDSPoolRetrieve(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset, CFE_ES_GenPoolBD_t **BdPtr)
+CFE_Status_t ES_UT_CDSPoolRetrieve(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset, CFE_ES_GenPoolBD_t **BdPtr)
 {
     static CFE_ES_GenPoolBD_t BdBuf;
 
@@ -425,19 +426,19 @@ int32 ES_UT_CDSPoolRetrieve(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset, C
     return CFE_PSP_ReadFromCDS(&BdBuf, Offset, sizeof(BdBuf));
 }
 
-int32 ES_UT_CDSPoolCommit(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset, const CFE_ES_GenPoolBD_t *BdPtr)
+CFE_Status_t ES_UT_CDSPoolCommit(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset, const CFE_ES_GenPoolBD_t *BdPtr)
 {
     return CFE_PSP_WriteToCDS(BdPtr, Offset, sizeof(*BdPtr));
 }
 
 /* Commit failure routine for pool coverage testing */
-int32 ES_UT_PoolCommitFail(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset, const CFE_ES_GenPoolBD_t *BdPtr)
+CFE_Status_t ES_UT_PoolCommitFail(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset, const CFE_ES_GenPoolBD_t *BdPtr)
 {
     return CFE_ES_CDS_ACCESS_ERROR;
 }
 
 /* Retrieve failure routine for pool coverage testing */
-int32 ES_UT_PoolRetrieveFail(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset, CFE_ES_GenPoolBD_t **BdPtr)
+CFE_Status_t ES_UT_PoolRetrieveFail(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t Offset, CFE_ES_GenPoolBD_t **BdPtr)
 {
     return CFE_ES_CDS_ACCESS_ERROR;
 }
@@ -559,7 +560,8 @@ void ES_UT_SetupSingleCDSRegistry(const char *CDSName, size_t BlockSize, bool Is
     }
 }
 
-int32 ES_UT_SetupOSCleanupHook(void *UserObj, int32 StubRetcode, uint32 CallCount, const UT_StubContext_t *Context)
+CFE_Status_t ES_UT_SetupOSCleanupHook(void *UserObj, int32 StubRetcode, uint32 CallCount,
+                                      const UT_StubContext_t *Context)
 {
     osal_id_t ObjList[8];
 

--- a/modules/evs/fsw/src/cfe_evs.c
+++ b/modules/evs/fsw/src/cfe_evs.c
@@ -43,7 +43,7 @@ CFE_Status_t CFE_EVS_Register(const void *Filters, uint16 NumEventFilters, uint1
 {
     uint16               FilterLimit;
     uint16               i;
-    int32                Status;
+    CFE_Status_t         Status;
     CFE_ES_AppId_t       AppID;
     CFE_EVS_BinFilter_t *AppFilters;
     EVS_AppData_t *      AppDataPtr;
@@ -118,7 +118,7 @@ CFE_Status_t CFE_EVS_Register(const void *Filters, uint16 NumEventFilters, uint1
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spec, ...)
 {
-    int32              Status;
+    CFE_Status_t       Status;
     CFE_ES_AppId_t     AppID;
     CFE_TIME_SysTime_t Time;
     va_list            Ptr;
@@ -168,7 +168,7 @@ CFE_Status_t CFE_EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spe
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_EVS_SendEventWithAppID(uint16 EventID, uint16 EventType, CFE_ES_AppId_t AppID, const char *Spec, ...)
 {
-    int32              Status = CFE_SUCCESS;
+    CFE_Status_t       Status = CFE_SUCCESS;
     CFE_TIME_SysTime_t Time;
     va_list            Ptr;
     EVS_AppData_t *    AppDataPtr;
@@ -217,7 +217,7 @@ CFE_Status_t CFE_EVS_SendEventWithAppID(uint16 EventID, uint16 EventType, CFE_ES
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time, uint16 EventID, uint16 EventType, const char *Spec, ...)
 {
-    int32          Status;
+    CFE_Status_t   Status;
     CFE_ES_AppId_t AppID;
     va_list        Ptr;
     EVS_AppData_t *AppDataPtr;
@@ -261,9 +261,9 @@ CFE_Status_t CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time, uint16 EventID, uin
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_ResetFilter(uint16 EventID)
+CFE_Status_t CFE_EVS_ResetFilter(uint16 EventID)
 {
-    int32            Status;
+    CFE_Status_t     Status;
     EVS_BinFilter_t *FilterPtr = NULL;
     CFE_ES_AppId_t   AppID;
     EVS_AppData_t *  AppDataPtr;
@@ -302,7 +302,7 @@ int32 CFE_EVS_ResetFilter(uint16 EventID)
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_EVS_ResetAllFilters(void)
 {
-    int32          Status;
+    CFE_Status_t   Status;
     CFE_ES_AppId_t AppID;
     uint32         i;
     EVS_AppData_t *AppDataPtr;

--- a/modules/evs/fsw/src/cfe_evs_dispatch.c
+++ b/modules/evs/fsw/src/cfe_evs_dispatch.c
@@ -78,7 +78,7 @@ void CFE_EVS_ProcessCommandPacket(const CFE_SB_Buffer_t *SBBufPtr)
 void CFE_EVS_ProcessGroundCommand(const CFE_SB_Buffer_t *SBBufPtr, CFE_SB_MsgId_t MsgId)
 {
     /* status will get reset if it passes length check */
-    int32             Status  = CFE_STATUS_WRONG_MSG_LENGTH;
+    CFE_Status_t      Status  = CFE_STATUS_WRONG_MSG_LENGTH;
     CFE_MSG_FcnCode_t FcnCode = 0;
 
     CFE_MSG_GetFcnCode(&SBBufPtr->Msg, &FcnCode);

--- a/modules/evs/fsw/src/cfe_evs_log.c
+++ b/modules/evs/fsw/src/cfe_evs_log.c
@@ -111,10 +111,10 @@ void EVS_ClearLog(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFileCmd_t *data)
+CFE_Status_t CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFileCmd_t *data)
 {
     const CFE_EVS_LogFileCmd_Payload_t *CmdPtr = &data->Payload;
-    int32                               Result;
+    CFE_Status_t                        Result;
     int32                               LogIndex;
     int32                               OsStatus;
     int32                               BytesWritten;
@@ -235,10 +235,10 @@ int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFileCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_SetLogModeCmd(const CFE_EVS_SetLogModeCmd_t *data)
+CFE_Status_t CFE_EVS_SetLogModeCmd(const CFE_EVS_SetLogModeCmd_t *data)
 {
     const CFE_EVS_SetLogMode_Payload_t *CmdPtr = &data->Payload;
-    int32                               Status;
+    CFE_Status_t                        Status;
 
     if ((CmdPtr->LogMode == CFE_EVS_LogMode_OVERWRITE) || (CmdPtr->LogMode == CFE_EVS_LogMode_DISCARD))
     {

--- a/modules/evs/fsw/src/cfe_evs_log.h
+++ b/modules/evs/fsw/src/cfe_evs_log.h
@@ -68,7 +68,7 @@ void EVS_ClearLog(void);
  *
  * This routine writes the contents of the internal event log to a file
  */
-int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFileCmd_t *data);
+CFE_Status_t CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFileCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -76,6 +76,6 @@ int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFileCmd_t *data);
  *
  * This routine sets the internal event log mode.
  */
-int32 CFE_EVS_SetLogModeCmd(const CFE_EVS_SetLogModeCmd_t *data);
+CFE_Status_t CFE_EVS_SetLogModeCmd(const CFE_EVS_SetLogModeCmd_t *data);
 
 #endif /* CFE_EVS_LOG_H */

--- a/modules/evs/fsw/src/cfe_evs_task.c
+++ b/modules/evs/fsw/src/cfe_evs_task.c
@@ -51,10 +51,10 @@ CFE_EVS_Global_t CFE_EVS_Global;
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_EarlyInit(void)
+CFE_Status_t CFE_EVS_EarlyInit(void)
 {
     int32               OsStatus;
-    int32               Status;
+    CFE_Status_t        Status;
     int32               PspStatus;
     uint32              resetAreaSize = 0;
     cpuaddr             resetAreaAddr;
@@ -166,9 +166,9 @@ int32 CFE_EVS_EarlyInit(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_CleanUpApp(CFE_ES_AppId_t AppID)
+CFE_Status_t CFE_EVS_CleanUpApp(CFE_ES_AppId_t AppID)
 {
-    int32          Status = CFE_SUCCESS;
+    CFE_Status_t   Status = CFE_SUCCESS;
     EVS_AppData_t *AppDataPtr;
 
     /* Query and verify the caller's AppID */
@@ -193,7 +193,7 @@ int32 CFE_EVS_CleanUpApp(CFE_ES_AppId_t AppID)
  *-----------------------------------------------------------------*/
 void CFE_EVS_TaskMain(void)
 {
-    int32            Status;
+    CFE_Status_t     Status;
     CFE_SB_Buffer_t *SBBufPtr;
 
     CFE_ES_PerfLogEntry(CFE_MISSION_EVS_MAIN_PERF_ID);
@@ -251,9 +251,9 @@ void CFE_EVS_TaskMain(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_TaskInit(void)
+CFE_Status_t CFE_EVS_TaskInit(void)
 {
-    int32          Status;
+    CFE_Status_t   Status;
     CFE_ES_AppId_t AppID;
     char           VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
 
@@ -311,7 +311,7 @@ int32 CFE_EVS_TaskInit(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_NoopCmd(const CFE_EVS_NoopCmd_t *data)
+CFE_Status_t CFE_EVS_NoopCmd(const CFE_EVS_NoopCmd_t *data)
 {
     char VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
     CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE", CFE_SRC_VERSION, CFE_BUILD_CODENAME,
@@ -326,7 +326,7 @@ int32 CFE_EVS_NoopCmd(const CFE_EVS_NoopCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_ClearLogCmd(const CFE_EVS_ClearLogCmd_t *data)
+CFE_Status_t CFE_EVS_ClearLogCmd(const CFE_EVS_ClearLogCmd_t *data)
 {
     EVS_ClearLog();
     return CFE_SUCCESS;
@@ -338,10 +338,10 @@ int32 CFE_EVS_ClearLogCmd(const CFE_EVS_ClearLogCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_SendHkCmd(const CFE_EVS_SendHkCmd_t *data)
+CFE_Status_t CFE_EVS_SendHkCmd(const CFE_EVS_SendHkCmd_t *data)
 {
     uint32                i, j;
-    EVS_AppData_t *       AppDataPtr;
+    EVS_AppData_t        *AppDataPtr;
     CFE_EVS_AppTlmData_t *AppTlmDataPtr;
 
     /* Copy hk variables that are maintained in the event log */
@@ -389,7 +389,7 @@ int32 CFE_EVS_SendHkCmd(const CFE_EVS_SendHkCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_ResetCountersCmd(const CFE_EVS_ResetCountersCmd_t *data)
+CFE_Status_t CFE_EVS_ResetCountersCmd(const CFE_EVS_ResetCountersCmd_t *data)
 {
     /* Status of commands processed by EVS task */
     CFE_EVS_Global.EVS_TlmPkt.Payload.CommandCounter      = 0;
@@ -413,12 +413,12 @@ int32 CFE_EVS_ResetCountersCmd(const CFE_EVS_ResetCountersCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_SetFilterCmd(const CFE_EVS_SetFilterCmd_t *data)
+CFE_Status_t CFE_EVS_SetFilterCmd(const CFE_EVS_SetFilterCmd_t *data)
 {
     const CFE_EVS_AppNameEventIDMaskCmd_Payload_t *CmdPtr = &data->Payload;
-    EVS_BinFilter_t *                              FilterPtr;
-    int32                                          Status;
-    EVS_AppData_t *                                AppDataPtr;
+    EVS_BinFilter_t                               *FilterPtr;
+    CFE_Status_t                                   Status;
+    EVS_AppData_t                                 *AppDataPtr;
     char                                           LocalName[OS_MAX_API_NAME];
 
     /* Copy appname from command, ensures NULL termination */
@@ -476,10 +476,10 @@ int32 CFE_EVS_SetFilterCmd(const CFE_EVS_SetFilterCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_EnablePortsCmd(const CFE_EVS_EnablePortsCmd_t *data)
+CFE_Status_t CFE_EVS_EnablePortsCmd(const CFE_EVS_EnablePortsCmd_t *data)
 {
     const CFE_EVS_BitMaskCmd_Payload_t *CmdPtr = &data->Payload;
-    int32                               ReturnCode;
+    CFE_Status_t                        ReturnCode;
 
     /* Need to check for an out of range bitmask, since oue bit masks are only 4 bits */
     if (CmdPtr->BitMask == 0x0 || CmdPtr->BitMask > 0x0F)
@@ -508,10 +508,10 @@ int32 CFE_EVS_EnablePortsCmd(const CFE_EVS_EnablePortsCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_DisablePortsCmd(const CFE_EVS_DisablePortsCmd_t *data)
+CFE_Status_t CFE_EVS_DisablePortsCmd(const CFE_EVS_DisablePortsCmd_t *data)
 {
     const CFE_EVS_BitMaskCmd_Payload_t *CmdPtr = &data->Payload;
-    int32                               ReturnCode;
+    CFE_Status_t                        ReturnCode;
 
     /* Need to check for an out of range bitmask, since oue bit masks are only 4 bits */
     if (CmdPtr->BitMask == 0x0 || CmdPtr->BitMask > 0x0F)
@@ -541,12 +541,12 @@ int32 CFE_EVS_DisablePortsCmd(const CFE_EVS_DisablePortsCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_EnableEventTypeCmd(const CFE_EVS_EnableEventTypeCmd_t *data)
+CFE_Status_t CFE_EVS_EnableEventTypeCmd(const CFE_EVS_EnableEventTypeCmd_t *data)
 {
     uint32                              i;
     const CFE_EVS_BitMaskCmd_Payload_t *CmdPtr = &data->Payload;
-    int32                               ReturnCode;
-    EVS_AppData_t *                     AppDataPtr;
+    CFE_Status_t                        ReturnCode;
+    EVS_AppData_t                      *AppDataPtr;
 
     /* Need to check for an out of range bitmask, since our bit masks are only 4 bits */
     if (CmdPtr->BitMask == 0x0 || CmdPtr->BitMask > 0x0F)
@@ -585,12 +585,12 @@ int32 CFE_EVS_EnableEventTypeCmd(const CFE_EVS_EnableEventTypeCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_DisableEventTypeCmd(const CFE_EVS_DisableEventTypeCmd_t *data)
+CFE_Status_t CFE_EVS_DisableEventTypeCmd(const CFE_EVS_DisableEventTypeCmd_t *data)
 {
     uint32                              i;
     const CFE_EVS_BitMaskCmd_Payload_t *CmdPtr = &data->Payload;
-    int32                               ReturnCode;
-    EVS_AppData_t *                     AppDataPtr;
+    CFE_Status_t                        ReturnCode;
+    EVS_AppData_t                      *AppDataPtr;
 
     /* Need to check for an out of range bitmask, since our bit masks are only 4 bits */
     if (CmdPtr->BitMask == 0x0 || CmdPtr->BitMask > 0x0F)
@@ -630,10 +630,10 @@ int32 CFE_EVS_DisableEventTypeCmd(const CFE_EVS_DisableEventTypeCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_SetEventFormatModeCmd(const CFE_EVS_SetEventFormatModeCmd_t *data)
+CFE_Status_t CFE_EVS_SetEventFormatModeCmd(const CFE_EVS_SetEventFormatModeCmd_t *data)
 {
     const CFE_EVS_SetEventFormatMode_Payload_t *CmdPtr = &data->Payload;
-    int32                                       Status;
+    CFE_Status_t                                Status;
 
     if ((CmdPtr->MsgFormat == CFE_EVS_MsgFormat_SHORT) || (CmdPtr->MsgFormat == CFE_EVS_MsgFormat_LONG))
     {
@@ -660,11 +660,11 @@ int32 CFE_EVS_SetEventFormatModeCmd(const CFE_EVS_SetEventFormatModeCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_EnableAppEventTypeCmd(const CFE_EVS_EnableAppEventTypeCmd_t *data)
+CFE_Status_t CFE_EVS_EnableAppEventTypeCmd(const CFE_EVS_EnableAppEventTypeCmd_t *data)
 {
     const CFE_EVS_AppNameBitMaskCmd_Payload_t *CmdPtr = &data->Payload;
-    EVS_AppData_t *                            AppDataPtr;
-    int32                                      Status;
+    EVS_AppData_t                             *AppDataPtr;
+    CFE_Status_t                               Status;
     char                                       LocalName[OS_MAX_API_NAME];
 
     /* Copy appname from command, ensures NULL termination */
@@ -722,11 +722,11 @@ int32 CFE_EVS_EnableAppEventTypeCmd(const CFE_EVS_EnableAppEventTypeCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_DisableAppEventTypeCmd(const CFE_EVS_DisableAppEventTypeCmd_t *data)
+CFE_Status_t CFE_EVS_DisableAppEventTypeCmd(const CFE_EVS_DisableAppEventTypeCmd_t *data)
 {
-    EVS_AppData_t *                            AppDataPtr;
+    EVS_AppData_t                             *AppDataPtr;
     const CFE_EVS_AppNameBitMaskCmd_Payload_t *CmdPtr = &data->Payload;
-    int32                                      Status;
+    CFE_Status_t                               Status;
     char                                       LocalName[OS_MAX_API_NAME];
 
     /* Copy appname from command, ensures NULL termination */
@@ -784,11 +784,11 @@ int32 CFE_EVS_DisableAppEventTypeCmd(const CFE_EVS_DisableAppEventTypeCmd_t *dat
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_EnableAppEventsCmd(const CFE_EVS_EnableAppEventsCmd_t *data)
+CFE_Status_t CFE_EVS_EnableAppEventsCmd(const CFE_EVS_EnableAppEventsCmd_t *data)
 {
-    EVS_AppData_t *                     AppDataPtr;
+    EVS_AppData_t                      *AppDataPtr;
     const CFE_EVS_AppNameCmd_Payload_t *CmdPtr = &data->Payload;
-    int32                               Status;
+    CFE_Status_t                        Status;
     char                                LocalName[OS_MAX_API_NAME];
 
     /* Copy appname from command, ensures NULL termination */
@@ -831,11 +831,11 @@ int32 CFE_EVS_EnableAppEventsCmd(const CFE_EVS_EnableAppEventsCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_DisableAppEventsCmd(const CFE_EVS_DisableAppEventsCmd_t *data)
+CFE_Status_t CFE_EVS_DisableAppEventsCmd(const CFE_EVS_DisableAppEventsCmd_t *data)
 {
-    EVS_AppData_t *                     AppDataPtr;
+    EVS_AppData_t                      *AppDataPtr;
     const CFE_EVS_AppNameCmd_Payload_t *CmdPtr = &data->Payload;
-    int32                               Status;
+    CFE_Status_t                        Status;
     char                                LocalName[OS_MAX_API_NAME];
 
     /* Copy appname from command, ensures NULL termination */
@@ -878,11 +878,11 @@ int32 CFE_EVS_DisableAppEventsCmd(const CFE_EVS_DisableAppEventsCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_ResetAppCounterCmd(const CFE_EVS_ResetAppCounterCmd_t *data)
+CFE_Status_t CFE_EVS_ResetAppCounterCmd(const CFE_EVS_ResetAppCounterCmd_t *data)
 {
-    EVS_AppData_t *                     AppDataPtr;
+    EVS_AppData_t                      *AppDataPtr;
     const CFE_EVS_AppNameCmd_Payload_t *CmdPtr = &data->Payload;
-    int32                               Status;
+    CFE_Status_t                        Status;
     char                                LocalName[OS_MAX_API_NAME];
 
     /* Copy appname from command, ensures NULL termination */
@@ -926,12 +926,12 @@ int32 CFE_EVS_ResetAppCounterCmd(const CFE_EVS_ResetAppCounterCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_ResetFilterCmd(const CFE_EVS_ResetFilterCmd_t *data)
+CFE_Status_t CFE_EVS_ResetFilterCmd(const CFE_EVS_ResetFilterCmd_t *data)
 {
     const CFE_EVS_AppNameEventIDCmd_Payload_t *CmdPtr = &data->Payload;
-    EVS_BinFilter_t *                          FilterPtr;
-    int32                                      Status;
-    EVS_AppData_t *                            AppDataPtr;
+    EVS_BinFilter_t                           *FilterPtr;
+    CFE_Status_t                               Status;
+    EVS_AppData_t                             *AppDataPtr;
     char                                       LocalName[OS_MAX_API_NAME];
 
     /* Copy appname from command, ensures NULL termination */
@@ -988,11 +988,11 @@ int32 CFE_EVS_ResetFilterCmd(const CFE_EVS_ResetFilterCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_ResetAllFiltersCmd(const CFE_EVS_ResetAllFiltersCmd_t *data)
+CFE_Status_t CFE_EVS_ResetAllFiltersCmd(const CFE_EVS_ResetAllFiltersCmd_t *data)
 {
-    EVS_AppData_t *                     AppDataPtr;
+    EVS_AppData_t                      *AppDataPtr;
     const CFE_EVS_AppNameCmd_Payload_t *CmdPtr = &data->Payload;
-    int32                               Status;
+    CFE_Status_t                        Status;
     uint32                              i;
     char                                LocalName[OS_MAX_API_NAME];
 
@@ -1039,12 +1039,12 @@ int32 CFE_EVS_ResetAllFiltersCmd(const CFE_EVS_ResetAllFiltersCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_AddEventFilterCmd(const CFE_EVS_AddEventFilterCmd_t *data)
+CFE_Status_t CFE_EVS_AddEventFilterCmd(const CFE_EVS_AddEventFilterCmd_t *data)
 {
     const CFE_EVS_AppNameEventIDMaskCmd_Payload_t *CmdPtr = &data->Payload;
-    EVS_BinFilter_t *                              FilterPtr;
-    int32                                          Status;
-    EVS_AppData_t *                                AppDataPtr;
+    EVS_BinFilter_t                               *FilterPtr;
+    CFE_Status_t                                   Status;
+    EVS_AppData_t                                 *AppDataPtr;
     char                                           LocalName[OS_MAX_API_NAME];
 
     /* Copy appname from command, ensures NULL termination */
@@ -1121,12 +1121,12 @@ int32 CFE_EVS_AddEventFilterCmd(const CFE_EVS_AddEventFilterCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_DeleteEventFilterCmd(const CFE_EVS_DeleteEventFilterCmd_t *data)
+CFE_Status_t CFE_EVS_DeleteEventFilterCmd(const CFE_EVS_DeleteEventFilterCmd_t *data)
 {
     const CFE_EVS_AppNameEventIDCmd_Payload_t *CmdPtr = &data->Payload;
-    EVS_BinFilter_t *                          FilterPtr;
-    int32                                      Status;
-    EVS_AppData_t *                            AppDataPtr;
+    EVS_BinFilter_t                           *FilterPtr;
+    CFE_Status_t                               Status;
+    EVS_AppData_t                             *AppDataPtr;
     char                                       LocalName[OS_MAX_API_NAME];
 
     /* Copy appname from command, ensures NULL termination */
@@ -1185,9 +1185,9 @@ int32 CFE_EVS_DeleteEventFilterCmd(const CFE_EVS_DeleteEventFilterCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFileCmd_t *data)
+CFE_Status_t CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFileCmd_t *data)
 {
-    int32                               Result;
+    CFE_Status_t                        Result;
     osal_id_t                           FileHandle = OS_OBJECT_ID_UNDEFINED;
     int32                               OsStatus;
     int32                               BytesWritten;
@@ -1195,7 +1195,7 @@ int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFileCmd_t *data)
     uint32                              i;
     static CFE_EVS_AppDataFile_t        AppDataFile;
     CFE_FS_Header_t                     FileHdr;
-    EVS_AppData_t *                     AppDataPtr;
+    EVS_AppData_t                      *AppDataPtr;
     const CFE_EVS_AppDataCmd_Payload_t *CmdPtr = &data->Payload;
     char                                LocalName[OS_MAX_PATH_LEN];
 

--- a/modules/evs/fsw/src/cfe_evs_task.h
+++ b/modules/evs/fsw/src/cfe_evs_task.h
@@ -141,7 +141,7 @@ extern CFE_EVS_Global_t CFE_EVS_Global;
  *
  * This function performs any necessary EVS task initialization.
  */
-int32 CFE_EVS_TaskInit(void);
+CFE_Status_t CFE_EVS_TaskInit(void);
 
 /*
  * EVS Message Handler Functions
@@ -153,7 +153,7 @@ int32 CFE_EVS_TaskInit(void);
  *
  * Request for housekeeping status telemetry packet.
  */
-int32 CFE_EVS_SendHkCmd(const CFE_EVS_SendHkCmd_t *data);
+CFE_Status_t CFE_EVS_SendHkCmd(const CFE_EVS_SendHkCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -161,7 +161,7 @@ int32 CFE_EVS_SendHkCmd(const CFE_EVS_SendHkCmd_t *data);
  *
  * This function processes "noop" commands received on the EVS command pipe.
  */
-int32 CFE_EVS_NoopCmd(const CFE_EVS_NoopCmd_t *data);
+CFE_Status_t CFE_EVS_NoopCmd(const CFE_EVS_NoopCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -169,7 +169,7 @@ int32 CFE_EVS_NoopCmd(const CFE_EVS_NoopCmd_t *data);
  *
  * This function processes "clear log" commands received on the EVS command pipe.
  */
-int32 CFE_EVS_ClearLogCmd(const CFE_EVS_ClearLogCmd_t *data);
+CFE_Status_t CFE_EVS_ClearLogCmd(const CFE_EVS_ClearLogCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -177,7 +177,7 @@ int32 CFE_EVS_ClearLogCmd(const CFE_EVS_ClearLogCmd_t *data);
  *
  * This function resets all the global counter variables that are part of the task telemetry.
  */
-int32 CFE_EVS_ResetCountersCmd(const CFE_EVS_ResetCountersCmd_t *data);
+CFE_Status_t CFE_EVS_ResetCountersCmd(const CFE_EVS_ResetCountersCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -186,7 +186,7 @@ int32 CFE_EVS_ResetCountersCmd(const CFE_EVS_ResetCountersCmd_t *data);
  * This routine sets the filter mask for the given event_id in the
  * calling task's filter array
  */
-int32 CFE_EVS_SetFilterCmd(const CFE_EVS_SetFilterCmd_t *data);
+CFE_Status_t CFE_EVS_SetFilterCmd(const CFE_EVS_SetFilterCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -196,7 +196,7 @@ int32 CFE_EVS_SetFilterCmd(const CFE_EVS_SetFilterCmd_t *data);
  * @note Shifting is done so the value not masked off is placed in the ones spot:
  * necessary for comparing with true.
  */
-int32 CFE_EVS_EnablePortsCmd(const CFE_EVS_EnablePortsCmd_t *data);
+CFE_Status_t CFE_EVS_EnablePortsCmd(const CFE_EVS_EnablePortsCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -206,7 +206,7 @@ int32 CFE_EVS_EnablePortsCmd(const CFE_EVS_EnablePortsCmd_t *data);
  * @note Shifting is done so the value not masked off is placed in the ones spot:
  * necessary for comparing with true.
  */
-int32 CFE_EVS_DisablePortsCmd(const CFE_EVS_DisablePortsCmd_t *data);
+CFE_Status_t CFE_EVS_DisablePortsCmd(const CFE_EVS_DisablePortsCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -215,7 +215,7 @@ int32 CFE_EVS_DisablePortsCmd(const CFE_EVS_DisablePortsCmd_t *data);
  * This routine sets the given event types to an enabled state across all
  * registered applications
  */
-int32 CFE_EVS_EnableEventTypeCmd(const CFE_EVS_EnableEventTypeCmd_t *data);
+CFE_Status_t CFE_EVS_EnableEventTypeCmd(const CFE_EVS_EnableEventTypeCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -224,7 +224,7 @@ int32 CFE_EVS_EnableEventTypeCmd(const CFE_EVS_EnableEventTypeCmd_t *data);
  * This routine sets the given event types to a disabled state across all
  * registered applications
  */
-int32 CFE_EVS_DisableEventTypeCmd(const CFE_EVS_DisableEventTypeCmd_t *data);
+CFE_Status_t CFE_EVS_DisableEventTypeCmd(const CFE_EVS_DisableEventTypeCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -232,7 +232,7 @@ int32 CFE_EVS_DisableEventTypeCmd(const CFE_EVS_DisableEventTypeCmd_t *data);
  *
  * This routine sets the Event Format Mode
  */
-int32 CFE_EVS_SetEventFormatModeCmd(const CFE_EVS_SetEventFormatModeCmd_t *data);
+CFE_Status_t CFE_EVS_SetEventFormatModeCmd(const CFE_EVS_SetEventFormatModeCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -241,7 +241,7 @@ int32 CFE_EVS_SetEventFormatModeCmd(const CFE_EVS_SetEventFormatModeCmd_t *data)
  * This routine sets the given event type for the given application identifier to an
  * enabled state
  */
-int32 CFE_EVS_EnableAppEventTypeCmd(const CFE_EVS_EnableAppEventTypeCmd_t *data);
+CFE_Status_t CFE_EVS_EnableAppEventTypeCmd(const CFE_EVS_EnableAppEventTypeCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -250,7 +250,7 @@ int32 CFE_EVS_EnableAppEventTypeCmd(const CFE_EVS_EnableAppEventTypeCmd_t *data)
  * This routine sets the given event type for the given application identifier to a
  * disabled state
  */
-int32 CFE_EVS_DisableAppEventTypeCmd(const CFE_EVS_DisableAppEventTypeCmd_t *data);
+CFE_Status_t CFE_EVS_DisableAppEventTypeCmd(const CFE_EVS_DisableAppEventTypeCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -258,7 +258,7 @@ int32 CFE_EVS_DisableAppEventTypeCmd(const CFE_EVS_DisableAppEventTypeCmd_t *dat
  *
  * This routine enables application events for the given application identifier
  */
-int32 CFE_EVS_EnableAppEventsCmd(const CFE_EVS_EnableAppEventsCmd_t *data);
+CFE_Status_t CFE_EVS_EnableAppEventsCmd(const CFE_EVS_EnableAppEventsCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -266,7 +266,7 @@ int32 CFE_EVS_EnableAppEventsCmd(const CFE_EVS_EnableAppEventsCmd_t *data);
  *
  * This routine disables application events for the given application identifier
  */
-int32 CFE_EVS_DisableAppEventsCmd(const CFE_EVS_DisableAppEventsCmd_t *data);
+CFE_Status_t CFE_EVS_DisableAppEventsCmd(const CFE_EVS_DisableAppEventsCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -275,7 +275,7 @@ int32 CFE_EVS_DisableAppEventsCmd(const CFE_EVS_DisableAppEventsCmd_t *data);
  * This routine sets the application event counter to zero for the given
  * application identifier
  */
-int32 CFE_EVS_ResetAppCounterCmd(const CFE_EVS_ResetAppCounterCmd_t *data);
+CFE_Status_t CFE_EVS_ResetAppCounterCmd(const CFE_EVS_ResetAppCounterCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -284,7 +284,7 @@ int32 CFE_EVS_ResetAppCounterCmd(const CFE_EVS_ResetAppCounterCmd_t *data);
  * This routine sets the application event filter counter to zero for the given
  * application identifier and event identifier
  */
-int32 CFE_EVS_ResetFilterCmd(const CFE_EVS_ResetFilterCmd_t *data);
+CFE_Status_t CFE_EVS_ResetFilterCmd(const CFE_EVS_ResetFilterCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -293,7 +293,7 @@ int32 CFE_EVS_ResetFilterCmd(const CFE_EVS_ResetFilterCmd_t *data);
  * This routine adds the given event filter for the given application
  * identifier and event identifier.
  */
-int32 CFE_EVS_AddEventFilterCmd(const CFE_EVS_AddEventFilterCmd_t *data);
+CFE_Status_t CFE_EVS_AddEventFilterCmd(const CFE_EVS_AddEventFilterCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -302,7 +302,7 @@ int32 CFE_EVS_AddEventFilterCmd(const CFE_EVS_AddEventFilterCmd_t *data);
  * This routine deletes the event filter for the given application
  * identifier and event identifier
  */
-int32 CFE_EVS_DeleteEventFilterCmd(const CFE_EVS_DeleteEventFilterCmd_t *data);
+CFE_Status_t CFE_EVS_DeleteEventFilterCmd(const CFE_EVS_DeleteEventFilterCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -312,7 +312,7 @@ int32 CFE_EVS_DeleteEventFilterCmd(const CFE_EVS_DeleteEventFilterCmd_t *data);
  * have registered with the EVS.  The application data includes the Application ID,
  * Active Flag, Event Count, Event Types Active Flag, and Filter Data.
  */
-int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFileCmd_t *data);
+CFE_Status_t CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFileCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -321,6 +321,6 @@ int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFileCmd_t *data);
  * This routine sets all application event filter counters to zero for the given
  * application identifier
  */
-int32 CFE_EVS_ResetAllFiltersCmd(const CFE_EVS_ResetAllFiltersCmd_t *data);
+CFE_Status_t CFE_EVS_ResetAllFiltersCmd(const CFE_EVS_ResetAllFiltersCmd_t *data);
 
 #endif /* CFE_EVS_TASK_H */

--- a/modules/evs/fsw/src/cfe_evs_utils.c
+++ b/modules/evs/fsw/src/cfe_evs_utils.c
@@ -68,11 +68,11 @@ EVS_AppData_t *EVS_GetAppDataByID(CFE_ES_AppId_t AppID)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 EVS_GetCurrentContext(EVS_AppData_t **AppDataOut, CFE_ES_AppId_t *AppIDOut)
+CFE_Status_t EVS_GetCurrentContext(EVS_AppData_t **AppDataOut, CFE_ES_AppId_t *AppIDOut)
 {
     CFE_ES_AppId_t AppID;
     EVS_AppData_t *AppDataPtr;
-    int32          Status;
+    CFE_Status_t   Status;
 
     /* Get the caller's AppID */
     Status = CFE_ES_GetAppID(&AppID);
@@ -109,9 +109,9 @@ int32 EVS_GetCurrentContext(EVS_AppData_t **AppDataOut, CFE_ES_AppId_t *AppIDOut
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 EVS_GetApplicationInfo(EVS_AppData_t **AppDataOut, const char *pAppName)
+CFE_Status_t EVS_GetApplicationInfo(EVS_AppData_t **AppDataOut, const char *pAppName)
 {
-    int32          Status;
+    CFE_Status_t   Status;
     CFE_ES_AppId_t AppID;
     EVS_AppData_t *AppDataPtr;
 
@@ -150,7 +150,7 @@ int32 EVS_GetApplicationInfo(EVS_AppData_t **AppDataOut, const char *pAppName)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 EVS_NotRegistered(EVS_AppData_t *AppDataPtr, CFE_ES_AppId_t CallerID)
+CFE_Status_t EVS_NotRegistered(EVS_AppData_t *AppDataPtr, CFE_ES_AppId_t CallerID)
 {
     char AppName[OS_MAX_API_NAME];
 
@@ -591,7 +591,7 @@ void EVS_OutputPort(uint8 PortNum, char *Message)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spec, ...)
+CFE_Status_t EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spec, ...)
 {
     CFE_TIME_SysTime_t Time;
     va_list            Ptr;

--- a/modules/evs/fsw/src/cfe_evs_utils.h
+++ b/modules/evs/fsw/src/cfe_evs_utils.h
@@ -77,7 +77,7 @@ EVS_AppData_t *EVS_GetAppDataByID(CFE_ES_AppId_t AppID);
  * @param[out]   AppIDOut       Location to store AppID
  * @returns CFE_SUCCESS if successful, or relevant error code.
  */
-int32 EVS_GetCurrentContext(EVS_AppData_t **AppDataOut, CFE_ES_AppId_t *AppIDOut);
+CFE_Status_t EVS_GetCurrentContext(EVS_AppData_t **AppDataOut, CFE_ES_AppId_t *AppIDOut);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -169,7 +169,7 @@ static inline bool EVS_AppDataIsMatch(EVS_AppData_t *AppDataPtr, CFE_ES_AppId_t 
  * This routine returns the application ID and
  * status specifying the validity of the ID
  */
-int32 EVS_GetApplicationInfo(EVS_AppData_t **AppDataOut, const char *pAppName);
+CFE_Status_t EVS_GetApplicationInfo(EVS_AppData_t **AppDataOut, const char *pAppName);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -178,7 +178,7 @@ int32 EVS_GetApplicationInfo(EVS_AppData_t **AppDataOut, const char *pAppName);
  * This routine sends one "not registered" event per application
  * Assumptions and Notes:
  */
-int32 EVS_NotRegistered(EVS_AppData_t *AppDataPtr, CFE_ES_AppId_t CallerID);
+CFE_Status_t EVS_NotRegistered(EVS_AppData_t *AppDataPtr, CFE_ES_AppId_t CallerID);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -250,6 +250,6 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint1
  * This routine also does not need to acquire the mutex semaphore,
  * which can be time consuming on some platforms.
  */
-int32 EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spec, ...);
+CFE_Status_t EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spec, ...);
 
 #endif /* CFE_EVS_UTILS_H */

--- a/modules/fs/fsw/src/cfe_fs_api.c
+++ b/modules/fs/fsw/src/cfe_fs_api.c
@@ -117,9 +117,9 @@ const char *CFE_FS_GetDefaultExtension(CFE_FS_FileCategory_t FileCategory)
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, osal_id_t FileDes)
 {
-    int32 OsStatus;
-    int32 Result;
-    int32 EndianCheck = 0x01020304;
+    int32        OsStatus;
+    CFE_Status_t Result;
+    int32        EndianCheck = 0x01020304;
 
     if (Hdr == NULL)
     {
@@ -191,7 +191,7 @@ CFE_Status_t CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr)
 {
     CFE_TIME_SysTime_t Time;
     int32              OsStatus;
-    int32              Result;
+    CFE_Status_t       Result;
     int32              EndianCheck = 0x01020304;
     CFE_ES_AppId_t     AppID;
 
@@ -279,7 +279,7 @@ CFE_Status_t CFE_FS_WriteHeader(osal_id_t FileDes, CFE_FS_Header_t *Hdr)
 CFE_Status_t CFE_FS_SetTimestamp(osal_id_t FileDes, CFE_TIME_SysTime_t NewTimestamp)
 {
     int32              OsStatus;
-    int32              Result;
+    CFE_Status_t       Result;
     CFE_FS_Header_t    TempHdr;
     int32              EndianCheck  = 0x01020304;
     CFE_TIME_SysTime_t OutTimestamp = NewTimestamp;
@@ -366,18 +366,18 @@ void CFE_FS_ByteSwapUint32(uint32 *Uint32ToSwapPtr)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_FS_ParseInputFileNameEx(char *OutputBuffer, const char *InputBuffer, size_t OutputBufSize,
-                                  size_t InputBufSize, const char *DefaultInput, const char *DefaultPath,
-                                  const char *DefaultExtension)
+CFE_Status_t CFE_FS_ParseInputFileNameEx(char *OutputBuffer, const char *InputBuffer, size_t OutputBufSize,
+                                         size_t InputBufSize, const char *DefaultInput, const char *DefaultPath,
+                                         const char *DefaultExtension)
 {
-    int32       Status;
-    const char *InputPtr;
-    const char *ComponentPtr;
-    size_t      ComponentLen;
-    char        ComponentTerm;
-    size_t      OutputLen;
-    size_t      InputLen;
-    bool        LastPathReached;
+    CFE_Status_t Status;
+    const char  *InputPtr;
+    const char  *ComponentPtr;
+    size_t       ComponentLen;
+    char         ComponentTerm;
+    size_t       OutputLen;
+    size_t       InputLen;
+    bool         LastPathReached;
 
     /* The filename consists of a pathname, filename, and extension component. */
     enum
@@ -579,8 +579,8 @@ int32 CFE_FS_ParseInputFileNameEx(char *OutputBuffer, const char *InputBuffer, s
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_FS_ParseInputFileName(char *OutputBuffer, const char *InputName, size_t OutputBufSize,
-                                CFE_FS_FileCategory_t FileCategory)
+CFE_Status_t CFE_FS_ParseInputFileName(char *OutputBuffer, const char *InputName, size_t OutputBufSize,
+                                       CFE_FS_FileCategory_t FileCategory)
 {
     return CFE_FS_ParseInputFileNameEx(OutputBuffer, NULL, OutputBufSize, 0, InputName,
                                        CFE_FS_GetDefaultMountPoint(FileCategory),
@@ -595,10 +595,10 @@ int32 CFE_FS_ParseInputFileName(char *OutputBuffer, const char *InputName, size_
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_FS_ExtractFilenameFromPath(const char *OriginalPath, char *FileNameOnly)
 {
-    uint32 i, j;
-    int    StringLength;
-    int    DirMarkIdx;
-    int32  ReturnCode;
+    uint32       i, j;
+    int          StringLength;
+    int          DirMarkIdx;
+    CFE_Status_t ReturnCode;
 
     if (OriginalPath == NULL || FileNameOnly == NULL)
     {
@@ -672,13 +672,13 @@ CFE_Status_t CFE_FS_ExtractFilenameFromPath(const char *OriginalPath, char *File
  *-----------------------------------------------------------------*/
 bool CFE_FS_RunBackgroundFileDump(uint32 ElapsedTime, void *Arg)
 {
-    CFE_FS_CurrentFileState_t *       State;
+    CFE_FS_CurrentFileState_t        *State;
     CFE_FS_BackgroundFileDumpEntry_t *Curr;
-    CFE_FS_FileWriteMetaData_t *      Meta;
+    CFE_FS_FileWriteMetaData_t       *Meta;
     int32                             OsStatus;
-    int32                             Status;
+    CFE_Status_t                      Status;
     CFE_FS_Header_t                   FileHdr;
-    void *                            RecordPtr;
+    void                             *RecordPtr;
     size_t                            RecordSize;
     bool                              IsEOF;
 
@@ -828,10 +828,10 @@ bool CFE_FS_RunBackgroundFileDump(uint32 ElapsedTime, void *Arg)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_FS_BackgroundFileDumpRequest(CFE_FS_FileWriteMetaData_t *Meta)
+CFE_Status_t CFE_FS_BackgroundFileDumpRequest(CFE_FS_FileWriteMetaData_t *Meta)
 {
     CFE_FS_BackgroundFileDumpEntry_t *Curr;
-    int32                             Status;
+    CFE_Status_t                      Status;
     uint32                            PendingRequestCount;
 
     /* Pre-validate inputs */

--- a/modules/fs/fsw/src/cfe_fs_priv.c
+++ b/modules/fs/fsw/src/cfe_fs_priv.c
@@ -46,7 +46,7 @@ CFE_FS_Global_t CFE_FS_Global;
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_FS_EarlyInit(void)
+CFE_Status_t CFE_FS_EarlyInit(void)
 {
     int32 OsStatus;
 

--- a/modules/msg/fsw/src/cfe_msg_init.c
+++ b/modules/msg/fsw/src/cfe_msg_init.c
@@ -33,7 +33,7 @@
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_MSG_Size_t Size)
 {
-    int32 status;
+    CFE_Status_t status;
 
     if (MsgPtr == NULL)
     {

--- a/modules/msg/fsw/src/cfe_msg_msgid_shared.c
+++ b/modules/msg/fsw/src/cfe_msg_msgid_shared.c
@@ -32,7 +32,7 @@
 CFE_Status_t CFE_MSG_GetTypeFromMsgId(CFE_SB_MsgId_t MsgId, CFE_MSG_Type_t *Type)
 {
     CFE_MSG_Message_t msg;
-    int32             Status;
+    CFE_Status_t      Status;
 
     /* Memset to initialize avoids possible GCC bug 53119 */
     memset(&msg, 0, sizeof(msg));

--- a/modules/resourceid/fsw/src/cfe_resourceid_api.c
+++ b/modules/resourceid/fsw/src/cfe_resourceid_api.c
@@ -76,7 +76,7 @@ uint32 CFE_ResourceId_GetSerial(CFE_ResourceId_t ResourceId)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_ResourceId_ToIndex(CFE_ResourceId_t Id, uint32 BaseValue, uint32 TableSize, uint32 *Idx)
+CFE_Status_t CFE_ResourceId_ToIndex(CFE_ResourceId_t Id, uint32 BaseValue, uint32 TableSize, uint32 *Idx)
 {
     uint32 Serial;
 

--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -98,7 +98,7 @@ CFE_Status_t CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16 Depth, const c
     CFE_ES_TaskId_t  TskId;
     osal_id_t        SysQueueId;
     int32            OsStatus;
-    int32            Status;
+    CFE_Status_t     Status;
     CFE_SB_PipeD_t * PipeDscPtr;
     CFE_ResourceId_t PendingPipeId = CFE_RESOURCEID_UNDEFINED;
     uint16           PendingEventId;
@@ -281,7 +281,7 @@ CFE_Status_t CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16 Depth, const c
 CFE_Status_t CFE_SB_DeletePipe(CFE_SB_PipeId_t PipeId)
 {
     CFE_ES_AppId_t CallerId;
-    int32          Status = 0;
+    CFE_Status_t   Status = 0;
 
     /* get the callers Application Id */
     CFE_ES_GetAppID(&CallerId);
@@ -297,9 +297,9 @@ CFE_Status_t CFE_SB_DeletePipe(CFE_SB_PipeId_t PipeId)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_DeletePipeWithAppId(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId)
+CFE_Status_t CFE_SB_DeletePipeWithAppId(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId)
 {
-    int32 Status = 0;
+    CFE_Status_t Status = 0;
 
     Status = CFE_SB_DeletePipeFull(PipeId, AppId);
 
@@ -334,10 +334,10 @@ void CFE_SB_RemovePipeFromRoute(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId)
+CFE_Status_t CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId)
 {
     CFE_SB_PipeD_t *            PipeDscPtr;
-    int32                       Status;
+    CFE_Status_t                Status;
     CFE_ES_TaskId_t             TskId;
     CFE_SB_BufferD_t *          BufDscPtr;
     osal_id_t                   SysQueueId;
@@ -487,7 +487,7 @@ CFE_Status_t CFE_SB_SetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 Opts)
     CFE_ES_AppId_t  AppID;
     CFE_ES_TaskId_t TskId;
     uint16          PendingEventID;
-    int32           Status;
+    CFE_Status_t    Status;
     char            FullName[(OS_MAX_API_NAME * 2)];
 
     PendingEventID = 0;
@@ -570,7 +570,7 @@ CFE_Status_t CFE_SB_SetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 Opts)
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_SB_GetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 *OptsPtr)
 {
-    int32           Status;
+    CFE_Status_t    Status;
     CFE_ES_TaskId_t TskId;
     char            FullName[(OS_MAX_API_NAME * 2)];
     uint16          PendingEventID;
@@ -646,7 +646,7 @@ CFE_Status_t CFE_SB_GetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 *OptsPtr)
 CFE_Status_t CFE_SB_GetPipeName(char *PipeNameBuf, size_t PipeNameSize, CFE_SB_PipeId_t PipeId)
 {
     int32           OsStatus;
-    int32           Status;
+    CFE_Status_t    Status;
     CFE_ES_TaskId_t TskId;
     char            FullName[(OS_MAX_API_NAME * 2)];
     uint16          PendingEventID;
@@ -739,7 +739,7 @@ CFE_Status_t CFE_SB_GetPipeName(char *PipeNameBuf, size_t PipeNameSize, CFE_SB_P
 CFE_Status_t CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *PipeName)
 {
     int32           OsStatus;
-    int32           Status;
+    CFE_Status_t    Status;
     CFE_ES_TaskId_t TskId;
     uint32          Idx;
     char            FullName[(OS_MAX_API_NAME * 2)];
@@ -874,12 +874,12 @@ CFE_Status_t CFE_SB_Subscribe(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_Qos_t Quality, uint16 MsgLim,
-                           uint8 Scope)
+CFE_Status_t CFE_SB_SubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_Qos_t Quality, uint16 MsgLim,
+                                  uint8 Scope)
 {
     CFE_SBR_RouteId_t      RouteId;
     CFE_SB_PipeD_t *       PipeDscPtr;
-    int32                  Status;
+    CFE_Status_t           Status;
     CFE_ES_TaskId_t        TskId;
     CFE_ES_AppId_t         AppId;
     CFE_SB_DestinationD_t *DestPtr;
@@ -1116,7 +1116,7 @@ int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_
 CFE_Status_t CFE_SB_Unsubscribe(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId)
 {
     CFE_ES_AppId_t CallerId;
-    int32          Status = 0;
+    CFE_Status_t   Status = 0;
 
     /* get the callers Application Id */
     CFE_ES_GetAppID(&CallerId);
@@ -1135,7 +1135,7 @@ CFE_Status_t CFE_SB_Unsubscribe(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId)
 CFE_Status_t CFE_SB_UnsubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId)
 {
     CFE_ES_AppId_t CallerId;
-    int32          Status = 0;
+    CFE_Status_t   Status = 0;
 
     /* get the callers Application Id */
     CFE_ES_GetAppID(&CallerId);
@@ -1151,9 +1151,9 @@ CFE_Status_t CFE_SB_UnsubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeI
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_UnsubscribeWithAppId(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId)
+CFE_Status_t CFE_SB_UnsubscribeWithAppId(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId)
 {
-    int32 Status = 0;
+    CFE_Status_t Status = 0;
 
     Status = CFE_SB_UnsubscribeFull(MsgId, PipeId, (uint8)CFE_SB_MSG_LOCAL, AppId);
 
@@ -1166,9 +1166,9 @@ int32 CFE_SB_UnsubscribeWithAppId(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, 
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint8 Scope, CFE_ES_AppId_t AppId)
+CFE_Status_t CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint8 Scope, CFE_ES_AppId_t AppId)
 {
-    int32                  Status;
+    CFE_Status_t           Status;
     CFE_SBR_RouteId_t      RouteId;
     CFE_ES_TaskId_t        TskId;
     CFE_SB_DestinationD_t *DestPtr;
@@ -1290,7 +1290,7 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint8
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_SB_TransmitMsg(const CFE_MSG_Message_t *MsgPtr, bool IsOrigination)
 {
-    int32             Status;
+    CFE_Status_t      Status;
     CFE_MSG_Size_t    Size  = 0;
     CFE_SB_MsgId_t    MsgId = CFE_SB_INVALID_MSG_ID;
     CFE_ES_TaskId_t   TskId;
@@ -1393,13 +1393,13 @@ CFE_Status_t CFE_SB_TransmitMsg(const CFE_MSG_Message_t *MsgPtr, bool IsOriginat
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_TransmitMsgValidate(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgIdPtr, CFE_MSG_Size_t *SizePtr,
-                                 CFE_SBR_RouteId_t *RouteIdPtr)
+CFE_Status_t CFE_SB_TransmitMsgValidate(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgIdPtr,
+                                        CFE_MSG_Size_t *SizePtr, CFE_SBR_RouteId_t *RouteIdPtr)
 {
     CFE_ES_TaskId_t TskId;
     char            FullName[(OS_MAX_API_NAME * 2)];
     uint16          PendingEventID;
-    int32           Status;
+    CFE_Status_t    Status;
 
     PendingEventID = 0;
     Status         = CFE_SUCCESS;
@@ -1748,7 +1748,7 @@ void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_SB_ReceiveBuffer(CFE_SB_Buffer_t **BufPtr, CFE_SB_PipeId_t PipeId, int32 TimeOut)
 {
-    int32                  Status;
+    CFE_Status_t           Status;
     int32                  OsStatus;
     CFE_SB_BufferD_t *     BufDscPtr;
     size_t                 BufDscSize;
@@ -2059,7 +2059,7 @@ CFE_SB_Buffer_t *CFE_SB_AllocateMessageBuffer(size_t MsgSize)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_ZeroCopyBufferValidate(CFE_SB_Buffer_t *BufPtr, CFE_SB_BufferD_t **BufDscPtr)
+CFE_Status_t CFE_SB_ZeroCopyBufferValidate(CFE_SB_Buffer_t *BufPtr, CFE_SB_BufferD_t **BufDscPtr)
 {
     cpuaddr BufDscAddr;
 
@@ -2099,7 +2099,7 @@ int32 CFE_SB_ZeroCopyBufferValidate(CFE_SB_Buffer_t *BufPtr, CFE_SB_BufferD_t **
 CFE_Status_t CFE_SB_ReleaseMessageBuffer(CFE_SB_Buffer_t *BufPtr)
 {
     CFE_SB_BufferD_t *BufDscPtr;
-    int32             Status;
+    CFE_Status_t      Status;
 
     Status = CFE_SB_ZeroCopyBufferValidate(BufPtr, &BufDscPtr);
 
@@ -2125,7 +2125,7 @@ CFE_Status_t CFE_SB_ReleaseMessageBuffer(CFE_SB_Buffer_t *BufPtr)
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_SB_TransmitBuffer(CFE_SB_Buffer_t *BufPtr, bool IsOrigination)
 {
-    int32             Status;
+    CFE_Status_t      Status;
     CFE_SB_BufferD_t *BufDscPtr;
     CFE_SBR_RouteId_t RouteId;
 

--- a/modules/sb/fsw/src/cfe_sb_buf.c
+++ b/modules/sb/fsw/src/cfe_sb_buf.c
@@ -225,9 +225,9 @@ CFE_SB_DestinationD_t *CFE_SB_GetDestinationBlk(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_PutDestinationBlk(CFE_SB_DestinationD_t *Dest)
+CFE_Status_t CFE_SB_PutDestinationBlk(CFE_SB_DestinationD_t *Dest)
 {
-    int32 Stat;
+    CFE_Status_t Stat;
 
     if (Dest == NULL)
     {

--- a/modules/sb/fsw/src/cfe_sb_init.c
+++ b/modules/sb/fsw/src/cfe_sb_init.c
@@ -52,10 +52,10 @@ const size_t CFE_SB_MemPoolDefSize[CFE_PLATFORM_ES_POOL_MAX_BUCKETS] = {
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_EarlyInit(void)
+CFE_Status_t CFE_SB_EarlyInit(void)
 {
-    int32 OsStatus;
-    int32 Stat;
+    int32        OsStatus;
+    CFE_Status_t Stat;
 
     /* Clear task global */
     memset(&CFE_SB_Global, 0, sizeof(CFE_SB_Global));
@@ -97,9 +97,9 @@ int32 CFE_SB_EarlyInit(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_InitBuffers(void)
+CFE_Status_t CFE_SB_InitBuffers(void)
 {
-    int32 Stat = 0;
+    CFE_Status_t Stat = 0;
 
     Stat = CFE_ES_PoolCreateEx(&CFE_SB_Global.Mem.PoolHdl, CFE_SB_Global.Mem.Partition.Data,
                                CFE_PLATFORM_SB_BUF_MEMORY_BYTES, CFE_PLATFORM_ES_POOL_MAX_BUCKETS,

--- a/modules/sb/fsw/src/cfe_sb_priv.c
+++ b/modules/sb/fsw/src/cfe_sb_priv.c
@@ -84,7 +84,7 @@
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_CleanUpApp(CFE_ES_AppId_t AppId)
+CFE_Status_t CFE_SB_CleanUpApp(CFE_ES_AppId_t AppId)
 {
     uint32          i;
     uint32          DelCount;
@@ -191,7 +191,7 @@ CFE_SB_DestinationD_t *CFE_SB_GetDestPtr(CFE_SBR_RouteId_t RouteId, CFE_SB_PipeI
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_ValidateMsgId(CFE_SB_MsgId_t MsgId)
+CFE_Status_t CFE_SB_ValidateMsgId(CFE_SB_MsgId_t MsgId)
 {
     if (!CFE_SB_IsValidMsgId(MsgId))
     {
@@ -337,7 +337,7 @@ void CFE_SB_FinishSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_AddDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *NewNode)
+CFE_Status_t CFE_SB_AddDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *NewNode)
 {
     CFE_SB_DestinationD_t *WBS; /* Will Be Second (WBS) node */
     CFE_SB_DestinationD_t *listheadptr;
@@ -431,7 +431,7 @@ void CFE_SB_RemoveDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *Nod
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_ZeroCopyReleaseAppId(CFE_ES_AppId_t AppId)
+CFE_Status_t CFE_SB_ZeroCopyReleaseAppId(CFE_ES_AppId_t AppId)
 {
     CFE_SB_BufferLink_t *NextLink;
     CFE_SB_BufferD_t *   DscPtr;

--- a/modules/sb/fsw/src/cfe_sb_priv.h
+++ b/modules/sb/fsw/src/cfe_sb_priv.h
@@ -295,7 +295,7 @@ typedef struct
  *
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_AppInit(void);
+CFE_Status_t CFE_SB_AppInit(void);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -303,7 +303,7 @@ int32 CFE_SB_AppInit(void);
  *
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_InitBuffers(void);
+CFE_Status_t CFE_SB_InitBuffers(void);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -358,7 +358,7 @@ char *CFE_SB_GetAppTskName(CFE_ES_TaskId_t TaskId, char *FullName);
  * @param AppId   The application that owns the pipe
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_DeletePipeWithAppId(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId);
+CFE_Status_t CFE_SB_DeletePipeWithAppId(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -368,7 +368,7 @@ int32 CFE_SB_DeletePipeWithAppId(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId);
  *
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId);
+CFE_Status_t CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -386,8 +386,8 @@ int32 CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId);
  *
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_Qos_t Quality, uint16 MsgLim,
-                           uint8 Scope);
+CFE_Status_t CFE_SB_SubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_Qos_t Quality, uint16 MsgLim,
+                                  uint8 Scope);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -398,7 +398,7 @@ int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_
  *
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_UnsubscribeWithAppId(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId);
+CFE_Status_t CFE_SB_UnsubscribeWithAppId(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -408,7 +408,7 @@ int32 CFE_SB_UnsubscribeWithAppId(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, 
  *
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint8 Scope, CFE_ES_AppId_t AppId);
+CFE_Status_t CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint8 Scope, CFE_ES_AppId_t AppId);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -421,8 +421,8 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint8
  *
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_TransmitMsgValidate(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgIdPtr, CFE_MSG_Size_t *SizePtr,
-                                 CFE_SBR_RouteId_t *RouteIdPtr);
+CFE_Status_t CFE_SB_TransmitMsgValidate(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t *MsgIdPtr,
+                                        CFE_MSG_Size_t *SizePtr, CFE_SBR_RouteId_t *RouteIdPtr);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -436,7 +436,7 @@ int32 CFE_SB_TransmitMsgValidate(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t
  *
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_ZeroCopyReleaseAppId(CFE_ES_AppId_t AppId);
+CFE_Status_t CFE_SB_ZeroCopyReleaseAppId(CFE_ES_AppId_t AppId);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -472,7 +472,7 @@ void CFE_SB_DecrBufUseCnt(CFE_SB_BufferD_t *bd);
  * SB internal function to validate a given MsgId.
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_ValidateMsgId(CFE_SB_MsgId_t MsgId);
+CFE_Status_t CFE_SB_ValidateMsgId(CFE_SB_MsgId_t MsgId);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -500,7 +500,7 @@ void CFE_SB_SetSubscriptionReporting(uint32 state);
  *
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_SendSubscriptionReport(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_Qos_t Quality);
+CFE_Status_t CFE_SB_SendSubscriptionReport(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_Qos_t Quality);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -541,7 +541,7 @@ CFE_SB_DestinationD_t *CFE_SB_GetDestinationBlk(void);
  *
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_PutDestinationBlk(CFE_SB_DestinationD_t *Dest);
+CFE_Status_t CFE_SB_PutDestinationBlk(CFE_SB_DestinationD_t *Dest);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -663,7 +663,7 @@ void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_
  *
  * \returns CFE_SUCCESS if validation passed, or error code.
  */
-int32 CFE_SB_ZeroCopyBufferValidate(CFE_SB_Buffer_t *BufPtr, CFE_SB_BufferD_t **BufDscPtr);
+CFE_Status_t CFE_SB_ZeroCopyBufferValidate(CFE_SB_Buffer_t *BufPtr, CFE_SB_BufferD_t **BufDscPtr);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -676,7 +676,7 @@ int32 CFE_SB_ZeroCopyBufferValidate(CFE_SB_Buffer_t *BufPtr, CFE_SB_BufferD_t **
  * \param[in] RouteId The route ID to add destination node to
  * \param[in] NewNode Pointer to the destination to add
  */
-int32 CFE_SB_AddDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *NewNode);
+CFE_Status_t CFE_SB_AddDestNode(CFE_SBR_RouteId_t RouteId, CFE_SB_DestinationD_t *NewNode);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -756,7 +756,7 @@ size_t CFE_SB_MsgHdrSize(const CFE_MSG_Message_t *MsgPtr);
  * \param[in] data Pointer to command structure
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_NoopCmd(const CFE_SB_NoopCmd_t *data);
+CFE_Status_t CFE_SB_NoopCmd(const CFE_SB_NoopCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -765,7 +765,7 @@ int32 CFE_SB_NoopCmd(const CFE_SB_NoopCmd_t *data);
  * \param[in] data Pointer to command structure
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_ResetCountersCmd(const CFE_SB_ResetCountersCmd_t *data);
+CFE_Status_t CFE_SB_ResetCountersCmd(const CFE_SB_ResetCountersCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -774,7 +774,7 @@ int32 CFE_SB_ResetCountersCmd(const CFE_SB_ResetCountersCmd_t *data);
  * \param[in] data Pointer to command structure
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_EnableSubReportingCmd(const CFE_SB_EnableSubReportingCmd_t *data);
+CFE_Status_t CFE_SB_EnableSubReportingCmd(const CFE_SB_EnableSubReportingCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -783,7 +783,7 @@ int32 CFE_SB_EnableSubReportingCmd(const CFE_SB_EnableSubReportingCmd_t *data);
  * \param[in] data Pointer to command structure
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_DisableSubReportingCmd(const CFE_SB_DisableSubReportingCmd_t *data);
+CFE_Status_t CFE_SB_DisableSubReportingCmd(const CFE_SB_DisableSubReportingCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -794,7 +794,7 @@ int32 CFE_SB_DisableSubReportingCmd(const CFE_SB_DisableSubReportingCmd_t *data)
  * \param[in] data Pointer to command structure
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_SendHKTlmCmd(const CFE_SB_SendHkCmd_t *data);
+CFE_Status_t CFE_SB_SendHKTlmCmd(const CFE_SB_SendHkCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -806,7 +806,7 @@ int32 CFE_SB_SendHKTlmCmd(const CFE_SB_SendHkCmd_t *data);
  * \param[in] data Pointer to command structure
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data);
+CFE_Status_t CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -818,7 +818,7 @@ int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data);
  * \param[in] data Pointer to command structure
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data);
+CFE_Status_t CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -829,7 +829,7 @@ int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data);
  * \param[in] data Pointer to command structure
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_SendStatsCmd(const CFE_SB_SendSbStatsCmd_t *data);
+CFE_Status_t CFE_SB_SendStatsCmd(const CFE_SB_SendSbStatsCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -840,7 +840,7 @@ int32 CFE_SB_SendStatsCmd(const CFE_SB_SendSbStatsCmd_t *data);
  * \param[in] data Pointer to command structure
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_WriteRoutingInfoCmd(const CFE_SB_WriteRoutingInfoCmd_t *data);
+CFE_Status_t CFE_SB_WriteRoutingInfoCmd(const CFE_SB_WriteRoutingInfoCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -851,7 +851,7 @@ int32 CFE_SB_WriteRoutingInfoCmd(const CFE_SB_WriteRoutingInfoCmd_t *data);
  * \param[in] data Pointer to command structure
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_WritePipeInfoCmd(const CFE_SB_WritePipeInfoCmd_t *data);
+CFE_Status_t CFE_SB_WritePipeInfoCmd(const CFE_SB_WritePipeInfoCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -862,7 +862,7 @@ int32 CFE_SB_WritePipeInfoCmd(const CFE_SB_WritePipeInfoCmd_t *data);
  * \param[in] data Pointer to command structure
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_WriteMapInfoCmd(const CFE_SB_WriteMapInfoCmd_t *data);
+CFE_Status_t CFE_SB_WriteMapInfoCmd(const CFE_SB_WriteMapInfoCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -875,7 +875,7 @@ int32 CFE_SB_WriteMapInfoCmd(const CFE_SB_WriteMapInfoCmd_t *data);
  * \param[in] data Pointer to command structure
  * \return Execution status, see \ref CFEReturnCodes
  */
-int32 CFE_SB_SendPrevSubsCmd(const CFE_SB_SendPrevSubsCmd_t *data);
+CFE_Status_t CFE_SB_SendPrevSubsCmd(const CFE_SB_SendPrevSubsCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**

--- a/modules/sb/fsw/src/cfe_sb_task.c
+++ b/modules/sb/fsw/src/cfe_sb_task.c
@@ -57,7 +57,7 @@ typedef struct
  *-----------------------------------------------------------------*/
 void CFE_SB_TaskMain(void)
 {
-    int32            Status;
+    CFE_Status_t     Status;
     CFE_SB_Buffer_t *SBBufPtr;
 
     CFE_ES_PerfLogEntry(CFE_MISSION_SB_MAIN_PERF_ID);
@@ -115,11 +115,11 @@ void CFE_SB_TaskMain(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_AppInit(void)
+CFE_Status_t CFE_SB_AppInit(void)
 {
     uint32              CfgFileEventsToFilter = 0;
     CFE_ES_MemPoolBuf_t TmpPtr;
-    int32               Status;
+    CFE_Status_t        Status;
     char                VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
 
     /* Get the assigned Application ID for the SB Task */
@@ -287,7 +287,7 @@ int32 CFE_SB_AppInit(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_NoopCmd(const CFE_SB_NoopCmd_t *data)
+CFE_Status_t CFE_SB_NoopCmd(const CFE_SB_NoopCmd_t *data)
 {
     char VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
     CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE",
@@ -304,7 +304,7 @@ int32 CFE_SB_NoopCmd(const CFE_SB_NoopCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_ResetCountersCmd(const CFE_SB_ResetCountersCmd_t *data)
+CFE_Status_t CFE_SB_ResetCountersCmd(const CFE_SB_ResetCountersCmd_t *data)
 {
     CFE_EVS_SendEvent(CFE_SB_CMD1_RCVD_EID, CFE_EVS_EventType_DEBUG, "Reset Counters Cmd Rcvd");
 
@@ -319,7 +319,7 @@ int32 CFE_SB_ResetCountersCmd(const CFE_SB_ResetCountersCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_EnableSubReportingCmd(const CFE_SB_EnableSubReportingCmd_t *data)
+CFE_Status_t CFE_SB_EnableSubReportingCmd(const CFE_SB_EnableSubReportingCmd_t *data)
 {
     CFE_SB_SetSubscriptionReporting(CFE_SB_ENABLE);
     return CFE_SUCCESS;
@@ -331,7 +331,7 @@ int32 CFE_SB_EnableSubReportingCmd(const CFE_SB_EnableSubReportingCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_DisableSubReportingCmd(const CFE_SB_DisableSubReportingCmd_t *data)
+CFE_Status_t CFE_SB_DisableSubReportingCmd(const CFE_SB_DisableSubReportingCmd_t *data)
 {
     CFE_SB_SetSubscriptionReporting(CFE_SB_DISABLE);
     return CFE_SUCCESS;
@@ -343,7 +343,7 @@ int32 CFE_SB_DisableSubReportingCmd(const CFE_SB_DisableSubReportingCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_SendHKTlmCmd(const CFE_SB_SendHkCmd_t *data)
+CFE_Status_t CFE_SB_SendHKTlmCmd(const CFE_SB_SendHkCmd_t *data)
 {
     CFE_SB_LockSharedData(__FILE__, __LINE__);
 
@@ -386,7 +386,7 @@ void CFE_SB_ResetCounters(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data)
+CFE_Status_t CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data)
 {
     CFE_SB_MsgId_t                   MsgId;
     CFE_SB_PipeD_t *                 PipeDscPtr;
@@ -453,7 +453,7 @@ int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data)
+CFE_Status_t CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data)
 {
     CFE_SB_MsgId_t                   MsgId;
     CFE_SB_PipeD_t *                 PipeDscPtr;
@@ -520,7 +520,7 @@ int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_SendStatsCmd(const CFE_SB_SendSbStatsCmd_t *data)
+CFE_Status_t CFE_SB_SendStatsCmd(const CFE_SB_SendSbStatsCmd_t *data)
 {
     uint32                   PipeDscCount;
     uint32                   PipeStatCount;
@@ -659,10 +659,10 @@ void CFE_SB_CollectRouteInfo(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_SendSubscriptionReport(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_Qos_t Quality)
+CFE_Status_t CFE_SB_SendSubscriptionReport(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_Qos_t Quality)
 {
     CFE_SB_SingleSubscriptionTlm_t SubRptMsg;
-    int32                          Status = CFE_SUCCESS;
+    CFE_Status_t                   Status = CFE_SUCCESS;
 
     memset(&SubRptMsg, 0, sizeof(SubRptMsg));
 
@@ -770,11 +770,11 @@ void CFE_SB_BackgroundFileEventHandler(void *Meta, CFE_FS_FileWriteEvent_t Event
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_WriteRoutingInfoCmd(const CFE_SB_WriteRoutingInfoCmd_t *data)
+CFE_Status_t CFE_SB_WriteRoutingInfoCmd(const CFE_SB_WriteRoutingInfoCmd_t *data)
 {
     const CFE_SB_WriteFileInfoCmd_Payload_t *CmdPtr;
     CFE_SB_BackgroundFileStateInfo_t *       StatePtr;
-    int32                                    Status;
+    CFE_Status_t                             Status;
 
     StatePtr = &CFE_SB_Global.BackgroundFile;
     CmdPtr   = &data->Payload;
@@ -909,11 +909,11 @@ bool CFE_SB_WritePipeInfoDataGetter(void *Meta, uint32 RecordNum, void **Buffer,
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_WritePipeInfoCmd(const CFE_SB_WritePipeInfoCmd_t *data)
+CFE_Status_t CFE_SB_WritePipeInfoCmd(const CFE_SB_WritePipeInfoCmd_t *data)
 {
     const CFE_SB_WriteFileInfoCmd_Payload_t *CmdPtr;
     CFE_SB_BackgroundFileStateInfo_t *       StatePtr;
-    int32                                    Status;
+    CFE_Status_t                             Status;
 
     StatePtr = &CFE_SB_Global.BackgroundFile;
     CmdPtr   = &data->Payload;
@@ -1033,11 +1033,11 @@ bool CFE_SB_WriteMsgMapInfoDataGetter(void *Meta, uint32 RecordNum, void **Buffe
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_WriteMapInfoCmd(const CFE_SB_WriteMapInfoCmd_t *data)
+CFE_Status_t CFE_SB_WriteMapInfoCmd(const CFE_SB_WriteMapInfoCmd_t *data)
 {
     const CFE_SB_WriteFileInfoCmd_Payload_t *CmdPtr;
     CFE_SB_BackgroundFileStateInfo_t *       StatePtr;
-    int32                                    Status;
+    CFE_Status_t                             Status;
 
     StatePtr = &CFE_SB_Global.BackgroundFile;
     CmdPtr   = &data->Payload;
@@ -1098,7 +1098,7 @@ int32 CFE_SB_WriteMapInfoCmd(const CFE_SB_WriteMapInfoCmd_t *data)
 void CFE_SB_SendRouteSub(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
 {
     CFE_SB_DestinationD_t *destptr;
-    int32                  status;
+    CFE_Status_t           status;
 
     destptr = CFE_SBR_GetDestListHeadPtr(RouteId);
 
@@ -1148,9 +1148,9 @@ void CFE_SB_SendRouteSub(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_SendPrevSubsCmd(const CFE_SB_SendPrevSubsCmd_t *data)
+CFE_Status_t CFE_SB_SendPrevSubsCmd(const CFE_SB_SendPrevSubsCmd_t *data)
 {
-    int32 status;
+    CFE_Status_t status;
 
     /* Take semaphore to ensure data does not change during this function */
     CFE_SB_LockSharedData(__func__, __LINE__);

--- a/modules/sb/fsw/src/cfe_sb_util.c
+++ b/modules/sb/fsw/src/cfe_sb_util.c
@@ -128,10 +128,10 @@ void CFE_SB_TimeStampMsg(CFE_MSG_Message_t *MsgPtr)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_MessageStringGet(char *DestStringPtr, const char *SourceStringPtr, const char *DefaultString,
-                              size_t DestMaxSize, size_t SourceMaxSize)
+CFE_Status_t CFE_SB_MessageStringGet(char *DestStringPtr, const char *SourceStringPtr, const char *DefaultString,
+                                     size_t DestMaxSize, size_t SourceMaxSize)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     /*
      * Error in caller if DestMaxSize == 0.
@@ -183,10 +183,10 @@ int32 CFE_SB_MessageStringGet(char *DestStringPtr, const char *SourceStringPtr, 
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_SB_MessageStringSet(char *DestStringPtr, const char *SourceStringPtr, size_t DestMaxSize,
-                              size_t SourceMaxSize)
+CFE_Status_t CFE_SB_MessageStringSet(char *DestStringPtr, const char *SourceStringPtr, size_t DestMaxSize,
+                                     size_t SourceMaxSize)
 {
-    int32 Result;
+    CFE_Status_t Result;
 
     if (SourceStringPtr == NULL || DestStringPtr == NULL)
     {

--- a/modules/tbl/fsw/src/cfe_tbl_api.c
+++ b/modules/tbl/fsw/src/cfe_tbl_api.c
@@ -49,7 +49,7 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
 {
     CFE_TBL_TxnState_t     Txn;
     CFE_TBL_RegistryRec_t *RegRecPtr     = NULL;
-    CFE_TBL_CritRegRec_t * CritRegRecPtr = NULL;
+    CFE_TBL_CritRegRec_t  *CritRegRecPtr = NULL;
     CFE_Status_t           Status;
     CFE_ES_AppId_t         ThisAppId;
     char                   AppName[OS_MAX_API_NAME]           = {"UNKNOWN"};
@@ -211,10 +211,10 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
 CFE_Status_t CFE_TBL_Share(CFE_TBL_Handle_t *TblHandlePtr, const char *TblName)
 {
     CFE_TBL_TxnState_t          Txn;
-    int32                       Status;
+    CFE_Status_t                Status;
     CFE_ES_AppId_t              ThisAppId;
     CFE_TBL_AccessDescriptor_t *AccessDescPtr            = NULL;
-    CFE_TBL_RegistryRec_t *     RegRecPtr                = NULL;
+    CFE_TBL_RegistryRec_t      *RegRecPtr                = NULL;
     char                        AppName[OS_MAX_API_NAME] = {"UNKNOWN"};
 
     if (TblHandlePtr == NULL || TblName == NULL)
@@ -292,7 +292,7 @@ CFE_Status_t CFE_TBL_Share(CFE_TBL_Handle_t *TblHandlePtr, const char *TblName)
 CFE_Status_t CFE_TBL_Unregister(CFE_TBL_Handle_t TblHandle)
 {
     CFE_TBL_TxnState_t     Txn;
-    int32                  Status;
+    CFE_Status_t           Status;
     CFE_ES_AppId_t         ThisAppId;
     CFE_TBL_RegistryRec_t *RegRecPtr                = NULL;
     char                   AppName[OS_MAX_API_NAME] = {"UNKNOWN"};
@@ -356,11 +356,11 @@ CFE_Status_t CFE_TBL_Unregister(CFE_TBL_Handle_t TblHandle)
 CFE_Status_t CFE_TBL_Load(CFE_TBL_Handle_t TblHandle, CFE_TBL_SrcEnum_t SrcType, const void *SrcDataPtr)
 {
     CFE_TBL_TxnState_t          Txn;
-    int32                       Status;
+    CFE_Status_t                Status;
     CFE_ES_AppId_t              ThisAppId;
-    CFE_TBL_LoadBuff_t *        WorkingBufferPtr;
+    CFE_TBL_LoadBuff_t         *WorkingBufferPtr;
     CFE_TBL_AccessDescriptor_t *AccessDescPtr;
-    CFE_TBL_RegistryRec_t *     RegRecPtr;
+    CFE_TBL_RegistryRec_t      *RegRecPtr;
     char                        AppName[OS_MAX_API_NAME] = {"UNKNOWN"};
     bool                        FirstTime                = false;
 
@@ -596,9 +596,9 @@ CFE_Status_t CFE_TBL_Load(CFE_TBL_Handle_t TblHandle, CFE_TBL_SrcEnum_t SrcType,
 CFE_Status_t CFE_TBL_Update(CFE_TBL_Handle_t TblHandle)
 {
     CFE_TBL_TxnState_t          Txn;
-    int32                       Status;
+    CFE_Status_t                Status;
     CFE_ES_AppId_t              ThisAppId;
-    CFE_TBL_RegistryRec_t *     RegRecPtr                = NULL;
+    CFE_TBL_RegistryRec_t      *RegRecPtr                = NULL;
     CFE_TBL_AccessDescriptor_t *AccessDescPtr            = NULL;
     char                        AppName[OS_MAX_API_NAME] = {"UNKNOWN"};
 
@@ -672,7 +672,7 @@ CFE_Status_t CFE_TBL_Update(CFE_TBL_Handle_t TblHandle)
 CFE_Status_t CFE_TBL_GetAddress(void **TblPtr, CFE_TBL_Handle_t TblHandle)
 {
     CFE_TBL_TxnState_t Txn;
-    int32              Status;
+    CFE_Status_t       Status;
     CFE_ES_AppId_t     ThisAppId;
 
     if (TblPtr == NULL)
@@ -714,7 +714,7 @@ CFE_Status_t CFE_TBL_GetAddress(void **TblPtr, CFE_TBL_Handle_t TblHandle)
 CFE_Status_t CFE_TBL_ReleaseAddress(CFE_TBL_Handle_t TblHandle)
 {
     CFE_TBL_TxnState_t Txn;
-    int32              Status;
+    CFE_Status_t       Status;
     CFE_ES_AppId_t     ThisAppId;
 
     /* Verify that this application has the right to perform operation */
@@ -756,7 +756,7 @@ CFE_Status_t CFE_TBL_GetAddresses(void **TblPtrs[], uint16 NumTables, const CFE_
     CFE_TBL_TxnState_t Txn;
     CFE_Status_t       FinalStatus;
     uint16             i;
-    int32              Status;
+    CFE_Status_t       Status;
     CFE_ES_AppId_t     ThisAppId;
 
     if (TblPtrs == NULL || TblHandles == NULL)
@@ -840,7 +840,7 @@ CFE_Status_t CFE_TBL_ReleaseAddresses(uint16 NumTables, const CFE_TBL_Handle_t T
 CFE_Status_t CFE_TBL_Validate(CFE_TBL_Handle_t TblHandle)
 {
     CFE_TBL_TxnState_t     Txn;
-    int32                  Status;
+    CFE_Status_t           Status;
     CFE_ES_AppId_t         ThisAppId;
     CFE_TBL_RegistryRec_t *RegRecPtr;
     char                   AppName[OS_MAX_API_NAME] = {"UNKNOWN"};
@@ -988,8 +988,8 @@ CFE_Status_t CFE_TBL_Validate(CFE_TBL_Handle_t TblHandle)
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_TBL_Manage(CFE_TBL_Handle_t TblHandle)
 {
-    int32 Status           = CFE_SUCCESS;
-    bool  FinishedManaging = false;
+    CFE_Status_t Status           = CFE_SUCCESS;
+    bool         FinishedManaging = false;
 
     while (!FinishedManaging)
     {
@@ -1047,7 +1047,7 @@ CFE_Status_t CFE_TBL_Manage(CFE_TBL_Handle_t TblHandle)
 CFE_Status_t CFE_TBL_GetStatus(CFE_TBL_Handle_t TblHandle)
 {
     CFE_TBL_TxnState_t Txn;
-    int32              Status;
+    CFE_Status_t       Status;
     CFE_ES_AppId_t     ThisAppId;
 
     /* Verify that this application has the right to perform operation */
@@ -1079,7 +1079,7 @@ CFE_Status_t CFE_TBL_GetStatus(CFE_TBL_Handle_t TblHandle)
 CFE_Status_t CFE_TBL_GetInfo(CFE_TBL_Info_t *TblInfoPtr, const char *TblName)
 {
     CFE_TBL_TxnState_t     Txn;
-    int32                  Status               = CFE_SUCCESS;
+    CFE_Status_t           Status               = CFE_SUCCESS;
     int32                  NumAccessDescriptors = 0;
     CFE_TBL_RegistryRec_t *RegRecPtr;
 
@@ -1131,7 +1131,7 @@ CFE_Status_t CFE_TBL_GetInfo(CFE_TBL_Info_t *TblInfoPtr, const char *TblName)
 CFE_Status_t CFE_TBL_DumpToBuffer(CFE_TBL_Handle_t TblHandle)
 {
     CFE_TBL_TxnState_t     Txn;
-    int32                  Status;
+    CFE_Status_t           Status;
     CFE_TBL_RegistryRec_t *RegRecPtr   = NULL;
     CFE_TBL_DumpControl_t *DumpCtrlPtr = NULL;
     CFE_ES_AppId_t         ThisAppId;
@@ -1203,7 +1203,7 @@ static void CFE_TBL_NotifyOtherAppHelper(CFE_TBL_AccessDescriptor_t *AccessDescP
 CFE_Status_t CFE_TBL_Modified(CFE_TBL_Handle_t TblHandle)
 {
     CFE_TBL_TxnState_t     Txn;
-    int32                  Status;
+    CFE_Status_t           Status;
     CFE_TBL_RegistryRec_t *RegRecPtr = NULL;
     CFE_ES_AppId_t         ThisAppId;
     size_t                 FilenameLen;
@@ -1266,7 +1266,7 @@ CFE_Status_t CFE_TBL_NotifyByMessage(CFE_TBL_Handle_t TblHandle, CFE_SB_MsgId_t 
                                      uint32 Parameter)
 {
     CFE_TBL_TxnState_t     Txn;
-    int32                  Status;
+    CFE_Status_t           Status;
     CFE_TBL_RegistryRec_t *RegRecPtr = NULL;
     CFE_ES_AppId_t         ThisAppId;
 

--- a/modules/tbl/fsw/src/cfe_tbl_internal.c
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.c
@@ -66,12 +66,12 @@ static void CFE_TBL_CheckInactiveBufferHelper(CFE_TBL_AccessDescriptor_t *AccDes
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TBL_EarlyInit(void)
+CFE_Status_t CFE_TBL_EarlyInit(void)
 {
-    uint16 i;
-    uint32 j;
-    int32  OsStatus;
-    int32  Status;
+    uint16       i;
+    uint32       j;
+    int32        OsStatus;
+    CFE_Status_t Status;
 
     /* Clear task global */
     memset(&CFE_TBL_Global, 0, sizeof(CFE_TBL_Global));
@@ -278,10 +278,10 @@ void CFE_TBL_FormTableName(char *FullTblName, const char *TblName, CFE_ES_AppId_
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TBL_LockRegistry(void)
+CFE_Status_t CFE_TBL_LockRegistry(void)
 {
-    int32 OsStatus;
-    int32 Status;
+    int32        OsStatus;
+    CFE_Status_t Status;
 
     OsStatus = OS_MutSemTake(CFE_TBL_Global.RegistryMutex);
 
@@ -303,10 +303,10 @@ int32 CFE_TBL_LockRegistry(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TBL_UnlockRegistry(void)
+CFE_Status_t CFE_TBL_UnlockRegistry(void)
 {
-    int32 OsStatus;
-    int32 Status;
+    int32        OsStatus;
+    CFE_Status_t Status;
 
     OsStatus = OS_MutSemGive(CFE_TBL_Global.RegistryMutex);
 
@@ -328,10 +328,10 @@ int32 CFE_TBL_UnlockRegistry(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr, CFE_TBL_RegistryRec_t *RegRecPtr,
-                               bool CalledByApp)
+CFE_Status_t CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr, CFE_TBL_RegistryRec_t *RegRecPtr,
+                                      bool CalledByApp)
 {
-    int32                         Status = CFE_SUCCESS;
+    CFE_Status_t                  Status = CFE_SUCCESS;
     int32                         OsStatus;
     int32                         i;
     CFE_TBL_CheckInactiveBuffer_t CheckStat;
@@ -457,10 +457,10 @@ int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr, CFE_TBL_Re
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBufferPtr, CFE_TBL_RegistryRec_t *RegRecPtr,
-                           const char *Filename)
+CFE_Status_t CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBufferPtr,
+                                  CFE_TBL_RegistryRec_t *RegRecPtr, const char *Filename)
 {
-    int32              Status = CFE_SUCCESS;
+    CFE_Status_t       Status = CFE_SUCCESS;
     int32              OsStatus;
     CFE_FS_Header_t    StdFileHeader;
     CFE_TBL_File_Hdr_t TblFileHeader;
@@ -615,11 +615,11 @@ static void CFE_TBL_CheckLockHelper(CFE_TBL_AccessDescriptor_t *AccDescPtr, void
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TBL_UpdateInternal(CFE_TBL_Handle_t TblHandle, CFE_TBL_RegistryRec_t *RegRecPtr,
-                             CFE_TBL_AccessDescriptor_t *AccessDescPtr)
+CFE_Status_t CFE_TBL_UpdateInternal(CFE_TBL_Handle_t TblHandle, CFE_TBL_RegistryRec_t *RegRecPtr,
+                                    CFE_TBL_AccessDescriptor_t *AccessDescPtr)
 {
-    int32 Status     = CFE_SUCCESS;
-    bool  LockStatus = false;
+    CFE_Status_t Status     = CFE_SUCCESS;
+    bool         LockStatus = false;
 
     if ((!RegRecPtr->LoadPending) || (RegRecPtr->LoadInProgress == CFE_TBL_NO_LOAD_IN_PROGRESS))
     {
@@ -737,12 +737,12 @@ void CFE_TBL_NotifyTblUsersOfUpdate(CFE_TBL_RegistryRec_t *RegRecPtr)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TBL_ReadHeaders(osal_id_t FileDescriptor, CFE_FS_Header_t *StdFileHeaderPtr,
-                          CFE_TBL_File_Hdr_t *TblFileHeaderPtr, const char *LoadFilename)
+CFE_Status_t CFE_TBL_ReadHeaders(osal_id_t FileDescriptor, CFE_FS_Header_t *StdFileHeaderPtr,
+                                 CFE_TBL_File_Hdr_t *TblFileHeaderPtr, const char *LoadFilename)
 {
-    int32 Status;
-    int32 OsStatus;
-    int32 EndianCheck = 0x01020304;
+    CFE_Status_t Status;
+    int32        OsStatus;
+    int32        EndianCheck = 0x01020304;
 
 #if (CFE_PLATFORM_TBL_VALID_SCID_COUNT > 0)
     static uint32 ListSC[2] = {CFE_PLATFORM_TBL_VALID_SCID_1, CFE_PLATFORM_TBL_VALID_SCID_2};
@@ -916,7 +916,7 @@ void CFE_TBL_ByteSwapUint32(uint32 *Uint32ToSwapPtr)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TBL_CleanUpApp(CFE_ES_AppId_t AppId)
+CFE_Status_t CFE_TBL_CleanUpApp(CFE_ES_AppId_t AppId)
 {
     uint32             i;
     CFE_TBL_TxnState_t Txn;
@@ -1004,7 +1004,7 @@ void CFE_TBL_UpdateCriticalTblCDS(CFE_TBL_RegistryRec_t *RegRecPtr)
 {
     CFE_TBL_CritRegRec_t *CritRegRecPtr = NULL;
 
-    int32 Status;
+    CFE_Status_t Status;
 
     /* Copy an image of the updated table to the CDS for safekeeping */
     Status = CFE_ES_CopyToCDS(RegRecPtr->CDSHandle, RegRecPtr->Buffers[RegRecPtr->ActiveBufferIndex].BufferPtr);
@@ -1052,9 +1052,9 @@ void CFE_TBL_UpdateCriticalTblCDS(CFE_TBL_RegistryRec_t *RegRecPtr)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TBL_SendNotificationMsg(CFE_TBL_RegistryRec_t *RegRecPtr)
+CFE_Status_t CFE_TBL_SendNotificationMsg(CFE_TBL_RegistryRec_t *RegRecPtr)
 {
-    int32 Status = CFE_SUCCESS;
+    CFE_Status_t Status = CFE_SUCCESS;
 
     /* First, determine if a message should be sent */
     if (RegRecPtr->NotifyByMsg)

--- a/modules/tbl/fsw/src/cfe_tbl_internal.h
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.h
@@ -113,7 +113,7 @@ void CFE_TBL_FormTableName(char *FullTblName, const char *TblName, CFE_ES_AppId_
 **
 ** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
 */
-int32 CFE_TBL_LockRegistry(void);
+CFE_Status_t CFE_TBL_LockRegistry(void);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -129,7 +129,7 @@ int32 CFE_TBL_LockRegistry(void);
 ** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
 **
 */
-int32 CFE_TBL_UnlockRegistry(void);
+CFE_Status_t CFE_TBL_UnlockRegistry(void);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -162,8 +162,8 @@ int32 CFE_TBL_UnlockRegistry(void);
 ** \retval #CFE_TBL_ERR_NO_BUFFER_AVAIL     \copydoc CFE_TBL_ERR_NO_BUFFER_AVAIL
 **
 */
-int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr, CFE_TBL_RegistryRec_t *RegRecPtr,
-                               bool CalledByApp);
+CFE_Status_t CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr, CFE_TBL_RegistryRec_t *RegRecPtr,
+                                      bool CalledByApp);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -205,8 +205,8 @@ int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr, CFE_TBL_Re
 ** \retval #CFE_TBL_ERR_BAD_SUBTYPE_ID       \copydoc CFE_TBL_ERR_BAD_SUBTYPE_ID
 **
 */
-int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBufferPtr, CFE_TBL_RegistryRec_t *RegRecPtr,
-                           const char *Filename);
+CFE_Status_t CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBufferPtr,
+                                  CFE_TBL_RegistryRec_t *RegRecPtr, const char *Filename);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -230,8 +230,8 @@ int32 CFE_TBL_LoadFromFile(const char *AppName, CFE_TBL_LoadBuff_t *WorkingBuffe
 **
 ** \retval #CFE_SUCCESS                     \copydoc CFE_SUCCESS
 */
-int32 CFE_TBL_UpdateInternal(CFE_TBL_Handle_t TblHandle, CFE_TBL_RegistryRec_t *RegRecPtr,
-                             CFE_TBL_AccessDescriptor_t *AccessDescPtr);
+CFE_Status_t CFE_TBL_UpdateInternal(CFE_TBL_Handle_t TblHandle, CFE_TBL_RegistryRec_t *RegRecPtr,
+                                    CFE_TBL_AccessDescriptor_t *AccessDescPtr);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -283,8 +283,8 @@ void CFE_TBL_NotifyTblUsersOfUpdate(CFE_TBL_RegistryRec_t *RegRecPtr);
 ** \retval #CFE_TBL_ERR_BAD_PROCESSOR_ID    \copydoc CFE_TBL_ERR_BAD_PROCESSOR_ID
 **
 */
-int32 CFE_TBL_ReadHeaders(osal_id_t FileDescriptor, CFE_FS_Header_t *StdFileHeaderPtr,
-                          CFE_TBL_File_Hdr_t *TblFileHeaderPtr, const char *LoadFilename);
+CFE_Status_t CFE_TBL_ReadHeaders(osal_id_t FileDescriptor, CFE_FS_Header_t *StdFileHeaderPtr,
+                                 CFE_TBL_File_Hdr_t *TblFileHeaderPtr, const char *LoadFilename);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -375,7 +375,7 @@ void CFE_TBL_UpdateCriticalTblCDS(CFE_TBL_RegistryRec_t *RegRecPtr);
 ** \param[in]  RegRecPtr Pointer to Registry Record of Table whose owner needs notifying.
 **
 */
-int32 CFE_TBL_SendNotificationMsg(CFE_TBL_RegistryRec_t *RegRecPtr);
+CFE_Status_t CFE_TBL_SendNotificationMsg(CFE_TBL_RegistryRec_t *RegRecPtr);
 
 /*---------------------------------------------------------------------------------------*/
 /**

--- a/modules/tbl/fsw/src/cfe_tbl_task.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task.c
@@ -50,7 +50,7 @@ CFE_TBL_Global_t CFE_TBL_Global;
  *-----------------------------------------------------------------*/
 void CFE_TBL_TaskMain(void)
 {
-    int32            Status;
+    CFE_Status_t     Status;
     CFE_SB_Buffer_t *SBBufPtr;
 
     CFE_ES_PerfLogEntry(CFE_MISSION_TBL_MAIN_PERF_ID);
@@ -108,10 +108,10 @@ void CFE_TBL_TaskMain(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TBL_TaskInit(void)
+CFE_Status_t CFE_TBL_TaskInit(void)
 {
-    int32 Status;
-    char  VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
+    CFE_Status_t Status;
+    char         VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
 
     /*
     ** Initialize global Table Services data
@@ -164,8 +164,8 @@ int32 CFE_TBL_TaskInit(void)
     /*
     ** Task startup event message
     */
-    CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE",
-        CFE_SRC_VERSION, CFE_BUILD_CODENAME, CFE_LAST_OFFICIAL);
+    CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE", CFE_SRC_VERSION, CFE_BUILD_CODENAME,
+                                CFE_LAST_OFFICIAL);
     Status = CFE_EVS_SendEvent(CFE_TBL_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "cFE TBL Initialized: %s",
                                VersionString);
 

--- a/modules/tbl/fsw/src/cfe_tbl_task.h
+++ b/modules/tbl/fsw/src/cfe_tbl_task.h
@@ -397,7 +397,7 @@ int16 CFE_TBL_SearchCmdHndlrTbl(CFE_SB_MsgId_t MessageID, uint16 CommandCode);
 ** \return Any of the return values from #CFE_SB_Subscribe
 ** \return Any of the return values from #CFE_EVS_SendEvent
 */
-int32 CFE_TBL_TaskInit(void);
+CFE_Status_t CFE_TBL_TaskInit(void);
 
 /*---------------------------------------------------------------------------------------*/
 /**

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
@@ -42,9 +42,9 @@
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TBL_SendHkCmd(const CFE_TBL_SendHkCmd_t *data)
+CFE_Status_t CFE_TBL_SendHkCmd(const CFE_TBL_SendHkCmd_t *data)
 {
-    int32                  Status;
+    CFE_Status_t           Status;
     int32                  OsStatus;
     uint32                 i;
     CFE_TBL_DumpControl_t *DumpCtrlPtr;
@@ -305,7 +305,7 @@ void CFE_TBL_GetTblRegData(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TBL_NoopCmd(const CFE_TBL_NoopCmd_t *data)
+CFE_Status_t CFE_TBL_NoopCmd(const CFE_TBL_NoopCmd_t *data)
 {
     char VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
 
@@ -323,7 +323,7 @@ int32 CFE_TBL_NoopCmd(const CFE_TBL_NoopCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCountersCmd_t *data)
+CFE_Status_t CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCountersCmd_t *data)
 {
     CFE_TBL_Global.CommandCounter      = 0;
     CFE_TBL_Global.CommandErrorCounter = 0;
@@ -343,14 +343,14 @@ int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCountersCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
+CFE_Status_t CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t             ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
     const CFE_TBL_LoadCmd_Payload_t *CmdPtr     = &data->Payload;
     CFE_FS_Header_t                  StdFileHeader;
     CFE_TBL_File_Hdr_t               TblFileHeader;
     osal_id_t                        FileDescriptor = OS_OBJECT_ID_UNDEFINED;
-    int32                            Status;
+    CFE_Status_t                     Status;
     int32                            OsStatus;
     int16                            RegIndex;
     CFE_TBL_RegistryRec_t *          RegRecPtr;
@@ -527,7 +527,7 @@ int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data)
+CFE_Status_t CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t             ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
     int16                            RegIndex;
@@ -538,7 +538,7 @@ int32 CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data)
     void *                           DumpDataAddr = NULL;
     CFE_TBL_LoadBuff_t *             WorkingBufferPtr;
     int32                            DumpIndex;
-    int32                            Status;
+    CFE_Status_t                     Status;
     CFE_TBL_DumpControl_t *          DumpCtrlPtr;
 
     /* Make sure all strings are null terminated before attempting to process them */
@@ -795,7 +795,7 @@ CFE_TBL_CmdProcRet_t CFE_TBL_DumpToFile(const char *DumpFilename, const char *Ta
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data)
+CFE_Status_t CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t                 ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
     int16                                RegIndex;
@@ -936,7 +936,7 @@ int32 CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TBL_ActivateCmd(const CFE_TBL_ActivateCmd_t *data)
+CFE_Status_t CFE_TBL_ActivateCmd(const CFE_TBL_ActivateCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t                 ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
     int16                                RegIndex;
@@ -1188,10 +1188,10 @@ void CFE_TBL_DumpRegistryEventHandler(void *Meta, CFE_FS_FileWriteEvent_t Event,
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data)
+CFE_Status_t CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t                     ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
-    int32                                    Status;
+    CFE_Status_t                             Status;
     const CFE_TBL_DumpRegistryCmd_Payload_t *CmdPtr = &data->Payload;
     os_fstat_t                               FileStat;
 
@@ -1249,7 +1249,7 @@ int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data)
+CFE_Status_t CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t                     ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
     int16                                    RegIndex;
@@ -1288,7 +1288,7 @@ int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data)
+CFE_Status_t CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t               ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
     const CFE_TBL_DelCDSCmd_Payload_t *CmdPtr     = &data->Payload;
@@ -1296,7 +1296,7 @@ int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data)
     CFE_TBL_CritRegRec_t *             CritRegRecPtr = NULL;
     uint32                             i;
     int16                              RegIndex;
-    int32                              Status;
+    CFE_Status_t                       Status;
 
     /* Make sure all strings are null terminated before attempting to process them */
     CFE_SB_MessageStringGet(TableName, (char *)CmdPtr->TableName, NULL, sizeof(TableName), sizeof(CmdPtr->TableName));
@@ -1376,7 +1376,7 @@ int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TBL_AbortLoadCmd(const CFE_TBL_AbortLoadCmd_t *data)
+CFE_Status_t CFE_TBL_AbortLoadCmd(const CFE_TBL_AbortLoadCmd_t *data)
 {
     CFE_TBL_CmdProcRet_t                  ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
     int16                                 RegIndex;

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.h
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.h
@@ -121,7 +121,7 @@ void CFE_TBL_GetTblRegData(void);
 **
 ** \retval #CFE_TBL_DONT_INC_CTR \copydoc CFE_TBL_DONT_INC_CTR
 */
-int32 CFE_TBL_SendHkCmd(const CFE_TBL_SendHkCmd_t *data);
+CFE_Status_t CFE_TBL_SendHkCmd(const CFE_TBL_SendHkCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -138,7 +138,7 @@ int32 CFE_TBL_SendHkCmd(const CFE_TBL_SendHkCmd_t *data);
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
 */
-int32 CFE_TBL_NoopCmd(const CFE_TBL_NoopCmd_t *data);
+CFE_Status_t CFE_TBL_NoopCmd(const CFE_TBL_NoopCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -154,7 +154,7 @@ int32 CFE_TBL_NoopCmd(const CFE_TBL_NoopCmd_t *data);
 **
 ** \retval #CFE_TBL_DONT_INC_CTR \copydoc CFE_TBL_DONT_INC_CTR
 */
-int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCountersCmd_t *data);
+CFE_Status_t CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCountersCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -172,7 +172,7 @@ int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCountersCmd_t *data);
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
 */
-int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data);
+CFE_Status_t CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -190,7 +190,7 @@ int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data);
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
 */
-int32 CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data);
+CFE_Status_t CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -209,7 +209,7 @@ int32 CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data);
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
 */
-int32 CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data);
+CFE_Status_t CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -227,7 +227,7 @@ int32 CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data);
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
 */
-int32 CFE_TBL_ActivateCmd(const CFE_TBL_ActivateCmd_t *data);
+CFE_Status_t CFE_TBL_ActivateCmd(const CFE_TBL_ActivateCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -244,7 +244,7 @@ int32 CFE_TBL_ActivateCmd(const CFE_TBL_ActivateCmd_t *data);
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
 */
-int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data);
+CFE_Status_t CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -262,7 +262,7 @@ int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data);
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
 */
-int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data);
+CFE_Status_t CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -279,7 +279,7 @@ int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data);
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
 */
-int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data);
+CFE_Status_t CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -296,7 +296,7 @@ int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data);
 ** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
 ** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
 */
-int32 CFE_TBL_AbortLoadCmd(const CFE_TBL_AbortLoadCmd_t *data);
+CFE_Status_t CFE_TBL_AbortLoadCmd(const CFE_TBL_AbortLoadCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**

--- a/modules/tbl/fsw/src/cfe_tbl_transaction.c
+++ b/modules/tbl/fsw/src/cfe_tbl_transaction.c
@@ -276,7 +276,7 @@ CFE_Status_t CFE_TBL_FindAccessDescriptorForSelf(CFE_TBL_TxnState_t *Txn)
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_TBL_TxnGetTableStatus(CFE_TBL_TxnState_t *Txn)
 {
-    int32                  Status;
+    CFE_Status_t           Status;
     CFE_TBL_RegistryRec_t *RegRecPtr = CFE_TBL_TxnRegRec(Txn);
 
     /* Perform validations prior to performing any updates */
@@ -309,7 +309,7 @@ CFE_Status_t CFE_TBL_TxnGetTableStatus(CFE_TBL_TxnState_t *Txn)
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_TBL_TxnRemoveAccessLink(CFE_TBL_TxnState_t *Txn)
 {
-    int32                       Status        = CFE_SUCCESS;
+    CFE_Status_t                Status        = CFE_SUCCESS;
     CFE_TBL_AccessDescriptor_t *AccessDescPtr = CFE_TBL_TxnAccDesc(Txn);
     CFE_TBL_RegistryRec_t *     RegRecPtr     = CFE_TBL_TxnRegRec(Txn);
 
@@ -376,7 +376,7 @@ CFE_Status_t CFE_TBL_TxnRemoveAccessLink(CFE_TBL_TxnState_t *Txn)
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_TBL_TxnGetTableAddress(CFE_TBL_TxnState_t *Txn, void **TblPtr)
 {
-    int32                       Status;
+    CFE_Status_t                Status;
     CFE_TBL_AccessDescriptor_t *AccessDescPtr = CFE_TBL_TxnAccDesc(Txn);
     CFE_TBL_RegistryRec_t *     RegRecPtr     = CFE_TBL_TxnRegRec(Txn);
     CFE_ES_AppId_t              ThisAppId;

--- a/modules/time/fsw/src/cfe_time_api.c
+++ b/modules/time/fsw/src/cfe_time_api.c
@@ -731,7 +731,7 @@ void CFE_TIME_ExternalTone(void)
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_TIME_RegisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPtr)
 {
-    int32          Status;
+    CFE_Status_t   Status;
     CFE_ES_AppId_t AppId;
     uint32         AppIndex;
 
@@ -770,7 +770,7 @@ CFE_Status_t CFE_TIME_RegisterSynchCallback(CFE_TIME_SynchCallbackPtr_t Callback
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_TIME_UnregisterSynchCallback(CFE_TIME_SynchCallbackPtr_t CallbackFuncPtr)
 {
-    int32          Status;
+    CFE_Status_t   Status;
     CFE_ES_AppId_t AppId;
     uint32         AppIndex;
 

--- a/modules/time/fsw/src/cfe_time_task.c
+++ b/modules/time/fsw/src/cfe_time_task.c
@@ -46,7 +46,7 @@ CFE_TIME_Global_t CFE_TIME_Global;
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_EarlyInit(void)
+CFE_Status_t CFE_TIME_EarlyInit(void)
 {
     /*
     ** Initialize global Time Services nonzero data...
@@ -64,7 +64,7 @@ int32 CFE_TIME_EarlyInit(void)
  *-----------------------------------------------------------------*/
 void CFE_TIME_TaskMain(void)
 {
-    int32            Status;
+    CFE_Status_t     Status;
     CFE_SB_Buffer_t *SBBufPtr;
 
     CFE_ES_PerfLogEntry(CFE_MISSION_TIME_MAIN_PERF_ID);
@@ -122,13 +122,13 @@ void CFE_TIME_TaskMain(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_TaskInit(void)
+CFE_Status_t CFE_TIME_TaskInit(void)
 {
-    int32     Status;
-    int32     OsStatus;
-    osal_id_t TimeBaseId;
-    osal_id_t TimerId;
-    char      VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
+    CFE_Status_t Status;
+    int32        OsStatus;
+    osal_id_t    TimeBaseId;
+    osal_id_t    TimerId;
+    char         VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
 
     Status = CFE_EVS_Register(NULL, 0, 0);
     if (Status != CFE_SUCCESS)
@@ -315,7 +315,7 @@ int32 CFE_TIME_TaskInit(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_SendHkCmd(const CFE_TIME_SendHkCmd_t *data)
+CFE_Status_t CFE_TIME_SendHkCmd(const CFE_TIME_SendHkCmd_t *data)
 {
     CFE_TIME_Reference_t Reference;
 
@@ -353,7 +353,7 @@ int32 CFE_TIME_SendHkCmd(const CFE_TIME_SendHkCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_ToneSignalCmd(const CFE_TIME_ToneSignalCmd_t *data)
+CFE_Status_t CFE_TIME_ToneSignalCmd(const CFE_TIME_ToneSignalCmd_t *data)
 {
     /*
     ** Indication that tone signal occurred recently...
@@ -373,7 +373,7 @@ int32 CFE_TIME_ToneSignalCmd(const CFE_TIME_ToneSignalCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_ToneDataCmd(const CFE_TIME_ToneDataCmd_t *data)
+CFE_Status_t CFE_TIME_ToneDataCmd(const CFE_TIME_ToneDataCmd_t *data)
 {
     /*
     ** This command packet contains "time at the tone" data...
@@ -393,7 +393,7 @@ int32 CFE_TIME_ToneDataCmd(const CFE_TIME_ToneDataCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_OneHzCmd(const CFE_TIME_OneHzCmd_t *data)
+CFE_Status_t CFE_TIME_OneHzCmd(const CFE_TIME_OneHzCmd_t *data)
 {
     /*
      * Run the state machine updates required at 1Hz.
@@ -424,7 +424,7 @@ int32 CFE_TIME_OneHzCmd(const CFE_TIME_OneHzCmd_t *data)
  *
  *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
-int32 CFE_TIME_ToneSendCmd(const CFE_TIME_FakeToneCmd_t *data)
+CFE_Status_t CFE_TIME_ToneSendCmd(const CFE_TIME_FakeToneCmd_t *data)
 {
     /*
     ** Request for "time at tone" data packet (probably scheduler)...
@@ -445,7 +445,7 @@ int32 CFE_TIME_ToneSendCmd(const CFE_TIME_FakeToneCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_NoopCmd(const CFE_TIME_NoopCmd_t *data)
+CFE_Status_t CFE_TIME_NoopCmd(const CFE_TIME_NoopCmd_t *data)
 {
     char VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
 
@@ -464,7 +464,7 @@ int32 CFE_TIME_NoopCmd(const CFE_TIME_NoopCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_ResetCountersCmd(const CFE_TIME_ResetCountersCmd_t *data)
+CFE_Status_t CFE_TIME_ResetCountersCmd(const CFE_TIME_ResetCountersCmd_t *data)
 {
     CFE_TIME_Global.CommandCounter      = 0;
     CFE_TIME_Global.CommandErrorCounter = 0;
@@ -502,7 +502,7 @@ int32 CFE_TIME_ResetCountersCmd(const CFE_TIME_ResetCountersCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_SendDiagnosticTlm(const CFE_TIME_SendDiagnosticCmd_t *data)
+CFE_Status_t CFE_TIME_SendDiagnosticTlm(const CFE_TIME_SendDiagnosticCmd_t *data)
 {
     CFE_TIME_Global.CommandCounter++;
 
@@ -528,7 +528,7 @@ int32 CFE_TIME_SendDiagnosticTlm(const CFE_TIME_SendDiagnosticCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_SetStateCmd(const CFE_TIME_SetStateCmd_t *data)
+CFE_Status_t CFE_TIME_SetStateCmd(const CFE_TIME_SetStateCmd_t *data)
 {
     const CFE_TIME_StateCmd_Payload_t *CommandPtr = &data->Payload;
     const char *                       ClockStateText;
@@ -577,7 +577,7 @@ int32 CFE_TIME_SetStateCmd(const CFE_TIME_SetStateCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_SetSourceCmd(const CFE_TIME_SetSourceCmd_t *data)
+CFE_Status_t CFE_TIME_SetSourceCmd(const CFE_TIME_SetSourceCmd_t *data)
 {
     const CFE_TIME_SourceCmd_Payload_t *CommandPtr = &data->Payload;
 
@@ -644,7 +644,7 @@ int32 CFE_TIME_SetSourceCmd(const CFE_TIME_SetSourceCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_SetSignalCmd(const CFE_TIME_SetSignalCmd_t *data)
+CFE_Status_t CFE_TIME_SetSignalCmd(const CFE_TIME_SetSignalCmd_t *data)
 {
     const CFE_TIME_SignalCmd_Payload_t *CommandPtr = &data->Payload;
 
@@ -759,7 +759,7 @@ void CFE_TIME_SetDelayImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIM
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_AddDelayCmd(const CFE_TIME_AddDelayCmd_t *data)
+CFE_Status_t CFE_TIME_AddDelayCmd(const CFE_TIME_AddDelayCmd_t *data)
 {
     CFE_TIME_SetDelayImpl(&data->Payload, CFE_TIME_AdjustDirection_ADD);
     return CFE_SUCCESS;
@@ -771,7 +771,7 @@ int32 CFE_TIME_AddDelayCmd(const CFE_TIME_AddDelayCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_SubDelayCmd(const CFE_TIME_SubDelayCmd_t *data)
+CFE_Status_t CFE_TIME_SubDelayCmd(const CFE_TIME_SubDelayCmd_t *data)
 {
     CFE_TIME_SetDelayImpl(&data->Payload, CFE_TIME_AdjustDirection_SUBTRACT);
     return CFE_SUCCESS;
@@ -783,7 +783,7 @@ int32 CFE_TIME_SubDelayCmd(const CFE_TIME_SubDelayCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data)
+CFE_Status_t CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data)
 {
     const CFE_TIME_TimeCmd_Payload_t *CommandPtr = &data->Payload;
 
@@ -834,7 +834,7 @@ int32 CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_SetMETCmd(const CFE_TIME_SetMETCmd_t *data)
+CFE_Status_t CFE_TIME_SetMETCmd(const CFE_TIME_SetMETCmd_t *data)
 {
     const CFE_TIME_TimeCmd_Payload_t *CommandPtr = &data->Payload;
 
@@ -885,7 +885,7 @@ int32 CFE_TIME_SetMETCmd(const CFE_TIME_SetMETCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_SetSTCFCmd(const CFE_TIME_SetSTCFCmd_t *data)
+CFE_Status_t CFE_TIME_SetSTCFCmd(const CFE_TIME_SetSTCFCmd_t *data)
 {
     const CFE_TIME_TimeCmd_Payload_t *CommandPtr = &data->Payload;
 
@@ -936,7 +936,7 @@ int32 CFE_TIME_SetSTCFCmd(const CFE_TIME_SetSTCFCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_SetLeapSecondsCmd(const CFE_TIME_SetLeapSecondsCmd_t *data)
+CFE_Status_t CFE_TIME_SetLeapSecondsCmd(const CFE_TIME_SetLeapSecondsCmd_t *data)
 {
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
 
@@ -1020,7 +1020,7 @@ void CFE_TIME_AdjustImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_AddAdjustCmd(const CFE_TIME_AddAdjustCmd_t *data)
+CFE_Status_t CFE_TIME_AddAdjustCmd(const CFE_TIME_AddAdjustCmd_t *data)
 {
     CFE_TIME_AdjustImpl(&data->Payload, CFE_TIME_AdjustDirection_ADD);
     return CFE_SUCCESS;
@@ -1032,7 +1032,7 @@ int32 CFE_TIME_AddAdjustCmd(const CFE_TIME_AddAdjustCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_SubAdjustCmd(const CFE_TIME_SubAdjustCmd_t *data)
+CFE_Status_t CFE_TIME_SubAdjustCmd(const CFE_TIME_SubAdjustCmd_t *data)
 {
     CFE_TIME_AdjustImpl(&data->Payload, CFE_TIME_AdjustDirection_SUBTRACT);
     return CFE_SUCCESS;
@@ -1081,7 +1081,7 @@ void CFE_TIME_1HzAdjImpl(const CFE_TIME_OneHzAdjustmentCmd_Payload_t *CommandPtr
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_AddOneHzAdjustmentCmd(const CFE_TIME_AddOneHzAdjustmentCmd_t *data)
+CFE_Status_t CFE_TIME_AddOneHzAdjustmentCmd(const CFE_TIME_AddOneHzAdjustmentCmd_t *data)
 {
     CFE_TIME_1HzAdjImpl(&data->Payload, CFE_TIME_AdjustDirection_ADD);
     return CFE_SUCCESS;
@@ -1093,7 +1093,7 @@ int32 CFE_TIME_AddOneHzAdjustmentCmd(const CFE_TIME_AddOneHzAdjustmentCmd_t *dat
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_SubOneHzAdjustmentCmd(const CFE_TIME_SubOneHzAdjustmentCmd_t *data)
+CFE_Status_t CFE_TIME_SubOneHzAdjustmentCmd(const CFE_TIME_SubOneHzAdjustmentCmd_t *data)
 {
     CFE_TIME_1HzAdjImpl(&data->Payload, CFE_TIME_AdjustDirection_SUBTRACT);
     return CFE_SUCCESS;

--- a/modules/time/fsw/src/cfe_time_tone.c
+++ b/modules/time/fsw/src/cfe_time_tone.c
@@ -166,7 +166,7 @@ void CFE_TIME_ToneSend(void)
  *
  *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SRC_MET == true)
-int32 CFE_TIME_ToneSendMET(CFE_TIME_SysTime_t NewMET)
+CFE_Status_t CFE_TIME_ToneSendMET(CFE_TIME_SysTime_t NewMET)
 {
     CFE_TIME_Reference_t Reference;
     CFE_TIME_SysTime_t   Expected;
@@ -175,8 +175,8 @@ int32 CFE_TIME_ToneSendMET(CFE_TIME_SysTime_t NewMET)
     CFE_TIME_Compare_t   MinResult;
     CFE_TIME_Compare_t   MaxResult;
 
-    int16 ClockState;
-    int32 Result = CFE_SUCCESS;
+    int16        ClockState;
+    CFE_Status_t Result = CFE_SUCCESS;
 
     /* Start Performance Monitoring */
     CFE_ES_PerfLogEntry(CFE_MISSION_TIME_SENDMET_PERF_ID);
@@ -297,7 +297,7 @@ int32 CFE_TIME_ToneSendMET(CFE_TIME_SysTime_t NewMET)
  *
  *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SRC_GPS == true)
-int32 CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps)
+CFE_Status_t CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps)
 {
     CFE_TIME_Reference_t Reference;
     CFE_TIME_SysTime_t   NewSTCF;
@@ -307,8 +307,8 @@ int32 CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps)
     CFE_TIME_Compare_t   MinResult;
     CFE_TIME_Compare_t   MaxResult;
 
-    int16 ClockState;
-    int32 Result = CFE_SUCCESS;
+    int16        ClockState;
+    CFE_Status_t Result = CFE_SUCCESS;
 
     /* Zero out the Reference variable because we pass it into
      * a function before using it
@@ -435,7 +435,7 @@ int32 CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps)
  *
  *-----------------------------------------------------------------*/
 #if (CFE_PLATFORM_TIME_CFG_SRC_TIME == true)
-int32 CFE_TIME_ToneSendTime(CFE_TIME_SysTime_t NewTime)
+CFE_Status_t CFE_TIME_ToneSendTime(CFE_TIME_SysTime_t NewTime)
 {
     CFE_TIME_Reference_t Reference;
     CFE_TIME_SysTime_t   NewSTCF;
@@ -445,8 +445,8 @@ int32 CFE_TIME_ToneSendTime(CFE_TIME_SysTime_t NewTime)
     CFE_TIME_Compare_t   MinResult;
     CFE_TIME_Compare_t   MaxResult;
 
-    int16 ClockState;
-    int32 Result = CFE_SUCCESS;
+    int16        ClockState;
+    CFE_Status_t Result = CFE_SUCCESS;
 
     /* Zero out the Reference variable because we pass it into
      * a function before using it

--- a/modules/time/fsw/src/cfe_time_utils.c
+++ b/modules/time/fsw/src/cfe_time_utils.c
@@ -1014,10 +1014,10 @@ void CFE_TIME_Set1HzAdj(CFE_TIME_SysTime_t NewAdjust, int16 Direction)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_CleanUpApp(CFE_ES_AppId_t AppId)
+CFE_Status_t CFE_TIME_CleanUpApp(CFE_ES_AppId_t AppId)
 {
-    int32  Status;
-    uint32 AppIndex;
+    CFE_Status_t Status;
+    uint32       AppIndex;
 
     Status = CFE_ES_AppID_ToIndex(AppId, &AppIndex);
     if (Status != CFE_SUCCESS)

--- a/modules/time/fsw/src/cfe_time_utils.h
+++ b/modules/time/fsw/src/cfe_time_utils.h
@@ -329,7 +329,7 @@ CFE_TIME_SysTime_t CFE_TIME_LatchClock(void);
 /**
  * @brief Time task initialization
  */
-int32 CFE_TIME_TaskInit(void);
+CFE_Status_t CFE_TIME_TaskInit(void);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -486,7 +486,7 @@ void CFE_TIME_ToneSend(void); /* signal to send time at tone packet */
  * "time at the tone" data command will arrive within the
  * specified window for tone and data packet verification.
  */
-int32 CFE_TIME_ToneSendMET(CFE_TIME_SysTime_t NewMET);
+CFE_Status_t CFE_TIME_ToneSendMET(CFE_TIME_SysTime_t NewMET);
 #endif
 
 #if (CFE_PLATFORM_TIME_CFG_SRC_GPS == true)
@@ -499,7 +499,7 @@ int32 CFE_TIME_ToneSendMET(CFE_TIME_SysTime_t NewMET);
  * "time at the tone" data command will arrive within the
  * specified window for tone and data packet verification.
  */
-int32 CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps);
+CFE_Status_t CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps);
 #endif
 
 #if (CFE_PLATFORM_TIME_CFG_SRC_TIME == true)
@@ -512,7 +512,7 @@ int32 CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps);
  * "time at the tone" data command will arrive within the
  * specified window for tone and data packet verification.
  */
-int32 CFE_TIME_ToneSendTime(CFE_TIME_SysTime_t NewTime);
+CFE_Status_t CFE_TIME_ToneSendTime(CFE_TIME_SysTime_t NewTime);
 #endif
 
 /*---------------------------------------------------------------------------------------*/
@@ -666,7 +666,7 @@ void CFE_TIME_Local1HzTimerCallback(osal_id_t TimerId, void *Arg);
 /**
  * @brief  Onboard command (HK request)
  */
-int32 CFE_TIME_SendHkCmd(const CFE_TIME_SendHkCmd_t *data);
+CFE_Status_t CFE_TIME_SendHkCmd(const CFE_TIME_SendHkCmd_t *data);
 
 /*
 ** Command handler for "tone signal detected"...
@@ -676,7 +676,7 @@ int32 CFE_TIME_SendHkCmd(const CFE_TIME_SendHkCmd_t *data);
 /**
  * @brief  Time at tone command (signal)
  */
-int32 CFE_TIME_ToneSignalCmd(const CFE_TIME_ToneSignalCmd_t *data);
+CFE_Status_t CFE_TIME_ToneSignalCmd(const CFE_TIME_ToneSignalCmd_t *data);
 
 /*
 ** Command handler for "time at the tone"...
@@ -686,7 +686,7 @@ int32 CFE_TIME_ToneSignalCmd(const CFE_TIME_ToneSignalCmd_t *data);
 /**
  * @brief  Time at tone command (data)
  */
-int32 CFE_TIME_ToneDataCmd(const CFE_TIME_ToneDataCmd_t *data);
+CFE_Status_t CFE_TIME_ToneDataCmd(const CFE_TIME_ToneDataCmd_t *data);
 
 /*
 ** Command handler for 1Hz signal...
@@ -702,7 +702,7 @@ int32 CFE_TIME_ToneDataCmd(const CFE_TIME_ToneDataCmd_t *data);
  * This also implements the "fake tone" functionality when that is enabled,
  * as we do not need a separate MID for this job.
  */
-int32 CFE_TIME_OneHzCmd(const CFE_TIME_OneHzCmd_t *data);
+CFE_Status_t CFE_TIME_OneHzCmd(const CFE_TIME_OneHzCmd_t *data);
 
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
 
@@ -724,7 +724,7 @@ int32 CFE_TIME_OneHzCmd(const CFE_TIME_OneHzCmd_t *data);
  *       utilizing (mostly) the same code path as the
  *       non-fake tone mode.
  */
-int32 CFE_TIME_ToneSendCmd(const CFE_TIME_FakeToneCmd_t *data);
+CFE_Status_t CFE_TIME_ToneSendCmd(const CFE_TIME_FakeToneCmd_t *data);
 #endif
 
 /*
@@ -760,7 +760,7 @@ void CFE_TIME_AdjustImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_
  *
  * This is a wrapper around CFE_TIME_1HzAdjImpl()
  */
-int32 CFE_TIME_AddOneHzAdjustmentCmd(const CFE_TIME_AddOneHzAdjustmentCmd_t *data);
+CFE_Status_t CFE_TIME_AddOneHzAdjustmentCmd(const CFE_TIME_AddOneHzAdjustmentCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -768,7 +768,7 @@ int32 CFE_TIME_AddOneHzAdjustmentCmd(const CFE_TIME_AddOneHzAdjustmentCmd_t *dat
  *
  * This is a wrapper around CFE_TIME_AdjustImpl()
  */
-int32 CFE_TIME_AddAdjustCmd(const CFE_TIME_AddAdjustCmd_t *data);
+CFE_Status_t CFE_TIME_AddAdjustCmd(const CFE_TIME_AddAdjustCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -776,7 +776,7 @@ int32 CFE_TIME_AddAdjustCmd(const CFE_TIME_AddAdjustCmd_t *data);
  *
  * Wrapper around CFE_TIME_SetDelayImpl() for add/subtract operations
  */
-int32 CFE_TIME_AddDelayCmd(const CFE_TIME_AddDelayCmd_t *data);
+CFE_Status_t CFE_TIME_AddDelayCmd(const CFE_TIME_AddDelayCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -784,31 +784,31 @@ int32 CFE_TIME_AddDelayCmd(const CFE_TIME_AddDelayCmd_t *data);
  *
  * Wrapper around CFE_TIME_SetDelayImpl() for add/subtract operations
  */
-int32 CFE_TIME_SubDelayCmd(const CFE_TIME_SubDelayCmd_t *data);
+CFE_Status_t CFE_TIME_SubDelayCmd(const CFE_TIME_SubDelayCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * @brief  Time task ground command (diagnostics)
  */
-int32 CFE_TIME_SendDiagnosticTlm(const CFE_TIME_SendDiagnosticCmd_t *data);
+CFE_Status_t CFE_TIME_SendDiagnosticTlm(const CFE_TIME_SendDiagnosticCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * @brief  Time task ground command (NOOP)
  */
-int32 CFE_TIME_NoopCmd(const CFE_TIME_NoopCmd_t *data);
+CFE_Status_t CFE_TIME_NoopCmd(const CFE_TIME_NoopCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * @brief  Time task ground command (reset counters)
  */
-int32 CFE_TIME_ResetCountersCmd(const CFE_TIME_ResetCountersCmd_t *data);
+CFE_Status_t CFE_TIME_ResetCountersCmd(const CFE_TIME_ResetCountersCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * @brief  Time task ground command (set leaps)
  */
-int32 CFE_TIME_SetLeapSecondsCmd(const CFE_TIME_SetLeapSecondsCmd_t *data);
+CFE_Status_t CFE_TIME_SetLeapSecondsCmd(const CFE_TIME_SetLeapSecondsCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -819,37 +819,37 @@ int32 CFE_TIME_SetLeapSecondsCmd(const CFE_TIME_SetLeapSecondsCmd_t *data);
  * be a local h/w MET and an external MET since both would
  * need to be synchronized to the same tone signal.
  */
-int32 CFE_TIME_SetMETCmd(const CFE_TIME_SetMETCmd_t *data);
+CFE_Status_t CFE_TIME_SetMETCmd(const CFE_TIME_SetMETCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * @brief  Time task command (set tone source)
  */
-int32 CFE_TIME_SetSignalCmd(const CFE_TIME_SetSignalCmd_t *data);
+CFE_Status_t CFE_TIME_SetSignalCmd(const CFE_TIME_SetSignalCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * @brief  Time task command (set time source)
  */
-int32 CFE_TIME_SetSourceCmd(const CFE_TIME_SetSourceCmd_t *data);
+CFE_Status_t CFE_TIME_SetSourceCmd(const CFE_TIME_SetSourceCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * @brief  Time task command (set clock state)
  */
-int32 CFE_TIME_SetStateCmd(const CFE_TIME_SetStateCmd_t *data);
+CFE_Status_t CFE_TIME_SetStateCmd(const CFE_TIME_SetStateCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * @brief  Time task ground command (set STCF)
  */
-int32 CFE_TIME_SetSTCFCmd(const CFE_TIME_SetSTCFCmd_t *data);
+CFE_Status_t CFE_TIME_SetSTCFCmd(const CFE_TIME_SetSTCFCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * @brief  Time task ground command (calc STCF)
  */
-int32 CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data);
+CFE_Status_t CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -857,7 +857,7 @@ int32 CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data);
  *
  * This is a wrapper around CFE_TIME_1HzAdjImpl()
  */
-int32 CFE_TIME_SubOneHzAdjustmentCmd(const CFE_TIME_SubOneHzAdjustmentCmd_t *data);
+CFE_Status_t CFE_TIME_SubOneHzAdjustmentCmd(const CFE_TIME_SubOneHzAdjustmentCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -865,6 +865,6 @@ int32 CFE_TIME_SubOneHzAdjustmentCmd(const CFE_TIME_SubOneHzAdjustmentCmd_t *dat
  *
  * This is a wrapper around CFE_TIME_AdjustImpl()
  */
-int32 CFE_TIME_SubAdjustCmd(const CFE_TIME_SubAdjustCmd_t *data);
+CFE_Status_t CFE_TIME_SubAdjustCmd(const CFE_TIME_SubAdjustCmd_t *data);
 
 #endif /* CFE_TIME_UTILS_H */

--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -926,7 +926,7 @@ void Test_Print(void)
 /*
 ** Test function for use with register and unregister synch callback API tests
 */
-int32 ut_time_MyCallbackFunc(void)
+CFE_Status_t ut_time_MyCallbackFunc(void)
 {
     ut_time_CallbackCalled++;
     return CFE_SUCCESS;

--- a/modules/time/ut-coverage/time_UT.h
+++ b/modules/time/ut-coverage/time_UT.h
@@ -156,7 +156,7 @@ void Test_Print(void);
 ** \returns
 **        This function returns CFE_SUCCESS
 ******************************************************************************/
-int32 ut_time_MyCallbackFunc(void);
+CFE_Status_t ut_time_MyCallbackFunc(void);
 
 /*****************************************************************************/
 /**


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #921
  - Remaining `int32` return types converted to `CFE_Status_t`.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No change to behavior/logic- `CFE_Status_t` is currently typedef'd to `int32`, so no functional change to any types with this PR.
Synchronizing the return types to `CFE_Status_t` simplifies the code, and makes it more type-safe.

**Contributor Info**
Avi Weiss @thnkslprpt