### PR TITLE
Fix #1093, Align Pipe ID/Name reporting in SB event strings

### DIFF
--- a/modules/sb/fsw/inc/cfe_sb_eventids.h
+++ b/modules/sb/fsw/inc/cfe_sb_eventids.h
@@ -661,17 +661,6 @@
 #define CFE_SB_GETPIPEOPTS_EID 60
 
 /**
- * \brief SB Get Pipe Name API Success Event ID
- *
- *  \par Type: DEBUG
- *
- *  \par Cause:
- *
- *  #CFE_SB_GetPipeName success.
- */
-#define CFE_SB_GETPIPENAME_EID 62
-
-/**
  * \brief SB Get Pipe Name API Invalid Pointer Event ID
  *
  *  \par Type: ERROR

--- a/modules/sb/fsw/src/cfe_sb_task.c
+++ b/modules/sb/fsw/src/cfe_sb_task.c
@@ -671,7 +671,7 @@ int32 CFE_SB_SendSubscriptionReport(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId
 
         Status = CFE_SB_TransmitMsg(CFE_MSG_PTR(SubRptMsg.TelemetryHeader), true);
         CFE_EVS_SendEventWithAppID(CFE_SB_SUBSCRIPTION_RPT_EID, CFE_EVS_EventType_DEBUG, CFE_SB_Global.AppId,
-                                   "Sending Subscription Report Msg=0x%x,Pipe=%lu,Stat=0x%x",
+                                   "Sending Subscription Report Msg=0x%x,Pipe=%lx,Stat=0x%x",
                                    (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(PipeId),
                                    (unsigned int)Status);
     }

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -303,7 +303,7 @@ void Test_SB_AppInit_Sub1Fail(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetPoolBuf), 1, -1);
     UtAssert_INT32_EQ(CFE_SB_AppInit(), CFE_SB_BUF_ALOC_ERR);
 
-    CFE_UtAssert_EVENTCOUNT(3);
+    CFE_UtAssert_EVENTCOUNT(2);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_DEST_BLK_ERR_EID);
 
@@ -318,7 +318,7 @@ void Test_SB_AppInit_Sub2Fail(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetPoolBuf), 2, -1);
     UtAssert_INT32_EQ(CFE_SB_AppInit(), CFE_SB_BUF_ALOC_ERR);
 
-    CFE_UtAssert_EVENTCOUNT(4);
+    CFE_UtAssert_EVENTCOUNT(3);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_DEST_BLK_ERR_EID);
 
@@ -333,7 +333,7 @@ void Test_SB_AppInit_Sub3Fail(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetPoolBuf), 3, -1);
     UtAssert_INT32_EQ(CFE_SB_AppInit(), CFE_SB_BUF_ALOC_ERR);
 
-    CFE_UtAssert_EVENTCOUNT(5);
+    CFE_UtAssert_EVENTCOUNT(4);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_DEST_BLK_ERR_EID);
 
@@ -1861,7 +1861,7 @@ void Test_DeletePipe_InvalidPipeId(void)
 
     UtAssert_INT32_EQ(CFE_SB_DeletePipe(PipeId), CFE_SB_BAD_ARGUMENT);
 
-    CFE_UtAssert_EVENTCOUNT(1);
+    CFE_UtAssert_EVENTCOUNT(2);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_DEL_PIPE_ERR1_EID);
 }
@@ -1991,8 +1991,6 @@ void Test_GetPipeName(void)
     UT_SetDataBuffer(UT_KEY(OS_QueueGetInfo), &queue_info, sizeof(queue_info), false);
 
     CFE_UtAssert_SUCCESS(CFE_SB_GetPipeName(PipeName, sizeof(PipeName), PipeId));
-
-    CFE_UtAssert_EVENTSENT(CFE_SB_GETPIPENAME_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
 }
@@ -2235,7 +2233,7 @@ void Test_Subscribe_InvalidMsgId(void)
 
     UtAssert_INT32_EQ(CFE_SB_Subscribe(MsgId, PipeId), CFE_SB_BAD_ARGUMENT);
 
-    CFE_UtAssert_EVENTCOUNT(3);
+    CFE_UtAssert_EVENTCOUNT(2);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_SUB_ARG_ERR_EID);
 
@@ -2279,7 +2277,7 @@ void Test_Subscribe_DuplicateSubscription(void)
     CFE_UtAssert_SUCCESS(CFE_SB_Subscribe(MsgId, PipeId));
     CFE_UtAssert_SUCCESS(CFE_SB_Subscribe(MsgId, PipeId));
 
-    CFE_UtAssert_EVENTCOUNT(4);
+    CFE_UtAssert_EVENTCOUNT(3);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
     CFE_UtAssert_EVENTSENT(CFE_SB_DUP_SUBSCRIP_EID);
@@ -2346,7 +2344,7 @@ void Test_Subscribe_MaxDestCount(void)
         }
     }
 
-    CFE_UtAssert_EVENTCOUNT((2 * CFE_PLATFORM_SB_MAX_DEST_PER_PKT) + 3);
+    CFE_UtAssert_EVENTCOUNT((2 * CFE_PLATFORM_SB_MAX_DEST_PER_PKT) + 2);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
     CFE_UtAssert_EVENTSENT(CFE_SB_MAX_DESTS_MET_EID);
@@ -2526,7 +2524,7 @@ void Test_Subscribe_InvalidPipeOwner(void)
     PipeDscPtr->AppId = UT_SB_AppID_Modify(RealOwner, 1);
     CFE_SB_Subscribe(MsgId, PipeId);
 
-    CFE_UtAssert_EVENTCOUNT(3);
+    CFE_UtAssert_EVENTCOUNT(2);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_SUB_INV_CALLER_EID);
 
@@ -2573,7 +2571,7 @@ void Test_Unsubscribe_Basic(void)
     /* Check unsubscribe after unsubscribe produces event */
     UT_ClearEventHistory();
     CFE_UtAssert_SUCCESS(CFE_SB_Unsubscribe(MsgId, TestPipe));
-    CFE_UtAssert_EVENTCOUNT(2);
+    CFE_UtAssert_EVENTCOUNT(1);
     CFE_UtAssert_EVENTSENT(CFE_SB_UNSUB_NO_SUBS_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe));
@@ -2617,7 +2615,7 @@ void Test_Unsubscribe_Local(void)
 
     CFE_UtAssert_SUCCESS(CFE_SB_UnsubscribeLocal(SB_UT_LAST_VALID_MID, TestPipe));
 
-    CFE_UtAssert_EVENTCOUNT(4);
+    CFE_UtAssert_EVENTCOUNT(3);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
 
@@ -2660,7 +2658,7 @@ void Test_Unsubscribe_InvalParam(void)
     /* We must restore the old value so CFE_SB_DeletePipe() works */
     PipeDscPtr->PipeId = SavedPipeId;
 
-    CFE_UtAssert_EVENTCOUNT(4);
+    CFE_UtAssert_EVENTCOUNT(5);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_UNSUB_ARG_ERR_EID);
     CFE_UtAssert_EVENTSENT(CFE_SB_UNSUB_INV_PIPE_EID);
@@ -2709,7 +2707,7 @@ void Test_Unsubscribe_InvalidPipe(void)
 
     UtAssert_INT32_EQ(CFE_SB_Unsubscribe(MsgId, SB_UT_ALTERNATE_INVALID_PIPEID), CFE_SB_BAD_ARGUMENT);
 
-    CFE_UtAssert_EVENTCOUNT(3);
+    CFE_UtAssert_EVENTCOUNT(4);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_UNSUB_INV_PIPE_EID);
 
@@ -3066,7 +3064,7 @@ void Test_TransmitMsg_QueuePutError(void)
 
     CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
 
-    CFE_UtAssert_EVENTCOUNT(4);
+    CFE_UtAssert_EVENTCOUNT(3);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_Q_WR_ERR_EID);
 
@@ -3106,7 +3104,7 @@ void Test_TransmitMsg_PipeFull(void)
     /* Pipe overflow causes TransmitMsg to return CFE_SUCCESS */
     CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
 
-    CFE_UtAssert_EVENTCOUNT(4);
+    CFE_UtAssert_EVENTCOUNT(3);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_Q_FULL_ERR_EID);
 
@@ -3148,7 +3146,7 @@ void Test_TransmitMsg_MsgLimitExceeded(void)
      */
     CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
 
-    CFE_UtAssert_EVENTCOUNT(4);
+    CFE_UtAssert_EVENTCOUNT(3);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_MSGID_LIM_ERR_EID);
 
@@ -3632,7 +3630,7 @@ void Test_ReceiveBuffer_InvalidPipeId(void)
 
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&SBBufPtr, InvalidPipeId, CFE_SB_POLL), CFE_SB_BAD_ARGUMENT);
 
-    CFE_UtAssert_EVENTCOUNT(1);
+    CFE_UtAssert_EVENTCOUNT(2);
     CFE_UtAssert_EVENTSENT(CFE_SB_BAD_PIPEID_EID);
     UtAssert_UINT8_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgReceiveErrorCounter, 1);
     UT_ClearEventHistory();
@@ -4300,7 +4298,7 @@ void Test_CFE_SB_BadPipeInfo(void)
     CFE_ES_GetAppID(&AppID);
     UtAssert_INT32_EQ(CFE_SB_DeletePipeFull(SB_UT_PIPEID_0, AppID), CFE_SB_BAD_ARGUMENT);
 
-    CFE_UtAssert_EVENTCOUNT(2);
+    CFE_UtAssert_EVENTCOUNT(3);
 
     /* Reset the pipe ID and delete the pipe */
     PipeDscPtr->PipeId = PipeId;
@@ -4390,7 +4388,7 @@ void Test_SB_TransmitMsgPaths_Nominal(void)
 
     CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
 
-    CFE_UtAssert_EVENTCOUNT(3);
+    CFE_UtAssert_EVENTCOUNT(2);
 
     /*
      * Test Additional paths within CFE_SB_TransmitMsgValidate that skip sending events to avoid a loop


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1093
  - Removed the debug event from successful execution of `CFE_SB_GetPipeName()` and deleted the `CFE_SB_GETPIPENAME_EID` (`CFE_SB_GetPipeName()` was its only instance of use)
  - Updated all SB events that include the Pipe ID/Name in the event string to use the `PipeId` for nominal/success and `PipeName` for error cases (except where deviations are desirable)
  - Updated the format specifiers for `PipeId`s to `%lx` (if they weren't already set as such)

**Expected behavior changes**
No change to behavior other than what is outlined above.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.
Local tests confirm no change to coverage.

**System(s) tested on**
Intel(R) Celeron(R) N4100 CPU @ 1.10GHz x86_64
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS.

**Contributor Info**
Avi Weiss @thnkslprpt