### PR TITLE
Fix #1443, Replace for loop copy with single memcpy

### DIFF
--- a/modules/core_api/ut-stubs/src/cfe_fs_handlers.c
+++ b/modules/core_api/ut-stubs/src/cfe_fs_handlers.c
@@ -218,7 +218,7 @@ void UT_DefaultHandler_CFE_FS_ExtractFilenameFromPath(void *UserObj, UT_EntryKey
     const char *OriginalPath = UT_Hook_GetArgValueByName(Context, "OriginalPath", const char *);
     char *      FileNameOnly = UT_Hook_GetArgValueByName(Context, "FileNameOnly", char *);
 
-    int    i, j;
+    int    i;
     int    StringLength;
     int    DirMarkIdx;
     int32  status;
@@ -269,15 +269,9 @@ void UT_DefaultHandler_CFE_FS_ExtractFilenameFromPath(void *UserObj, UT_EntryKey
                     if (DirMarkIdx > 0)
                     {
                         /* Extract the filename portion */
-                        j = 0;
-
-                        for (i = DirMarkIdx + 1; i < StringLength; i++)
-                        {
-                            FileNameOnly[j] = OriginalPath[i];
-                            j++;
-                        }
-
-                        FileNameOnly[j] = '\0';
+                        i = DirMarkIdx + 1;
+                        memcpy(FileNameOnly, OriginalPath + i, StringLength - i);
+                        FileNameOnly[(StringLength - i) + 1] = '\0';
                     }
                     else
                     {

--- a/modules/fs/fsw/src/cfe_fs_api.c
+++ b/modules/fs/fsw/src/cfe_fs_api.c
@@ -595,7 +595,7 @@ int32 CFE_FS_ParseInputFileName(char *OutputBuffer, const char *InputName, size_
  *-----------------------------------------------------------------*/
 CFE_Status_t CFE_FS_ExtractFilenameFromPath(const char *OriginalPath, char *FileNameOnly)
 {
-    uint32 i, j;
+    uint32 i;
     int    StringLength;
     int    DirMarkIdx;
     int32  ReturnCode;
@@ -640,13 +640,9 @@ CFE_Status_t CFE_FS_ExtractFilenameFromPath(const char *OriginalPath, char *File
                 /*
                 ** Extract the filename portion
                 */
-                j = 0;
-                for (i = DirMarkIdx + 1; i < StringLength; i++)
-                {
-                    FileNameOnly[j] = OriginalPath[i];
-                    j++;
-                }
-                FileNameOnly[j] = '\0';
+                i = DirMarkIdx + 1;
+                memcpy(FileNameOnly, OriginalPath + i, StringLength - i);
+                FileNameOnly[(StringLength - i) + 1] = '\0';
 
                 ReturnCode = CFE_SUCCESS;
             }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1443
   - Character-by-character copy into `FileNameOnly` replaced by single call to `memcpy()` in 2 locations.

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No change to behavior.

**Contributor Info**
Avi Weiss @thnkslprpt