### PR TITLE
Fix #1424, Add event for NumEventFilters over max and remove FilterLimit variable

### DIFF
--- a/modules/evs/fsw/inc/cfe_evs_eventids.h
+++ b/modules/evs/fsw/inc/cfe_evs_eventids.h
@@ -77,6 +77,18 @@
 #define CFE_EVS_ERR_CRLOGFILE_EID 3
 
 /**
+ * \brief EVS Requested Number of Event Message Filters Truncated Event ID
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *
+ *  The number of event message filters passed in to CFE_EVS_Register() was above
+ *  the maximum limit and was truncated to CFE_PLATFORM_EVS_MAX_EVENT_FILTERS.
+ */
+#define CFE_EVS_FILTER_LIMIT_TRUNC_ERR_EID 4
+
+/**
  * \brief EVS Invalid Message ID Received Event ID
  *
  *  \par Type: ERROR


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1424
  - Event added when `NumEventFilters` over max allowed.
  - Refactored to remove unnecessary `FilterLimit` variable.
  - Wasn't sure if it was better to add a new EID on the end or re-use one of the now open slots... - I went with the latter.

**Testing performed**
GitHub CI actions (incl. Functional Tests, Code Coverage analysis etc.) all passing successfully.

**Expected behavior changes**
Only change to behavior is the new event report added as per the description above.

**Contributor Info**
Avi Weiss @thnkslprpt