### PR TITLE
Fix #1422, Replace UT_DisplayPkt() with UtPrintx()

### DIFF
--- a/modules/core_private/ut-stubs/inc/ut_support.h
+++ b/modules/core_private/ut-stubs/inc/ut_support.h
@@ -199,6 +199,17 @@ typedef struct
 /*
 ** Functions
 */
+
+#ifndef CFE_OMIT_DEPRECATED_6_8
+/*
+** The UT_DisplayPkt() function is being deprecated and UtPrintx() should be
+** used in its place to print the contents of a specific range of memory.
+*/
+
+#define UT_DisplayPkt(MsgPtr, size) (UtPrintx(MsgPtr, size))
+
+#endif
+
 /*****************************************************************************/
 /**
 ** \brief Initialize unit test
@@ -580,27 +591,6 @@ uint32 UT_PrintfIsInHistory(const char *MsgToSearchFor);
 **
 ******************************************************************************/
 uint16 UT_GetNumEventsSent(void);
-
-/*****************************************************************************/
-/**
-** \brief Display the contents of a packet
-**
-** \par Description
-**         Display the contents of a packet.  The contents is displayed as a
-**         series of bytes in hexadecimal.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \param[in] ptr   Pointer to packet to display
-**
-** \param[in] size  Size of packet in bytes
-**
-** \returns
-**        This function does not return a value.
-**
-******************************************************************************/
-void UT_DisplayPkt(CFE_MSG_Message_t *MsgPtr, size_t size);
 
 /*****************************************************************************/
 /**

--- a/modules/core_private/ut-stubs/src/ut_support.c
+++ b/modules/core_private/ut-stubs/src/ut_support.c
@@ -532,30 +532,6 @@ uint16 UT_GetNumEventsSent(void)
     return Total;
 }
 
-/*
-** Display the contents of a packet
-*/
-void UT_DisplayPkt(CFE_MSG_Message_t *MsgPtr, size_t size)
-{
-    uint8 *BytePtr = (uint8 *)MsgPtr;
-    size_t i;
-    size_t BufSize = UT_MAX_MESSAGE_LENGTH;
-    char   DisplayMsg[UT_MAX_MESSAGE_LENGTH];
-    char * msgPtr = DisplayMsg;
-
-    DisplayMsg[0] = '\0';
-
-    for (i = 0; i < size && BufSize > 3; i++)
-    {
-        snprintf(msgPtr, BufSize, "%02x ", *BytePtr);
-        msgPtr += 3;
-        BufSize -= 3;
-        ++BytePtr;
-    }
-
-    UtPrintf("%s", DisplayMsg);
-}
-
 CFE_ES_ResetData_t *UT_GetResetDataPtr(void)
 {
     return &UT_CFE_ES_ResetData.ResetData;

--- a/modules/msg/ut-coverage/test_cfe_msg_ccsdsext.c
+++ b/modules/msg/ut-coverage/test_cfe_msg_ccsdsext.c
@@ -219,7 +219,7 @@ void Test_MSG_Endian(void)
         CFE_UtAssert_SUCCESS(CFE_MSG_GetEndian(&msg, &actual));
         UtAssert_INT32_EQ(actual, CFE_MSG_Endian_Little);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetEndian(&msg, input[i]));
-        UT_DisplayPkt(&msg, sizeof(msg));
+        UtPrintx(&msg, sizeof(msg));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetEndian(&msg, &actual));
         UtAssert_INT32_EQ(actual, input[i]);
         if (input[i] == CFE_MSG_Endian_Little)
@@ -239,7 +239,7 @@ void Test_MSG_Endian(void)
         CFE_UtAssert_SUCCESS(CFE_MSG_GetEndian(&msg, &actual));
         UtAssert_INT32_EQ(actual, CFE_MSG_Endian_Big);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetEndian(&msg, input[i]));
-        UT_DisplayPkt(&msg, sizeof(msg));
+        UtPrintx(&msg, sizeof(msg));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetEndian(&msg, &actual));
         UtAssert_INT32_EQ(actual, input[i]);
         if (input[i] == CFE_MSG_Endian_Big)
@@ -279,7 +279,7 @@ void Test_MSG_PlaybackFlag(void)
         CFE_UtAssert_SUCCESS(CFE_MSG_GetPlaybackFlag(&msg, &actual));
         UtAssert_INT32_EQ(actual, CFE_MSG_PlayFlag_Playback);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetPlaybackFlag(&msg, input[i]));
-        UT_DisplayPkt(&msg, sizeof(msg));
+        UtPrintx(&msg, sizeof(msg));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetPlaybackFlag(&msg, &actual));
         UtAssert_INT32_EQ(actual, input[i]);
         if (input[i] == CFE_MSG_PlayFlag_Playback)
@@ -299,7 +299,7 @@ void Test_MSG_PlaybackFlag(void)
         CFE_UtAssert_SUCCESS(CFE_MSG_GetPlaybackFlag(&msg, &actual));
         UtAssert_INT32_EQ(actual, CFE_MSG_PlayFlag_Original);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetPlaybackFlag(&msg, input[i]));
-        UT_DisplayPkt(&msg, sizeof(msg));
+        UtPrintx(&msg, sizeof(msg));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetPlaybackFlag(&msg, &actual));
         UtAssert_INT32_EQ(actual, input[i]);
         if (input[i] == CFE_MSG_PlayFlag_Original)
@@ -339,7 +339,7 @@ void Test_MSG_Subsystem(void)
         CFE_UtAssert_SUCCESS(CFE_MSG_GetSubsystem(&msg, &actual));
         UtAssert_INT32_EQ(actual, TEST_SUBSYS_MAX);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetSubsystem(&msg, input[i]));
-        UT_DisplayPkt(&msg, sizeof(msg));
+        UtPrintx(&msg, sizeof(msg));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetSubsystem(&msg, &actual));
         UtAssert_INT32_EQ(actual, input[i]);
         if (input[i] == TEST_SUBSYS_MAX)
@@ -359,7 +359,7 @@ void Test_MSG_Subsystem(void)
         CFE_UtAssert_SUCCESS(CFE_MSG_GetSubsystem(&msg, &actual));
         UtAssert_INT32_EQ(actual, 0);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetSubsystem(&msg, input[i]));
-        UT_DisplayPkt(&msg, sizeof(msg));
+        UtPrintx(&msg, sizeof(msg));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetSubsystem(&msg, &actual));
         UtAssert_INT32_EQ(actual, input[i]);
         if (input[i] == 0)
@@ -396,7 +396,7 @@ void Test_MSG_System(void)
         CFE_UtAssert_SUCCESS(CFE_MSG_GetSystem(&msg, &actual));
         UtAssert_INT32_EQ(actual, TEST_SYSTEM_MAX);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetSystem(&msg, input[i]));
-        UT_DisplayPkt(&msg, sizeof(msg));
+        UtPrintx(&msg, sizeof(msg));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetSystem(&msg, &actual));
         UtAssert_INT32_EQ(actual, input[i]);
         if (input[i] == TEST_SYSTEM_MAX)
@@ -416,7 +416,7 @@ void Test_MSG_System(void)
         CFE_UtAssert_SUCCESS(CFE_MSG_GetSystem(&msg, &actual));
         UtAssert_INT32_EQ(actual, 0);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetSystem(&msg, input[i]));
-        UT_DisplayPkt(&msg, sizeof(msg));
+        UtPrintx(&msg, sizeof(msg));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetSystem(&msg, &actual));
         UtAssert_INT32_EQ(actual, input[i]);
         if (input[i] == 0)

--- a/modules/msg/ut-coverage/test_cfe_msg_ccsdspri.c
+++ b/modules/msg/ut-coverage/test_cfe_msg_ccsdspri.c
@@ -69,7 +69,7 @@ void Test_MSG_Size(void)
         CFE_UtAssert_SUCCESS(CFE_MSG_GetSize(&msg, &actual));
         UtAssert_INT32_EQ(actual, 0xFFFF + TEST_MSG_SIZE_OFFSET);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetSize(&msg, input[i]));
-        UT_DisplayPkt(&msg, sizeof(msg));
+        UtPrintx(&msg, sizeof(msg));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetSize(&msg, &actual));
         UtAssert_INT32_EQ(actual, input[i]);
         if (input[i] == 0xFFFF + TEST_MSG_SIZE_OFFSET)
@@ -89,7 +89,7 @@ void Test_MSG_Size(void)
         CFE_UtAssert_SUCCESS(CFE_MSG_GetSize(&msg, &actual));
         UtAssert_INT32_EQ(actual, TEST_MSG_SIZE_OFFSET);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetSize(&msg, input[i]));
-        UT_DisplayPkt(&msg, sizeof(msg));
+        UtPrintx(&msg, sizeof(msg));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetSize(&msg, &actual));
         UtAssert_INT32_EQ(actual, input[i]);
         if (input[i] == TEST_MSG_SIZE_OFFSET)
@@ -129,7 +129,7 @@ void Test_MSG_Type(void)
         CFE_UtAssert_SUCCESS(CFE_MSG_GetType(&msg, &actual));
         UtAssert_INT32_EQ(actual, CFE_MSG_Type_Cmd);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetType(&msg, input[i]));
-        UT_DisplayPkt(&msg, sizeof(msg));
+        UtPrintx(&msg, sizeof(msg));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetType(&msg, &actual));
         UtAssert_INT32_EQ(actual, input[i]);
         if (input[i] == CFE_MSG_Type_Cmd)
@@ -149,7 +149,7 @@ void Test_MSG_Type(void)
         CFE_UtAssert_SUCCESS(CFE_MSG_GetType(&msg, &actual));
         UtAssert_INT32_EQ(actual, CFE_MSG_Type_Tlm);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetType(&msg, input[i]));
-        UT_DisplayPkt(&msg, sizeof(msg));
+        UtPrintx(&msg, sizeof(msg));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetType(&msg, &actual));
         UtAssert_INT32_EQ(actual, input[i]);
         if (input[i] == CFE_MSG_Type_Tlm)
@@ -189,7 +189,7 @@ void Test_MSG_HeaderVersion(void)
         CFE_UtAssert_SUCCESS(CFE_MSG_GetHeaderVersion(&msg, &actual));
         UtAssert_INT32_EQ(actual, TEST_CCSDSVER_MAX);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetHeaderVersion(&msg, input[i]));
-        UT_DisplayPkt(&msg, sizeof(msg));
+        UtPrintx(&msg, sizeof(msg));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetHeaderVersion(&msg, &actual));
         UtAssert_INT32_EQ(actual, input[i]);
         if (input[i] == TEST_CCSDSVER_MAX)
@@ -209,7 +209,7 @@ void Test_MSG_HeaderVersion(void)
         CFE_UtAssert_SUCCESS(CFE_MSG_GetHeaderVersion(&msg, &actual));
         UtAssert_INT32_EQ(actual, 0);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetHeaderVersion(&msg, input[i]));
-        UT_DisplayPkt(&msg, sizeof(msg));
+        UtPrintx(&msg, sizeof(msg));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetHeaderVersion(&msg, &actual));
         UtAssert_INT32_EQ(actual, input[i]);
         if (input[i] == 0)
@@ -242,13 +242,13 @@ void Test_MSG_HasSecondaryHeader(void)
     UtAssert_BOOL_TRUE(actual);
 
     CFE_UtAssert_SUCCESS(CFE_MSG_SetHasSecondaryHeader(&msg, true));
-    UT_DisplayPkt(&msg, sizeof(msg));
+    UtPrintx(&msg, sizeof(msg));
     CFE_UtAssert_SUCCESS(CFE_MSG_GetHasSecondaryHeader(&msg, &actual));
     UtAssert_BOOL_TRUE(actual);
     UtAssert_INT32_EQ(Test_MSG_NotF(&msg), 0);
 
     CFE_UtAssert_SUCCESS(CFE_MSG_SetHasSecondaryHeader(&msg, false));
-    UT_DisplayPkt(&msg, sizeof(msg));
+    UtPrintx(&msg, sizeof(msg));
     CFE_UtAssert_SUCCESS(CFE_MSG_GetHasSecondaryHeader(&msg, &actual));
     UtAssert_BOOL_FALSE(actual);
     UtAssert_INT32_EQ(Test_MSG_NotF(&msg), MSG_HASSEC_FLAG);
@@ -259,13 +259,13 @@ void Test_MSG_HasSecondaryHeader(void)
     UtAssert_BOOL_FALSE(actual);
 
     CFE_UtAssert_SUCCESS(CFE_MSG_SetHasSecondaryHeader(&msg, false));
-    UT_DisplayPkt(&msg, sizeof(msg));
+    UtPrintx(&msg, sizeof(msg));
     CFE_UtAssert_SUCCESS(CFE_MSG_GetHasSecondaryHeader(&msg, &actual));
     UtAssert_BOOL_FALSE(actual);
     UtAssert_INT32_EQ(Test_MSG_NotZero(&msg), 0);
 
     CFE_UtAssert_SUCCESS(CFE_MSG_SetHasSecondaryHeader(&msg, true));
-    UT_DisplayPkt(&msg, sizeof(msg));
+    UtPrintx(&msg, sizeof(msg));
     CFE_UtAssert_SUCCESS(CFE_MSG_GetHasSecondaryHeader(&msg, &actual));
     UtAssert_BOOL_TRUE(actual);
     UtAssert_INT32_EQ(Test_MSG_NotZero(&msg), MSG_HASSEC_FLAG);
@@ -297,7 +297,7 @@ void Test_MSG_ApId(void)
         CFE_UtAssert_SUCCESS(CFE_MSG_GetApId(&msg, &actual));
         UtAssert_INT32_EQ(actual, TEST_APID_MAX);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetApId(&msg, input[i]));
-        UT_DisplayPkt(&msg, sizeof(msg));
+        UtPrintx(&msg, sizeof(msg));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetApId(&msg, &actual));
         UtAssert_INT32_EQ(actual, input[i]);
         if (input[i] == TEST_APID_MAX)
@@ -317,7 +317,7 @@ void Test_MSG_ApId(void)
         CFE_UtAssert_SUCCESS(CFE_MSG_GetApId(&msg, &actual));
         UtAssert_INT32_EQ(actual, 0);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetApId(&msg, input[i]));
-        UT_DisplayPkt(&msg, sizeof(msg));
+        UtPrintx(&msg, sizeof(msg));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetApId(&msg, &actual));
         UtAssert_INT32_EQ(actual, input[i]);
         if (input[i] == 0)
@@ -358,7 +358,7 @@ void Test_MSG_SegmentationFlag(void)
         CFE_UtAssert_SUCCESS(CFE_MSG_GetSegmentationFlag(&msg, &actual));
         UtAssert_INT32_EQ(actual, CFE_MSG_SegFlag_Unsegmented);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetSegmentationFlag(&msg, input[i]));
-        UT_DisplayPkt(&msg, sizeof(msg));
+        UtPrintx(&msg, sizeof(msg));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetSegmentationFlag(&msg, &actual));
         UtAssert_INT32_EQ(actual, input[i]);
         if (input[i] == CFE_MSG_SegFlag_Unsegmented)
@@ -378,7 +378,7 @@ void Test_MSG_SegmentationFlag(void)
         CFE_UtAssert_SUCCESS(CFE_MSG_GetSegmentationFlag(&msg, &actual));
         UtAssert_INT32_EQ(actual, CFE_MSG_SegFlag_Continue);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetSegmentationFlag(&msg, input[i]));
-        UT_DisplayPkt(&msg, sizeof(msg));
+        UtPrintx(&msg, sizeof(msg));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetSegmentationFlag(&msg, &actual));
         UtAssert_INT32_EQ(actual, input[i]);
         if (input[i] == CFE_MSG_SegFlag_Continue)
@@ -421,7 +421,7 @@ void Test_MSG_SequenceCount(void)
         CFE_UtAssert_SUCCESS(CFE_MSG_GetSequenceCount(&msg, &actual));
         UtAssert_INT32_EQ(actual, TEST_SEQUENCE_MAX);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetSequenceCount(&msg, input[i]));
-        UT_DisplayPkt(&msg, sizeof(msg));
+        UtPrintx(&msg, sizeof(msg));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetSequenceCount(&msg, &actual));
         UtAssert_INT32_EQ(actual, input[i]);
         if (input[i] == TEST_SEQUENCE_MAX)
@@ -441,7 +441,7 @@ void Test_MSG_SequenceCount(void)
         CFE_UtAssert_SUCCESS(CFE_MSG_GetSequenceCount(&msg, &actual));
         UtAssert_INT32_EQ(actual, 0);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetSequenceCount(&msg, input[i]));
-        UT_DisplayPkt(&msg, sizeof(msg));
+        UtPrintx(&msg, sizeof(msg));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetSequenceCount(&msg, &actual));
         UtAssert_INT32_EQ(actual, input[i]);
         if (input[i] == 0)

--- a/modules/msg/ut-coverage/test_cfe_msg_checksum.c
+++ b/modules/msg/ut-coverage/test_cfe_msg_checksum.c
@@ -68,7 +68,7 @@ void Test_MSG_Checksum(void)
     CFE_UtAssert_SUCCESS(CFE_MSG_ValidateChecksum(msgptr, &actual));
     UtAssert_BOOL_FALSE(actual);
     CFE_UtAssert_SUCCESS(CFE_MSG_GenerateChecksum(msgptr));
-    UT_DisplayPkt(msgptr, sizeof(cmd));
+    UtPrintx(msgptr, sizeof(cmd));
     CFE_UtAssert_SUCCESS(CFE_MSG_ValidateChecksum(msgptr, &actual));
     UtAssert_BOOL_TRUE(actual);
     UtAssert_INT32_EQ(Test_MSG_NotF(msgptr), MSG_LENGTH_FLAG);
@@ -81,7 +81,7 @@ void Test_MSG_Checksum(void)
     CFE_UtAssert_SUCCESS(CFE_MSG_ValidateChecksum(msgptr, &actual));
     UtAssert_BOOL_FALSE(actual);
     CFE_UtAssert_SUCCESS(CFE_MSG_GenerateChecksum(msgptr));
-    UT_DisplayPkt(msgptr, sizeof(cmd));
+    UtPrintx(msgptr, sizeof(cmd));
     CFE_UtAssert_SUCCESS(CFE_MSG_ValidateChecksum(msgptr, &actual));
     UtAssert_BOOL_TRUE(actual);
     UtAssert_INT32_EQ(Test_MSG_NotZero(msgptr), MSG_LENGTH_FLAG | MSG_HASSEC_FLAG | MSG_TYPE_FLAG);

--- a/modules/msg/ut-coverage/test_cfe_msg_fc.c
+++ b/modules/msg/ut-coverage/test_cfe_msg_fc.c
@@ -80,7 +80,7 @@ void Test_MSG_FcnCode(void)
         CFE_UtAssert_SUCCESS(CFE_MSG_GetFcnCode(msgptr, &actual));
         UtAssert_INT32_EQ(actual, TEST_FCNCODE_MAX);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetFcnCode(msgptr, input[i]));
-        UT_DisplayPkt(msgptr, sizeof(cmd));
+        UtPrintx(msgptr, sizeof(cmd));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetFcnCode(msgptr, &actual));
         UtAssert_INT32_EQ(actual, input[i]);
         UtAssert_INT32_EQ(Test_MSG_NotF(msgptr), 0);
@@ -95,7 +95,7 @@ void Test_MSG_FcnCode(void)
         CFE_UtAssert_SUCCESS(CFE_MSG_GetFcnCode(msgptr, &actual));
         UtAssert_INT32_EQ(actual, 0);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetFcnCode(msgptr, input[i]));
-        UT_DisplayPkt(msgptr, sizeof(cmd));
+        UtPrintx(msgptr, sizeof(cmd));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetFcnCode(msgptr, &actual));
         UtAssert_INT32_EQ(actual, input[i]);
         UtAssert_INT32_EQ(Test_MSG_NotZero(msgptr), MSG_HASSEC_FLAG | MSG_TYPE_FLAG);

--- a/modules/msg/ut-coverage/test_cfe_msg_init.c
+++ b/modules/msg/ut-coverage/test_cfe_msg_init.c
@@ -66,7 +66,7 @@ void Test_MSG_Init(void)
     msgidval_exp = 0;
 
     CFE_UtAssert_SUCCESS(CFE_MSG_Init(CFE_MSG_PTR(cmd), CFE_SB_ValueToMsgId(msgidval_exp), sizeof(cmd)));
-    UT_DisplayPkt(CFE_MSG_PTR(cmd), 0);
+    UtPrintx(CFE_MSG_PTR(cmd), 0);
     CFE_UtAssert_SUCCESS(CFE_MSG_GetMsgId(CFE_MSG_PTR(cmd), &msgid_act));
     UtAssert_INT32_EQ(CFE_SB_MsgIdToValue(msgid_act), msgidval_exp);
     CFE_UtAssert_SUCCESS(CFE_MSG_GetSize(CFE_MSG_PTR(cmd), &size));
@@ -101,7 +101,7 @@ void Test_MSG_Init(void)
     msgidval_exp = CFE_PLATFORM_SB_HIGHEST_VALID_MSGID;
 
     CFE_UtAssert_SUCCESS(CFE_MSG_Init(CFE_MSG_PTR(cmd), CFE_SB_ValueToMsgId(msgidval_exp), sizeof(cmd)));
-    UT_DisplayPkt(CFE_MSG_PTR(cmd), 0);
+    UtPrintx(CFE_MSG_PTR(cmd), 0);
     CFE_UtAssert_SUCCESS(CFE_MSG_GetMsgId(CFE_MSG_PTR(cmd), &msgid_act));
     UtAssert_INT32_EQ(CFE_SB_MsgIdToValue(msgid_act), msgidval_exp);
     CFE_UtAssert_SUCCESS(CFE_MSG_GetSize(CFE_MSG_PTR(cmd), &size));

--- a/modules/msg/ut-coverage/test_cfe_msg_msgid_v1.c
+++ b/modules/msg/ut-coverage/test_cfe_msg_msgid_v1.c
@@ -57,7 +57,7 @@ void Test_MSG_MsgId(void)
     CFE_UtAssert_SUCCESS(CFE_MSG_GetMsgId(&msg, &msgid));
     UtAssert_INT32_EQ(CFE_SB_MsgIdToValue(msgid), 0xFFFF);
     CFE_UtAssert_SUCCESS(CFE_MSG_SetMsgId(&msg, CFE_SB_ValueToMsgId(1)));
-    UT_DisplayPkt(&msg, sizeof(msg));
+    UtPrintx(&msg, sizeof(msg));
     CFE_UtAssert_SUCCESS(CFE_MSG_GetMsgId(&msg, &msgid));
     UtAssert_INT32_EQ(CFE_SB_MsgIdToValue(msgid), 1);
     UtAssert_INT32_EQ(Test_MSG_NotF(&msg), MSG_HDRVER_FLAG | MSG_APID_FLAG | MSG_TYPE_FLAG | MSG_HASSEC_FLAG);
@@ -67,7 +67,7 @@ void Test_MSG_MsgId(void)
     CFE_UtAssert_SUCCESS(CFE_MSG_GetMsgId(&msg, &msgid));
     UtAssert_INT32_EQ(CFE_SB_MsgIdToValue(msgid), 0);
     CFE_UtAssert_SUCCESS(CFE_MSG_SetMsgId(&msg, CFE_SB_ValueToMsgId(CFE_PLATFORM_SB_HIGHEST_VALID_MSGID)));
-    UT_DisplayPkt(&msg, sizeof(msg));
+    UtPrintx(&msg, sizeof(msg));
     CFE_UtAssert_SUCCESS(CFE_MSG_GetMsgId(&msg, &msgid));
     UtAssert_INT32_EQ(CFE_SB_MsgIdToValue(msgid), CFE_PLATFORM_SB_HIGHEST_VALID_MSGID);
     UtAssert_INT32_EQ(Test_MSG_NotZero(&msg), MSG_APID_FLAG | MSG_TYPE_FLAG | MSG_HASSEC_FLAG);

--- a/modules/msg/ut-coverage/test_cfe_msg_msgid_v2.c
+++ b/modules/msg/ut-coverage/test_cfe_msg_msgid_v2.c
@@ -65,7 +65,7 @@ void Test_MSG_MsgId(void)
     CFE_UtAssert_SUCCESS(CFE_MSG_GetMsgId(&msg, &msgid));
     UtAssert_INT32_EQ(CFE_SB_MsgIdToValue(msgid), 0xFFFF);
     CFE_UtAssert_SUCCESS(CFE_MSG_SetMsgId(&msg, 0));
-    UT_DisplayPkt(&msg, sizeof(msg));
+    UtPrintx(&msg, sizeof(msg));
     CFE_UtAssert_SUCCESS(CFE_MSG_GetMsgId(&msg, &msgid));
     UtAssert_INT32_EQ(CFE_SB_MsgIdToValue(msgid), 0);
     UtAssert_INT32_EQ(Test_MSG_NotF(&msg), MSG_APID_FLAG | MSG_TYPE_FLAG | local_subsys_flag);
@@ -75,7 +75,7 @@ void Test_MSG_MsgId(void)
     CFE_UtAssert_SUCCESS(CFE_MSG_GetMsgId(&msg, &msgid));
     UtAssert_INT32_EQ(CFE_SB_MsgIdToValue(msgid), 0);
     CFE_UtAssert_SUCCESS(CFE_MSG_SetMsgId(&msg, CFE_PLATFORM_SB_HIGHEST_VALID_MSGID));
-    UT_DisplayPkt(&msg, sizeof(msg));
+    UtPrintx(&msg, sizeof(msg));
     CFE_UtAssert_SUCCESS(CFE_MSG_GetMsgId(&msg, &msgid));
     UtAssert_INT32_EQ(CFE_SB_MsgIdToValue(msgid), CFE_PLATFORM_SB_HIGHEST_VALID_MSGID);
     UtAssert_INT32_EQ(Test_MSG_NotZero(&msg), MSG_APID_FLAG | MSG_TYPE_FLAG | local_subsys_flag);

--- a/modules/msg/ut-coverage/test_cfe_msg_time.c
+++ b/modules/msg/ut-coverage/test_cfe_msg_time.c
@@ -71,7 +71,7 @@ void Test_MSG_Time(void)
         UtAssert_INT32_EQ(actual.Seconds, 0xFFFFFFFF);
         UtAssert_INT32_EQ(actual.Subseconds, 0xFFFF0000);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetMsgTime(msgptr, input[i]));
-        UT_DisplayPkt(msgptr, sizeof(tlm));
+        UtPrintx(msgptr, sizeof(tlm));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetMsgTime(msgptr, &actual));
         UtAssert_INT32_EQ(actual.Seconds, input[i].Seconds);
         UtAssert_INT32_EQ(actual.Subseconds, input[i].Subseconds & 0xFFFF0000);
@@ -87,7 +87,7 @@ void Test_MSG_Time(void)
         UtAssert_INT32_EQ(actual.Seconds, 0);
         UtAssert_INT32_EQ(actual.Subseconds, 0);
         CFE_UtAssert_SUCCESS(CFE_MSG_SetMsgTime(msgptr, input[i]));
-        UT_DisplayPkt(msgptr, sizeof(tlm));
+        UtPrintx(msgptr, sizeof(tlm));
         CFE_UtAssert_SUCCESS(CFE_MSG_GetMsgTime(msgptr, &actual));
         UtAssert_INT32_EQ(actual.Seconds, input[i].Seconds);
         UtAssert_INT32_EQ(actual.Subseconds, input[i].Subseconds & 0xFFFF0000);


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1422
  - all instances of `UT_DisplayPkt()` replaced with `UtPrintx()`
  - the declaration and definition of `UT_DisplayPkt()` deleted
  - `UT_DisplayPkt()` turned into a simple macro that calls `UtPrintx()` and placed inside deprecation guards

**Testing performed**
GitHub CI actions (incl. Functional tests and Coverage Analysis etc.) all passing successfully.

Tested locally with standard cFS bundle tests - confirmed output text is correctly displayed and identical to before the change (the only difference other than the inclusion of the memory address, is the spacing and that the alphanumeric characters/digits in the hexadecimal output are now capitalized).

Before changes:
![Screenshot 2023-03-29 12 54 25](https://user-images.githubusercontent.com/9024662/228429661-9abf8946-033e-44b4-9996-be0f2abe48d9.png)

After changes:
![Screenshot 2023-03-29 12 54 19](https://user-images.githubusercontent.com/9024662/228429647-189f63d3-4215-4911-b861-e1a1d2f53761.png)

**Expected behavior changes**
Test log prints now include the memory address along with the data.

**System(s) tested on**
Intel(R) Celeron(R) N4100 CPU @ 1.10GHz x86_64
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS.

**Contributor Info**
Avi Weiss @thnkslprpt