### PR TITLE
Fix #1409, Add additional context to log file write error event

### DIFF
--- a/modules/evs/fsw/src/cfe_evs_log.c
+++ b/modules/evs/fsw/src/cfe_evs_log.c
@@ -212,8 +212,8 @@ int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFileCmd_t *data)
             else
             {
                 EVS_SendEvent(CFE_EVS_ERR_WRLOGFILE_EID, CFE_EVS_EventType_ERROR,
-                              "Write Log File Command Error: OS_write = %ld, filename = %s", (long)OsStatus,
-                              LogFilename);
+                              "Write Log File Command Error on entry %d of %d: OS_write = %ld, filename = %s", (int)i,
+                              (int)CFE_EVS_Global.EVS_LogPtr->LogCount, (long)OsStatus, LogFilename);
             }
         }
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1409
  - Entry index and total log count added to the event report in case of error during writing of the event log entries to file in `CFE_EVS_WriteLogDataFileCmd()`.

**Testing performed**
GitHub CI actions (incl. Functional Tests, Coverage Analysis etc.) all passing successfully.

**Expected behavior changes**
No change to behavior.

**Contributor Info**
Avi Weiss @thnkslprpt