### PR TITLE
Fix #1408, Use LogFullFlag instead of checking LogCount

### DIFF
--- a/modules/evs/fsw/src/cfe_evs_log.c
+++ b/modules/evs/fsw/src/cfe_evs_log.c
@@ -167,7 +167,7 @@ int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFileCmd_t *data)
             OS_MutSemTake(CFE_EVS_Global.EVS_SharedDataMutexID);
 
             /* Is the log full? -- Doesn't matter if wrap mode is enabled */
-            if (CFE_EVS_Global.EVS_LogPtr->LogCount == CFE_PLATFORM_EVS_LOG_MAX)
+            if (CFE_EVS_Global.EVS_LogPtr->LogFullFlag)
             {
                 /* Start with log entry that will be overwritten next (oldest) */
                 LogIndex = CFE_EVS_Global.EVS_LogPtr->Next;

--- a/modules/evs/ut-coverage/evs_UT.c
+++ b/modules/evs/ut-coverage/evs_UT.c
@@ -1024,14 +1024,14 @@ void Test_Logging(void)
     /* Test successfully writing all log entries */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(OS_MutSemCreate), 1, OS_SUCCESS);
-    CFE_EVS_Global.EVS_LogPtr->LogCount = CFE_PLATFORM_EVS_LOG_MAX;
+    CFE_EVS_Global.EVS_LogPtr->LogFullFlag = true;
     CFE_UtAssert_SUCCESS(CFE_EVS_WriteLogDataFileCmd(&CmdBuf.logfilecmd));
 
     /* Test writing a log entry with a write failure */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(OS_MutSemCreate), 1, OS_SUCCESS);
     UT_SetDefaultReturnValue(UT_KEY(OS_write), OS_ERROR);
-    CFE_EVS_Global.EVS_LogPtr->LogCount = CFE_PLATFORM_EVS_LOG_MAX;
+    CFE_EVS_Global.EVS_LogPtr->LogFullFlag = true;
     UtAssert_INT32_EQ(CFE_EVS_WriteLogDataFileCmd(&CmdBuf.logfilecmd), CFE_EVS_FILE_WRITE_ERROR);
 
     /* Test successfully writing a single event log entry using a specified


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1408
  - `LogCount == CFE_PLATFORM_EVS_LOG_MAX` replaced by `LogFullFlag == true` (this is what that flag is for...).

**Testing performed**
GitHub CI actions (incl. Functional Tests) all passing successfully.
Local tests with cFS suite confirm coverage overall unaffected.

**Expected behavior changes**
No change to behavior.

**System(s) tested on**
Intel(R) Celeron(R) N4100 CPU @ 1.10GHz x86_64
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS.

**Contributor Info**
Avi Weiss @thnkslprpt