### PR TITLE
Fix #1407, Add error report on EVS failure during log header write

### DIFF
--- a/modules/evs/fsw/inc/cfe_evs_eventids.h
+++ b/modules/evs/fsw/inc/cfe_evs_eventids.h
@@ -180,6 +180,17 @@
 #define CFE_EVS_ERR_CRDATFILE_EID 13
 
 /**
+ * \brief EVS Write File Header to Log File Failure Event ID
+ *
+ *  \par Type: ERROR
+ *
+ *  \par Cause:
+ *
+ *  Bytes written during Write File Header to Log File was not equal to the expected header size.
+ */
+#define CFE_EVS_WRITE_HEADER_ERR_EID 14
+
+/**
  * \brief EVS Invalid Command Code Received Event ID
  *
  *  \par Type: ERROR

--- a/modules/evs/fsw/src/cfe_evs_log.c
+++ b/modules/evs/fsw/src/cfe_evs_log.c
@@ -216,6 +216,12 @@ int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFileCmd_t *data)
                               LogFilename);
             }
         }
+        else
+        {
+            EVS_SendEvent(CFE_EVS_WRITE_HEADER_ERR_EID, CFE_EVS_EventType_ERROR,
+                          "Write File Header to Log File Error: WriteHdr RC: %d, Expected: %d, filename = %s",
+                          (int)BytesWritten, (int)sizeof(LogFileHdr), LogFilename);
+        }
 
         OS_close(LogFileHandle);
     }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1407
  - Event (and new EID) added for failure of `CFE_FS_WriteHeader()` to write the expected amount of data.

**Testing performed**
GitHub CI actions all passing successfully.

Local tests (seeded with bad value for `BytesWritten`) to check formatting etc.:

![Screenshot 2023-03-30 08 48 25](https://user-images.githubusercontent.com/9024662/228686940-00181854-3a7d-4a33-b797-e39efe29c024.png)

**Expected behavior changes**
No change to behavior other than event report on error as per above.

**System(s) tested on**
Intel(R) Celeron(R) N4100 CPU @ 1.10GHz x86_64
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS.

**Contributor Info**
Avi Weiss @thnkslprpt