### PR TITLE
Fix #1466, Add status return to CFE_ES_WaitForStartupSync()

### DIFF
--- a/modules/cfe_testcase/src/es_behavior_test.c
+++ b/modules/cfe_testcase/src/es_behavior_test.c
@@ -74,7 +74,7 @@ void TestWaitBehavior(void)
     UtAssert_INT32_EQ(CFE_ES_WaitForSystemState(CFE_ES_SystemState_CORE_READY, 10000), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_WaitForSystemState(CFE_ES_SystemState_APPS_INIT, 10000), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_WaitForSystemState(CFE_ES_SystemState_OPERATIONAL, 10000), CFE_SUCCESS);
-    UtAssert_VOIDCALL(CFE_ES_WaitForStartupSync(10000));
+    UtAssert_INT32_EQ(CFE_ES_WaitForStartupSync(10000), CFE_SUCCESS);
 
     end        = CFE_TIME_GetTime();
     TimePassed = CFE_TIME_Subtract(end, start);

--- a/modules/core_api/fsw/inc/cfe_es.h
+++ b/modules/core_api/fsw/inc/cfe_es.h
@@ -452,10 +452,14 @@ CFE_Status_t CFE_ES_WaitForSystemState(uint32 MinSystemState, uint32 TimeOutMill
 **                                   wait indefinitely to avoid hanging a critical
 **                                   application because a non-critical app did not start.
 **
+** \return Passes through the return value from CFE_ES_WaitForSystemState()
+** \retval #CFE_SUCCESS                State successfully achieved
+** \retval #CFE_ES_OPERATION_TIMED_OUT Timeout was reached
+**
 ** \sa #CFE_ES_RunLoop
 **
 ******************************************************************************/
-void CFE_ES_WaitForStartupSync(uint32 TimeOutMilliseconds);
+CFE_Status_t CFE_ES_WaitForStartupSync(uint32 TimeOutMilliseconds);
 
 /*****************************************************************************/
 /**

--- a/modules/core_api/ut-stubs/src/cfe_es_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_es_stubs.c
@@ -907,11 +907,15 @@ CFE_Status_t CFE_ES_TaskID_ToIndex(CFE_ES_TaskId_t TaskID, uint32 *Idx)
  * Generated stub function for CFE_ES_WaitForStartupSync()
  * ----------------------------------------------------
  */
-void CFE_ES_WaitForStartupSync(uint32 TimeOutMilliseconds)
+CFE_Status_t CFE_ES_WaitForStartupSync(uint32 TimeOutMilliseconds)
 {
+    UT_GenStub_SetupReturnBuffer(CFE_ES_WaitForStartupSync, CFE_Status_t);
+
     UT_GenStub_AddParam(CFE_ES_WaitForStartupSync, uint32, TimeOutMilliseconds);
 
     UT_GenStub_Execute(CFE_ES_WaitForStartupSync, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(CFE_ES_WaitForStartupSync, CFE_Status_t);
 }
 
 /*

--- a/modules/es/fsw/src/cfe_es_api.c
+++ b/modules/es/fsw/src/cfe_es_api.c
@@ -658,9 +658,13 @@ CFE_Status_t CFE_ES_WaitForSystemState(uint32 MinSystemState, uint32 TimeOutMill
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-void CFE_ES_WaitForStartupSync(uint32 TimeOutMilliseconds)
+CFE_Status_t CFE_ES_WaitForStartupSync(uint32 TimeOutMilliseconds)
 {
-    CFE_ES_WaitForSystemState(CFE_ES_SystemState_OPERATIONAL, TimeOutMilliseconds);
+    CFE_Status_t Status;
+
+    Status = CFE_ES_WaitForSystemState(CFE_ES_SystemState_OPERATIONAL, TimeOutMilliseconds);
+
+    return Status;
 }
 
 /*----------------------------------------------------------------

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -4441,21 +4441,11 @@ void TestAPI(void)
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "UT", &UtAppRecPtr, NULL);
     CFE_ES_Global.SystemState = CFE_ES_SystemState_CORE_READY;
 
-    /* Note - CFE_ES_WaitForStartupSync() returns void, nothing to check for
-     * here.  This is for code coverage
-     */
-    UtAssert_VOIDCALL(CFE_ES_WaitForStartupSync(99));
-
     /* Test waiting for apps to initialize as an external app
      */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_EARLY_INIT, "UT", &UtAppRecPtr, NULL);
     CFE_ES_Global.SystemState = CFE_ES_SystemState_CORE_READY;
-
-    /* Note - CFE_ES_WaitForStartupSync() returns void, nothing to check for
-     * here.  This is for code coverage
-     */
-    UtAssert_VOIDCALL(CFE_ES_WaitForStartupSync(99));
 
     /* Test successfully adding a time-stamped message to the system log that
      * causes the log index to be reset


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1466
  - Converts `CFE_ES_WaitForStartupSync()` from void return to `CFE_Status_t`, and carries through the return value from `CFE_ES_WaitForSystemState()`.

**Testing performed**
GitHub CI actions all passing successfully.
Local tests confirm all tests passing and LCOV confirms coverage of amended lines, and total coverage unaffected.

These 2 UT calls to `CFE_ES_WaitForStartupSync()` would have had to be updated, but as far as I can tell they are not actually required for coverage, and are not needed for the test blocks that they are part of (`ES_ResetUnitTest()` is run immediately after both).
https://github.com/nasa/cFE/blob/7c03369f9582b22b2c9599748e6ed7fa18d37e5c/modules/es/ut-coverage/es_UT.c#L4441-L4463

Coverage is already provided by the prior call to `CFE_ES_WaitForStartupSync()`:
https://github.com/nasa/cFE/blob/7c03369f9582b22b2c9599748e6ed7fa18d37e5c/modules/es/ut-coverage/es_UT.c#L4434

`CFE_ES_WaitForSystemState()` is already fully covered elsewhere.

**Expected behavior changes**
`CFE_ES_WaitForStartupSync()` now carries through the status/return of `CFE_ES_WaitForSystemState()` allowing additional handling by the user.

**System(s) tested on**
Intel(R) Celeron(R) N4100 CPU @ 1.10GHz x86_64
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS.

**Contributor Info**
Avi Weiss @thnkslprpt