### PR TITLE
Fix #1723, Add NULL check for AppFileName parameter in CFE_ES_ReloadApp

### DIFF
--- a/modules/cfe_testcase/src/es_application_control_test.c
+++ b/modules/cfe_testcase/src/es_application_control_test.c
@@ -45,7 +45,7 @@ void TestApplicationControl(void)
      * error is ignored in CFE_ES_ReloadApp and file io error is returned
      * most other functions return a CFE_ES_BAD_ARGUMENT in this situation
      */
-    UtAssert_UINT32_EQ(CFE_ES_ReloadApp(TestAppId, NULL), CFE_ES_FILE_IO_ERR);
+    UtAssert_UINT32_EQ(CFE_ES_ReloadApp(TestAppId, NULL), CFE_ES_BAD_ARGUMENT);
     UtAssert_UINT32_EQ(CFE_ES_ReloadApp(TestAppId, "/cf/NOT_cfe_testcase.so"), CFE_ES_FILE_IO_ERR);
     UtAssert_UINT32_EQ(CFE_ES_ReloadApp(CFE_ES_APPID_UNDEFINED, "/cf/cfe_testcase.so"),
                        CFE_ES_ERR_RESOURCEID_NOT_VALID);

--- a/modules/core_private/ut-stubs/inc/ut_osprintf_stubs.h
+++ b/modules/core_private/ut-stubs/inc/ut_osprintf_stubs.h
@@ -104,5 +104,7 @@
 #define UT_OSP_FORMAT_VOLATILE            78
 #define UT_OSP_RELOAD_NO_FILE             79
 #define UT_OSP_EXTERNAL_APP_EXIT          80
+#define UT_OSP_INVALID_ID_AND_FILENAME    81
+#define UT_OSP_INVALID_FILENAME           82
 
 #endif /* UT_OSPRINTF_STUBS_H */

--- a/modules/core_private/ut-stubs/src/ut_osprintf_stubs.c
+++ b/modules/core_private/ut-stubs/src/ut_osprintf_stubs.c
@@ -109,4 +109,6 @@ const char *UT_OSP_MESSAGES[] = {
     [UT_OSP_FORMAT_VOLATILE]            = "%s: Formatting Volatile(RAM) Volume.\n",
     [UT_OSP_RELOAD_NO_FILE]             = "%s: Cannot Reload Application %s, File %s does not exist.\n",
     [UT_OSP_EXTERNAL_APP_EXIT]          = "%s: Application %s called CFE_ES_ExitApp\n",
+    [UT_OSP_INVALID_ID_AND_FILENAME]    = "%s: Application ID and AppFileName Parameters are NULL, , AppID = %lu\n",
+    [UT_OSP_INVALID_FILENAME]           = "%s: AppFileName Parameter is NULL\n",
 };

--- a/modules/es/fsw/src/cfe_es_api.c
+++ b/modules/es/fsw/src/cfe_es_api.c
@@ -227,7 +227,27 @@ CFE_Status_t CFE_ES_ReloadApp(CFE_ES_AppId_t AppID, const char *AppFileName)
     os_fstat_t          FileStatus;
     CFE_ES_AppRecord_t *AppRecPtr = CFE_ES_LocateAppRecordByID(AppID);
 
-    if (AppRecPtr != NULL)
+    if (AppRecPtr == NULL)
+    {
+        if (AppFileName == NULL)
+        {
+            ReturnCode = CFE_ES_BAD_ARGUMENT;
+            CFE_ES_WriteToSysLog("%s: Application ID and AppFileName Parameters are NULL, , AppID = %lu\n", __func__,
+                                 CFE_RESOURCEID_TO_ULONG(AppID));
+        }
+        else
+        {
+            ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
+            CFE_ES_WriteToSysLog("%s: Invalid Application ID received, AppID = %lu\n", __func__,
+                                 CFE_RESOURCEID_TO_ULONG(AppID));
+        }
+    }
+    else if (AppFileName == NULL)
+    {
+        ReturnCode = CFE_ES_BAD_ARGUMENT;
+        CFE_ES_WriteToSysLog("%s: AppFileName Parameter is NULL\n", __func__);
+    }
+    else
     {
         CFE_ES_LockSharedData(__func__, __LINE__);
 
@@ -269,13 +289,6 @@ CFE_Status_t CFE_ES_ReloadApp(CFE_ES_AppId_t AppID, const char *AppFileName)
         }
 
         CFE_ES_UnlockSharedData(__func__, __LINE__);
-    }
-    else /* App ID is not valid */
-    {
-        ReturnCode = CFE_ES_ERR_RESOURCEID_NOT_VALID;
-
-        CFE_ES_WriteToSysLog("%s: Invalid Application ID received, AppID = %lu\n", __func__,
-                             CFE_RESOURCEID_TO_ULONG(AppID));
     }
 
     return ReturnCode;

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -4002,6 +4002,20 @@ void TestAPI(void)
     /* Verify requirement to report error */
     CFE_UtAssert_PRINTF(UT_OSP_MESSAGES[UT_OSP_INVALID_ID]);
 
+    /* Test CFE_ES_ReloadApp with a NULL AppFileName */
+    ES_ResetUnitTest();
+    ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
+    AppId = CFE_ES_AppRecordGetID(UtAppRecPtr);
+    UtAssert_INT32_EQ(CFE_ES_ReloadApp(AppId, NULL), CFE_ES_BAD_ARGUMENT);
+    /* Verify requirement to report error */
+    CFE_UtAssert_PRINTF(UT_OSP_MESSAGES[UT_OSP_INVALID_FILENAME]);
+
+    /* Test CFE_ES_ReloadApp with bad AppID argument and NULL AppFileName */
+    ES_ResetUnitTest();
+    UtAssert_INT32_EQ(CFE_ES_ReloadApp(CFE_ES_APPID_UNDEFINED, NULL), CFE_ES_BAD_ARGUMENT);
+    /* Verify requirement to report error */
+    CFE_UtAssert_PRINTF(UT_OSP_MESSAGES[UT_OSP_INVALID_ID_AND_FILENAME]);
+
     /* Test reloading a core app */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1723
  - Adds check for `NULL` input for the 2nd parameter in `CFE_ES_ReloadApp()` - `AppFileName.`
Previously only the 1st parameter, `AppID`, was directly checked for `NULL.`

**Testing performed**
GitHub CI actions all passing successfully. Coverage unaffected.

**Expected behavior changes**
Will fail faster/earlier with NULL input for `AppFileName.`
Clearer error logs ease future maintainability and debugging.

**Contributor Info**
Avi Weiss @thnkslprpt