### PR TITLE
Fix #2280, Move calls to `CFE_ES_GetAppName()` higher to reduce code duplication

### DIFF
--- a/modules/tbl/fsw/src/cfe_tbl_api.c
+++ b/modules/tbl/fsw/src/cfe_tbl_api.c
@@ -357,13 +357,14 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
                         {
                             Status = CFE_TBL_GetWorkingBuffer(&WorkingBufferPtr, RegRecPtr, true);
 
+                            CFE_ES_GetAppName(AppName, ThisAppId, sizeof(AppName));
+
                             if (Status != CFE_SUCCESS)
                             {
                                 /* Unable to get a working buffer - this error is not really */
                                 /* possible at this point during table registration.  But we */
                                 /* do need to handle the error case because if the function */
                                 /* call did fail, WorkingBufferPtr would be a NULL pointer. */
-                                CFE_ES_GetAppName(AppName, ThisAppId, sizeof(AppName));
                                 CFE_ES_WriteToSysLog("%s: Failed to get work buffer for '%s.%s' (ErrCode=0x%08X)\n",
                                                      __func__, AppName, Name, (unsigned int)Status);
                             }
@@ -374,7 +375,6 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
 
                                 if (Status != CFE_SUCCESS)
                                 {
-                                    CFE_ES_GetAppName(AppName, ThisAppId, sizeof(AppName));
                                     CFE_ES_WriteToSysLog("%s: Failed to recover '%s.%s' from CDS (ErrCode=0x%08X)\n",
                                                          __func__, AppName, Name, (unsigned int)Status);
                                 }
@@ -419,7 +419,6 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
                                 {
                                     /* If an error occurred while trying to get the previous contents registry info, */
                                     /* Log the error in the System Log and pretend like we created a new CDS */
-                                    CFE_ES_GetAppName(AppName, ThisAppId, sizeof(AppName));
                                     CFE_ES_WriteToSysLog("%s: Failed to recover '%s.%s' info from CDS TblReg\n",
                                                          __func__, AppName, Name);
                                     Status = CFE_SUCCESS;


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2280
  - 3 calls to `CFE_ES_GetAppName()` in `CFE_TBL_Register()` reduced to 1 by moving the call up 1 layer in the nesting.

**Testing performed**
GitHub CI actions all passing successfully.

**Expected behavior changes**
No change.

**Contributor Info**
Avi Weiss @thnkslprpt