### PR TITLE
Fix #2282, Move calls to CFE_SB_GetPipeName() up higher to reduce duplication

### DIFF
--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -1676,13 +1676,13 @@ void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_
     /* send an event for each pipe write error that may have occurred */
     for (i = 0; i < SBSndErr.EvtsToSnd; i++)
     {
+        CFE_SB_GetPipeName(PipeName, sizeof(PipeName), SBSndErr.EvtBuf[i].PipeId);
+
         if (SBSndErr.EvtBuf[i].EventId == CFE_SB_MSGID_LIM_ERR_EID)
         {
             /* Determine if event can be sent without causing recursive event problem */
             if (CFE_SB_RequestToSendEvent(TskId, CFE_SB_MSGID_LIM_ERR_EID_BIT) == CFE_SB_GRANTED)
             {
-                CFE_SB_GetPipeName(PipeName, sizeof(PipeName), SBSndErr.EvtBuf[i].PipeId);
-
                 CFE_ES_PerfLogEntry(CFE_MISSION_SB_MSG_LIM_PERF_ID);
                 CFE_ES_PerfLogExit(CFE_MISSION_SB_MSG_LIM_PERF_ID);
 
@@ -1700,8 +1700,6 @@ void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_
             /* Determine if event can be sent without causing recursive event problem */
             if (CFE_SB_RequestToSendEvent(TskId, CFE_SB_Q_FULL_ERR_EID_BIT) == CFE_SB_GRANTED)
             {
-                CFE_SB_GetPipeName(PipeName, sizeof(PipeName), SBSndErr.EvtBuf[i].PipeId);
-
                 CFE_ES_PerfLogEntry(CFE_MISSION_SB_PIPE_OFLOW_PERF_ID);
                 CFE_ES_PerfLogExit(CFE_MISSION_SB_PIPE_OFLOW_PERF_ID);
 
@@ -1719,8 +1717,6 @@ void CFE_SB_BroadcastBufferToRoute(CFE_SB_BufferD_t *BufDscPtr, CFE_SBR_RouteId_
             /* Determine if event can be sent without causing recursive event problem */
             if (CFE_SB_RequestToSendEvent(TskId, CFE_SB_Q_WR_ERR_EID_BIT) == CFE_SB_GRANTED)
             {
-                CFE_SB_GetPipeName(PipeName, sizeof(PipeName), SBSndErr.EvtBuf[i].PipeId);
-
                 CFE_EVS_SendEventWithAppID(CFE_SB_Q_WR_ERR_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
                                            "Pipe Write Err,MsgId 0x%x,pipe %s,sender %s,stat %ld",
                                            (unsigned int)CFE_SB_MsgIdToValue(BufDscPtr->MsgId), PipeName,

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -4499,7 +4499,7 @@ void Test_SB_TransmitMsgPaths_FullErr(void)
 
     CFE_UtAssert_EVENTNOTSENT(CFE_SB_Q_FULL_ERR_EID_BIT);
 
-    CFE_UtAssert_EVENTCOUNT(2);
+    CFE_UtAssert_EVENTCOUNT(3);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
 }
@@ -4535,7 +4535,7 @@ void Test_SB_TransmitMsgPaths_WriteErr(void)
 
     CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
 
-    CFE_UtAssert_EVENTCOUNT(2);
+    CFE_UtAssert_EVENTCOUNT(3);
 
     CFE_UtAssert_EVENTNOTSENT(CFE_SB_Q_WR_ERR_EID);
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2282
  - 3 calls to `CFE_SB_GetPipeName()` reduced to 1 by moving it up to the start of the `for` loop block.

The `PipeName` is now ready to use in any of the error blocks if needed.

**Testing performed**
GitHub CI actions all passing successfully.

A couple of the coverage tests which were checking the error conditions but suppressing the actual sending of an event now have the extra event generated by `CFE_SB_GetPipeName()` from earlier in the `for` block.

https://github.com/nasa/cFE/pull/2265 will remove the event from nominal execution of `CFE_SB_GetPipeName()` anyway, so these event counts will go back down once that is merged (also the call will no longer be 'indirectly recursive').

**Expected behavior changes**
No change to behavior other than that described above.

**Contributor Info**
Avi Weiss @thnkslprpt