### PR TITLE
Fix #1473, Add helper for `CFE_SB_Write...InfoCmd()` with common logic

### DIFF
--- a/modules/sb/fsw/src/cfe_sb_priv.h
+++ b/modules/sb/fsw/src/cfe_sb_priv.h
@@ -835,7 +835,8 @@ int32 CFE_SB_SendStatsCmd(const CFE_SB_SendSbStatsCmd_t *data);
 /**
  * \brief Command Message Handler function
  *
- * SB internal function to handle processing of 'Write Routing Info' Cmd
+ * SB internal function to handle processing of 'Write Routing Info' Cmd.
+ * Calls CFE_SB_WriteInfo() to write the routing information to a file.
  *
  * \param[in] data Pointer to command structure
  * \return Execution status, see \ref CFEReturnCodes
@@ -846,7 +847,8 @@ int32 CFE_SB_WriteRoutingInfoCmd(const CFE_SB_WriteRoutingInfoCmd_t *data);
 /**
  * \brief Command Message Handler function
  *
- * SB internal function to handle processing of 'Write Pipe Info' Cmd
+ * SB internal function to handle processing of 'Write Pipe Info' Cmd.
+ * calls CFE_SB_WriteInfo() to write the pipe information to a file.
  *
  * \param[in] data Pointer to command structure
  * \return Execution status, see \ref CFEReturnCodes
@@ -857,12 +859,30 @@ int32 CFE_SB_WritePipeInfoCmd(const CFE_SB_WritePipeInfoCmd_t *data);
 /**
  * \brief Command Message Handler function
  *
- * SB internal function to handle processing of 'Write Map Info' Cmd
+ * SB internal function to handle processing of 'Write Map Info' Cmd.
+ * Calls CFE_SB_WriteInfo() to write the message map information to a file.
  *
  * \param[in] data Pointer to command structure
  * \return Execution status, see \ref CFEReturnCodes
  */
 int32 CFE_SB_WriteMapInfoCmd(const CFE_SB_WriteMapInfoCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Performs the actual write of Pipe/Routing/Map data to a file
+ *
+ * This is an internal helper function which is called by CFE_SB_WriteRoutingInfoCmd(),
+ * CFE_SB_WritePipeInfoCmd() or CFE_SB_WriteMapInfoCmd(). The function performs the
+ * file write based on the type of information (Routing, Pipe or Message Map).
+ *
+ * @param[in] data            Pointer to the command structure
+ * @param[in] InfoType        File sub-type
+ * @param[in] FileDescription Description of file for the FS header
+ * @param[in] DataCallback    Application callback to get a data record from the SB global state object
+ * @param[in] FileName        Default file name (as defined in the the configuation file)
+ */
+void CFE_SB_WriteInfo(const CFE_SB_WriteFileInfoCmd_t *data, enum CFE_FS_SubType InfoType, const char *FileDescription,
+                      CFE_FS_FileWriteGetData_t DataCallback, const char *FileName);
 
 /*---------------------------------------------------------------------------------------*/
 /**


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1473
  - Moves the common logic out of the 3 `CFE_SB_Write*InfoCmd()` functions into a helper function to reduce code duplication.

The 3 different commands now call `CFE_SB_WriteInfo()` with their personalised input parameters to perform the actual write. (I was considering naming the new function `CFE_SB_PerformWriteInfoCmd()`).

**Testing performed**
GitHub CI actions all passing successfully.
Local testing shows net coverage (for the full cFS bundle) is unaffected and the changes result in a net reduction of 22 lines and 12 branches.

Before the changes:
```
  lines......: 98.1% (13074 of 13326 lines)
  functions..: 97.0% (1041 of 1073 functions)
  branches...: 97.1% (5870 of 6047 branches)
```
After the changes:
```
  lines......: 98.1% (13052 of 13304 lines)
  functions..: 97.0% (1042 of 1074 functions)
  branches...: 97.1% (5858 of 6035 branches)
```

**Expected behavior changes**
No change to behavior.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss @thnkslprpt