### PR TITLE
Fix #2287, remove return value doxygen markup

### DIFF
--- a/modules/es/fsw/src/cfe_es_resource.h
+++ b/modules/es/fsw/src/cfe_es_resource.h
@@ -468,7 +468,6 @@ static inline void CFE_ES_TaskRecordSetUsed(CFE_ES_TaskRecord_t *TaskRecPtr, CFE
  * that are known to refer to an actual table location (i.e. non-null).
  *
  * @param[in]   TaskRecPtr   pointer to task table entry
- * @returns true if the entry is in use/configured, or false if it is free/empty
  */
 static inline void CFE_ES_TaskRecordSetFree(CFE_ES_TaskRecord_t *TaskRecPtr)
 {


### PR DESCRIPTION
The CFE_ES_TaskRecordSetFree() function is a void, it should not have any documentation about return value.  Remove this line.  Appears to be a cut and paste error, produces a warning in newer Doxygen versions.

**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #2287

**Testing performed**
Build documentation 

**Expected behavior changes**
None

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.