### PR TITLE
Fix #1453, Remove sparsely used `CFE_BIT`-related macros

### DIFF
--- a/modules/core_api/fsw/inc/cfe_sb.h
+++ b/modules/core_api/fsw/inc/cfe_sb.h
@@ -38,14 +38,6 @@
 #include "cfe_sb_api_typedefs.h"
 #include "cfe_es_api_typedefs.h"
 
-/*
-** Macro Definitions
-*/
-#define CFE_BIT(x)    (1 << (x))              /**< \brief Places a one at bit positions 0 - 31*/
-#define CFE_SET(i, x) ((i) |= CFE_BIT(x))     /**< \brief Sets bit x of i */
-#define CFE_CLR(i, x) ((i) &= ~CFE_BIT(x))    /**< \brief Clears bit x of i */
-#define CFE_TST(i, x) (((i)&CFE_BIT(x)) != 0) /**< \brief true(non zero) if bit x of i is set */
-
 /****************** Function Prototypes **********************/
 
 /** @defgroup CFEAPISBPipe cFE Pipe Management APIs

--- a/modules/sb/fsw/src/cfe_sb_priv.c
+++ b/modules/sb/fsw/src/cfe_sb_priv.c
@@ -300,14 +300,15 @@ uint32 CFE_SB_RequestToSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit)
         return CFE_SB_DENIED;
     }
 
-    /* if bit is set... */
-    if (CFE_TST(CFE_SB_Global.StopRecurseFlags[Indx], Bit))
+    /* Check if Bit is set */
+    if (CFE_SB_Global.StopRecurseFlags[Indx] & (1 << Bit))
     {
         return CFE_SB_DENIED;
     }
     else
     {
-        CFE_SET(CFE_SB_Global.StopRecurseFlags[Indx], Bit);
+        /* Set Bit */
+        CFE_SB_Global.StopRecurseFlags[Indx] |= (1 << Bit);
         return CFE_SB_GRANTED;
     }
 }
@@ -328,7 +329,7 @@ void CFE_SB_FinishSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit)
     }
 
     /* clear the bit so the task may send this event again */
-    CFE_CLR(CFE_SB_Global.StopRecurseFlags[Indx], Bit);
+    CFE_SB_Global.StopRecurseFlags[Indx] &= ~(1 << Bit);
 }
 
 /*----------------------------------------------------------------

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -4392,7 +4392,7 @@ void Test_SB_TransmitMsgPaths_Nominal(void)
 
     /* Repress sending the no subscriptions event and process request */
     CFE_SB_Global.HKTlmMsg.Payload.NoSubscribersCounter = 0;
-    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_SEND_NO_SUBS_EID_BIT);
+    CFE_SB_Global.StopRecurseFlags[1] |= (1 << CFE_SB_SEND_NO_SUBS_EID_BIT);
     CFE_SB_ProcessCmdPipePkt(&Housekeeping.SBBuf);
 
     /* The no subs event should not be in history but count should increment */
@@ -4401,7 +4401,7 @@ void Test_SB_TransmitMsgPaths_Nominal(void)
 
     /* Repress get buffer error */
     CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter = 0;
-    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_GET_BUF_ERR_EID_BIT);
+    CFE_SB_Global.StopRecurseFlags[1] |= (1 << CFE_SB_GET_BUF_ERR_EID_BIT);
 
     /* Set up for dispatch FIRST */
     UT_SetupBasicMsgDispatch(&UT_TPID_CFE_SB_SEND_HK, sizeof(Housekeeping.SendHkCmd), false);
@@ -4449,7 +4449,7 @@ void Test_SB_TransmitMsgPaths_Nominal(void)
     Size                                               = CFE_MISSION_SB_MAX_SB_MSG_SIZE + 1;
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_MSG_TOO_BIG_EID_BIT);
+    CFE_SB_Global.StopRecurseFlags[1] |= (1 << CFE_SB_MSG_TOO_BIG_EID_BIT);
     CFE_SB_TransmitMsg(CFE_MSG_PTR(Housekeeping.SBBuf), true);
     CFE_UtAssert_EVENTNOTSENT(CFE_SB_MSG_TOO_BIG_EID);
     UtAssert_UINT32_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter, 1);
@@ -4458,14 +4458,14 @@ void Test_SB_TransmitMsgPaths_Nominal(void)
     CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter = 0;
     MsgId                                              = CFE_SB_INVALID_MSG_ID;
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_SEND_INV_MSGID_EID_BIT);
+    CFE_SB_Global.StopRecurseFlags[1] |= (1 << CFE_SB_SEND_INV_MSGID_EID_BIT);
     CFE_SB_TransmitMsg(CFE_MSG_PTR(Housekeeping.SBBuf), true);
     CFE_UtAssert_EVENTNOTSENT(CFE_SB_SEND_INV_MSGID_EID);
     UtAssert_UINT32_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter, 1);
 
     /* CFE_SB_SEND_BAD_ARG_EID loop filter */
     CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter = 0;
-    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_SEND_BAD_ARG_EID_BIT);
+    CFE_SB_Global.StopRecurseFlags[1] |= (1 << CFE_SB_SEND_BAD_ARG_EID_BIT);
     CFE_SB_TransmitMsg(NULL, true);
     CFE_UtAssert_EVENTNOTSENT(CFE_SB_SEND_BAD_ARG_EID);
     UtAssert_UINT32_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter, 1);
@@ -4502,7 +4502,7 @@ void Test_SB_TransmitMsgPaths_LimitErr(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
 
-    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_MSGID_LIM_ERR_EID_BIT);
+    CFE_SB_Global.StopRecurseFlags[1] |= (1 << CFE_SB_MSGID_LIM_ERR_EID_BIT);
     CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
     CFE_SB_Global.StopRecurseFlags[1] = 0;
 
@@ -4540,7 +4540,7 @@ void Test_SB_TransmitMsgPaths_FullErr(void)
 
     /* Tell the QueuePut stub to return OS_QUEUE_FULL on its next call */
     UT_SetDeferredRetcode(UT_KEY(OS_QueuePut), 1, OS_QUEUE_FULL);
-    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_Q_FULL_ERR_EID_BIT);
+    CFE_SB_Global.StopRecurseFlags[1] |= (1 << CFE_SB_Q_FULL_ERR_EID_BIT);
     CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
     CFE_SB_Global.StopRecurseFlags[1] = 0;
 
@@ -4572,7 +4572,7 @@ void Test_SB_TransmitMsgPaths_WriteErr(void)
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
     UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
 
-    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_Q_WR_ERR_EID_BIT);
+    CFE_SB_Global.StopRecurseFlags[1] |= (1 << CFE_SB_Q_WR_ERR_EID_BIT);
     CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
     CFE_SB_Global.StopRecurseFlags[1] = 0;
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1453
  - Remove the `CFE-BIT` family of macros. They were nicely designed but used only a few times (out of ~200 bit-check/manipulation expressions), so better to simplify and remove the abstraction.

_Note: There are 4 uses (total) of the `CFE-BIT` macros in SC and HS._

**Testing performed**
GitHub CI actions all passing successfully.

**Expected behavior changes**
No change to behavior.

**Contributor Info**
Avi Weiss @thnkslprpt