### PR TITLE
Fix #2296, add option to link to generated files

### DIFF
--- a/cmake/global_functions.cmake
+++ b/cmake/global_functions.cmake
@@ -151,7 +151,7 @@ endfunction(generate_c_headerfile)
 #
 function(generate_config_includefile)
 
-    cmake_parse_arguments(GENCONFIG_ARG "" "OUTPUT_DIRECTORY;FILE_NAME;FALLBACK_FILE;MATCH_SUFFIX" "PREFIXES" ${ARGN} )
+    cmake_parse_arguments(GENCONFIG_ARG "" "OUTPUT_DIRECTORY;FILE_NAME;FALLBACK_FILE;MATCH_SUFFIX" "PREFIXES;GENERATED_FILE" ${ARGN} )
     if (NOT GENCONFIG_ARG_OUTPUT_DIRECTORY)
         set(GENCONFIG_ARG_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/inc")
     endif (NOT GENCONFIG_ARG_OUTPUT_DIRECTORY)
@@ -168,13 +168,20 @@ function(generate_config_includefile)
       set(TGTFILE ${GENCONFIG_ARG_FILE_NAME})
     endif()
 
-    # Use the common search function to find the candidate(s)
-    cfe_locate_implementation_file(SRC_LOCAL_PATH_LIST "${TGTFILE}"
-      ALLOW_LIST
-      FALLBACK_FILE "${GENCONFIG_ARG_FALLBACK_FILE}"
-      PREFIX ${GENCONFIG_ARG_PREFIXES} ${ARCH_PREFIXES}
-      SUBDIR config
-    )
+    if (GENCONFIG_ARG_GENERATED_FILE)
+      # A generated file may not yet exist at the time this runs, so just use
+      # what the caller said, no searching.
+      set(SRC_LOCAL_PATH_LIST ${GENCONFIG_ARG_GENERATED_FILE})
+      message(STATUS "Using file: [generated] ${SRC_LOCAL_PATH_LIST} for ${TGTFILE}")
+    else()
+      # Use the common search function to find the candidate(s)
+      cfe_locate_implementation_file(SRC_LOCAL_PATH_LIST "${TGTFILE}"
+        ALLOW_LIST
+        FALLBACK_FILE "${GENCONFIG_ARG_FALLBACK_FILE}"
+        PREFIX ${GENCONFIG_ARG_PREFIXES} ${ARCH_PREFIXES}
+        SUBDIR config
+      )
+    endif()
 
     set(WRAPPER_FILE_CONTENT)
     foreach(SELECTED_FILE ${SRC_LOCAL_PATH_LIST})


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Update the "generate_config_includefile" to be aware of generated files. This should not call cfe_locate_implementation_file() in this context because the file may not exist at the time.  For this type of use case it should just directly link the file without any checking.

Fixes #2296

**Testing performed**
Build HS (with additional patch) that needs this

**Expected behavior changes**
Files that are expected to be generated (e.g. via EDS tool) do not need to exist.

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
