### PR TITLE
Fix #1527, Implement common command-handler return pattern across cFE

### DIFF
--- a/modules/core_api/fsw/inc/cfe_error.h
+++ b/modules/core_api/fsw/inc/cfe_error.h
@@ -155,6 +155,14 @@ char *CFE_ES_StatusToString(CFE_Status_t status, CFE_StatusString_t *status_stri
 #define CFE_STATUS_NO_COUNTER_INCREMENT ((CFE_Status_t)0x48000001)
 
 /**
+ * @brief Command Execution Failure
+ *
+ *  This error code will be returned when a command function fails
+ *  to successfully execute its command
+ */
+#define CFE_STATUS_COMMAND_FAILURE ((CFE_Status_t)0xc8000001)
+
+/**
  * @brief Wrong Message Length
  *
  *  This error code will be returned when a message validation process
@@ -1250,14 +1258,6 @@ char *CFE_ES_StatusToString(CFE_Status_t status, CFE_StatusString_t *status_stri
  *
  */
 #define CFE_TBL_ERR_BAD_PROCESSOR_ID ((CFE_Status_t)0xcc000029)
-
-/**
- * @brief Message Error
- *
- *  Error code indicating that the TBL command was not processed
- *  successfully and that the error counter should be incremented.
- */
-#define CFE_TBL_MESSAGE_ERROR ((CFE_Status_t)0xcc00002a)
 
 /**
 **  Error code indicating that the TBL file is shorter than

--- a/modules/es/fsw/src/cfe_es_dispatch.c
+++ b/modules/es/fsw/src/cfe_es_dispatch.c
@@ -79,6 +79,7 @@ void CFE_ES_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
 {
     CFE_SB_MsgId_t    MessageID   = CFE_SB_INVALID_MSG_ID;
     CFE_MSG_FcnCode_t CommandCode = 0;
+    CFE_Status_t      Status      = CFE_STATUS_NO_COUNTER_INCREMENT;
 
     CFE_MSG_GetMsgId(&SBBufPtr->Msg, &MessageID);
     switch (CFE_SB_MsgIdToValue(MessageID))
@@ -101,168 +102,168 @@ void CFE_ES_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
                 case CFE_ES_NOOP_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_NoopCmd_t)))
                     {
-                        CFE_ES_NoopCmd((const CFE_ES_NoopCmd_t *)SBBufPtr);
+                        Status = CFE_ES_NoopCmd((const CFE_ES_NoopCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_RESET_COUNTERS_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_ResetCountersCmd_t)))
                     {
-                        CFE_ES_ResetCountersCmd((const CFE_ES_ResetCountersCmd_t *)SBBufPtr);
+                        Status = CFE_ES_ResetCountersCmd((const CFE_ES_ResetCountersCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_RESTART_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_RestartCmd_t)))
                     {
-                        CFE_ES_RestartCmd((const CFE_ES_RestartCmd_t *)SBBufPtr);
+                        Status = CFE_ES_RestartCmd((const CFE_ES_RestartCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_START_APP_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_StartAppCmd_t)))
                     {
-                        CFE_ES_StartAppCmd((const CFE_ES_StartAppCmd_t *)SBBufPtr);
+                        Status = CFE_ES_StartAppCmd((const CFE_ES_StartAppCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_STOP_APP_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_StopAppCmd_t)))
                     {
-                        CFE_ES_StopAppCmd((const CFE_ES_StopAppCmd_t *)SBBufPtr);
+                        Status = CFE_ES_StopAppCmd((const CFE_ES_StopAppCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_RESTART_APP_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_RestartAppCmd_t)))
                     {
-                        CFE_ES_RestartAppCmd((const CFE_ES_RestartAppCmd_t *)SBBufPtr);
+                        Status = CFE_ES_RestartAppCmd((const CFE_ES_RestartAppCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_RELOAD_APP_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_ReloadAppCmd_t)))
                     {
-                        CFE_ES_ReloadAppCmd((const CFE_ES_ReloadAppCmd_t *)SBBufPtr);
+                        Status = CFE_ES_ReloadAppCmd((const CFE_ES_ReloadAppCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_QUERY_ONE_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_QueryOneCmd_t)))
                     {
-                        CFE_ES_QueryOneCmd((const CFE_ES_QueryOneCmd_t *)SBBufPtr);
+                        Status = CFE_ES_QueryOneCmd((const CFE_ES_QueryOneCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_QUERY_ALL_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_QueryAllCmd_t)))
                     {
-                        CFE_ES_QueryAllCmd((const CFE_ES_QueryAllCmd_t *)SBBufPtr);
+                        Status = CFE_ES_QueryAllCmd((const CFE_ES_QueryAllCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_QUERY_ALL_TASKS_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_QueryAllTasksCmd_t)))
                     {
-                        CFE_ES_QueryAllTasksCmd((const CFE_ES_QueryAllTasksCmd_t *)SBBufPtr);
+                        Status = CFE_ES_QueryAllTasksCmd((const CFE_ES_QueryAllTasksCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_CLEAR_SYS_LOG_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_ClearSysLogCmd_t)))
                     {
-                        CFE_ES_ClearSysLogCmd((const CFE_ES_ClearSysLogCmd_t *)SBBufPtr);
+                        Status = CFE_ES_ClearSysLogCmd((const CFE_ES_ClearSysLogCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_WRITE_SYS_LOG_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_WriteSysLogCmd_t)))
                     {
-                        CFE_ES_WriteSysLogCmd((const CFE_ES_WriteSysLogCmd_t *)SBBufPtr);
+                        Status = CFE_ES_WriteSysLogCmd((const CFE_ES_WriteSysLogCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_OVER_WRITE_SYS_LOG_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_OverWriteSysLogCmd_t)))
                     {
-                        CFE_ES_OverWriteSysLogCmd((const CFE_ES_OverWriteSysLogCmd_t *)SBBufPtr);
+                        Status = CFE_ES_OverWriteSysLogCmd((const CFE_ES_OverWriteSysLogCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_CLEAR_ER_LOG_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_ClearERLogCmd_t)))
                     {
-                        CFE_ES_ClearERLogCmd((const CFE_ES_ClearERLogCmd_t *)SBBufPtr);
+                        Status = CFE_ES_ClearERLogCmd((const CFE_ES_ClearERLogCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_WRITE_ER_LOG_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_WriteERLogCmd_t)))
                     {
-                        CFE_ES_WriteERLogCmd((const CFE_ES_WriteERLogCmd_t *)SBBufPtr);
+                        Status = CFE_ES_WriteERLogCmd((const CFE_ES_WriteERLogCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_START_PERF_DATA_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_StartPerfDataCmd_t)))
                     {
-                        CFE_ES_StartPerfDataCmd((const CFE_ES_StartPerfDataCmd_t *)SBBufPtr);
+                        Status = CFE_ES_StartPerfDataCmd((const CFE_ES_StartPerfDataCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_STOP_PERF_DATA_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_StopPerfDataCmd_t)))
                     {
-                        CFE_ES_StopPerfDataCmd((const CFE_ES_StopPerfDataCmd_t *)SBBufPtr);
+                        Status = CFE_ES_StopPerfDataCmd((const CFE_ES_StopPerfDataCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_SET_PERF_FILTER_MASK_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_SetPerfFilterMaskCmd_t)))
                     {
-                        CFE_ES_SetPerfFilterMaskCmd((const CFE_ES_SetPerfFilterMaskCmd_t *)SBBufPtr);
+                        Status = CFE_ES_SetPerfFilterMaskCmd((const CFE_ES_SetPerfFilterMaskCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_SET_PERF_TRIGGER_MASK_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_SetPerfTriggerMaskCmd_t)))
                     {
-                        CFE_ES_SetPerfTriggerMaskCmd((const CFE_ES_SetPerfTriggerMaskCmd_t *)SBBufPtr);
+                        Status = CFE_ES_SetPerfTriggerMaskCmd((const CFE_ES_SetPerfTriggerMaskCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_RESET_PR_COUNT_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_ResetPRCountCmd_t)))
                     {
-                        CFE_ES_ResetPRCountCmd((const CFE_ES_ResetPRCountCmd_t *)SBBufPtr);
+                        Status = CFE_ES_ResetPRCountCmd((const CFE_ES_ResetPRCountCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_SET_MAX_PR_COUNT_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_SetMaxPRCountCmd_t)))
                     {
-                        CFE_ES_SetMaxPRCountCmd((const CFE_ES_SetMaxPRCountCmd_t *)SBBufPtr);
+                        Status = CFE_ES_SetMaxPRCountCmd((const CFE_ES_SetMaxPRCountCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_DELETE_CDS_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_DeleteCDSCmd_t)))
                     {
-                        CFE_ES_DeleteCDSCmd((const CFE_ES_DeleteCDSCmd_t *)SBBufPtr);
+                        Status = CFE_ES_DeleteCDSCmd((const CFE_ES_DeleteCDSCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_SEND_MEM_POOL_STATS_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_SendMemPoolStatsCmd_t)))
                     {
-                        CFE_ES_SendMemPoolStatsCmd((const CFE_ES_SendMemPoolStatsCmd_t *)SBBufPtr);
+                        Status = CFE_ES_SendMemPoolStatsCmd((const CFE_ES_SendMemPoolStatsCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_ES_DUMP_CDS_REGISTRY_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_DumpCDSRegistryCmd_t)))
                     {
-                        CFE_ES_DumpCDSRegistryCmd((const CFE_ES_DumpCDSRegistryCmd_t *)SBBufPtr);
+                        Status = CFE_ES_DumpCDSRegistryCmd((const CFE_ES_DumpCDSRegistryCmd_t *)SBBufPtr);
                     }
                     break;
 
@@ -270,9 +271,23 @@ void CFE_ES_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
                     CFE_EVS_SendEvent(CFE_ES_CC1_ERR_EID, CFE_EVS_EventType_ERROR,
                                       "Invalid ground command code: ID = 0x%X, CC = %d",
                                       (unsigned int)CFE_SB_MsgIdToValue(MessageID), (int)CommandCode);
-                    CFE_ES_Global.TaskData.CommandErrorCounter++;
+                    Status = CFE_STATUS_BAD_COMMAND_CODE;
                     break;
             }
+
+            /*
+             * Any command functions returning a Status of CFE_STATUS_NO_COUNTER_INCREMENT
+             * will not increment either counter
+             */
+            if (Status == CFE_SUCCESS)
+            {
+                CFE_ES_Global.TaskData.CommandCounter++;
+            }
+            else if ((Status == CFE_STATUS_COMMAND_FAILURE) || (Status == CFE_STATUS_BAD_COMMAND_CODE))
+            {
+                CFE_ES_Global.TaskData.CommandErrorCounter++;
+            }
+
             break;
 
         default:

--- a/modules/sb/fsw/src/cfe_sb_priv.h
+++ b/modules/sb/fsw/src/cfe_sb_priv.h
@@ -516,16 +516,6 @@ int32 CFE_SB_ValidateMsgId(CFE_SB_MsgId_t MsgId);
 
 /*---------------------------------------------------------------------------------------*/
 /**
- * Increment the command counter based on the status input.
- *
- * This small utility was written to eliminate duplicate code.
- *
- * @param status  typically #CFE_SUCCESS or an SB error code
- */
-void CFE_SB_IncrCmdCtr(int32 status);
-
-/*---------------------------------------------------------------------------------------*/
-/**
  * SB internal function to enable and disable subscription reporting.
  */
 void CFE_SB_SetSubscriptionReporting(uint32 state);

--- a/modules/tbl/fsw/src/cfe_tbl_dispatch.c
+++ b/modules/tbl/fsw/src/cfe_tbl_dispatch.c
@@ -93,11 +93,11 @@ const CFE_TBL_CmdHandlerTblRec_t CFE_TBL_CmdHandlerTbl[] = {
  *-----------------------------------------------------------------*/
 void CFE_TBL_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
 {
-    CFE_SB_MsgId_t       MessageID   = CFE_SB_INVALID_MSG_ID;
-    CFE_MSG_FcnCode_t    CommandCode = 0;
-    int16                CmdIndx;
-    CFE_MSG_Size_t       ActualLength = 0;
-    CFE_TBL_CmdProcRet_t CmdStatus    = CFE_TBL_INC_ERR_CTR; /* Assume a failed command */
+    CFE_SB_MsgId_t    MessageID   = CFE_SB_INVALID_MSG_ID;
+    CFE_MSG_FcnCode_t CommandCode = 0;
+    int16             CmdIndx;
+    CFE_MSG_Size_t    ActualLength = 0;
+    CFE_Status_t      CmdStatus    = CFE_STATUS_COMMAND_FAILURE; /* Assume a failed command */
 
     CFE_MSG_GetMsgId(&SBBufPtr->Msg, &MessageID);
     CFE_MSG_GetFcnCode(&SBBufPtr->Msg, &CommandCode);
@@ -126,11 +126,11 @@ void CFE_TBL_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
         /* Only update command counters when message has a command code */
         if (CFE_TBL_CmdHandlerTbl[CmdIndx].MsgTypes == CFE_TBL_CMD_MSGTYPE)
         {
-            if (CmdStatus == CFE_TBL_INC_CMD_CTR)
+            if (CmdStatus == CFE_SUCCESS)
             {
                 CFE_TBL_Global.CommandCounter++;
             }
-            else if (CmdStatus == CFE_TBL_INC_ERR_CTR)
+            else if (CmdStatus == CFE_STATUS_COMMAND_FAILURE)
             {
                 CFE_TBL_Global.CommandErrorCounter++;
             }

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
@@ -95,7 +95,7 @@ int32 CFE_TBL_SendHkCmd(const CFE_TBL_SendHkCmd_t *data)
 
             /* If dump file was successfully written, update the file header so that the timestamp */
             /* is the time of the actual capturing of the data, NOT the time when it was written to the file */
-            if (Status == CFE_TBL_INC_CMD_CTR)
+            if (Status == CFE_SUCCESS)
             {
                 DumpTime = DumpCtrlPtr->DumpBufferPtr->FileTime;
 
@@ -130,7 +130,7 @@ int32 CFE_TBL_SendHkCmd(const CFE_TBL_SendHkCmd_t *data)
         }
     }
 
-    return CFE_TBL_DONT_INC_CTR;
+    return CFE_STATUS_NO_COUNTER_INCREMENT;
 }
 
 /*----------------------------------------------------------------
@@ -321,7 +321,7 @@ int32 CFE_TBL_NoopCmd(const CFE_TBL_NoopCmd_t *data)
                                 CFE_LAST_OFFICIAL);
     CFE_EVS_SendEvent(CFE_TBL_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", VersionString);
 
-    return CFE_TBL_INC_CMD_CTR;
+    return CFE_SUCCESS;
 }
 
 /*----------------------------------------------------------------
@@ -341,7 +341,7 @@ int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCountersCmd_t *data)
 
     CFE_EVS_SendEvent(CFE_TBL_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "Reset Counters command");
 
-    return CFE_TBL_DONT_INC_CTR;
+    return CFE_STATUS_NO_COUNTER_INCREMENT;
 }
 
 /*----------------------------------------------------------------
@@ -352,7 +352,7 @@ int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCountersCmd_t *data)
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
 {
-    CFE_TBL_CmdProcRet_t             ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
+    CFE_Status_t                     ReturnCode = CFE_STATUS_COMMAND_FAILURE; /* Assume failure */
     const CFE_TBL_LoadCmd_Payload_t *CmdPtr     = &data->Payload;
     CFE_FS_Header_t                  StdFileHeader;
     CFE_TBL_File_Hdr_t               TblFileHeader;
@@ -471,7 +471,7 @@ int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
                                         '\0';
 
                                     /* Increment successful command completion counter */
-                                    ReturnCode = CFE_TBL_INC_CMD_CTR;
+                                    ReturnCode = CFE_SUCCESS;
                                 }
                             }
                             else
@@ -536,7 +536,7 @@ int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data)
 {
-    CFE_TBL_CmdProcRet_t             ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
+    CFE_Status_t             ReturnCode = CFE_STATUS_COMMAND_FAILURE; /* Assume failure */
     CFE_TBL_TxnState_t               Txn;
     const CFE_TBL_DumpCmd_Payload_t *CmdPtr = &data->Payload;
     char                             DumpFilename[OS_MAX_PATH_LEN];
@@ -616,7 +616,7 @@ int32 CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data)
                             CFE_TBL_SendNotificationMsg(RegRecPtr);
 
                             /* Consider the command completed successfully */
-                            ReturnCode = CFE_TBL_INC_CMD_CTR;
+                            ReturnCode = CFE_SUCCESS;
                         }
                         else
                         {
@@ -653,17 +653,17 @@ int32 CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-CFE_TBL_CmdProcRet_t CFE_TBL_DumpToFile(const char *DumpFilename, const char *TableName, const void *DumpDataAddr,
-                                        size_t TblSizeInBytes)
+CFE_Status_t CFE_TBL_DumpToFile(const char *DumpFilename, const char *TableName, const void *DumpDataAddr,
+                                size_t TblSizeInBytes)
 {
-    CFE_TBL_CmdProcRet_t ReturnCode      = CFE_TBL_INC_ERR_CTR; /* Assume failure */
-    bool                 FileExistedPrev = false;
-    CFE_FS_Header_t      StdFileHeader;
-    CFE_TBL_File_Hdr_t   TblFileHeader;
-    osal_id_t            FileDescriptor = OS_OBJECT_ID_UNDEFINED;
-    int32                Status;
-    int32                OsStatus;
-    int32                EndianCheck = 0x01020304;
+    CFE_Status_t       ReturnCode      = CFE_STATUS_COMMAND_FAILURE; /* Assume failure */
+    bool               FileExistedPrev = false;
+    CFE_FS_Header_t    StdFileHeader;
+    CFE_TBL_File_Hdr_t TblFileHeader;
+    osal_id_t          FileDescriptor = OS_OBJECT_ID_UNDEFINED;
+    int32              Status;
+    int32              OsStatus;
+    int32              EndianCheck = 0x01020304;
 
     /* Clear Header of any garbage before copying content */
     memset(&TblFileHeader, 0, sizeof(CFE_TBL_File_Hdr_t));
@@ -737,7 +737,7 @@ CFE_TBL_CmdProcRet_t CFE_TBL_DumpToFile(const char *DumpFilename, const char *Ta
                         .LastFileDumped[sizeof(CFE_TBL_Global.HkPacket.Payload.LastFileDumped) - 1] = 0;
 
                     /* Increment Successful Command Counter */
-                    ReturnCode = CFE_TBL_INC_CMD_CTR;
+                    ReturnCode = CFE_SUCCESS;
                 }
                 else
                 {
@@ -779,7 +779,7 @@ CFE_TBL_CmdProcRet_t CFE_TBL_DumpToFile(const char *DumpFilename, const char *Ta
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data)
 {
-    CFE_TBL_CmdProcRet_t                 ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
+    CFE_Status_t                         ReturnCode = CFE_STATUS_COMMAND_FAILURE; /* Assume failure */
     CFE_TBL_TxnState_t                   Txn;
     CFE_Status_t                         Status;
     const CFE_TBL_ValidateCmd_Payload_t *CmdPtr = &data->Payload;
@@ -872,7 +872,7 @@ int32 CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data)
                 }
 
                 /* Increment Successful Command Counter */
-                ReturnCode = CFE_TBL_INC_CMD_CTR;
+                ReturnCode = CFE_SUCCESS;
             }
             else
             {
@@ -898,7 +898,7 @@ int32 CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data)
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_ActivateCmd(const CFE_TBL_ActivateCmd_t *data)
 {
-    CFE_TBL_CmdProcRet_t                 ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
+    CFE_Status_t                         ReturnCode = CFE_STATUS_COMMAND_FAILURE; /* Assume failure */
     int16                                RegIndex;
     const CFE_TBL_ActivateCmd_Payload_t *CmdPtr = &data->Payload;
     char                                 TableName[CFE_TBL_MAX_FULL_NAME_LEN];
@@ -945,7 +945,7 @@ int32 CFE_TBL_ActivateCmd(const CFE_TBL_ActivateCmd_t *data)
                 }
 
                 /* Increment Successful Command Counter */
-                ReturnCode = CFE_TBL_INC_CMD_CTR;
+                ReturnCode = CFE_SUCCESS;
             }
             else
             {
@@ -1150,7 +1150,7 @@ void CFE_TBL_DumpRegistryEventHandler(void *Meta, CFE_FS_FileWriteEvent_t Event,
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data)
 {
-    CFE_TBL_CmdProcRet_t                     ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
+    CFE_Status_t                             ReturnCode = CFE_STATUS_COMMAND_FAILURE; /* Assume failure */
     int32                                    Status;
     const CFE_TBL_DumpRegistryCmd_Payload_t *CmdPtr = &data->Payload;
     os_fstat_t                               FileStat;
@@ -1195,7 +1195,7 @@ int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data)
             if (Status == CFE_SUCCESS)
             {
                 /* Increment the TBL generic command counter (successfully queued for background job) */
-                ReturnCode = CFE_TBL_INC_CMD_CTR;
+                ReturnCode = CFE_SUCCESS;
             }
         }
     }
@@ -1211,7 +1211,7 @@ int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data)
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data)
 {
-    CFE_TBL_CmdProcRet_t                     ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
+    CFE_Status_t                             ReturnCode = CFE_STATUS_COMMAND_FAILURE; /* Assume failure */
     int16                                    RegIndex;
     const CFE_TBL_SendRegistryCmd_Payload_t *CmdPtr = &data->Payload;
     char                                     TableName[CFE_TBL_MAX_FULL_NAME_LEN];
@@ -1231,7 +1231,7 @@ int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data)
                           "Table Registry entry for '%s' will be telemetered", TableName);
 
         /* Increment Successful Command Counter */
-        ReturnCode = CFE_TBL_INC_CMD_CTR;
+        ReturnCode = CFE_SUCCESS;
     }
     else /* Table could not be found in Registry */
     {
@@ -1250,7 +1250,7 @@ int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data)
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data)
 {
-    CFE_TBL_CmdProcRet_t               ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
+    CFE_Status_t                       ReturnCode = CFE_STATUS_COMMAND_FAILURE; /* Assume failure */
     const CFE_TBL_DelCDSCmd_Payload_t *CmdPtr     = &data->Payload;
     char                               TableName[CFE_TBL_MAX_FULL_NAME_LEN];
     CFE_TBL_CritRegRec_t *             CritRegRecPtr = NULL;
@@ -1313,7 +1313,7 @@ int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data)
                 CritRegRecPtr->CDSHandle = CFE_ES_CDS_BAD_HANDLE;
 
                 /* Increment Successful Command Counter */
-                ReturnCode = CFE_TBL_INC_CMD_CTR;
+                ReturnCode = CFE_SUCCESS;
             }
         }
         else
@@ -1338,7 +1338,7 @@ int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data)
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_AbortLoadCmd(const CFE_TBL_AbortLoadCmd_t *data)
 {
-    CFE_TBL_CmdProcRet_t                  ReturnCode = CFE_TBL_INC_ERR_CTR; /* Assume failure */
+    CFE_Status_t                          ReturnCode = CFE_STATUS_COMMAND_FAILURE; /* Assume failure */
     int16                                 RegIndex;
     const CFE_TBL_AbortLoadCmd_Payload_t *CmdPtr = &data->Payload;
     CFE_TBL_RegistryRec_t *               RegRecPtr;
@@ -1363,7 +1363,7 @@ int32 CFE_TBL_AbortLoadCmd(const CFE_TBL_AbortLoadCmd_t *data)
             CFE_TBL_AbortLoad(RegRecPtr);
 
             /* Increment Successful Command Counter */
-            ReturnCode = CFE_TBL_INC_CMD_CTR;
+            ReturnCode = CFE_SUCCESS;
         }
         else
         {

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.h
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.h
@@ -42,20 +42,6 @@
 
 /*********************  Macro and Constant Type Definitions   ***************************/
 
-/*
- * For backward compatibility, keep this enumeration for now but map the
- * values to the globally-defined codes in cfe_error.h, so it won't be confusing
- * if intermixed with a typical CFE int32 return code.
- */
-typedef enum
-{
-    CFE_TBL_INC_ERR_CTR =
-        CFE_TBL_MESSAGE_ERROR, /**< Error detected in (or while processing) message, increment command error counter */
-    CFE_TBL_DONT_INC_CTR =
-        CFE_STATUS_NO_COUNTER_INCREMENT, /**< No errors detected but don't increment command counter */
-    CFE_TBL_INC_CMD_CTR = CFE_SUCCESS    /**< No errors detected and increment command counter */
-} CFE_TBL_CmdProcRet_t;
-
 typedef int32 (*CFE_TBL_MsgProcFuncPtr_t)(const void *MsgPtr);
 
 #define CFE_TBL_BAD_CMD_CODE (-1) /**< Command Code found in Message does not match any in #CFE_TBL_CmdHandlerTbl */
@@ -119,7 +105,7 @@ void CFE_TBL_GetTblRegData(void);
 **
 ** \param[in] data points to the message received via command pipe that needs processing
 **
-** \retval #CFE_TBL_DONT_INC_CTR \copydoc CFE_TBL_DONT_INC_CTR
+** \retval #CFE_STATUS_NO_COUNTER_INCREMENT \copydoc CFE_STATUS_NO_COUNTER_INCREMENT
 */
 int32 CFE_TBL_SendHkCmd(const CFE_TBL_SendHkCmd_t *data);
 
@@ -135,8 +121,7 @@ int32 CFE_TBL_SendHkCmd(const CFE_TBL_SendHkCmd_t *data);
 **
 ** \param[in] data points to the message received via command pipe that needs processing
 **
-** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
-** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
+** \retval #CFE_SUCCESS  \copydoc CFE_SUCCESS
 */
 int32 CFE_TBL_NoopCmd(const CFE_TBL_NoopCmd_t *data);
 
@@ -152,7 +137,7 @@ int32 CFE_TBL_NoopCmd(const CFE_TBL_NoopCmd_t *data);
 **
 ** \param[in] data points to the message received via command pipe that needs processing
 **
-** \retval #CFE_TBL_DONT_INC_CTR \copydoc CFE_TBL_DONT_INC_CTR
+** \retval #CFE_STATUS_NO_COUNTER_INCREMENT \copydoc CFE_STATUS_NO_COUNTER_INCREMENT
 */
 int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCountersCmd_t *data);
 
@@ -169,8 +154,8 @@ int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCountersCmd_t *data);
 **
 ** \param[in] data points to the message received via command pipe that needs processing
 **
-** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
-** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
+** \retval #CFE_STATUS_COMMAND_FAILURE  \copydoc CFE_STATUS_COMMAND_FAILURE
+** \retval #CFE_SUCCESS  \copydoc CFE_SUCCESS
 */
 int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data);
 
@@ -187,8 +172,8 @@ int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data);
 **
 ** \param[in] data points to the message received via command pipe that needs processing
 **
-** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
-** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
+** \retval #CFE_STATUS_COMMAND_FAILURE  \copydoc CFE_STATUS_COMMAND_FAILURE
+** \retval #CFE_SUCCESS  \copydoc CFE_SUCCESS
 */
 int32 CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data);
 
@@ -206,8 +191,8 @@ int32 CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data);
 **
 ** \param[in] data points to the message received via command pipe that needs processing
 **
-** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
-** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
+** \retval #CFE_STATUS_COMMAND_FAILURE  \copydoc CFE_STATUS_COMMAND_FAILURE
+** \retval #CFE_SUCCESS  \copydoc CFE_SUCCESS
 */
 int32 CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data);
 
@@ -224,8 +209,8 @@ int32 CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data);
 **
 ** \param[in] data points to the message received via command pipe that needs processing
 **
-** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
-** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
+** \retval #CFE_STATUS_COMMAND_FAILURE  \copydoc CFE_STATUS_COMMAND_FAILURE
+** \retval #CFE_SUCCESS  \copydoc CFE_SUCCESS
 */
 int32 CFE_TBL_ActivateCmd(const CFE_TBL_ActivateCmd_t *data);
 
@@ -241,8 +226,8 @@ int32 CFE_TBL_ActivateCmd(const CFE_TBL_ActivateCmd_t *data);
 **
 ** \param[in] data points to the message received via command pipe that needs processing
 **
-** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
-** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
+** \retval #CFE_STATUS_COMMAND_FAILURE  \copydoc CFE_STATUS_COMMAND_FAILURE
+** \retval #CFE_SUCCESS  \copydoc CFE_SUCCESS
 */
 int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data);
 
@@ -259,8 +244,8 @@ int32 CFE_TBL_DumpRegistryCmd(const CFE_TBL_DumpRegistryCmd_t *data);
 **
 ** \param[in] data points to the message received via command pipe that needs processing
 **
-** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
-** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
+** \retval #CFE_STATUS_COMMAND_FAILURE  \copydoc CFE_STATUS_COMMAND_FAILURE
+** \retval #CFE_SUCCESS  \copydoc CFE_SUCCESS
 */
 int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data);
 
@@ -276,8 +261,8 @@ int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data);
 **
 ** \param[in] data points to the message received via command pipe that needs processing
 **
-** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
-** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
+** \retval #CFE_STATUS_COMMAND_FAILURE  \copydoc CFE_STATUS_COMMAND_FAILURE
+** \retval #CFE_SUCCESS  \copydoc CFE_SUCCESS
 */
 int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data);
 
@@ -293,8 +278,8 @@ int32 CFE_TBL_DeleteCDSCmd(const CFE_TBL_DeleteCDSCmd_t *data);
 **
 ** \param[in] data points to the message received via command pipe that needs processing
 **
-** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
-** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
+** \retval #CFE_STATUS_COMMAND_FAILURE  \copydoc CFE_STATUS_COMMAND_FAILURE
+** \retval #CFE_SUCCESS  \copydoc CFE_SUCCESS
 */
 int32 CFE_TBL_AbortLoadCmd(const CFE_TBL_AbortLoadCmd_t *data);
 
@@ -319,11 +304,11 @@ int32 CFE_TBL_AbortLoadCmd(const CFE_TBL_AbortLoadCmd_t *data);
 **
 ** \param[in] TblSizeInBytes  Size of block of data to be written to the file
 **
-** \retval #CFE_TBL_INC_ERR_CTR  \copydoc CFE_TBL_INC_ERR_CTR
-** \retval #CFE_TBL_INC_CMD_CTR  \copydoc CFE_TBL_INC_CMD_CTR
+** \retval #CFE_STATUS_COMMAND_FAILURE  \copydoc CFE_STATUS_COMMAND_FAILURE
+** \retval #CFE_SUCCESS  \copydoc CFE_SUCCESS
 */
-CFE_TBL_CmdProcRet_t CFE_TBL_DumpToFile(const char *DumpFilename, const char *TableName, const void *DumpDataAddr,
-                                        size_t TblSizeInBytes);
+CFE_Status_t CFE_TBL_DumpToFile(const char *DumpFilename, const char *TableName, const void *DumpDataAddr,
+                                size_t TblSizeInBytes);
 
 /*---------------------------------------------------------------------------------------*/
 /**

--- a/modules/tbl/ut-coverage/tbl_UT.c
+++ b/modules/tbl/ut-coverage/tbl_UT.c
@@ -68,8 +68,8 @@ static union
     uint8              Bytes[UT_TBL_LOAD_BUFFER_SIZE];
 } UT_TBL_LoadBuffer;
 
-void * Tbl1Ptr = NULL;
-void * Tbl2Ptr = NULL;
+void  *Tbl1Ptr = NULL;
+void  *Tbl2Ptr = NULL;
 void **ArrayOfPtrsToTblPtrs[2];
 
 /* Normal dispatching registers the MsgID+CC in order to follow a
@@ -509,7 +509,7 @@ void Test_CFE_TBL_DeleteCDSCmd(void)
     UT_InitData();
     strncpy(DelCDSCmd.Payload.TableName, "0", sizeof(DelCDSCmd.Payload.TableName) - 1);
     DelCDSCmd.Payload.TableName[sizeof(DelCDSCmd.Payload.TableName) - 1] = '\0';
-    UtAssert_INT32_EQ(CFE_TBL_DeleteCDSCmd(&DelCDSCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DeleteCDSCmd(&DelCDSCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test failure to find table in the critical table registry */
     UT_InitData();
@@ -522,7 +522,7 @@ void Test_CFE_TBL_DeleteCDSCmd(void)
 
     strncpy(DelCDSCmd.Payload.TableName, "-1", sizeof(DelCDSCmd.Payload.TableName) - 1);
     DelCDSCmd.Payload.TableName[sizeof(DelCDSCmd.Payload.TableName) - 1] = '\0';
-    UtAssert_INT32_EQ(CFE_TBL_DeleteCDSCmd(&DelCDSCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DeleteCDSCmd(&DelCDSCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test finding the table in the critical table registry, but CDS is not
      * tagged as a table
@@ -531,27 +531,27 @@ void Test_CFE_TBL_DeleteCDSCmd(void)
     snprintf(DelCDSCmd.Payload.TableName, sizeof(DelCDSCmd.Payload.TableName), "%d",
              CFE_PLATFORM_TBL_MAX_CRITICAL_TABLES + CFE_PLATFORM_TBL_MAX_NUM_TABLES - 1);
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_DeleteCDS), 1, CFE_ES_CDS_WRONG_TYPE_ERR);
-    UtAssert_INT32_EQ(CFE_TBL_DeleteCDSCmd(&DelCDSCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DeleteCDSCmd(&DelCDSCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test deletion when CDS owning application is still active */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_DeleteCDS), 1, CFE_ES_CDS_OWNER_ACTIVE_ERR);
-    UtAssert_INT32_EQ(CFE_TBL_DeleteCDSCmd(&DelCDSCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DeleteCDSCmd(&DelCDSCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test deletion where the table cannot be located in the CDS registry */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_DeleteCDS), 1, CFE_ES_ERR_NAME_NOT_FOUND);
-    UtAssert_INT32_EQ(CFE_TBL_DeleteCDSCmd(&DelCDSCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DeleteCDSCmd(&DelCDSCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test deletion error while deleting table from the CDS */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_DeleteCDS), 1, CFE_SUCCESS - 1);
-    UtAssert_INT32_EQ(CFE_TBL_DeleteCDSCmd(&DelCDSCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DeleteCDSCmd(&DelCDSCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test successful removal of the table from the CDS */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_DeleteCDS), 1, CFE_SUCCESS);
-    UtAssert_INT32_EQ(CFE_TBL_DeleteCDSCmd(&DelCDSCmd), CFE_TBL_INC_CMD_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DeleteCDSCmd(&DelCDSCmd), CFE_SUCCESS);
 }
 
 /*
@@ -571,14 +571,14 @@ void Test_CFE_TBL_TlmRegCmd(void)
      */
     strncpy(TlmRegCmd.Payload.TableName, CFE_TBL_Global.Registry[0].Name, sizeof(TlmRegCmd.Payload.TableName) - 1);
     TlmRegCmd.Payload.TableName[sizeof(TlmRegCmd.Payload.TableName) - 1] = '\0';
-    UtAssert_INT32_EQ(CFE_TBL_SendRegistryCmd(&TlmRegCmd), CFE_TBL_INC_CMD_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_SendRegistryCmd(&TlmRegCmd), CFE_SUCCESS);
 
     /* Test when table name does not exist */
     UT_InitData();
 
     snprintf(TlmRegCmd.Payload.TableName, sizeof(TlmRegCmd.Payload.TableName), "%d",
              CFE_PLATFORM_TBL_MAX_NUM_TABLES + 1);
-    UtAssert_INT32_EQ(CFE_TBL_SendRegistryCmd(&TlmRegCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_SendRegistryCmd(&TlmRegCmd), CFE_STATUS_COMMAND_FAILURE);
 }
 
 /*
@@ -600,12 +600,12 @@ void Test_CFE_TBL_AbortLoadCmd(void)
     strncpy(AbortLdCmd.Payload.TableName, CFE_TBL_Global.Registry[0].Name, sizeof(AbortLdCmd.Payload.TableName) - 1);
     AbortLdCmd.Payload.TableName[sizeof(AbortLdCmd.Payload.TableName) - 1] = '\0';
     CFE_TBL_Global.Registry[0].LoadInProgress                              = 1;
-    UtAssert_INT32_EQ(CFE_TBL_AbortLoadCmd(&AbortLdCmd), CFE_TBL_INC_CMD_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_AbortLoadCmd(&AbortLdCmd), CFE_SUCCESS);
 
     /* Test when table name does exist but no table load is in progress */
     UT_InitData();
     CFE_TBL_Global.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
-    UtAssert_INT32_EQ(CFE_TBL_AbortLoadCmd(&AbortLdCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_AbortLoadCmd(&AbortLdCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test when table name does exist, a table load is in progress, and the
      * table is dump only
@@ -613,13 +613,13 @@ void Test_CFE_TBL_AbortLoadCmd(void)
     UT_InitData();
     CFE_TBL_Global.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
     CFE_TBL_Global.Registry[0].DumpOnly       = true;
-    UtAssert_INT32_EQ(CFE_TBL_AbortLoadCmd(&AbortLdCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_AbortLoadCmd(&AbortLdCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test when table name not found in the registry */
     UT_InitData();
     snprintf(AbortLdCmd.Payload.TableName, sizeof(AbortLdCmd.Payload.TableName), "%d",
              CFE_PLATFORM_TBL_MAX_NUM_TABLES + 1);
-    UtAssert_INT32_EQ(CFE_TBL_AbortLoadCmd(&AbortLdCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_AbortLoadCmd(&AbortLdCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test when table is double buffered */
     UT_InitData();
@@ -653,7 +653,7 @@ void Test_CFE_TBL_ActivateCmd(void)
      */
     UT_InitData();
     CFE_TBL_Global.Registry[0].DumpOnly = true;
-    UtAssert_INT32_EQ(CFE_TBL_ActivateCmd(&ActivateCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_ActivateCmd(&ActivateCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test when table name exists, the table is not a dump-only, a load is in
      * progress, and the table is double-buffered
@@ -662,7 +662,7 @@ void Test_CFE_TBL_ActivateCmd(void)
     CFE_TBL_Global.Registry[0].DumpOnly       = false;
     CFE_TBL_Global.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
     CFE_TBL_Global.Registry[0].DoubleBuffered = true;
-    UtAssert_INT32_EQ(CFE_TBL_ActivateCmd(&ActivateCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_ActivateCmd(&ActivateCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test when table name exists, the table is not a dump-only, a load is in
      * progress, the table isn't double-buffered, and ValidationStatus = true
@@ -670,7 +670,7 @@ void Test_CFE_TBL_ActivateCmd(void)
     UT_InitData();
     CFE_TBL_Global.Registry[0].DoubleBuffered                                     = false;
     CFE_TBL_Global.LoadBuffs[CFE_TBL_Global.Registry[0].LoadInProgress].Validated = true;
-    UtAssert_INT32_EQ(CFE_TBL_ActivateCmd(&ActivateCmd), CFE_TBL_INC_CMD_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_ActivateCmd(&ActivateCmd), CFE_SUCCESS);
 
     /* Test when table name exists, the table is not a dump-only, no load is in
      * progress, and no notification message should be sent
@@ -678,7 +678,7 @@ void Test_CFE_TBL_ActivateCmd(void)
     UT_InitData();
     CFE_TBL_Global.Registry[0].NotifyByMsg    = false;
     CFE_TBL_Global.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
-    UtAssert_INT32_EQ(CFE_TBL_ActivateCmd(&ActivateCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_ActivateCmd(&ActivateCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test when table name exists, the table is not a dump-only, no load in in
      * progress, and a notification message should be sent
@@ -687,13 +687,13 @@ void Test_CFE_TBL_ActivateCmd(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_TransmitMsg), 1, CFE_SB_INTERNAL_ERR);
     CFE_TBL_Global.Registry[0].NotifyByMsg    = true;
     CFE_TBL_Global.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
-    UtAssert_INT32_EQ(CFE_TBL_ActivateCmd(&ActivateCmd), CFE_TBL_INC_CMD_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_ActivateCmd(&ActivateCmd), CFE_SUCCESS);
 
     /* Test when the table name doesn't exist */
     UT_InitData();
     snprintf(ActivateCmd.Payload.TableName, sizeof(ActivateCmd.Payload.TableName), "%d",
              CFE_PLATFORM_TBL_MAX_NUM_TABLES + 1);
-    UtAssert_INT32_EQ(CFE_TBL_ActivateCmd(&ActivateCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_ActivateCmd(&ActivateCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Restore original values */
     CFE_TBL_Global.Registry[0].LoadInProgress = load;
@@ -712,12 +712,14 @@ void Test_CFE_TBL_DumpToFile(void)
     /* Test with an error creating the dump file */
     UT_InitData();
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
-    UtAssert_INT32_EQ(CFE_TBL_DumpToFile("filename", "tablename", "dumpaddress", TblSizeInBytes), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DumpToFile("filename", "tablename", "dumpaddress", TblSizeInBytes),
+                      CFE_STATUS_COMMAND_FAILURE);
 
     /* Test with an error writing the cFE file header */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_WriteHeader), 1, sizeof(CFE_FS_Header_t) - 1);
-    UtAssert_INT32_EQ(CFE_TBL_DumpToFile("filename", "tablename", "dumpaddress", TblSizeInBytes), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DumpToFile("filename", "tablename", "dumpaddress", TblSizeInBytes),
+                      CFE_STATUS_COMMAND_FAILURE);
 
     /* Test with an error writing the table file header */
     UT_InitData();
@@ -727,21 +729,23 @@ void Test_CFE_TBL_DumpToFile(void)
      */
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_WriteHeader), 6, sizeof(CFE_FS_Header_t));
     UT_SetDeferredRetcode(UT_KEY(OS_write), 1, sizeof(CFE_TBL_File_Hdr_t) - 1);
-    UtAssert_INT32_EQ(CFE_TBL_DumpToFile("filename", "tablename", "dumpaddress", TblSizeInBytes), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DumpToFile("filename", "tablename", "dumpaddress", TblSizeInBytes),
+                      CFE_STATUS_COMMAND_FAILURE);
 
     /* Test with an error writing the table to a file */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(OS_write), 2, TblSizeInBytes - 1);
-    UtAssert_INT32_EQ(CFE_TBL_DumpToFile("filename", "tablename", "dumpaddress", TblSizeInBytes), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DumpToFile("filename", "tablename", "dumpaddress", TblSizeInBytes),
+                      CFE_STATUS_COMMAND_FAILURE);
 
     /* Test successful file creation and data dumped */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(OS_OpenCreate), 1, OS_ERROR);
-    UtAssert_INT32_EQ(CFE_TBL_DumpToFile("filename", "tablename", "dumpaddress", TblSizeInBytes), CFE_TBL_INC_CMD_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DumpToFile("filename", "tablename", "dumpaddress", TblSizeInBytes), CFE_SUCCESS);
 
     /* Test where file already exists so data is overwritten */
     UT_InitData();
-    UtAssert_INT32_EQ(CFE_TBL_DumpToFile("filename", "tablename", "dumpaddress", TblSizeInBytes), CFE_TBL_INC_CMD_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DumpToFile("filename", "tablename", "dumpaddress", TblSizeInBytes), CFE_SUCCESS);
 }
 
 /*
@@ -753,7 +757,7 @@ void Test_CFE_TBL_ResetCmd(void)
 
     /* Test run through function (there are no additional paths) */
     UT_InitData();
-    UtAssert_INT32_EQ(CFE_TBL_ResetCountersCmd(NULL), CFE_TBL_DONT_INC_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_ResetCountersCmd(NULL), CFE_STATUS_NO_COUNTER_INCREMENT);
 }
 
 /*
@@ -762,7 +766,7 @@ void Test_CFE_TBL_ResetCmd(void)
 void Test_CFE_TBL_ValidateCmd(void)
 {
     uint8                     Buff;
-    uint8 *                   BuffPtr = &Buff;
+    uint8                    *BuffPtr = &Buff;
     CFE_TBL_ValidateCmd_t     ValidateCmd;
     CFE_TBL_CallbackFuncPtr_t ValFuncPtr = (CFE_TBL_CallbackFuncPtr_t)((unsigned long)&UT_InitializeTableRegistryNames);
 
@@ -772,7 +776,7 @@ void Test_CFE_TBL_ValidateCmd(void)
     UT_InitData();
     snprintf(ValidateCmd.Payload.TableName, sizeof(ValidateCmd.Payload.TableName), "%d",
              CFE_PLATFORM_TBL_MAX_NUM_TABLES + 1);
-    UtAssert_INT32_EQ(CFE_TBL_ValidateCmd(&ValidateCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_ValidateCmd(&ValidateCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test where the active buffer has data, but too many table validations
      * have been requested
@@ -784,7 +788,7 @@ void Test_CFE_TBL_ValidateCmd(void)
     CFE_TBL_Global.Registry[0].Buffers[CFE_TBL_Global.Registry[0].ActiveBufferIndex].BufferPtr = BuffPtr;
 
     UT_SetDeferredRetcode(UT_KEY(CFE_ResourceId_FindNext), 1, 0);
-    UtAssert_INT32_EQ(CFE_TBL_ValidateCmd(&ValidateCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_ValidateCmd(&ValidateCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test where the active buffer has data, but there is no validation
      * function pointer
@@ -792,7 +796,7 @@ void Test_CFE_TBL_ValidateCmd(void)
     UT_InitData();
     UT_TBL_ResetValidationState(0);
     CFE_TBL_Global.Registry[0].ValidationFuncPtr = NULL;
-    UtAssert_INT32_EQ(CFE_TBL_ValidateCmd(&ValidateCmd), CFE_TBL_INC_CMD_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_ValidateCmd(&ValidateCmd), CFE_SUCCESS);
 
     /* Test where the active buffer has data, the validation function pointer
      * exists, and the active table flag is set
@@ -801,7 +805,7 @@ void Test_CFE_TBL_ValidateCmd(void)
     UT_TBL_ResetValidationState(0);
     CFE_TBL_Global.Registry[0].ValidationFuncPtr = ValFuncPtr;
     ValidateCmd.Payload.ActiveTableFlag          = true;
-    UtAssert_INT32_EQ(CFE_TBL_ValidateCmd(&ValidateCmd), CFE_TBL_INC_CMD_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_ValidateCmd(&ValidateCmd), CFE_SUCCESS);
 
     /* Test with the buffer inactive, the table is double-buffered, and the
      * validation function pointer exists
@@ -812,7 +816,7 @@ void Test_CFE_TBL_ValidateCmd(void)
     CFE_TBL_Global.Registry[0].DoubleBuffered = true;
     CFE_TBL_Global.Registry[0].Buffers[1 - CFE_TBL_Global.Registry[0].ActiveBufferIndex].BufferPtr = BuffPtr;
     CFE_TBL_Global.Registry[0].ValidationFuncPtr                                                   = ValFuncPtr;
-    UtAssert_INT32_EQ(CFE_TBL_ValidateCmd(&ValidateCmd), CFE_TBL_INC_CMD_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_ValidateCmd(&ValidateCmd), CFE_SUCCESS);
 
     /* Test with the buffer inactive, the table is single-buffered with a
      * load in progress, the validation function pointer exists, and no
@@ -824,7 +828,7 @@ void Test_CFE_TBL_ValidateCmd(void)
     CFE_TBL_Global.Registry[0].DoubleBuffered                                     = false;
     CFE_TBL_Global.LoadBuffs[CFE_TBL_Global.Registry[0].LoadInProgress].BufferPtr = BuffPtr;
     CFE_TBL_Global.Registry[0].LoadInProgress                                     = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
-    UtAssert_INT32_EQ(CFE_TBL_ValidateCmd(&ValidateCmd), CFE_TBL_INC_CMD_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_ValidateCmd(&ValidateCmd), CFE_SUCCESS);
 
     /* Test with the buffer inactive, the table is single-buffered with a
      * load in progress, the validation function pointer exists, and a
@@ -837,19 +841,19 @@ void Test_CFE_TBL_ValidateCmd(void)
     CFE_TBL_Global.Registry[0].DoubleBuffered                                     = false;
     CFE_TBL_Global.LoadBuffs[CFE_TBL_Global.Registry[0].LoadInProgress].BufferPtr = BuffPtr;
     CFE_TBL_Global.Registry[0].LoadInProgress                                     = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
-    UtAssert_INT32_EQ(CFE_TBL_ValidateCmd(&ValidateCmd), CFE_TBL_INC_CMD_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_ValidateCmd(&ValidateCmd), CFE_SUCCESS);
 
     /* Test where no inactive buffer is present (single-buffered table without
      * load in progress)
      */
     UT_InitData();
     CFE_TBL_Global.Registry[0].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
-    UtAssert_INT32_EQ(CFE_TBL_ValidateCmd(&ValidateCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_ValidateCmd(&ValidateCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test with an illegal buffer */
     UT_InitData();
     ValidateCmd.Payload.ActiveTableFlag = 0xffff;
-    UtAssert_INT32_EQ(CFE_TBL_ValidateCmd(&ValidateCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_ValidateCmd(&ValidateCmd), CFE_STATUS_COMMAND_FAILURE);
 }
 
 /*
@@ -861,7 +865,7 @@ void Test_CFE_TBL_NoopCmd(void)
 
     /* Test run through function (there are no additional paths) */
     UT_InitData();
-    UtAssert_INT32_EQ(CFE_TBL_NoopCmd(NULL), CFE_TBL_INC_CMD_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_NoopCmd(NULL), CFE_SUCCESS);
 }
 
 /*
@@ -980,7 +984,7 @@ void Test_CFE_TBL_DumpRegCmd(void)
     CFE_TBL_DumpRegistryCmd_t DumpRegCmd;
     CFE_ES_AppId_t            AppID;
     size_t                    LocalSize;
-    void *                    LocalBuf;
+    void                     *LocalBuf;
 
     /* Get the AppID being used for UT */
     CFE_ES_GetAppID(&AppID);
@@ -997,23 +1001,23 @@ void Test_CFE_TBL_DumpRegCmd(void)
     UT_SetDefaultReturnValue(UT_KEY(CFE_FS_BackgroundFileDumpIsPending), false);
     strncpy(DumpRegCmd.Payload.DumpFilename, "X", sizeof(DumpRegCmd.Payload.DumpFilename) - 1);
     DumpRegCmd.Payload.DumpFilename[sizeof(DumpRegCmd.Payload.DumpFilename) - 1] = '\0';
-    UtAssert_INT32_EQ(CFE_TBL_DumpRegistryCmd(&DumpRegCmd), CFE_TBL_INC_CMD_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DumpRegistryCmd(&DumpRegCmd), CFE_SUCCESS);
 
     /* Test command with a bad file name */
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_ParseInputFileNameEx), 1, CFE_FS_INVALID_PATH);
-    UtAssert_INT32_EQ(CFE_TBL_DumpRegistryCmd(&DumpRegCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DumpRegistryCmd(&DumpRegCmd), CFE_STATUS_COMMAND_FAILURE);
     UT_ResetState(UT_KEY(CFE_FS_ParseInputFileNameEx));
 
     /* Test command with the dump file already pending (max requests pending) */
     UT_SetDefaultReturnValue(UT_KEY(CFE_FS_BackgroundFileDumpIsPending), true);
     UT_SetDefaultReturnValue(UT_KEY(CFE_FS_BackgroundFileDumpRequest), CFE_STATUS_REQUEST_ALREADY_PENDING);
-    UtAssert_INT32_EQ(CFE_TBL_DumpRegistryCmd(&DumpRegCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DumpRegistryCmd(&DumpRegCmd), CFE_STATUS_COMMAND_FAILURE);
     UT_ResetState(UT_KEY(CFE_FS_BackgroundFileDumpRequest));
 
     /* Test command with the dump file already pending (local) */
     UT_SetDefaultReturnValue(UT_KEY(CFE_FS_BackgroundFileDumpIsPending), false);
     UT_SetDefaultReturnValue(UT_KEY(CFE_FS_BackgroundFileDumpRequest), CFE_STATUS_REQUEST_ALREADY_PENDING);
-    UtAssert_INT32_EQ(CFE_TBL_DumpRegistryCmd(&DumpRegCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DumpRegistryCmd(&DumpRegCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Check event generators */
     UT_ClearEventHistory();
@@ -1111,7 +1115,7 @@ void Test_CFE_TBL_DumpCmd(void)
 {
     int                i, u;
     uint8              Buff;
-    uint8 *            BuffPtr = &Buff;
+    uint8             *BuffPtr = &Buff;
     CFE_TBL_LoadBuff_t Load    = {0};
     CFE_TBL_DumpCmd_t  DumpCmd;
     CFE_ES_AppId_t     AppID;
@@ -1125,7 +1129,7 @@ void Test_CFE_TBL_DumpCmd(void)
     /* Test where the table cannot be found in the registry */
     UT_InitData();
     snprintf(DumpCmd.Payload.TableName, sizeof(DumpCmd.Payload.TableName), "%d", CFE_PLATFORM_TBL_MAX_NUM_TABLES + 1);
-    UtAssert_INT32_EQ(CFE_TBL_DumpCmd(&DumpCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DumpCmd(&DumpCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test with an active buffer, the pointer is created, validation passes,
      * the table is dump only, no dump is already in progress, and have a
@@ -1153,7 +1157,7 @@ void Test_CFE_TBL_DumpCmd(void)
     CFE_TBL_Global.LoadBuffs[CFE_TBL_Global.Registry[2].LoadInProgress] = Load;
     CFE_TBL_Global.Registry[2].NotifyByMsg                              = true;
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_TransmitMsg), 1, CFE_SB_INTERNAL_ERR);
-    UtAssert_INT32_EQ(CFE_TBL_DumpCmd(&DumpCmd), CFE_TBL_INC_CMD_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DumpCmd(&DumpCmd), CFE_SUCCESS);
 
     /* Test with an active buffer, a pointer is created, the table is dump
      * only, no dump is already progress, and fails to get a working buffer;
@@ -1173,7 +1177,7 @@ void Test_CFE_TBL_DumpCmd(void)
     }
 
     CFE_TBL_Global.Registry[2].NotifyByMsg = true;
-    UtAssert_INT32_EQ(CFE_TBL_DumpCmd(&DumpCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DumpCmd(&DumpCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test with an active buffer, a pointer is created, the table is dump
      * only, and no dump fails to find a free dump control block; too many
@@ -1183,7 +1187,7 @@ void Test_CFE_TBL_DumpCmd(void)
     CFE_TBL_Global.Registry[2].DumpControlId = CFE_TBL_NO_DUMP_PENDING;
     CFE_TBL_Global.Registry[2].NotifyByMsg   = true;
     UT_SetDeferredRetcode(UT_KEY(CFE_ResourceId_FindNext), 1, 0);
-    UtAssert_INT32_EQ(CFE_TBL_DumpCmd(&DumpCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DumpCmd(&DumpCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test with an inactive buffer, double-buffered, dump already in progress;
      * dump is already pending
@@ -1193,7 +1197,7 @@ void Test_CFE_TBL_DumpCmd(void)
     CFE_TBL_Global.Registry[2].DoubleBuffered = true;
     CFE_TBL_Global.Registry[2].Buffers[(1 - CFE_TBL_Global.Registry[2].ActiveBufferIndex)].BufferPtr = BuffPtr;
     CFE_TBL_Global.Registry[2].DumpControlId = CFE_TBL_DUMPCTRLID_C(CFE_ResourceId_FromInteger(1));
-    UtAssert_INT32_EQ(CFE_TBL_DumpCmd(&DumpCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DumpCmd(&DumpCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test with an inactive buffer, single-buffered, pointer created, is a
      * dump only table
@@ -1206,14 +1210,14 @@ void Test_CFE_TBL_DumpCmd(void)
     strncpy(DumpCmd.Payload.DumpFilename, CFE_TBL_Global.Registry[2].LastFileLoaded,
             sizeof(DumpCmd.Payload.DumpFilename) - 1);
     DumpCmd.Payload.DumpFilename[sizeof(DumpCmd.Payload.DumpFilename) - 1] = '\0';
-    UtAssert_INT32_EQ(CFE_TBL_DumpCmd(&DumpCmd), CFE_TBL_INC_CMD_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DumpCmd(&DumpCmd), CFE_SUCCESS);
 
     /* Test with an inactive buffer, single-buffered: No inactive buffer for
      * table due to load in progress
      */
     UT_InitData();
     CFE_TBL_Global.Registry[2].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS;
-    UtAssert_INT32_EQ(CFE_TBL_DumpCmd(&DumpCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DumpCmd(&DumpCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test with an inactive buffer, single-buffered: No inactive buffer for
      * table due to user defined address
@@ -1221,12 +1225,12 @@ void Test_CFE_TBL_DumpCmd(void)
     UT_InitData();
     CFE_TBL_Global.Registry[2].LoadInProgress = CFE_TBL_NO_LOAD_IN_PROGRESS + 1;
     CFE_TBL_Global.Registry[2].UserDefAddr    = true;
-    UtAssert_INT32_EQ(CFE_TBL_DumpCmd(&DumpCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DumpCmd(&DumpCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test with an illegal buffer parameter */
     UT_InitData();
     DumpCmd.Payload.ActiveTableFlag = CFE_TBL_BufferSelect_ACTIVE + 1;
-    UtAssert_INT32_EQ(CFE_TBL_DumpCmd(&DumpCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_DumpCmd(&DumpCmd), CFE_STATUS_COMMAND_FAILURE);
 }
 
 /*
@@ -1265,7 +1269,7 @@ void Test_CFE_TBL_LoadCmd(void)
     /* Test response to inability to open file */
     UT_InitData();
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
-    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test response to inability to find the table in the registry */
     UT_InitData();
@@ -1273,7 +1277,7 @@ void Test_CFE_TBL_LoadCmd(void)
     TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
-    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* The rest of the tests will use registry 0, note empty name matches */
     CFE_TBL_Global.Registry[0].OwnerAppId = AppID;
@@ -1283,7 +1287,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     CFE_TBL_Global.Registry[0].DumpOnly = true;
-    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_STATUS_COMMAND_FAILURE);
     CFE_TBL_Global.Registry[0].DumpOnly = false;
 
     /* Test attempt to load a table with a load already pending */
@@ -1291,7 +1295,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     CFE_TBL_Global.Registry[0].LoadPending = true;
-    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_STATUS_COMMAND_FAILURE);
     CFE_TBL_Global.Registry[0].LoadPending = false;
 
     /* Test where the file isn't dump only and passes table checks, get a
@@ -1307,7 +1311,7 @@ void Test_CFE_TBL_LoadCmd(void)
     CFE_TBL_Global.LoadBuffs[CFE_TBL_Global.Registry[0].LoadInProgress].BufferPtr = &LoadBuffer;
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
-    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test with no extra byte => successful load */
     UT_InitData();
@@ -1315,7 +1319,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_SetDeferredRetcode(UT_KEY(OS_read), 3, 0);
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
-    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_TBL_INC_CMD_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_SUCCESS);
 
     /* Test with differing amount of data from header's claim */
     UT_InitData();
@@ -1323,7 +1327,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_SetDeferredRetcode(UT_KEY(OS_read), 2, 0);
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
-    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test with no working buffers available */
     UT_InitData();
@@ -1338,7 +1342,7 @@ void Test_CFE_TBL_LoadCmd(void)
 
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
-    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test with interal CFE_TBL_GetWorkingBuffer error (memcpy with matching address */
     UT_InitData();
@@ -1351,7 +1355,7 @@ void Test_CFE_TBL_LoadCmd(void)
     TblFileHeader.TableName[sizeof(TblFileHeader.TableName) - 1] = '\0';
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
-    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test with table header indicating data beyond size of the table */
     UT_InitData();
@@ -1359,14 +1363,14 @@ void Test_CFE_TBL_LoadCmd(void)
     CFE_TBL_Global.Registry[0].Size = sizeof(UT_Table1_t) - 1;
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
-    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test with table header indicating no data in the file */
     UT_InitData();
     UT_TBL_SetupHeader(&TblFileHeader, 0, 0);
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
-    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test where file has partial load for uninitialized table and offset
      * is non-zero
@@ -1377,7 +1381,7 @@ void Test_CFE_TBL_LoadCmd(void)
     CFE_TBL_Global.Registry[0].Size            = sizeof(UT_Table1_t);
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
-    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test where file has partial load for uninitialized table and offset
      * is zero
@@ -1388,12 +1392,12 @@ void Test_CFE_TBL_LoadCmd(void)
     CFE_TBL_Global.Registry[0].Size            = sizeof(UT_Table1_t);
     UT_SetReadBuffer(&TblFileHeader, sizeof(TblFileHeader));
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
-    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_STATUS_COMMAND_FAILURE);
 
     /* Test response to inability to read the file header */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_ReadHeader), 1, sizeof(CFE_FS_Header_t) - 1);
-    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_TBL_INC_ERR_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_STATUS_COMMAND_FAILURE);
 }
 
 /*
@@ -1403,10 +1407,10 @@ void Test_CFE_TBL_SendHkCmd(void)
 {
     int                    i;
     CFE_TBL_LoadBuff_t     DumpBuff;
-    CFE_TBL_LoadBuff_t *   DumpBuffPtr = &DumpBuff;
+    CFE_TBL_LoadBuff_t    *DumpBuffPtr = &DumpBuff;
     CFE_TBL_RegistryRec_t *RegRecPtr;
     uint8                  Buff;
-    void *                 BuffPtr    = &Buff;
+    void                  *BuffPtr    = &Buff;
     int32                  LoadInProg = 0;
     CFE_TBL_DumpControl_t *DumpCtrlPtr;
 
@@ -1435,7 +1439,7 @@ void Test_CFE_TBL_SendHkCmd(void)
 
     UT_SetDeferredRetcode(UT_KEY(CFE_SB_TransmitMsg), 1, CFE_SUCCESS - 1);
     CFE_TBL_Global.HkTlmTblRegIndex = CFE_TBL_NOT_FOUND + 1;
-    UtAssert_INT32_EQ(CFE_TBL_SendHkCmd(NULL), CFE_TBL_DONT_INC_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_SendHkCmd(NULL), CFE_STATUS_NO_COUNTER_INCREMENT);
 
     for (i = 1; i < CFE_PLATFORM_TBL_MAX_SIMULTANEOUS_LOADS; i++)
     {
@@ -1450,7 +1454,7 @@ void Test_CFE_TBL_SendHkCmd(void)
     DumpCtrlPtr->State              = CFE_TBL_DUMP_PERFORMED;
     CFE_TBL_Global.HkTlmTblRegIndex = CFE_TBL_NOT_FOUND + 1;
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
-    UtAssert_INT32_EQ(CFE_TBL_SendHkCmd(NULL), CFE_TBL_DONT_INC_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_SendHkCmd(NULL), CFE_STATUS_NO_COUNTER_INCREMENT);
 
     /* Test response to an invalid table and a dump file create failure */
     UT_InitData();
@@ -1458,21 +1462,21 @@ void Test_CFE_TBL_SendHkCmd(void)
     CFE_TBL_Global.HkTlmTblRegIndex = CFE_TBL_NOT_FOUND;
     DumpCtrlPtr->State              = CFE_TBL_DUMP_PERFORMED;
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
-    UtAssert_INT32_EQ(CFE_TBL_SendHkCmd(NULL), CFE_TBL_DONT_INC_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_SendHkCmd(NULL), CFE_STATUS_NO_COUNTER_INCREMENT);
 
     /* Test response to a file time stamp failure */
     UT_InitData();
     UT_TBL_SetupPendingDump(0, DumpBuffPtr, RegRecPtr, &DumpCtrlPtr);
     DumpCtrlPtr->State = CFE_TBL_DUMP_PERFORMED;
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_SetTimestamp), 1, OS_SUCCESS - 1);
-    UtAssert_INT32_EQ(CFE_TBL_SendHkCmd(NULL), CFE_TBL_DONT_INC_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_SendHkCmd(NULL), CFE_STATUS_NO_COUNTER_INCREMENT);
 
     /* Test response to OS_OpenCreate failure */
     UT_InitData();
     UT_TBL_SetupPendingDump(0, DumpBuffPtr, RegRecPtr, &DumpCtrlPtr);
     DumpCtrlPtr->State = CFE_TBL_DUMP_PERFORMED;
     UT_SetDeferredRetcode(UT_KEY(OS_OpenCreate), 3, -1);
-    UtAssert_INT32_EQ(CFE_TBL_SendHkCmd(NULL), CFE_TBL_DONT_INC_CTR);
+    UtAssert_INT32_EQ(CFE_TBL_SendHkCmd(NULL), CFE_STATUS_NO_COUNTER_INCREMENT);
 }
 
 /*
@@ -1502,7 +1506,7 @@ void Test_CFE_TBL_Register(void)
     char                        TblName[CFE_MISSION_TBL_MAX_NAME_LENGTH + 2];
     int16                       i;
     CFE_TBL_AccessDescriptor_t *AccessDescPtr;
-    CFE_TBL_RegistryRec_t *     RegRecPtr;
+    CFE_TBL_RegistryRec_t      *RegRecPtr;
 
     UtPrintf("Begin Test Register");
 
@@ -2136,8 +2140,8 @@ void Test_CFE_TBL_Load(void)
     UT_Table1_t                 TestTable1;
     CFE_FS_Header_t             StdFileHeader;
     CFE_TBL_File_Hdr_t          TblFileHeader;
-    void *                      App2TblPtr;
-    CFE_TBL_RegistryRec_t *     RegRecPtr;
+    void                       *App2TblPtr;
+    CFE_TBL_RegistryRec_t      *RegRecPtr;
     CFE_TBL_AccessDescriptor_t *AccessDescPtr;
 
     memset(&TestTable1, 0, sizeof(TestTable1));
@@ -2550,7 +2554,7 @@ void Test_CFE_TBL_ReleaseAddresses(void)
 void Test_CFE_TBL_Validate(void)
 {
     int16                       RegIndex;
-    CFE_TBL_RegistryRec_t *     RegRecPtr;
+    CFE_TBL_RegistryRec_t      *RegRecPtr;
     CFE_TBL_ValidationResult_t *ValResultPtr;
 
     UtPrintf("Begin Test Validate");
@@ -2646,14 +2650,14 @@ void Test_CFE_TBL_Validate(void)
 void Test_CFE_TBL_Manage(void)
 {
     int16                       RegIndex;
-    CFE_TBL_RegistryRec_t *     RegRecPtr;
-    CFE_TBL_LoadBuff_t *        WorkingBufferPtr;
+    CFE_TBL_RegistryRec_t      *RegRecPtr;
+    CFE_TBL_LoadBuff_t         *WorkingBufferPtr;
     UT_Table1_t                 TestTable1;
-    void *                      App2TblPtr;
+    void                       *App2TblPtr;
     CFE_TBL_AccessDescriptor_t *AccessDescPtr;
     CFE_TBL_Handle_t            AccessIterator;
     CFE_TBL_ValidationResult_t *ValResultPtr;
-    CFE_TBL_DumpControl_t *     DumpCtrlPtr;
+    CFE_TBL_DumpControl_t      *DumpCtrlPtr;
 
     memset(&TestTable1, 0, sizeof(TestTable1));
 
@@ -2959,9 +2963,9 @@ void Test_CFE_TBL_DumpToBuffer(void)
 void Test_CFE_TBL_Update(void)
 {
     int16                       RegIndex;
-    CFE_TBL_LoadBuff_t *        WorkingBufferPtr;
+    CFE_TBL_LoadBuff_t         *WorkingBufferPtr;
     CFE_TBL_AccessDescriptor_t *AccessDescPtr;
-    CFE_TBL_RegistryRec_t *     RegRecPtr;
+    CFE_TBL_RegistryRec_t      *RegRecPtr;
     AccessDescPtr = &CFE_TBL_Global.Handles[App1TblHandle1];
     RegRecPtr     = &CFE_TBL_Global.Registry[AccessDescPtr->RegIndex];
 
@@ -3071,11 +3075,11 @@ void Test_CFE_TBL_TblMod(void)
     UT_TempFile_t               File;
     uint32                      Index;
     CFE_TBL_Info_t              TblInfo1;
-    void *                      TblDataAddr;
-    UT_Table1_t *               TblDataPtr;
+    void                       *TblDataAddr;
+    UT_Table1_t                *TblDataPtr;
     char                        MyFilename[OS_MAX_PATH_LEN];
     CFE_TBL_AccessDescriptor_t *AccessDescPtr;
-    CFE_TBL_RegistryRec_t *     RegRecPtr;
+    CFE_TBL_RegistryRec_t      *RegRecPtr;
     CFE_TBL_Handle_t            AccessIterator;
     uint8                       CDS_Data[sizeof(UT_Table1_t)];
     uint32                      ExpectedCrc;
@@ -3247,17 +3251,17 @@ void Test_CFE_TBL_TblMod(void)
 void Test_CFE_TBL_Internal(void)
 {
     CFE_TBL_TxnState_t          Txn;
-    CFE_TBL_LoadBuff_t *        WorkingBufferPtr;
-    CFE_TBL_RegistryRec_t *     RegRecPtr;
+    CFE_TBL_LoadBuff_t         *WorkingBufferPtr;
+    CFE_TBL_RegistryRec_t      *RegRecPtr;
     CFE_TBL_AccessDescriptor_t *AccessDescPtr;
-    CFE_TBL_DumpControl_t *     DumpCtrlPtr;
+    CFE_TBL_DumpControl_t      *DumpCtrlPtr;
     char                        FilenameLong[OS_MAX_PATH_LEN + 10];
     char                        Filename[OS_MAX_PATH_LEN];
     int32                       i;
     CFE_FS_Header_t             StdFileHeader;
     CFE_TBL_File_Hdr_t          TblFileHeader;
     osal_id_t                   FileDescriptor;
-    void *                      TblPtr;
+    void                       *TblPtr;
 
     UtPrintf("Begin Test Internal");
 

--- a/modules/time/fsw/src/cfe_time_dispatch.c
+++ b/modules/time/fsw/src/cfe_time_dispatch.c
@@ -72,6 +72,7 @@ void CFE_TIME_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
 {
     CFE_SB_MsgId_t    MessageID   = CFE_SB_INVALID_MSG_ID;
     CFE_MSG_FcnCode_t CommandCode = 0;
+    CFE_Status_t      Status      = CFE_STATUS_NO_COUNTER_INCREMENT;
 
     CFE_MSG_GetMsgId(&SBBufPtr->Msg, &MessageID);
 
@@ -125,42 +126,42 @@ void CFE_TIME_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
                 case CFE_TIME_NOOP_CC:
                     if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_NoopCmd_t)))
                     {
-                        CFE_TIME_NoopCmd((const CFE_TIME_NoopCmd_t *)SBBufPtr);
+                        Status = CFE_TIME_NoopCmd((const CFE_TIME_NoopCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_TIME_RESET_COUNTERS_CC:
                     if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_ResetCountersCmd_t)))
                     {
-                        CFE_TIME_ResetCountersCmd((const CFE_TIME_ResetCountersCmd_t *)SBBufPtr);
+                        Status = CFE_TIME_ResetCountersCmd((const CFE_TIME_ResetCountersCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_TIME_SEND_DIAGNOSTIC_CC:
                     if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SendDiagnosticCmd_t)))
                     {
-                        CFE_TIME_SendDiagnosticTlm((const CFE_TIME_SendDiagnosticCmd_t *)SBBufPtr);
+                        Status = CFE_TIME_SendDiagnosticTlm((const CFE_TIME_SendDiagnosticCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_TIME_SET_STATE_CC:
                     if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SetStateCmd_t)))
                     {
-                        CFE_TIME_SetStateCmd((const CFE_TIME_SetStateCmd_t *)SBBufPtr);
+                        Status = CFE_TIME_SetStateCmd((const CFE_TIME_SetStateCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_TIME_SET_SOURCE_CC:
                     if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SetSourceCmd_t)))
                     {
-                        CFE_TIME_SetSourceCmd((const CFE_TIME_SetSourceCmd_t *)SBBufPtr);
+                        Status = CFE_TIME_SetSourceCmd((const CFE_TIME_SetSourceCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_TIME_SET_SIGNAL_CC:
                     if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SetSignalCmd_t)))
                     {
-                        CFE_TIME_SetSignalCmd((const CFE_TIME_SetSignalCmd_t *)SBBufPtr);
+                        Status = CFE_TIME_SetSignalCmd((const CFE_TIME_SetSignalCmd_t *)SBBufPtr);
                     }
                     break;
 
@@ -170,14 +171,14 @@ void CFE_TIME_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
                 case CFE_TIME_ADD_DELAY_CC:
                     if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_AddDelayCmd_t)))
                     {
-                        CFE_TIME_AddDelayCmd((const CFE_TIME_AddDelayCmd_t *)SBBufPtr);
+                        Status = CFE_TIME_AddDelayCmd((const CFE_TIME_AddDelayCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_TIME_SUB_DELAY_CC:
                     if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SubDelayCmd_t)))
                     {
-                        CFE_TIME_SubDelayCmd((const CFE_TIME_SubDelayCmd_t *)SBBufPtr);
+                        Status = CFE_TIME_SubDelayCmd((const CFE_TIME_SubDelayCmd_t *)SBBufPtr);
                     }
                     break;
 
@@ -187,67 +188,80 @@ void CFE_TIME_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
                 case CFE_TIME_SET_TIME_CC:
                     if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SetTimeCmd_t)))
                     {
-                        CFE_TIME_SetTimeCmd((const CFE_TIME_SetTimeCmd_t *)SBBufPtr);
+                        Status = CFE_TIME_SetTimeCmd((const CFE_TIME_SetTimeCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_TIME_SET_MET_CC:
                     if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SetMETCmd_t)))
                     {
-                        CFE_TIME_SetMETCmd((const CFE_TIME_SetMETCmd_t *)SBBufPtr);
+                        Status = CFE_TIME_SetMETCmd((const CFE_TIME_SetMETCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_TIME_SET_STCF_CC:
                     if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SetSTCFCmd_t)))
                     {
-                        CFE_TIME_SetSTCFCmd((const CFE_TIME_SetSTCFCmd_t *)SBBufPtr);
+                        Status = CFE_TIME_SetSTCFCmd((const CFE_TIME_SetSTCFCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_TIME_SET_LEAP_SECONDS_CC:
                     if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SetLeapSecondsCmd_t)))
                     {
-                        CFE_TIME_SetLeapSecondsCmd((const CFE_TIME_SetLeapSecondsCmd_t *)SBBufPtr);
+                        Status = CFE_TIME_SetLeapSecondsCmd((const CFE_TIME_SetLeapSecondsCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_TIME_ADD_ADJUST_CC:
                     if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_AddAdjustCmd_t)))
                     {
-                        CFE_TIME_AddAdjustCmd((const CFE_TIME_AddAdjustCmd_t *)SBBufPtr);
+                        Status = CFE_TIME_AddAdjustCmd((const CFE_TIME_AddAdjustCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_TIME_SUB_ADJUST_CC:
                     if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SubAdjustCmd_t)))
                     {
-                        CFE_TIME_SubAdjustCmd((const CFE_TIME_SubAdjustCmd_t *)SBBufPtr);
+                        Status = CFE_TIME_SubAdjustCmd((const CFE_TIME_SubAdjustCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_TIME_ADD_ONE_HZ_ADJUSTMENT_CC:
                     if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_AddOneHzAdjustmentCmd_t)))
                     {
-                        CFE_TIME_AddOneHzAdjustmentCmd((const CFE_TIME_AddOneHzAdjustmentCmd_t *)SBBufPtr);
+                        Status = CFE_TIME_AddOneHzAdjustmentCmd((const CFE_TIME_AddOneHzAdjustmentCmd_t *)SBBufPtr);
                     }
                     break;
 
                 case CFE_TIME_SUB_ONE_HZ_ADJUSTMENT_CC:
                     if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SubOneHzAdjustmentCmd_t)))
                     {
-                        CFE_TIME_SubOneHzAdjustmentCmd((const CFE_TIME_SubOneHzAdjustmentCmd_t *)SBBufPtr);
+                        Status = CFE_TIME_SubOneHzAdjustmentCmd((const CFE_TIME_SubOneHzAdjustmentCmd_t *)SBBufPtr);
                     }
                     break;
 
                 default:
-
-                    CFE_TIME_Global.CommandErrorCounter++;
+                    Status = CFE_STATUS_BAD_COMMAND_CODE;
                     CFE_EVS_SendEvent(CFE_TIME_CC_ERR_EID, CFE_EVS_EventType_ERROR,
                                       "Invalid command code -- ID = 0x%X, CC = %d",
                                       (unsigned int)CFE_SB_MsgIdToValue(MessageID), (int)CommandCode);
                     break;
             } /* switch (CFE_TIME_CMD_MID -- command code)*/
+
+            /*
+             * Any command functions returning a Status of CFE_STATUS_NO_COUNTER_INCREMENT
+             * will not increment either counter
+             */
+            if (Status == CFE_SUCCESS)
+            {
+                CFE_TIME_Global.CommandCounter++;
+            }
+            else if ((Status == CFE_STATUS_COMMAND_FAILURE) || (Status == CFE_STATUS_BAD_COMMAND_CODE))
+            {
+                CFE_TIME_Global.CommandErrorCounter++;
+            }
+
             break;
 
         default:

--- a/modules/time/fsw/src/cfe_time_utils.h
+++ b/modules/time/fsw/src/cfe_time_utils.h
@@ -735,20 +735,22 @@ int32 CFE_TIME_ToneSendCmd(const CFE_TIME_FakeToneCmd_t *data);
 /**
  * @brief  Time task ground command (tone delay)
  */
-void CFE_TIME_SetDelayImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_AdjustDirection_Enum_t Direction);
+CFE_Status_t CFE_TIME_SetDelayImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr,
+                                   CFE_TIME_AdjustDirection_Enum_t   Direction);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * @brief  Time task ground command (1Hz adjust)
  */
-void CFE_TIME_1HzAdjImpl(const CFE_TIME_OneHzAdjustmentCmd_Payload_t *CommandPtr,
-                         CFE_TIME_AdjustDirection_Enum_t              Direction);
+CFE_Status_t CFE_TIME_1HzAdjImpl(const CFE_TIME_OneHzAdjustmentCmd_Payload_t *CommandPtr,
+                                 CFE_TIME_AdjustDirection_Enum_t              Direction);
 
 /*---------------------------------------------------------------------------------------*/
 /**
  * @brief  Time task ground command (adjust STCF)
  */
-void CFE_TIME_AdjustImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_AdjustDirection_Enum_t Direction);
+CFE_Status_t CFE_TIME_AdjustImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr,
+                                 CFE_TIME_AdjustDirection_Enum_t   Direction);
 
 /*
 ** Ground command handlers...


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1527
  - Major changes are to convert ES, TIME and SB to the pattern already used by TBL and EVS - namely, to increment the command counters centrally in the command processing function (in XX_dispatch.c), rather than individually inside each command.
    - this results in a reduction of locations where `CommandCounter`'s are incremented from 41 to 5, and `ErrorCounter`'s from 71 to 11
  - Introduced the `CFE_STATUS_COMMAND_FAILURE` macro which can be used by command functions to signal a general failure to execute their command. This macro can also be used by other cFS components and apps for command execution failures.

Summary of module-specific changes:
**_ES_**
- move incrementing of Command/Error counters from the individual commands into `CFE_ES_TaskPipe()`
  - there were 4 locations (in `CFE_ES_QueryAllCmd()` and `CFE_ES_QueryAllTasksCmd()`) where `CFE_SUCCESS` was returned during a failure/error event after the `ErrorCounter` was incremented. These now return `CFE_STATUS_COMMAND_FAILURE` which improves the clarity of these functions.

**_TIME_**
- move incrementing of Command/Error counters from the individual commands into `CFE_TIME_TaskPipe()`
- `CFE_TIME_SetDelayImpl()`, `CFE_TIME_AdjustImpl()` and `CFE_TIME_1HzAdjImpl()` were changed from `void` return type to `CFE_Status_t` in order to carry through the result of their respective add/subtract versions over to `CFE_TIME_TaskPipe()` and increment the required counters

**_SB_**
- move incrementing of Command/Error counters from the individual commands into `CFE_SB_ProcessCmdPipePkt()`
- removed the `CFE_SB_IncrCmdCtr()` helper function as it is no longer required with these changes - its functionality has been folded into `CFE_SB_ProcessCmdPipePkt()`

**_TBL_**
- removed `CFE_TBL_MESSAGE_ERROR` (essentially replaced by `CFE_STATUS_COMMAND_FAILURE)`
- removed the `CFE_TBL_CmdProcRet_t` enumeration
  - The constants in this enum were already mapped to CFE macros anyway. The only real change here is that `CFE_TBL_INC_ERR_CTR,` which was previously mapped to `CFE_TBL_MESSAGE_ERROR,` has now been replaced by the new `CFE_STATUS_COMMAND_FAILURE` macro which was introduced in this PR.
    - _Note: I haven't added any deprecation for the removal of `CFE_TBL_MESSAGE_ERROR` or `CFE_TBL_CmdProcRet_t` - if this is required in this case, just let me know._
- `CFE_TBL_NoopCmd()` erroneously noted a possible error return in doxygen comments - this has been removed as the function always returns `CFE_SUCCESS`.

_Note: https://github.com/nasa/cFE/pull/2264 which converts the remaining `int32` return types to `CFE_Status_t` (along with most of the local `status`/`return` variables) is complementary to this PR._

**Testing performed**
GitHub CI actions all passing successfully.

Local testing with full cFS suite confirms net coverage unchanged.
Prior to changes:
```
  lines......: 98.1% (13074 of 13326 lines)
  functions..: 97.0% (1041 of 1073 functions)
  branches...: 97.1% (5870 of 6047 branches)
```
After changes:
```
  lines......: 98.1% (13056 of 13308 lines)
  functions..: 97.0% (1040 of 1072 functions)
  branches...: 97.1% (5886 of 6063 branches)
```
**Expected behavior changes**
Behavior largely unchanged, other than the modifications listed above.

cFE command-handling code is now simpler, more consistent and easier to maintain.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss @thnkslprpt