### PR TITLE
Fix #1901, remove else statement that was unreachable by unit tests

### DIFF
--- a/modules/tbl/fsw/inc/cfe_tbl_events.h
+++ b/modules/tbl/fsw/inc/cfe_tbl_events.h
@@ -346,18 +346,6 @@
 #define CFE_TBL_NO_WORK_BUFFERS_ERR_EID 60
 
 /**
- * \brief TBL Load Table Command Get Working Buffer Internal Failure Event ID
- *
- *  \par Type: ERROR
- *
- *  \par Cause:
- *
- *  \link #CFE_TBL_LOAD_CC TBL Load Table Command \endlink failure due to
- *  internal get working buffer error.
- */
-#define CFE_TBL_INTERNAL_ERROR_ERR_EID 61
-
-/**
  * \brief TBL Write File Creation Failure Event ID
  *
  *  \par Type: ERROR

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
@@ -475,15 +475,10 @@ int32 CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
                                                   TblFileHeader.TableName);
                             }
                         }
-                        else if (Status == CFE_TBL_ERR_NO_BUFFER_AVAIL)
+                        else
                         {
                             CFE_EVS_SendEvent(CFE_TBL_NO_WORK_BUFFERS_ERR_EID, CFE_EVS_EventType_ERROR,
                                               "No working buffers available for table '%s'", TblFileHeader.TableName);
-                        }
-                        else
-                        {
-                            CFE_EVS_SendEvent(CFE_TBL_INTERNAL_ERROR_ERR_EID, CFE_EVS_EventType_ERROR,
-                                              "Internal Error (Status=0x%08X)", (unsigned int)Status);
                         }
                     }
                     else


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [X] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [X] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #1901.  `CFE_TBL_GetWorkingBuffer()` could only ever return `CFE_SUCCESS` or `CFE_TBL_ERR_NO_BUFFER_AVAIL`. Removed else statement that would never be able to be reached.

**Testing performed**
Unit tests

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
 - OS: Ubuntu 18.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Haven Carlson - NASA
