### PR TITLE
Fix #1398, Consistent use of `CFE_EVS_EventType_Enum_t` for `EventType`

### DIFF
--- a/modules/cfe_assert/src/cfe_assert_runner.c
+++ b/modules/cfe_assert/src/cfe_assert_runner.c
@@ -154,7 +154,7 @@ bool CFE_Assert_Status_DeferredCheck(CFE_Status_t Status, UtAssert_CaseType_t Ca
 
 void CFE_Assert_StatusReport(uint8 MessageType, const char *Prefix, const char *OutputMessage)
 {
-    uint16 EventType;
+    CFE_EVS_EventType_Enum_t EventType;
 
     switch (MessageType)
     {

--- a/modules/core_api/fsw/inc/cfe_evs.h
+++ b/modules/core_api/fsw/inc/cfe_evs.h
@@ -152,7 +152,8 @@ CFE_Status_t CFE_EVS_Register(const void *Filters, uint16 NumEventFilters, uint1
 ** \sa #CFE_EVS_SendEventWithAppID, #CFE_EVS_SendTimedEvent
 **
 **/
-CFE_Status_t CFE_EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spec, ...) OS_PRINTF(3, 4);
+CFE_Status_t CFE_EVS_SendEvent(uint16 EventID, CFE_EVS_EventType_Enum_t EventType, const char *Spec, ...)
+    OS_PRINTF(3, 4);
 
 /**
 ** \brief Generate a software event given the specified Application ID.
@@ -201,8 +202,8 @@ CFE_Status_t CFE_EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spe
 ** \sa #CFE_EVS_SendEvent, #CFE_EVS_SendTimedEvent
 **
 **/
-CFE_Status_t CFE_EVS_SendEventWithAppID(uint16 EventID, uint16 EventType, CFE_ES_AppId_t AppID, const char *Spec, ...)
-    OS_PRINTF(4, 5);
+CFE_Status_t CFE_EVS_SendEventWithAppID(uint16 EventID, CFE_EVS_EventType_Enum_t EventType, CFE_ES_AppId_t AppID,
+                                        const char *Spec, ...) OS_PRINTF(4, 5);
 
 /**
 ** \brief Generate a software event with a specific time tag.
@@ -251,8 +252,8 @@ CFE_Status_t CFE_EVS_SendEventWithAppID(uint16 EventID, uint16 EventType, CFE_ES
 ** \sa #CFE_EVS_SendEvent, #CFE_EVS_SendEventWithAppID
 **
 **/
-CFE_Status_t CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time, uint16 EventID, uint16 EventType, const char *Spec, ...)
-    OS_PRINTF(4, 5);
+CFE_Status_t CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time, uint16 EventID, CFE_EVS_EventType_Enum_t EventType,
+                                    const char *Spec, ...) OS_PRINTF(4, 5);
 /**@}*/
 
 /** @defgroup CFEAPIEVSResetFilter cFE Reset Event Filter APIs

--- a/modules/core_api/ut-stubs/src/cfe_evs_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_evs_stubs.c
@@ -84,14 +84,14 @@ CFE_Status_t CFE_EVS_ResetFilter(uint16 EventID)
  * Generated stub function for CFE_EVS_SendEvent()
  * ----------------------------------------------------
  */
-CFE_Status_t CFE_EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spec, ...)
+CFE_Status_t CFE_EVS_SendEvent(uint16 EventID, CFE_EVS_EventType_Enum_t EventType, const char *Spec, ...)
 {
     va_list UtStub_ArgList;
 
     UT_GenStub_SetupReturnBuffer(CFE_EVS_SendEvent, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_EVS_SendEvent, uint16, EventID);
-    UT_GenStub_AddParam(CFE_EVS_SendEvent, uint16, EventType);
+    UT_GenStub_AddParam(CFE_EVS_SendEvent, CFE_EVS_EventType_Enum_t, EventType);
     UT_GenStub_AddParam(CFE_EVS_SendEvent, const char *, Spec);
 
     va_start(UtStub_ArgList, Spec);
@@ -106,14 +106,15 @@ CFE_Status_t CFE_EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spe
  * Generated stub function for CFE_EVS_SendEventWithAppID()
  * ----------------------------------------------------
  */
-CFE_Status_t CFE_EVS_SendEventWithAppID(uint16 EventID, uint16 EventType, CFE_ES_AppId_t AppID, const char *Spec, ...)
+CFE_Status_t CFE_EVS_SendEventWithAppID(uint16 EventID, CFE_EVS_EventType_Enum_t EventType, CFE_ES_AppId_t AppID,
+                                        const char *Spec, ...)
 {
     va_list UtStub_ArgList;
 
     UT_GenStub_SetupReturnBuffer(CFE_EVS_SendEventWithAppID, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_EVS_SendEventWithAppID, uint16, EventID);
-    UT_GenStub_AddParam(CFE_EVS_SendEventWithAppID, uint16, EventType);
+    UT_GenStub_AddParam(CFE_EVS_SendEventWithAppID, CFE_EVS_EventType_Enum_t, EventType);
     UT_GenStub_AddParam(CFE_EVS_SendEventWithAppID, CFE_ES_AppId_t, AppID);
     UT_GenStub_AddParam(CFE_EVS_SendEventWithAppID, const char *, Spec);
 
@@ -129,7 +130,8 @@ CFE_Status_t CFE_EVS_SendEventWithAppID(uint16 EventID, uint16 EventType, CFE_ES
  * Generated stub function for CFE_EVS_SendTimedEvent()
  * ----------------------------------------------------
  */
-CFE_Status_t CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time, uint16 EventID, uint16 EventType, const char *Spec, ...)
+CFE_Status_t CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time, uint16 EventID, CFE_EVS_EventType_Enum_t EventType,
+                                    const char *Spec, ...)
 {
     va_list UtStub_ArgList;
 
@@ -137,7 +139,7 @@ CFE_Status_t CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time, uint16 EventID, uin
 
     UT_GenStub_AddParam(CFE_EVS_SendTimedEvent, CFE_TIME_SysTime_t, Time);
     UT_GenStub_AddParam(CFE_EVS_SendTimedEvent, uint16, EventID);
-    UT_GenStub_AddParam(CFE_EVS_SendTimedEvent, uint16, EventType);
+    UT_GenStub_AddParam(CFE_EVS_SendTimedEvent, CFE_EVS_EventType_Enum_t, EventType);
     UT_GenStub_AddParam(CFE_EVS_SendTimedEvent, const char *, Spec);
 
     va_start(UtStub_ArgList, Spec);

--- a/modules/evs/config/default_cfe_evs_msgdefs.h
+++ b/modules/evs/config/default_cfe_evs_msgdefs.h
@@ -222,10 +222,10 @@ typedef struct CFE_EVS_HousekeepingTlm_Payload
 typedef struct CFE_EVS_PacketID
 {
     char AppName[CFE_MISSION_MAX_API_LEN]; /**< \cfetlmmnemonic \EVS_APPNAME
-                                        \brief Application name */
+                                                \brief Application name */
     uint16 EventID;                        /**< \cfetlmmnemonic \EVS_EVENTID
                                                 \brief Numerical event identifier */
-    uint16 EventType;                      /**< \cfetlmmnemonic \EVS_EVENTTYPE
+    CFE_EVS_EventType_Enum_t EventType;    /**< \cfetlmmnemonic \EVS_EVENTTYPE
                                                 \brief Numerical event type identifier */
     uint32 SpacecraftID;                   /**< \cfetlmmnemonic \EVS_SCID
                                                 \brief Spacecraft identifier */

--- a/modules/evs/fsw/src/cfe_evs.c
+++ b/modules/evs/fsw/src/cfe_evs.c
@@ -116,7 +116,7 @@ CFE_Status_t CFE_EVS_Register(const void *Filters, uint16 NumEventFilters, uint1
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-CFE_Status_t CFE_EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spec, ...)
+CFE_Status_t CFE_EVS_SendEvent(uint16 EventID, CFE_EVS_EventType_Enum_t EventType, const char *Spec, ...)
 {
     int32              Status;
     CFE_ES_AppId_t     AppID;
@@ -166,7 +166,8 @@ CFE_Status_t CFE_EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spe
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-CFE_Status_t CFE_EVS_SendEventWithAppID(uint16 EventID, uint16 EventType, CFE_ES_AppId_t AppID, const char *Spec, ...)
+CFE_Status_t CFE_EVS_SendEventWithAppID(uint16 EventID, CFE_EVS_EventType_Enum_t EventType, CFE_ES_AppId_t AppID,
+                                        const char *Spec, ...)
 {
     int32              Status = CFE_SUCCESS;
     CFE_TIME_SysTime_t Time;
@@ -215,7 +216,8 @@ CFE_Status_t CFE_EVS_SendEventWithAppID(uint16 EventID, uint16 EventType, CFE_ES
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-CFE_Status_t CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time, uint16 EventID, uint16 EventType, const char *Spec, ...)
+CFE_Status_t CFE_EVS_SendTimedEvent(CFE_TIME_SysTime_t Time, uint16 EventID, CFE_EVS_EventType_Enum_t EventType,
+                                    const char *Spec, ...)
 {
     int32          Status;
     CFE_ES_AppId_t AppID;

--- a/modules/evs/fsw/src/cfe_evs_utils.c
+++ b/modules/evs/fsw/src/cfe_evs_utils.c
@@ -184,7 +184,7 @@ int32 EVS_NotRegistered(EVS_AppData_t *AppDataPtr, CFE_ES_AppId_t CallerID)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-bool EVS_IsFiltered(EVS_AppData_t *AppDataPtr, uint16 EventID, uint16 EventType)
+bool EVS_IsFiltered(EVS_AppData_t *AppDataPtr, uint16 EventID, CFE_EVS_EventType_Enum_t EventType)
 {
     EVS_BinFilter_t *FilterPtr;
     bool             Filtered = false;
@@ -449,7 +449,7 @@ void EVS_DisableTypes(EVS_AppData_t *AppDataPtr, uint8 BitMask)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint16 EventType,
+void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, CFE_EVS_EventType_Enum_t EventType,
                                 const CFE_TIME_SysTime_t *TimeStamp, const char *MsgSpec, va_list ArgPtr)
 {
     CFE_EVS_LongEventTlm_t  LongEventTlm;  /* The "long" flavor is always generated, as this is what is logged */
@@ -591,7 +591,7 @@ void EVS_OutputPort(uint8 PortNum, char *Message)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spec, ...)
+int32 EVS_SendEvent(uint16 EventID, CFE_EVS_EventType_Enum_t EventType, const char *Spec, ...)
 {
     CFE_TIME_SysTime_t Time;
     va_list            Ptr;

--- a/modules/evs/fsw/src/cfe_evs_utils.h
+++ b/modules/evs/fsw/src/cfe_evs_utils.h
@@ -188,7 +188,7 @@ int32 EVS_NotRegistered(EVS_AppData_t *AppDataPtr, CFE_ES_AppId_t CallerID);
  * is filtered for the given application identifier.  Otherwise a value of
  * false is returned.
  */
-bool EVS_IsFiltered(EVS_AppData_t *AppDataPtr, uint16 EventID, uint16 EventType);
+bool EVS_IsFiltered(EVS_AppData_t *AppDataPtr, uint16 EventID, CFE_EVS_EventType_Enum_t EventType);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -238,7 +238,7 @@ void EVS_DisableTypes(EVS_AppData_t *AppDataPtr, uint8 BitMask);
  * If configured for short events, a separate short message is generated using a subset
  * of the information from the long message.
  */
-void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint16 EventType,
+void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, CFE_EVS_EventType_Enum_t EventType,
                                 const CFE_TIME_SysTime_t *Time, const char *MsgSpec, va_list ArgPtr);
 
 /*---------------------------------------------------------------------------------------*/
@@ -250,6 +250,6 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint1
  * This routine also does not need to acquire the mutex semaphore,
  * which can be time consuming on some platforms.
  */
-int32 EVS_SendEvent(uint16 EventID, uint16 EventType, const char *Spec, ...);
+int32 EVS_SendEvent(uint16 EventID, CFE_EVS_EventType_Enum_t EventType, const char *Spec, ...);
 
 #endif /* CFE_EVS_UTILS_H */


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1398
  - Remaining `EventType` parameters/variables declared explicitly as `int16` converted over to use the defined type

Note: https://github.com/nasa/cFE/issues/1447 and https://github.com/nasa/cFE/issues/1438 are unresolved but it seems unlikely the enum will be removed completely. I think it is worth clearing this issue up in the meantime - to improve consistency in cFE.

**Testing performed**
GitHub CI actions all passing successfully.

**Expected behavior changes**
No change.

**Contributor Info**
Avi Weiss @thnkslprpt