### PR TITLE
Fix #1448, Simplify and clarify `EVS_AddLog` logic

### DIFF
--- a/modules/evs/fsw/src/cfe_evs_log.c
+++ b/modules/evs/fsw/src/cfe_evs_log.c
@@ -42,20 +42,15 @@ void EVS_AddLog(CFE_EVS_LongEventTlm_t *EVS_PktPtr)
     /* Serialize access to event log control variables */
     OS_MutSemTake(CFE_EVS_Global.EVS_SharedDataMutexID);
 
-    if ((CFE_EVS_Global.EVS_LogPtr->LogFullFlag == true) &&
-        (CFE_EVS_Global.EVS_LogPtr->LogMode == CFE_EVS_LogMode_DISCARD))
+    if (CFE_EVS_Global.EVS_LogPtr->LogFullFlag == true)
     {
-        /* If log is full and in discard mode, just count the event */
         CFE_EVS_Global.EVS_LogPtr->LogOverflowCounter++;
     }
-    else
-    {
-        if (CFE_EVS_Global.EVS_LogPtr->LogFullFlag == true)
-        {
-            /* If log is full and in wrap mode, count it and store it */
-            CFE_EVS_Global.EVS_LogPtr->LogOverflowCounter++;
-        }
 
+    /* If the log is not full, _or_ if it is in OVERWRITE mode, add the event to the log */
+    if ((CFE_EVS_Global.EVS_LogPtr->LogFullFlag == false) ||
+        (CFE_EVS_Global.EVS_LogPtr->LogMode == CFE_EVS_LogMode_OVERWRITE))
+    {
         /* Copy the event data to the next available entry in the log */
         memcpy(&CFE_EVS_Global.EVS_LogPtr->LogEntry[CFE_EVS_Global.EVS_LogPtr->Next], EVS_PktPtr, sizeof(*EVS_PktPtr));
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1448
  - Removes duplication of incrementing the `LogOverflowCounter`
  - Simplifies the function and makes logical flow a little clearer

**Testing performed**
GitHub CI actions all passing successfully.

Would be good to add functional tests for this in the future - I noticed that changing the second block to just a simple `else` also passes all the coverage tests. 

**Expected behavior changes**
No change.

**Contributor Info**
Avi Weiss @thnkslprpt