### PR TITLE
Fix #2311, correct fallback file case

### DIFF
--- a/modules/core_api/mission_build.cmake
+++ b/modules/core_api/mission_build.cmake
@@ -13,12 +13,12 @@
 generate_config_includefile(
     FILE_NAME           "cfe_mission_cfg.h"
     MATCH_SUFFIX        "mission_cfg.h"
-    PREFIXES            ${MISSIONCONFIG}
+    PREFIXES            ${MISSIONCONFIG} cfe
 )
 
 generate_config_includefile(
     FILE_NAME           "cfe_perfids.h"
     MATCH_SUFFIX        "perfids.h"
-    PREFIXES            ${MISSIONCONFIG}
+    PREFIXES            ${MISSIONCONFIG} cfe
 )
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Only include the "FALLBACK_FILE" if the normal search came up empty. Do not return a list containing the fallback/default along with the user-supplied files, only return the user-supplied files.  This was an issue when using "ALLOW_LIST" in that it had both.

Fixes #2311

**Testing performed**
Build with normal/default config, and build with overrides

**Expected behavior changes**
Overrides should work correctly again.

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
