### PR TITLE
Fix #2317, Correct unbalanced brackets in `CFE_MSG_CMD_HDR_INIT` macro

### DIFF
--- a/modules/msg/option_inc/default_cfe_msg_hdr_priext.h
+++ b/modules/msg/option_inc/default_cfe_msg_hdr_priext.h
@@ -54,24 +54,14 @@
 /**
  * \brief Macro to initialize a command header, useful in tables that define commands
  */
-#define CFE_MSG_CMD_HDR_INIT(mid, size, fc, cksum)       \
-    {                                                    \
-    .Msg.CCSDS = \
-    { \
-        .Pri = \
-        { \
-            .StreamId = {(((mid)&0x80)<<5, (mid)&0x7F}, \
-            .Sequence = {0xC0, 0}, \
-            .Length = {((size)-7)>>8, ((size)-7)&0xFF} \
-        }, \
-        .Ext = \
-        { \
-            .Subsystem = {0, ((mid)>>8)&0xFF}, \
-            .SystemId = {0, 0) \
-        } \
-    }, \
-    CFE_MSG_CMD_HDR_SEC_INIT(fc, cksum) \
-}
+#define CFE_MSG_CMD_HDR_INIT(mid, size, fc, cksum)                                         \
+    {                                                                                      \
+        .Msg.CCSDS = {.Pri = {.StreamId = {((mid)&0x80) << 5, (mid)&0x7F},                 \
+                              .Sequence = {0xC0, 0},                                       \
+                              .Length   = {((size)-7) >> 8, ((size)-7) & 0xFF}},             \
+                      .Ext = {.Subsystem = {0, ((mid) >> 8) & 0xFF}, .SystemId = {0, 0}}}, \
+        CFE_MSG_CMD_HDR_SEC_INIT(fc, cksum)                                                \
+    }
 
 /*
  * Type Definitions


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2317 
  - unbalanced brackets/parentheses corrected

**Testing performed**
GitHub CI actions all passing successfully.

**Expected behavior changes**
Balanced brackets - could avoid future compiler warnings/errors or code bugs if not picked up by the compiler.

**Contributor Info**
Avi Weiss @thnkslprpt