### PR TITLE
Fix #2323, Remove unnecessary asserts in TIME invalid command length UT

### DIFF
--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -1400,13 +1400,8 @@ void Test_PipeCmds(void)
 
     /* Noop with bad size */
     UT_InitData();
-    memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_Global.CommandCounter      = 0;
-    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_NOOP_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
     /* Test sending the reset counters command */
     UT_InitData();
@@ -1437,13 +1432,8 @@ void Test_PipeCmds(void)
 
     /* Reset counters with bad size */
     UT_InitData();
-    memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_Global.CommandCounter      = 0;
-    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_RESET_COUNTERS_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
     /* Test sending the request diagnostics command */
     UT_InitData();
@@ -1454,13 +1444,8 @@ void Test_PipeCmds(void)
 
     /* Request diagnostics with bad size */
     UT_InitData();
-    memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_Global.CommandCounter      = 0;
-    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_SEND_DIAGNOSTIC_TLM_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
     /* Test sending a clock state = invalid command */
     UT_InitData();
@@ -1494,13 +1479,8 @@ void Test_PipeCmds(void)
 
     /* Set state with invalid size */
     UT_InitData();
-    memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_Global.CommandCounter      = 0;
-    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_SET_STATE_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
     /* Test sending the set time source = internal command */
     UT_InitData();
@@ -1537,13 +1517,8 @@ void Test_PipeCmds(void)
 
     /* Set time source with invalid size */
     UT_InitData();
-    memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_Global.CommandCounter      = 0;
-    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_SET_SOURCE_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
     /* Test sending a set tone signal source = primary command */
     UT_InitData();
@@ -1594,13 +1569,8 @@ void Test_PipeCmds(void)
 
     /* Set tone signal source with invalid size */
     UT_InitData();
-    memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_Global.CommandCounter      = 0;
-    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_SET_SIGNAL_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
     /* Test sending a time tone add delay command */
     UT_InitData();
@@ -1623,13 +1593,8 @@ void Test_PipeCmds(void)
 
     /* Time tone add delay with invalid size */
     UT_InitData();
-    memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_Global.CommandCounter      = 0;
-    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_ADD_DELAY_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
     /* Test sending a time tone subtract delay command */
     UT_InitData();
@@ -1650,13 +1615,8 @@ void Test_PipeCmds(void)
 
     /* Time tone subtract delay with invalid size */
     UT_InitData();
-    memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_Global.CommandCounter      = 0;
-    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_SUB_DELAY_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
     /* Test sending a set time command */
     UT_InitData();
@@ -1677,13 +1637,8 @@ void Test_PipeCmds(void)
 
     /* Set time with invalid size */
     UT_InitData();
-    memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_Global.CommandCounter      = 0;
-    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_SET_TIME_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
     /* Test sending a set MET command */
     UT_InitData();
@@ -1704,13 +1659,8 @@ void Test_PipeCmds(void)
 
     /* Set MET with invalid size */
     UT_InitData();
-    memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_Global.CommandCounter      = 0;
-    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_SET_MET_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
     /* Test sending a set STCF command */
     UT_InitData();
@@ -1731,13 +1681,8 @@ void Test_PipeCmds(void)
 
     /* Set STCF with invalid size */
     UT_InitData();
-    memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_Global.CommandCounter      = 0;
-    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_SET_STCF_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
     /* Test sending an adjust STCF positive command */
     UT_InitData();
@@ -1758,13 +1703,8 @@ void Test_PipeCmds(void)
 
     /* Adjust STCF positive with invalid size */
     UT_InitData();
-    memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_Global.CommandCounter      = 0;
-    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_ADD_ADJUST_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
     /* Test sending an adjust STCF negative command */
     UT_InitData();
@@ -1785,13 +1725,8 @@ void Test_PipeCmds(void)
 
     /* Adjust STCF negative with invalid size */
     UT_InitData();
-    memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_Global.CommandCounter      = 0;
-    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_SUB_ADJUST_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
     /* Test sending an adjust STCF 1 Hz positive command */
     UT_InitData();
@@ -1813,13 +1748,8 @@ void Test_PipeCmds(void)
 
     /* Adjust STCF 1Hz positive with invalid size */
     UT_InitData();
-    memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_Global.CommandCounter      = 0;
-    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_ADD_ONEHZ_ADJUSTMENT_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
     /* Test sending an adjust STCF 1 Hz negative command */
     UT_InitData();
@@ -1841,13 +1771,8 @@ void Test_PipeCmds(void)
 
     /* Adjust STCF 1 Hz negative with invalid size */
     UT_InitData();
-    memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_Global.CommandCounter      = 0;
-    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_SUB_ONEHZ_ADJUSTMENT_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
     /* Test response to sending a tone delay command using an invalid time */
     UT_InitData();
@@ -1905,13 +1830,8 @@ void Test_PipeCmds(void)
 
     /* Set leap seconds with invalid size */
     UT_InitData();
-    memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CFE_TIME_Global.CommandCounter      = 0;
-    CFE_TIME_Global.CommandErrorCounter = 0;
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, 0, UT_TPID_CFE_TIME_CMD_SET_LEAP_SECONDS_CC);
     CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandCounter, 0);
-    UtAssert_UINT32_EQ(CFE_TIME_Global.CommandErrorCounter, 1);
 
     /* Test response to sending an invalid command */
     UT_InitData();


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2323 
  - Removed asserts of command counters in the tests for commands sent with an invalid command length. Checking for `CFE_UtAssert_EVENTSENT(CFE_TIME_LEN_ERR_EID)` seems sufficient, and aligns TIME with the testing pattern in the other cFE modules.

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).
Local testing with cFS suite confirms no change to coverage.

**Expected behavior changes**
This simplifies the coverage tests and makes them easier to maintain. Also, TIME is now consistent with the other modules.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss @thnkslprpt