### PR TITLE
Fix #1432, Add element to write error event in `CFE_EVS_WriteAppDataFileCmd()`

### DIFF
--- a/modules/evs/fsw/src/cfe_evs_task.c
+++ b/modules/evs/fsw/src/cfe_evs_task.c
@@ -1268,8 +1268,8 @@ int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFileCmd_t *data)
                     else
                     {
                         EVS_SendEvent(CFE_EVS_ERR_WRDATFILE_EID, CFE_EVS_EventType_ERROR,
-                                      "Write App Data Command Error: OS_write = %ld, filename = %s", (long)OsStatus,
-                                      LocalName);
+                                      "Write App Data Command Error: At entry = %d, OS_write = %ld, filename = %s",
+                                      (int)EntryCount, (long)OsStatus, LocalName);
                         break;
                     }
                 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1432 
  - Adds element number to the event that reports a write error in `CFE_EVS_WriteAppDataFileCmd()` to provide more context for operations/ground personnel

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Coverage/Functional Tests etc.).

**Expected behavior changes**
No change to behavior other than the variable added to the `EVS_SendEvent()` mentioned above.

**Contributor Info**
Avi Weiss @thnkslprpt