### PR TITLE
Fix #2301, adjust UT pool buffer size for platform config

### DIFF
--- a/modules/core_api/ut-stubs/src/cfe_es_handlers.c
+++ b/modules/core_api/ut-stubs/src/cfe_es_handlers.c
@@ -420,6 +420,8 @@ void UT_DefaultHandler_CFE_ES_GetPoolBuf(void *UserObj, UT_EntryKey_t FuncKey, c
              */
             UtAssert_Failed("Pool buffer empty in %s: need at least %lu bytes, given %lu", __func__,
                             (unsigned long)PositionEnd, (unsigned long)PoolSize);
+
+            UtAssert_Abort("Configuration error, pool buffer too small for test cases");
         }
     }
 

--- a/modules/core_private/ut-stubs/src/ut_support.c
+++ b/modules/core_private/ut-stubs/src/ut_support.c
@@ -50,7 +50,7 @@ typedef union
     long long int AlignLong;
     long double   AlignDbl;
     void *        AlignPtr;
-    char          Content[128 * 1024];
+    char          Content[2 * CFE_PLATFORM_ES_MAX_BLOCK_SIZE];
 } UT_Buffer_t;
 
 static UT_Buffer_t UT_CFE_ES_MemoryPool;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
If the CFE_PLATFORM_ES_MAX_BLOCK_SIZE is increased, then increase the UT pool buffer accordingly.  This had been hardcoded to 128k.

Also consider pool exhaustion to be a fatal error, as continuing the test will certainly segfault and this makes the original error harder to spot.

Fixes #2301

**Testing performed**
Build and run TBL test with configuration specified in issue.

**Expected behavior changes**
TBL tests pass with larger sizes.

**System(s) tested on**
Debian

**Additional context**
Pool buffer being too small will also now stop/abort the test, as this is a bug that will certainly segfault later, better to stop and report the error more obviously.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.