### PR TITLE
Fix #1929, Remove redundant status check in `CFE_ES_RegisterCDSEx()`

### DIFF
--- a/modules/es/fsw/src/cfe_es_cds.c
+++ b/modules/es/fsw/src/cfe_es_cds.c
@@ -427,14 +427,7 @@ int32 CFE_ES_RegisterCDSEx(CFE_ES_CDSHandle_t *HandlePtr, size_t UserBlockSize, 
         CFE_ES_WriteToSysLog("%s: Failed to update CDS Registry (Stat=0x%08X)\n", __func__,
                              (unsigned int)RegUpdateStatus);
 
-        /*
-         * Return failure only if this was the primary error,
-         * do not overwrite a preexisting error.
-         */
-        if (Status == CFE_SUCCESS)
-        {
-            Status = RegUpdateStatus;
-        }
+        Status = RegUpdateStatus;
     }
 
     if (Status == CFE_SUCCESS && !IsNewOffset)


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1929
  - Additional status check was made redundant with the changes [here](https://github.com/nasa/cFE/pull/946/files#r1186575348) in https://github.com/nasa/cFE/pull/946

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).
This PR (slightly) increases coverage by one branch by removing an unreachable branch.

**Expected behavior changes**
No change to behavior.

**Contributor Info**
Avi Weiss @thnkslprpt