### PR TITLE
Fix #1933, Remove unreachable/dead branch in `CFE_ES_RunPerfLogDump()`

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -104,8 +104,8 @@ jobs:
 
       - name: Confirm Minimum Coverage
         run: |
-          missed_branches=52
-          missed_lines=18
+          missed_branches=50
+          missed_lines=17
           branch_nums=$(grep -A 3 "Overall coverage rate" lcov_out.txt | grep branches | grep -oP "[0-9]+[0-9]*")
           line_nums=$(grep -A 3 "Overall coverage rate" lcov_out.txt | grep lines | grep -oP "[0-9]+[0-9]*")
 

--- a/modules/es/fsw/src/cfe_es_perf.c
+++ b/modules/es/fsw/src/cfe_es_perf.c
@@ -462,11 +462,7 @@ bool CFE_ES_RunPerfLogDump(uint32 ElapsedTime, void *Arg)
                 {
                     CFE_ES_FileWriteByteCntErr(State->DataFileName, BlockSize, Status);
 
-                    /* skip to cleanup  */
-                    if (State->CurrentState < CFE_ES_PerfDumpState_CLEANUP)
-                    {
-                        State->PendingState = CFE_ES_PerfDumpState_CLEANUP;
-                    }
+                    State->PendingState = CFE_ES_PerfDumpState_CLEANUP;
                 }
                 else
                 {


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1933 
  - As noted in the issue, no way that `CurrentState` can be `>= CFE_ES_PerfDumpState_CLEANUP` - making the negative branch here unreachable

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).
This PR (slightly) increases coverage by one branch by removing an unreachable branch.

**Expected behavior changes**
No change to behavior.

**Contributor Info**
Avi Weiss @thnkslprpt