### PR TITLE
Fix #1519, Refactor `CFE_TBL_SearchCmdHndlrTbl` to simplify and unmix variables

### DIFF
--- a/docs/cFE Application Developers Guide.md
+++ b/docs/cFE Application Developers Guide.md
@@ -319,7 +319,7 @@ directory is described as a note under each folder.
     |   |-- All mission and platform configuration files are placed here
     |-- apps
     |   |-- Contains application source code.
-    |   |-- Application source code may be shared amoung multiple build CPUs
+    |   |-- Application source code may be shared among multiple build CPUs
     |-- libs
     |   |-- Contains Core Flight System (cFS) Sample Library (sample_lib)
     |-- tools
@@ -664,7 +664,7 @@ the content (payload) of those messages.  This supports cases where target syste
 and all messages and data files are desired to use those formats, as opposed to the normal/default CFE encapsulation formats.  In this case, it
 is important _not_ to change the payload formats, as this will make it more difficult to take a new application update in the future.
 
-**IMPORANT**: All the header files above with "INTERFACE" scope control the table/message interface of the component.  Changing any of the
+**IMPORTANT**: All the header files above with "INTERFACE" scope control the table/message interface of the component.  Changing any of the
 values or definitions in these files will affect the inter-processor communication - either table files, exported data products, commands, or
 telemetry messages.  Caution should be exercised when customizing any of these files, as any changes will need to be propagated to all
 other CFE instances, ground systems, test software or scripts, or any other tools that interact with the flight software.
@@ -686,7 +686,7 @@ recommended to only override/modify the more granular headers defined above.
 | _module_`_msg.h`           | Complete message interface: Combination of `msgdefs.h`, `msgstruct.h` and all dependencies |
 | _module_`_tbl.h`           | Complete table interface: Combination of `tbldefs.h`, `tblstruct.h` and all dependencies   |
 
-**IMPORANT**: Files from a limited scope may depend on files from a broader scope, but not the other way around.  For example,
+**IMPORTANT**: Files from a limited scope may depend on files from a broader scope, but not the other way around.  For example,
 the `platform_cfg.h` may depend on items defined in `mission_cfg.h`, but items in `mission_cfg.h` must **not** depend on items
 defined in `platform_cfg.h`.
 

--- a/modules/tbl/fsw/src/cfe_tbl_dispatch.c
+++ b/modules/tbl/fsw/src/cfe_tbl_dispatch.c
@@ -169,18 +169,15 @@ void CFE_TBL_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
  *-----------------------------------------------------------------*/
 int16 CFE_TBL_SearchCmdHndlrTbl(CFE_SB_MsgId_t MessageID, uint16 CommandCode)
 {
-    int16 TblIndx    = CFE_TBL_BAD_CMD_CODE;
+    int16 TblIndx;
+    int16 Result;
     bool  FoundMsg   = false;
     bool  FoundMatch = false;
 
-    do
+    for (TblIndx = 0; CFE_TBL_CmdHandlerTbl[TblIndx].MsgTypes != CFE_TBL_TERM_MSGTYPE; TblIndx++)
     {
-        /* Point to next entry in Command Handler Table */
-        TblIndx++;
-
         /* Check to see if we found a matching Message ID */
-        if (CFE_SB_MsgId_Equal(CFE_TBL_CmdHandlerTbl[TblIndx].MsgId, MessageID) &&
-            (CFE_TBL_CmdHandlerTbl[TblIndx].MsgTypes != CFE_TBL_TERM_MSGTYPE))
+        if (CFE_SB_MsgId_Equal(CFE_TBL_CmdHandlerTbl[TblIndx].MsgId, MessageID))
         {
             /* Flag any found message IDs so that if there is an error,        */
             /* we can determine if it was a bad message ID or bad command code */
@@ -194,31 +191,35 @@ int16 CFE_TBL_SearchCmdHndlrTbl(CFE_SB_MsgId_t MessageID, uint16 CommandCode)
                 {
                     /* Found matching message ID and Command Code */
                     FoundMatch = true;
+                    break;
                 }
             }
             else /* Message is not a command message with specific command code */
             {
-                /* Automatically assume a match when legit */
-                /* Message ID is all that is required      */
+                /* Automatically assume a match when legit Message ID is all that is required      */
                 FoundMatch = true;
+                break;
             }
         }
-    } while ((!FoundMatch) && (CFE_TBL_CmdHandlerTbl[TblIndx].MsgTypes != CFE_TBL_TERM_MSGTYPE));
+    }
 
-    /* If we failed to find a match, return a negative index */
-    if (!FoundMatch)
+    if (FoundMatch)
+    {
+        Result = TblIndx;
+    }
+    else /* If we failed to find a match, return a negative index */
     {
         /* Determine if the message ID was bad or the command code */
         if (FoundMsg)
         {
             /* A matching message ID was found, so the command code must be bad */
-            TblIndx = CFE_TBL_BAD_CMD_CODE;
+            Result = CFE_TBL_BAD_CMD_CODE;
         }
         else /* No matching message ID was found */
         {
-            TblIndx = CFE_TBL_BAD_MSG_ID;
+            Result = CFE_TBL_BAD_MSG_ID;
         }
     }
 
-    return TblIndx;
+    return Result;
 }


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1519
  - Loop simplified, and avoids mixing of `index`/`return` during the loop (must mix at the end of the function to avoid multiple returns)
  - a few documentation typos also corrected in this PR

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Coverage/Functional Tests etc.).
Local testing to confirm net coverage unchanged and test commands also fine.

**Expected behavior changes**
No change to behavior.
Function is cleaner/simpler which eases future maintenance.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss @thnkslprpt