### PR TITLE
Fix #2335, generalize update header parameter

### DIFF
--- a/modules/cfe_testcase/src/sb_sendrecv_test.c
+++ b/modules/cfe_testcase/src/sb_sendrecv_test.c
@@ -145,8 +145,9 @@ void TestBasicTransmitRecv(void)
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId1, -100), CFE_SB_BAD_ARGUMENT);
 
     /*
-     * Note, the CFE_SB_TransmitMsg ignores the "IncrementSequence" flag for commands.
-     * Thus, all the sequence numbers should come back with the original value set (11)
+     * Note, the CFE_SB_TransmitMsg now adheres to the "UpdateHeader" flag.
+     * Thus, the sequence numbers should come back with the value from the Route (1-2)
+     * rather than the value the message was filled with initially.
      *
      * Note this also utilizes the CFE_SB_PEND_FOREVER flag - if working correctly,
      * there should be a message in the queue, so it should not block.
@@ -157,7 +158,7 @@ void TestBasicTransmitRecv(void)
     CFE_Assert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
     CmdPtr = (const CFE_FT_TestCmdMessage_t *)MsgBuf;
     UtAssert_UINT32_EQ(CmdPtr->CmdPayload, 0x0c0ffee);
-    UtAssert_UINT32_EQ(Seq1, 11);
+    UtAssert_UINT32_EQ(Seq1, 1);
 
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId1, CFE_SB_PEND_FOREVER), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf->Msg, &MsgId), CFE_SUCCESS);
@@ -165,7 +166,7 @@ void TestBasicTransmitRecv(void)
     CFE_Assert_MSGID_EQ(MsgId, CFE_FT_CMD_MSGID);
     CmdPtr = (const CFE_FT_TestCmdMessage_t *)MsgBuf;
     UtAssert_UINT32_EQ(CmdPtr->CmdPayload, 0x1c0ffee);
-    UtAssert_UINT32_EQ(Seq1, 11);
+    UtAssert_UINT32_EQ(Seq1, 2);
 
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId1, CFE_SB_PEND_FOREVER), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetMsgId(&MsgBuf->Msg, &MsgId), CFE_SUCCESS);
@@ -480,7 +481,7 @@ void TestZeroCopyTransmitRecv(void)
     /* Receive and get initial sequence count */
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId1, CFE_SB_POLL), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&MsgBuf->Msg, &SeqCmd1), CFE_SUCCESS);
-    UtAssert_UINT32_EQ(SeqCmd1, 1234); /* NOTE: commands currently do NOT honor "Increment" flag */
+    UtAssert_UINT32_EQ(SeqCmd1, 6); /* NOTE: commands now honor "Update" flag */
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId2, CFE_SB_POLL), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&MsgBuf->Msg, &SeqTlm1), CFE_SUCCESS);
 
@@ -497,7 +498,7 @@ void TestZeroCopyTransmitRecv(void)
     /* Receive and get current sequence count */
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId1, CFE_SB_POLL), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&MsgBuf->Msg, &SeqCmd2), CFE_SUCCESS);
-    UtAssert_UINT32_EQ(SeqCmd2, 1234); /* NOTE: commands currently do NOT honor "Increment" flag */
+    UtAssert_UINT32_EQ(SeqCmd2, 7); /* NOTE: commands now honor "Update" flag */
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&MsgBuf, PipeId2, CFE_SB_POLL), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_MSG_GetSequenceCount(&MsgBuf->Msg, &SeqTlm2), CFE_SUCCESS);
     UtAssert_UINT32_EQ(SeqTlm2, CFE_MSG_GetNextSequenceCount(SeqTlm1)); /* should be +1 from the previous */

--- a/modules/core_api/fsw/inc/cfe_msg.h
+++ b/modules/core_api/fsw/inc/cfe_msg.h
@@ -59,6 +59,31 @@
  * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
  */
 CFE_Status_t CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_MSG_Size_t Size);
+
+/*****************************************************************************/
+/**
+ * \brief Set/compute all dynamically-updated headers on a message
+ *
+ * \par Description
+ *          This routine updates all dynamic header fields on a message, and is typically
+ *          invoked via SB just prior to broadcasting the message.  Dynamic headers include
+ *          are values that should be computed/updated per message, including:
+ *                  - the sequence number
+ *                  - the timestamp, if present
+ *                  - any error control or checksum fields, if present
+ *
+ *          The MSG module implementation determines which header fields meet this criteria
+ *          and how they should be computed.
+ *
+ * \param[inout] MsgPtr  A pointer to the buffer that contains the message @nonnull.
+ * \param[in]    SeqCnt  The current sequence number from the message route
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ * \retval #CFE_SUCCESS             \copybrief CFE_SUCCESS
+ * \retval #CFE_MSG_BAD_ARGUMENT    \copybrief CFE_MSG_BAD_ARGUMENT
+ */
+CFE_Status_t CFE_MSG_UpdateHeader(CFE_MSG_Message_t *MsgPtr, CFE_MSG_SequenceCount_t SeqCnt);
+
 /**\}*/
 
 /** \defgroup CFEAPIMSGHeaderPri cFE Message Primary Header APIs

--- a/modules/core_api/fsw/inc/cfe_sb.h
+++ b/modules/core_api/fsw/inc/cfe_sb.h
@@ -402,18 +402,26 @@ CFE_Status_t CFE_SB_UnsubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeI
 **          software bus will read the message ID from the message header to
 **          determine which pipes should receive the message.
 **
+**          In general, the "UpdateHeader" parameter should be passed as "true"
+**          if the message was newly constructed by the sender and is being sent
+**          for the first time.  When forwarding a message that originated from
+**          an external entity (e.g. messages passing through CI or SBN), the
+**          parameter should be passed as "false" to not overwrite existing data.
+**
 ** \par Assumptions, External Events, and Notes:
 **          - This routine will not normally wait for the receiver tasks to
 **            process the message before returning control to the caller's task.
 **          - However, if a higher priority task is pending and subscribed to
 **            this message, that task may get to run before returning
 **            control to the caller.
+**          - In previous versions of CFE, the boolean parameter referred to the
+**            sequence number header of telemetry messages only.  This has been
+**            extended to apply more generically to any headers, as determined by
+**            the CFE MSG implementation.
 **
 ** \param[in]  MsgPtr       A pointer to the message to be sent @nonnull.  This must point
 **                          to the first byte of the message header.
-** \param[in] IncrementSequenceCount Boolean to increment the internally tracked
-**                                   sequence count and update the message if the
-**                                   buffer contains a telemetry message
+** \param[in] UpdateHeader  Update the headers of the message
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS         \copybrief CFE_SUCCESS
@@ -421,7 +429,7 @@ CFE_Status_t CFE_SB_UnsubscribeLocal(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeI
 ** \retval #CFE_SB_MSG_TOO_BIG  \copybrief CFE_SB_MSG_TOO_BIG
 ** \retval #CFE_SB_BUF_ALOC_ERR \covtest \copybrief CFE_SB_BUF_ALOC_ERR
 **/
-CFE_Status_t CFE_SB_TransmitMsg(const CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount);
+CFE_Status_t CFE_SB_TransmitMsg(const CFE_MSG_Message_t *MsgPtr, bool UpdateHeader);
 
 /*****************************************************************************/
 /**
@@ -536,6 +544,12 @@ CFE_Status_t CFE_SB_ReleaseMessageBuffer(CFE_SB_Buffer_t *BufPtr);
 **          internal buffer.  The "zero copy" interface can be used to improve
 **          performance in high-rate, high-volume software bus traffic.
 **
+**          In general, the "UpdateHeader" parameter should be passed as "true"
+**          if the message was newly constructed by the sender and is being sent
+**          for the first time.  When forwarding a message that originated from
+**          an external entity (e.g. messages passing through CI or SBN), the
+**          parameter should be passed as "false" to not overwrite existing data.
+**
 ** \par Assumptions, External Events, and Notes:
 **          -# A handle returned by #CFE_SB_AllocateMessageBuffer is "consumed" by
 **             a _successful_ call to #CFE_SB_TransmitBuffer.
@@ -553,17 +567,15 @@ CFE_Status_t CFE_SB_ReleaseMessageBuffer(CFE_SB_Buffer_t *BufPtr);
 **          -# This function will increment and apply the internally tracked
 **             sequence counter if set to do so.
 **
-** \param[in] BufPtr                 A pointer to the buffer to be sent @nonnull.
-** \param[in] IncrementSequenceCount Boolean to increment the internally tracked
-**                                   sequence count and update the message if the
-**                                   buffer contains a telemetry message
+** \param[in] BufPtr        A pointer to the buffer to be sent @nonnull.
+** \param[in] UpdateHeader  Update the headers of the message
 **
 ** \return Execution status, see \ref CFEReturnCodes
 ** \retval #CFE_SUCCESS         \copybrief CFE_SUCCESS
 ** \retval #CFE_SB_BAD_ARGUMENT \copybrief CFE_SB_BAD_ARGUMENT
 ** \retval #CFE_SB_MSG_TOO_BIG  \copybrief CFE_SB_MSG_TOO_BIG
 **/
-CFE_Status_t CFE_SB_TransmitBuffer(CFE_SB_Buffer_t *BufPtr, bool IncrementSequenceCount);
+CFE_Status_t CFE_SB_TransmitBuffer(CFE_SB_Buffer_t *BufPtr, bool UpdateHeader);
 
 /** @} */
 

--- a/modules/core_api/ut-stubs/src/cfe_config_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_config_stubs.c
@@ -25,8 +25,8 @@
 #include "cfe_config.h"
 #include "utgenstub.h"
 
-extern void UT_DefaultHandler_CFE_Config_GetObjPointer(void *, UT_EntryKey_t, const UT_StubContext_t *);
-extern void UT_DefaultHandler_CFE_Config_GetString(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_Config_GetObjPointer(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_Config_GetString(void *, UT_EntryKey_t, const UT_StubContext_t *);
 
 /*
  * ----------------------------------------------------

--- a/modules/core_api/ut-stubs/src/cfe_error_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_error_stubs.c
@@ -19,20 +19,25 @@
 /**
  * @file
  *
- * cfe_msg_init test header
+ * Auto-Generated stub implementations for functions defined in cfe_error header
  */
-#ifndef TEST_CFE_MSG_INIT_H
-#define TEST_CFE_MSG_INIT_H
+
+#include "cfe_error.h"
+#include "utgenstub.h"
 
 /*
- * Includes
+ * ----------------------------------------------------
+ * Generated stub function for CFE_ES_StatusToString()
+ * ----------------------------------------------------
  */
+char *CFE_ES_StatusToString(CFE_Status_t status, CFE_StatusString_t *status_string)
+{
+    UT_GenStub_SetupReturnBuffer(CFE_ES_StatusToString, char *);
 
-/*
- * Functions
- */
-/* Test extended header mission functionality */
-void Test_MSG_Init(void);
-void Test_MSG_UpdateHeader(void);
+    UT_GenStub_AddParam(CFE_ES_StatusToString, CFE_Status_t, status);
+    UT_GenStub_AddParam(CFE_ES_StatusToString, CFE_StatusString_t *, status_string);
 
-#endif /* TEST_CFE_MSG_INIT_H */
+    UT_GenStub_Execute(CFE_ES_StatusToString, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(CFE_ES_StatusToString, char *);
+}

--- a/modules/core_api/ut-stubs/src/cfe_es_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_es_stubs.c
@@ -69,6 +69,7 @@ CFE_Status_t CFE_ES_AppID_ToIndex(CFE_ES_AppId_t AppID, uint32 *Idx)
  */
 void CFE_ES_BackgroundWakeup(void)
 {
+
     UT_GenStub_Execute(CFE_ES_BackgroundWakeup, Basic, NULL);
 }
 
@@ -216,6 +217,7 @@ void CFE_ES_ExitApp(uint32 ExitStatus)
  */
 void CFE_ES_ExitChildTask(void)
 {
+
     UT_GenStub_Execute(CFE_ES_ExitChildTask, Basic, NULL);
 }
 
@@ -602,6 +604,7 @@ CFE_Status_t CFE_ES_IncrementGenCounter(CFE_ES_CounterId_t CounterId)
  */
 void CFE_ES_IncrementTaskCounter(void)
 {
+
     UT_GenStub_Execute(CFE_ES_IncrementTaskCounter, Basic, NULL);
 }
 
@@ -731,6 +734,7 @@ int32 CFE_ES_PoolDelete(CFE_ES_MemHandle_t PoolID)
  */
 void CFE_ES_ProcessAsyncEvent(void)
 {
+
     UT_GenStub_Execute(CFE_ES_ProcessAsyncEvent, Basic, NULL);
 }
 
@@ -949,21 +953,4 @@ CFE_Status_t CFE_ES_WriteToSysLog(const char *SpecStringPtr, ...)
     va_end(UtStub_ArgList);
 
     return UT_GenStub_GetReturnValue(CFE_ES_WriteToSysLog, CFE_Status_t);
-}
-
-/*
- * ----------------------------------------------------
- * Generated stub function for CFE_ES_StatusToString()
- * ----------------------------------------------------
- */
-char *CFE_ES_StatusToString(CFE_Status_t status, CFE_StatusString_t *status_string)
-{
-    UT_GenStub_SetupReturnBuffer(CFE_ES_StatusToString, char *);
-
-    UT_GenStub_AddParam(CFE_ES_StatusToString, CFE_Status_t, status);
-    UT_GenStub_AddParam(CFE_ES_StatusToString, CFE_StatusString_t *, status_string);
-
-    UT_GenStub_Execute(CFE_ES_StatusToString, Basic, NULL);
-
-    return UT_GenStub_GetReturnValue(CFE_ES_StatusToString, char *);
 }

--- a/modules/core_api/ut-stubs/src/cfe_msg_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_msg_stubs.c
@@ -623,6 +623,23 @@ CFE_Status_t CFE_MSG_SetType(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Type_t Type)
 
 /*
  * ----------------------------------------------------
+ * Generated stub function for CFE_MSG_UpdateHeader()
+ * ----------------------------------------------------
+ */
+CFE_Status_t CFE_MSG_UpdateHeader(CFE_MSG_Message_t *MsgPtr, CFE_MSG_SequenceCount_t SeqCnt)
+{
+    UT_GenStub_SetupReturnBuffer(CFE_MSG_UpdateHeader, CFE_Status_t);
+
+    UT_GenStub_AddParam(CFE_MSG_UpdateHeader, CFE_MSG_Message_t *, MsgPtr);
+    UT_GenStub_AddParam(CFE_MSG_UpdateHeader, CFE_MSG_SequenceCount_t, SeqCnt);
+
+    UT_GenStub_Execute(CFE_MSG_UpdateHeader, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(CFE_MSG_UpdateHeader, CFE_Status_t);
+}
+
+/*
+ * ----------------------------------------------------
  * Generated stub function for CFE_MSG_ValidateChecksum()
  * ----------------------------------------------------
  */

--- a/modules/core_api/ut-stubs/src/cfe_sb_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_sb_stubs.c
@@ -384,12 +384,12 @@ void CFE_SB_TimeStampMsg(CFE_MSG_Message_t *MsgPtr)
  * Generated stub function for CFE_SB_TransmitBuffer()
  * ----------------------------------------------------
  */
-CFE_Status_t CFE_SB_TransmitBuffer(CFE_SB_Buffer_t *BufPtr, bool IncrementSequenceCount)
+CFE_Status_t CFE_SB_TransmitBuffer(CFE_SB_Buffer_t *BufPtr, bool UpdateHeader)
 {
     UT_GenStub_SetupReturnBuffer(CFE_SB_TransmitBuffer, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_SB_TransmitBuffer, CFE_SB_Buffer_t *, BufPtr);
-    UT_GenStub_AddParam(CFE_SB_TransmitBuffer, bool, IncrementSequenceCount);
+    UT_GenStub_AddParam(CFE_SB_TransmitBuffer, bool, UpdateHeader);
 
     UT_GenStub_Execute(CFE_SB_TransmitBuffer, Basic, UT_DefaultHandler_CFE_SB_TransmitBuffer);
 
@@ -401,12 +401,12 @@ CFE_Status_t CFE_SB_TransmitBuffer(CFE_SB_Buffer_t *BufPtr, bool IncrementSequen
  * Generated stub function for CFE_SB_TransmitMsg()
  * ----------------------------------------------------
  */
-CFE_Status_t CFE_SB_TransmitMsg(const CFE_MSG_Message_t *MsgPtr, bool IncrementSequenceCount)
+CFE_Status_t CFE_SB_TransmitMsg(const CFE_MSG_Message_t *MsgPtr, bool UpdateHeader)
 {
     UT_GenStub_SetupReturnBuffer(CFE_SB_TransmitMsg, CFE_Status_t);
 
     UT_GenStub_AddParam(CFE_SB_TransmitMsg, const CFE_MSG_Message_t *, MsgPtr);
-    UT_GenStub_AddParam(CFE_SB_TransmitMsg, bool, IncrementSequenceCount);
+    UT_GenStub_AddParam(CFE_SB_TransmitMsg, bool, UpdateHeader);
 
     UT_GenStub_Execute(CFE_SB_TransmitMsg, Basic, UT_DefaultHandler_CFE_SB_TransmitMsg);
 

--- a/modules/core_api/ut-stubs/src/cfe_time_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_time_stubs.c
@@ -113,6 +113,7 @@ void CFE_TIME_ExternalTime(CFE_TIME_SysTime_t NewTime)
  */
 void CFE_TIME_ExternalTone(void)
 {
+
     UT_GenStub_Execute(CFE_TIME_ExternalTone, Basic, NULL);
 }
 
@@ -263,6 +264,7 @@ CFE_TIME_SysTime_t CFE_TIME_GetUTC(void)
  */
 void CFE_TIME_Local1HzISR(void)
 {
+
     UT_GenStub_Execute(CFE_TIME_Local1HzISR, Basic, NULL);
 }
 

--- a/modules/msg/fsw/src/cfe_msg_init.c
+++ b/modules/msg/fsw/src/cfe_msg_init.c
@@ -22,6 +22,7 @@
 #include "cfe_msg.h"
 #include "cfe_msg_priv.h"
 #include "cfe_msg_defaults.h"
+#include "cfe_time.h"
 #include "string.h"
 
 /*----------------------------------------------------------------
@@ -51,4 +52,35 @@ CFE_Status_t CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_M
     }
 
     return status;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Implemented per public API
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+CFE_Status_t CFE_MSG_UpdateHeader(CFE_MSG_Message_t *MsgPtr, CFE_MSG_SequenceCount_t SeqCnt)
+{
+    if (MsgPtr == NULL)
+    {
+        return CFE_MSG_BAD_ARGUMENT;
+    }
+
+    /* Sequence count is in the basic CCSDS Primary Hdr, so all msgs have it */
+    CFE_MSG_SetSequenceCount(MsgPtr, SeqCnt);
+
+    /*
+     * TLM packets have a timestamp in the secondary header.
+     * This may fail if this is not a TLM packet (that is OK)
+     */
+    CFE_MSG_SetMsgTime(MsgPtr, CFE_TIME_GetTime());
+
+    /*
+     * CMD packets have a checksum in the secondary header.
+     * This may fail if this is not a CMD packet (that is OK)
+     */
+    CFE_MSG_GenerateChecksum(MsgPtr);
+
+    return CFE_SUCCESS;
 }

--- a/modules/msg/ut-coverage/msg_UT.c
+++ b/modules/msg/ut-coverage/msg_UT.c
@@ -43,6 +43,7 @@ void UtTest_Setup(void)
     UtPrintf("Message header coverage test...");
 
     UT_ADD_TEST(Test_MSG_Init);
+    UT_ADD_TEST(Test_MSG_UpdateHeader);
     Test_MSG_CCSDSPri();
     Test_MSG_CCSDSExt();
     Test_MSG_MsgId_Shared();

--- a/modules/msg/ut-coverage/test_cfe_msg_init.c
+++ b/modules/msg/ut-coverage/test_cfe_msg_init.c
@@ -124,3 +124,40 @@ void Test_MSG_Init(void)
     UtAssert_UINT32_EQ(Test_MSG_Pri_NotZero(CFE_MSG_PTR(cmd)) & ~MSG_HDRVER_FLAG,
                        MSG_APID_FLAG | MSG_HASSEC_FLAG | MSG_TYPE_FLAG | MSG_LENGTH_FLAG | MSG_SEGMENT_FLAG);
 }
+
+/*
+ * Test MSG Update Header
+ */
+void Test_MSG_UpdateHeader(void)
+{
+    union
+    {
+        CFE_MSG_Message_t         msg;
+        CFE_MSG_CommandHeader_t   cmd;
+        CFE_MSG_TelemetryHeader_t tlm;
+
+    } LocalBuf;
+    CFE_MSG_SequenceCount_t SeqCnt;
+    CFE_MSG_SequenceCount_t CheckCnt;
+
+    memset(&LocalBuf, 0, sizeof(LocalBuf));
+    SeqCnt   = 1;
+    CheckCnt = 0;
+
+    /* bad buffer */
+    UtAssert_INT32_EQ(CFE_MSG_UpdateHeader(NULL, SeqCnt), CFE_MSG_BAD_ARGUMENT);
+
+    /* nominal, cmd */
+    CFE_MSG_SetType(&LocalBuf.msg, CFE_MSG_Type_Cmd);
+    CFE_UtAssert_SUCCESS(CFE_MSG_UpdateHeader(&LocalBuf.msg, SeqCnt));
+    CFE_MSG_GetSequenceCount(&LocalBuf.msg, &CheckCnt);
+    UtAssert_UINT32_EQ(CheckCnt, SeqCnt);
+    ++SeqCnt;
+
+    /* nominal, tlm */
+    CFE_MSG_SetType(&LocalBuf.msg, CFE_MSG_Type_Tlm);
+    CFE_UtAssert_SUCCESS(CFE_MSG_UpdateHeader(&LocalBuf.msg, SeqCnt));
+    CFE_MSG_GetSequenceCount(&LocalBuf.msg, &CheckCnt);
+    UtAssert_UINT32_EQ(CheckCnt, SeqCnt);
+    ++SeqCnt;
+}

--- a/modules/sb/fsw/src/cfe_sb_priv.h
+++ b/modules/sb/fsw/src/cfe_sb_priv.h
@@ -150,7 +150,7 @@ typedef struct CFE_SB_BufferD
     size_t         ContentSize;   /**< Actual size of message content currently stored in the buffer */
     CFE_MSG_Type_t ContentType;   /**< Type of message content currently stored in the buffer */
 
-    bool AutoSequence; /**< If message should get its sequence number assigned from the route */
+    bool NeedsUpdate; /**< If message should get its header fields automatically updated */
 
     uint16 UseCount; /**< Number of active references to this buffer in the system */
 

--- a/modules/sb/ut-coverage/sb_UT.h
+++ b/modules/sb/ut-coverage/sb_UT.h
@@ -1854,7 +1854,7 @@ void Test_TransmitMsg_BasicSend(void);
 
 /*****************************************************************************/
 /**
-** \brief Test successful send/receive for packet sequence count
+** \brief Test successful send of messages with header update
 **
 ** \par Description
 **        This function tests successful send/receive for packet sequence
@@ -1866,7 +1866,7 @@ void Test_TransmitMsg_BasicSend(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_TransmitMsg_SequenceCount(void);
+void Test_TransmitMsg_UpdateHeader(void);
 
 /*****************************************************************************/
 /**

--- a/modules/tbl/fsw/src/cfe_tbl_internal.c
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.c
@@ -1379,7 +1379,7 @@ int32 CFE_TBL_SendNotificationMsg(CFE_TBL_RegistryRec_t *RegRecPtr)
         CFE_TBL_Global.NotifyMsg.Payload.Parameter = RegRecPtr->NotificationParam;
 
         CFE_SB_TimeStampMsg(CFE_MSG_PTR(CFE_TBL_Global.NotifyMsg.CommandHeader));
-        Status = CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TBL_Global.NotifyMsg.CommandHeader), false);
+        Status = CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TBL_Global.NotifyMsg.CommandHeader), true);
 
         if (Status != CFE_SUCCESS)
         {

--- a/modules/time/fsw/src/cfe_time_tone.c
+++ b/modules/time/fsw/src/cfe_time_tone.c
@@ -150,7 +150,7 @@ void CFE_TIME_ToneSend(void)
     /*
     ** Send "time at the tone" command data packet...
     */
-    CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TIME_Global.ToneDataCmd.CommandHeader), false);
+    CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TIME_Global.ToneDataCmd.CommandHeader), true);
 
     /*
     ** Count of "time at the tone" commands sent with internal data...
@@ -275,7 +275,7 @@ int32 CFE_TIME_ToneSendMET(CFE_TIME_SysTime_t NewMET)
             /*
             ** Send "time at the tone" command data packet...
             */
-            CFE_SB_TransmitMsg(&CFE_TIME_Global.ToneDataCmd.CommandHeader.Msg, false);
+            CFE_SB_TransmitMsg(&CFE_TIME_Global.ToneDataCmd.CommandHeader.Msg, true);
 
             /*
             ** Count of "time at the tone" commands sent with external data...
@@ -415,7 +415,7 @@ int32 CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps)
             /*
             ** Send "time at the tone" command data packet...
             */
-            CFE_SB_TransmitMsg(&CFE_TIME_Global.ToneDataCmd.CommandHeader.Msg, false);
+            CFE_SB_TransmitMsg(&CFE_TIME_Global.ToneDataCmd.CommandHeader.Msg, true);
 
             /*
             ** Count of "time at the tone" commands sent with external data...
@@ -555,7 +555,7 @@ int32 CFE_TIME_ToneSendTime(CFE_TIME_SysTime_t NewTime)
             /*
             ** Send "time at the tone" command data packet...
             */
-            CFE_SB_TransmitMsg(&CFE_TIME_Global.ToneDataCmd.CommandHeader.Msg, false);
+            CFE_SB_TransmitMsg(&CFE_TIME_Global.ToneDataCmd.CommandHeader.Msg, true);
 
             /*
             ** Count of "time at the tone" commands sent with external data...
@@ -1088,7 +1088,7 @@ void CFE_TIME_Tone1HzTask(void)
         /*
         ** Send tone signal command packet...
         */
-        CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TIME_Global.ToneSignalCmd.CommandHeader), false);
+        CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TIME_Global.ToneSignalCmd.CommandHeader), true);
 
 #if (CFE_MISSION_TIME_CFG_FAKE_TONE == true)
         /*
@@ -1096,7 +1096,7 @@ void CFE_TIME_Tone1HzTask(void)
         ** to send the tone to other time clients.
         ** (this is done by scheduler in non-fake mode)
         */
-        CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TIME_Global.ToneSendCmd.CommandHeader), false);
+        CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TIME_Global.ToneSendCmd.CommandHeader), true);
 #endif
 
         /*
@@ -1287,7 +1287,7 @@ void CFE_TIME_Local1HzTask(void)
         ** This used to be optional in previous CFE versions, but it is now required
         ** as TIME subscribes to this itself to do state machine tasks.
         */
-        CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TIME_Global.Local1HzCmd.CommandHeader), false);
+        CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TIME_Global.Local1HzCmd.CommandHeader), true);
 
         CFE_TIME_Global.LocalTaskCounter++;
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Expand the "Increment Sequence" boolean on transmit message functions to be a more general "Update Header" boolean, so it can be used for other fields like timestamps, checksums, or user-defined fields too.

Fixes #2335
Fixes #1157

**Testing performed**
Build and run CFE, sanity check, confirm headers are as expected

**Expected behavior changes**
Headers will be updated more consistently/generically. 

*Note --*  Messages classified as Commands  will have headers updated, too - specifically the sequence count and checksum.  This will apply to messages being created by SCH/SCH_LAB, and the time signals sent by CFE TIME.  Previously the sequence counter was not set in any of these messages, so it would have always been zero.  Hence receivers would not be relying on it for anything, and thus setting it nonzero shouldn't break anything, either.  But there is a slight chance that some code had a dependency on this always being zero.
 

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
