### PR TITLE
Fix #2337, add msg verify capability

### DIFF
--- a/modules/core_api/fsw/inc/cfe_msg.h
+++ b/modules/core_api/fsw/inc/cfe_msg.h
@@ -700,4 +700,30 @@ CFE_Status_t CFE_MSG_GetTypeFromMsgId(CFE_SB_MsgId_t MsgId, CFE_MSG_Type_t *Type
 
 /**\}*/
 
+/** \defgroup CFEAPIMSGMsgVerify cFE Message Checking APIs
+ * \{
+ */
+/*****************************************************************************/
+/**
+ * \brief Checks message headers against expected values
+ *
+ * \par Description
+ *        This routine validates that any error-control field(s) in the message header
+ *        matches the expected value.
+ *
+ *        The specific function of this API is entirely dependent on the header fields
+ *        and may be a no-op if no error checking is implemented.  In that case, it
+ *        will always output "true".
+ *
+ * \param[in]  MsgPtr        Message Pointer @nonnull
+ * \param[out] VerifyStatus  Output variable to be set to verification result @nonnull
+ *
+ * \return Execution status, see \ref CFEReturnCodes
+ * \retval #CFE_SUCCESS            \copybrief CFE_SUCCESS
+ * \retval #CFE_MSG_BAD_ARGUMENT   \copybrief CFE_MSG_BAD_ARGUMENT
+ */
+CFE_Status_t CFE_MSG_Verify(const CFE_MSG_Message_t *MsgPtr, bool *VerifyStatus);
+
+/**\}*/
+
 #endif /* CFE_MSG_H */

--- a/modules/msg/CMakeLists.txt
+++ b/modules/msg/CMakeLists.txt
@@ -16,35 +16,36 @@
 # Add the basic set of files which are always built
 # Defined as absolute so this list can also be used to build unit tests
 set(${DEP}_SRC
-    ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/cfe_msg_ccsdspri.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/cfe_msg_init.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/cfe_msg_msgid_shared.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/cfe_msg_sechdr_checksum.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/cfe_msg_sechdr_fc.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/cfe_msg_sechdr_time.c
+    fsw/src/cfe_msg_ccsdspri.c
+    fsw/src/cfe_msg_init.c
+    fsw/src/cfe_msg_verify.c
+    fsw/src/cfe_msg_msgid_shared.c
+    fsw/src/cfe_msg_sechdr_checksum.c
+    fsw/src/cfe_msg_sechdr_fc.c
+    fsw/src/cfe_msg_sechdr_time.c
 )
 
 # Source selection for if CCSDS extended header is included, and MsgId version use
 if (MISSION_INCLUDE_CCSDSEXT_HEADER)
     message(STATUS "CCSDS primary and extended header included in message header")
     list(APPEND ${DEP}_SRC
-        ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/cfe_msg_ccsdsext.c
-        ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/cfe_msg_initdefaulthdr_priext.c)
+        fsw/src/cfe_msg_ccsdsext.c
+        fsw/src/cfe_msg_initdefaulthdr_priext.c)
     if (MISSION_MSGID_V2)  # MsgId v2 or v1 can be used with extended headers
       message(STATUS "Message Id version 2 in use (MsgId V2)")
       list(APPEND ${DEP}_SRC
-           ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/cfe_msg_msgid_v2.c)
+           fsw/src/cfe_msg_msgid_v2.c)
     else (MISSION_MSGID_V2)
       message(STATUS "Message Id version 1 in use (MsgId V1)")
       list(APPEND ${DEP}_SRC
-           ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/cfe_msg_msgid_v1.c)
+           fsw/src/cfe_msg_msgid_v1.c)
     endif (MISSION_MSGID_V2)
 else (MISSION_INCLUDE_CCSDSEXT_HEADER)
     message(STATUS "CCSDS primary header included in message header (not including CCSDS extended header)")
     message(STATUS "Message Id version 1 in use (MsgId V1)")
     list(APPEND ${DEP}_SRC
-        ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/cfe_msg_initdefaulthdr_pri.c
-        ${CMAKE_CURRENT_SOURCE_DIR}/fsw/src/cfe_msg_msgid_v1.c)
+        fsw/src/cfe_msg_initdefaulthdr_pri.c
+        fsw/src/cfe_msg_msgid_v1.c)
     if (MISSION_MSGID_V2)
         message(FATAL_ERROR "Message Id (MsgId) version 2 can only be used if MISSION_INCLUDE_CCSDSEXT_HEADER is set")
     endif (MISSION_MSGID_V2)

--- a/modules/msg/fsw/src/cfe_msg_verify.c
+++ b/modules/msg/fsw/src/cfe_msg_verify.c
@@ -16,40 +16,33 @@
  * limitations under the License.
  ************************************************************************/
 
-/*
- * Message header unit tests
- */
+#include "cfe_msg.h"
+#include "cfe_msg_priv.h"
+#include "cfe_msg_defaults.h"
+#include "cfe_time.h"
 
-/*
- * Includes
- */
-#include "utassert.h"
-#include "ut_support.h"
-#include "test_cfe_msg_init.h"
-#include "test_cfe_msg_ccsdspri.h"
-#include "test_cfe_msg_ccsdsext.h"
-#include "test_cfe_msg_verify.h"
-#include "test_cfe_msg_msgid_shared.h"
-#include "test_cfe_msg_msgid.h"
-#include "test_cfe_msg_fc.h"
-#include "test_cfe_msg_checksum.h"
-#include "test_cfe_msg_time.h"
-
-/*
- * Functions
- */
-void UtTest_Setup(void)
+/*----------------------------------------------------------------
+ *
+ * Implemented per public API
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+CFE_Status_t CFE_MSG_Verify(const CFE_MSG_Message_t *MsgPtr, bool *VerifyStatus)
 {
-    UT_Init("msg");
-    UtPrintf("Message header coverage test...");
+    if (MsgPtr == NULL || VerifyStatus == NULL)
+    {
+        return CFE_MSG_BAD_ARGUMENT;
+    }
 
-    UT_ADD_TEST(Test_MSG_Init);
-    Test_MSG_CCSDSPri();
-    Test_MSG_CCSDSExt();
-    Test_MSG_MsgId_Shared();
-    UT_ADD_TEST(Test_MSG_Verify);
-    UT_ADD_TEST(Test_MSG_MsgId);
-    UT_ADD_TEST(Test_MSG_Checksum);
-    UT_ADD_TEST(Test_MSG_FcnCode);
-    UT_ADD_TEST(Test_MSG_Time);
+    /*
+     * In the default implementation, there is not anything to check here.
+     * Only commands have a checksum, but the value of that checksum was historically
+     * not enforced by CFE.
+     *
+     * This is mainly a hook for user expansion, in case a custom implementation
+     * has message verification capability.
+     */
+    *VerifyStatus = true;
+
+    return CFE_SUCCESS;
 }

--- a/modules/msg/ut-coverage/CMakeLists.txt
+++ b/modules/msg/ut-coverage/CMakeLists.txt
@@ -7,23 +7,23 @@
 #
 ##################################################################
 
-# Unit test object library sources, options, and includes
-add_library(ut_${DEP}_objs OBJECT ${${DEP}_SRC})
-target_compile_options(ut_${DEP}_objs PRIVATE ${UT_COVERAGE_COMPILE_FLAGS})
-target_include_directories(ut_${DEP}_objs PRIVATE
-     $<TARGET_PROPERTY:${DEP},INCLUDE_DIRECTORIES>)
+set(UNIT_SRCS)
+foreach(SRC ${${DEP}_SRC})
+    get_filename_component(UNITNAME "${SRC}" NAME)
+    list(APPEND UNIT_SRCS "../${SRC}")
+endforeach()
 
 set (ut_${DEP}_tests
     msg_UT.c
     test_msg_not.c
     test_msg_pri_not.c
     test_cfe_msg_init.c
+    test_cfe_msg_verify.c
     test_cfe_msg_ccsdspri.c
     test_cfe_msg_msgid_shared.c
     test_cfe_msg_checksum.c
     test_cfe_msg_fc.c
-    test_cfe_msg_time.c
-    $<TARGET_OBJECTS:ut_${DEP}_objs>)
+    test_cfe_msg_time.c)
 
 # Add extended header tests if appropriate
 if (MISSION_INCLUDE_CCSDSEXT_HEADER)
@@ -44,21 +44,15 @@ else (MISSION_MSGID_V2)
         test_cfe_msg_msgid_v1.c)
 endif (MISSION_MSGID_V2)
 
-# Add executable
-add_executable(${DEP}_UT ${ut_${DEP}_tests})
 
-# Add include to get private defaults
-target_include_directories(${DEP}_UT PRIVATE ../fsw/src)
+add_cfe_coverage_test(${DEP} ALL
+    "msg_UT.c;${ut_${DEP}_tests}"  # This list needs to be passed as a single argument
+    "${UNIT_SRCS}"
+)
 
-# Also add the UT_COVERAGE_LINK_FLAGS to the link command
-# This should enable coverage analysis on platforms that support this
-target_link_libraries(${DEP}_UT
-    ${UT_COVERAGE_LINK_FLAGS}
-    ut_core_private_stubs
-    ut_core_api_stubs
-    ut_assert)
+# This permits UT test cases to directly access private headers in the fsw/src dir
+target_include_directories(coverage-${DEP}-ALL-testrunner PRIVATE
+    ../fsw/src
+)
 
-add_test(${DEP}_UT ${DEP}_UT)
-foreach(TGT ${INSTALL_TARGET_LIST})
-    install(TARGETS ${DEP}_UT DESTINATION ${TGT}/${UT_INSTALL_SUBDIR})
-endforeach()
+target_link_libraries(coverage-${DEP}-ALL-testrunner ut_core_private_stubs)

--- a/modules/msg/ut-coverage/test_cfe_msg_verify.c
+++ b/modules/msg/ut-coverage/test_cfe_msg_verify.c
@@ -17,7 +17,7 @@
  ************************************************************************/
 
 /*
- * Message header unit tests
+ * Test message verify
  */
 
 /*
@@ -25,31 +25,35 @@
  */
 #include "utassert.h"
 #include "ut_support.h"
-#include "test_cfe_msg_init.h"
-#include "test_cfe_msg_ccsdspri.h"
-#include "test_cfe_msg_ccsdsext.h"
+#include "cfe_msg.h"
 #include "test_cfe_msg_verify.h"
-#include "test_cfe_msg_msgid_shared.h"
-#include "test_cfe_msg_msgid.h"
-#include "test_cfe_msg_fc.h"
-#include "test_cfe_msg_checksum.h"
-#include "test_cfe_msg_time.h"
+#include "cfe_error.h"
+#include "cfe_msg_defaults.h"
+
+#include <string.h>
 
 /*
- * Functions
+ * Test MSG Verify
  */
-void UtTest_Setup(void)
+void Test_MSG_Verify(void)
 {
-    UT_Init("msg");
-    UtPrintf("Message header coverage test...");
+    union
+    {
+        CFE_MSG_Message_t         msg;
+        CFE_MSG_CommandHeader_t   cmd;
+        CFE_MSG_TelemetryHeader_t tlm;
+    } LocalBuf;
+    bool Result;
 
-    UT_ADD_TEST(Test_MSG_Init);
-    Test_MSG_CCSDSPri();
-    Test_MSG_CCSDSExt();
-    Test_MSG_MsgId_Shared();
-    UT_ADD_TEST(Test_MSG_Verify);
-    UT_ADD_TEST(Test_MSG_MsgId);
-    UT_ADD_TEST(Test_MSG_Checksum);
-    UT_ADD_TEST(Test_MSG_FcnCode);
-    UT_ADD_TEST(Test_MSG_Time);
+    memset(&LocalBuf, 0, sizeof(LocalBuf));
+    Result = false;
+
+    /* bad buffer */
+    UtAssert_INT32_EQ(CFE_MSG_Verify(NULL, &Result), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_Verify(&LocalBuf.msg, NULL), CFE_MSG_BAD_ARGUMENT);
+
+    /* nominal */
+    Result = false;
+    CFE_UtAssert_SUCCESS(CFE_MSG_Verify(&LocalBuf.msg, &Result));
+    UtAssert_BOOL_TRUE(Result);
 }

--- a/modules/msg/ut-coverage/test_cfe_msg_verify.h
+++ b/modules/msg/ut-coverage/test_cfe_msg_verify.h
@@ -16,40 +16,21 @@
  * limitations under the License.
  ************************************************************************/
 
-/*
- * Message header unit tests
+/**
+ * @file
+ *
+ * cfe_msg_verify test header
  */
+#ifndef TEST_CFE_MSG_VERIFY_H
+#define TEST_CFE_MSG_VERIFY_H
 
 /*
  * Includes
  */
-#include "utassert.h"
-#include "ut_support.h"
-#include "test_cfe_msg_init.h"
-#include "test_cfe_msg_ccsdspri.h"
-#include "test_cfe_msg_ccsdsext.h"
-#include "test_cfe_msg_verify.h"
-#include "test_cfe_msg_msgid_shared.h"
-#include "test_cfe_msg_msgid.h"
-#include "test_cfe_msg_fc.h"
-#include "test_cfe_msg_checksum.h"
-#include "test_cfe_msg_time.h"
 
 /*
  * Functions
  */
-void UtTest_Setup(void)
-{
-    UT_Init("msg");
-    UtPrintf("Message header coverage test...");
+void Test_MSG_Verify(void);
 
-    UT_ADD_TEST(Test_MSG_Init);
-    Test_MSG_CCSDSPri();
-    Test_MSG_CCSDSExt();
-    Test_MSG_MsgId_Shared();
-    UT_ADD_TEST(Test_MSG_Verify);
-    UT_ADD_TEST(Test_MSG_MsgId);
-    UT_ADD_TEST(Test_MSG_Checksum);
-    UT_ADD_TEST(Test_MSG_FcnCode);
-    UT_ADD_TEST(Test_MSG_Time);
-}
+#endif /* TEST_CFE_MSG_VERIFY_H */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Adds a "verify" API to the msg module.  This always returns success in the default implementation, because checksums were not historically enforced.  However it can be made more strict in a custom implementation.

Fixes #2337

**Testing performed**
Build and run tests (API is not used yet)

**Expected behavior changes**
None at this time, follow on change to enable it

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
