### PR TITLE
Fix #2339, Refactor common logic out of `CFE_TIME_SetTime/MET/STCFCmd()`

### DIFF
--- a/modules/time/fsw/src/cfe_time_task.c
+++ b/modules/time/fsw/src/cfe_time_task.c
@@ -771,14 +771,16 @@ int32 CFE_TIME_SubDelayCmd(const CFE_TIME_SubDelayCmd_t *data)
 
 /*----------------------------------------------------------------
  *
- * Application-scope internal function
- * See description in header file for argument/return detail
+ * Internal helper routine - not part of API
+ *
+ * This function performs the common logic for CFE_TIME_SetTimeCmd(),
+ * CFE_TIME_SetMETCmd() and CFE_TIME_SetSTCFCmd().
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data)
+static void CFE_TIME_SetCommand(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, void (*SetTimeFunc)(CFE_TIME_SysTime_t),
+                                const char *TimeType, uint16 SuccessEventID, uint16 ConfigErrorEventID,
+                                uint16 ErrorEventID)
 {
-    const CFE_TIME_TimeCmd_Payload_t *CommandPtr = &data->Payload;
-
     /*
     ** Verify "micro-seconds" command argument...
     */
@@ -791,11 +793,11 @@ int32 CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data)
         NewTime.Seconds    = CommandPtr->Seconds;
         NewTime.Subseconds = CFE_TIME_Micro2SubSecs(CommandPtr->MicroSeconds);
 
-        CFE_TIME_SetTime(NewTime);
+        SetTimeFunc(NewTime);
 
         CFE_TIME_Global.CommandCounter++;
-        CFE_EVS_SendEvent(CFE_TIME_TIME_EID, CFE_EVS_EventType_INFORMATION,
-                          "Set Time -- secs = %u, usecs = %u, ssecs = 0x%X", (unsigned int)CommandPtr->Seconds,
+        CFE_EVS_SendEvent(SuccessEventID, CFE_EVS_EventType_INFORMATION,
+                          "Set %s -- secs = %u, usecs = %u, ssecs = 0x%X", TimeType, (unsigned int)CommandPtr->Seconds,
                           (unsigned int)CommandPtr->MicroSeconds,
                           (unsigned int)CFE_TIME_Micro2SubSecs(CommandPtr->MicroSeconds));
 
@@ -805,18 +807,29 @@ int32 CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data)
         */
         CFE_TIME_Global.CommandErrorCounter++;
 
-        CFE_EVS_SendEvent(CFE_TIME_TIME_CFG_EID, CFE_EVS_EventType_ERROR,
-                          "Set Time commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to TRUE");
+        CFE_EVS_SendEvent(ConfigErrorEventID, CFE_EVS_EventType_ERROR,
+                          "Set %s commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to TRUE", TimeType);
 
 #endif /* CFE_PLATFORM_TIME_CFG_SERVER */
     }
     else
     {
         CFE_TIME_Global.CommandErrorCounter++;
-        CFE_EVS_SendEvent(CFE_TIME_TIME_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid Time -- secs = %u, usecs = %u",
+        CFE_EVS_SendEvent(ErrorEventID, CFE_EVS_EventType_ERROR, "Invalid %s -- secs = %u, usecs = %u", TimeType,
                           (unsigned int)CommandPtr->Seconds, (unsigned int)CommandPtr->MicroSeconds);
     }
+}
 
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data)
+{
+    CFE_TIME_SetCommand(&data->Payload, CFE_TIME_SetTime, "Time", CFE_TIME_TIME_EID, CFE_TIME_TIME_CFG_EID,
+                        CFE_TIME_TIME_ERR_EID);
     return CFE_SUCCESS;
 }
 
@@ -828,46 +841,8 @@ int32 CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data)
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_SetMETCmd(const CFE_TIME_SetMETCmd_t *data)
 {
-    const CFE_TIME_TimeCmd_Payload_t *CommandPtr = &data->Payload;
-
-    /*
-    ** Verify "micro-seconds" command argument...
-    */
-    if (CommandPtr->MicroSeconds < 1000000)
-    {
-#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
-
-        CFE_TIME_SysTime_t NewMET;
-
-        NewMET.Seconds    = CommandPtr->Seconds;
-        NewMET.Subseconds = CFE_TIME_Micro2SubSecs(CommandPtr->MicroSeconds);
-
-        CFE_TIME_SetMET(NewMET);
-
-        CFE_TIME_Global.CommandCounter++;
-        CFE_EVS_SendEvent(CFE_TIME_MET_EID, CFE_EVS_EventType_INFORMATION,
-                          "Set MET -- secs = %u, usecs = %u, ssecs = 0x%X", (unsigned int)CommandPtr->Seconds,
-                          (unsigned int)CommandPtr->MicroSeconds,
-                          (unsigned int)CFE_TIME_Micro2SubSecs(CommandPtr->MicroSeconds));
-
-#else /* not CFE_PLATFORM_TIME_CFG_SERVER */
-        /*
-        ** We want to know if disabled commands are being sent...
-        */
-        CFE_TIME_Global.CommandErrorCounter++;
-
-        CFE_EVS_SendEvent(CFE_TIME_MET_CFG_EID, CFE_EVS_EventType_ERROR,
-                          "Set MET commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to TRUE");
-
-#endif /* CFE_PLATFORM_TIME_CFG_SERVER */
-    }
-    else
-    {
-        CFE_TIME_Global.CommandErrorCounter++;
-        CFE_EVS_SendEvent(CFE_TIME_MET_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid MET -- secs = %u, usecs = %u",
-                          (unsigned int)CommandPtr->Seconds, (unsigned int)CommandPtr->MicroSeconds);
-    }
-
+    CFE_TIME_SetCommand(&data->Payload, CFE_TIME_SetMET, "MET", CFE_TIME_MET_EID, CFE_TIME_MET_CFG_EID,
+                        CFE_TIME_MET_ERR_EID);
     return CFE_SUCCESS;
 }
 
@@ -879,46 +854,8 @@ int32 CFE_TIME_SetMETCmd(const CFE_TIME_SetMETCmd_t *data)
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_SetSTCFCmd(const CFE_TIME_SetSTCFCmd_t *data)
 {
-    const CFE_TIME_TimeCmd_Payload_t *CommandPtr = &data->Payload;
-
-    /*
-    ** Verify "micro-seconds" command argument...
-    */
-    if (CommandPtr->MicroSeconds < 1000000)
-    {
-#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
-
-        CFE_TIME_SysTime_t NewSTCF;
-
-        NewSTCF.Seconds    = CommandPtr->Seconds;
-        NewSTCF.Subseconds = CFE_TIME_Micro2SubSecs(CommandPtr->MicroSeconds);
-
-        CFE_TIME_SetSTCF(NewSTCF);
-
-        CFE_TIME_Global.CommandCounter++;
-        CFE_EVS_SendEvent(CFE_TIME_STCF_EID, CFE_EVS_EventType_INFORMATION,
-                          "Set STCF -- secs = %u, usecs = %u, ssecs = 0x%X", (unsigned int)CommandPtr->Seconds,
-                          (unsigned int)CommandPtr->MicroSeconds,
-                          (unsigned int)CFE_TIME_Micro2SubSecs(CommandPtr->MicroSeconds));
-
-#else /* not CFE_PLATFORM_TIME_CFG_SERVER */
-        /*
-        ** We want to know if disabled commands are being sent...
-        */
-        CFE_TIME_Global.CommandErrorCounter++;
-
-        CFE_EVS_SendEvent(CFE_TIME_STCF_CFG_EID, CFE_EVS_EventType_ERROR,
-                          "Set STCF commands invalid without CFE_PLATFORM_TIME_CFG_SERVER set to TRUE");
-
-#endif /* CFE_PLATFORM_TIME_CFG_SERVER */
-    }
-    else
-    {
-        CFE_TIME_Global.CommandErrorCounter++;
-        CFE_EVS_SendEvent(CFE_TIME_STCF_ERR_EID, CFE_EVS_EventType_ERROR, "Invalid STCF -- secs = %u, usecs = %u",
-                          (unsigned int)CommandPtr->Seconds, (unsigned int)CommandPtr->MicroSeconds);
-    }
-
+    CFE_TIME_SetCommand(&data->Payload, CFE_TIME_SetSTCF, "STCF", CFE_TIME_STCF_EID, CFE_TIME_STCF_CFG_EID,
+                        CFE_TIME_STCF_ERR_EID);
     return CFE_SUCCESS;
 }
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2339
  - Near-identical logic in `CFE_TIME_SetTimeCmd()`, `CFE_TIME_SetMETCmd()` and `CFE_TIME_SetSTCFCmd()` has been factored out into a helper routine.

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Coverage/Functional Tests etc.).
Local tests confirm the modified commands are working as expected:
![Screenshot 2023-05-19 19 49 12](https://github.com/nasa/cFE/assets/9024662/1ac2b751-c9a3-4e5a-8623-298f946ebbea)
Net coverage is unchanged (total lines reduced by 22, total branches reduced by 4).

**Expected behavior changes**
Behavior/logic is unchanged.
Code duplication reduced, easing future maintenance.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss @thnkslprpt