### PR TITLE
Fix #2341, Rename TimeA/TimeB parameter to improve consistency

### DIFF
--- a/docs/cFE Application Developers Guide.md
+++ b/docs/cFE Application Developers Guide.md
@@ -3496,10 +3496,10 @@ hours later.
 The rule that is used by the `CFE_TIME_Compare` function is that if the
 smaller delta time is found going in a counter-clockwise direction, then
 the first time is considered greater than the second and the comparison
-function would return `CFE_TIME_A_GT_B`. Likewise, if the smaller
+function would return `CFE_TIME_1_GT_2`. Likewise, if the smaller
 delta time is found going in a clockwise direction, as demonstrated in
 the example above, then the first time is less than the second and the
-comparison function would return `CFE_TIME_A_LT_B`. This rule was
+comparison function would return `CFE_TIME_1_LT_2`. This rule was
 chosen because it seemed unlikely that someone would require the ability
 to compare two times whose delta time was greater than or equal to
 2,147,483,647 seconds (approximately 68 years). If a mission does
@@ -3519,18 +3519,18 @@ time between two absolute times could either be 5 hours or 7 hours. An
 example of a delta time computation function is shown below:
 
 ```c
-CFE_TIME_SysTime_t ComputeDeltaTime(CFE_TIME_SysTime_t TimeA,
-                                    CFE_TIME_SysTime_t TimeB)
+CFE_TIME_SysTime_t ComputeDeltaTime(CFE_TIME_SysTime_t Time1,
+                                    CFE_TIME_SysTime_t Time2)
 {
     CFE_TIME_SysTime_t Result;
 
-    if (CFE_TIME_Compare(TimeA, TimeB) == CFE_TIME_A_GT_B)
+    if (CFE_TIME_Compare(Time1, Time2) == CFE_TIME_1_GT_2)
     {
-        Result = CFE_TIME_Subtract(TimeA, TimeB);
+        Result = CFE_TIME_Subtract(Time1, Time2);
     }
     else
     {
-        Result = CFE_TIME_Subtract(TimeB, TimeA);
+        Result = CFE_TIME_Subtract(Time2, Time1);
     }
 
     return Result;

--- a/modules/cfe_testcase/src/es_behavior_test.c
+++ b/modules/cfe_testcase/src/es_behavior_test.c
@@ -79,7 +79,7 @@ void TestWaitBehavior(void)
     end        = CFE_TIME_GetTime();
     TimePassed = CFE_TIME_Subtract(end, start);
 
-    UtAssert_UINT32_EQ(CFE_TIME_Compare(TimePassed, TimeExpected), CFE_TIME_A_LT_B);
+    UtAssert_UINT32_EQ(CFE_TIME_Compare(TimePassed, TimeExpected), CFE_TIME_1_LT_2);
 }
 
 void ESBehaviorestSetup(void)

--- a/modules/cfe_testcase/src/time_arithmetic_test.c
+++ b/modules/cfe_testcase/src/time_arithmetic_test.c
@@ -98,8 +98,8 @@ void TestTimeCompare(void)
     UtPrintf("Testing: CFE_TIME_Compare");
     CFE_TIME_SysTime_t time1 = {1000, 1000};
     CFE_TIME_SysTime_t time2 = {999, 999};
-    UtAssert_UINT32_EQ(CFE_TIME_Compare(time1, time2), CFE_TIME_A_GT_B);
-    UtAssert_UINT32_EQ(CFE_TIME_Compare(time2, time1), CFE_TIME_A_LT_B);
+    UtAssert_UINT32_EQ(CFE_TIME_Compare(time1, time2), CFE_TIME_1_GT_2);
+    UtAssert_UINT32_EQ(CFE_TIME_Compare(time2, time1), CFE_TIME_1_LT_2);
 
     time1.Seconds    = 500;
     time1.Subseconds = 1;
@@ -113,8 +113,8 @@ void TestTimeCompare(void)
     time1.Subseconds = 1;
     time2.Seconds    = UINT32_MAX;
     time2.Subseconds = UINT32_MAX;
-    UtAssert_UINT32_EQ(CFE_TIME_Compare(time1, time2), CFE_TIME_A_GT_B);
-    UtAssert_UINT32_EQ(CFE_TIME_Compare(time2, time1), CFE_TIME_A_LT_B);
+    UtAssert_UINT32_EQ(CFE_TIME_Compare(time1, time2), CFE_TIME_1_GT_2);
+    UtAssert_UINT32_EQ(CFE_TIME_Compare(time2, time1), CFE_TIME_1_LT_2);
 }
 
 void TimeArithmeticTestSetup(void)

--- a/modules/cfe_testcase/src/time_current_test.c
+++ b/modules/cfe_testcase/src/time_current_test.c
@@ -41,13 +41,13 @@ void TimeInRange(CFE_TIME_SysTime_t Start, CFE_TIME_SysTime_t Time, CFE_TIME_Sys
     CFE_TIME_Print(TimeStr, Time);
 
     Compare = CFE_TIME_Compare(Start, Time);
-    UtAssert_True((Compare == CFE_TIME_EQUAL) || (Compare == CFE_TIME_A_LT_B), "%s: %lu %lu (%s) <= %lu %lu (%s)", Str,
+    UtAssert_True((Compare == CFE_TIME_EQUAL) || (Compare == CFE_TIME_1_LT_2), "%s: %lu %lu (%s) <= %lu %lu (%s)", Str,
                   (long unsigned)Start.Seconds, (long unsigned)Start.Subseconds, StartStr, (long unsigned)Time.Seconds,
                   (long unsigned)Time.Subseconds, TimeStr);
 
     Delta   = CFE_TIME_Subtract(Time, Start);
     Compare = CFE_TIME_Compare(Delta, Range);
-    UtAssert_True((Compare == CFE_TIME_EQUAL) || (Compare == CFE_TIME_A_LT_B), "%s: Delta %lu %lu <= Range %lu %lu",
+    UtAssert_True((Compare == CFE_TIME_EQUAL) || (Compare == CFE_TIME_1_LT_2), "%s: Delta %lu %lu <= Range %lu %lu",
                   Str, (long unsigned)Delta.Seconds, (long unsigned)Delta.Subseconds, (long unsigned)Range.Seconds,
                   (long unsigned)Range.Subseconds);
 }

--- a/modules/core_api/fsw/inc/cfe_time.h
+++ b/modules/core_api/fsw/inc/cfe_time.h
@@ -372,27 +372,27 @@ CFE_TIME_SysTime_t CFE_TIME_Subtract(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_
 **        strange cases that result from these situations can be handled by defining
 **        the comparison function for times as follows:
 **        Plot the two times on the circumference of a circle where 0 is at the
-**        top and 0x80000000 is at the bottom.  If the shortest arc from time A
-**        to time B runs clockwise around the circle, then time A is less than
-**        time B.  If the shortest arc from A to B runs counter-clockwise, then
-**        time A is greater than time B.
+**        top and 0x80000000 is at the bottom.  If the shortest arc from time 1
+**        to time 2 runs clockwise around the circle, then time 1 is less than
+**        time 2.  If the shortest arc from 1 to 2 runs counter-clockwise, then
+**        time 1 is greater than time 2.
 **
 ** \par Assumptions, External Events, and Notes:
 **          None
 **
-** \param[in] TimeA   The first time to compare.
+** \param[in] Time1   The first time to compare.
 **
-** \param[in] TimeB   The second time to compare.
+** \param[in] Time2   The second time to compare.
 **
 ** \return The result of comparing the two times.
 ** \retval #CFE_TIME_EQUAL  \copybrief CFE_TIME_EQUAL
-** \retval #CFE_TIME_A_GT_B \copybrief CFE_TIME_A_GT_B
-** \retval #CFE_TIME_A_LT_B \copybrief CFE_TIME_A_LT_B
+** \retval #CFE_TIME_1_GT_2 \copybrief CFE_TIME_1_GT_2
+** \retval #CFE_TIME_1_LT_2 \copybrief CFE_TIME_1_LT_2
 **
 ** \sa #CFE_TIME_Add, #CFE_TIME_Subtract
 **
 ******************************************************************************/
-CFE_TIME_Compare_t CFE_TIME_Compare(CFE_TIME_SysTime_t TimeA, CFE_TIME_SysTime_t TimeB);
+CFE_TIME_Compare_t CFE_TIME_Compare(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2);
 /**@}*/
 
 /** @defgroup CFEAPITIMEConvert cFE Time Conversion APIs

--- a/modules/core_api/fsw/inc/cfe_time_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_time_api_typedefs.h
@@ -68,9 +68,9 @@
 */
 typedef enum CFE_TIME_Compare
 {
-    CFE_TIME_A_LT_B = -1, /**< \brief The first specified time is considered to be before the second specified time */
+    CFE_TIME_1_LT_2 = -1, /**< \brief The first specified time is considered to be before the second specified time */
     CFE_TIME_EQUAL  = 0,  /**< \brief The two specified times are considered to be equal */
-    CFE_TIME_A_GT_B = 1   /**< \brief The first specified time is considered to be after the second specified time */
+    CFE_TIME_1_GT_2 = 1   /**< \brief The first specified time is considered to be after the second specified time */
 } CFE_TIME_Compare_t;
 
 /**

--- a/modules/core_api/ut-stubs/src/cfe_time_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_time_stubs.c
@@ -57,12 +57,12 @@ CFE_TIME_SysTime_t CFE_TIME_Add(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Tim
  * Generated stub function for CFE_TIME_Compare()
  * ----------------------------------------------------
  */
-CFE_TIME_Compare_t CFE_TIME_Compare(CFE_TIME_SysTime_t TimeA, CFE_TIME_SysTime_t TimeB)
+CFE_TIME_Compare_t CFE_TIME_Compare(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2)
 {
     UT_GenStub_SetupReturnBuffer(CFE_TIME_Compare, CFE_TIME_Compare_t);
 
-    UT_GenStub_AddParam(CFE_TIME_Compare, CFE_TIME_SysTime_t, TimeA);
-    UT_GenStub_AddParam(CFE_TIME_Compare, CFE_TIME_SysTime_t, TimeB);
+    UT_GenStub_AddParam(CFE_TIME_Compare, CFE_TIME_SysTime_t, Time1);
+    UT_GenStub_AddParam(CFE_TIME_Compare, CFE_TIME_SysTime_t, Time2);
 
     UT_GenStub_Execute(CFE_TIME_Compare, Basic, NULL);
 

--- a/modules/time/fsw/src/cfe_time_api.c
+++ b/modules/time/fsw/src/cfe_time_api.c
@@ -452,36 +452,36 @@ CFE_TIME_SysTime_t CFE_TIME_Subtract(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-CFE_TIME_Compare_t CFE_TIME_Compare(CFE_TIME_SysTime_t TimeA, CFE_TIME_SysTime_t TimeB)
+CFE_TIME_Compare_t CFE_TIME_Compare(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2)
 {
     CFE_TIME_Compare_t Result;
 
-    if (TimeA.Seconds > TimeB.Seconds)
+    if (Time1.Seconds > Time2.Seconds)
     {
         /*
         ** Assume rollover if difference is too large...
         */
-        if ((TimeA.Seconds - TimeB.Seconds) > CFE_TIME_NEGATIVE)
+        if ((Time1.Seconds - Time2.Seconds) > CFE_TIME_NEGATIVE)
         {
-            Result = CFE_TIME_A_LT_B;
+            Result = CFE_TIME_1_LT_2;
         }
         else
         {
-            Result = CFE_TIME_A_GT_B;
+            Result = CFE_TIME_1_GT_2;
         }
     }
-    else if (TimeA.Seconds < TimeB.Seconds)
+    else if (Time1.Seconds < Time2.Seconds)
     {
         /*
         ** Assume rollover if difference is too large...
         */
-        if ((TimeB.Seconds - TimeA.Seconds) > CFE_TIME_NEGATIVE)
+        if ((Time2.Seconds - Time1.Seconds) > CFE_TIME_NEGATIVE)
         {
-            Result = CFE_TIME_A_GT_B;
+            Result = CFE_TIME_1_GT_2;
         }
         else
         {
-            Result = CFE_TIME_A_LT_B;
+            Result = CFE_TIME_1_LT_2;
         }
     }
     else
@@ -489,13 +489,13 @@ CFE_TIME_Compare_t CFE_TIME_Compare(CFE_TIME_SysTime_t TimeA, CFE_TIME_SysTime_t
         /*
         ** Seconds are equal, check sub-seconds
         */
-        if (TimeA.Subseconds > TimeB.Subseconds)
+        if (Time1.Subseconds > Time2.Subseconds)
         {
-            Result = CFE_TIME_A_GT_B;
+            Result = CFE_TIME_1_GT_2;
         }
-        else if (TimeA.Subseconds < TimeB.Subseconds)
+        else if (Time1.Subseconds < Time2.Subseconds)
         {
-            Result = CFE_TIME_A_LT_B;
+            Result = CFE_TIME_1_LT_2;
         }
         else
         {

--- a/modules/time/fsw/src/cfe_time_tone.c
+++ b/modules/time/fsw/src/cfe_time_tone.c
@@ -234,7 +234,7 @@ int32 CFE_TIME_ToneSendMET(CFE_TIME_SysTime_t NewMET)
         ** Ignore bad external time data only if clock state is valid...
         */
         if ((Reference.ClockSetState == CFE_TIME_SetState_WAS_SET) &&
-            ((MinResult == CFE_TIME_A_LT_B) || (MaxResult == CFE_TIME_A_GT_B)))
+            ((MinResult == CFE_TIME_1_LT_2) || (MaxResult == CFE_TIME_1_GT_2)))
         {
             Result = CFE_TIME_OUT_OF_RANGE;
 
@@ -375,7 +375,7 @@ int32 CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps)
         ** If state is valid then ignore bad external time data...
         */
         if ((Reference.ClockSetState == CFE_TIME_SetState_WAS_SET) &&
-            ((MinResult == CFE_TIME_A_LT_B) || (MaxResult == CFE_TIME_A_GT_B)))
+            ((MinResult == CFE_TIME_1_LT_2) || (MaxResult == CFE_TIME_1_GT_2)))
         {
             Result = CFE_TIME_OUT_OF_RANGE;
 
@@ -513,7 +513,7 @@ int32 CFE_TIME_ToneSendTime(CFE_TIME_SysTime_t NewTime)
         ** If state is valid then ignore bad external time data...
         */
         if ((Reference.ClockSetState == CFE_TIME_SetState_WAS_SET) &&
-            ((MinResult == CFE_TIME_A_LT_B) || (MaxResult == CFE_TIME_A_GT_B)))
+            ((MinResult == CFE_TIME_1_LT_2) || (MaxResult == CFE_TIME_1_GT_2)))
         {
             Result = CFE_TIME_OUT_OF_RANGE;
 
@@ -707,7 +707,7 @@ void CFE_TIME_ToneVerify(CFE_TIME_SysTime_t Time1, CFE_TIME_SysTime_t Time2)
             ** Compute elapsed time between tone and data packet...
             */
             result = CFE_TIME_Compare(Time1, Time2);
-            if (result == CFE_TIME_A_GT_B)
+            if (result == CFE_TIME_1_GT_2)
             {
                 /*
                 ** Local clock has rolled over...
@@ -979,7 +979,7 @@ void CFE_TIME_Tone1HzISR(void)
     */
     Result = CFE_TIME_Compare(ToneSignalLatch, CFE_TIME_Global.ToneSignalLatch);
 
-    if (Result == CFE_TIME_A_LT_B)
+    if (Result == CFE_TIME_1_LT_2)
     {
         /*
         ** Local clock has rolled over...

--- a/modules/time/fsw/src/cfe_time_utils.c
+++ b/modules/time/fsw/src/cfe_time_utils.c
@@ -614,7 +614,7 @@ void CFE_TIME_GetReference(CFE_TIME_Reference_t *Reference)
     /*
     ** Compute the amount of time "since" the tone...
     */
-    if (CFE_TIME_Compare(Reference->CurrentLatch, Reference->AtToneLatch) == CFE_TIME_A_LT_B)
+    if (CFE_TIME_Compare(Reference->CurrentLatch, Reference->AtToneLatch) == CFE_TIME_1_LT_2)
     {
         /*
         ** Local clock has rolled over since last tone...

--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -570,12 +570,12 @@ void Test_TimeOp(void)
     /* Test adding with both times equal zero */
     result = CFE_TIME_Add(time1, time2);
     UtAssert_MemCmp(&result, &exp_result, sizeof(CFE_TIME_SysTime_t),
-                    "CFE_TIME_Add, Time A = time B = 0 seconds/subseconds");
+                    "CFE_TIME_Add, Time 1 = Time 2 = 0 seconds/subseconds");
 
     /* Test subtracting with both times equal zero */
     result = CFE_TIME_Subtract(time1, time2);
     UtAssert_MemCmp(&result, &exp_result, sizeof(CFE_TIME_SysTime_t),
-                    "CFE_TIME_Subtract, Time A = time B = 0 seconds/subseconds");
+                    "CFE_TIME_Subtract, Time 1 = Time 2 = 0 seconds/subseconds");
 
     /* Test comparing with both times equal zero */
     UtAssert_INT32_EQ(CFE_TIME_Compare(time1, time2), CFE_TIME_EQUAL);
@@ -592,7 +592,7 @@ void Test_TimeOp(void)
 
     result = CFE_TIME_Add(time1, time2);
     UtAssert_MemCmp(&result, &exp_result, sizeof(CFE_TIME_SysTime_t),
-                    "CFE_TIME_Add, Time A = time B = maximum seconds/subseconds (rollover)");
+                    "CFE_TIME_Add, Time 1 = Time 2 = maximum seconds/subseconds (rollover)");
 
     /* Test subtracting two maximum time values (zero result) */
     exp_result.Subseconds = 0;
@@ -600,7 +600,7 @@ void Test_TimeOp(void)
 
     result = CFE_TIME_Subtract(time1, time2);
     UtAssert_MemCmp(&result, &exp_result, sizeof(CFE_TIME_SysTime_t),
-                    "CFE_TIME_Subtract, Time A = time B = maximum seconds/subseconds (zero result)");
+                    "CFE_TIME_Subtract, Time 1 = Time 2 = maximum seconds/subseconds (zero result)");
 
     /* Test comparing two maximum time values */
     UtAssert_INT32_EQ(CFE_TIME_Compare(time1, time2), CFE_TIME_EQUAL);
@@ -611,45 +611,45 @@ void Test_TimeOp(void)
     time2.Subseconds = 0x00000001;
     time2.Seconds    = 0x0000ffff;
 
-    /* Test adding two time values; time A > time B (minimal time
+    /* Test adding two time values; time A > Time 2 (minimal time
      * rollover case)
      */
     exp_result.Subseconds = 0;
     exp_result.Seconds    = 0;
 
     result = CFE_TIME_Add(time1, time2);
-    UtAssert_MemCmp(&result, &exp_result, sizeof(CFE_TIME_SysTime_t), "CFE_TIME_Add, Time A > time B (rollover)");
+    UtAssert_MemCmp(&result, &exp_result, sizeof(CFE_TIME_SysTime_t), "CFE_TIME_Add, Time 1 > Time 2 (rollover)");
 
-    /* Test subtracting two time values; time A > time B */
+    /* Test subtracting two time values; time A > Time 2 */
     exp_result.Subseconds = 0xfffffffe;
     exp_result.Seconds    = 0xfffe0001;
 
     result = CFE_TIME_Subtract(time1, time2);
-    UtAssert_MemCmp(&result, &exp_result, sizeof(CFE_TIME_SysTime_t), "CFE_TIME_Subtract, Time A > time B");
+    UtAssert_MemCmp(&result, &exp_result, sizeof(CFE_TIME_SysTime_t), "CFE_TIME_Subtract, Time 1 > Time 2");
 
-    /* Test comparing two time values; time A > time B (assumes time has
+    /* Test comparing two time values; time A > Time 2 (assumes time has
      * rolled over)
      */
-    UtAssert_INT32_EQ(CFE_TIME_Compare(time1, time2), CFE_TIME_A_LT_B);
+    UtAssert_INT32_EQ(CFE_TIME_Compare(time1, time2), CFE_TIME_1_LT_2);
 
-    /* Test adding two time values; time A < time B */
+    /* Test adding two time values; time A < Time 2 */
     exp_result.Subseconds = 0;
     exp_result.Seconds    = 0;
 
     result = CFE_TIME_Add(time2, time1);
-    UtAssert_MemCmp(&result, &exp_result, sizeof(CFE_TIME_SysTime_t), "CFE_TIME_Add, Time A < time B");
+    UtAssert_MemCmp(&result, &exp_result, sizeof(CFE_TIME_SysTime_t), "CFE_TIME_Add, Time 1 < Time 2");
 
-    /* Test subtracting two time values; time A < time B (rollover) */
+    /* Test subtracting two time values; time A < Time 2 (rollover) */
     exp_result.Subseconds = 0x00000002;
     exp_result.Seconds    = 0x0001fffe;
 
     result = CFE_TIME_Subtract(time2, time1);
-    UtAssert_MemCmp(&result, &exp_result, sizeof(CFE_TIME_SysTime_t), "CFE_TIME_Subtract, Time A < time B (rollover)");
+    UtAssert_MemCmp(&result, &exp_result, sizeof(CFE_TIME_SysTime_t), "CFE_TIME_Subtract, Time 1 < Time 2 (rollover)");
 
-    /* Test comparing two time values; time A < time B (assumes time has
+    /* Test comparing two time values; time A < Time 2 (assumes time has
      * rolled over)
      */
-    UtAssert_INT32_EQ(CFE_TIME_Compare(time2, time1), CFE_TIME_A_GT_B);
+    UtAssert_INT32_EQ(CFE_TIME_Compare(time2, time1), CFE_TIME_1_GT_2);
 
     /* Initialize so that only subseconds are different; seconds are
      * the same
@@ -659,16 +659,16 @@ void Test_TimeOp(void)
     time2.Subseconds = 29;
     time2.Seconds    = 3;
 
-    /* Test adding two time values; time A subseconds > time B subseconds
+    /* Test adding two time values; time A subseconds > Time 2 subseconds
      * (seconds same) */
     exp_result.Subseconds = 59;
     exp_result.Seconds    = 6;
 
     result = CFE_TIME_Add(time1, time2);
     UtAssert_MemCmp(&result, &exp_result, sizeof(CFE_TIME_SysTime_t),
-                    "CFE_TIME_Add, Time A subseconds > time B subseconds (seconds same)");
+                    "CFE_TIME_Add, Time 1 subseconds > Time 2 subseconds (seconds same)");
 
-    /* Test subtracting two time values; time A subseconds > time B
+    /* Test subtracting two time values; time A subseconds > Time 2
      * subseconds (seconds same)
      */
     exp_result.Subseconds = 1;
@@ -676,14 +676,14 @@ void Test_TimeOp(void)
 
     result = CFE_TIME_Subtract(time1, time2);
     UtAssert_MemCmp(&result, &exp_result, sizeof(CFE_TIME_SysTime_t),
-                    "CFE_TIME_Subtract, Time A subseconds > time B subseconds (seconds same)");
+                    "CFE_TIME_Subtract, Time 1 subseconds > Time 2 subseconds (seconds same)");
 
-    /* Test comparing two time values; time A subseconds > time B subseconds
+    /* Test comparing two time values; time A subseconds > Time 2 subseconds
      * (seconds same)
      */
-    UtAssert_INT32_EQ(CFE_TIME_Compare(time1, time2), CFE_TIME_A_GT_B);
+    UtAssert_INT32_EQ(CFE_TIME_Compare(time1, time2), CFE_TIME_1_GT_2);
 
-    /* Test adding two time values; time A subseconds < time B subseconds
+    /* Test adding two time values; time A subseconds < Time 2 subseconds
      * (seconds same)
      */
     exp_result.Subseconds = 59;
@@ -691,9 +691,9 @@ void Test_TimeOp(void)
 
     result = CFE_TIME_Add(time2, time1);
     UtAssert_MemCmp(&result, &exp_result, sizeof(CFE_TIME_SysTime_t),
-                    "CFE_TIME_Add, Time A subseconds < time B subseconds (seconds same)");
+                    "CFE_TIME_Add, Time 1 subseconds < Time 2 subseconds (seconds same)");
 
-    /* Test subtracting two time values; time A subseconds < time B
+    /* Test subtracting two time values; time A subseconds < Time 2
      * subseconds (seconds same)
      */
     exp_result.Subseconds = 0xffffffff;
@@ -701,12 +701,12 @@ void Test_TimeOp(void)
 
     result = CFE_TIME_Subtract(time2, time1);
     UtAssert_MemCmp(&result, &exp_result, sizeof(CFE_TIME_SysTime_t),
-                    "CFE_TIME_Subtract, Time A subseconds < time B subseconds (seconds same)");
+                    "CFE_TIME_Subtract, Time 1 subseconds < Time 2 subseconds (seconds same)");
 
-    /* Test comparing two time values; time A subseconds < time B subseconds
+    /* Test comparing two time values; time A subseconds < Time 2 subseconds
      * (seconds same)
      */
-    UtAssert_INT32_EQ(CFE_TIME_Compare(time2, time1), CFE_TIME_A_LT_B);
+    UtAssert_INT32_EQ(CFE_TIME_Compare(time2, time1), CFE_TIME_1_LT_2);
 
     /* Initialize so that only seconds are different; subseconds are
      * the same
@@ -716,7 +716,7 @@ void Test_TimeOp(void)
     time2.Subseconds = 18;
     time2.Seconds    = 7;
 
-    /* Test adding two time values; time A seconds > time B seconds
+    /* Test adding two time values; time A seconds > Time 2 seconds
      * (subseconds same)
      */
     exp_result.Subseconds = 36;
@@ -724,9 +724,9 @@ void Test_TimeOp(void)
 
     result = CFE_TIME_Add(time1, time2);
     UtAssert_MemCmp(&result, &exp_result, sizeof(CFE_TIME_SysTime_t),
-                    "CFE_TIME_Add, Time A seconds > time B seconds (subseconds same)");
+                    "CFE_TIME_Add, Time 1 seconds > Time 2 seconds (subseconds same)");
 
-    /* Test subtracting two time values; time A seconds > time B seconds
+    /* Test subtracting two time values; time A seconds > Time 2 seconds
      * (subseconds same)
      */
     exp_result.Subseconds = 0;
@@ -734,14 +734,14 @@ void Test_TimeOp(void)
 
     result = CFE_TIME_Subtract(time1, time2);
     UtAssert_MemCmp(&result, &exp_result, sizeof(CFE_TIME_SysTime_t),
-                    "CFE_TIME_Subtract, Time A seconds > time B seconds (subseconds same)");
+                    "CFE_TIME_Subtract, Time 1 seconds > Time 2 seconds (subseconds same)");
 
-    /* Test comparing two time values; time A seconds > time B seconds
+    /* Test comparing two time values; time A seconds > Time 2 seconds
      * (subseconds same)
      */
-    UtAssert_INT32_EQ(CFE_TIME_Compare(time1, time2), CFE_TIME_A_GT_B);
+    UtAssert_INT32_EQ(CFE_TIME_Compare(time1, time2), CFE_TIME_1_GT_2);
 
-    /* Test adding two time values; time A seconds < time B seconds
+    /* Test adding two time values; time A seconds < Time 2 seconds
      * (subseconds same)
      */
     exp_result.Subseconds = 36;
@@ -749,9 +749,9 @@ void Test_TimeOp(void)
 
     result = CFE_TIME_Add(time2, time1);
     UtAssert_MemCmp(&result, &exp_result, sizeof(CFE_TIME_SysTime_t),
-                    "CFE_TIME_Add, Time A seconds < time B seconds (subseconds same)");
+                    "CFE_TIME_Add, Time 1 seconds < Time 2 seconds (subseconds same)");
 
-    /* Test subtracting two time values; time A seconds < time B seconds
+    /* Test subtracting two time values; time A seconds < Time 2 seconds
      * (subseconds same)
      */
     exp_result.Subseconds = 0;
@@ -759,13 +759,13 @@ void Test_TimeOp(void)
 
     result = CFE_TIME_Subtract(time2, time1);
     UtAssert_MemCmp(&result, &exp_result, sizeof(CFE_TIME_SysTime_t),
-                    "CFE_TIME_Subtract, Time A seconds < time B seconds (subseconds same)");
+                    "CFE_TIME_Subtract, Time 1 seconds < Time 2 seconds (subseconds same)");
 
-    /* Test comparing two time values; time A seconds < time B seconds
+    /* Test comparing two time values; time A seconds < Time 2 seconds
      * (subseconds same)
      */
     UT_InitData();
-    UtAssert_INT32_EQ(CFE_TIME_Compare(time2, time1), CFE_TIME_A_LT_B);
+    UtAssert_INT32_EQ(CFE_TIME_Compare(time2, time1), CFE_TIME_1_LT_2);
 }
 
 /*


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2341
  - Converts `TimeA`/`TimeB` parameter names to `Time1`/`Time2` - making all consistent across cFE (the other option is to reverse this and convert the others to TimeA/TimeB)
    - also converts the enumerated types `CFE_TIME_A_GT_B` and `CFE_TIME_A_LT_B` to `CFE_TIME_1_GT_2` and `CFE_TIME_1_LT_2` to remain consistent
    - some test strings using TimeA/TimeB also updated for consistency

Note: If this PR is merged it will require a minor update to SC which utilises the `CFE_TIME_A_GT_B` enumerated type [here](https://github.com/nasa/SC/blob/5e9a1d63b63b59cf5d762a915fc28dbe821935db/fsw/src/sc_utils.c#L118-L143) and in a couple of tests.

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Coverage/Functional Tests etc.).

**Expected behavior changes**


**Contributor Info**
Avi Weiss @thnkslprpt