### PR TITLE
Fix #2343, Update `CFE_PLATFORM_ES_DEFAULT_SYSLOG_MODE` macro in es_verify.h

### DIFF
--- a/modules/es/fsw/src/cfe_es_verify.h
+++ b/modules/es/fsw/src/cfe_es_verify.h
@@ -118,12 +118,21 @@
 #endif
 
 /*
-** SysLog mode
+** Default System Log Mode following Power On Reset
 */
-#if CFE_PLATFORM_ES_DEFAULT_SYSLOG_MODE < 0
-#error CFE_PLATFORM_ES_DEFAULT_SYSLOG_MODE cannot be less than 0!
-#elif CFE_PLATFORM_ES_DEFAULT_SYSLOG_MODE > 1
-#error CFE_PLATFORM_ES_DEFAULT_SYSLOG_MODE cannot be greater than 1!
+#if CFE_PLATFORM_ES_DEFAULT_POR_SYSLOG_MODE < 0
+#error CFE_PLATFORM_ES_DEFAULT_POR_SYSLOG_MODE cannot be less than 0!
+#elif CFE_PLATFORM_ES_DEFAULT_POR_SYSLOG_MODE > 1
+#error CFE_PLATFORM_ES_DEFAULT_POR_SYSLOG_MODE cannot be greater than 1!
+#endif
+
+/*
+** Default System Log Mode following Processor Reset
+*/
+#if CFE_PLATFORM_ES_DEFAULT_PR_SYSLOG_MODE < 0
+#error CFE_PLATFORM_ES_DEFAULT_PR_SYSLOG_MODE cannot be less than 0!
+#elif CFE_PLATFORM_ES_DEFAULT_PR_SYSLOG_MODE > 1
+#error CFE_PLATFORM_ES_DEFAULT_PR_SYSLOG_MODE cannot be greater than 1!
 #endif
 
 /*

--- a/modules/tbl/config/default_cfe_tbl_internal_cfg.h
+++ b/modules/tbl/config/default_cfe_tbl_internal_cfg.h
@@ -125,7 +125,7 @@
 **       This number must be less than 32767.  It should be recognized that this parameter
 **       determines the size of the Critical Table Registry which is maintained in the Critical
 **       Data Store.  An excessively high number will waste Critical Data Store memory.  Therefore,
-**       this number must not exceed the value defined in CFE_ES_CDS_MAX_CRITICAL_TABLES.
+**       this number must not exceed the value defined in CFE_PLATFORM_ES_CDS_MAX_NUM_ENTRIES.
 */
 #define CFE_PLATFORM_TBL_MAX_CRITICAL_TABLES 32
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2343
  - Updates the compile-time checks on `CFE_PLATFORM_ES_DEFAULT_SYSLOG_MODE` (which doesn't exist anymore) to the new macros

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).
Local testing confirms the checks are behaving as expected when invalid values for the 2 macros are used:
![Screenshot 2023-05-21 15 50 54](https://github.com/nasa/cFE/assets/9024662/caf1d8d0-90f9-4d14-923e-e28d1498fc12)

**Expected behavior changes**
Checks will actually check what they intended to now.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss @thnkslprpt