### PR TITLE
Fix #1397, Rename overloaded `EVS_PacketID_t` to `EVS_EventContext_t`

### DIFF
--- a/modules/evs/config/default_cfe_evs_msgdefs.h
+++ b/modules/evs/config/default_cfe_evs_msgdefs.h
@@ -219,10 +219,10 @@ typedef struct CFE_EVS_HousekeepingTlm_Payload
 
 /** Telemetry packet structures */
 
-typedef struct CFE_EVS_PacketID
+typedef struct CFE_EVS_EventContext
 {
     char AppName[CFE_MISSION_MAX_API_LEN]; /**< \cfetlmmnemonic \EVS_APPNAME
-                                        \brief Application name */
+                                                \brief Application name */
     uint16 EventID;                        /**< \cfetlmmnemonic \EVS_EVENTID
                                                 \brief Numerical event identifier */
     uint16 EventType;                      /**< \cfetlmmnemonic \EVS_EVENTTYPE
@@ -231,20 +231,20 @@ typedef struct CFE_EVS_PacketID
                                                 \brief Spacecraft identifier */
     uint32 ProcessorID;                    /**< \cfetlmmnemonic \EVS_PROCESSORID
                                                 \brief Numerical processor identifier */
-} CFE_EVS_PacketID_t;
+} CFE_EVS_EventContext_t;
 
 /**
 **  \cfeevstlm Event Message Telemetry Packet (Long format)
 **/
 typedef struct CFE_EVS_LongEventTlm_Payload
 {
-    CFE_EVS_PacketID_t PacketID;                                    /**< \brief Event packet information */
-    char               Message[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH]; /**< \cfetlmmnemonic \EVS_EVENT
-                                                                 \brief Event message string */
-    uint8 Spare1;                                                   /**< \cfetlmmnemonic \EVS_SPARE1
-                                                                         \brief Structure padding */
-    uint8 Spare2;                                                   /**< \cfetlmmnemonic \EVS_SPARE2
-                                                                     \brief Structure padding */
+    CFE_EVS_EventContext_t EventContext;                                /**< \brief Event packet context */
+    char                   Message[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH]; /**< \cfetlmmnemonic \EVS_EVENT
+                                                                             \brief Event message string */
+    uint8 Spare1;                                                       /**< \cfetlmmnemonic \EVS_SPARE1
+                                                                             \brief Structure padding */
+    uint8 Spare2;                                                       /**< \cfetlmmnemonic \EVS_SPARE2
+                                                                             \brief Structure padding */
 } CFE_EVS_LongEventTlm_Payload_t;
 
 /**
@@ -252,7 +252,7 @@ typedef struct CFE_EVS_LongEventTlm_Payload
 **/
 typedef struct CFE_EVS_ShortEventTlm_Payload
 {
-    CFE_EVS_PacketID_t PacketID; /**< \brief Event packet information */
+    CFE_EVS_EventContext_t EventContext; /**< \brief Event packet context */
 } CFE_EVS_ShortEventTlm_Payload_t;
 
 #endif

--- a/modules/evs/eds/cfe_evs.xml
+++ b/modules/evs/eds/cfe_evs.xml
@@ -263,7 +263,7 @@
         </EntryList>
       </ContainerDataType>
 
-      <ContainerDataType name="PacketID" shortDescription="Telemetry packet structures">
+      <ContainerDataType name="EventContext" shortDescription="Telemetry packet structures">
         <EntryList>
           <Entry name="AppName" type="BASE_TYPES/ApiName" shortDescription="Application name">
             <LongDescription>
@@ -295,7 +295,7 @@
 
       <ContainerDataType name="LongEventTlm_Payload" shortDescription="Event Message Telemetry Payload Long Format">
         <EntryList>
-          <Entry name="PacketID" type="PacketID" shortDescription="Event packet information" />
+          <Entry name="EventContext" type="EventContext" shortDescription="Event packet context" />
           <Entry name="Message" type="EventMessage" shortDescription="Event message string">
             <LongDescription>
               \cfetlmmnemonic  \EVS_EVENT
@@ -306,7 +306,7 @@
 
       <ContainerDataType name="ShortEventTlm_Payload" shortDescription="Event Message Telemetry Payload Short Format">
         <EntryList>
-          <Entry name="PacketID" type="PacketID" shortDescription="Event packet information" />
+          <Entry name="EventContext" type="EventContext" shortDescription="Event packet context" />
         </EntryList>
       </ContainerDataType>
 

--- a/modules/evs/fsw/src/cfe_evs_utils.c
+++ b/modules/evs/fsw/src/cfe_evs_utils.c
@@ -462,8 +462,8 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint1
     /* Initialize EVS event packets */
     CFE_MSG_Init(CFE_MSG_PTR(LongEventTlm.TelemetryHeader), CFE_SB_ValueToMsgId(CFE_EVS_LONG_EVENT_MSG_MID),
                  sizeof(LongEventTlm));
-    LongEventTlm.Payload.PacketID.EventID   = EventID;
-    LongEventTlm.Payload.PacketID.EventType = EventType;
+    LongEventTlm.Payload.EventContext.EventID   = EventID;
+    LongEventTlm.Payload.EventContext.EventType = EventType;
 
     /* vsnprintf() returns the total expanded length of the formatted string */
     /* vsnprintf() copies and zero terminates portion that fits in the buffer */
@@ -482,10 +482,10 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint1
     }
 
     /* Obtain task and system information */
-    CFE_ES_GetAppName((char *)LongEventTlm.Payload.PacketID.AppName, EVS_AppDataGetID(AppDataPtr),
-                      sizeof(LongEventTlm.Payload.PacketID.AppName));
-    LongEventTlm.Payload.PacketID.SpacecraftID = CFE_PSP_GetSpacecraftId();
-    LongEventTlm.Payload.PacketID.ProcessorID  = CFE_PSP_GetProcessorId();
+    CFE_ES_GetAppName((char *)LongEventTlm.Payload.EventContext.AppName, EVS_AppDataGetID(AppDataPtr),
+                      sizeof(LongEventTlm.Payload.EventContext.AppName));
+    LongEventTlm.Payload.EventContext.SpacecraftID = CFE_PSP_GetSpacecraftId();
+    LongEventTlm.Payload.EventContext.ProcessorID  = CFE_PSP_GetProcessorId();
 
     /* Set the packet timestamp */
     CFE_MSG_SetMsgTime(CFE_MSG_PTR(LongEventTlm.TelemetryHeader), *TimeStamp);
@@ -512,7 +512,7 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, uint1
         CFE_MSG_Init(CFE_MSG_PTR(ShortEventTlm.TelemetryHeader), CFE_SB_ValueToMsgId(CFE_EVS_SHORT_EVENT_MSG_MID),
                      sizeof(ShortEventTlm));
         CFE_MSG_SetMsgTime(CFE_MSG_PTR(ShortEventTlm.TelemetryHeader), *TimeStamp);
-        ShortEventTlm.Payload.PacketID = LongEventTlm.Payload.PacketID;
+        ShortEventTlm.Payload.EventContext = LongEventTlm.Payload.EventContext;
         CFE_SB_TransmitMsg(CFE_MSG_PTR(ShortEventTlm.TelemetryHeader), true);
     }
 
@@ -546,9 +546,9 @@ void EVS_SendViaPorts(CFE_EVS_LongEventTlm_t *EVS_PktPtr)
     CFE_TIME_Print(TimeBuffer, PktTime);
 
     snprintf(PortMessage, sizeof(PortMessage), "%s %u/%u/%s %u: %s", TimeBuffer,
-             (unsigned int)EVS_PktPtr->Payload.PacketID.SpacecraftID,
-             (unsigned int)EVS_PktPtr->Payload.PacketID.ProcessorID, EVS_PktPtr->Payload.PacketID.AppName,
-             (unsigned int)EVS_PktPtr->Payload.PacketID.EventID, EVS_PktPtr->Payload.Message);
+             (unsigned int)EVS_PktPtr->Payload.EventContext.SpacecraftID,
+             (unsigned int)EVS_PktPtr->Payload.EventContext.ProcessorID, EVS_PktPtr->Payload.EventContext.AppName,
+             (unsigned int)EVS_PktPtr->Payload.EventContext.EventID, EVS_PktPtr->Payload.Message);
 
     if (CFE_EVS_Global.EVS_TlmPkt.Payload.OutputPort & CFE_EVS_PORT1_BIT)
     {

--- a/modules/evs/ut-coverage/evs_UT.c
+++ b/modules/evs/ut-coverage/evs_UT.c
@@ -106,12 +106,12 @@ static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_SEND_HK = {.MsgId = CFE_SB_
 
 static UT_SoftwareBusSnapshot_Entry_t UT_EVS_LONGFMT_SNAPSHOTDATA = {
     .MsgId          = CFE_SB_MSGID_WRAP_VALUE(0),
-    .SnapshotOffset = offsetof(CFE_EVS_LongEventTlm_t, Payload.PacketID.EventID),
+    .SnapshotOffset = offsetof(CFE_EVS_LongEventTlm_t, Payload.EventContext.EventID),
     .SnapshotSize   = sizeof(uint16)};
 
 static UT_SoftwareBusSnapshot_Entry_t UT_EVS_SHORTFMT_SNAPSHOTDATA = {
     .MsgId          = CFE_SB_MSGID_WRAP_VALUE(0),
-    .SnapshotOffset = offsetof(CFE_EVS_ShortEventTlm_t, Payload.PacketID.EventID),
+    .SnapshotOffset = offsetof(CFE_EVS_ShortEventTlm_t, Payload.EventContext.EventID),
     .SnapshotSize   = sizeof(uint16)};
 
 typedef struct
@@ -699,16 +699,16 @@ void Test_Format(void)
     CFE_TIME_SysTime_t              time = {0, 0};
     CFE_EVS_SetEventFormatModeCmd_t modecmd;
     CFE_EVS_EnableAppEventTypeCmd_t appbitcmd;
-    CFE_EVS_PacketID_t              CapturedMsg;
+    CFE_EVS_EventContext_t          CapturedMsg;
     UT_SoftwareBusSnapshot_Entry_t  LongFmtSnapshotData = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_LONG_EVENT_MSG_MID),
                                                           .SnapshotBuffer = &CapturedMsg,
                                                           .SnapshotOffset =
-                                                              offsetof(CFE_EVS_LongEventTlm_t, Payload.PacketID),
+                                                              offsetof(CFE_EVS_LongEventTlm_t, Payload.EventContext),
                                                           .SnapshotSize = sizeof(CapturedMsg)};
     UT_SoftwareBusSnapshot_Entry_t  ShortFmtSnapshotData = {
         .MsgId          = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_SHORT_EVENT_MSG_MID),
         .SnapshotBuffer = &CapturedMsg,
-        .SnapshotOffset = offsetof(CFE_EVS_ShortEventTlm_t, Payload.PacketID),
+        .SnapshotOffset = offsetof(CFE_EVS_ShortEventTlm_t, Payload.EventContext),
         .SnapshotSize   = sizeof(CapturedMsg)};
     EVS_AppData_t *      AppDataPtr;
     CFE_ES_AppId_t       AppID;
@@ -1932,13 +1932,13 @@ void Test_Squelching(void)
             if (i < CFE_PLATFORM_EVS_MAX_APP_EVENT_BURST)
             {
                 UtAssert_UINT32_EQ(SnapshotData.Count, i + 1);
-                UtAssert_UINT32_EQ(CapturedTlm.Payload.PacketID.EventID, EVENT_ID);
+                UtAssert_UINT32_EQ(CapturedTlm.Payload.EventContext.EventID, EVENT_ID);
                 UtAssert_UINT32_EQ(EVS_Retval, CFE_SUCCESS);
             }
             else if (i == CFE_PLATFORM_EVS_MAX_APP_EVENT_BURST)
             {
                 UtAssert_UINT32_EQ(SnapshotData.Count, i + 1);
-                UtAssert_UINT32_EQ(CapturedTlm.Payload.PacketID.EventID, CFE_EVS_SQUELCHED_ERR_EID);
+                UtAssert_UINT32_EQ(CapturedTlm.Payload.EventContext.EventID, CFE_EVS_SQUELCHED_ERR_EID);
                 UtAssert_UINT32_EQ(EVS_Retval, CFE_EVS_APP_SQUELCHED);
             }
             else
@@ -1957,7 +1957,7 @@ void Test_Squelching(void)
         UT_SetDataBuffer(UT_KEY(CFE_PSP_GetTime), &InjectedTime, sizeof(InjectedTime), false);
         EVS_Retval = SendEventFuncs[j](EVENT_ID);
         UtAssert_UINT32_EQ(SnapshotData.Count, CFE_PLATFORM_EVS_MAX_APP_EVENT_BURST + 2);
-        UtAssert_UINT32_EQ(CapturedTlm.Payload.PacketID.EventID, EVENT_ID);
+        UtAssert_UINT32_EQ(CapturedTlm.Payload.EventContext.EventID, EVENT_ID);
         UtAssert_UINT32_EQ(EVS_Retval, CFE_SUCCESS);
 
         /*
@@ -1966,7 +1966,7 @@ void Test_Squelching(void)
         UT_SetDataBuffer(UT_KEY(CFE_PSP_GetTime), &InjectedTime, sizeof(InjectedTime), false);
         EVS_Retval = SendEventFuncs[j](EVENT_ID);
         UtAssert_UINT32_EQ(SnapshotData.Count, CFE_PLATFORM_EVS_MAX_APP_EVENT_BURST + 3);
-        UtAssert_UINT32_EQ(CapturedTlm.Payload.PacketID.EventID, CFE_EVS_SQUELCHED_ERR_EID);
+        UtAssert_UINT32_EQ(CapturedTlm.Payload.EventContext.EventID, CFE_EVS_SQUELCHED_ERR_EID);
         UtAssert_UINT32_EQ(EVS_Retval, CFE_EVS_APP_SQUELCHED);
 
         /*
@@ -1986,7 +1986,7 @@ void Test_Squelching(void)
         UT_SetDataBuffer(UT_KEY(CFE_PSP_GetTime), &InjectedTime, sizeof(InjectedTime), false);
         EVS_Retval = SendEventFuncs[j](EVENT_ID);
         UtAssert_UINT32_EQ(SnapshotData.Count, CFE_PLATFORM_EVS_MAX_APP_EVENT_BURST + 4);
-        UtAssert_UINT32_EQ(CapturedTlm.Payload.PacketID.EventID, EVENT_ID);
+        UtAssert_UINT32_EQ(CapturedTlm.Payload.EventContext.EventID, EVENT_ID);
         UtAssert_UINT32_EQ(EVS_Retval, CFE_SUCCESS);
         UtAssert_UINT32_EQ(AppDataPtr->SquelchedCount, CFE_EVS_MAX_SQUELCH_COUNT);
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1397
  - Renames overloaded (and confusing) `CFE_EVS_PacketID_t` type to `CFE_EVS_EventContext_t`

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
No change to behavior.

**Contributor Info**
Avi Weiss @thnkslprpt