### PR TITLE
Fix #1514, Use `XOR` to swap between ping-pong buffers (style change only)

### DIFF
--- a/modules/tbl/fsw/src/cfe_tbl_api.c
+++ b/modules/tbl/fsw/src/cfe_tbl_api.c
@@ -867,12 +867,12 @@ CFE_Status_t CFE_TBL_Validate(CFE_TBL_Handle_t TblHandle)
             {
                 /* Call the Application's Validation function for the Inactive Buffer */
                 Status =
-                    (RegRecPtr->ValidationFuncPtr)(RegRecPtr->Buffers[(1U - RegRecPtr->ActiveBufferIndex)].BufferPtr);
+                    (RegRecPtr->ValidationFuncPtr)(RegRecPtr->Buffers[(RegRecPtr->ActiveBufferIndex ^ 1)].BufferPtr);
 
                 /* Allow buffer to be activated after passing validation */
                 if (Status == CFE_SUCCESS)
                 {
-                    RegRecPtr->Buffers[(1U - RegRecPtr->ActiveBufferIndex)].Validated = true;
+                    RegRecPtr->Buffers[(RegRecPtr->ActiveBufferIndex ^ 1)].Validated = true;
                 }
             }
             else

--- a/modules/tbl/fsw/src/cfe_tbl_internal.c
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.c
@@ -344,7 +344,7 @@ int32 CFE_TBL_GetWorkingBuffer(CFE_TBL_LoadBuff_t **WorkingBufferPtr, CFE_TBL_Re
     {
         if (RegRecPtr->DoubleBuffered)
         {
-            *WorkingBufferPtr = &RegRecPtr->Buffers[(1U - RegRecPtr->ActiveBufferIndex)];
+            *WorkingBufferPtr = &RegRecPtr->Buffers[(RegRecPtr->ActiveBufferIndex ^ 1)];
         }
         else
         {

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
@@ -264,7 +264,7 @@ void CFE_TBL_GetTblRegData(void)
     {
         /* For a double buffered table, the inactive is the other allocated buffer */
         CFE_TBL_Global.TblRegPacket.Payload.InactiveBufferAddr =
-            CFE_ES_MEMADDRESS_C(RegRecPtr->Buffers[(1U - RegRecPtr->ActiveBufferIndex)].BufferPtr);
+            CFE_ES_MEMADDRESS_C(RegRecPtr->Buffers[(RegRecPtr->ActiveBufferIndex ^ 1)].BufferPtr);
     }
     else
     {
@@ -565,7 +565,7 @@ int32 CFE_TBL_DumpCmd(const CFE_TBL_DumpCmd_t *data)
             /* If this is a double buffered table, locating the inactive buffer is trivial */
             if (RegRecPtr->DoubleBuffered)
             {
-                DumpDataAddr = RegRecPtr->Buffers[(1U - RegRecPtr->ActiveBufferIndex)].BufferPtr;
+                DumpDataAddr = RegRecPtr->Buffers[(RegRecPtr->ActiveBufferIndex ^ 1)].BufferPtr;
             }
             else
             {
@@ -827,7 +827,7 @@ int32 CFE_TBL_ValidateCmd(const CFE_TBL_ValidateCmd_t *data)
             /* If this is a double buffered table, locating the inactive buffer is trivial */
             if (RegRecPtr->DoubleBuffered)
             {
-                ValidationDataPtr = RegRecPtr->Buffers[(1U - RegRecPtr->ActiveBufferIndex)].BufferPtr;
+                ValidationDataPtr = RegRecPtr->Buffers[(RegRecPtr->ActiveBufferIndex ^ 1)].BufferPtr;
             }
             else
             {
@@ -966,7 +966,7 @@ int32 CFE_TBL_ActivateCmd(const CFE_TBL_ActivateCmd_t *data)
             /* Determine if the inactive buffer has been successfully validated or not */
             if (RegRecPtr->DoubleBuffered)
             {
-                ValidationStatus = RegRecPtr->Buffers[(1U - RegRecPtr->ActiveBufferIndex)].Validated;
+                ValidationStatus = RegRecPtr->Buffers[(RegRecPtr->ActiveBufferIndex ^ 1)].Validated;
             }
             else
             {

--- a/modules/tbl/ut-coverage/tbl_UT.c
+++ b/modules/tbl/ut-coverage/tbl_UT.c
@@ -726,7 +726,7 @@ void Test_CFE_TBL_ValidateCmd(void)
     UT_InitData();
     ValidateCmd.Payload.ActiveTableFlag       = CFE_TBL_BufferSelect_INACTIVE;
     CFE_TBL_Global.Registry[0].DoubleBuffered = true;
-    CFE_TBL_Global.Registry[0].Buffers[1 - CFE_TBL_Global.Registry[0].ActiveBufferIndex].BufferPtr = BuffPtr;
+    CFE_TBL_Global.Registry[0].Buffers[CFE_TBL_Global.Registry[0].ActiveBufferIndex ^ 1].BufferPtr = BuffPtr;
     CFE_TBL_Global.ValidationResults[0].State    = CFE_TBL_VALIDATION_FREE;
     CFE_TBL_Global.Registry[0].ValidationFuncPtr = ValFuncPtr;
     UtAssert_INT32_EQ(CFE_TBL_ValidateCmd(&ValidateCmd), CFE_TBL_INC_CMD_CTR);
@@ -1111,7 +1111,7 @@ void Test_CFE_TBL_DumpCmd(void)
     UT_InitData();
     DumpCmd.Payload.ActiveTableFlag           = CFE_TBL_BufferSelect_INACTIVE;
     CFE_TBL_Global.Registry[2].DoubleBuffered = true;
-    CFE_TBL_Global.Registry[2].Buffers[(1 - CFE_TBL_Global.Registry[2].ActiveBufferIndex)].BufferPtr = BuffPtr;
+    CFE_TBL_Global.Registry[2].Buffers[(CFE_TBL_Global.Registry[2].ActiveBufferIndex ^ 1)].BufferPtr = BuffPtr;
     CFE_TBL_Global.Registry[2].DumpControlIndex = CFE_TBL_NO_DUMP_PENDING + 1;
     UtAssert_INT32_EQ(CFE_TBL_DumpCmd(&DumpCmd), CFE_TBL_INC_ERR_CTR);
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1514
  - Changes swap pattern for ping-pong buffers from `1 - ActiveBuffer` to `ActiveBuffer ^ 1`.

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
No change to behavior.

**Contributor Info**
Avi Weiss @thnkslprpt