### PR TITLE
Fix #2352, make shared tbl configurable

### DIFF
--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -60,6 +60,14 @@ extern CFE_FT_Global_t CFE_FT_Global;
  */
 #define CFE_ASSERT_LOG_FILE_NAME "/cf/cfe_test.log"
 
+/**
+ * Name of the shared table used by CFE_TEST_APP for requirements verification
+ *
+ * This filename was made configurable such that projects can replace the
+ * sample app table with a project specific table for the purpose of CI/CD.
+ */
+#define CFE_ASSERT_SHARED_TBL_NAME "SAMPLE_APP.SampleAppTable"
+
 void TimeInRange(CFE_TIME_SysTime_t Start, CFE_TIME_SysTime_t Time, CFE_TIME_SysTime_t Range, const char *Str);
 
 void CFE_TestMain(void);

--- a/modules/cfe_testcase/src/tbl_content_access_test.c
+++ b/modules/cfe_testcase/src/tbl_content_access_test.c
@@ -45,7 +45,7 @@ void TestGetAddress(void)
     TBL_TEST_Table_t  TestTable = {1, 2};
 
     CFE_TBL_Handle_t SharedTblHandle = CFE_TBL_BAD_TABLE_HANDLE;
-    const char *     SharedTblName   = "SAMPLE_APP.SampleAppTable";
+    const char *     SharedTblName   = CFE_ASSERT_SHARED_TBL_NAME;
 
     UtPrintf("Testing: CFE_TBL_GetAddress");
 

--- a/modules/cfe_testcase/src/tbl_information_test.c
+++ b/modules/cfe_testcase/src/tbl_information_test.c
@@ -77,7 +77,7 @@ void TestGetInfo(void)
 void TestNotifyByMessage(void)
 {
     CFE_TBL_Handle_t  SharedTblHandle = CFE_TBL_BAD_TABLE_HANDLE;
-    const char *      SharedTblName   = "SAMPLE_APP.SampleAppTable";
+    const char *      SharedTblName   = CFE_ASSERT_SHARED_TBL_NAME;
     CFE_SB_MsgId_t    TestMsgId       = CFE_SB_ValueToMsgId(CFE_TEST_CMD_MID);
     CFE_MSG_FcnCode_t TestCmdCode     = 0;
     uint32            TestParameter   = 0;

--- a/modules/cfe_testcase/src/tbl_registration_test.c
+++ b/modules/cfe_testcase/src/tbl_registration_test.c
@@ -190,7 +190,7 @@ void TestTableShare(void)
 {
     UtPrintf("Testing: CFE_TBL_Share");
     CFE_TBL_Handle_t SharedTblHandle;
-    const char *     SharedTblName = "SAMPLE_APP.SampleAppTable";
+    const char *     SharedTblName = CFE_ASSERT_SHARED_TBL_NAME;
     const char *     BadTblName    = "SampleAppTable";
 
     UtAssert_INT32_EQ(CFE_TBL_Share(NULL, SharedTblName), CFE_TBL_BAD_ARGUMENT);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x ] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
This fix makes the shared table used in the cFE functional tests project configurable
Fixes #2352 

**Testing performed**
Executed functional tests and confirmed that the tests were successful.

**Contributor Info - All information REQUIRED for consideration of pull request**
Dan Knutsen
NASA Goddard
