### PR TITLE
Fix #2363, Increase slp time in funct test workflow

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -89,7 +89,7 @@ jobs:
 
             counter=$(grep -c "BEGIN" cf/cfe_test.tmp)
             echo "Waiting for CFE Tests"
-            sleep 60
+            sleep 120
           done
 
           ../host/cmdUtil --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x ] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Increase the wait time required to call a test 'frozen'.  This will prevent tests from erroneously being called 'frozen' and allow the tests to complete successfully.
Fixes Issue #2363 

**Testing performed**
Ran workflow

**Expected behavior changes**
Tests complete successfully 

**Contributor Info - All information REQUIRED for consideration of pull request**
Dan Knutsen
NASA Goddard
