### PR TITLE
Fix #2362, Add source routing APIs to SB

### DIFF
--- a/modules/cfe_testcase/src/sb_sendrecv_test.c
+++ b/modules/cfe_testcase/src/sb_sendrecv_test.c
@@ -642,6 +642,39 @@ void TestMiscMessageUtils(void)
                       CFE_SB_BAD_ARGUMENT);
 }
 
+void TestSourceRouting(void)
+{
+    CFE_SB_Buffer_t       *TxBufPtr;
+    const CFE_SB_Buffer_t *RxBufPtr;
+    size_t                 RxSize;
+    CFE_SB_MsgId_t         RxMsgId;
+    CFE_SB_PipeId_t        PipeId;
+
+    /* Random data -- not a CCSDS header (this is intentional) */
+    const uint8_t Content[16] = { 0xe9, 0xf2, 0x67, 0x3d, 0x5e, 0x54, 0x1a, 0xa5,
+                                  0xe9, 0xe2, 0x11, 0xe8, 0x71, 0x85, 0xb7, 0x0d };
+
+    /* Setup, create a pipe and subscribe (one cmd, one tlm) */
+    UtAssert_INT32_EQ(CFE_SB_CreatePipe(&PipeId, 5, "TestPipe"), CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_SB_SubscribeEx(CFE_FT_CMD_MSGID, PipeId, CFE_SB_DEFAULT_QOS, 3), CFE_SUCCESS);
+
+    TxBufPtr = CFE_SB_AllocateMessageBuffer(sizeof(Content));
+    UtAssert_NOT_NULL(TxBufPtr);
+    memcpy(TxBufPtr, Content, sizeof(Content));
+
+    UtAssert_INT32_EQ(CFE_SB_TransmitBufferWithRoute(TxBufPtr, sizeof(Content), CFE_FT_CMD_MSGID, false, CFE_SB_POLL),
+                      CFE_SUCCESS);
+    UtAssert_INT32_EQ(CFE_SB_ReceiveBufferWithRoute(PipeId, &RxBufPtr, &RxSize, &RxMsgId, false, CFE_SB_POLL),
+                      CFE_SUCCESS);
+
+    UtAssert_ADDRESS_EQ(RxBufPtr, TxBufPtr);
+    UtAssert_UINT32_EQ(RxSize, sizeof(Content));
+    CFE_Assert_MSGID_EQ(RxMsgId, CFE_FT_CMD_MSGID);
+
+    /* Cleanup */
+    UtAssert_INT32_EQ(CFE_SB_DeletePipe(PipeId), CFE_SUCCESS);
+}
+
 void SBSendRecvTestSetup(void)
 {
     CFE_FT_CMD_MSGID = CFE_SB_ValueToMsgId(CFE_TEST_CMD_MID);
@@ -650,6 +683,7 @@ void SBSendRecvTestSetup(void)
     UtTest_Add(TestBasicTransmitRecv, NULL, NULL, "Test Basic Transmit/Receive");
     UtTest_Add(TestZeroCopyTransmitRecv, NULL, NULL, "Test Zero Copy Transmit/Receive");
     UtTest_Add(TestMsgBroadcast, NULL, NULL, "Test Msg Broadcast");
+    UtTest_Add(TestSourceRouting, NULL, NULL, "Test Source Routing APIs");
     UtTest_Add(TestMiscMessageUtils, NULL, NULL, "Test Miscellaneous Message Utility APIs");
     UtTest_Add(TestMessageUserDataAccess, NULL, NULL, "Test Message UserData APIs");
 }

--- a/modules/core_api/fsw/inc/cfe_sb.h
+++ b/modules/core_api/fsw/inc/cfe_sb.h
@@ -478,6 +478,49 @@ CFE_Status_t CFE_SB_TransmitMsg(const CFE_MSG_Message_t *MsgPtr, bool IsOriginat
 **/
 CFE_Status_t CFE_SB_ReceiveBuffer(CFE_SB_Buffer_t **BufPtr, CFE_SB_PipeId_t PipeId, int32 TimeOut);
 
+/*****************************************************************************/
+/**
+** \brief Receive a generic buffer
+**
+** \par Description
+**          This routine accepts an abstract buffer via the software bus
+**          from the specified pipe, without relying on the MsgId and/or routing
+**          information from the message headers.  As a result, the buffer need not
+**          strictly be a CFE CMD/TLM message, it can be any arbitrary data.  The
+**          routing information is passed out-of-band and will be returned in the specified
+**          buffers.
+**
+**          The message also may be verified if "EnableVerify" is set to true.  In this
+**          case, CFE_MSG_Verify() is invoked on the received message, and if this results
+**          in validation failure, the message will be internally discarded and not passed
+**          back to the caller.  Note that in this case, the buffer cannot be arbitrary data,
+**          it must be compliant with the expected headers.  Arbitrary data can only be passed
+**          by setting this parameter to "false"
+**
+** \par Assumptions, External Events, and Notes:
+**       -  See CFE_SB_ReceiveBuffer()
+**
+** \param[in]  PipeId        Pipe ID to receive from
+** \param[out] BufPtr        A pointer to the buffer to be received @nonnull.
+** \param[out] ContentSize   Actual content size of the message
+** \param[out] RoutingMsgId  Destination/Route to which the message was sent
+** \param[in]  IsTermination Indicates this is termination point, headers should be verified
+** \param[in]  TimeOut       Maxmimum amount of time to block
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS         \copybrief CFE_SUCCESS
+** \retval #CFE_SB_BAD_ARGUMENT \copybrief CFE_SB_BAD_ARGUMENT
+** \retval #CFE_SB_TIME_OUT     \copybrief CFE_SB_TIME_OUT
+** \retval #CFE_SB_PIPE_RD_ERR  \covtest \copybrief CFE_SB_PIPE_RD_ERR
+** \retval #CFE_SB_NO_MESSAGE   \copybrief CFE_SB_NO_MESSAGE
+*/
+CFE_Status_t CFE_SB_ReceiveBufferWithRoute(CFE_SB_PipeId_t         PipeId,
+                                           const CFE_SB_Buffer_t **BufPtr,
+                                           size_t                 *ContentSize,
+                                           CFE_SB_MsgId_t         *RoutingMsgId,
+                                           bool                    IsTermination,
+                                           int32                   TimeOut);
+
 /** @} */
 
 /** @defgroup CFEAPISBZeroCopy cFE Zero Copy APIs
@@ -590,6 +633,43 @@ CFE_Status_t CFE_SB_ReleaseMessageBuffer(CFE_SB_Buffer_t *BufPtr);
 **/
 CFE_Status_t CFE_SB_TransmitBuffer(CFE_SB_Buffer_t *BufPtr, bool IsOrigination);
 
+/*****************************************************************************/
+/**
+** \brief Transmit a generic buffer with source routing
+**
+** \par Description
+**          This routine sends an abstract buffer via the software bus directly
+**          to the specified destination, without relying on the MsgId and/or routing
+**          information from the message headers.  As a result, the buffer need not
+**          strictly be a CFE CMD/TLM message, it can be any arbitrary data (but see note).
+**          The buffer will be delivered to subscribers based on the message ID passed in.
+**
+** \par Assumptions, External Events, and Notes:
+**       -# See CFE_SB_TransmitBuffer() - the passed-in buffer object is consumed by this
+**          call in a similar manner.
+**       -# If "EnableUpdate" is passed as "true", then the content must be a CFE message
+**          with the expected headers (it cannot be arbitrary data, as the header update
+**          will modify it based on the normally expected header).  Only when this boolean
+**          is passed as "false" does this routine not access the buffer at all.
+**       -# For normal broadcast messages, the TimeOut should generally be CFE_SB_POLL only.
+**          Nonzero timeouts may be useful for point-to-point connections as a future enhancement.
+**
+** \param[in] BufPtr        A pointer to the buffer to be sent @nonnull.
+** \param[in] ContentSize   Actual content size of the message
+** \param[in] RoutingMsgId  Destination/Route to which the message should be broadcast
+** \param[in] IsOrigination Indicates this is the origination point, update headers during transmit
+** \param[in] TimeOut       Maxmimum amount of time to block (not for broadcast)
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS         \copybrief CFE_SUCCESS
+** \retval #CFE_SB_BAD_ARGUMENT \copybrief CFE_SB_BAD_ARGUMENT
+** \retval #CFE_SB_MSG_TOO_BIG  \copybrief CFE_SB_MSG_TOO_BIG
+*/
+CFE_Status_t CFE_SB_TransmitBufferWithRoute(CFE_SB_Buffer_t *BufPtr,
+                                            size_t           ContentSize,
+                                            CFE_SB_MsgId_t   RoutingMsgId,
+                                            bool             IsOrigination,
+                                            int32            TimeOut);
 /** @} */
 
 /** @defgroup CFEAPISBMessageCharacteristics cFE Message Characteristics APIs

--- a/modules/core_api/fsw/inc/cfe_sb_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_sb_api_typedefs.h
@@ -141,6 +141,13 @@ typedef union CFE_SB_Msg
     CFE_MSG_Message_t Msg;        /**< \brief Base message type without enforced alignment */
     long long int     LongInt;    /**< \brief Align to support Long Integer */
     long double       LongDouble; /**< \brief Align to support Long Double */
+
+    /**
+     * \brief Allows access as opaque octet data
+     * This may be used in conjunction with the APIs that include routes:
+     * CFE_SB_TransmitBufferWithRoute(), CFE_SB_ReceiveBufferWithRoute()
+     */
+    uint8 RawData[sizeof(CFE_MSG_Message_t)];
 } CFE_SB_Buffer_t;
 
 #endif /* CFE_SB_API_TYPEDEFS_H */

--- a/modules/core_api/ut-stubs/src/cfe_sb_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_sb_stubs.c
@@ -361,6 +361,32 @@ CFE_Status_t CFE_SB_ReceiveBuffer(CFE_SB_Buffer_t **BufPtr, CFE_SB_PipeId_t Pipe
 
 /*
  * ----------------------------------------------------
+ * Generated stub function for CFE_SB_ReceiveBufferWithRoute()
+ * ----------------------------------------------------
+ */
+CFE_Status_t CFE_SB_ReceiveBufferWithRoute(CFE_SB_PipeId_t         PipeId,
+                                           const CFE_SB_Buffer_t **BufPtr,
+                                           size_t                 *ContentSize,
+                                           CFE_SB_MsgId_t         *RoutingMsgId,
+                                           bool                    IsTermination,
+                                           int32                   TimeOut)
+{
+    UT_GenStub_SetupReturnBuffer(CFE_SB_ReceiveBufferWithRoute, CFE_Status_t);
+
+    UT_GenStub_AddParam(CFE_SB_ReceiveBufferWithRoute, CFE_SB_PipeId_t, PipeId);
+    UT_GenStub_AddParam(CFE_SB_ReceiveBufferWithRoute, const CFE_SB_Buffer_t **, BufPtr);
+    UT_GenStub_AddParam(CFE_SB_ReceiveBufferWithRoute, size_t *, ContentSize);
+    UT_GenStub_AddParam(CFE_SB_ReceiveBufferWithRoute, CFE_SB_MsgId_t *, RoutingMsgId);
+    UT_GenStub_AddParam(CFE_SB_ReceiveBufferWithRoute, bool, IsTermination);
+    UT_GenStub_AddParam(CFE_SB_ReceiveBufferWithRoute, int32, TimeOut);
+
+    UT_GenStub_Execute(CFE_SB_ReceiveBufferWithRoute, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(CFE_SB_ReceiveBufferWithRoute, CFE_Status_t);
+}
+
+/*
+ * ----------------------------------------------------
  * Generated stub function for CFE_SB_ReleaseMessageBuffer()
  * ----------------------------------------------------
  */
@@ -503,6 +529,30 @@ CFE_Status_t CFE_SB_TransmitBuffer(CFE_SB_Buffer_t *BufPtr, bool IsOrigination)
     UT_GenStub_Execute(CFE_SB_TransmitBuffer, Basic, UT_DefaultHandler_CFE_SB_TransmitBuffer);
 
     return UT_GenStub_GetReturnValue(CFE_SB_TransmitBuffer, CFE_Status_t);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CFE_SB_TransmitBufferWithRoute()
+ * ----------------------------------------------------
+ */
+CFE_Status_t CFE_SB_TransmitBufferWithRoute(CFE_SB_Buffer_t *BufPtr,
+                                            size_t           ContentSize,
+                                            CFE_SB_MsgId_t   RoutingMsgId,
+                                            bool             IsOrigination,
+                                            int32            TimeOut)
+{
+    UT_GenStub_SetupReturnBuffer(CFE_SB_TransmitBufferWithRoute, CFE_Status_t);
+
+    UT_GenStub_AddParam(CFE_SB_TransmitBufferWithRoute, CFE_SB_Buffer_t *, BufPtr);
+    UT_GenStub_AddParam(CFE_SB_TransmitBufferWithRoute, size_t, ContentSize);
+    UT_GenStub_AddParam(CFE_SB_TransmitBufferWithRoute, CFE_SB_MsgId_t, RoutingMsgId);
+    UT_GenStub_AddParam(CFE_SB_TransmitBufferWithRoute, bool, IsOrigination);
+    UT_GenStub_AddParam(CFE_SB_TransmitBufferWithRoute, int32, TimeOut);
+
+    UT_GenStub_Execute(CFE_SB_TransmitBufferWithRoute, Basic, NULL);
+
+    return UT_GenStub_GetReturnValue(CFE_SB_TransmitBufferWithRoute, CFE_Status_t);
 }
 
 /*

--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -1450,6 +1450,55 @@ CFE_Status_t CFE_SB_ReceiveBuffer(CFE_SB_Buffer_t **BufPtr, CFE_SB_PipeId_t Pipe
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
+CFE_Status_t CFE_SB_ReceiveBufferWithRoute(CFE_SB_PipeId_t         PipeId,
+                                           const CFE_SB_Buffer_t **BufPtr,
+                                           CFE_MSG_Size_t         *BufSize,
+                                           CFE_SB_MsgId_t         *RoutingMsgId,
+                                           bool                    IsTermination,
+                                           int32                   TimeOut)
+{
+    CFE_SB_ReceiveTxn_State_t  TxnBuf;
+    CFE_SB_MessageTxn_State_t *Txn;
+
+    Txn = CFE_SB_ReceiveTxn_Init(&TxnBuf, BufPtr);
+
+    if (CFE_SB_MessageTxn_IsOK(Txn))
+    {
+        CFE_SB_MessageTxn_SetTimeout(Txn, TimeOut);
+    }
+
+    if (CFE_SB_MessageTxn_IsOK(Txn))
+    {
+        CFE_SB_ReceiveTxn_SetPipeId(Txn, PipeId);
+        CFE_SB_MessageTxn_SetEndpoint(Txn, IsTermination);
+    }
+
+    if (BufPtr != NULL)
+    {
+        *BufPtr = CFE_SB_ReceiveTxn_Execute(Txn);
+    }
+
+    /* Export the other details if the user asked for them */
+    if (BufSize != NULL)
+    {
+        *BufSize = CFE_SB_MessageTxn_GetContentSize(Txn);
+    }
+    if (RoutingMsgId != NULL)
+    {
+        *RoutingMsgId = CFE_SB_MessageTxn_GetRoutingMsgId(Txn);
+    }
+
+    CFE_SB_MessageTxn_ReportEvents(Txn);
+
+    return CFE_SB_MessageTxn_GetStatus(Txn);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Implemented per public API
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_SB_Buffer_t *CFE_SB_AllocateMessageBuffer(size_t MsgSize)
 {
     CFE_ES_AppId_t    AppId;
@@ -1637,6 +1686,46 @@ CFE_Status_t CFE_SB_TransmitMsg(const CFE_MSG_Message_t *MsgPtr, bool IsOriginat
          * accessed in this function anymore
          */
         BufPtr = NULL;
+    }
+
+    /* send an event for each pipe write error that may have occurred */
+    CFE_SB_MessageTxn_ReportEvents(Txn);
+
+    return CFE_SB_MessageTxn_GetStatus(Txn);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Implemented per public API
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+CFE_Status_t CFE_SB_TransmitBufferWithRoute(CFE_SB_Buffer_t *BufPtr,
+                                            size_t           ContentSize,
+                                            CFE_SB_MsgId_t   RoutingMsgId,
+                                            bool             IsOrigination,
+                                            int32            TimeOut)
+{
+    CFE_SB_TransmitTxn_State_t TxnBuf;
+    CFE_SB_MessageTxn_State_t *Txn;
+
+    Txn = CFE_SB_TransmitTxn_Init(&TxnBuf, BufPtr);
+
+    /*
+     * Sanity Check that the pointers are not NULL
+     */
+    if (CFE_SB_MessageTxn_IsOK(Txn))
+    {
+        /* Save passed-in parameters and execute */
+        CFE_SB_MessageTxn_SetContentSize(Txn, ContentSize);
+        CFE_SB_MessageTxn_SetRoutingMsgId(Txn, RoutingMsgId);
+        CFE_SB_MessageTxn_SetTimeout(Txn, TimeOut);
+        CFE_SB_MessageTxn_SetEndpoint(Txn, IsOrigination);
+    }
+
+    if (CFE_SB_MessageTxn_IsOK(Txn))
+    {
+        CFE_SB_TransmitTxn_Execute(Txn, BufPtr);
     }
 
     /* send an event for each pipe write error that may have occurred */

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -3515,9 +3515,48 @@ void Test_TransmitMsg_API(void)
     SB_UT_ADD_SUBTEST(Test_TransmitTxn_FindDestinations);
     SB_UT_ADD_SUBTEST(Test_TransmitTxn_PipeHandler);
     SB_UT_ADD_SUBTEST(Test_TransmitTxn_Execute);
+    SB_UT_ADD_SUBTEST(Test_TransmitBufferWithRoute);
 
     SB_UT_ADD_SUBTEST(Test_AllocateMessageBuffer);
     SB_UT_ADD_SUBTEST(Test_ReleaseMessageBuffer);
+}
+
+void Test_TransmitBufferWithRoute(void)
+{
+    /* Test case for:
+     * CFE_Status_t CFE_SB_TransmitBufferWithRoute(CFE_SB_Buffer_t *BufPtr, CFE_MSG_Size_t BufSize, CFE_SB_MsgId_t
+     * RoutingMsgId, bool EnableUpdate, int32 TimeOut);
+     */
+
+    CFE_SB_Buffer_t       *SendPtr;
+    const CFE_SB_Buffer_t *ReceivePtr = NULL;
+    CFE_SB_PipeId_t        PipeId     = CFE_SB_INVALID_PIPE;
+    CFE_SB_MsgId_t         MsgId      = SB_UT_TLM_MID;
+    CFE_SB_MsgId_t         RecvMsgId  = CFE_SB_INVALID_MSG_ID;
+    size_t                 RecvSize;
+
+    static const uint8_t RandomBytes[] = { 0x4a, 0x75, 0x62, 0x34, 0x1d, 0xa5, 0x48, 0x5b, 0xc6, 0xb4, 0x40, 0x3f };
+
+    CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId, 3, "TestPipe"));
+    CFE_UtAssert_SETUP(CFE_SB_Subscribe(MsgId, PipeId));
+
+    UtAssert_NOT_NULL(SendPtr = CFE_SB_AllocateMessageBuffer(sizeof(SB_UT_Test_Tlm_t)));
+    memcpy(SendPtr, RandomBytes, sizeof(RandomBytes));
+
+    /* Test a successful pass */
+    CFE_UtAssert_SUCCESS(CFE_SB_TransmitBufferWithRoute(SendPtr, sizeof(RandomBytes), MsgId, false, CFE_SB_POLL));
+    CFE_UtAssert_SUCCESS(CFE_SB_ReceiveBufferWithRoute(PipeId, &ReceivePtr, &RecvSize, &RecvMsgId, false, CFE_SB_POLL));
+
+    UtAssert_ADDRESS_EQ(SendPtr, ReceivePtr);
+    UtAssert_EQ(size_t, RecvSize, sizeof(RandomBytes));
+    CFE_UtAssert_MSGID_EQ(RecvMsgId, MsgId);
+
+    /* Test bad input */
+    UtAssert_INT32_EQ(CFE_SB_TransmitBufferWithRoute(NULL, 0, MsgId, false, CFE_SB_POLL), CFE_SB_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_SB_TransmitBufferWithRoute(SendPtr, sizeof(RandomBytes), MsgId, false, -1000),
+                      CFE_SB_BAD_ARGUMENT);
+
+    CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
 }
 
 /*
@@ -4160,6 +4199,89 @@ void UT_CFE_MSG_Verify_CustomHandler(void *UserObj, UT_EntryKey_t FuncKey, const
     *IsAcceptable = (UT_GetStubCount(FuncKey) & 1) == 0;
 }
 
+void Test_ReceiveBufferWithRoute(void)
+{
+    /* Test case for:
+     * CFE_Status_t CFE_SB_ReceiveBufferWithRoute(CFE_SB_Buffer_t **BufPtr, CFE_MSG_Size_t *BufSize, CFE_SB_PipeId_t
+     * RxRoute, bool EnableVerify, int32 TimeOut);
+     */
+
+    CFE_SB_BufferD_t       BufDsc[2];
+    const void            *BufDscP[2];
+    CFE_SB_PipeId_t        PipeId;
+    CFE_SB_PipeD_t        *PipeDscPtr;
+    // CFE_SB_MsgId_t   TestMsgId  = SB_UT_TLM_MID;
+    CFE_SB_MsgId_t         RecvMsgId;
+    size_t                 TestSize;
+    size_t                 RecvSize;
+    const CFE_SB_Buffer_t *RecvBufPtr;
+
+    UT_SetHandlerFunction(UT_KEY(CFE_MSG_VerificationAction), UT_CFE_MSG_Verify_CustomHandler, NULL);
+    CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId, 3, "TestPipe"));
+    CFE_UtAssert_SETUP(CFE_SB_Subscribe(SB_UT_TLM_MID, PipeId));
+    CFE_UtAssert_SETUP(CFE_SB_Subscribe(SB_UT_CMD_MID, PipeId));
+    PipeDscPtr = CFE_SB_LocatePipeDescByID(PipeId);
+    TestSize   = 5;
+
+    memset(BufDsc, 0, sizeof(BufDsc));
+    BufDscP[0]            = &BufDsc[0];
+    BufDsc[0].ContentSize = TestSize;
+    BufDsc[0].MsgId       = SB_UT_TLM_MID;
+    BufDscP[1]            = &BufDsc[1];
+    BufDsc[1].ContentSize = TestSize + 1;
+    BufDsc[1].MsgId       = SB_UT_CMD_MID;
+    CFE_SB_TrackingListReset(&BufDsc[0].Link);
+    CFE_SB_TrackingListReset(&BufDsc[1].Link);
+
+    /* Bad Input (all subsequent steps skipped) */
+    UtAssert_INT32_EQ(CFE_SB_ReceiveBufferWithRoute(PipeId, NULL, NULL, NULL, false, CFE_SB_POLL), CFE_SB_BAD_ARGUMENT);
+    UtAssert_STUB_COUNT(OS_QueueGet, 0);
+    UtAssert_STUB_COUNT(CFE_MSG_VerificationAction, 0);
+
+    /*
+     * Note for these test cases -
+     * the default stub handlers for OS_QueueGet registers data based on
+     * its OSAL ID rather than the function name key as is typical.
+     */
+
+    /* Nominal - no verify */
+    RecvBufPtr = NULL;
+    RecvMsgId  = CFE_SB_INVALID_MSG_ID;
+    RecvSize   = 0;
+    UT_SetDataBuffer(OS_ObjectIdToInteger(PipeDscPtr->SysQueueId), &BufDscP[0], sizeof(BufDscP[0]), false);
+    UtAssert_INT32_EQ(CFE_SB_ReceiveBufferWithRoute(PipeId, &RecvBufPtr, &RecvSize, &RecvMsgId, false, CFE_SB_POLL),
+                      CFE_SUCCESS);
+    UtAssert_ADDRESS_EQ(RecvBufPtr, &BufDsc[0].Content);
+    UtAssert_EQ(size_t, RecvSize, TestSize);
+    CFE_UtAssert_MSGID_EQ(RecvMsgId, SB_UT_TLM_MID);
+    UtAssert_STUB_COUNT(CFE_MSG_VerificationAction, 0);
+    UtAssert_STUB_COUNT(OS_QueueGet, 1);
+
+    /* With verify - two bufs in queue, fail verify first, then verify success */
+    RecvMsgId = CFE_SB_INVALID_MSG_ID;
+    RecvSize  = 0;
+    UT_SetDataBuffer(OS_ObjectIdToInteger(PipeDscPtr->SysQueueId), BufDscP, sizeof(BufDscP), false);
+    UtAssert_INT32_EQ(CFE_SB_ReceiveBufferWithRoute(PipeId, &RecvBufPtr, &RecvSize, &RecvMsgId, true, CFE_SB_POLL),
+                      CFE_SUCCESS);
+    UtAssert_ADDRESS_EQ(RecvBufPtr, &BufDsc[1].Content);
+    UtAssert_EQ(size_t, RecvSize, TestSize + 1);
+    CFE_UtAssert_MSGID_EQ(RecvMsgId, SB_UT_CMD_MID);
+    UtAssert_STUB_COUNT(CFE_MSG_VerificationAction, 2);
+    UtAssert_STUB_COUNT(OS_QueueGet, 3);
+
+    /* With verify - one buf in queue, fails verify, then empty queue */
+    UT_SetDataBuffer(OS_ObjectIdToInteger(PipeDscPtr->SysQueueId), &BufDscP[1], sizeof(BufDscP[1]), false);
+    UtAssert_INT32_EQ(CFE_SB_ReceiveBufferWithRoute(PipeId, &RecvBufPtr, &RecvSize, &RecvMsgId, true, CFE_SB_POLL),
+                      CFE_SB_NO_MESSAGE);
+    UtAssert_NULL(RecvBufPtr);
+    UtAssert_EQ(size_t, RecvSize, 0);
+    CFE_UtAssert_MSGID_EQ(RecvMsgId, CFE_SB_INVALID_MSG_ID);
+    UtAssert_STUB_COUNT(CFE_MSG_VerificationAction, 3);
+    UtAssert_STUB_COUNT(OS_QueueGet, 5);
+
+    CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
+}
+
 /*
 ** Function for calling SB receive message API test functions
 */
@@ -4172,6 +4294,7 @@ void Test_ReceiveBuffer_API(void)
     SB_UT_ADD_SUBTEST(Test_ReceiveBuffer_PipeReadError);
     SB_UT_ADD_SUBTEST(Test_ReceiveBuffer_PendForever);
     SB_UT_ADD_SUBTEST(Test_ReceiveBuffer_InvalidBufferPtr);
+    SB_UT_ADD_SUBTEST(Test_ReceiveBufferWithRoute);
 }
 
 static void SB_UT_PipeIdModifyHandler(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -4210,7 +4210,6 @@ void Test_ReceiveBufferWithRoute(void)
     const void            *BufDscP[2];
     CFE_SB_PipeId_t        PipeId;
     CFE_SB_PipeD_t        *PipeDscPtr;
-    // CFE_SB_MsgId_t   TestMsgId  = SB_UT_TLM_MID;
     CFE_SB_MsgId_t         RecvMsgId;
     size_t                 TestSize;
     size_t                 RecvSize;

--- a/modules/sb/ut-coverage/sb_UT.h
+++ b/modules/sb/ut-coverage/sb_UT.h
@@ -1836,6 +1836,21 @@ void Test_TransmitMsg_InvalidMsgId(void);
 
 /*****************************************************************************/
 /**
+** \brief Test response to sending a source-routed message
+**
+** \par Description
+**        This function tests the response to sending a source-routed message
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+******************************************************************************/
+void Test_TransmitBufferWithRoute(void);
+
+/*****************************************************************************/
+/**
 ** \brief Test response to sending a message which has no subscribers
 **
 ** \par Description


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Add two new APIs that allow more control over the message routing. These allow the caller to directly specify the route (MsgId) and size of the content, and the message will be delivered based on the passed in values vs. the values inside the message itself.

This restructures the existing/historical API calls to use the same underlying mechanism.  Send/Receive actions have a transaction object associated and this tracks the status and events.  Common event reporting is done based on this transaction object.

Fixes #2362

**Testing performed**
Build and run CFE including functional test app
Build and run sanity tests

**Expected behavior changes**
Adds two new APIs.  Existing APIs should be backward compatible, with some possible changes to the expected event IDs that might be generated under some off-nominal conditions.

**System(s) tested on**
Debian

**Additional context**
The new API allows the passed object to be any arbitrary data -- it does not need to be a CFE/CCSDS message at all.  Therefore this could be more suitable for things like CFDP PDU packets, etc. as it would not need to be forced to look like a CMD/TLM message.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
