### PR TITLE
Fix #2368, cFE Functional Test 23

### DIFF
--- a/modules/cfe_testcase/src/es_misc_test.c
+++ b/modules/cfe_testcase/src/es_misc_test.c
@@ -84,7 +84,10 @@ void TestWriteToSysLog(void)
         {
             break;
         }
-        CFE_Assert_STATUS_MUST_BE(CFE_SUCCESS);
+        if (!CFE_Assert_STATUS_MAY_BE(CFE_ES_ERR_SYS_LOG_TRUNCATED))
+        {
+            CFE_Assert_STATUS_MUST_BE(CFE_SUCCESS);
+        }
     }
 
     UtAssert_MIR("MIR (Manual Inspection Required) for CFE_ES_WriteToSysLog");


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x ] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #2368 - cFE Functional Test 23 Failing
If the cFE functional tests are executed multiple times in a row, because of differences in pre-test log messages -  CFE_ES_WriteToSysLog can return CFE_ES_ERR_SYS_LOG_TRUNCATED during execution of cFE test 23.   Functional test 23 was updated to allow for the CFE_ES_ERR_SYS_LOG_TRUNCATED return value - as that is an acceptable/nominal condition.

**Testing performed**
Successfully executed functional tests multiple times in a row.

**Expected behavior changes**
cFE Functional Test 23 should no longer intermittently fail.

**Contributor Info - All information REQUIRED for consideration of pull request**
Dan Knutsen
NASA Goddard
