### PR TITLE
Fix #2358, adds TIME module command to set CFE_TIME_Print() format

### DIFF
--- a/docs/src/mnem_maps/cfe_time_cmd_mnem_map
+++ b/docs/src/mnem_maps/cfe_time_cmd_mnem_map
@@ -31,4 +31,5 @@ TIME_ADD1HZSTCF=$sc_$cpu_TIME_Add1HzSTCF \
 TIME_SUB1HZSTCF=$sc_$cpu_TIME_Sub1HzSTCF \
 TIME_STOPADD1HZ=$sc_$cpu_TIME_StopAdd1Hz \
 TIME_STOPSUB1HZ=$sc_$cpu_TIME_StopSub1Hz \
-TIME_SETSIGNAL=$sc_$cpu_TIME_SetSignal
+TIME_SETSIGNAL=$sc_$cpu_TIME_SetSignal \
+TIME_SETPRINT=$sc_$cpu_TIME_SetPrint

--- a/modules/core_api/fsw/inc/cfe_error.h
+++ b/modules/core_api/fsw/inc/cfe_error.h
@@ -1362,6 +1362,15 @@ char *CFE_ES_StatusToString(CFE_Status_t status, CFE_StatusString_t *status_stri
  *
  */
 #define CFE_TIME_BAD_ARGUMENT ((CFE_Status_t)0xce000005)
+
+/**
+ * @brief Time Format Production Too Long
+ *
+ * The formatting of a time into a string would overflow the
+ * output buffer length of CFE_TIME_PRINTED_STRING_SIZE.
+ *
+ */
+#define CFE_TIME_FORMAT_TOO_LONG ((CFE_Status_t)0xce000006)
 /**@}*/
 
 #endif /* CFE_ERROR_H */

--- a/modules/core_api/fsw/inc/cfe_time_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_time_api_typedefs.h
@@ -42,7 +42,10 @@
 */
 
 #define CFE_TIME_PRINTED_STRING_SIZE \
-    24 /**< \brief Required size of buffer to be passed into #CFE_TIME_Print (includes null terminator) */
+    32 /**< \brief Required size of buffer to be passed into #CFE_TIME_Print (includes null terminator) */
+
+#define CFE_TIME_FORMAT_SIZE \
+    32 /**< \brief The maximum length we will accept for the format string (incl. null)--affects cmd and tlm */
 
 /*****************************************************************************/
 /*

--- a/modules/time/config/default_cfe_time_extern_typedefs.h
+++ b/modules/time/config/default_cfe_time_extern_typedefs.h
@@ -279,4 +279,29 @@ enum CFE_TIME_SetState
  */
 typedef uint8 CFE_TIME_SetState_Enum_t;
 
+enum CFE_TIME_PrintState
+{
+    /**
+     * @brief Print timestamp using format string.
+     */
+    CFE_TIME_PrintState_DateTime       = 0,
+
+    /**
+     * @brief Print secs+micros since start/reset.
+     */
+    CFE_TIME_PrintState_SecsSinceStart = 1,
+
+    /**
+     * @brief Do not print timestamps at all.
+     */
+    CFE_TIME_PrintState_None           = 2
+};
+
+/**
+ * @brief Time print status values (how to print timestamps)
+ *
+ * @sa enum CFE_TIME_PrintState
+ */
+typedef uint8 CFE_TIME_PrintState_Enum_t;
+
 #endif /* CFE_TIME_EXTERN_TYPEDEFS_H */

--- a/modules/time/config/default_cfe_time_fcncodes.h
+++ b/modules/time/config/default_cfe_time_fcncodes.h
@@ -689,6 +689,28 @@
 **  \sa #CFE_TIME_SET_STATE_CC, #CFE_TIME_SET_SOURCE_CC
 */
 #define CFE_TIME_SET_SIGNAL_CC 15 /* set clock signal (pri vs red) */
+
+/** \cfetimecmd Set Print Format Options
+**
+**  \par Description
+**       This command sets the time print mode/format (used by EVS when sending
+**       to stdout, and by ES for syslog messages).
+**
+**  \cfecmdmnemonic \TIME_SETPRINT
+**
+**  \par Command Structure
+**       #CFE_TIME_SetPrintCmd_t
+**
+**  \par Command Verification
+**       Successful execution of this command may be verified by examining
+**       housekeeping output from the TIME module.
+**
+**  \par Criticality
+**       This command is non-critical, usually used in ground systems and
+**       doing ground tests.
+*/
+#define CFE_TIME_SET_PRINT_CC 16 /* set print format command */
+
 /** \} */
 
 #endif

--- a/modules/time/config/default_cfe_time_interface_cfg.h
+++ b/modules/time/config/default_cfe_time_interface_cfg.h
@@ -198,4 +198,17 @@
 */
 #define CFE_MISSION_TIME_FS_FACTOR 789004800
 
+/**
+ ** \brief On boot, define the time print type.
+ */
+#define CFE_TIME_PRINT_DEFAULT CFE_TIME_PrintState_DateTime
+
+/**
+ ** \brief On boot, the CFE_TIME_Print() function will use
+ ** the following strftime-like (+ microseconds) format
+ ** when "printing" times. (Only relevant if CFE_TIME_PRINT_DEFAULT
+ ** is set to CFE_TIME_PrintState_DateTime.)
+ */
+#define CFE_TIME_PRINTFMT_DEFAULT "%Y-%j %H:%M:%S.%f"
+
 #endif

--- a/modules/time/config/default_cfe_time_msgstruct.h
+++ b/modules/time/config/default_cfe_time_msgstruct.h
@@ -98,6 +98,24 @@ typedef struct CFE_TIME_SetStateCmd
 } CFE_TIME_SetStateCmd_t;
 
 /**
+ * \brief Payload for the command to set the time print format
+ */
+typedef struct CFE_TIME_SetPrintCmd_Payload
+{
+    CFE_TIME_PrintState_Enum_t PrintState;
+    char PrintFormat[CFE_TIME_FORMAT_SIZE];
+} CFE_TIME_SetPrintCmd_Payload_t;
+
+/**
+ * \brief Command to set the time print format
+ */
+typedef struct CFE_TIME_SetPrintCmd
+{
+    CFE_MSG_CommandHeader_t        CommandHeader; /**< \brief Command header */
+    CFE_TIME_SetPrintCmd_Payload_t Payload;
+} CFE_TIME_SetPrintCmd_t;
+
+/**
  * \brief Set time data source command payload
  */
 typedef struct CFE_TIME_SourceCmd_Payload
@@ -273,6 +291,9 @@ typedef struct CFE_TIME_HousekeepingTlm_Payload
     uint32 SubsecsDelay; /**< \cfetlmmnemonic \TIME_1HZDLYSSECS
                               \brief Current 1 Hz SCTF Delay (sub-seconds) */
 #endif
+
+    CFE_TIME_PrintState_Enum_t PrintState;
+    char PrintFormat[CFE_TIME_FORMAT_SIZE];
 } CFE_TIME_HousekeepingTlm_Payload_t;
 
 typedef struct CFE_TIME_HousekeepingTlm

--- a/modules/time/fsw/src/cfe_time_dispatch.c
+++ b/modules/time/fsw/src/cfe_time_dispatch.c
@@ -240,6 +240,13 @@ void CFE_TIME_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
                     }
                     break;
 
+                case CFE_TIME_SET_PRINT_CC:
+                    if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SetPrintCmd_t)))
+                    {
+                        CFE_TIME_SetPrintCmd((const CFE_TIME_SetPrintCmd_t *)SBBufPtr);
+                    }
+                    break;
+
                 default:
 
                     CFE_TIME_Global.CommandErrorCounter++;

--- a/modules/time/fsw/src/cfe_time_task.c
+++ b/modules/time/fsw/src/cfe_time_task.c
@@ -1090,3 +1090,16 @@ int32 CFE_TIME_Sub1HZAdjustmentCmd(const CFE_TIME_Sub1HZAdjustmentCmd_t *data)
     CFE_TIME_1HzAdjImpl(&data->Payload, CFE_TIME_AdjustDirection_SUBTRACT);
     return CFE_SUCCESS;
 }
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 CFE_TIME_SetPrintCmd(const CFE_TIME_SetPrintCmd_t *data)
+{
+    CFE_TIME_Global.PrintState = data->Payload.PrintState;
+    strncpy(CFE_TIME_Global.PrintFormat, data->Payload.PrintFormat, CFE_TIME_FORMAT_SIZE);
+    return CFE_SUCCESS;
+}

--- a/modules/time/fsw/src/cfe_time_utils.c
+++ b/modules/time/fsw/src/cfe_time_utils.c
@@ -353,6 +353,12 @@ void CFE_TIME_InitData(void)
     */
     CFE_MSG_Init(CFE_MSG_PTR(CFE_TIME_Global.Local1HzCmd.CommandHeader), CFE_SB_ValueToMsgId(CFE_TIME_1HZ_CMD_MID),
                  sizeof(CFE_TIME_Global.Local1HzCmd));
+
+    /*
+    ** Configure the default time print format.
+    */
+    CFE_TIME_Global.PrintState = CFE_TIME_PRINT_DEFAULT;
+    strncpy(CFE_TIME_Global.PrintFormat, CFE_TIME_PRINTFMT_DEFAULT, CFE_TIME_FORMAT_SIZE);
 }
 
 /*----------------------------------------------------------------
@@ -408,6 +414,9 @@ void CFE_TIME_GetHkData(const CFE_TIME_Reference_t *Reference)
     CFE_TIME_Global.HkPacket.Payload.SecondsDelay = Reference->AtToneDelay.Seconds;
     CFE_TIME_Global.HkPacket.Payload.SubsecsDelay = Reference->AtToneDelay.Subseconds;
 #endif
+
+    strncpy(CFE_TIME_Global.HkPacket.Payload.PrintFormat, CFE_TIME_Global.PrintFormat, CFE_TIME_FORMAT_SIZE);
+    CFE_TIME_Global.HkPacket.Payload.PrintState = CFE_TIME_Global.PrintState;
 }
 
 /*----------------------------------------------------------------

--- a/modules/time/fsw/src/cfe_time_utils.h
+++ b/modules/time/fsw/src/cfe_time_utils.h
@@ -312,6 +312,16 @@ typedef struct
     ** One callback per app is allowed
     */
     CFE_TIME_SynchCallbackRegEntry_t SynchCallback[CFE_PLATFORM_ES_MAX_APPLICATIONS];
+
+    /*
+    ** What form should CFE_TIME_Print produce.
+    */
+    CFE_TIME_PrintState_Enum_t PrintState;
+
+    /*
+    ** For formatted CFE_TIME_Print output, use this format string.
+    */
+    char PrintFormat[CFE_TIME_FORMAT_SIZE];
 } CFE_TIME_Global_t;
 
 /*
@@ -866,5 +876,11 @@ int32 CFE_TIME_Sub1HZAdjustmentCmd(const CFE_TIME_Sub1HZAdjustmentCmd_t *data);
  * This is a wrapper around CFE_TIME_AdjustImpl()
  */
 int32 CFE_TIME_SubAdjustCmd(const CFE_TIME_SubAdjustCmd_t *data);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief  Time task ground command (print format adjust)
+ */
+int32 CFE_TIME_SetPrintCmd(const CFE_TIME_SetPrintCmd_t *data);
 
 #endif /* CFE_TIME_UTILS_H */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [X] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [X] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Adds a CFE TIME command to configure how to print time information, mostly used by CFE_EVS to print to stdout, and CFE ES for writing to syslog.

**Testing performed**
Build and test using standard cFE coverage tests which have been updated to test different formats and error conditions.

**Expected behavior changes**
Enhances CFE_TIME_Print() function and allows for more concise and helpful timestamps.

**System(s) tested on**
Ubuntu 23 desktop VM.

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov