### PR TITLE
Fix #26, Add timestamp for SB messages which are missing it

### DIFF
--- a/modules/sb/eds/cfe_sb.xml
+++ b/modules/sb/eds/cfe_sb.xml
@@ -254,7 +254,7 @@
 
       <ContainerDataType name="StatsTlm_Payload" shortDescription="SB Statistics Telemetry Packet">
         <LongDescription>
-          SB Statistics packet sent (via CFE_SB_SendMsg) in response to #CFE_SB_SEND_SB_STATS_CC
+          SB Statistics packet sent (via CFE_SB_TransmitMsg) in response to #CFE_SB_SEND_SB_STATS_CC
         </LongDescription>
         <EntryList>
           <Entry name="MsgIdsInUse" type="BASE_TYPES/uint32" shortDescription="Current number of MsgIds with a destination">

--- a/modules/sb/fsw/src/cfe_sb_task.c
+++ b/modules/sb/fsw/src/cfe_sb_task.c
@@ -669,6 +669,7 @@ int32 CFE_SB_SendSubscriptionReport(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId
         SubRptMsg.Payload.Qos     = Quality;
         SubRptMsg.Payload.SubType = CFE_SB_SUBSCRIPTION;
 
+        CFE_SB_TimeStampMsg(CFE_MSG_PTR(SubRptMsg.TelemetryHeader));
         Status = CFE_SB_TransmitMsg(CFE_MSG_PTR(SubRptMsg.TelemetryHeader), true);
         CFE_EVS_SendEventWithAppID(CFE_SB_SUBSCRIPTION_RPT_EID, CFE_EVS_EventType_DEBUG, CFE_SB_Global.AppId,
                                    "Sending Subscription Report Msg=0x%x,Pipe=%lu,Stat=0x%x",
@@ -1111,6 +1112,7 @@ void CFE_SB_SendRouteSub(CFE_SBR_RouteId_t RouteId, void *ArgPtr)
             if (CFE_SB_Global.PrevSubMsg.Payload.Entries >= CFE_SB_SUB_ENTRIES_PER_PKT)
             {
                 CFE_SB_UnlockSharedData(__func__, __LINE__);
+                CFE_SB_TimeStampMsg(CFE_MSG_PTR(CFE_SB_Global.PrevSubMsg.TelemetryHeader));
                 status = CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_SB_Global.PrevSubMsg.TelemetryHeader), true);
                 CFE_EVS_SendEvent(CFE_SB_FULL_SUB_PKT_EID, CFE_EVS_EventType_DEBUG,
                                   "Full Sub Pkt %d Sent,Entries=%d,Stat=0x%x\n",
@@ -1160,6 +1162,7 @@ int32 CFE_SB_SendPrevSubsCmd(const CFE_SB_SendPrevSubsCmd_t *data)
     /* if pkt has any number of entries, send it as a partial pkt */
     if (CFE_SB_Global.PrevSubMsg.Payload.Entries > 0)
     {
+        CFE_SB_TimeStampMsg(CFE_MSG_PTR(CFE_SB_Global.PrevSubMsg.TelemetryHeader));
         status = CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_SB_Global.PrevSubMsg.TelemetryHeader), true);
         CFE_EVS_SendEvent(CFE_SB_PART_SUB_PKT_EID, CFE_EVS_EventType_DEBUG,
                           "Partial Sub Pkt %d Sent,Entries=%d,Stat=0x%x",


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #26
  - Adds timestamp for 3 messages that were sent without it
  - Also removes mention of deprecated function `CFE_SB_SendMsg()` in docs

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Messages will be stamped with updated time before being sent.

**Contributor Info**
Avi Weiss @thnkslprpt