### PR TITLE
Fix #2375, Use `size_t` for variables/parameters representing size

### DIFF
--- a/modules/cfe_testcase/src/tbl_content_mang_test.c
+++ b/modules/cfe_testcase/src/tbl_content_mang_test.c
@@ -279,8 +279,8 @@ void TblTest_GenerateTblFiles(void)
 {
     osal_id_t fh1 = OS_OBJECT_ID_UNDEFINED;
     osal_id_t fh2 = OS_OBJECT_ID_UNDEFINED;
-    uint32    PartialOffset;
-    uint32    PartialSize;
+    size_t    PartialOffset;
+    size_t    PartialSize;
     union
     {
         uint8              u8;

--- a/modules/core_api/ut-stubs/src/cfe_sb_handlers.c
+++ b/modules/core_api/ut-stubs/src/cfe_sb_handlers.c
@@ -39,8 +39,8 @@
 typedef struct
 {
     CFE_SB_MsgId_t     MsgId;
-    uint32             UserLength;
-    uint32             TotalLength;
+    size_t             UserLength;
+    size_t             TotalLength;
     uint16             CommandCode;
     CFE_TIME_SysTime_t TimeStamp;
 } CFE_SB_StubMsg_MetaData_t;
@@ -343,7 +343,7 @@ void UT_DefaultHandler_CFE_SB_GetUserData(void *UserObj, UT_EntryKey_t FuncKey, 
     CFE_MSG_Message_t *MsgPtr = UT_Hook_GetArgValueByName(Context, "MsgPtr", CFE_MSG_Message_t *);
     uint8 *            BytePtr;
     void *             Result;
-    uint16             HdrSize;
+    size_t             HdrSize;
 
     if (UT_Stub_CopyToLocal(UT_KEY(CFE_SB_GetUserData), &Result, sizeof(Result)) != sizeof(Result))
     {

--- a/modules/core_private/ut-stubs/inc/ut_support.h
+++ b/modules/core_private/ut-stubs/inc/ut_support.h
@@ -102,7 +102,7 @@ typedef struct
 {
     CFE_SB_MsgId_t MsgId;
     uint16         SnapshotOffset;
-    uint16         SnapshotSize;
+    size_t         SnapshotSize;
     uint16         Count;
     void *         SnapshotBuffer;
 } UT_SoftwareBusSnapshot_Entry_t;
@@ -333,7 +333,7 @@ void UT_SetStatusBSPResetArea(int32 status, uint32 Signature, uint32 ClockSignal
 **        This function does not return a value.
 **
 ******************************************************************************/
-void UT_SetReadBuffer(void *Buff, int NumBytes);
+void UT_SetReadBuffer(void *Buff, size_t NumBytes);
 
 /*****************************************************************************/
 /**
@@ -353,7 +353,7 @@ void UT_SetReadBuffer(void *Buff, int NumBytes);
 **        This function does not return a value.
 **
 ******************************************************************************/
-void UT_SetReadHeader(void *Hdr, int NumBytes);
+void UT_SetReadHeader(void *Hdr, size_t NumBytes);
 
 /*****************************************************************************/
 /**
@@ -393,7 +393,7 @@ void UT_SetDummyFuncRtn(int Return);
 ** \sa
 **
 ******************************************************************************/
-void UT_SetSizeofESResetArea(int32 Size);
+void UT_SetSizeofESResetArea(size_t Size);
 
 /*****************************************************************************/
 /**
@@ -411,7 +411,7 @@ void UT_SetSizeofESResetArea(int32 Size);
 **        This function does not return a value.
 **
 ******************************************************************************/
-uint8 *UT_SetCDSSize(int32 Size);
+uint8 *UT_SetCDSSize(size_t Size);
 
 /*****************************************************************************/
 /**

--- a/modules/core_private/ut-stubs/src/ut_support.c
+++ b/modules/core_private/ut-stubs/src/ut_support.c
@@ -43,7 +43,7 @@ uint8 UT_Endianess;
 static char           UT_appname[80];
 static char           UT_subsys[5];
 static CFE_ES_AppId_t UT_AppID;
-static uint32         UT_LastCDSSize = 0;
+static size_t         UT_LastCDSSize = 0;
 
 typedef union
 {
@@ -310,7 +310,7 @@ void UT_SetStatusBSPResetArea(int32 status, uint32 Signature, uint32 ClockSignal
 /*
 ** Set the contents of the buffer to read
 */
-void UT_SetReadBuffer(void *Buff, int NumBytes)
+void UT_SetReadBuffer(void *Buff, size_t NumBytes)
 {
     UT_SetDataBuffer(UT_KEY(OS_read), Buff, NumBytes, true);
 }
@@ -318,7 +318,7 @@ void UT_SetReadBuffer(void *Buff, int NumBytes)
 /*
 ** Set the contents of the header to read
 */
-void UT_SetReadHeader(void *Hdr, int NumBytes)
+void UT_SetReadHeader(void *Hdr, size_t NumBytes)
 {
     UT_SetDataBuffer(UT_KEY(CFE_FS_ReadHeader), Hdr, NumBytes, true);
 }
@@ -334,7 +334,7 @@ void UT_SetDummyFuncRtn(int Return)
 /*
 ** Set the size of the ES reset area
 */
-void UT_SetSizeofESResetArea(int32 Size)
+void UT_SetSizeofESResetArea(size_t Size)
 {
     UT_ResetState(UT_KEY(CFE_PSP_GetResetArea));
     if (Size > 0)
@@ -351,12 +351,12 @@ void UT_SetSizeofESResetArea(int32 Size)
 /*
 ** Set the CDS size returned by the BSP
 */
-uint8 *UT_SetCDSSize(int32 Size)
+uint8 *UT_SetCDSSize(size_t Size)
 {
     UT_ResetState(UT_KEY(CFE_PSP_GetCDSSize));
     UT_ResetState(UT_KEY(CFE_PSP_ReadFromCDS));
     UT_ResetState(UT_KEY(CFE_PSP_WriteToCDS));
-    if (Size <= 0)
+    if (Size == 0)
     {
         UT_LastCDSSize = 0;
         return NULL;
@@ -507,7 +507,7 @@ CFE_ES_ResetData_t *UT_GetResetDataPtr(void)
 ** But on the upside this concession avoids a far more complicated issue of
 ** needing a fully-fledged implementation of printf in the OS_printf stub.
 */
-static int UT_StrCmpFormatStr(const char *FormatStr, const char *TestStr, uint32 FormatLength, uint32 TestLength)
+static int UT_StrCmpFormatStr(const char *FormatStr, const char *TestStr, size_t FormatLength, size_t TestLength)
 {
     const char *ChunkStart;
     const char *ChunkEnd;
@@ -607,13 +607,13 @@ static int UT_StrCmpFormatStr(const char *FormatStr, const char *TestStr, uint32
  * A string comparison function that will match exact strings only
  * (Printf style conversion strings are compared literally)
  */
-static int UT_StrCmpExact(const char *RefStr, const char *TestStr, uint32 RefLength, uint32 TestLength)
+static int UT_StrCmpExact(const char *RefStr, const char *TestStr, size_t RefLength, size_t TestLength)
 {
     return (RefLength == TestLength && memcmp(RefStr, TestStr, RefLength) == 0);
 }
 
 static uint32 UT_GetMessageCount(const char *Msg, UT_Buffer_t *Buf,
-                                 int (*Comparator)(const char *, const char *, uint32, uint32))
+                                 int (*Comparator)(const char *, const char *, size_t, size_t))
 {
     uint32 Count  = 0;
     uint32 MsgLen = strlen(Msg);

--- a/modules/es/fsw/src/cfe_es_apps.c
+++ b/modules/es/fsw/src/cfe_es_apps.c
@@ -75,7 +75,7 @@ void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath)
     const char *TokenList[CFE_ES_STARTSCRIPT_MAX_TOKENS_PER_LINE];
     uint32      NumTokens;
     uint32      NumLines;
-    uint32      BuffLen; /* Length of the current buffer */
+    size_t      BuffLen; /* Length of the current buffer */
     osal_id_t   AppFile = OS_OBJECT_ID_UNDEFINED;
     int32       Status;
     int32       OsStatus;

--- a/modules/es/fsw/src/cfe_es_start.h
+++ b/modules/es/fsw/src/cfe_es_start.h
@@ -71,7 +71,7 @@ typedef struct
     char                  ObjectName[OS_MAX_API_NAME]; /* task or OS object name */
     CFE_ES_FuncPtrUnion_t FuncPtrUnion;                /* task or function reference */
     uint32                ObjectPriority;              /* object priority */
-    uint32                ObjectSize;                  /* size used for stack, queue size, etc. */
+    size_t                ObjectSize;                  /* size used for stack, queue size, etc. */
     uint32                ObjectFlags;                 /* extra flags to pass */
 } CFE_ES_ObjectTable_t;
 

--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -951,7 +951,7 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAllCmd_t *data)
     osal_id_t                           FileDescriptor = OS_OBJECT_ID_UNDEFINED;
     uint32                              i;
     uint32                              EntryCount = 0;
-    uint32                              FileSize   = 0;
+    size_t                              FileSize   = 0;
     int32                               OsStatus;
     int32                               Result;
     CFE_ES_AppInfo_t                    AppInfo;
@@ -1088,8 +1088,8 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAllCmd_t *data)
         OS_close(FileDescriptor);
         CFE_ES_Global.TaskData.CommandCounter++;
         CFE_EVS_SendEvent(CFE_ES_ALL_APPS_EID, CFE_EVS_EventType_DEBUG,
-                          "App Info file written to %s, Entries=%d, FileSize=%d", QueryAllFilename, (int)EntryCount,
-                          (int)FileSize);
+                          "App Info file written to %s, Entries=%d, FileSize=%lu", QueryAllFilename, (int)EntryCount,
+                          (unsigned long)FileSize);
     }
     else
     {
@@ -1111,7 +1111,7 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasksCmd_t *data)
     osal_id_t                           FileDescriptor = OS_OBJECT_ID_UNDEFINED;
     uint32                              i;
     uint32                              EntryCount = 0;
-    uint32                              FileSize   = 0;
+    size_t                              FileSize   = 0;
     int32                               OsStatus;
     int32                               Result;
     CFE_ES_TaskInfo_t                   TaskInfo;
@@ -1240,8 +1240,8 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasksCmd_t *data)
         OS_close(FileDescriptor);
         CFE_ES_Global.TaskData.CommandCounter++;
         CFE_EVS_SendEvent(CFE_ES_TASKINFO_EID, CFE_EVS_EventType_DEBUG,
-                          "Task Info file written to %s, Entries=%d, FileSize=%d", QueryAllFilename, (int)EntryCount,
-                          (int)FileSize);
+                          "Task Info file written to %s, Entries=%d, FileSize=%lu", QueryAllFilename, (int)EntryCount,
+                          (unsigned long)FileSize);
     }
     else
     {

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -460,7 +460,7 @@ void ES_UT_SetupMemPoolId(CFE_ES_MemPoolRecord_t **OutPoolRecPtr)
     }
 }
 
-void ES_UT_SetupCDSGlobal(uint32 CDS_Size)
+void ES_UT_SetupCDSGlobal(size_t CDS_Size)
 {
     CFE_ES_CDS_Instance_t *CDS = &CFE_ES_Global.CDSVars;
 
@@ -1135,7 +1135,7 @@ static void ES_UT_Config_IterateAll(void *UserObj, UT_EntryKey_t FuncKey, const 
 
 void TestApps(void)
 {
-    int                     NumBytes;
+    size_t                  NumBytes;
     CFE_ES_AppInfo_t        AppInfo;
     CFE_ES_AppId_t          AppId;
     CFE_ES_TaskId_t         TaskId;
@@ -3935,7 +3935,7 @@ void TestAPI(void)
     osal_id_t            TestObjId;
     char                 AppName[OS_MAX_API_NAME + 12];
     char                 SysLogBuf[CFE_TIME_PRINTED_STRING_SIZE + 20];
-    uint32               SysLogBufSize;
+    size_t               SysLogBufSize;
     uint32               StackBuf[8];
     uint8                Data[12];
     uint32               ResetType;
@@ -4678,7 +4678,7 @@ void TestCDS()
     CFE_ES_CDSHandle_t   CDSHandle;
     CFE_ES_CDS_RegRec_t *UtCDSRegRecPtr;
     uint32               i;
-    uint32               TempSize;
+    size_t               TempSize;
     uint8                BlockData[ES_UT_CDS_BLOCK_SIZE];
 
     UtPrintf("Begin Test CDS");

--- a/modules/evs/ut-coverage/evs_UT.c
+++ b/modules/evs/ut-coverage/evs_UT.c
@@ -155,7 +155,7 @@ static int32 UT_EVS_MSGInitHook(void *UserObj, int32 StubRetcode, uint32 CallCou
     return StubRetcode;
 }
 
-static void UT_EVS_DoDispatchCheckEvents_Impl(void *MsgPtr, uint32 MsgSize, UT_TaskPipeDispatchId_t DispatchId,
+static void UT_EVS_DoDispatchCheckEvents_Impl(void *MsgPtr, size_t MsgSize, UT_TaskPipeDispatchId_t DispatchId,
                                               const UT_SoftwareBusSnapshot_Entry_t *SnapshotCfg,
                                               UT_EVS_EventCapture_t *               EventCapture)
 {
@@ -172,13 +172,13 @@ static void UT_EVS_DoDispatchCheckEvents_Impl(void *MsgPtr, uint32 MsgSize, UT_T
     UT_SetHookFunction(UT_KEY(CFE_SB_TransmitMsg), NULL, NULL);
 }
 
-static void UT_EVS_DoDispatchCheckEvents(void *MsgPtr, uint32 MsgSize, UT_TaskPipeDispatchId_t DispatchId,
+static void UT_EVS_DoDispatchCheckEvents(void *MsgPtr, size_t MsgSize, UT_TaskPipeDispatchId_t DispatchId,
                                          UT_EVS_EventCapture_t *EventCapture)
 {
     UT_EVS_DoDispatchCheckEvents_Impl(MsgPtr, MsgSize, DispatchId, &UT_EVS_LONGFMT_SNAPSHOTDATA, EventCapture);
 }
 
-static void UT_EVS_DoDispatchCheckEventsShort(void *MsgPtr, uint32 MsgSize, UT_TaskPipeDispatchId_t DispatchId,
+static void UT_EVS_DoDispatchCheckEventsShort(void *MsgPtr, size_t MsgSize, UT_TaskPipeDispatchId_t DispatchId,
                                               UT_EVS_EventCapture_t *EventCapture)
 {
     UT_EVS_DoDispatchCheckEvents_Impl(MsgPtr, MsgSize, DispatchId, &UT_EVS_SHORTFMT_SNAPSHOTDATA, EventCapture);

--- a/modules/sb/fsw/src/cfe_sb_task.c
+++ b/modules/sb/fsw/src/cfe_sb_task.c
@@ -43,7 +43,7 @@ typedef struct
 {
     const char *Filename;   /* File name for error reporting */
     osal_id_t   Fd;         /* File id for writing */
-    uint32      FileSize;   /* File size for reporting */
+    size_t      FileSize;   /* File size for reporting */
     uint32      EntryCount; /* Entry count for reporting */
     int32       Status;     /* File write status */
 } CFE_SB_FileWriteCallback_t;

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -3202,7 +3202,7 @@ void Test_TransmitMsg_GetPoolBufErr(void)
 */
 void Test_AllocateMessageBuffer(void)
 {
-    uint16 MsgSize = 10;
+    size_t MsgSize = 10;
     uint32 MemUse;
 
     /* Attempt to allocate a message buffer greater than the max size */
@@ -3394,7 +3394,7 @@ void Test_ReleaseMessageBuffer(void)
     CFE_SB_Buffer_t *ZeroCpyMsgPtr2 = NULL;
     CFE_SB_Buffer_t *ZeroCpyMsgPtr3 = NULL;
     CFE_SB_BufferD_t BadBufferDesc;
-    uint16           MsgSize = 10;
+    size_t           MsgSize = 10;
 
     ZeroCpyMsgPtr1 = CFE_SB_AllocateMessageBuffer(MsgSize);
     ZeroCpyMsgPtr2 = CFE_SB_AllocateMessageBuffer(MsgSize);

--- a/modules/tbl/ut-coverage/tbl_UT.c
+++ b/modules/tbl/ut-coverage/tbl_UT.c
@@ -603,7 +603,7 @@ void Test_CFE_TBL_ActivateCmd(void)
 */
 void Test_CFE_TBL_DumpToFile(void)
 {
-    uint32 TblSizeInBytes = 9;
+    size_t TblSizeInBytes = 9;
 
     UtPrintf("Begin Test Dump to File");
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2375
  - Updated size variables/parameters to `size_t` where appropriate

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Some signed variables changed to unsigned but it would have been illogical/impossible to input negative values in those cases.

**Contributor Info**
Avi Weiss @thnkslprpt