### PR TITLE
Fix #1930, add code coverage for null check

### DIFF
--- a/modules/es/fsw/src/cfe_es_generic_pool.h
+++ b/modules/es/fsw/src/cfe_es_generic_pool.h
@@ -160,6 +160,39 @@ int32 CFE_ES_GenPoolGetBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, size_t *BlockOf
 
 /*---------------------------------------------------------------------------------------*/
 /**
+ * \brief Create a new block of the given size.
+ *
+ * \note Internal helper routine only, not part of API.
+ *
+ * \param[inout] PoolRecPtr      Pointer to pool structure
+ * \param[in]    BucketId        Bucket ID
+ * \param[in]    NewSize         Size of block
+ * \param[out]   BlockOffsetPtr  Location to output new block offset 
+ *
+ * \return #CFE_SUCCESS, or error code #CFE_ES_BUFFER_NOT_IN_POOL #CFE_ES_ERR_MEM_BLOCK_SIZE
+ *         \ref CFEReturnCodes
+ */
+int32 CFE_ES_GenPoolCreatePoolBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 BucketId, size_t NewSize, 
+                                    size_t *BlockOffsetPtr);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * \brief Find and re-allocate a previously returned block
+ *
+ * \note Internal helper routine only, not part of API.
+ *
+ * \param[inout] PoolRecPtr      Pointer to pool structure
+ * \param[in]    BucketId        Bucket ID
+ * \param[in]    NewSize         Size of block
+ * \param[out]   BlockOffsetPtr  Location to output new block offset 
+ *
+ * \return #CFE_SUCCESS, or error code #CFE_ES_BUFFER_NOT_IN_POOL \ref CFEReturnCodes
+ */
+int32 CFE_ES_GenPoolRecyclePoolBlock(CFE_ES_GenPoolRecord_t *PoolRecPtr, uint16 BucketId, size_t NewSize,
+                                     size_t *BlockOffsetPtr);
+
+/*---------------------------------------------------------------------------------------*/
+/**
  * \brief Returns a block to the pool
  *
  * This marks the previously allocated block as deallocated,

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -2457,6 +2457,16 @@ void TestGenericPool(void)
     /* Reset the structure so it will rebuild */
     Pool1.TailPosition = 0;
     CFE_UtAssert_SUCCESS(CFE_ES_GenPoolRebuild(&Pool1));
+
+    /* Branch coverage for no buffer in pool */
+    ES_ResetUnitTest();
+    UtAssert_INT32_EQ(CFE_ES_GenPoolCreatePoolBlock(&Pool1, 0, Pool1.Buckets[0].BlockSize, &Offset1),
+                      CFE_ES_BUFFER_NOT_IN_POOL);
+
+    ES_ResetUnitTest();
+    UtAssert_INT32_EQ(CFE_ES_GenPoolRecyclePoolBlock(&Pool1, 0, Pool1.Buckets[0].BlockSize, &Offset1),
+                      CFE_ES_BUFFER_NOT_IN_POOL);
+
 }
 
 void TestTask(void)


### PR DESCRIPTION

**Checklist (Please check before submitting)**

* [ x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [ x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

Fix #1930 update code coverage test for CFE_ES_GenPoolRecyclePoolBlock and CFE_ES_GenPoolCreatePoolBlock for null pointer check.

**Testing performed**
Steps taken to test the contribution:
1. Build SIMULATION=native ENABLE_UNIT_TESTS=true prep
2. make
3. make test
4. make lcov

**Expected behavior changes**
No impact on behavior

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
 - Note CLAs apply to only software contributions.

Anh Van, GSFC
