### PR TITLE
Fix #2378, refactor SB to support additional use cases

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -104,8 +104,8 @@ jobs:
 
       - name: Confirm Minimum Coverage
         run: |
-          missed_branches=50
-          missed_lines=17
+          missed_branches=39
+          missed_lines=19
           branch_nums=$(grep -A 3 "Overall coverage rate" lcov_out.txt | grep branches | grep -oP "[0-9]+[0-9]*")
           line_nums=$(grep -A 3 "Overall coverage rate" lcov_out.txt | grep lines | grep -oP "[0-9]+[0-9]*")
 

--- a/modules/sb/fsw/src/cfe_sb_buf.c
+++ b/modules/sb/fsw/src/cfe_sb_buf.c
@@ -128,7 +128,6 @@ CFE_SB_BufferD_t *CFE_SB_GetBufferFromPool(size_t MaxMsgSize)
     bd = (CFE_SB_BufferD_t *)addr;
     memset(bd, 0, CFE_SB_BUFFERD_CONTENT_OFFSET);
 
-    bd->MsgId         = CFE_SB_INVALID_MSG_ID;
     bd->UseCount      = 1;
     bd->AllocatedSize = AllocSize;
 

--- a/modules/sb/fsw/src/cfe_sb_priv.c
+++ b/modules/sb/fsw/src/cfe_sb_priv.c
@@ -291,9 +291,14 @@ char *CFE_SB_GetAppTskName(CFE_ES_TaskId_t TaskId, char *FullName)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-uint32 CFE_SB_RequestToSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit)
+uint32 CFE_SB_RequestToSendEvent(CFE_ES_TaskId_t TaskId, int32 Bit)
 {
     uint32 Indx;
+
+    if (Bit < 0)
+    {
+        return CFE_SB_GRANTED;
+    }
 
     if (CFE_ES_TaskID_ToIndex(TaskId, &Indx) != CFE_SUCCESS)
     {
@@ -318,9 +323,14 @@ uint32 CFE_SB_RequestToSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-void CFE_SB_FinishSendEvent(CFE_ES_TaskId_t TaskId, uint32 Bit)
+void CFE_SB_FinishSendEvent(CFE_ES_TaskId_t TaskId, int32 Bit)
 {
     uint32 Indx;
+
+    if (Bit < 0)
+    {
+        return;
+    }
 
     if (CFE_ES_TaskID_ToIndex(TaskId, &Indx) != CFE_SUCCESS)
     {
@@ -469,4 +479,1050 @@ int32 CFE_SB_ZeroCopyReleaseAppId(CFE_ES_AppId_t AppId)
     }
 
     return CFE_SUCCESS;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 CFE_SB_ZeroCopyBufferValidate(CFE_SB_Buffer_t *BufPtr, CFE_SB_BufferD_t **BufDscPtr)
+{
+    cpuaddr BufDscAddr;
+
+    /*
+     * Calculate descriptor pointer from buffer pointer -
+     * The buffer is just a member (offset) in the descriptor
+     */
+    BufDscAddr = (cpuaddr)BufPtr - offsetof(CFE_SB_BufferD_t, Content);
+    *BufDscPtr = (CFE_SB_BufferD_t *)BufDscAddr;
+
+    /*
+     * Check that the descriptor is actually a "zero copy" type,
+     */
+    if (!CFE_RESOURCEID_TEST_DEFINED((*BufDscPtr)->AppId))
+    {
+        return CFE_SB_BUFFER_INVALID;
+    }
+
+    /* Basic sanity check passed */
+    return CFE_SUCCESS;
+}
+
+/******************************************************************
+ *
+ * MESSAGE TRANSACTION IMPLEMENTATION FUNCTIONS
+ *
+ ******************************************************************/
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void CFE_SB_MessageTxn_Init(CFE_SB_MessageTxn_State_t *TxnPtr, CFE_SB_PipeSetEntry_t *PipeSet, uint16 MaxPipes,
+                            const void *RefMemPtr)
+{
+    memset(TxnPtr, 0, offsetof(CFE_SB_TransmitTxn_State_t, DestSet));
+    TxnPtr->PipeSet  = PipeSet;
+    TxnPtr->MaxPipes = MaxPipes;
+
+    /* The reference pointer is kept just for (potential) reporting in events, etc.
+     * It is not dereferenced from here. */
+    TxnPtr->RefMemPtr = RefMemPtr;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function
+ * Not invoked outside of this unit
+ *
+ *-----------------------------------------------------------------*/
+void CFE_SB_MessageTxn_SetTimeout(CFE_SB_MessageTxn_State_t *TxnPtr, int32 Timeout)
+{
+    TxnPtr->UserTimeoutParam = Timeout;
+    if (Timeout > 0)
+    {
+        /* Convert to an absolute timeout */
+        TxnPtr->TimeoutMode = CFE_SB_MessageTxn_TimeoutMode_TIMED;
+        CFE_PSP_GetTime(&TxnPtr->AbsTimeout);
+        TxnPtr->AbsTimeout = OS_TimeAdd(TxnPtr->AbsTimeout, OS_TimeFromTotalMilliseconds(Timeout));
+    }
+    else if (Timeout == CFE_SB_POLL)
+    {
+        TxnPtr->TimeoutMode = CFE_SB_MessageTxn_TimeoutMode_POLL;
+    }
+    else if (Timeout == CFE_SB_PEND_FOREVER)
+    {
+        TxnPtr->TimeoutMode = CFE_SB_MessageTxn_TimeoutMode_PEND;
+    }
+    else
+    {
+        CFE_SB_MessageTxn_SetEventAndStatus(TxnPtr, CFE_SB_RCV_BAD_ARG_EID, CFE_SB_BAD_ARGUMENT);
+    }
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function
+ * Not invoked outside of this unit
+ *
+ *-----------------------------------------------------------------*/
+void CFE_SB_MessageTxn_GetEventDetails(const CFE_SB_MessageTxn_State_t *TxnPtr, const CFE_SB_PipeSetEntry_t *ContextPtr,
+                                       uint16 EventId, CFE_ES_TaskId_t TskId, char *EvtMsg, size_t EvtMsgSize,
+                                       CFE_EVS_EventType_Enum_t *EventType, int32 *ReqBit)
+{
+    char  FullName[(OS_MAX_API_NAME * 2)];
+    char  PipeName[OS_MAX_API_NAME];
+    int32 LocalOsStatus;
+
+    if (ContextPtr == NULL)
+    {
+        LocalOsStatus = INT32_MIN; /* should not be used; do not alias any actual OS status */
+    }
+    else
+    {
+        LocalOsStatus = ContextPtr->OsStatus;
+        if (ContextPtr->PendingEventId == CFE_SB_BAD_PIPEID_EID)
+        {
+            /* do not attempt to map to a pipe name if reporting a bad pipeID event - use its ID */
+            snprintf(PipeName, sizeof(PipeName), "%lu", CFE_RESOURCEID_TO_ULONG(ContextPtr->PipeId));
+        }
+        else
+        {
+            CFE_SB_GetPipeName(PipeName, sizeof(PipeName), ContextPtr->PipeId);
+        }
+    }
+
+    switch (EventId)
+    {
+        case CFE_SB_SEND_BAD_ARG_EID:
+            *ReqBit    = CFE_SB_SEND_BAD_ARG_EID_BIT;
+            *EventType = CFE_EVS_EventType_ERROR;
+
+            snprintf(EvtMsg, EvtMsgSize, "Send Err:Bad input argument,Arg 0x%lx,App %s",
+                     (unsigned long)TxnPtr->RefMemPtr, CFE_SB_GetAppTskName(TskId, FullName));
+            break;
+
+        case CFE_SB_SEND_INV_MSGID_EID:
+            *ReqBit    = CFE_SB_SEND_INV_MSGID_EID_BIT;
+            *EventType = CFE_EVS_EventType_ERROR;
+
+            snprintf(EvtMsg, EvtMsgSize, "Send Err:Invalid MsgId(0x%x)in msg,App %s",
+                     (unsigned int)CFE_SB_MsgIdToValue(TxnPtr->RoutingMsgId), CFE_SB_GetAppTskName(TskId, FullName));
+            break;
+
+        case CFE_SB_MSG_TOO_BIG_EID:
+            *ReqBit    = CFE_SB_MSG_TOO_BIG_EID_BIT;
+            *EventType = CFE_EVS_EventType_ERROR;
+
+            snprintf(EvtMsg, EvtMsgSize, "Send Err:Msg Too Big MsgId=0x%x,app=%s,size=%d,MaxSz=%d",
+                     (unsigned int)CFE_SB_MsgIdToValue(TxnPtr->RoutingMsgId), CFE_SB_GetAppTskName(TskId, FullName),
+                     (int)TxnPtr->ContentSize, CFE_MISSION_SB_MAX_SB_MSG_SIZE);
+            break;
+
+        case CFE_SB_SEND_NO_SUBS_EID:
+            *ReqBit    = CFE_SB_SEND_NO_SUBS_EID_BIT;
+            *EventType = CFE_EVS_EventType_INFORMATION;
+
+            snprintf(EvtMsg, EvtMsgSize, "No subscribers for MsgId 0x%x,sender %s",
+                     (unsigned int)CFE_SB_MsgIdToValue(TxnPtr->RoutingMsgId), CFE_SB_GetAppTskName(TskId, FullName));
+            break;
+
+        case CFE_SB_GET_BUF_ERR_EID:
+            *ReqBit    = CFE_SB_GET_BUF_ERR_EID_BIT;
+            *EventType = CFE_EVS_EventType_ERROR;
+
+            snprintf(EvtMsg, EvtMsgSize, "Send Err:Request for Buffer Failed. MsgId 0x%x,app %s,size %d",
+                     (unsigned int)CFE_SB_MsgIdToValue(TxnPtr->RoutingMsgId), CFE_SB_GetAppTskName(TskId, FullName),
+                     (int)TxnPtr->ContentSize);
+            break;
+
+        case CFE_SB_MSGID_LIM_ERR_EID:
+            *ReqBit    = CFE_SB_MSGID_LIM_ERR_EID_BIT;
+            *EventType = CFE_EVS_EventType_ERROR;
+
+            snprintf(EvtMsg, EvtMsgSize, "Msg Limit Err,MsgId 0x%x,pipe %s,sender %s",
+                     (unsigned int)CFE_SB_MsgIdToValue(TxnPtr->RoutingMsgId), PipeName,
+                     CFE_SB_GetAppTskName(TskId, FullName));
+            break;
+
+        case CFE_SB_Q_FULL_ERR_EID:
+            *ReqBit    = CFE_SB_Q_FULL_ERR_EID_BIT;
+            *EventType = CFE_EVS_EventType_ERROR;
+
+            snprintf(EvtMsg, EvtMsgSize, "Pipe Overflow,MsgId 0x%x,pipe %s,sender %s",
+                     (unsigned int)CFE_SB_MsgIdToValue(TxnPtr->RoutingMsgId), PipeName,
+                     CFE_SB_GetAppTskName(TskId, FullName));
+            break;
+
+        case CFE_SB_Q_WR_ERR_EID:
+            *ReqBit    = CFE_SB_Q_WR_ERR_EID_BIT;
+            *EventType = CFE_EVS_EventType_ERROR;
+
+            snprintf(EvtMsg, EvtMsgSize, "Pipe Write Err,MsgId 0x%x,pipe %s,sender %s,stat %ld",
+                     (unsigned int)CFE_SB_MsgIdToValue(TxnPtr->RoutingMsgId), PipeName,
+                     CFE_SB_GetAppTskName(TskId, FullName), (long)LocalOsStatus);
+            break;
+
+        case CFE_SB_Q_RD_ERR_EID:
+            *ReqBit    = -1;
+            *EventType = CFE_EVS_EventType_ERROR;
+
+            snprintf(EvtMsg, EvtMsgSize, "Pipe Read Err,pipe %s,app %s,stat %ld", PipeName,
+                     CFE_SB_GetAppTskName(TskId, FullName), (long)LocalOsStatus);
+            break;
+        case CFE_SB_RCV_BAD_ARG_EID:
+            *ReqBit    = -1;
+            *EventType = CFE_EVS_EventType_ERROR;
+
+            snprintf(EvtMsg, EvtMsgSize, "Rcv Err:Bad Input Arg:BufPtr 0x%lx,pipe %s,t/o %d,app %s",
+                     (unsigned long)TxnPtr->RefMemPtr, PipeName, (int)TxnPtr->UserTimeoutParam,
+                     CFE_SB_GetAppTskName(TskId, FullName));
+            break;
+        case CFE_SB_BAD_PIPEID_EID:
+            *ReqBit    = -1;
+            *EventType = CFE_EVS_EventType_ERROR;
+
+            snprintf(EvtMsg, EvtMsgSize, "Rcv Err:PipeId %s does not exist,app %s", PipeName,
+                     CFE_SB_GetAppTskName(TskId, FullName));
+            break;
+
+        default:
+            EvtMsg[0]  = 0;
+            *ReqBit    = 0;
+            *EventType = 0;
+            break;
+    }
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function
+ * Not invoked outside of this unit
+ *
+ *-----------------------------------------------------------------*/
+bool CFE_SB_MessageTxn_ReportSingleEvent(const CFE_SB_MessageTxn_State_t *TxnPtr,
+                                         const CFE_SB_PipeSetEntry_t *ContextPtr, uint16 EventId)
+{
+    CFE_ES_TaskId_t          TskId;
+    CFE_EVS_EventType_Enum_t EventType;
+    char                     Message[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH];
+    int32                    ReqBit;
+
+    /* get task id for events and Sender Info*/
+    CFE_ES_GetTaskID(&TskId);
+
+    CFE_SB_MessageTxn_GetEventDetails(TxnPtr, ContextPtr, EventId, TskId, Message, sizeof(Message), &EventType,
+                                      &ReqBit);
+
+    if (EventType > 0 && CFE_SB_RequestToSendEvent(TskId, ReqBit) == CFE_SB_GRANTED)
+    {
+        CFE_EVS_SendEventWithAppID(EventId, EventType, CFE_SB_Global.AppId, "%s", Message);
+
+        /* clear the bit so the task may send this event again */
+        CFE_SB_FinishSendEvent(TskId, ReqBit);
+    }
+
+    /* If the event type was an error, this should increment the general error counter */
+    return (EventType >= CFE_EVS_EventType_ERROR);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void CFE_SB_MessageTxn_ReportEvents(const CFE_SB_MessageTxn_State_t *TxnPtr)
+{
+    uint32 i;
+    uint32 NumErrors;
+    bool   IsError;
+
+    NumErrors = 0;
+
+    if (TxnPtr->TransactionEventId != 0)
+    {
+        IsError = CFE_SB_MessageTxn_ReportSingleEvent(TxnPtr, NULL, TxnPtr->TransactionEventId);
+        if (IsError)
+        {
+            ++NumErrors;
+        }
+    }
+
+    for (i = 0; i < TxnPtr->NumPipes; ++i)
+    {
+        if (TxnPtr->PipeSet[i].PendingEventId != 0)
+        {
+            IsError =
+                CFE_SB_MessageTxn_ReportSingleEvent(TxnPtr, &TxnPtr->PipeSet[i], TxnPtr->PipeSet[i].PendingEventId);
+            if (IsError)
+            {
+                ++NumErrors;
+            }
+        }
+    }
+
+    if (NumErrors > 0)
+    {
+        /*
+         * Increment the error only if there was a real error,
+         * such as a validation issue or failure to allocate a buffer.
+         *
+         * Note that transmit side just has one error counter, whereas
+         * receive side has two - these differeniate between a bad passed-in
+         * arg vs some other internal error such as queue access.
+         */
+        CFE_SB_LockSharedData(__func__, __LINE__);
+
+        if (TxnPtr->IsTransmit)
+        {
+            CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter++;
+        }
+        else if (TxnPtr->Status == CFE_SB_BAD_ARGUMENT)
+        {
+            ++CFE_SB_Global.HKTlmMsg.Payload.MsgReceiveErrorCounter;
+        }
+        else
+        {
+            /* For any other unexpected error (e.g. CFE_SB_Q_RD_ERR_EID) */
+            ++CFE_SB_Global.HKTlmMsg.Payload.InternalErrorCounter;
+        }
+
+        CFE_SB_UnlockSharedData(__func__, __LINE__);
+    }
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void CFE_SB_MessageTxn_SetEventAndStatus(CFE_SB_MessageTxn_State_t *TxnPtr, uint16 EventId, CFE_Status_t Status)
+{
+    if (TxnPtr->TransactionEventId == 0)
+    {
+        TxnPtr->TransactionEventId = EventId;
+    }
+    if (TxnPtr->Status == CFE_SUCCESS)
+    {
+        TxnPtr->Status = Status;
+    }
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void CFE_SB_MessageTxn_SetRoutingMsgId(CFE_SB_MessageTxn_State_t *TxnPtr, CFE_SB_MsgId_t RoutingMsgId)
+{
+    /* validate the msgid in the message */
+    if (!CFE_SB_IsValidMsgId(RoutingMsgId))
+    {
+        CFE_SB_MessageTxn_SetEventAndStatus(TxnPtr, CFE_SB_SEND_INV_MSGID_EID, CFE_SB_BAD_ARGUMENT);
+    }
+    else
+    {
+        TxnPtr->RoutingMsgId = RoutingMsgId;
+    }
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void CFE_SB_MessageTxn_SetContentSize(CFE_SB_MessageTxn_State_t *TxnPtr, size_t ContentSize)
+{
+    if (ContentSize > CFE_MISSION_SB_MAX_SB_MSG_SIZE)
+    {
+        CFE_SB_MessageTxn_SetEventAndStatus(TxnPtr, CFE_SB_MSG_TOO_BIG_EID, CFE_SB_MSG_TOO_BIG);
+    }
+    else
+    {
+        TxnPtr->ContentSize = ContentSize;
+    }
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void CFE_SB_TransmitTxn_SetupFromMsg(CFE_SB_MessageTxn_State_t *TxnPtr, const CFE_MSG_Message_t *MsgPtr)
+{
+    CFE_Status_t   Status;
+    CFE_MSG_Size_t MsgSize;
+    CFE_SB_MsgId_t MsgId;
+
+    if (CFE_SB_MessageTxn_IsOK(TxnPtr))
+    {
+        /* In this context, the user should have set the the size and MsgId in the content */
+        Status = CFE_MSG_GetMsgId(MsgPtr, &MsgId);
+        if (Status == CFE_SUCCESS)
+        {
+            CFE_SB_MessageTxn_SetRoutingMsgId(TxnPtr, MsgId);
+        }
+        else
+        {
+            CFE_SB_MessageTxn_SetEventAndStatus(TxnPtr, CFE_SB_SEND_BAD_ARG_EID, Status);
+        }
+    }
+
+    if (CFE_SB_MessageTxn_IsOK(TxnPtr))
+    {
+        Status = CFE_MSG_GetSize(MsgPtr, &MsgSize);
+        if (Status == CFE_SUCCESS)
+        {
+            CFE_SB_MessageTxn_SetContentSize(TxnPtr, MsgSize);
+        }
+        else
+        {
+            CFE_SB_MessageTxn_SetEventAndStatus(TxnPtr, CFE_SB_SEND_BAD_ARG_EID, Status);
+        }
+    }
+}
+
+/******************************************************************
+ *
+ * TRANSMIT TRANSACTION IMPLEMENTATION FUNCTIONS
+ *
+ ******************************************************************/
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+CFE_SB_MessageTxn_State_t *CFE_SB_TransmitTxn_Init(CFE_SB_TransmitTxn_State_t *TxnPtr, const void *RefMemPtr)
+{
+    CFE_SB_MessageTxn_Init(&TxnPtr->MessageTxn_State, TxnPtr->DestSet, CFE_PLATFORM_SB_MAX_DEST_PER_PKT, RefMemPtr);
+    TxnPtr->MessageTxn_State.IsTransmit = true;
+
+    /* No matter what, the mem pointer from the caller should not be NULL */
+    if (RefMemPtr == NULL)
+    {
+        CFE_SB_MessageTxn_SetEventAndStatus(&TxnPtr->MessageTxn_State, CFE_SB_SEND_BAD_ARG_EID, CFE_SB_BAD_ARGUMENT);
+    }
+
+    return &TxnPtr->MessageTxn_State;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function
+ * Not invoked outside of this unit
+ *
+ *-----------------------------------------------------------------*/
+void CFE_SB_TransmitTxn_FindDestinations(CFE_SB_MessageTxn_State_t *TxnPtr, CFE_SB_BufferD_t *BufDscPtr)
+{
+    CFE_SB_PipeD_t *       PipeDscPtr;
+    CFE_SB_DestinationD_t *DestPtr;
+    CFE_SB_PipeSetEntry_t *ContextPtr;
+    CFE_ES_AppId_t         AppId;
+    bool                   IsAcceptable;
+    CFE_Status_t           Status;
+
+    /*
+     * get app id for loopback testing  -
+     * This is only used if one or more of the destinations has its "IGNOREMINE" option set,
+     * but it should NOT be gotten while locked.  So since we do not know (yet) if we need it,
+     * it is better to get it and not need it than need it and not have it.
+     */
+    CFE_ES_GetAppID(&AppId);
+
+    /* take semaphore to prevent a task switch during processing */
+    CFE_SB_LockSharedData(__func__, __LINE__);
+
+    /* Get the routing id */
+    BufDscPtr->DestRouteId = CFE_SBR_GetRouteId(TxnPtr->RoutingMsgId);
+
+    /* For an invalid route / no subscribers this whole logic can be skipped */
+    if (CFE_SBR_IsValidRouteId(BufDscPtr->DestRouteId))
+    {
+        /* If this is the origination, then update the message content (while locked) before actually sending */
+        if (TxnPtr->IsEndpoint)
+        {
+            CFE_SBR_IncrementSequenceCounter(BufDscPtr->DestRouteId);
+
+            /* Set the sequence count from the route */
+            Status =
+                CFE_MSG_SetSequenceCount(&BufDscPtr->Content.Msg, CFE_SBR_GetSequenceCounter(BufDscPtr->DestRouteId));
+        }
+
+        /* Send the packet to all destinations  */
+        DestPtr = CFE_SBR_GetDestListHeadPtr(BufDscPtr->DestRouteId);
+        while (DestPtr != NULL && TxnPtr->NumPipes < TxnPtr->MaxPipes)
+        {
+            ContextPtr = NULL;
+
+            if (DestPtr->Active == CFE_SB_ACTIVE) /* destination is active */
+            {
+                PipeDscPtr = CFE_SB_LocatePipeDescByID(DestPtr->PipeId);
+            }
+            else
+            {
+                PipeDscPtr = NULL;
+            }
+
+            if (CFE_SB_PipeDescIsMatch(PipeDscPtr, DestPtr->PipeId))
+            {
+                if ((PipeDscPtr->Opts & CFE_SB_PIPEOPTS_IGNOREMINE) == 0 ||
+                    !CFE_RESOURCEID_TEST_EQUAL(PipeDscPtr->AppId, AppId))
+                {
+                    ContextPtr = &TxnPtr->PipeSet[TxnPtr->NumPipes];
+                    ++TxnPtr->NumPipes;
+                }
+            }
+
+            if (ContextPtr != NULL)
+            {
+                memset(ContextPtr, 0, sizeof(*ContextPtr));
+
+                ContextPtr->PipeId     = DestPtr->PipeId;
+                ContextPtr->SysQueueId = PipeDscPtr->SysQueueId;
+
+                /* if Msg limit exceeded, log event, increment counter */
+                /* and go to next destination */
+                if (DestPtr->BuffCount >= DestPtr->MsgId2PipeLim)
+                {
+                    ContextPtr->PendingEventId = CFE_SB_MSGID_LIM_ERR_EID;
+                    ++CFE_SB_Global.HKTlmMsg.Payload.MsgLimitErrorCounter;
+                    ++PipeDscPtr->SendErrors;
+                    ++TxnPtr->NumPipeErrs;
+                }
+                else
+                {
+                    CFE_SB_IncrBufUseCnt(BufDscPtr);
+                    ++DestPtr->BuffCount;
+
+                    ++PipeDscPtr->CurrentQueueDepth;
+                    if (PipeDscPtr->CurrentQueueDepth > PipeDscPtr->PeakQueueDepth)
+                    {
+                        PipeDscPtr->PeakQueueDepth = PipeDscPtr->CurrentQueueDepth;
+                    }
+                }
+            }
+
+            DestPtr = DestPtr->Next;
+        }
+    }
+    else
+    {
+        /* if there have been no subscriptions for this pkt, */
+        /* increment the dropped pkt cnt, send event and return success */
+        CFE_SB_Global.HKTlmMsg.Payload.NoSubscribersCounter++;
+        CFE_SB_MessageTxn_SetEventAndStatus(TxnPtr, CFE_SB_SEND_NO_SUBS_EID, CFE_SUCCESS);
+    }
+
+    /*
+     * Remove this from whatever list it was in
+     *
+     * If it was a singleton/new buffer this has no effect.
+     * If it was a zero-copy buffer this removes it from the ZeroCopyList.
+     */
+    CFE_SB_TrackingListRemove(&BufDscPtr->Link);
+
+    /* clear the AppID field in case it was a zero copy buffer,
+     * as it is no longer owned by that app after broadcasting */
+    BufDscPtr->AppId = CFE_ES_APPID_UNDEFINED;
+
+    /* track the buffer as an in-transit message */
+    CFE_SB_TrackingListAdd(&CFE_SB_Global.InTransitList, &BufDscPtr->Link);
+
+    CFE_SB_UnlockSharedData(__func__, __LINE__);
+
+    /*
+     * Lastly, if this is the origination point, now that all headers should
+     * have known values (including sequence) - invoke the mission-specific
+     * message origination action.  This may update timestamps and/or compute
+     * any required error control fields.
+     */
+    if (CFE_SB_MessageTxn_IsOK(TxnPtr) && TxnPtr->IsEndpoint)
+    {
+        /* Update any other system-specific MSG headers based on the current sequence */
+        Status = CFE_MSG_OriginationAction(&BufDscPtr->Content.Msg, BufDscPtr->AllocatedSize, &IsAcceptable);
+        if (Status != CFE_SUCCESS || !IsAcceptable)
+        {
+            CFE_SB_MessageTxn_SetEventAndStatus(TxnPtr, CFE_SB_SEND_MESSAGE_INTEGRITY_FAIL_EID, Status);
+        }
+    }
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function
+ * Not invoked outside of this unit
+ *
+ *-----------------------------------------------------------------*/
+int32 CFE_SB_MessageTxn_GetOsTimeout(const CFE_SB_MessageTxn_State_t *TxnPtr)
+{
+    int32     OsTimeout;
+    OS_time_t TimeNow;
+
+    switch (TxnPtr->TimeoutMode)
+    {
+        case CFE_SB_MessageTxn_TimeoutMode_PEND:
+            OsTimeout = OS_PEND;
+            break;
+        case CFE_SB_MessageTxn_TimeoutMode_TIMED:
+            CFE_PSP_GetTime(&TimeNow);
+            OsTimeout = OS_TimeGetTotalMilliseconds(OS_TimeSubtract(TxnPtr->AbsTimeout, TimeNow));
+            if (OsTimeout < 0)
+            {
+                /* timeout has already expired, so all remaining pipes should be CHECK only */
+                OsTimeout = OS_CHECK;
+            }
+            break;
+        case CFE_SB_MessageTxn_TimeoutMode_POLL:
+        default:
+            OsTimeout = OS_CHECK;
+            break;
+    }
+
+    return OsTimeout;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function
+ * Not invoked outside of this unit
+ *
+ *-----------------------------------------------------------------*/
+bool CFE_SB_TransmitTxn_PipeHandler(CFE_SB_MessageTxn_State_t *TxnPtr, CFE_SB_PipeSetEntry_t *ContextPtr, void *Arg)
+{
+    CFE_SB_DestinationD_t *DestPtr;
+    CFE_SB_PipeD_t *       PipeDscPtr;
+    CFE_SB_BufferD_t *     BufDscPtr;
+
+    BufDscPtr = Arg;
+
+    /*
+     * Write the buffer descriptor to the queue of the pipe.  Note that
+     * accounting for depth and buffer limits was already done as part
+     * of "FindDestinations" assuming this write will be successful - which
+     * is the expected/typical result here.
+     */
+    ContextPtr->OsStatus =
+        OS_QueuePut(ContextPtr->SysQueueId, &BufDscPtr, sizeof(BufDscPtr), CFE_SB_MessageTxn_GetOsTimeout(TxnPtr));
+
+    /*
+     * If it succeeded, nothing else to do.  But if it fails then we must undo the
+     * optimistic depth accounting done earlier.
+     */
+    if (ContextPtr->OsStatus != OS_SUCCESS)
+    {
+        ++TxnPtr->NumPipeErrs;
+
+        CFE_SB_LockSharedData(__func__, __LINE__);
+
+        if (ContextPtr->OsStatus == OS_QUEUE_FULL)
+        {
+            ContextPtr->PendingEventId = CFE_SB_Q_FULL_ERR_EID;
+            CFE_SB_Global.HKTlmMsg.Payload.PipeOverflowErrorCounter++;
+        }
+        else
+        {
+            /* Unexpected error while writing to queue. */
+            ContextPtr->PendingEventId = CFE_SB_Q_WR_ERR_EID;
+            CFE_SB_Global.HKTlmMsg.Payload.InternalErrorCounter++;
+        }
+
+        PipeDscPtr = CFE_SB_LocatePipeDescByID(ContextPtr->PipeId);
+        if (CFE_SB_PipeDescIsMatch(PipeDscPtr, ContextPtr->PipeId) && PipeDscPtr->CurrentQueueDepth > 0)
+        {
+            --PipeDscPtr->CurrentQueueDepth;
+        }
+
+        DestPtr = CFE_SB_GetDestPtr(BufDscPtr->DestRouteId, ContextPtr->PipeId);
+        if (DestPtr != NULL && DestPtr->BuffCount > 0)
+        {
+            DestPtr->BuffCount--;
+        }
+
+        CFE_SB_DecrBufUseCnt(BufDscPtr);
+
+        CFE_SB_UnlockSharedData(__func__, __LINE__);
+    }
+
+    /* always keep going when sending (broadcast) */
+    return true;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function
+ * Not invoked outside of this unit
+ *
+ *-----------------------------------------------------------------*/
+void CFE_SB_MessageTxn_ProcessPipes(CFE_SB_MessageTxn_PipeHandler_t HandlerFunc, CFE_SB_MessageTxn_State_t *TxnPtr,
+                                    void *Arg)
+{
+    uint32                 i;
+    CFE_SB_PipeSetEntry_t *ContextPtr;
+    bool                   should_continue;
+
+    should_continue = true;
+    for (i = 0; should_continue && i < TxnPtr->NumPipes; ++i)
+    {
+        ContextPtr = &TxnPtr->PipeSet[i];
+
+        if (ContextPtr->PendingEventId == 0)
+        {
+            should_continue = HandlerFunc(TxnPtr, ContextPtr, Arg);
+        }
+    }
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void CFE_SB_TransmitTxn_Execute(CFE_SB_MessageTxn_State_t *TxnPtr, CFE_SB_Buffer_t *BufPtr)
+{
+    int32             Status;
+    CFE_SB_BufferD_t *BufDscPtr;
+
+    /* Sanity check on the input buffer - if this doesn't work, stop now */
+    Status = CFE_SB_ZeroCopyBufferValidate(BufPtr, &BufDscPtr);
+    if (Status != CFE_SUCCESS)
+    {
+        /* There is currently no event defined for this */
+        CFE_SB_MessageTxn_SetEventAndStatus(TxnPtr, 0, Status);
+        return;
+    }
+
+    /* Save passed-in routing parameters into the descriptor */
+    BufDscPtr->ContentSize = CFE_SB_MessageTxn_GetContentSize(TxnPtr);
+    BufDscPtr->MsgId       = CFE_SB_MessageTxn_GetRoutingMsgId(TxnPtr);
+
+    /* Convert the route to a set of pipes/destinations */
+    CFE_SB_TransmitTxn_FindDestinations(TxnPtr, BufDscPtr);
+
+    /* Note the above function always succeeds - even if no pipes are subscribed,
+     * the transaction will simply have 0 pipes and this next call becomes a no-op */
+    CFE_SB_MessageTxn_ProcessPipes(CFE_SB_TransmitTxn_PipeHandler, TxnPtr, BufDscPtr);
+
+    /*
+     * Decrement the buffer UseCount - This means that the caller
+     * should not use the buffer anymore after this call.
+     */
+    CFE_SB_LockSharedData(__func__, __LINE__);
+    CFE_SB_DecrBufUseCnt(BufDscPtr);
+    CFE_SB_UnlockSharedData(__func__, __LINE__);
+}
+
+/******************************************************************
+ *
+ * RECEIVE TRANSACTION IMPLEMENTATION FUNCTIONS
+ *
+ ******************************************************************/
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+CFE_SB_MessageTxn_State_t *CFE_SB_ReceiveTxn_Init(CFE_SB_ReceiveTxn_State_t *TxnPtr, const void *RefMemPtr)
+{
+    CFE_SB_MessageTxn_Init(&TxnPtr->MessageTxn_State, &TxnPtr->Source, 1, RefMemPtr);
+    TxnPtr->MessageTxn_State.IsTransmit = false;
+
+    /* No matter what, the mem pointer from the caller should not be NULL */
+    /* note that the event ID is different between send and recv */
+    if (RefMemPtr == NULL)
+    {
+        CFE_SB_MessageTxn_SetEventAndStatus(&TxnPtr->MessageTxn_State, CFE_SB_RCV_BAD_ARG_EID, CFE_SB_BAD_ARGUMENT);
+    }
+
+    return &TxnPtr->MessageTxn_State;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void CFE_SB_MessageTxn_SetEndpoint(CFE_SB_MessageTxn_State_t *TxnPtr, bool IsEndpoint)
+{
+    TxnPtr->IsEndpoint = IsEndpoint;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void CFE_SB_ReceiveTxn_SetPipeId(CFE_SB_MessageTxn_State_t *TxnPtr, CFE_SB_PipeId_t PipeId)
+{
+    CFE_SB_PipeD_t *       PipeDscPtr;
+    CFE_SB_PipeSetEntry_t *ContextPtr;
+
+    /* For now, there is just one of these */
+    ContextPtr = TxnPtr->PipeSet;
+    memset(ContextPtr, 0, sizeof(*ContextPtr));
+    ContextPtr->PipeId = PipeId;
+    TxnPtr->NumPipes   = 1;
+
+    PipeDscPtr = CFE_SB_LocatePipeDescByID(PipeId);
+
+    CFE_SB_LockSharedData(__func__, __LINE__);
+
+    /* If the pipe does not exist or PipeId is out of range... */
+    if (!CFE_SB_PipeDescIsMatch(PipeDscPtr, PipeId))
+    {
+        ContextPtr->PendingEventId = CFE_SB_BAD_PIPEID_EID;
+        CFE_SB_MessageTxn_SetEventAndStatus(TxnPtr, 0, CFE_SB_BAD_ARGUMENT);
+        ++TxnPtr->NumPipeErrs;
+    }
+    else
+    {
+        ContextPtr->SysQueueId = PipeDscPtr->SysQueueId;
+
+        /*
+         * Un-reference any previous buffer from the last call.
+         *
+         * NOTE: This is historical behavior where apps call CFE_SB_ReceiveBuffer()
+         * in the loop within the app's main task.  There is currently no separate
+         * API to "free" or unreference a buffer that was returned from SB.
+         *
+         * Instead, each time this function is invoked, it is implicitly interpreted
+         * as an indication that the caller is done with the previous buffer.
+         *
+         * Unfortunately this prevents pipe IDs from being serviced/shared across
+         * multiple child tasks in a worker pattern design.  This may be changed
+         * in a future version of CFE to decouple these actions, to allow for
+         * multiple workers to service the same pipe.
+         */
+        if (PipeDscPtr->LastBuffer != NULL)
+        {
+            /* Decrement the Buffer Use Count, which will Free buffer if it becomes 0 */
+            CFE_SB_DecrBufUseCnt(PipeDscPtr->LastBuffer);
+            PipeDscPtr->LastBuffer = NULL;
+        }
+    }
+
+    CFE_SB_UnlockSharedData(__func__, __LINE__);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function
+ * Not invoked outside of this unit
+ *
+ *-----------------------------------------------------------------*/
+void CFE_SB_ReceiveTxn_ExportReference(CFE_SB_MessageTxn_State_t *TxnPtr, CFE_SB_PipeSetEntry_t *ContextPtr,
+                                       CFE_SB_BufferD_t *BufDscPtr, CFE_SB_BufferD_t **ParentBufDscPtrP)
+{
+    CFE_SB_PipeD_t *       PipeDscPtr;
+    CFE_SB_DestinationD_t *DestPtr;
+
+    PipeDscPtr = CFE_SB_LocatePipeDescByID(ContextPtr->PipeId);
+
+    /* Now re-lock to store the buffer in the pipe descriptor */
+    CFE_SB_LockSharedData(__func__, __LINE__);
+
+    /*
+     * NOTE: This uses the same PipeDscPtr that was found earlier.
+     * But it has to be revalidated because its theoretically possible
+     * the pipe got deleted between now and then.
+     */
+    if (CFE_SB_PipeDescIsMatch(PipeDscPtr, ContextPtr->PipeId))
+    {
+        /*
+        ** Load the pipe tables 'CurrentBuff' with the buffer descriptor
+        ** ptr corresponding to the message just read. This is done so that
+        ** the buffer can be released on the next receive call for this pipe.
+        **
+        ** This counts as a new reference as it is being stored in the PipeDsc
+        */
+        CFE_SB_IncrBufUseCnt(BufDscPtr);
+        PipeDscPtr->LastBuffer = BufDscPtr;
+
+        /*
+         * Also set the Receivers pointer to the address of the actual message
+         * (currently this is "borrowing" the ref above, not its own ref)
+         */
+        *ParentBufDscPtrP = BufDscPtr;
+
+        /* get pointer to destination to be used in decrementing msg limit cnt*/
+        DestPtr = CFE_SB_GetDestPtr(BufDscPtr->DestRouteId, ContextPtr->PipeId);
+
+        /*
+        ** DestPtr would be NULL if the msg is unsubscribed to while it is on
+        ** the pipe. The BuffCount may be zero if the msg is unsubscribed to and
+        ** then resubscribed to while it is on the pipe. Both of these cases are
+        ** considered nominal and are handled by the code below.
+        */
+        if (DestPtr != NULL && DestPtr->BuffCount > 0)
+        {
+            DestPtr->BuffCount--;
+        }
+
+        if (PipeDscPtr->CurrentQueueDepth > 0)
+        {
+            --PipeDscPtr->CurrentQueueDepth;
+        }
+    }
+    else
+    {
+        CFE_SB_MessageTxn_SetEventAndStatus(TxnPtr, 0, CFE_SB_PIPE_RD_ERR);
+
+        /* should send the bad pipe ID event here too */
+        ContextPtr->PendingEventId = CFE_SB_BAD_PIPEID_EID;
+    }
+
+    /* Always decrement the use count, for the ref that was in the queue */
+    CFE_SB_DecrBufUseCnt(BufDscPtr);
+
+    CFE_SB_UnlockSharedData(__func__, __LINE__);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local Helper function
+ * Not invoked outside of this unit
+ *
+ *-----------------------------------------------------------------*/
+bool CFE_SB_ReceiveTxn_PipeHandler(CFE_SB_MessageTxn_State_t *TxnPtr, CFE_SB_PipeSetEntry_t *ContextPtr, void *Arg)
+{
+    CFE_SB_BufferD_t * BufDscPtr;
+    CFE_SB_BufferD_t **ParentBufDscPtrP;
+    size_t             BufDscSize;
+
+    ParentBufDscPtrP = Arg;
+
+    /* Read the buffer descriptor address from the queue.  */
+    ContextPtr->OsStatus = OS_QueueGet(ContextPtr->SysQueueId, &BufDscPtr, sizeof(BufDscPtr), &BufDscSize,
+                                       CFE_SB_MessageTxn_GetOsTimeout(TxnPtr));
+
+    /*
+     * translate the return value -
+     *
+     * CFE functions have their own set of RC values should not directly return OSAL codes
+     * The size should always match.  If it does not, then generate CFE_SB_Q_RD_ERR_EID.
+     */
+
+    if (ContextPtr->OsStatus == OS_SUCCESS && BufDscPtr != NULL && BufDscSize == sizeof(BufDscPtr))
+    {
+        CFE_SB_ReceiveTxn_ExportReference(TxnPtr, ContextPtr, BufDscPtr, ParentBufDscPtrP);
+    }
+    else
+    {
+        *ParentBufDscPtrP = NULL;
+
+        if (ContextPtr->OsStatus == OS_QUEUE_EMPTY)
+        {
+            /* normal if using CFE_SB_POLL */
+            CFE_SB_MessageTxn_SetEventAndStatus(TxnPtr, 0, CFE_SB_NO_MESSAGE);
+        }
+        else if (ContextPtr->OsStatus == OS_QUEUE_TIMEOUT)
+        {
+            /* normal if using a nonzero timeout */
+            CFE_SB_MessageTxn_SetEventAndStatus(TxnPtr, 0, CFE_SB_TIME_OUT);
+        }
+        else
+        {
+            /* off-nominal condition, report an error event */
+            CFE_SB_MessageTxn_SetEventAndStatus(TxnPtr, 0, CFE_SB_PIPE_RD_ERR);
+            ContextPtr->PendingEventId = CFE_SB_Q_RD_ERR_EID;
+        }
+    }
+
+    /* Read ops only process one pipe */
+    return false;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+const CFE_SB_Buffer_t *CFE_SB_ReceiveTxn_Execute(CFE_SB_MessageTxn_State_t *TxnPtr)
+{
+    CFE_SB_BufferD_t *     BufDscPtr;
+    const CFE_SB_Buffer_t *Result;
+    bool                   IsAcceptable;
+    CFE_Status_t           Status;
+
+    Result = NULL;
+
+    while (CFE_SB_MessageTxn_IsOK(TxnPtr))
+    {
+        BufDscPtr = NULL;
+
+        /*
+         * Read from the pipe(s).  Currently this is just one but someday could
+         * become more than one e.g. a high-pri and a low-pri queue.
+         */
+        CFE_SB_MessageTxn_ProcessPipes(CFE_SB_ReceiveTxn_PipeHandler, TxnPtr, &BufDscPtr);
+
+        /* If nothing received, then quit */
+        if (BufDscPtr == NULL)
+        {
+            TxnPtr->RoutingMsgId = CFE_SB_INVALID_MSG_ID;
+            TxnPtr->ContentSize  = 0;
+            Result               = NULL;
+            break;
+        }
+
+        if (TxnPtr->IsEndpoint)
+        {
+            Status = CFE_MSG_VerificationAction(&BufDscPtr->Content.Msg, BufDscPtr->AllocatedSize, &IsAcceptable);
+            if (Status != CFE_SUCCESS)
+            {
+                /* This typically should not happen - only if VerificationAction got bad arguments */
+                IsAcceptable = false;
+            }
+        }
+        else
+        {
+            /* If no verification being done at this stage - consider everything "good" */
+            IsAcceptable = true;
+        }
+
+        if (IsAcceptable)
+        {
+            /*
+             * Replicate the buffer descriptor MsgId and ContentSize in the transaction.
+             *
+             * This does not use the functions that check the values because that will
+             * send an event and set an error status if they are bad.  But on the recv side,
+             * it is already here - whatever we got should be returned.  Error checking for
+             * size and MsgId should have been done on the transmit side, so they should never
+             * be bad at this point.
+             */
+            TxnPtr->RoutingMsgId = BufDscPtr->MsgId;
+            TxnPtr->ContentSize  = BufDscPtr->ContentSize;
+            Result               = &BufDscPtr->Content;
+            break;
+        }
+
+        /* Report an event indicating the buffer is being dropped */
+        CFE_SB_MessageTxn_ReportSingleEvent(TxnPtr, TxnPtr->PipeSet, CFE_SB_RCV_MESSAGE_INTEGRITY_FAIL_EID);
+
+        /*
+         * Also need to re-set the PipeId for proper accounting.  This buffer will be dropped,
+         * and this decrements the use count and removes it from the LastBuffer pointer in the
+         * Pipe Descriptor
+         */
+        CFE_SB_ReceiveTxn_SetPipeId(TxnPtr, TxnPtr->PipeSet->PipeId);
+    }
+
+    return Result;
 }

--- a/modules/sb/fsw/src/cfe_sb_priv.c
+++ b/modules/sb/fsw/src/cfe_sb_priv.c
@@ -955,8 +955,7 @@ void CFE_SB_TransmitTxn_FindDestinations(CFE_SB_MessageTxn_State_t *TxnPtr, CFE_
             CFE_SBR_IncrementSequenceCounter(BufDscPtr->DestRouteId);
 
             /* Set the sequence count from the route */
-            Status =
-                CFE_MSG_SetSequenceCount(&BufDscPtr->Content.Msg, CFE_SBR_GetSequenceCounter(BufDscPtr->DestRouteId));
+            CFE_MSG_SetSequenceCount(&BufDscPtr->Content.Msg, CFE_SBR_GetSequenceCounter(BufDscPtr->DestRouteId));
         }
 
         /* Send the packet to all destinations  */

--- a/modules/sb/fsw/src/cfe_sb_priv.h
+++ b/modules/sb/fsw/src/cfe_sb_priv.h
@@ -784,7 +784,6 @@ static inline bool CFE_SB_MessageTxn_IsOK(const CFE_SB_MessageTxn_State_t *TxnPt
     return (TxnPtr->Status == CFE_SUCCESS && TxnPtr->TransactionEventId == 0);
 }
 
-
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief Get transaction content size

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -390,7 +390,7 @@ void Test_SB_Main_RcvErr(void)
     UT_SetDeferredRetcode(UT_KEY(OS_QueueGet), 1, -1);
     CFE_SB_TaskMain();
 
-    CFE_UtAssert_EVENTCOUNT(6);
+    CFE_UtAssert_EVENTCOUNT(7);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_INIT_EID);
 
@@ -2883,6 +2883,591 @@ void Test_Unsubscribe_GetDestPtr(void)
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe2));
 }
 
+void Test_TransmitTxn_Init(void)
+{
+    /* Test case for:
+     * void CFE_SB_TransmitTxn_Init(CFE_SB_TransmitTxn_State_t *TxnPtr, const void *RefMemPtr);
+     */
+    CFE_SB_TransmitTxn_State_t TxnBuf;
+    CFE_SB_MessageTxn_State_t *Txn;
+    uint32                     MyData;
+
+    /* Call to ensure coverage */
+    memset(&Txn, 0xEE, sizeof(Txn));
+    MyData = 123;
+    UtAssert_ADDRESS_EQ(Txn = CFE_SB_TransmitTxn_Init(&TxnBuf, &MyData), &TxnBuf);
+
+    /* This should have cleared everything */
+    UtAssert_ADDRESS_EQ(Txn->RefMemPtr, &MyData);
+    UtAssert_ZERO(Txn->NumPipes);
+    UtAssert_ZERO(Txn->NumPipeErrs);
+    UtAssert_ZERO(Txn->TransactionEventId);
+    UtAssert_ZERO(Txn->TimeoutMode);
+    UtAssert_ZERO(Txn->ContentSize);
+    UtAssert_BOOL_FALSE(Txn->IsEndpoint);
+}
+
+void Test_MessageTxn_SetEventAndStatus(void)
+{
+    /* Test function for:
+     * void CFE_SB_MessageTxn_SetEventAndStatus(CFE_SB_MessageTxn_State_t *TxnPtr,
+     *               uint16 EventId, CFE_Status_t Status)
+     */
+    CFE_SB_MessageTxn_State_t Txn;
+
+    /*
+     * although this function is used throughout the other tests, this is needed to target
+     * certain branches/paths that don't get executed.  Namely - this should only store
+     * the first error/event that occurs.
+     */
+
+    /* Set only an event ID first, then attempt to set both */
+    memset(&Txn, 0, sizeof(Txn));
+
+    UtAssert_BOOL_TRUE(CFE_SB_MessageTxn_IsOK(&Txn));
+
+    CFE_SB_MessageTxn_SetEventAndStatus(&Txn, CFE_SB_MSG_TOO_BIG_EID, CFE_SUCCESS);
+    UtAssert_UINT16_EQ(Txn.TransactionEventId, CFE_SB_MSG_TOO_BIG_EID);
+    UtAssert_INT32_EQ(Txn.Status, CFE_SUCCESS);
+    UtAssert_BOOL_FALSE(CFE_SB_MessageTxn_IsOK(&Txn));
+
+    CFE_SB_MessageTxn_SetEventAndStatus(&Txn, CFE_SB_SEND_INV_MSGID_EID, CFE_SB_BAD_ARGUMENT);
+    UtAssert_UINT16_EQ(Txn.TransactionEventId, CFE_SB_MSG_TOO_BIG_EID);
+    UtAssert_INT32_EQ(Txn.Status, CFE_SB_BAD_ARGUMENT);
+    UtAssert_BOOL_FALSE(CFE_SB_MessageTxn_IsOK(&Txn));
+
+    /* Set only a status code first, then attempt to set both */
+    memset(&Txn, 0, sizeof(Txn));
+
+    CFE_SB_MessageTxn_SetEventAndStatus(&Txn, 0, CFE_SB_BUF_ALOC_ERR);
+    UtAssert_UINT16_EQ(Txn.TransactionEventId, 0);
+    UtAssert_INT32_EQ(Txn.Status, CFE_SB_BUF_ALOC_ERR);
+    UtAssert_BOOL_FALSE(CFE_SB_MessageTxn_IsOK(&Txn));
+
+    CFE_SB_MessageTxn_SetEventAndStatus(&Txn, CFE_SB_SEND_INV_MSGID_EID, CFE_SB_BAD_ARGUMENT);
+    UtAssert_UINT16_EQ(Txn.TransactionEventId, CFE_SB_SEND_INV_MSGID_EID);
+    UtAssert_INT32_EQ(Txn.Status, CFE_SB_BUF_ALOC_ERR);
+    UtAssert_BOOL_FALSE(CFE_SB_MessageTxn_IsOK(&Txn));
+}
+
+void Test_MessageTxn_Timeout(void)
+{
+    /* Test case for:
+     * void CFE_SB_MessageTxn_SetTimeout(CFE_SB_MessageTxn_State_t *TxnPtr, int32 Timeout);
+     * int32 CFE_SB_MessageTxn_GetOsTimeout(const CFE_SB_MessageTxn_State_t *TxnPtr);
+     */
+    CFE_SB_MessageTxn_State_t Txn;
+    OS_time_t                 TestTime;
+
+    memset(&Txn, 0, sizeof(Txn));
+
+    UtAssert_VOIDCALL(CFE_SB_MessageTxn_SetTimeout(&Txn, CFE_SB_POLL));
+    UtAssert_INT32_EQ(CFE_SB_MessageTxn_GetOsTimeout(&Txn), OS_CHECK);
+
+    UtAssert_VOIDCALL(CFE_SB_MessageTxn_SetTimeout(&Txn, CFE_SB_PEND_FOREVER));
+    UtAssert_INT32_EQ(CFE_SB_MessageTxn_GetOsTimeout(&Txn), OS_PEND);
+
+    TestTime = OS_TimeFromTotalSeconds(1000000000);
+    UT_SetDataBuffer(UT_KEY(CFE_PSP_GetTime), &TestTime, sizeof(TestTime), false);
+    UtAssert_VOIDCALL(CFE_SB_MessageTxn_SetTimeout(&Txn, 100));
+
+    UT_SetDataBuffer(UT_KEY(CFE_PSP_GetTime), &TestTime, sizeof(TestTime), false);
+    UtAssert_INT32_EQ(CFE_SB_MessageTxn_GetOsTimeout(&Txn), 100);
+
+    TestTime = OS_TimeAdd(TestTime, OS_TimeFromTotalMilliseconds(10));
+    UT_SetDataBuffer(UT_KEY(CFE_PSP_GetTime), &TestTime, sizeof(TestTime), false);
+    UtAssert_INT32_EQ(CFE_SB_MessageTxn_GetOsTimeout(&Txn), 90);
+
+    TestTime = OS_TimeAdd(TestTime, OS_TimeFromTotalSeconds(1));
+    UT_SetDataBuffer(UT_KEY(CFE_PSP_GetTime), &TestTime, sizeof(TestTime), false);
+    UtAssert_INT32_EQ(CFE_SB_MessageTxn_GetOsTimeout(&Txn), OS_CHECK);
+
+    UtAssert_VOIDCALL(CFE_SB_MessageTxn_SetTimeout(&Txn, -1000));
+    UtAssert_INT32_EQ(Txn.Status, CFE_SB_BAD_ARGUMENT);
+}
+
+void Test_MessageTxn_SetupFromMsg(void)
+{
+    /* Test case for:
+     * CFE_Status_t CFE_SB_TransmitTxn_SetupFromMsg(CFE_SB_MessageTxn_State_t *TxnPtr, const CFE_MSG_Message_t
+     * *MsgPtr);
+     */
+    CFE_SB_MessageTxn_State_t Txn;
+    CFE_MSG_Message_t         Msg;
+    CFE_SB_MsgId_t            MsgId;
+    CFE_MSG_Size_t            MsgSize;
+
+    memset(&Msg, 0, sizeof(Msg));
+
+    /* Transaction already failed case (no-op) */
+    memset(&Txn, 0, sizeof(Txn));
+    Txn.Status = -20;
+    UtAssert_VOIDCALL(CFE_SB_TransmitTxn_SetupFromMsg(&Txn, &Msg));
+    UtAssert_INT32_EQ(Txn.Status, -20);
+
+    /* CFE_MSG_GetMsgId() fail case */
+    memset(&Txn, 0, sizeof(Txn));
+    UT_SetDeferredRetcode(UT_KEY(CFE_MSG_GetMsgId), 1, -10);
+    UtAssert_VOIDCALL(CFE_SB_TransmitTxn_SetupFromMsg(&Txn, &Msg));
+    UtAssert_INT32_EQ(Txn.Status, -10);
+    UtAssert_UINT32_EQ(Txn.TransactionEventId, CFE_SB_SEND_BAD_ARG_EID);
+
+    /* Invalid MsgId case */
+    memset(&Txn, 0, sizeof(Txn));
+    MsgId = CFE_SB_INVALID_MSG_ID;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
+    UtAssert_VOIDCALL(CFE_SB_TransmitTxn_SetupFromMsg(&Txn, &Msg));
+    UtAssert_INT32_EQ(Txn.Status, CFE_SB_BAD_ARGUMENT);
+    UtAssert_UINT32_EQ(Txn.TransactionEventId, CFE_SB_SEND_INV_MSGID_EID);
+
+    /* CFE_MSG_GetSize() fail case */
+    memset(&Txn, 0, sizeof(Txn));
+    MsgId = SB_UT_TLM_MID;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
+    UT_SetDeferredRetcode(UT_KEY(CFE_MSG_GetSize), 1, -11);
+    UtAssert_VOIDCALL(CFE_SB_TransmitTxn_SetupFromMsg(&Txn, &Msg));
+    UtAssert_INT32_EQ(Txn.Status, -11);
+    UtAssert_UINT32_EQ(Txn.TransactionEventId, CFE_SB_SEND_BAD_ARG_EID);
+
+    /* Message too big case */
+    memset(&Txn, 0, sizeof(Txn));
+    MsgId = SB_UT_TLM_MID;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
+    MsgSize = 1 + CFE_MISSION_SB_MAX_SB_MSG_SIZE;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
+    UtAssert_VOIDCALL(CFE_SB_TransmitTxn_SetupFromMsg(&Txn, &Msg));
+    UtAssert_INT32_EQ(Txn.Status, CFE_SB_MSG_TOO_BIG);
+    UtAssert_UINT32_EQ(Txn.TransactionEventId, CFE_SB_MSG_TOO_BIG_EID);
+
+    /* Nominal case */
+    memset(&Txn, 0, sizeof(Txn));
+    MsgId = SB_UT_TLM_MID;
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
+    MsgSize = sizeof(Msg);
+    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), false);
+
+    UtAssert_VOIDCALL(CFE_SB_TransmitTxn_SetupFromMsg(&Txn, &Msg));
+    UtAssert_INT32_EQ(Txn.Status, CFE_SUCCESS);
+    UtAssert_ZERO(Txn.TransactionEventId);
+    CFE_UtAssert_MSGID_EQ(Txn.RoutingMsgId, SB_UT_TLM_MID);
+    UtAssert_UINT32_EQ(Txn.ContentSize, sizeof(Msg));
+}
+
+void Test_TransmitTxn_FindDestinations(void)
+{
+    /* Test case for:
+     * void CFE_SB_TransmitTxn_FindDestinations(CFE_SB_MessageTxn_State_t *TxnPtr, CFE_SB_BufferD_t *BufDscPtr);
+     */
+
+    CFE_SB_TransmitTxn_State_t TxnBuf;
+    CFE_SB_MessageTxn_State_t *Txn;
+    CFE_SB_BufferD_t           BufDsc;
+    CFE_SB_PipeD_t *           PipeDscPtr;
+    CFE_SB_PipeId_t            PipeId = CFE_SB_INVALID_PIPE;
+    CFE_SB_MsgId_t             MsgId  = SB_UT_TLM_MID;
+    CFE_SBR_RouteId_t          RouteId;
+    CFE_SB_DestinationD_t *    DestPtr;
+
+    memset(&BufDsc, 0, sizeof(BufDsc));
+    CFE_SB_TrackingListReset(&BufDsc.Link); /* so tracking list ops work */
+
+    CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId, 2, "TestPipe"));
+    CFE_UtAssert_SETUP(CFE_SB_SubscribeFull(MsgId, PipeId, CFE_SB_DEFAULT_QOS, 2, CFE_SB_MSG_GLOBAL));
+    PipeDscPtr                 = CFE_SB_LocatePipeDescByID(PipeId);
+    RouteId                    = CFE_SBR_GetRouteId(MsgId);
+    DestPtr                    = CFE_SB_GetDestPtr(RouteId, PipeId);
+    Txn                        = CFE_SB_TransmitTxn_Init(&TxnBuf, &BufDsc.Content);
+    PipeDscPtr->PeakQueueDepth = 1;
+
+    CFE_SB_Global.HKTlmMsg.Payload.NoSubscribersCounter = 0;
+
+    /* No subscriber case */
+    Txn->RoutingMsgId = CFE_SB_INVALID_MSG_ID;
+    UtAssert_VOIDCALL(CFE_SB_TransmitTxn_FindDestinations(Txn, &BufDsc));
+    UtAssert_UINT32_EQ(CFE_SB_Global.HKTlmMsg.Payload.NoSubscribersCounter, 1);
+    UtAssert_UINT32_EQ(Txn->TransactionEventId, CFE_SB_SEND_NO_SUBS_EID);
+    UtAssert_UINT32_EQ(BufDsc.UseCount, 0);
+
+    /* Nominal Case 1 */
+    memset(&BufDsc, 0, sizeof(BufDsc));
+    Txn = CFE_SB_TransmitTxn_Init(&TxnBuf, &BufDsc.Content);
+    CFE_SB_TrackingListReset(&BufDsc.Link); /* so tracking list ops work */
+    Txn->RoutingMsgId = MsgId;
+    UtAssert_VOIDCALL(CFE_SB_TransmitTxn_FindDestinations(Txn, &BufDsc));
+    UtAssert_UINT32_EQ(Txn->NumPipes, 1);
+    CFE_UtAssert_RESOURCEID_EQ(Txn->PipeSet[0].PipeId, PipeId);
+    UtAssert_UINT32_EQ(Txn->PipeSet[0].PendingEventId, 0);
+    UtAssert_UINT32_EQ(BufDsc.UseCount, 1);
+    UtAssert_UINT32_EQ(DestPtr->BuffCount, 1);
+    UtAssert_UINT32_EQ(PipeDscPtr->CurrentQueueDepth, 1);
+    UtAssert_UINT32_EQ(PipeDscPtr->PeakQueueDepth, 1);
+    UtAssert_UINT32_EQ(PipeDscPtr->SendErrors, 0);
+    UtAssert_UINT32_EQ(Txn->NumPipeErrs, 0);
+
+    /* Nominal Case 2 */
+    memset(&BufDsc, 0, sizeof(BufDsc));
+    Txn = CFE_SB_TransmitTxn_Init(&TxnBuf, &BufDsc.Content);
+    CFE_SB_TrackingListReset(&BufDsc.Link); /* so tracking list ops work */
+    Txn->RoutingMsgId = MsgId;
+    UtAssert_VOIDCALL(CFE_SB_TransmitTxn_FindDestinations(Txn, &BufDsc));
+    UtAssert_UINT32_EQ(Txn->NumPipes, 1);
+    CFE_UtAssert_RESOURCEID_EQ(Txn->PipeSet[0].PipeId, PipeId);
+    UtAssert_UINT32_EQ(Txn->PipeSet[0].PendingEventId, 0);
+    UtAssert_UINT32_EQ(BufDsc.UseCount, 1);
+    UtAssert_UINT32_EQ(DestPtr->BuffCount, 2);
+    UtAssert_UINT32_EQ(PipeDscPtr->CurrentQueueDepth, 2);
+    UtAssert_UINT32_EQ(PipeDscPtr->PeakQueueDepth, 2);
+    UtAssert_UINT32_EQ(PipeDscPtr->SendErrors, 0);
+    UtAssert_UINT32_EQ(Txn->NumPipeErrs, 0);
+
+    /* MsgLim Error Case */
+    memset(&BufDsc, 0, sizeof(BufDsc));
+    Txn = CFE_SB_TransmitTxn_Init(&TxnBuf, &BufDsc.Content);
+    CFE_SB_TrackingListReset(&BufDsc.Link); /* so tracking list ops work */
+    Txn->RoutingMsgId = MsgId;
+    UtAssert_VOIDCALL(CFE_SB_TransmitTxn_FindDestinations(Txn, &BufDsc));
+    UtAssert_UINT32_EQ(Txn->NumPipes, 1);
+    CFE_UtAssert_RESOURCEID_EQ(Txn->PipeSet[0].PipeId, PipeId);
+    UtAssert_UINT32_EQ(Txn->PipeSet[0].PendingEventId, CFE_SB_MSGID_LIM_ERR_EID);
+    UtAssert_ZERO(BufDsc.UseCount);
+    UtAssert_UINT32_EQ(DestPtr->BuffCount, 2);
+    UtAssert_UINT32_EQ(PipeDscPtr->CurrentQueueDepth, 2);
+    UtAssert_UINT32_EQ(PipeDscPtr->PeakQueueDepth, 2);
+    UtAssert_UINT32_EQ(PipeDscPtr->SendErrors, 1);
+    UtAssert_UINT32_EQ(Txn->NumPipeErrs, 1);
+    DestPtr->BuffCount = 0;
+
+    /* Destination Inactive Case */
+    memset(&BufDsc, 0, sizeof(BufDsc));
+    Txn = CFE_SB_TransmitTxn_Init(&TxnBuf, &BufDsc.Content);
+    CFE_SB_TrackingListReset(&BufDsc.Link); /* so tracking list ops work */
+    Txn->RoutingMsgId = MsgId;
+    DestPtr->Active   = CFE_SB_INACTIVE;
+    UtAssert_VOIDCALL(CFE_SB_TransmitTxn_FindDestinations(Txn, &BufDsc));
+    UtAssert_ZERO(Txn->NumPipes);
+    UtAssert_UINT32_EQ(BufDsc.UseCount, 0);
+    UtAssert_UINT32_EQ(DestPtr->BuffCount, 0);
+    DestPtr->Active = CFE_SB_ACTIVE;
+
+    /* Pipe "Ignore Mine" Option Case w/Matching AppID */
+    Txn               = CFE_SB_TransmitTxn_Init(&TxnBuf, &BufDsc.Content);
+    Txn->RoutingMsgId = MsgId;
+    PipeDscPtr->Opts |= CFE_SB_PIPEOPTS_IGNOREMINE;
+    UtAssert_VOIDCALL(CFE_SB_TransmitTxn_FindDestinations(Txn, &BufDsc));
+    UtAssert_ZERO(Txn->NumPipes);
+    UtAssert_UINT32_EQ(BufDsc.UseCount, 0);
+    UtAssert_UINT32_EQ(DestPtr->BuffCount, 0);
+
+    /* Pipe "Ignore Mine" Option Case w/Non-Matching AppID */
+    Txn               = CFE_SB_TransmitTxn_Init(&TxnBuf, &BufDsc.Content);
+    Txn->RoutingMsgId = MsgId;
+    PipeDscPtr->AppId = CFE_ES_APPID_UNDEFINED;
+    UtAssert_VOIDCALL(CFE_SB_TransmitTxn_FindDestinations(Txn, &BufDsc));
+    UtAssert_UINT32_EQ(Txn->NumPipes, 1);
+    UtAssert_UINT32_EQ(BufDsc.UseCount, 1);
+    UtAssert_UINT32_EQ(DestPtr->BuffCount, 1);
+    CFE_ES_GetAppID(&PipeDscPtr->AppId);
+    PipeDscPtr->Opts &= ~CFE_SB_PIPEOPTS_IGNOREMINE;
+
+    /* DestPtr List too long - this emulates a hypothetical bug in SBR allowing list to grow too long */
+    /* Hack to make it infinite length */
+    DestPtr->Next     = DestPtr;
+    Txn               = CFE_SB_TransmitTxn_Init(&TxnBuf, &BufDsc.Content);
+    Txn->RoutingMsgId = MsgId;
+    UtAssert_VOIDCALL(CFE_SB_TransmitTxn_FindDestinations(Txn, &BufDsc));
+    UtAssert_UINT32_EQ(Txn->NumPipes, CFE_PLATFORM_SB_MAX_DEST_PER_PKT);
+
+    CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
+}
+
+void Test_TransmitTxn_PipeHandler(void)
+{
+    /* Test function for:
+     * bool CFE_SB_TransmitTxn_PipeHandler(CFE_SB_MessageTxn_State_t *TxnPtr, CFE_SB_PipeSetEntry_t *ContextPtr, void
+     * *Arg);
+     */
+
+    CFE_SB_TransmitTxn_State_t TxnBuf;
+    CFE_SB_MessageTxn_State_t *Txn;
+    CFE_SB_PipeId_t            PipeId = CFE_SB_INVALID_PIPE;
+    CFE_SB_MsgId_t             MsgId  = SB_UT_TLM_MID;
+    CFE_SB_BufferD_t           SBBufD;
+
+    memset(&SBBufD, 0, sizeof(SBBufD));
+    memset(&TxnBuf, 0, sizeof(TxnBuf));
+    CFE_SB_TrackingListReset(&SBBufD.Link); /* so tracking list ops work */
+    Txn = CFE_SB_TransmitTxn_Init(&TxnBuf, &SBBufD.Content);
+
+    CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId, 3, "TestPipe"));
+    CFE_UtAssert_SETUP(CFE_SB_Subscribe(MsgId, PipeId));
+
+    SBBufD.DestRouteId = CFE_SBR_GetRouteId(MsgId);
+
+    CFE_SB_LocatePipeDescByID(PipeId)->CurrentQueueDepth     = 1;
+    CFE_SB_GetDestPtr(SBBufD.DestRouteId, PipeId)->BuffCount = 1;
+
+    Txn->NumPipes                  = 6;
+    Txn->NumPipeErrs               = 1;
+    Txn->PipeSet[0].PipeId         = PipeId;
+    Txn->PipeSet[1].PipeId         = PipeId;
+    Txn->PipeSet[2].PipeId         = PipeId;
+    Txn->PipeSet[2].PendingEventId = 1;
+    Txn->PipeSet[3].PipeId         = PipeId;
+    Txn->PipeSet[4].PipeId         = PipeId;
+    Txn->PipeSet[5].PipeId         = SB_UT_ALTERNATE_INVALID_PIPEID;
+
+    UT_SetDeferredRetcode(UT_KEY(OS_QueuePut), 2, OS_QUEUE_FULL);
+    UT_SetDeferredRetcode(UT_KEY(OS_QueuePut), 1, OS_ERROR);
+    UT_SetDeferredRetcode(UT_KEY(OS_QueuePut), 1, OS_ERROR);
+    UT_SetDeferredRetcode(UT_KEY(OS_QueuePut), 1, OS_ERROR);
+
+    UtAssert_VOIDCALL(CFE_SB_MessageTxn_ProcessPipes(CFE_SB_TransmitTxn_PipeHandler, Txn, &SBBufD));
+    UtAssert_STUB_COUNT(OS_QueuePut, 5);
+    UtAssert_UINT32_EQ(Txn->NumPipeErrs, 5);
+    UtAssert_UINT32_EQ(Txn->PipeSet[0].PendingEventId, 0);
+    UtAssert_UINT32_EQ(Txn->PipeSet[1].PendingEventId, CFE_SB_Q_FULL_ERR_EID);
+    UtAssert_UINT32_EQ(Txn->PipeSet[2].PendingEventId, 1);
+    UtAssert_UINT32_EQ(Txn->PipeSet[3].PendingEventId, CFE_SB_Q_WR_ERR_EID);
+    UtAssert_UINT32_EQ(Txn->PipeSet[4].PendingEventId, CFE_SB_Q_WR_ERR_EID);
+    UtAssert_UINT32_EQ(Txn->PipeSet[5].PendingEventId, CFE_SB_Q_WR_ERR_EID);
+
+    CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
+}
+
+void Test_TransmitTxn_Execute(void)
+{
+    /* Test case for:
+     * CFE_Status_t CFE_SB_TransmitTxn_Execute(CFE_SB_MessageTxn_State_t *TxnPtr, CFE_SB_Buffer_t *BufPtr);
+     */
+    CFE_SB_BufferD_t           SBBufD;
+    CFE_SB_TransmitTxn_State_t TxnBuf;
+    CFE_SB_MessageTxn_State_t *Txn;
+    CFE_ES_AppId_t             MyAppId;
+    CFE_SB_PipeId_t            PipeId = CFE_SB_INVALID_PIPE;
+    CFE_SB_MsgId_t             MsgId  = SB_UT_TLM_MID;
+
+    memset(&SBBufD, 0, sizeof(SBBufD));
+    memset(&TxnBuf, 0, sizeof(TxnBuf));
+    CFE_SB_TrackingListReset(&SBBufD.Link); /* so tracking list ops work */
+    Txn = CFE_SB_TransmitTxn_Init(&TxnBuf, &SBBufD.Content);
+    CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId, 2, "TestPipe"));
+    CFE_UtAssert_SETUP(CFE_ES_GetAppID(&MyAppId));
+
+    /* no subs - this should still keep status as SUCCESS but trigger CFE_SB_SEND_NO_SUBS_EID event */
+    SBBufD.AppId = MyAppId;
+    UtAssert_VOIDCALL(CFE_SB_TransmitTxn_Execute(Txn, &SBBufD.Content));
+    UtAssert_STUB_COUNT(OS_QueuePut, 0);
+    UtAssert_UINT32_EQ(Txn->TransactionEventId, CFE_SB_SEND_NO_SUBS_EID);
+    UtAssert_INT32_EQ(Txn->Status, CFE_SUCCESS);
+    UtAssert_BOOL_FALSE(CFE_RESOURCEID_TEST_DEFINED(SBBufD.AppId));
+
+    /* add a subscriber - nominal case */
+    CFE_UtAssert_SETUP(CFE_SB_SubscribeFull(MsgId, PipeId, CFE_SB_DEFAULT_QOS, 2, CFE_SB_MSG_GLOBAL));
+    Txn               = CFE_SB_TransmitTxn_Init(&TxnBuf, &SBBufD.Content);
+    Txn->RoutingMsgId = MsgId;
+    SBBufD.AppId      = MyAppId;
+    UtAssert_VOIDCALL(CFE_SB_TransmitTxn_Execute(Txn, &SBBufD.Content));
+    UtAssert_BOOL_TRUE(CFE_SB_MessageTxn_IsOK(Txn));
+    UtAssert_STUB_COUNT(OS_QueuePut, 1);
+    UtAssert_BOOL_FALSE(CFE_RESOURCEID_TEST_DEFINED(SBBufD.AppId));
+
+    /* error writing to the pipe - this also still keeps status as SUCCESS but trigger CFE_SB_Q_WR_ERR_EID */
+    Txn               = CFE_SB_TransmitTxn_Init(&TxnBuf, &SBBufD.Content);
+    Txn->RoutingMsgId = MsgId;
+    SBBufD.AppId      = MyAppId;
+    UT_SetDeferredRetcode(UT_KEY(OS_QueuePut), 1, OS_ERROR);
+    UtAssert_VOIDCALL(CFE_SB_TransmitTxn_Execute(Txn, &SBBufD.Content));
+    UtAssert_BOOL_TRUE(CFE_SB_MessageTxn_IsOK(Txn));
+    UtAssert_UINT32_EQ(Txn->PipeSet[0].PendingEventId, CFE_SB_Q_WR_ERR_EID);
+    UtAssert_STUB_COUNT(OS_QueuePut, 2);
+    UtAssert_BOOL_FALSE(CFE_RESOURCEID_TEST_DEFINED(SBBufD.AppId));
+
+    /* Validation fail */
+    Txn = CFE_SB_TransmitTxn_Init(&TxnBuf, &SBBufD.Content);
+    UtAssert_VOIDCALL(CFE_SB_TransmitTxn_Execute(Txn, &SBBufD.Content));
+    UtAssert_BOOL_FALSE(CFE_SB_MessageTxn_IsOK(Txn));
+    UtAssert_INT32_EQ(Txn->Status, CFE_SB_BUFFER_INVALID);
+    UtAssert_STUB_COUNT(OS_QueuePut, 2);
+
+    CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
+}
+
+void Test_MessageTxn_GetEventDetails(void)
+{
+    /* Test case for:
+     * void CFE_SB_MessageTxn_GetEventDetails(const CFE_SB_MessageTxn_State_t *TxnPtr, CFE_ES_TaskId_t TskId, uint16
+     * EventId,char *EvtMsg, size_t EvtMsgSize, const CFE_SB_PipeSetEntry_t *ContextPtr,CFE_EVS_EventType_Enum_t
+     * *EventType, int32 *ReqBit);
+     */
+
+    CFE_SB_MessageTxn_State_t Txn;
+    CFE_SB_PipeSetEntry_t     Entry;
+    CFE_ES_TaskId_t           MyTskId;
+    char                      EvtMsg[64];
+    CFE_EVS_EventType_Enum_t  EvType;
+    int32                     EvReqBit;
+    CFE_SB_PipeId_t           PipeId;
+
+    CFE_UtAssert_SETUP(CFE_ES_GetTaskID(&MyTskId));
+    CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId, 3, "TestPipe"));
+    CFE_SB_MessageTxn_Init(&Txn, &Entry, 1, &PipeId);
+    EvReqBit     = 0;
+    EvType       = 0;
+    Entry.PipeId = PipeId;
+
+    memset(EvtMsg, 0xAA, sizeof(EvtMsg));
+    UtAssert_VOIDCALL(
+        CFE_SB_MessageTxn_GetEventDetails(&Txn, NULL, 0, MyTskId, EvtMsg, sizeof(EvtMsg), &EvType, &EvReqBit));
+    UtAssert_ZERO(EvtMsg[0]);
+    UtAssert_ZERO(EvReqBit);
+
+    memset(EvtMsg, 0xAA, sizeof(EvtMsg));
+    UtAssert_VOIDCALL(CFE_SB_MessageTxn_GetEventDetails(&Txn, NULL, CFE_SB_SEND_BAD_ARG_EID, MyTskId, EvtMsg,
+                                                        sizeof(EvtMsg), &EvType, &EvReqBit));
+    UtAssert_NONZERO(EvtMsg[0]);
+    UtAssert_NOT_NULL(memchr(EvtMsg, 0, sizeof(EvtMsg)));
+    UtAssert_UINT32_EQ(EvReqBit, CFE_SB_SEND_BAD_ARG_EID_BIT);
+
+    memset(EvtMsg, 0xAA, sizeof(EvtMsg));
+    UtAssert_VOIDCALL(CFE_SB_MessageTxn_GetEventDetails(&Txn, NULL, CFE_SB_SEND_INV_MSGID_EID, MyTskId, EvtMsg,
+                                                        sizeof(EvtMsg), &EvType, &EvReqBit));
+    UtAssert_NONZERO(EvtMsg[0]);
+    UtAssert_UINT32_EQ(EvReqBit, CFE_SB_SEND_INV_MSGID_EID_BIT);
+    UtAssert_NOT_NULL(memchr(EvtMsg, 0, sizeof(EvtMsg)));
+
+    memset(EvtMsg, 0xAA, sizeof(EvtMsg));
+    UtAssert_VOIDCALL(CFE_SB_MessageTxn_GetEventDetails(&Txn, NULL, CFE_SB_MSG_TOO_BIG_EID, MyTskId, EvtMsg,
+                                                        sizeof(EvtMsg), &EvType, &EvReqBit));
+    UtAssert_NONZERO(EvtMsg[0]);
+    UtAssert_NOT_NULL(memchr(EvtMsg, 0, sizeof(EvtMsg)));
+    UtAssert_UINT32_EQ(EvReqBit, CFE_SB_MSG_TOO_BIG_EID_BIT);
+
+    memset(EvtMsg, 0xAA, sizeof(EvtMsg));
+    UtAssert_VOIDCALL(CFE_SB_MessageTxn_GetEventDetails(&Txn, NULL, CFE_SB_SEND_NO_SUBS_EID, MyTskId, EvtMsg,
+                                                        sizeof(EvtMsg), &EvType, &EvReqBit));
+    UtAssert_NONZERO(EvtMsg[0]);
+    UtAssert_NOT_NULL(memchr(EvtMsg, 0, sizeof(EvtMsg)));
+    UtAssert_UINT32_EQ(EvReqBit, CFE_SB_SEND_NO_SUBS_EID_BIT);
+
+    memset(EvtMsg, 0xAA, sizeof(EvtMsg));
+    UtAssert_VOIDCALL(CFE_SB_MessageTxn_GetEventDetails(&Txn, &Entry, CFE_SB_GET_BUF_ERR_EID, MyTskId, EvtMsg,
+                                                        sizeof(EvtMsg), &EvType, &EvReqBit));
+    UtAssert_NONZERO(EvtMsg[0]);
+    UtAssert_NOT_NULL(memchr(EvtMsg, 0, sizeof(EvtMsg)));
+    UtAssert_UINT32_EQ(EvReqBit, CFE_SB_GET_BUF_ERR_EID_BIT);
+
+    memset(EvtMsg, 0xAA, sizeof(EvtMsg));
+    UtAssert_VOIDCALL(CFE_SB_MessageTxn_GetEventDetails(&Txn, &Entry, CFE_SB_MSGID_LIM_ERR_EID, MyTskId, EvtMsg,
+                                                        sizeof(EvtMsg), &EvType, &EvReqBit));
+    UtAssert_NONZERO(EvtMsg[0]);
+    UtAssert_NOT_NULL(memchr(EvtMsg, 0, sizeof(EvtMsg)));
+    UtAssert_UINT32_EQ(EvReqBit, CFE_SB_MSGID_LIM_ERR_EID_BIT);
+
+    memset(EvtMsg, 0xAA, sizeof(EvtMsg));
+    UtAssert_VOIDCALL(CFE_SB_MessageTxn_GetEventDetails(&Txn, &Entry, CFE_SB_Q_FULL_ERR_EID, MyTskId, EvtMsg,
+                                                        sizeof(EvtMsg), &EvType, &EvReqBit));
+    UtAssert_NONZERO(EvtMsg[0]);
+    UtAssert_NOT_NULL(memchr(EvtMsg, 0, sizeof(EvtMsg)));
+    UtAssert_UINT32_EQ(EvReqBit, CFE_SB_Q_FULL_ERR_EID_BIT);
+
+    memset(EvtMsg, 0xAA, sizeof(EvtMsg));
+    UtAssert_VOIDCALL(CFE_SB_MessageTxn_GetEventDetails(&Txn, NULL, CFE_SB_Q_WR_ERR_EID, MyTskId, EvtMsg,
+                                                        sizeof(EvtMsg), &EvType, &EvReqBit));
+    UtAssert_NONZERO(EvtMsg[0]);
+    UtAssert_NOT_NULL(memchr(EvtMsg, 0, sizeof(EvtMsg)));
+    UtAssert_UINT32_EQ(EvReqBit, CFE_SB_Q_WR_ERR_EID_BIT);
+
+    CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
+}
+
+void Test_MessageTxn_ReportSingleEvent(void)
+{
+    /* Test case for:
+     * bool CFE_SB_MessageTxn_ReportSingleEvent(uint16 EventId, const CFE_SB_MessageTxn_State_t *TxnPtr, const
+     * CFE_SB_PipeSetEntry_t *ContextPtr);
+     */
+    CFE_SB_PipeSetEntry_t     Entry;
+    CFE_SB_MessageTxn_State_t Txn;
+    CFE_SB_PipeId_t           PipeId;
+    CFE_ES_TaskId_t           MyTskId;
+
+    memset(&Txn, 0, sizeof(Txn));
+    memset(&Entry, 0, sizeof(Entry));
+    CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId, 3, "TestPipe"));
+    CFE_UtAssert_SETUP(CFE_ES_GetTaskID(&MyTskId));
+    Txn.NumPipes = 1;
+    Txn.PipeSet  = &Entry;
+    Entry.PipeId = PipeId;
+
+    /* Event ID == 0 is reserved for no event, nothing to report */
+    UT_ClearEventHistory();
+    UtAssert_BOOL_FALSE(CFE_SB_MessageTxn_ReportSingleEvent(&Txn, NULL, 0));
+    CFE_UtAssert_EVENTCOUNT(0);
+
+    /* No subscribers should be an information event (not an error) */
+    UT_ClearEventHistory();
+    UtAssert_BOOL_FALSE(CFE_SB_MessageTxn_ReportSingleEvent(&Txn, NULL, CFE_SB_SEND_NO_SUBS_EID));
+    CFE_UtAssert_EVENTCOUNT(1);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SEND_NO_SUBS_EID);
+
+    /* Queue write failure should be an error */
+    /* Note that with context != NULL, it looks up the pipe name, which generates a debug event */
+    UT_ClearEventHistory();
+    UtAssert_BOOL_TRUE(CFE_SB_MessageTxn_ReportSingleEvent(&Txn, &Entry, CFE_SB_Q_WR_ERR_EID));
+    CFE_UtAssert_EVENTCOUNT(2);
+    CFE_UtAssert_EVENTSENT(CFE_SB_Q_WR_ERR_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_GETPIPENAME_EID);
+
+    /* Check that the loop-avoidance works */
+    CFE_SB_RequestToSendEvent(MyTskId, CFE_SB_MSG_TOO_BIG_EID_BIT);
+    UT_ClearEventHistory();
+    UtAssert_BOOL_TRUE(CFE_SB_MessageTxn_ReportSingleEvent(&Txn, NULL, CFE_SB_MSG_TOO_BIG_EID));
+    CFE_UtAssert_EVENTCOUNT(0);
+    CFE_SB_FinishSendEvent(MyTskId, CFE_SB_MSG_TOO_BIG_EID_BIT);
+
+    CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
+}
+
+void Test_MessageTxn_ReportEvents(void)
+{
+    /* Test case for:
+     * void CFE_SB_MessageTxn_ReportEvents(const CFE_SB_MessageTxn_State_t *TxnPtr);
+     */
+    CFE_SB_PipeSetEntry_t     PipeSetEntry;
+    CFE_SB_MessageTxn_State_t Txn;
+
+    memset(&Txn, 0, sizeof(Txn));
+    Txn.PipeSet  = &PipeSetEntry;
+    Txn.NumPipes = 1;
+    Txn.MaxPipes = 1;
+
+    /* nominal */
+    UtAssert_VOIDCALL(CFE_SB_MessageTxn_ReportEvents(&Txn));
+    UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter);
+
+    /* with an event at the transaction level, known to be an error */
+    Txn.TransactionEventId = CFE_SB_MSG_TOO_BIG_EID;
+    Txn.IsTransmit         = true;
+    UtAssert_VOIDCALL(CFE_SB_MessageTxn_ReportEvents(&Txn));
+    UtAssert_UINT32_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter, 1);
+
+    /* with some undefined/unknown event at the transaction level, not an error */
+    Txn.TransactionEventId = 0xFFFF;
+    UtAssert_VOIDCALL(CFE_SB_MessageTxn_ReportEvents(&Txn));
+    UtAssert_UINT32_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter, 1);
+
+    /* with an event at the pipe level, known to be an error */
+    Txn.TransactionEventId        = 0;
+    Txn.PipeSet[0].PendingEventId = CFE_SB_Q_FULL_ERR_EID;
+    UtAssert_VOIDCALL(CFE_SB_MessageTxn_ReportEvents(&Txn));
+    UtAssert_UINT32_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter, 2);
+
+    /* with some undefined/unknown event at the pipe level, not an error */
+    Txn.PipeSet[0].PendingEventId = 0xFFFF;
+    UtAssert_VOIDCALL(CFE_SB_MessageTxn_ReportEvents(&Txn));
+    UtAssert_UINT32_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter, 2);
+}
+
 /*
 ** Function for calling SB send message API test functions
 */
@@ -2901,10 +3486,19 @@ void Test_TransmitMsg_API(void)
     SB_UT_ADD_SUBTEST(Test_TransmitBuffer_NoIncrement);
     SB_UT_ADD_SUBTEST(Test_TransmitMsg_ZeroCopyBufferValidate);
     SB_UT_ADD_SUBTEST(Test_TransmitMsg_DisabledDestination);
-    SB_UT_ADD_SUBTEST(Test_BroadcastBufferToRoute);
-    SB_UT_ADD_SUBTEST(Test_TransmitMsgValidate_MaxMsgSizePlusOne);
-    SB_UT_ADD_SUBTEST(Test_TransmitMsgValidate_NoSubscribers);
-    SB_UT_ADD_SUBTEST(Test_TransmitMsgValidate_InvalidMsgId);
+
+    SB_UT_ADD_SUBTEST(Test_MessageTxn_SetEventAndStatus);
+    SB_UT_ADD_SUBTEST(Test_MessageTxn_SetupFromMsg);
+    SB_UT_ADD_SUBTEST(Test_MessageTxn_Timeout);
+    SB_UT_ADD_SUBTEST(Test_MessageTxn_GetEventDetails);
+    SB_UT_ADD_SUBTEST(Test_MessageTxn_ReportSingleEvent);
+    SB_UT_ADD_SUBTEST(Test_MessageTxn_ReportEvents);
+
+    SB_UT_ADD_SUBTEST(Test_TransmitTxn_Init);
+    SB_UT_ADD_SUBTEST(Test_TransmitTxn_FindDestinations);
+    SB_UT_ADD_SUBTEST(Test_TransmitTxn_PipeHandler);
+    SB_UT_ADD_SUBTEST(Test_TransmitTxn_Execute);
+
     SB_UT_ADD_SUBTEST(Test_AllocateMessageBuffer);
     SB_UT_ADD_SUBTEST(Test_ReleaseMessageBuffer);
 }
@@ -3304,9 +3898,6 @@ void Test_TransmitMsg_ZeroCopyBufferValidate(void)
      * descriptor which is NOT from CFE_SB_AllocateMessageBuffer(). */
     memset(&BadZeroCpyBuf, 0, sizeof(BadZeroCpyBuf));
 
-    /* Null Buffer => BAD_ARGUMENT */
-    UtAssert_INT32_EQ(CFE_SB_ZeroCopyBufferValidate(NULL, &BufDscPtr), CFE_SB_BAD_ARGUMENT);
-
     /* Non-null buffer pointer but Non Zero-Copy => CFE_SB_BUFFER_INVALID */
     UtAssert_INT32_EQ(CFE_SB_ZeroCopyBufferValidate(&BadZeroCpyBuf.Content, &BufDscPtr), CFE_SB_BUFFER_INVALID);
 
@@ -3505,113 +4096,12 @@ void Test_TransmitMsg_DisabledDestination(void)
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
 }
 
-/*
-** Test successful CFE_SB_BroadcastBufferToRoute
-*/
-void Test_BroadcastBufferToRoute(void)
+void UT_CFE_MSG_Verify_CustomHandler(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
-    CFE_SB_PipeId_t   PipeId = CFE_SB_INVALID_PIPE;
-    CFE_SB_MsgId_t    MsgId  = SB_UT_TLM_MID;
-    CFE_SB_BufferD_t  SBBufD;
-    int32             PipeDepth;
-    CFE_SBR_RouteId_t RouteId;
+    bool *IsAcceptable = UT_Hook_GetArgValueByName(Context, "IsAcceptable", bool *);
 
-    memset(&SBBufD, 0, sizeof(SBBufD));
-    SBBufD.MsgId = MsgId;
-    CFE_SB_TrackingListReset(&SBBufD.Link);
-
-    PipeDepth = 2;
-    CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "TestPipe"));
-    CFE_UtAssert_SETUP(CFE_SB_Subscribe(MsgId, PipeId));
-
-    RouteId = CFE_SBR_GetRouteId(MsgId);
-
-    /* No return from this function - it handles all errors */
-    CFE_SB_BroadcastBufferToRoute(&SBBufD, RouteId);
-
-    CFE_UtAssert_EVENTCOUNT(2);
-    UT_ClearEventHistory();
-
-    /* Calling this with invalid route ID is essentially a no-op, called for coverage */
-    CFE_SB_BroadcastBufferToRoute(&SBBufD, CFE_SBR_INVALID_ROUTE_ID);
-
-    CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-}
-
-/*
-** Test response to sending a message with the message size larger than allowed
-*/
-void Test_TransmitMsgValidate_MaxMsgSizePlusOne(void)
-{
-    CFE_SB_MsgId_t    MsgId = SB_UT_TLM_MID;
-    CFE_SB_MsgId_t    MsgIdRtn;
-    SB_UT_Test_Tlm_t  TlmPkt;
-    CFE_MSG_Size_t    Size    = CFE_MISSION_SB_MAX_SB_MSG_SIZE + 1;
-    CFE_MSG_Size_t    SizeRtn = 0;
-    CFE_SBR_RouteId_t RouteIdRtn;
-
-    memset(&TlmPkt, 0, sizeof(TlmPkt));
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-
-    UtAssert_INT32_EQ(CFE_SB_TransmitMsgValidate(CFE_MSG_PTR(TlmPkt.TelemetryHeader), &MsgIdRtn, &SizeRtn, &RouteIdRtn),
-                      CFE_SB_MSG_TOO_BIG);
-    CFE_UtAssert_MSGID_EQ(MsgIdRtn, MsgId);
-    UtAssert_INT32_EQ(SizeRtn, Size);
-
-    CFE_UtAssert_EVENTCOUNT(1);
-
-    CFE_UtAssert_EVENTSENT(CFE_SB_MSG_TOO_BIG_EID);
-}
-
-/*
-** Test response to sending a message which has no subscribers
-*/
-void Test_TransmitMsgValidate_NoSubscribers(void)
-{
-    CFE_SB_MsgId_t    MsgId = SB_UT_TLM_MID;
-    CFE_SB_MsgId_t    MsgIdRtn;
-    SB_UT_Test_Tlm_t  TlmPkt;
-    CFE_MSG_Size_t    Size       = sizeof(TlmPkt);
-    CFE_MSG_Size_t    SizeRtn    = 0;
-    CFE_SBR_RouteId_t RouteIdRtn = CFE_SBR_INVALID_ROUTE_ID;
-
-    memset(&TlmPkt, 0, sizeof(TlmPkt));
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-
-    CFE_UtAssert_SUCCESS(
-        CFE_SB_TransmitMsgValidate(CFE_MSG_PTR(TlmPkt.TelemetryHeader), &MsgIdRtn, &SizeRtn, &RouteIdRtn));
-    CFE_UtAssert_MSGID_EQ(MsgIdRtn, MsgId);
-    UtAssert_INT32_EQ(SizeRtn, Size);
-    UtAssert_BOOL_FALSE(CFE_SBR_IsValidRouteId(RouteIdRtn));
-
-    CFE_UtAssert_EVENTCOUNT(1);
-
-    CFE_UtAssert_EVENTSENT(CFE_SB_SEND_NO_SUBS_EID);
-}
-
-/*
-** Test response to sending a message which has an invalid Msg ID
-*/
-void Test_TransmitMsgValidate_InvalidMsgId(void)
-{
-    CFE_SB_MsgId_t    MsgId = CFE_SB_INVALID_MSG_ID;
-    CFE_SB_MsgId_t    MsgIdRtn;
-    SB_UT_Test_Tlm_t  TlmPkt;
-    CFE_MSG_Size_t    SizeRtn;
-    CFE_SBR_RouteId_t RouteIdRtn;
-
-    memset(&TlmPkt, 0, sizeof(TlmPkt));
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-
-    UtAssert_INT32_EQ(CFE_SB_TransmitMsgValidate(CFE_MSG_PTR(TlmPkt.TelemetryHeader), &MsgIdRtn, &SizeRtn, &RouteIdRtn),
-                      CFE_SB_BAD_ARGUMENT);
-    CFE_UtAssert_EVENTCOUNT(1);
-    CFE_UtAssert_EVENTSENT(CFE_SB_SEND_INV_MSGID_EID);
+    /* Return alternating false/true (this is needed to avoid an endless loop) */
+    *IsAcceptable = (UT_GetStubCount(FuncKey) & 1) == 0;
 }
 
 /*
@@ -3630,17 +4120,18 @@ void Test_ReceiveBuffer_API(void)
 
 static void SB_UT_PipeIdModifyHandler(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
-    void *                  data        = UT_Hook_GetArgValueByName(Context, "data", void *);
+    CFE_SB_BufferD_t **     OutData     = UT_Hook_GetArgValueByName(Context, "data", void *);
     size_t *                size_copied = UT_Hook_GetArgValueByName(Context, "size_copied", size_t *);
     int32                   status;
-    static SB_UT_Test_Tlm_t FakeTlmPkt;
-    SB_UT_Test_Tlm_t **     OutData;
+    static CFE_SB_BufferD_t LocalBuf;
     CFE_SB_PipeD_t *        PipeDscPtr = UserObj;
 
-    OutData      = data;
-    *OutData     = &FakeTlmPkt;
-    *size_copied = sizeof(*OutData);
-    status       = OS_SUCCESS;
+    memset(&LocalBuf, 0, sizeof(LocalBuf));
+    CFE_SB_TrackingListReset(&LocalBuf.Link);
+    LocalBuf.UseCount = 1;
+    *OutData          = &LocalBuf;
+    *size_copied      = sizeof(*OutData);
+    status            = OS_SUCCESS;
     UT_Stub_SetReturnValue(FuncKey, status);
 
     /* Modify the PipeID so it fails to match */
@@ -3700,8 +4191,8 @@ void Test_ReceiveBuffer_InvalidPipeId(void)
     UT_SetHandlerFunction(UT_KEY(OS_QueueGet), SB_UT_PipeIdModifyHandler, PipeDscPtr);
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&SBBufPtr, PipeId, CFE_SB_POLL), CFE_SB_PIPE_RD_ERR);
     CFE_UtAssert_EVENTSENT(CFE_SB_BAD_PIPEID_EID);
-    UtAssert_UINT8_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgReceiveErrorCounter, 2);
-    UtAssert_UINT8_EQ(CFE_SB_Global.HKTlmMsg.Payload.InternalErrorCounter, 0);
+    UtAssert_UINT8_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgReceiveErrorCounter, 1);
+    UtAssert_UINT8_EQ(CFE_SB_Global.HKTlmMsg.Payload.InternalErrorCounter, 1);
     UT_SetHandlerFunction(UT_KEY(OS_QueueGet), NULL, NULL);
 
     /* restore the PipeID so it can be deleted */
@@ -3793,7 +4284,7 @@ void Test_ReceiveBuffer_PipeReadError(void)
     UT_SetDeferredRetcode(UT_KEY(OS_QueueGet), 1, OS_ERROR);
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&SBBufPtr, PipeId, CFE_SB_PEND_FOREVER), CFE_SB_PIPE_RD_ERR);
 
-    CFE_UtAssert_EVENTCOUNT(2);
+    CFE_UtAssert_EVENTCOUNT(3);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_Q_RD_ERR_EID);
 
@@ -4187,11 +4678,6 @@ void Test_SB_SpecialCases(void)
     SB_UT_ADD_SUBTEST(Test_PutDestBlk_ErrLogic);
     SB_UT_ADD_SUBTEST(Test_CFE_SB_Buffers);
     SB_UT_ADD_SUBTEST(Test_CFE_SB_BadPipeInfo);
-    SB_UT_ADD_SUBTEST(Test_SB_TransmitMsgPaths_Nominal);
-    SB_UT_ADD_SUBTEST(Test_SB_TransmitMsgPaths_LimitErr);
-    SB_UT_ADD_SUBTEST(Test_SB_TransmitMsgPaths_FullErr);
-    SB_UT_ADD_SUBTEST(Test_SB_TransmitMsgPaths_WriteErr);
-    SB_UT_ADD_SUBTEST(Test_SB_TransmitMsgPaths_IgnoreOpt);
     SB_UT_ADD_SUBTEST(Test_ReceiveBuffer_UnsubResubPath);
     SB_UT_ADD_SUBTEST(Test_MessageString);
 }
@@ -4358,281 +4844,6 @@ void Test_CFE_SB_BadPipeInfo(void)
 
     CFE_UtAssert_EVENTCOUNT(4);
 
-    CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-}
-
-/*
-** Test send housekeeping information command
-*/
-void Test_SB_TransmitMsgPaths_Nominal(void)
-{
-    union
-    {
-        CFE_SB_Buffer_t    SBBuf;
-        CFE_SB_SendHkCmd_t SendHkCmd;
-    } Housekeeping;
-    CFE_SB_MsgId_t   MsgId;
-    CFE_SB_PipeId_t  PipeId = CFE_SB_INVALID_PIPE;
-    SB_UT_Test_Tlm_t TlmPkt;
-    int32            PipeDepth = 2;
-    CFE_MSG_Size_t   Size;
-    CFE_MSG_Type_t   Type;
-
-    memset(&Housekeeping, 0, sizeof(Housekeeping));
-    memset(&TlmPkt, 0, sizeof(TlmPkt));
-
-    /* Set up for dispatch FIRST */
-    UT_SetupBasicMsgDispatch(&UT_TPID_CFE_SB_SEND_HK, sizeof(Housekeeping.SendHkCmd), false);
-
-    /* For internal send message call */
-    MsgId = CFE_SB_ValueToMsgId(CFE_SB_HK_TLM_MID);
-    Size  = sizeof(CFE_SB_Global.HKTlmMsg);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-
-    /* Repress sending the no subscriptions event and process request */
-    CFE_SB_Global.HKTlmMsg.Payload.NoSubscribersCounter = 0;
-    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_SEND_NO_SUBS_EID_BIT);
-    CFE_SB_ProcessCmdPipePkt(&Housekeeping.SBBuf);
-
-    /* The no subs event should not be in history but count should increment */
-    CFE_UtAssert_EVENTNOTSENT(CFE_SB_SEND_NO_SUBS_EID);
-    UtAssert_INT32_EQ(CFE_SB_Global.HKTlmMsg.Payload.NoSubscribersCounter, 1);
-
-    /* Repress get buffer error */
-    CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter = 0;
-    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_GET_BUF_ERR_EID_BIT);
-
-    /* Set up for dispatch FIRST */
-    UT_SetupBasicMsgDispatch(&UT_TPID_CFE_SB_SEND_HK, sizeof(Housekeeping.SendHkCmd), false);
-
-    /* For internal send message call */
-    MsgId = CFE_SB_ValueToMsgId(CFE_SB_HK_TLM_MID);
-    Size  = sizeof(CFE_SB_Global.HKTlmMsg);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-
-    UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetPoolBuf), 1, CFE_ES_ERR_MEM_BLOCK_SIZE);
-    CFE_SB_ProcessCmdPipePkt(&Housekeeping.SBBuf);
-    UtAssert_INT32_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter, 0);
-
-    CFE_UtAssert_EVENTNOTSENT(CFE_SB_GET_BUF_ERR_EID);
-
-    CFE_UtAssert_EVENTCOUNT(0);
-
-    CFE_SB_Global.StopRecurseFlags[1] = 0;
-
-    /* Create a message ID with the command bit set and disable reporting */
-    MsgId = SB_UT_CMD_MID;
-    Size  = sizeof(TlmPkt);
-    Type  = CFE_MSG_Type_Cmd;
-    CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "TestPipe"));
-
-    /* Will fail because of deferred CFE_ES_GetPoolBuf failure return */
-    UtAssert_INT32_EQ(CFE_SB_Subscribe(MsgId, PipeId), CFE_SB_BUF_ALOC_ERR);
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
-
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
-
-    CFE_UtAssert_EVENTCOUNT(3);
-
-    /*
-     * Test Additional paths within CFE_SB_TransmitMsgValidate that skip sending events to avoid a loop
-     * For all of these they should skip sending the event but still increment the MsgSendErrorCounter
-     */
-
-    /* CFE_SB_MSG_TOO_BIG_EID loop filter */
-    CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter = 0;
-    Size                                               = CFE_MISSION_SB_MAX_SB_MSG_SIZE + 1;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_MSG_TOO_BIG_EID_BIT);
-    CFE_SB_TransmitMsg(CFE_MSG_PTR(Housekeeping.SBBuf), true);
-    CFE_UtAssert_EVENTNOTSENT(CFE_SB_MSG_TOO_BIG_EID);
-    UtAssert_UINT32_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter, 1);
-
-    /* CFE_SB_SEND_INV_MSGID_EID loop filter */
-    CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter = 0;
-    MsgId                                              = CFE_SB_INVALID_MSG_ID;
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_SEND_INV_MSGID_EID_BIT);
-    CFE_SB_TransmitMsg(CFE_MSG_PTR(Housekeeping.SBBuf), true);
-    CFE_UtAssert_EVENTNOTSENT(CFE_SB_SEND_INV_MSGID_EID);
-    UtAssert_UINT32_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter, 1);
-
-    /* CFE_SB_SEND_BAD_ARG_EID loop filter */
-    CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter = 0;
-    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_SEND_BAD_ARG_EID_BIT);
-    CFE_SB_TransmitMsg(NULL, true);
-    CFE_UtAssert_EVENTNOTSENT(CFE_SB_SEND_BAD_ARG_EID);
-    UtAssert_UINT32_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter, 1);
-
-    CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-}
-
-void Test_SB_TransmitMsgPaths_LimitErr(void)
-{
-    CFE_SB_MsgId_t   MsgId;
-    CFE_SB_PipeId_t  PipeId = CFE_SB_INVALID_PIPE;
-    SB_UT_Test_Tlm_t TlmPkt;
-    int32            PipeDepth = 2;
-    CFE_MSG_Type_t   Type      = CFE_MSG_Type_Tlm;
-    CFE_MSG_Size_t   Size      = sizeof(TlmPkt);
-
-    memset(&TlmPkt, 0, sizeof(TlmPkt));
-
-    /* Test inhibiting sending a "message ID limit error" message */
-    MsgId = SB_UT_TLM_MID;
-    CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "MsgLimTestPipe"));
-
-    /* Set maximum allowed messages on the pipe at one time to 1 */
-    CFE_UtAssert_SETUP(CFE_SB_SubscribeEx(MsgId, PipeId, CFE_SB_DEFAULT_QOS, 1));
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
-
-    /* First send should pass */
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
-
-    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_MSGID_LIM_ERR_EID_BIT);
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
-    CFE_SB_Global.StopRecurseFlags[1] = 0;
-
-    CFE_UtAssert_EVENTNOTSENT(CFE_SB_MSGID_LIM_ERR_EID);
-
-    CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-}
-
-void Test_SB_TransmitMsgPaths_FullErr(void)
-{
-    CFE_SB_MsgId_t   MsgId;
-    CFE_SB_PipeId_t  PipeId = CFE_SB_INVALID_PIPE;
-    SB_UT_Test_Tlm_t TlmPkt;
-    int32            PipeDepth = 2;
-    CFE_MSG_Type_t   Type      = CFE_MSG_Type_Tlm;
-    CFE_MSG_Size_t   Size      = sizeof(TlmPkt);
-
-    memset(&TlmPkt, 0, sizeof(TlmPkt));
-
-    /* Test inhibiting sending a "pipe full" message */
-    MsgId = SB_UT_TLM_MID;
-    CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "PipeFullTestPipe"));
-    CFE_UtAssert_SETUP(CFE_SB_Subscribe(MsgId, PipeId));
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
-
-    /* This send should pass */
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
-
-    /* Tell the QueuePut stub to return OS_QUEUE_FULL on its next call */
-    UT_SetDeferredRetcode(UT_KEY(OS_QueuePut), 1, OS_QUEUE_FULL);
-    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_Q_FULL_ERR_EID_BIT);
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
-    CFE_SB_Global.StopRecurseFlags[1] = 0;
-
-    CFE_UtAssert_EVENTNOTSENT(CFE_SB_Q_FULL_ERR_EID_BIT);
-
-    CFE_UtAssert_EVENTCOUNT(2);
-
-    CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-}
-
-void Test_SB_TransmitMsgPaths_WriteErr(void)
-{
-    CFE_SB_MsgId_t   MsgId;
-    CFE_SB_PipeId_t  PipeId = CFE_SB_INVALID_PIPE;
-    SB_UT_Test_Tlm_t TlmPkt;
-    int32            PipeDepth = 2;
-    CFE_MSG_Type_t   Type      = CFE_MSG_Type_Tlm;
-    CFE_MSG_Size_t   Size      = sizeof(TlmPkt);
-
-    memset(&TlmPkt, 0, sizeof(TlmPkt));
-
-    /* Test inhibiting sending a "pipe write error" message */
-    MsgId = SB_UT_TLM_MID;
-    CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "TestPipe"));
-    CFE_UtAssert_SETUP(CFE_SB_Subscribe(MsgId, PipeId));
-    UT_SetDeferredRetcode(UT_KEY(OS_QueuePut), 1, OS_ERROR);
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
-
-    CFE_SB_Global.StopRecurseFlags[1] |= CFE_BIT(CFE_SB_Q_WR_ERR_EID_BIT);
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
-    CFE_SB_Global.StopRecurseFlags[1] = 0;
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
-
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
-
-    CFE_UtAssert_EVENTCOUNT(2);
-
-    CFE_UtAssert_EVENTNOTSENT(CFE_SB_Q_WR_ERR_EID);
-
-    CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
-}
-
-void Test_SB_TransmitMsgPaths_IgnoreOpt(void)
-{
-    CFE_SB_MsgId_t   MsgId;
-    CFE_SB_PipeId_t  PipeId = CFE_SB_INVALID_PIPE;
-    SB_UT_Test_Tlm_t TlmPkt;
-    int32            PipeDepth = 2;
-    CFE_MSG_Type_t   Type      = CFE_MSG_Type_Tlm;
-    CFE_MSG_Size_t   Size      = sizeof(TlmPkt);
-    CFE_SB_PipeD_t * PipeDscPtr;
-    CFE_ES_AppId_t   AppId;
-
-    memset(&TlmPkt, 0, sizeof(TlmPkt));
-
-    /* Setup Test skipping sending to a pipe when the pipe option is set to ignore */
-    MsgId = SB_UT_TLM_MID;
-    CFE_UtAssert_SETUP(CFE_SB_CreatePipe(&PipeId, PipeDepth, "SkipPipe"));
-    CFE_UtAssert_SETUP(CFE_SB_Subscribe(MsgId, PipeId));
-    CFE_UtAssert_SETUP(CFE_SB_SetPipeOpts(PipeId, CFE_SB_PIPEOPTS_IGNOREMINE));
-
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
-
-    /* Test skipping this pipe and the send should pass */
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
-    UtAssert_STUB_COUNT(OS_QueuePut, 0);
-
-    /* Set up and send again without matching ApId and it should transmit */
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), &MsgId, sizeof(MsgId), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &Size, sizeof(Size), false);
-    UT_SetDataBuffer(UT_KEY(CFE_MSG_GetType), &Type, sizeof(Type), false);
-    PipeDscPtr        = CFE_SB_LocatePipeDescByID(PipeId);
-    AppId             = PipeDscPtr->AppId;
-    PipeDscPtr->AppId = CFE_ES_APPID_UNDEFINED;
-
-    /* Also hit case where not the peak depth */
-    PipeDscPtr->PeakQueueDepth += 2;
-    CFE_UtAssert_SUCCESS(CFE_SB_TransmitMsg(CFE_MSG_PTR(TlmPkt.TelemetryHeader), true));
-    UtAssert_STUB_COUNT(OS_QueuePut, 1);
-
-    /* Set AppId back so it can be deleted */
-    PipeDscPtr->AppId = AppId;
-
-    CFE_UtAssert_TEARDOWN(CFE_SB_SetPipeOpts(PipeId, 0));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
 }
 

--- a/modules/sb/ut-coverage/sb_UT.h
+++ b/modules/sb/ut-coverage/sb_UT.h
@@ -2047,7 +2047,7 @@ void Test_TransmitMsg_DisabledDestination(void);
 
 /*****************************************************************************/
 /**
-** \brief Test CFE_SB_BroadcastBufferToRoute
+** \brief Test CFE_SB_TransmitTxn_BroadcastToRoute
 **
 ** \par Description
 **        This function tests broadcasting a message buffer with the metadata.
@@ -2058,23 +2058,7 @@ void Test_TransmitMsg_DisabledDestination(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_BroadcastBufferToRoute(void);
-
-/*****************************************************************************/
-/**
-** \brief Test response to sending a message which has no subscribers
-**
-** \par Description
-**        This function tests the response to sending a message which has no
-**        subscribers.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-******************************************************************************/
-void Test_TransmitMsgValidate_NoSubscribers(void);
+void Test_TransmitTxn_PipeHandler(void);
 
 /*****************************************************************************/
 /**
@@ -2090,7 +2074,7 @@ void Test_TransmitMsgValidate_NoSubscribers(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_TransmitMsgValidate_InvalidMsgId(void);
+void Test_TransmitTxn_SetupFromMsg_InvalidMsgId(void);
 
 /*****************************************************************************/
 /**
@@ -2107,7 +2091,7 @@ void Test_TransmitMsgValidate_InvalidMsgId(void);
 ** \returns
 **        This function does not return a value.
 ******************************************************************************/
-void Test_TransmitMsgValidate_MaxMsgSizePlusOne(void);
+void Test_TransmitTxn_SetupFromMsg_MaxMsgSizePlusOne(void);
 
 /*****************************************************************************/
 /**
@@ -2456,25 +2440,6 @@ void Test_CFE_SB_Buffers(void);
 **        This function does not return a value.
 ******************************************************************************/
 void Test_CFE_SB_BadPipeInfo(void);
-
-/*****************************************************************************/
-/**
-** \brief Test TransmitMsgFull function paths
-**
-** \par Description
-**        This function tests branch paths in the TransmitMsgFull function.
-**
-** \par Assumptions, External Events, and Notes:
-**        None
-**
-** \returns
-**        This function does not return a value.
-******************************************************************************/
-void Test_SB_TransmitMsgPaths_Nominal(void);
-void Test_SB_TransmitMsgPaths_LimitErr(void);
-void Test_SB_TransmitMsgPaths_FullErr(void);
-void Test_SB_TransmitMsgPaths_WriteErr(void);
-void Test_SB_TransmitMsgPaths_IgnoreOpt(void);
 
 /*****************************************************************************/
 /**


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Cleans up the internal SB implementation so it can better support future enhancements such as message integrity, additional header fields and timestamping.

Fixes #2378

**Testing performed**
Full suite of tests on SB implementation

**Expected behavior changes**
API behavior is preserved, fully backward compatible

**System(s) tested on**
Debian 

**Additional context**
Replaces #2367 based on code review and discussion.  This PR represents the refactoring change, along with some other refinements.  The routing change will be a separate PR.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
