### PR TITLE
fix #2316 - CFE_TIME_Print() calls strftime()

### DIFF
--- a/modules/core_api/fsw/inc/cfe_time.h
+++ b/modules/core_api/fsw/inc/cfe_time.h
@@ -691,6 +691,8 @@ CFE_Status_t CFE_TIME_UnregisterSynchCallback(CFE_TIME_SynchCallbackPtr_t Callba
 **           - \c \\0 = trailing null
 **
 ** \par Assumptions, External Events, and Notes:
+**        - This function calls strftime to format the output. Systems without this
+**          C99-standard function will have to write their own implementation.
 **        - The value of the time argument is simply added to the configuration
 **          definitions for the ground epoch and converted into a fixed length
 **          string in the buffer provided by the caller.
@@ -706,8 +708,12 @@ CFE_Status_t CFE_TIME_UnregisterSynchCallback(CFE_TIME_SynchCallbackPtr_t Callba
 **
 ** \param[in]  TimeToPrint   The time to print into the character array.
 **
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS                      \copybrief CFE_SUCCESS
+** \retval #CFE_TIME_BAD_ARGUMENT            \copybrief CFE_TIME_BAD_ARGUMENT
+**
 ******************************************************************************/
-void CFE_TIME_Print(char *PrintBuffer, CFE_TIME_SysTime_t TimeToPrint);
+CFE_Status_t CFE_TIME_Print(char *PrintBuffer, CFE_TIME_SysTime_t TimeToPrint);
 
 /*****************************************************************************/
 /**

--- a/modules/core_api/ut-stubs/src/cfe_time_handlers.c
+++ b/modules/core_api/ut-stubs/src/cfe_time_handlers.c
@@ -45,13 +45,14 @@
  * Default handler for CFE_TIME_Print coverage stub function
  *
  *------------------------------------------------------------*/
-void UT_DefaultHandler_CFE_TIME_Print(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+CFE_Status_t UT_DefaultHandler_CFE_TIME_Print(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
     char *             PrintBuffer = UT_Hook_GetArgValueByName(Context, "PrintBuffer", char *);
     CFE_TIME_SysTime_t TimeToPrint = UT_Hook_GetArgValueByName(Context, "TimeToPrint", CFE_TIME_SysTime_t);
 
     snprintf(PrintBuffer, CFE_TIME_PRINTED_STRING_SIZE, "UT %u.%u -", (unsigned int)TimeToPrint.Seconds,
              (unsigned int)TimeToPrint.Subseconds);
+    return CFE_SUCCESS;
 }
 
 /*------------------------------------------------------------

--- a/modules/core_api/ut-stubs/src/cfe_time_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_time_stubs.c
@@ -305,12 +305,16 @@ uint32 CFE_TIME_Micro2SubSecs(uint32 MicroSeconds)
  * Generated stub function for CFE_TIME_Print()
  * ----------------------------------------------------
  */
-void CFE_TIME_Print(char *PrintBuffer, CFE_TIME_SysTime_t TimeToPrint)
+CFE_Status_t CFE_TIME_Print(char *PrintBuffer, CFE_TIME_SysTime_t TimeToPrint)
 {
+    UT_GenStub_SetupReturnBuffer(CFE_TIME_Print, CFE_Status_t);
+
     UT_GenStub_AddParam(CFE_TIME_Print, char *, PrintBuffer);
     UT_GenStub_AddParam(CFE_TIME_Print, CFE_TIME_SysTime_t, TimeToPrint);
 
     UT_GenStub_Execute(CFE_TIME_Print, Basic, UT_DefaultHandler_CFE_TIME_Print);
+
+    return UT_GenStub_GetReturnValue(CFE_TIME_Print, CFE_Status_t);
 }
 
 /*

--- a/modules/time/config/default_cfe_time_interface_cfg.h
+++ b/modules/time/config/default_cfe_time_interface_cfg.h
@@ -151,23 +151,14 @@
 **  \cfetimecfg Default EPOCH Values
 **
 **  \par Description:
-**      Default ground time epoch values
+**      Default ground time epoch values (from Jan. 1, 1970 00:00:00)
 **      Note: these values are used only by the CFE_TIME_Print() API function
 **
 **  \par Limits
-**      Year - must be within 136 years
-**      Day - Jan 1 = 1, Feb 1 = 32, etc.
-**      Hour - 0 to 23
-**      Minute - 0 to 59
-**      Second - 0 to 59
 **      Micros - 0 to 999999
 */
-#define CFE_MISSION_TIME_EPOCH_YEAR   1980
-#define CFE_MISSION_TIME_EPOCH_DAY    1
-#define CFE_MISSION_TIME_EPOCH_HOUR   0
-#define CFE_MISSION_TIME_EPOCH_MINUTE 0
-#define CFE_MISSION_TIME_EPOCH_SECOND 0
-#define CFE_MISSION_TIME_EPOCH_MICROS 0
+#define CFE_MISSION_TIME_EPOCH_SECONDS 315532800 /* Jan. 1, 1980 00:00:00 */
+#define CFE_MISSION_TIME_EPOCH_MICROS  0
 
 /**
 **  \cfetimecfg Time File System Factor

--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -821,7 +821,7 @@ void Test_ConvertTime(void)
 **
 ** NOTE: Test results depend on the epoch values in cfe_mission_cfg.h (the
 **       tests below assume an epoch of 1980-001-00:00:00.00000).  Full
-**       coverage is possible only when CFE_MISSION_TIME_EPOCH_SECOND > 0
+**       coverage is possible only when CFE_MISSION_TIME_EPOCH_SECONDS > 0
 */
 void Test_Print(void)
 {
@@ -834,8 +834,7 @@ void Test_Print(void)
 
     UtPrintf("Begin Test Print");
 
-    if (CFE_MISSION_TIME_EPOCH_YEAR != 1980 || CFE_MISSION_TIME_EPOCH_DAY != 1 || CFE_MISSION_TIME_EPOCH_HOUR != 0 ||
-        CFE_MISSION_TIME_EPOCH_MINUTE != 0 || CFE_MISSION_TIME_EPOCH_SECOND != 0 || CFE_MISSION_TIME_EPOCH_MICROS != 0)
+    if (CFE_MISSION_TIME_EPOCH_SECONDS != 0 || CFE_MISSION_TIME_EPOCH_MICROS != 0)
     {
         UtPrintf("Custom epoch time requires manual inspection for CFE_TIME_Print");
         usingDefaultEpoch = false;
@@ -843,11 +842,10 @@ void Test_Print(void)
 
     /* Test print with null print buffer argument */
     UT_InitData();
-    UtAssert_VOIDCALL(CFE_TIME_Print(NULL, time));
-    CFE_UtAssert_SYSLOG(TIME_SYSLOG_MSGS[6]);
+    UtAssert_INT32_EQ(CFE_TIME_Print(NULL, time), CFE_TIME_BAD_ARGUMENT);
 
     /* Test with zero time value */
-    CFE_TIME_Print(timeBuf, time);
+    CFE_UtAssert_SUCCESS(CFE_TIME_Print(timeBuf, time));
     if (usingDefaultEpoch)
     {
         strcpy(expectedBuf, "1980-001-00:00:00.00000");
@@ -860,12 +858,12 @@ void Test_Print(void)
     }
 
     /* Test with a time value that causes seconds >= 60 when
-     * CFE_MISSION_TIME_EPOCH_SECOND > 0
+     * CFE_MISSION_TIME_EPOCH_SECONDS > 0
      */
     time.Subseconds = 0;
     time.Seconds    = 59;
 
-    CFE_TIME_Print(timeBuf, time);
+    CFE_UtAssert_SUCCESS(CFE_TIME_Print(timeBuf, time));
     if (usingDefaultEpoch)
     {
         strcpy(expectedBuf, "1980-001-00:00:59.00000");
@@ -881,7 +879,7 @@ void Test_Print(void)
     time.Subseconds = 215000;
     time.Seconds    = 1041472984;
 
-    CFE_TIME_Print(timeBuf, time);
+    CFE_UtAssert_SUCCESS(CFE_TIME_Print(timeBuf, time));
     if (usingDefaultEpoch)
     {
         strcpy(expectedBuf, "2013-001-02:03:04.00005");
@@ -893,14 +891,14 @@ void Test_Print(void)
                      (unsigned int)time.Seconds, (unsigned int)time.Subseconds, timeBuf);
     }
 
-    /* Test with maximum seconds and subseconds values */
-    time.Subseconds = 0xffffffff;
-    time.Seconds    = 0xffffffff;
+    /* Test with sufficiently-large seconds and subseconds values */
+    time.Subseconds = 0x7fffffff;
+    time.Seconds    = 0x7fffffff;
 
-    CFE_TIME_Print(timeBuf, time);
+    CFE_UtAssert_SUCCESS(CFE_TIME_Print(timeBuf, time));
     if (usingDefaultEpoch)
     {
-        strcpy(expectedBuf, "2116-038-06:28:15.99999");
+        strcpy(expectedBuf, "2048-019-03:14:07.49999");
         UtAssert_STRINGBUF_EQ(timeBuf, sizeof(timeBuf), expectedBuf, sizeof(expectedBuf));
     }
     else


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [X] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [X] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
CFE_TIME_Print() calls strftime to format times and returns a status code rather than creating a syslog entry. Note that this may be expanded to allow this to be configurable or parameterized (although EVS may just call strftime directly.)
Re-introduced from #2356. #2388, #2389 reverted this PR.

Also collapsed epoch defines to SECONDS and MICROS for more performance and simpler configuration.

**Testing performed**
Standard build and UT tests updated.

**Expected behavior changes**
Function returns CFE_Status_t status.
_NOTE_ strftime uses time_t which *may* be 32- or 64-bit and *may* be signed or unsigned, depending on the platform.

**System(s) tested on**
Ubuntu 22.04LTS

**Additional context**
https://en.wikipedia.org/w/index.php?title=Time_t&oldid=450752800

**Third party code**
None.

**Contributor Info - All information REQUIRED for consideration of pull request**
Christopher.D.Knight@nasa.gov