### PR TITLE
Fix #2391, add cfe to prefix list for msgids.h and platform_cfg.h

### DIFF
--- a/modules/core_api/arch_build.cmake
+++ b/modules/core_api/arch_build.cmake
@@ -15,7 +15,7 @@ generate_config_includefile(
     FILE_NAME           "cfe_msgids.h"
     MATCH_SUFFIX        "msgids.h"
     FALLBACK_FILE        "${CMAKE_CURRENT_LIST_DIR}/config/default_cfe_msgids.h"
-    PREFIXES            ${BUILD_CONFIG}
+    PREFIXES            ${BUILD_CONFIG} cfe 
 )
 
 generate_config_includefile(

--- a/modules/core_private/arch_build.cmake
+++ b/modules/core_private/arch_build.cmake
@@ -15,7 +15,7 @@ generate_config_includefile(
     FILE_NAME           "cfe_platform_cfg.h"
     FALLBACK_FILE        "${CMAKE_CURRENT_LIST_DIR}/config/default_cfe_platform_cfg.h"
     MATCH_SUFFIX        "platform_cfg.h"
-    PREFIXES            ${BUILD_CONFIG}
+    PREFIXES            ${BUILD_CONFIG} cfe
 )
 
 generate_config_includefile(


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
This allows the script to pick up the file if it was named simply "cfe_msgids.h" or "cfe_platform_cfg.h", rather than insisting it be named with a platform-specific prefix

Fixes #2391

**Testing performed**
Build and run with stakeholder configuration

**Expected behavior changes**
A file named `cfe_msgids.h` is picked up by the build system, as expected.

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
