### PR TITLE
Fix #2393, set AtLeapSeconds in ExternalTone test case

### DIFF
--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -1278,6 +1278,7 @@ void Test_External(void)
     CFE_TIME_Global.ReferenceState[0].AtToneDelay.Subseconds = 0;
     CFE_TIME_Global.ReferenceState[0].AtToneLatch.Seconds    = 0;
     CFE_TIME_Global.ReferenceState[0].AtToneLatch.Subseconds = 0;
+    CFE_TIME_Global.ReferenceState[0].AtToneLeapSeconds      = 0;
     CFE_TIME_Global.MaxDelta.Seconds                         = 0;
     CFE_TIME_Global.MaxDelta.Subseconds                      = 1;
     CFE_TIME_Global.MaxLocalClock.Seconds                    = 0;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Setting this value to 0 allows it to get the same result regardless of the setting of CFE_MISSION_TIME_CFG_DEFAULT_UTC.

Fixes #2393

**Testing performed**
Build and run CFE TIME tests

**Expected behavior changes**
Tests now pass as expected

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
