### PR TITLE
Fix #1991, TriggerMode unsigned compare with 0

### DIFF
--- a/modules/es/fsw/src/cfe_es_perf.c
+++ b/modules/es/fsw/src/cfe_es_perf.c
@@ -155,8 +155,7 @@ int32 CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfDataCmd_t *data)
         PerfDumpState->PendingState == CFE_ES_PerfDumpState_IDLE)
     {
         /* Make sure Trigger Mode is valid */
-        /* cppcheck-suppress unsignedPositive */
-        if ((CmdPtr->TriggerMode >= CFE_ES_PERF_TRIGGER_START) && (CmdPtr->TriggerMode < CFE_ES_PERF_MAX_MODES))
+        if (CmdPtr->TriggerMode < CFE_ES_PERF_MAX_MODES)
         {
             CFE_ES_Global.TaskData.CommandCounter++;
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #1991 

This allows removal of cpp-check warning suppression and fixes a CodeSonar static analysis warning

**Testing performed**
CI

**Expected behavior changes**
None

**System(s) tested on**
CI

**Additional context**
Doesn't actually impact code coverage since it looks like this check was getting compiled out anyways.

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC