### PR TITLE
Fix #2334, Uninitialized PktTime in EVS_SendViaPorts

### DIFF
--- a/modules/evs/fsw/src/cfe_evs_utils.c
+++ b/modules/evs/fsw/src/cfe_evs_utils.c
@@ -540,7 +540,7 @@ void EVS_SendViaPorts(CFE_EVS_LongEventTlm_t *EVS_PktPtr)
 {
     char               PortMessage[CFE_EVS_MAX_PORT_MSG_LENGTH];
     char               TimeBuffer[CFE_TIME_PRINTED_STRING_SIZE];
-    CFE_TIME_SysTime_t PktTime;
+    CFE_TIME_SysTime_t PktTime = {0};
 
     CFE_MSG_GetMsgTime(CFE_MSG_PTR(EVS_PktPtr->TelemetryHeader), &PktTime);
     CFE_TIME_Print(TimeBuffer, PktTime);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #2334 

Resolves CodeSonar warning

**Testing performed**
CI

**Expected behavior changes**
None

**System(s) tested on**
CI

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC