### PR TITLE
Fix #2402, Uninitialized ExceptionTaskID in CFE_ES_RunExceptionScan

### DIFF
--- a/modules/es/fsw/src/cfe_es_erlog.c
+++ b/modules/es/fsw/src/cfe_es_erlog.c
@@ -274,7 +274,7 @@ bool CFE_ES_RunExceptionScan(uint32 ElapsedTime, void *Arg)
     uint32                     PspContextId;
     char                       ReasonString[CFE_ES_ERLOG_DESCRIPTION_MAX_LENGTH];
     CFE_ES_TaskInfo_t          EsTaskInfo;
-    osal_id_t                  ExceptionTaskID;
+    osal_id_t                  ExceptionTaskID = OS_OBJECT_ID_UNDEFINED;
     uint32                     ResetType;
     CFE_ES_LogEntryType_Enum_t LogType;
     CFE_ES_AppRecord_t *       AppRecPtr;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #2402

**Testing performed**
CI

**Expected behavior changes**
Squash static analysis warning

**System(s) tested on**
CI

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC