### PR TITLE
Revert "Fix #2395, do not directly use cfe_test_msgids.h"

### DIFF
--- a/modules/cfe_testcase/src/sb_sendrecv_test.c
+++ b/modules/cfe_testcase/src/sb_sendrecv_test.c
@@ -29,6 +29,7 @@
 
 #include "cfe_test.h"
 #include "cfe_msgids.h"
+#include "cfe_test_msgids.h"
 
 #define CFE_FT_STRINGBUF_SIZE 12
 

--- a/modules/cfe_testcase/src/sb_subscription_test.c
+++ b/modules/cfe_testcase/src/sb_subscription_test.c
@@ -29,6 +29,7 @@
 
 #include "cfe_test.h"
 #include "cfe_msgids.h"
+#include "cfe_test_msgids.h"
 
 /*
  * This test procedure should be agnostic to specific MID values, but it should

--- a/modules/cfe_testcase/src/tbl_information_test.c
+++ b/modules/cfe_testcase/src/tbl_information_test.c
@@ -30,6 +30,7 @@
 #include "cfe_test.h"
 #include "cfe_test_table.h"
 #include "cfe_msgids.h"
+#include "cfe_test_msgids.h"
 
 void TestGetStatus(void)
 {

--- a/modules/cfe_testcase/src/tbl_registration_test.c
+++ b/modules/cfe_testcase/src/tbl_registration_test.c
@@ -30,6 +30,7 @@
 #include "cfe_test.h"
 #include "cfe_test_table.h"
 #include "cfe_msgids.h"
+#include "cfe_test_msgids.h"
 
 int32 CallbackFunc(void *TblPtr)
 {

--- a/modules/core_api/config/default_cfe_msgids.h
+++ b/modules/core_api/config/default_cfe_msgids.h
@@ -37,6 +37,5 @@
 #include "cfe_sb_msgids.h"
 #include "cfe_tbl_msgids.h"
 #include "cfe_time_msgids.h"
-#include "cfe_test_msgids.h"
 
 #endif /* CFE_MSGIDS_H */


### PR DESCRIPTION
Reverts nasa/cFE#2399