### PR TITLE
Fix #2406 Remove nonexist reference for perf tool

### DIFF
--- a/modules/core_api/fsw/inc/cfe_es.h
+++ b/modules/core_api/fsw/inc/cfe_es.h
@@ -1458,7 +1458,7 @@ CFE_Status_t CFE_ES_GetMemPoolStats(CFE_ES_MemPoolStats_t *BufPtr, CFE_ES_MemHan
 ** \par Description
 **        This macro logs the entry or start event/marker for the specified
 **        entry \c id. This macro, in conjunction with the #CFE_ES_PerfLogExit,
-**        is used by the Software Performance Analysis tool (see section 5.15).
+**        is used by the Software Performance Analysis tool.
 **
 ** \par Assumptions, External Events, and Notes:
 **        None
@@ -1477,7 +1477,7 @@ CFE_Status_t CFE_ES_GetMemPoolStats(CFE_ES_MemPoolStats_t *BufPtr, CFE_ES_MemHan
 ** \par Description
 **        This macro logs the exit or end event/marker for the specified
 **        entry \c id. This macro, in conjunction with the #CFE_ES_PerfLogEntry,
-**        is used by the Software Performance Analysis tool (see section 5.15).
+**        is used by the Software Performance Analysis tool.
 **
 ** \par Assumptions, External Events, and Notes:
 **        None
@@ -1498,7 +1498,7 @@ CFE_Status_t CFE_ES_GetMemPoolStats(CFE_ES_MemPoolStats_t *BufPtr, CFE_ES_MemHan
 ** \par Description
 **        This function logs the entry and exit marker for the specified
 **        \c id. This function is used by the Software Performance Analysis
-**        tool (see section 5.15).
+**        tool.
 **
 ** \par Assumptions, External Events, and Notes:
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Remove non-existent reference to Performance Analyzer Tool in CFE_ES documentation.

**Testing performed**
None, doc change only.

**Expected behavior changes**
 -  no impact to behavior


**Contributor Info - All information REQUIRED for consideration of pull request**
Isaac Rowe, NASA JSC (Jacobs Technology)
