### PR TITLE
Fix #2413, Update Dev Guide to fix out-of-date references and broken links

### DIFF
--- a/docs/README_functionaltest.md
+++ b/docs/README_functionaltest.md
@@ -19,10 +19,6 @@ This must be the first library loaded for any functional test.
 - `cfe_testcase`: a CFE-compatible library implementing test cases for CFE core apps.
 This must be loaded after `cfe_assert`.
 
-- `cfe_testrunner`: a CFE application that actually executes the tests.  This is a very
-simple app that waits for CFE startup to complete, then executes all registered test
-cases.  It also must be loaded after `cfe_assert`.
-
 
 ## Example startup script entries
 

--- a/docs/cFE Application Developers Guide.md
+++ b/docs/cFE Application Developers Guide.md
@@ -16,7 +16,7 @@ Table of Contents
    * [3. cFE Deployment Environment](#3-cfe-deployment-environment)
      * [3.1 Assumed On-Board Directory Structure](#31-assumed-on-board-directory-structure)
    * [4. cFE Application Architecture](#4-cfe-application-architecture)
-     * [4.1	Application Model](#41application-model)
+     * [4.1	Application Models](#41-application-models)
        * [4.1.1 "Software Only" Application](#411-software-only-application)
        * [4.1.2 "Hardware Servicing" Application](#412-hardware-servicing-application)
        * [4.1.3 Multi-threaded Applications](#413-multi-threaded-applications)
@@ -67,14 +67,14 @@ Table of Contents
      * [6.3 Software Bus Message Subscription](#63-software-bus-message-subscription)
      * [6.4 Unsubscribing from Receiving Software Bus Messages](#64-unsubscribing-from-receiving-software-bus-messages)
      * [6.5 Creating Software Bus Messages](#65-creating-software-bus-messages)
-       * [6.5.1 Software Bus Message Header Types](#651-software-bus-message-header-types)
-       * [6.5.2 Modifying Software Bus Message Header Information](#652-modifying-software-bus-message-header-information)
-         * [6.5.2.1 Modifying SB Command Message Header Information](#6521-modifying-sb-command-message-header-information)
-         * [6.5.2.2 Modifying SB Telemetry Message Header Information](#6522-modifying-sb-telemetry-message-header-information)
-       * [6.5.3 Reading Software Bus Message Header Information](#653-reading-software-bus-message-header-information)
+       * [6.5.1 Software Bus Message Header Types](#651-message-header-types)
+       * [6.5.2 Modifying Software Bus Message Header Information](#652-setting-message-header-information)
+         * [6.5.2.1 Modifying SB Command Message Header Information](#6521-modifying-command-message-header-information)
+         * [6.5.2.2 Modifying SB Telemetry Message Header Information](#6522-modifying-telemetry-message-header-information)
+       * [6.5.3 Reading Software Bus Message Header Information](#653-reading-message-header-information)
      * [6.6 Sending Software Bus Messages](#66-sending-software-bus-messages)
      * [6.7 Receiving Software Bus Messages](#67-receiving-software-bus-messages)
-     * [6.8 Improving Message Transfer Performance for Large SB Messages](#68-improving-message-transfer-performance-for-large-sb-messages)
+     * [6.8 Improving Message Transfer Performance for Large SB Messages](#68-improving-message-transfer-performance-for-large-messages)
      * [6.9 Best Practices for using Software Bus](#69-best-practices-for-using-software-bus)
    * [7. Event Service Interface](#7-event-service-interface)
      * [7.1 Event Messages](#71-event-messages)
@@ -84,8 +84,7 @@ Table of Contents
        * [7.4.1 Binary Filtering Scheme](#741-binary-filtering-scheme)
      * [7.5 Sending an Event Message](#75-sending-an-event-message)
        * [7.5.1 Event Message Text](#751-event-message-text)
-     * [7.6 Event Service Un-registration](#76-event-service-un-registration)
-     * [7.7 Best Practices for using Event Services](#77-best-practices-for-using-event-services)
+     * [7.6 Best Practices for using Event Services](#76-best-practices-for-using-event-services)
    * [8. Table Service Interface](#8-table-service-interface)
      * [8.1 Table Terminology](#81-table-terminology)
        * [8.1.1 Tables](#811-tables)
@@ -161,7 +160,7 @@ available to the application as a library of functions.  The cFE also provides
 a File Service (FS) API that is available to applications (there is no task
 associated with File Service).
 
-It is important for application developers to realize the long term goal
+It is important for application developers to realize the long-term goal
 of the cFE. With a standard set of services providing a standard API,
 all applications developed with the cFE have an opportunity to become
 useful on future missions through code reuse. In order to achieve this
@@ -250,7 +249,7 @@ Other documentation can be found in the associated repository's docs directory.
   | Command                                 | A SB Message defined by the receiving Application. Commands can originate from other onboard Applications or from the ground.                                    |
   | Core Flight Executive (cFE)             | A runtime environment and a set of services for hosting FSW Applications.                                                                                        |
   | Critical Data Store                     | A collection of data that is not modified by the OS or cFE following a Processor Reset.                                                                          |
-  | Cyclic Redundancy Check                 | A polynomial based method for checking that a data set has remained unchanged from one time period to another.                                                   |
+  | Cyclic Redundancy Check                 | A polynomial-based method for checking that a data set has remained unchanged from one time period to another.                                                   |
   | Developer                               | Anyone who is coding a cFE Application.                                                                                                                          |
   | Event Data                              | Data describing an Event that is supplied to the cFE Event Service. The cFE includes this data in an Event Message.                                              |
   | Event Filter                            | A numeric value (bit mask) used to determine how frequently to output an application Event Message defined by its Event ID (see definition of Event ID below).   |
@@ -319,7 +318,7 @@ directory is described as a note under each folder.
     |   |-- All mission and platform configuration files are placed here
     |-- apps
     |   |-- Contains application source code.
-    |   |-- Application source code may be shared amoung multiple build CPUs
+    |   |-- Application source code may be shared among multiple build CPUs
     |-- libs
     |   |-- Contains Core Flight System (cFS) Sample Library (sample_lib)
     |-- tools
@@ -337,7 +336,6 @@ Module descriptions are provided in the table below.
    |-- modules
    |   |-- cfe_assert
    |   |-- cfe_testcase
-   |   |-- cfe_testrunner
    |   |-- core_api
    |   |-- core_private
    |   |-- es
@@ -425,7 +423,6 @@ complete cFE core executive.  These modules are all contained under the `modules
 |:--------------------------|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `modules/cfe_assert/`     | A CFE-compatible library wrapping the basic UT assert library. This is the same library that all other unit tests use, but configured to be dynamically loaded into the CFE environment, and using CFE syslog for its output. This must be the first library loaded for any functional test. |
 | `modules/cfe_testcase/`   | A CFE-compatible library implementing test cases for CFE core apps. This must be loaded after cfe_assert.                                                                                                                                                                                    |
-| `modules/cfe_testrunner/` | A CFE application that actually executes the tests. This is a very simple app that waits for CFE startup to complete, then executes all registered test cases. It also must be loaded after cfe_assert.                                                                                      |
 | `modules/core_api/`       | Contains the public interface definition of the complete CFE core - public API/headers only, no implementation                                                                                                                                                                               |
 | `modules/core_private/`   | Contains the inter-module interface definition of the CFE core - internal API/headers only, no implementation                                                                                                                                                                                |
 | `modules/es/`             | Implementation of the Executive Services (ES) core module - provides app and task management                                                                                                                                                                                                 |
@@ -526,13 +523,13 @@ volume table.
 
 # 4. cFE Application Architecture
 
-In order to achieve the long term goals of the cFE, the Developer should
+In order to achieve the long-term goals of the cFE, the Developer should
 structure their Applications with one of the following frameworks. Each
 of the frameworks described below has been designed to minimize code
 modification when the code is ported to either another platform and/or
 another mission.
 
-## 4.1	Application Models
+## 4.1 Application Models
 
 ### 4.1.1 "Software Only" Application
 
@@ -543,7 +540,7 @@ which are either telemetry or commands. Examples of existing "Software Only"
 Applications include the Stored Command (SC) and Scheduler (SCH) applications.
 
 A "Software Only" Application has the most promise of being reusable
-because it is insulated from most mission and platform specific
+because it is insulated from most mission and platform-specific
 characteristics.
 
 A "Software Only" application should never interface directly with any piece of
@@ -554,7 +551,7 @@ the cFE APIs or to the OS Abstraction Layer.
 ### 4.1.2 "Hardware Servicing" Application
 
 A "Hardware Servicing" Application is a cFE Application that communicates
-directly with a piece of hardware. This could be mission specific
+directly with a piece of hardware. This could be mission-specific
 hardware, such as an experiment, or more common hardware, such as a
 receiver or transmitter. "Hardware Servicing" Applications should follow
 the Device Driver model as shown in the following diagram.
@@ -664,7 +661,7 @@ the content (payload) of those messages.  This supports cases where target syste
 and all messages and data files are desired to use those formats, as opposed to the normal/default CFE encapsulation formats.  In this case, it
 is important _not_ to change the payload formats, as this will make it more difficult to take a new application update in the future.
 
-**IMPORANT**: All the header files above with "INTERFACE" scope control the table/message interface of the component.  Changing any of the
+**IMPORTANT**: All the header files above with "INTERFACE" scope control the table/message interface of the component.  Changing any of the
 values or definitions in these files will affect the inter-processor communication - either table files, exported data products, commands, or
 telemetry messages.  Caution should be exercised when customizing any of these files, as any changes will need to be propagated to all
 other CFE instances, ground systems, test software or scripts, or any other tools that interact with the flight software.
@@ -686,7 +683,7 @@ recommended to only override/modify the more granular headers defined above.
 | _module_`_msg.h`           | Complete message interface: Combination of `msgdefs.h`, `msgstruct.h` and all dependencies |
 | _module_`_tbl.h`           | Complete table interface: Combination of `tbldefs.h`, `tblstruct.h` and all dependencies   |
 
-**IMPORANT**: Files from a limited scope may depend on files from a broader scope, but not the other way around.  For example,
+**IMPORTANT**: Files from a limited scope may depend on files from a broader scope, but not the other way around.  For example,
 the `platform_cfg.h` may depend on items defined in `mission_cfg.h`, but items in `mission_cfg.h` must **not** depend on items
 defined in `platform_cfg.h`.
 
@@ -1160,7 +1157,7 @@ manage a block of memory provided to it by the application; mempool does
 not create the block itself. Because of this, the application must
 ensure that sufficient memory is provided to store the mempool
 management structures in addition to the memory needed by the
-application. After initialization, mempool allocates fixed size blocks
+application. After initialization, mempool allocates fixed-size blocks
 as requested from the application memory block. As each block is
 requested mempool creates a block descriptor with management
 structures as well as space for the user application data (see Figure
@@ -1192,7 +1189,7 @@ type.
 Figure 5.1 Block Descriptor
 
 For example, if the application requests 60 bytes, mempool will return a pointer
-to the 64 user accessible bytes with the 12 byte descriptor "hidden" on
+to the 64 user-accessible bytes with the 12-byte descriptor "hidden" on
 the front for a total memory allocation of 72 bytes. All of this memory
 is allocated from the application pool. Once this memory is allocated it
 can only be used again for application requests of 64 bytes or less. It
@@ -1200,12 +1197,12 @@ cannot be combined with other blocks to create larger memory
 allocations.
 
 With the call to `CFE_ES_PoolCreate`, mempool takes the memory block
-allocated by the application and creates one 168 byte management data
+allocated by the application and creates one 168-byte management data
 structure as shown in Figure 5.2 starting at the address of the provided
 block. This memory is not available to user applications. As an
 initialization check, mempool requires that the provided application
-block contain enough space for one 168 byte management structure plus
-one 12 byte descriptor plus the smallest fixed size block (8 bytes).
+block contain enough space for one 168-byte management structure plus
+one 12-byte descriptor plus the smallest fixed-size block (8 bytes).
 This constraint allows mempool to create at least one user application
 block.
 
@@ -1375,7 +1372,7 @@ void SAMPLE_TaskMain(void)
 }
 ```
 
-### 5.10.4	Standard CRC Calculations
+### 5.10.4 Standard CRC Calculations
 There are many Applications that require a validation of received data or of
 data in memory.  This is usually done by a Cyclic Redundancy Check (CRC).
 There are many different ways to calculate a CRC.  To help ensure that the
@@ -1412,8 +1409,10 @@ to use.  By default this is set to CRC-16/ARC, but it can be configured based on
 preference and the set of available CRC algorithms.
 
 Unless there is a specific interface with a specified CRC calculation, applications
-should use the `CFE_MISSION_ES_DEFAULT_CRC` value for TypeCRC when invoking this API.
+must use the CFE_MISSION_ES_DEFAULT_CRC type.
 
+Currently only CFE_ES_CrcType_CRC_16 is supported. CFE_ES_CrcType_CRC_8 and CFE_ES_CrcType_CRC_32 are yet
+to be implemented.
 
 ## 5.11 File System Functions
 
@@ -1492,7 +1491,7 @@ These functions are typically used to track the performance of an application's
 main execution loop.  Applications can track performance of multiple sections
 of code, but must define a unique "performance id" (or "perfid") for each
 segment of code to monitor.  Applications typically define these perfids in
-their xx_mission_cfg.h file.  A common pattern for performance monitoring is
+their `xx_mission_cfg.h` file.  A common pattern for performance monitoring is
 shown below.
 
 ```c
@@ -1508,7 +1507,7 @@ void XX_AppMain(void)
     CFE_ES_PerfLogEntry(XX_APPMAIN_PERF_ID);
 
     /*
-    ** Perform application specific initialization...
+    ** Perform application-specific initialization...
     */
     if (Result == CFE_SUCCESS)
     {
@@ -1998,7 +1997,7 @@ typedef struct
  */
 typedef struct
 {
-    uint8 Time[6]; /**< \brief Time, big endian: 4 byte seconds, 2 byte subseconds */
+    uint8 Time[6]; /**< \brief Time, big endian: 4-byte seconds, 2-byte subseconds */
 } CFE_MSG_TelemetrySecondaryHeader_t;
 ```
 
@@ -2049,7 +2048,7 @@ all commands and then to differentiate those commands using a command code.
 The most common update for telemetry messages is to put the current time in
 the Message. This is accomplished with one of two API functions. The
 most commonly used function would be `CFE_SB_TimeStampMsg()`. This API would
-insert the current time, in the mission defined format with the mission
+insert the current time, in the mission-defined format with the mission
 defined epoch, into the Message Header. The other API that can modify
 the Message Header time is `CFE_MSG_SetMsgTime()`.  This API call sets the
 time in the Message Header to the time specified during the call. This is
@@ -2067,7 +2066,7 @@ for extracting that field from the header:
 | **Message Header Field** | **API for Reading the Header Field** |
 |:-------------------------|:-------------------------------------|
 | Message ID               | CFE_MSG_GetMsgId                     |
-| Message Time             | CFE_MSG_GetTime                      |
+| Message Time             | CFE_MSG_GetMsgTime                   |
 | Total Message Length     | CFE_MSG_GetSize                      |
 | Command Code             | CFE_MSG_GetFcnCode                   |
 
@@ -2167,7 +2166,7 @@ poll the pipe to check for a message (by using `CFE_SB_POLL` in place of
 
 If a Message fails to arrive within the specified timeout period, the
 cFE will return the `CFE_SB_TIME_OUT` status code. If the Pipe does not have
-any data present when the CFE_SB_ReceiveBuffer API is called, the cFE will return
+any data present when the `CFE_SB_ReceiveBuffer` API is called, the cFE will return
 a `CFE_SB_NO_MESSAGE` status code.
 
 After a message is received, the Message Header accessor functions (as
@@ -2180,7 +2179,7 @@ the application can react to it appropriately.
 Occasionally, there is a need for large quantities of data to be passed
 between Applications that are on the same processor (e.g.- Science data
 analysis and/or compression algorithms along with the science data
-acquisition Application). The drawback to using CFE_SB_TransmitMsg
+acquisition Application). The drawback to using `CFE_SB_TransmitMsg`
 is that the message is copied into a SB Buffer.  If the
 copy is too time-consuming, the Developer can choose to utilize the
 "Zero Copy" protocol.
@@ -2581,7 +2580,7 @@ conventions in order to be useful and understandable:
 
 -   It should always be clear what radix a numerical value is expressed
     in. By default, numbers should be in decimal. A hexadecimal number
-    should be indicated by prefixing 0x to the digits. Binary should
+    should be indicated by prefixing `0x` to the digits. Binary should
     use a "B" suffix.
 
 -   Floating-point numbers of unknown magnitude should be expressed in a
@@ -2680,7 +2679,7 @@ A Double Buffered Table has the disadvantage of requiring a dedicated
 Inactive Table Buffer that is the same size as the Active Table Buffer.
 The advantage to a Double Buffered Table is that the switch from
 Inactive to Active is deterministic, quick and never blocking. This
-makes Double Buffered Tables ideal for providing data to time critical
+makes Double Buffered Tables ideal for providing data to time-critical
 operations and Interrupt Service Routines.
 
 ### 8.1.4 Loading/Activating a Table
@@ -2702,7 +2701,7 @@ replaced by the contents of the Inactive Table Image.
 
 An Operator has the ability to command Table Services to make a Table
 Dump File. The current contents of the Active Table Image are written to
-an onboard filesystem with a command specified filename. This provides a
+an onboard filesystem with a command-specified filename. This provides a
 mechanism for Operators to obtain the current settings of Application
 parameters. The dump file is in the same format as a Table Load file and
 can be used later as a Load Image. Note that Applications can define a
@@ -2913,7 +2912,7 @@ Table Validation Request has been made as shown below:
 An Application has control of when the contents of the Table are updated
 within its execution cycle. If an Application wishes to change the
 contents of a Table with a known file or block of memory, it can use the
-CFE_TBL_Load API. This is useful when an Application wishes to load
+`CFE_TBL_Load` API. This is useful when an Application wishes to load
 the Table with default values or when the Application is changing modes
 and wishes to use a different parameter set. An example of this can be
 seen below:
@@ -3081,7 +3080,7 @@ int32 XX_TableInit(void)
     ** Register my table with Table Services
     */
     Status = CFE_TBL_Register(&XX_AppData.MyTableHandle,   /* Table Handle (to be returned) */
-                              "MyTableName",               /* Application specific Table Name */
+                              "MyTableName",               /* Application-specific Table Name */
                               sizeof(XX_MyTable_t),        /* Size of Table being Registered */
                               CFE_TBL_OPT_DEFAULT,         /* Deflt: Single Buff. and Loadable */
                               &XX_ValidateTable);          /* Ptr to table validation function */
@@ -3228,11 +3227,11 @@ document, the magic number on all cFE compliant files is `0x63464531`
 which appears as 'cFE1' when seen in ASCII.
 
 The `SubType` is an indication of the contents/format of the file. There
-are some SubType values that are dedicated to the cFE itself.
-Application developers should examine the cfe_fs.h file to determine
-what SubType values are allowed for them to use to prevent a type
+are some `SubType` values that are dedicated to the cFE itself.
+Application developers should examine the `cfe_fs.h` file to determine
+what `SubType` values are allowed for them to use to prevent a type
 collision in the future. When reading a file, an Application should
-verify the SubType is of the appropriate value before processing data.
+verify the `SubType` is of the appropriate value before processing data.
 This will help avoid situations where an operator specifies the wrong
 filename when sending a command to an Application.
 
@@ -3241,7 +3240,7 @@ to determine the version of the header type as well as where the user
 data is relative to the beginning of the file.
 
 The `SpacecraftID`, `ProcessorID` and `ApplicationID` are all automatically
-filled by cFE File Services routines when creating a cFE compliant file.
+filled by cFE File Services routines when creating a cFE-compliant file.
 These fields help identify where and how the file was created.
 
 The `TimeSeconds` and `TimeSubSeconds` elements contain the Spacecraft Time
@@ -3304,7 +3303,7 @@ following the standard header. This function is called
 Time is maintained and accessed through the cFE Time Service (TIME) API.
 The cFE Time Service is an API that allows Applications the ability to
 access, convert and manipulate the current time. The definitions for
-the TIME API are found in cfe_time.h.
+the TIME API are found in `cfe_time.h`.
 
 ## 10.1 Time Formats
 
@@ -3396,7 +3395,7 @@ Service time values are summarized below.
 The following Time Service API functions are available for obtaining
 time information. Most Developer's will only need one time function,
 `CFE_TIME_GetTime`. This function provides the caller with the current
-spacecraft time relative to the mission specific epoch time and may be
+spacecraft time relative to the mission-specific epoch time and may be
 either TAI or UTC. Developers should attempt to use this function in all
 cases to ensure portability of their software to future missions. Two
 additional time functions are provided for exceptions. The first of
@@ -3442,14 +3441,14 @@ current time with what information they have available.
 
 If an Application requires accurate time knowledge for its processing,
 it may require using the `CFE_TIME_GetClockState` function. When this
-function returns `CFE_TIME_VALID`, then the Application can feel
+function returns `CFE_TIME_ClockState_VALID`, then the Application can feel
 comfortable that the time obtained through any of the `CFE_TIME_Get...`
 functions is synchronized with the primary onboard time base. If the
-function returns `CFE_TIME_FLYWHEEL`, then the Application knows that
+function returns `CFE_TIME_ClockState_FLYWHEEL`, then the Application knows that
 the time obtained from any of the `CFE_TIME_Get...` functions was
 synchronized at some point in the past, but it is now nothing more than a
 "best guess" based upon a non-optimal time base. When the return value
-is `CFE_TIME_INVALID`, then the Application knows that the
+is `CFE_TIME_ClockState_INVALID`, then the Application knows that the
 `CFE_TIME_Get...` functions are returning a local time that has never
 been synchronized to the primary onboard time base.
 

--- a/docs/src/cfe_evs.dox
+++ b/docs/src/cfe_evs.dox
@@ -163,7 +163,7 @@
   \ref cfeevsugmsgfilter (only the Binary Filtering Scheme
   exists currently).   Note that applications are limited in the number of events that
   they can register for filtering (see #CFE_PLATFORM_EVS_MAX_EVENT_FILTERS in cfe_platform_cfg.h
-  for the mission defined limit).  The filtering method uses a mask to determine if the
+  for the mission-defined limit).  The filtering method uses a mask to determine if the
   message is forwarded to the software bus, making it available in telemetry (see
   \ref cfeevsugmsgfilter for a description on filtering).  Commands are available to
   \link #CFE_EVS_SET_FILTER_CC modify the filter mask \endlink for any registered event.

--- a/docs/src/cfe_frontpage.dox
+++ b/docs/src/cfe_frontpage.dox
@@ -106,10 +106,10 @@
 
    \section cfebackground_s1 Core Flight Executive (cFE) Goals
 
-   The main long term goal of the cFE is to form the basis for a platform and project
+   The main long-term goal of the cFE is to form the basis for a platform and project
    independent reusable software framework. The cFE with the OSAL allow the development
    of portable embedded system software that is independent of a particular Real Time
-   Operating System and hardware platform. A secondary long term goal is to create a
+   Operating System and hardware platform. A secondary long-term goal is to create a
    standardized, product-line approach for development of embedded aerospace flight
    software. <BR>
 
@@ -121,7 +121,7 @@
    promoting the growth of the application and library layers where new applications, libraries,
    tools, and lessons learned can be contributed and shared. <BR>
 
-   It is important for application developers to realize the long term and functional
+   It is important for application developers to realize the long-term and functional
    goals of the cFE.  With a standard set of services providing a standard API, all
    applications developed with the cFE have an opportunity to become useful on
    future missions through code reuse.  In order to achieve this goal,

--- a/docs/src/cfe_glossary.dox
+++ b/docs/src/cfe_glossary.dox
@@ -44,7 +44,7 @@
              cFE following a Processor Reset.
      <TR>
         <TD> \anchor cfeadg_crc Cyclic Redundancy Check
-        <TD> A polynomial based method for checking that a data set
+        <TD> A polynomial-based method for checking that a data set
              has remained unchanged from one time period to another.
      <TR>
         <TD> \anchor cfeadg_developer Developer

--- a/docs/src/cfe_tbl.dox
+++ b/docs/src/cfe_tbl.dox
@@ -116,7 +116,7 @@
   The default table type for a cFE Application to use is a single buffered table.  The principle
   advantage of a single buffered table is that it can share one of several shared table buffers
   for uploaded and pending table images.  Since many cFE Applications have relatively small tables
-  that are not changed at time critical moments or are not changed very often during a mission,
+  that are not changed at time-critical moments or are not changed very often during a mission,
   single buffered tables represent the most memory resource efficient method of being managed.
 
   The number of single buffered tables that can have inactive table images being manipulated at one

--- a/docs/src/cfe_time.dox
+++ b/docs/src/cfe_time.dox
@@ -68,7 +68,7 @@
   easily be manipulated and utilized. These components include:
 
   The <B>Ground Epoch</B> is an arbitrary date and time that establishes the zero point
-  for spacecraft time calculations.  The selection of the epoch is mission specific,
+  for spacecraft time calculations.  The selection of the epoch is mission-specific,
   although in the past, it was common to select the same epoch as defined for the
   Operating System used by the computers hosting the ground system software.  Recent
   mission epoch selections have also included using zero seconds after midnight,
@@ -247,7 +247,7 @@
   #define CFE_MISSION_TIME_CFG_DEFAULT_UTC  TRUE
   \endverbatim
 
-  The choice of time format is a mission specific decision and is not directly
+  The choice of time format is a mission-specific decision and is not directly
   affected by the hardware configuration.
 
   \sa #CFE_MISSION_TIME_CFG_DEFAULT_TAI, #CFE_MISSION_TIME_CFG_DEFAULT_UTC <BR>
@@ -659,7 +659,7 @@
   to the current STCF.  In addition there is a 1Hz adjustment
   (#CFE_TIME_ADD_ONE_HZ_ADJUSTMENT_CC and #CFE_TIME_SUB_ONE_HZ_ADJUSTMENT_CC)
   that can be made to the STCF to compensate for oscillator drift.
-  Mission specific ground correlation should be used to assist in
+  Mission-specific ground correlation should be used to assist in
   determining the proper values to use. The Leap Seconds should be
   set to the current TAI-UTC. Note that the International Earth
   Rotation and Reference Systems Service Bulletin C, which defines

--- a/docs/src/mnem_maps/cfe_es_cmd_mnem_map
+++ b/docs/src/mnem_maps/cfe_es_cmd_mnem_map
@@ -1,6 +1,6 @@
 #---------------------------------------------------------------------------
 # Each of the following assignment statements should have the documentation
-# mnemonic on the left followed by the mission specific command mnemonic
+# mnemonic on the left followed by the mission-specific command mnemonic
 # on the right of the equals operator.
 #
 # FORMATTING DETAILS TO REMEMBER!

--- a/docs/src/mnem_maps/cfe_es_tlm_mnem_map
+++ b/docs/src/mnem_maps/cfe_es_tlm_mnem_map
@@ -1,6 +1,6 @@
 #---------------------------------------------------------------------------
 # Each of the following assignment statements should have the documentation
-# mnemonic on the left followed by the mission specific telemetry mnemonic
+# mnemonic on the left followed by the mission-specific telemetry mnemonic
 # on the right of the equals operator.
 #
 # FORMATTING DETAILS TO REMEMBER!

--- a/docs/src/mnem_maps/cfe_evs_cmd_mnem_map
+++ b/docs/src/mnem_maps/cfe_evs_cmd_mnem_map
@@ -1,6 +1,6 @@
 #---------------------------------------------------------------------------
 # Each of the following assignment statements should have the documentation
-# mnemonic on the left followed by the mission specific command mnemonic
+# mnemonic on the left followed by the mission-specific command mnemonic
 # on the right of the equals operator.
 #
 # FORMATTING DETAILS TO REMEMBER!

--- a/docs/src/mnem_maps/cfe_evs_tlm_mnem_map
+++ b/docs/src/mnem_maps/cfe_evs_tlm_mnem_map
@@ -1,6 +1,6 @@
 #---------------------------------------------------------------------------
 # Each of the following assignment statements should have the documentation
-# mnemonic on the left followed by the mission specific telemetry mnemonic
+# mnemonic on the left followed by the mission-specific telemetry mnemonic
 # on the right of the equals operator.
 #
 # FORMATTING DETAILS TO REMEMBER!

--- a/docs/src/mnem_maps/cfe_sb_cmd_mnem_map
+++ b/docs/src/mnem_maps/cfe_sb_cmd_mnem_map
@@ -1,6 +1,6 @@
 #---------------------------------------------------------------------------
 # Each of the following assignment statements should have the documentation
-# mnemonic on the left followed by the mission specific command mnemonic
+# mnemonic on the left followed by the mission-specific command mnemonic
 # on the right of the equals operator.
 #
 # FORMATTING DETAILS TO REMEMBER!

--- a/docs/src/mnem_maps/cfe_sb_tlm_mnem_map
+++ b/docs/src/mnem_maps/cfe_sb_tlm_mnem_map
@@ -1,6 +1,6 @@
 #---------------------------------------------------------------------------
 # Each of the following assignment statements should have the documentation
-# mnemonic on the left followed by the mission specific telemetry mnemonic
+# mnemonic on the left followed by the mission-specific telemetry mnemonic
 # on the right of the equals operator.
 #
 # FORMATTING DETAILS TO REMEMBER!

--- a/docs/src/mnem_maps/cfe_tbl_cmd_mnem_map
+++ b/docs/src/mnem_maps/cfe_tbl_cmd_mnem_map
@@ -1,6 +1,6 @@
 #---------------------------------------------------------------------------
 # Each of the following assignment statements should have the documentation
-# mnemonic on the left followed by the mission specific command mnemonic
+# mnemonic on the left followed by the mission-specific command mnemonic
 # on the right of the equals operator.
 #
 # FORMATTING DETAILS TO REMEMBER!

--- a/docs/src/mnem_maps/cfe_tbl_tlm_mnem_map
+++ b/docs/src/mnem_maps/cfe_tbl_tlm_mnem_map
@@ -1,6 +1,6 @@
 #---------------------------------------------------------------------------
 # Each of the following assignment statements should have the documentation
-# mnemonic on the left followed by the mission specific telemetry mnemonic
+# mnemonic on the left followed by the mission-specific telemetry mnemonic
 # on the right of the equals operator.
 #
 # FORMATTING DETAILS TO REMEMBER!

--- a/docs/src/mnem_maps/cfe_time_cmd_mnem_map
+++ b/docs/src/mnem_maps/cfe_time_cmd_mnem_map
@@ -1,6 +1,6 @@
 #---------------------------------------------------------------------------
 # Each of the following assignment statements should have the documentation
-# mnemonic on the left followed by the mission specific command mnemonic
+# mnemonic on the left followed by the mission-specific command mnemonic
 # on the right of the equals operator.
 #
 # FORMATTING DETAILS TO REMEMBER!

--- a/docs/src/mnem_maps/cfe_time_tlm_mnem_map
+++ b/docs/src/mnem_maps/cfe_time_tlm_mnem_map
@@ -1,6 +1,6 @@
 #---------------------------------------------------------------------------
 # Each of the following assignment statements should have the documentation
-# mnemonic on the left followed by the mission specific telemetry mnemonic
+# mnemonic on the left followed by the mission-specific telemetry mnemonic
 # on the right of the equals operator.
 #
 # FORMATTING DETAILS TO REMEMBER!

--- a/modules/core_api/fsw/inc/cfe_error.h
+++ b/modules/core_api/fsw/inc/cfe_error.h
@@ -104,7 +104,7 @@ char *CFE_ES_StatusToString(CFE_Status_t status, CFE_StatusString_t *status_stri
 **      Mission Defined - These bits are available for Mission
 **                        specific coding standards.  They can
 **                        be used to classify error codes related
-**                        to mission specific library function calls, etc.
+**                        to mission-specific library function calls, etc.
 **
 **      Code - is the status code
 */

--- a/modules/core_api/fsw/inc/cfe_tbl.h
+++ b/modules/core_api/fsw/inc/cfe_tbl.h
@@ -70,7 +70,7 @@
 **
 ** \param[in] Name                 The raw table name.  This name will be combined with the name of the
 **                                 application to produce a name of the form "AppName.RawTableName".
-**                                 This application specific name will be used in commands
+**                                 This application-specific name will be used in commands
 **                                 for modifying or viewing the contents of the table.
 **
 ** \param[in] Size                 The size, in bytes, of the table to be created @nonzero.  This is the size that will
@@ -105,7 +105,7 @@
 **                                                                 the pointer to the "active" table is changed to
 **                                                                 point to the "inactive" buffer thus making it
 **                                                                 the new "active" buffer.  This feature is most
-**                                                                 useful for time critical applications (ie -
+**                                                                 useful for time-critical applications (ie -
 **                                                                 interrupt service routines, etc).  This option is
 **                                                                 mutually exclusive with the
 **                                                                 #CFE_TBL_OPT_SNGL_BUFFER and #CFE_TBL_OPT_DEFAULT
@@ -209,7 +209,7 @@ CFE_Status_t CFE_TBL_Register(CFE_TBL_Handle_t *TblHandlePtr, const char *Name, 
 **                           identify table to cFE when performing Table operations.
 **                           This value is returned at the address specified by TblHandlePtr.
 **
-** \param[in]  TblName       The application specific name of the table of the form "AppName.RawTableName",
+** \param[in]  TblName       The application-specific name of the table of the form "AppName.RawTableName",
 **                           where RawTableName is the name specified in the #CFE_TBL_Register API call.
 **                           Example: "ACS.TamParams" for a table called "TamParams"
 **                           that was registered by the application called "ACS".
@@ -688,7 +688,7 @@ CFE_Status_t CFE_TBL_GetStatus(CFE_TBL_Handle_t TblHandle);
 **                           with table characteristics and information. *TblInfoPtr is the description of the tables
 **                           characteristics and registry information stored in the #CFE_TBL_Info_t data structure
 **                           format.
-** \param[in]  TblName       The application specific name @nonnull of the table of the form "AppName.RawTableName",
+** \param[in]  TblName       The application-specific name @nonnull of the table of the form "AppName.RawTableName",
 **                           where RawTableName is the name specified in the #CFE_TBL_Register API call.
 **                           Example: "ACS.TamParams" for a table called "TamParams"
 **                           that was registered by the application called "ACS".

--- a/modules/es/config/default_cfe_es_fcncodes.h
+++ b/modules/es/config/default_cfe_es_fcncodes.h
@@ -303,12 +303,12 @@
 */
 #define CFE_ES_RESTART_APP_CC 6
 
-/** \cfeescmd Stops, Unloads, Loads from the command specified File and Restarts an Application
+/** \cfeescmd Stops, Unloads, Loads from the command-specified File and Restarts an Application
 **
 **  \par Description
 **       This command halts and removes the specified Application
 **       from the system.  Then it immediately loads the Application from
-**       the command specified file and restarts it.  This command is
+**       the command-specified file and restarts it.  This command is
 **       especially useful for restarting a Command Ingest Application
 **       since once it has been stopped, no further commands can come in
 **       to restart it.
@@ -845,7 +845,7 @@
 **       - \b \c \ES_CMDPC - command execution counter will
 **         increment
 **       - \b \c \ES_MAXPROCRESETS - Current maximum number of processor resets
-**         before an automatic power-on reset will go to the command specified value.
+**         before an automatic power-on reset will go to the command-specified value.
 **       - The #CFE_ES_SET_MAX_PR_COUNT_EID informational event message will be
 **         generated.
 **

--- a/modules/es/config/default_cfe_es_internal_cfg.h
+++ b/modules/es/config/default_cfe_es_internal_cfg.h
@@ -238,7 +238,7 @@
 **       Defines the ram disk sector size. The ram disk is 1 of 4 memory areas that
 **       are preserved on a processor reset.
 **       NOTE: Changing this value changes memory allocation, and may
-**       require changes to platform specific values (in CFE_PSP) such as
+**       require changes to platform-specific values (in CFE_PSP) such as
 **       USER_RESERVED_MEM in VxWorks depending on the memory areas
 **       being used for preserved data and on OS specific behavior.
 **
@@ -256,7 +256,7 @@
 **       Defines the ram disk number of sectors. The ram disk is one of four memory
 **       areas that are preserved on a processor reset.
 **       NOTE: Changing this value changes memory allocation, and may
-**       require changes to platform specific values (in CFE_PSP) such as
+**       require changes to platform-specific values (in CFE_PSP) such as
 **       USER_RESERVED_MEM in VxWorks depending on the memory areas
 **       being used for preserved data and on OS specific behavior.
 **
@@ -298,7 +298,7 @@
 **       Defines the Critical Data Store (CDS) area size in bytes size. The CDS is
 **       one of four memory areas that are preserved during a processor reset.
 **       NOTE: Changing this value changes memory allocation, and may
-**       require changes to platform specific values (in CFE_PSP) such as
+**       require changes to platform-specific values (in CFE_PSP) such as
 **       USER_RESERVED_MEM in VxWorks depending on the memory areas
 **       being used for preserved data and on OS specific behavior.
 **
@@ -318,7 +318,7 @@
 **       #CFE_PSP_GetUserReservedArea. The User Reserved Memory is one of four memory
 **       areas that are preserved during a processor reset.
 **       NOTE: Changing this value changes memory allocation, and may
-**       require changes to platform specific values (in CFE_PSP) such as
+**       require changes to platform-specific values (in CFE_PSP) such as
 **       USER_RESERVED_MEM in VxWorks depending on the memory areas
 **       being used for preserved data and on OS specific behavior.
 **

--- a/modules/es/fsw/src/cfe_es_cds.c
+++ b/modules/es/fsw/src/cfe_es_cds.c
@@ -80,7 +80,7 @@ int32 CFE_ES_CDS_EarlyInit(void)
         return CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
     }
 
-    /* Always truncate the size to the nearest 4 byte boundary */
+    /* Always truncate the size to the nearest 4-byte boundary */
     CDS->TotalSize = PlatformSize & 0xfffffffc;
 
     /* Compute the minimum size required for the CDS with the current configuration of the cFE */

--- a/modules/evs/config/default_cfe_evs_fcncodes.h
+++ b/modules/evs/config/default_cfe_evs_fcncodes.h
@@ -106,7 +106,7 @@
 /** \cfeevscmd Enable Event Type
 **
 **  \par Description
-**       This command enables the command specified Event Type allowing event
+**       This command enables the command-specified Event Type allowing event
 **       messages of this type to be sent through Event Service.  An Event Type
 **       is defined to be a classification of an Event Message such as debug,
 **       informational, error and critical. This command is a global enable of a
@@ -154,7 +154,7 @@
 /** \cfeevscmd Disable Event Type
 **
 **  \par Description
-**      This command disables the command specified Event Type preventing event
+**      This command disables the command-specified Event Type preventing event
 **      messages of this type to be sent through Event Service.   An Event Type
 **      is defined to be a classification of an Event Message such as debug,
 **      informational, error and critical. This command is a global disable of a
@@ -203,7 +203,7 @@
 /** \cfeevscmd Set Event Format Mode
 **
 **  \par Description
-**  This command sets the event format mode to the command specified value.
+**  This command sets the event format mode to the command-specified value.
 **  The event format mode may be either short or long.  A short event format
 **  detaches the Event Data from the event message and only includes the
 **  following information in the event packet: Processor ID, Application ID,
@@ -250,9 +250,9 @@
 /** \cfeevscmd Enable Application Event Type
 **
 **  \par Description
-**      This command enables the command specified event type for the command
+**      This command enables the command-specified event type for the command
 **      specified application, allowing the application to send event messages
-**      of the command specified event type through Event Service.  An Event
+**      of the command-specified event type through Event Service.  An Event
 **      Type is defined to be a classification of an Event Message such as
 **      debug, informational, critical, and error.
 **      Note: In order for this command to take effect, applications must be
@@ -302,9 +302,9 @@
 /** \cfeevscmd Disable Application Event Type
 **
 **  \par Description
-**      This command disables the command specified event type for the command
+**      This command disables the command-specified event type for the command
 **      specified application, preventing the application from sending event
-**      messages of the command specified event type through Event Service.
+**      messages of the command-specified event type through Event Service.
 **      An Event Type is defined to be a classification of an Event Message such
 **      as debug, informational, critical, and error.  Note: In order for this
 **      command to take effect, applications must be registered for Event Service.
@@ -355,7 +355,7 @@
 /** \cfeevscmd Enable Event Services for an Application
 **
 **  \par Description
-**      This command enables the command specified application to send events
+**      This command enables the command-specified application to send events
 **      through the Event Service.  Note: In order for this command to take
 **      effect, applications must be registered for Event Service.
 **
@@ -394,7 +394,7 @@
 /** \cfeevscmd Disable Event Services for an Application
 **
 **  \par Description
-**      This command disables the command specified application from sending
+**      This command disables the command-specified application from sending
 **      events through Event Service.  Note: In order for this command to take
 **      effect, applications must be registered for Event Service.
 **
@@ -433,7 +433,7 @@
 /** \cfeevscmd Reset Application Event Counters
 **
 **  \par Description
-**      This command sets the command specified application's event counter to zero.
+**      This command sets the command-specified application's event counter to zero.
 **      Note: In order for this command to take effect, applications must be registered
 **      for Event Service.
 **
@@ -469,8 +469,8 @@
 /** \cfeevscmd Set Application Event Filter
 **
 **  \par Description
-**      This command sets the command specified application's event filter mask
-**      to the command specified value for the command specified event.  Note:
+**      This command sets the command-specified application's event filter mask
+**      to the command-specified value for the command-specified event.  Note:
 **      In order for this command to take effect, applications must be
 **      registered for Event Service.
 **
@@ -511,7 +511,7 @@
 /** \cfeevscmd Enable Event Services Output Ports
 **
 **  \par Description
-**      This command enables the command specified port to output event messages
+**      This command enables the command-specified port to output event messages
 **
 **  \cfecmdmnemonic \EVS_ENAPORT
 **
@@ -589,8 +589,8 @@
 /** \cfeevscmd Reset an Event Filter for an Application
 **
 **  \par Description
-**      This command resets the command specified application's event filter for
-**      the command specified event ID.  Note: In order for this command to take
+**      This command resets the command-specified application's event filter for
+**      the command-specified event ID.  Note: In order for this command to take
 **      effect, applications must be registered for Event Service.
 **
 **  \cfecmdmnemonic \EVS_RSTBINFLTRCTR
@@ -625,7 +625,7 @@
 /** \cfeevscmd Reset All Event Filters for an Application
 **
 **  \par Description
-**      This command resets all of the command specified applications event
+**      This command resets all of the command-specified applications event
 **      filters.  Note: In order for this command to take effect, applications
 **      must be registered for Event Service.
 **
@@ -804,7 +804,7 @@
 /** \cfeevscmd Set Logging Mode
 **
 **  \par Description
-**       This command sets the logging mode to the command specified value.
+**       This command sets the logging mode to the command-specified value.
 **
 **  \cfecmdmnemonic \EVS_SETLOGMODE
 **

--- a/modules/fs/config/default_cfe_fs_interface_cfg.h
+++ b/modules/fs/config/default_cfe_fs_interface_cfg.h
@@ -36,6 +36,6 @@
 
 #define CFE_FS_HDR_DESC_MAX_LEN 32 /**< \brief Max length of description field in a standard cFE File Header */
 
-#define CFE_FS_FILE_CONTENT_ID 0x63464531 /**< \brief Magic Number for cFE compliant files (= 'cFE1') */
+#define CFE_FS_FILE_CONTENT_ID 0x63464531 /**< \brief Magic Number for cFE-compliant files (= 'cFE1') */
 
 #endif /* CFE_FS_INTERFACE_CFG_H */

--- a/modules/msg/option_inc/default_cfe_msg_sechdr.h
+++ b/modules/msg/option_inc/default_cfe_msg_sechdr.h
@@ -72,7 +72,7 @@ typedef struct
  */
 typedef struct
 {
-    uint8 Time[6]; /**< \brief Time, big endian: 4 byte seconds, 2 byte subseconds */
+    uint8 Time[6]; /**< \brief Time, big endian: 4-byte seconds, 2-byte subseconds */
 } CFE_MSG_TelemetrySecondaryHeader_t;
 
 #endif /* DEFAULT_CFE_MSG_SECHDR_H */

--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -44,7 +44,7 @@
 **
 **      MsgIdkey - This is a unique numeric key within a mission namespace that is used with
 **                 cFS software bus internal structures.
-**                 It is algorithmically created in a mission defined way from the MsgId to support
+**                 It is algorithmically created in a mission-defined way from the MsgId to support
 **                 efficient lookup and mapping implementations
 **                 It is NOT exposed to user applications.
 **
@@ -1427,7 +1427,7 @@ int32 CFE_SB_TransmitMsgValidate(const CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t
     {
         CFE_MSG_GetSize(MsgPtr, SizePtr);
 
-        /* Verify the size of the pkt is < or = the mission defined max */
+        /* Verify the size of the pkt is < or = the mission-defined max */
         if (*SizePtr > CFE_MISSION_SB_MAX_SB_MSG_SIZE)
         {
             PendingEventID = CFE_SB_MSG_TOO_BIG_EID;

--- a/modules/sb/fsw/src/cfe_sb_priv.c
+++ b/modules/sb/fsw/src/cfe_sb_priv.c
@@ -49,7 +49,7 @@
 **
 **      MsgIdkey - This is a unique numeric key within a mission namespace that is used with
 **                 cFS software bus internal structures.
-**                 It is algorithmically created in a mission defined way from the MsgId to support
+**                 It is algorithmically created in a mission-defined way from the MsgId to support
 **                 efficient lookup and mapping implementations
 **                 It is NOT exposed to user applications.
 **

--- a/modules/tbl/config/default_cfe_tbl_fcncodes.h
+++ b/modules/tbl/config/default_cfe_tbl_fcncodes.h
@@ -162,7 +162,7 @@
 **
 **  \par Description
 **       This command will cause the Table Services to put the contents
-**       of the specified table buffer into the command specified file.
+**       of the specified table buffer into the command-specified file.
 **
 **  \cfecmdmnemonic \TBL_DUMP
 **
@@ -302,7 +302,7 @@
 **
 **  \par Description
 **       This command will cause Table Services to write some of the
-**       contents of the Table Registry to the command specified file.
+**       contents of the Table Registry to the command-specified file.
 **       This allows the operator to see the current state and configuration
 **       of all tables that have been registered with the cFE.
 **
@@ -346,7 +346,7 @@
 **
 **  \par Description
 **       This command will cause Table Services to telemeter the contents
-**       of the Table Registry for the command specified table.
+**       of the Table Registry for the command-specified table.
 **
 **  \cfecmdmnemonic \TBL_TLMREG
 **

--- a/modules/tbl/fsw/src/cfe_tbl_internal.c
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.c
@@ -268,7 +268,7 @@ void CFE_TBL_FormTableName(char *FullTblName, const char *TblName, CFE_ES_AppId_
     /* Ensure that AppName is null terminated */
     AppName[OS_MAX_API_NAME - 1] = '\0';
 
-    /* Complete formation of application specific table name */
+    /* Complete formation of application-specific table name */
     sprintf(FullTblName, "%s.%s", AppName, TblName);
 }
 

--- a/modules/tbl/fsw/src/cfe_tbl_internal.h
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.h
@@ -86,14 +86,14 @@ int16 CFE_TBL_FindTableInRegistry(const char *TblName);
 **
 ** \par Description
 **        Takes a given raw table name and combines it with the calling
-**        Application's name to make the application specific name of the
+**        Application's name to make the application-specific name of the
 **        form: "AppName.RawTableName"
 **
 ** \par Assumptions, External Events, and Notes:
 **        AppName portion will be truncated to OS_MAX_API_NAME.
 **
 ** \param[in, out] FullTblName  Pointer to character buffer of #CFE_TBL_MAX_FULL_NAME_LEN
-**                              size that will be filled with the application specific name
+**                              size that will be filled with the application-specific name
 **                              of the form "AppName.RawTableName"
 ** \param[in] TblName           Pointer to character string containing the raw table name.
 ** \param[in] ThisAppId         Application ID of the Application making the call.

--- a/modules/time/config/default_cfe_time_fcncodes.h
+++ b/modules/time/config/default_cfe_time_fcncodes.h
@@ -148,7 +148,7 @@
 **
 **  \par Description
 **       This command selects the Time Service clock source.  Although the
-**       list of potential clock sources is mission specific and defined
+**       list of potential clock sources is mission-specific and defined
 **       via configuration parameters, this command provides a common method
 **       for switching between the local processor clock and an external
 **       source for time data.<BR><BR>
@@ -176,7 +176,7 @@
 **       following telemetry:
 **       - \b \c \TIME_CMDPC - command execution counter will increment
 **       - \b \c \TIME_SOURCE - Diagnostic Telemetry point will indicate the
-**         command specified value
+**         command-specified value
 **       - The #CFE_TIME_SOURCE_EID informational event message will be generated
 **
 **  \par Error Conditions
@@ -227,7 +227,7 @@
 **       following telemetry:
 **       - \b \c \TIME_CMDPC - command execution counter will increment
 **       - \b \c \TIME_STATEFLG - Housekeeping Telemetry point "may" indicate the
-**         command specified value (see above)
+**         command-specified value (see above)
 **       - The #CFE_TIME_STATE_EID informational event message will be generated
 **
 **  \par Error Conditions
@@ -270,7 +270,7 @@
 **       Successful execution of this command may be verified with the
 **       following telemetry:
 **       - \b \c \TIME_CMDPC - command execution counter will increment
-**       - \b \c \TIME_LATENTS - Housekeeping Telemetry point indicating command specified values
+**       - \b \c \TIME_LATENTS - Housekeeping Telemetry point indicating command-specified values
 **       - \b \c \TIME_LATENTDIR - Diagnostic Telemetry point indicating commanded latency direction
 **       - The #CFE_TIME_DELAY_EID informational event message will be generated
 **
@@ -308,7 +308,7 @@
 **       Successful execution of this command may be verified with the
 **       following telemetry:
 **       - \b \c \TIME_CMDPC - command execution counter will increment
-**       - \b \c \TIME_LATENTS - Housekeeping Telemetry point indicating command specified values
+**       - \b \c \TIME_LATENTS - Housekeeping Telemetry point indicating command-specified values
 **       - \b \c \TIME_LATENTDIR - Diagnostic Telemetry point indicating commanded latency direction
 **       - The #CFE_TIME_DELAY_EID informational event message will be generated
 **
@@ -570,7 +570,7 @@
 **       There was some debate about whether the maximum 1Hz clock drift correction
 **       factor would ever need to exceed some small fraction of a second.  But, the
 **       decision was made to provide the capability to make 1Hz adjustments greater
-**       than one second and leave it to the ground system to provide mission specific
+**       than one second and leave it to the ground system to provide mission-specific
 **       limits.
 **
 **  \cfecmdmnemonic \TIME_ADD1HZSTCF
@@ -616,7 +616,7 @@
 **       There was some debate about whether the maximum 1Hz clock drift correction
 **       factor would ever need to exceed some small fraction of a second.  But, the
 **       decision was made to provide the capability to make 1Hz adjustments greater
-**       than one second and leave it to the ground system to provide mission specific
+**       than one second and leave it to the ground system to provide mission-specific
 **       limits.
 **
 **  \cfecmdmnemonic \TIME_SUB1HZSTCF
@@ -652,7 +652,7 @@
 **
 **  \par Description
 **       This command selects the Time Service tone signal source.  Although the
-**       list of potential tone signal sources is mission specific, a common
+**       list of potential tone signal sources is mission-specific, a common
 **       choice is the selection of primary or redundant tone signal.  The selection
 **       may be available to both the Time Server and Time Clients, depending on
 **       hardware configuration.<BR><BR>
@@ -671,7 +671,7 @@
 **       - \b \c \TIME_CMDPC - command execution counter will
 **         increment
 **       - \b \c \TIME_SIGNAL - Diagnostic Telemetry point will indicate the
-**         command specified value
+**         command-specified value
 **       - The #CFE_TIME_SIGNAL_EID informational event message will
 **         be generated
 **

--- a/modules/time/config/default_cfe_time_interface_cfg.h
+++ b/modules/time/config/default_cfe_time_interface_cfg.h
@@ -37,7 +37,7 @@
 **
 **  \par Description:
 **      The following definitions select either UTC or TAI as the default
-**      (mission specific) time format.  Although it is possible for an
+**      (mission-specific) time format.  Although it is possible for an
 **      application to request time in a specific format, most callers
 **      should use CFE_TIME_GetTime(), which returns time in the default
 **      format.  This avoids having to modify each individual caller


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2413
  - Delete references to 'cfe_testrunner' module that was removed in https://github.com/nasa/cFE/pull/1292
  - Update references to old function/variables: `CFE_MSG_GetTime`, `CFE_TIME_VALID`, `CFE_TIME_INVALID`, `CFE_TIME_FLYWHEEL`
  - A few typos etc. picked up along the way (and applied to other files at the same time)
  - Broken links in the Developer's Guide 'Table of Contents' fixed

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Doc changes only.

**Contributor Info**
Avi Weiss @thnkslprpt