### PR TITLE
Fix #2415, use correct object extension in table build

### DIFF
--- a/cmake/arch_build.cmake
+++ b/cmake/arch_build.cmake
@@ -312,6 +312,7 @@ function(add_cfe_tables TABLE_FQNAME TBL_DEFAULT_SRC_FILES)
             -DOUTPUT_FILE="${TABLE_RULEFILE}"
             -DTABLE_NAME="${TABLE_BASENAME}"
             -DSOURCES="${TBL_SRC}"
+            -DOBJEXT="${CMAKE_C_OUTPUT_EXTENSION}"
             -P "${TABLE_GENSCRIPT}"
           WORKING_DIRECTORY
             ${WORKING_DIRECTORY}

--- a/cmake/tables/elf2cfetbl_rules.mk
+++ b/cmake/tables/elf2cfetbl_rules.mk
@@ -1,5 +1,5 @@
 # Rule for traditional CFE table generation via elf2cfetbl
 
-elf/%.o:
+elf/%:
 	@mkdir -pv $(dir $(@))
 	cd $(dir $(@)) && $(AR) x $(abspath $(<)) $(notdir $(@))

--- a/cmake/tables/generate_elf_table_rules.cmake
+++ b/cmake/tables/generate_elf_table_rules.cmake
@@ -22,7 +22,7 @@ set(TABLE_RULES)
 foreach(TBL_SRC ${SOURCES})
 
     get_filename_component(DEP_FILE ${TBL_SRC} NAME)
-    set(DEP_FILE "${TMP_DIR}/${DEP_FILE}.o")
+    set(DEP_FILE "${TMP_DIR}/${DEP_FILE}${OBJEXT}")
     string(APPEND TABLE_RULES
         "${DEP_FILE}: ${ARCHIVE_FILE}\n"
         "${TABLE_BINARY}: ${DEP_FILE}\n"


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Do not assume ".o" for object files, use ${CMAKE_C_OUTPUT_EXTENSION}

Fixes #2415

**Testing performed**
Build tables for VxWorks (using .obj extension)

**Expected behavior changes**
Build should succeed now

**System(s) tested on**
GSFC VxWorks build host

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.