### PR TITLE
Fix #2421, adjust dependencies on table lib

### DIFF
--- a/cmake/arch_build.cmake
+++ b/cmake/arch_build.cmake
@@ -324,7 +324,7 @@ function(add_cfe_tables TABLE_FQNAME TBL_DEFAULT_SRC_FILES)
 
         # Add a custom target to generate the config file
         add_custom_target(generate_table_${TGT}_${APP_NAME}_${TABLE_BASENAME}
-            DEPENDS "${TABLE_RULEFILE}"
+            DEPENDS "${TABLE_RULEFILE}" ${TABLE_LIBNAME}
         )
         add_dependencies(cfetables generate_table_${TGT}_${APP_NAME}_${TABLE_BASENAME})
 
@@ -335,7 +335,7 @@ function(add_cfe_tables TABLE_FQNAME TBL_DEFAULT_SRC_FILES)
         # On older versions one may not reference the TARGET_OBJECTS property from the custom command.
         # As a workaround this is built into a static library, and then the desired object is extracted
         # before passing to elf2cfetbl.  It is roundabout but it works.
-        add_library(${TABLE_LIBNAME} STATIC ${TABLE_SELECTED_SRCS})
+        add_library(${TABLE_LIBNAME} STATIC EXCLUDE_FROM_ALL ${TABLE_SELECTED_SRCS})
         target_compile_definitions(${TABLE_LIBNAME} PRIVATE
           CFE_CPU_NAME=${TGT}
         )


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Instead of having the intermediate table library build as part of the "all" target, attach it as a dependency under the custom rule.  This way it will only be built in the context of the cfetables top level target, not both.

Fixes #2421

**Testing performed**
Build a configuration with lots of tables (> 100) repeatedly from a clean start using various `-j` values.

**Expected behavior changes**
Builds succeed, no race conditions/sporadic failures.

**System(s) tested on**
Debian

**Additional context**
This excludes the intermediate library from the `all` target and instead attaches it explicitly under the generate tables rule.  So it should avoid the case of having two legs of a parallel build both finding the dependency and attempting to build it.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
