### PR TITLE
Fix #2427, Race condition in TestCreateChild

### DIFF
--- a/modules/cfe_testcase/src/es_task_test.c
+++ b/modules/cfe_testcase/src/es_task_test.c
@@ -101,6 +101,7 @@ void TestCreateChild(void)
     size_t                     StackSize     = CFE_PLATFORM_ES_PERF_CHILD_STACK_SIZE;
     CFE_ES_TaskPriority_Atom_t Priority      = CFE_PLATFORM_ES_PERF_CHILD_PRIORITY;
     uint32                     Flags         = 0;
+    uint32                     Index         = 0;
     int32                      ExpectedCount = 5;
     int32                      RetryCount;
     char                       TaskNameBuf[16];
@@ -110,7 +111,11 @@ void TestCreateChild(void)
     CFE_FT_Global.Count = 0;
     UtAssert_INT32_EQ(CFE_ES_CreateChildTask(&TaskId, TaskName, TaskFunction, StackPointer, StackSize, Priority, Flags),
                       CFE_SUCCESS);
-    OS_TaskDelay(500);
+    while (CFE_FT_Global.Count != ExpectedCount && Index < 100)
+    {
+        OS_TaskDelay(10);
+        Index ++;
+    }
 
     UtAssert_INT32_GT(CFE_FT_Global.Count, ExpectedCount - 1);
     UtAssert_INT32_LT(CFE_FT_Global.Count, ExpectedCount + 1);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x ] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [ x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Correct race condition in TestCreateChild by reducing the step size.
- Fixes #2427 

**Testing performed**
Steps taken to test the contribution:
1. Tested updated functional test against Linux and VxWorks and confirmed that the test passes on both systems.

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - API Change: xxx (if applicable)
 - Behavior Change: xxx (if applicable)
 - Or no impact to behavior

**System(s) tested on**
 - VM & SP0
 - OS: Linux & VxWorks

**Contributor Info - All information REQUIRED for consideration of pull request**
Dan Knutsen
NASA Goddard
