### PR TITLE
Fix #2150, Adds a cast to the negation of unsigned expression

### DIFF
--- a/modules/evs/fsw/src/cfe_evs_utils.c
+++ b/modules/evs/fsw/src/cfe_evs_utils.c
@@ -301,7 +301,7 @@ bool EVS_CheckAndIncrementSquelchTokens(EVS_AppData_t *AppDataPtr)
      * CFE_PLATFORM_EVS_APP_EVENTS_PER_SEC) seconds after flooding stops if
      * saturated
      */
-    const int32 LOWER_THRESHOLD = -CFE_EVS_Global.EVS_EventBurstMax * 1000;
+    const int32 LOWER_THRESHOLD = -(int32)CFE_EVS_Global.EVS_EventBurstMax * 1000;
 
     /*
      * Set this to 1000 to avoid integer division while computing CreditCount


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2150
   - By casting the expression in question to `int32` before negating it, we ensure that the negation operation is being applied to a signed integer, and the result will be as expected.

**Testing performed**
-coverage
-functional test

**Expected behavior changes**
Supress CodeQL warning

**System(s) tested on**
 - OS: Ubuntu 20.04

**Additional context**
Concur with the issue that this pr addresses. The problem is that when you apply a negation operator (`-`) to an unsigned integer, the result will not be a negative number as maybe expected. Instead, due to two's complement arithmetic, we get a very large positive number. Then, it will cause unexpected results when that large number is assigned to a signed variable like int32. 

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, Vantage Systems
