### PR TITLE
Fix #2436, Adds an empty string or null pointer check for pipe creation

### DIFF
--- a/modules/cfe_testcase/src/sb_pipe_mang_test.c
+++ b/modules/cfe_testcase/src/sb_pipe_mang_test.c
@@ -47,6 +47,7 @@ void TestPipeCreate(void)
     UtAssert_INT32_EQ(CFE_SB_CreatePipe(&PipeId1, OS_QUEUE_MAX_DEPTH + 5, PipeName), CFE_SB_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_SB_CreatePipe(&PipeId1, 0, PipeName), CFE_SB_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_SB_CreatePipe(&PipeId1, PipeDepth, NULL), CFE_SB_PIPE_CR_ERR);
+    UtAssert_INT32_EQ(CFE_SB_CreatePipe(&PipeId1, PipeDepth, ""), CFE_SB_BAD_ARGUMENT);
 }
 
 void TestPipeCreateMax(void)

--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -123,7 +123,7 @@ CFE_Status_t CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16 Depth, const c
     CFE_ES_GetTaskID(&TskId);
 
     /* check input parameters */
-    if ((PipeIdPtr == NULL) || (Depth > OS_QUEUE_MAX_DEPTH) || (Depth == 0))
+    if ((PipeIdPtr == NULL) || (Depth > OS_QUEUE_MAX_DEPTH) || (Depth == 0) || (PipeName != NULL && PipeName[0] == '\0'))
     {
         PendingEventId = CFE_SB_CR_PIPE_BAD_ARG_EID;
         Status         = CFE_SB_BAD_ARGUMENT;

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -1645,6 +1645,8 @@ void Test_CreatePipe_API(void)
     SB_UT_ADD_SUBTEST(Test_CreatePipe_InvalPipeDepth);
     SB_UT_ADD_SUBTEST(Test_CreatePipe_MaxPipes);
     SB_UT_ADD_SUBTEST(Test_CreatePipe_SamePipeName);
+    SB_UT_ADD_SUBTEST(Test_CreatePipe_EmptyPipeName);
+    SB_UT_ADD_SUBTEST(Test_CreatePipe_PipeName_NullPtr);
 }
 
 /*
@@ -1796,6 +1798,40 @@ void Test_CreatePipe_SamePipeName(void)
 
     /* Call to CFE_SB_DeletePipe with the first pipe id created should work fine */
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
+}
+
+/*
+** Test create pipe response to empty pipe name
+*/
+void Test_CreatePipe_EmptyPipeName(void)
+{
+    CFE_SB_PipeId_t PipeId     = SB_UT_PIPEID_0;
+    uint16          PipeDepth  = 1;
+    char            PipeName[] = "";
+
+    /* Call to CFE_SB_CreatePipe with empty PipeName should fail */
+    UtAssert_INT32_EQ(CFE_SB_CreatePipe(&PipeId, PipeDepth, PipeName), CFE_SB_BAD_ARGUMENT);
+
+    UtAssert_INT32_EQ(CFE_SB_Global.HKTlmMsg.Payload.CreatePipeErrorCounter, 1);
+}
+
+/*
+** Test create pipe response to a null pipe name pointer.
+*/
+void Test_CreatePipe_PipeName_NullPtr(void)
+{
+    CFE_SB_PipeId_t PipeId    = SB_UT_PIPEID_0;
+    uint16          PipeDepth = 1;
+
+    /* To fail the pipe create, force the OS_QueueCreate call to return some
+     * type of error code.
+     */
+    UT_SetDeferredRetcode(UT_KEY(OS_QueueCreate), 1, OS_ERR_NO_FREE_IDS);
+
+    /* Call to CFE_SB_CreatePipe with empty PipeName should fail */
+    UtAssert_INT32_EQ(CFE_SB_CreatePipe(&PipeId, PipeDepth, NULL), CFE_SB_PIPE_CR_ERR);
+
+    UtAssert_INT32_EQ(CFE_SB_Global.HKTlmMsg.Payload.CreatePipeErrorCounter, 1);
 }
 
 /*

--- a/modules/sb/ut-coverage/sb_UT.h
+++ b/modules/sb/ut-coverage/sb_UT.h
@@ -1200,6 +1200,21 @@ void Test_CreatePipe_EmptyPipeName(void);
 
 /*****************************************************************************/
 /**
+** \brief Test create pipe response to a NULL pipe name
+**
+** \par Description
+**        This function tests the create pipe response to a null pipe name pointer.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \returns
+**        This function does not return a value.
+******************************************************************************/
+void Test_CreatePipe_PipeName_NullPtr(void);
+
+/*****************************************************************************/
+/**
 ** \brief Test create pipe response to a pipe name longer than allowed
 **
 ** \par Description


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
-Fixes #2436

**Testing performed**
build, functional test

**Expected behavior changes**
Assigns `CFE_SB_BAD_ARGUMENT` to Status when empty string are passed in for the `PipeName`

**System(s) tested on**
 - OS: Ubuntu 20.04

**Additional context**
I added a check for PipeName != NULL. This is to ensure that PipeName is not a NULL pointer, which would cause a segmentation fault when attempting to dereference it with PipeName[0].

This empty string check can potentially be performed at a lower level that processes PipeName at time of pipe creation: https://github.com/nasa/osal/blob/b5dd01c91f22ea913b0b87658ec5038c6de5275e/src/os/shared/src/osapi-idmap.c#L1168

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, Vantage Systems
