### PR TITLE
Fix #2444, Enforce keeping code coverage minimums up-to-date

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -36,6 +36,9 @@ jobs:
     if: ${{ needs.check-for-duplicates.outputs.should_skip != 'true' }}
     runs-on: ubuntu-20.04
     timeout-minutes: 15
+    env:
+      MISSED_BRANCHES_ALLOWED: 39
+      MISSED_LINES_ALLOWED: 19
 
     steps:
       - name: Install coverage tools
@@ -104,17 +107,43 @@ jobs:
 
       - name: Confirm Minimum Coverage
         run: |
-          missed_branches=39
-          missed_lines=19
           branch_nums=$(grep -A 3 "Overall coverage rate" lcov_out.txt | grep branches | grep -oP "[0-9]+[0-9]*")
           line_nums=$(grep -A 3 "Overall coverage rate" lcov_out.txt | grep lines | grep -oP "[0-9]+[0-9]*")
 
           branch_diff=$(echo $branch_nums | awk '{ print $4 - $3 }')
           line_diff=$(echo $line_nums | awk '{ print $4 - $3 }')
-          if [ $branch_diff -gt $missed_branches ] || [ $line_diff -gt $missed_lines ]
+          if [ $branch_diff -gt $MISSED_BRANCHES_ALLOWED ] || [ $line_diff -gt $MISSED_LINES_ALLOWED ]
           then
             grep -A 3 "Overall coverage rate" lcov_out.txt
-            echo "$branch_diff branches missed, $missed_branches allowed"
-            echo "$line_diff lines missed, $missed_lines allowed"
+            echo "$branch_diff branches missed, $MISSED_BRANCHES_ALLOWED allowed"
+            echo "$line_diff lines missed, $MISSED_LINES_ALLOWED allowed"
+            exit -1
+          fi
+
+      - name: Check that Minimum Coverage Limits are Correctly Calibrated
+        run: |
+          branch_nums=$(grep -A 3 "Overall coverage rate" lcov_out.txt | grep branches | grep -oP "[0-9]+[0-9]*")
+          line_nums=$(grep -A 3 "Overall coverage rate" lcov_out.txt | grep lines | grep -oP "[0-9]+[0-9]*")
+
+          branch_diff=$(echo $branch_nums | awk '{ print $4 - $3 }')
+          line_diff=$(echo $line_nums | awk '{ print $4 - $3 }')
+          if [ $branch_diff -lt $MISSED_BRANCHES_ALLOWED ] || [ $line_diff -lt $MISSED_LINES_ALLOWED ]
+          then
+            grep -A 3 "Overall coverage rate" lcov_out.txt
+            echo ""
+            if [ $branch_diff -lt $MISSED_BRANCHES_ALLOWED ]
+            then
+              echo "$branch_diff branches were missed, which is *less* than the expected/allowed amount: $MISSED_BRANCHES_ALLOWED"
+              echo "Please update (lower) the MISSED_BRANCHES_ALLOWED variable in this workflow file to match the new coverage level."
+              echo ""
+            fi
+
+            if [ $line_diff -lt $MISSED_LINES_ALLOWED ]
+            then
+              echo "$line_diff lines were missed, which is *less* than the expected/allowed amount: $MISSED_LINES_ALLOWED"
+              echo "Please update (lower) the MISSED_LINES_ALLOWED variable in this workflow file to match the new coverage level."
+              echo ""
+            fi
+
             exit -1
           fi


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2444
  - Adds an additional step in the code coverage workflow to check that the missed branches/lines variables are kept up to date. Note: This step will not run if the previous 'Confirm Minimum Coverage' step fails (it would be redundant anyway).

**Testing performed**
Tested all variations of coverage thresholds (above, below, split between lines/branches etc.) to confirm expected behavior.

New checks:
![Screenshot 2023-09-22 22 34 18](https://github.com/nasa/cFE/assets/9024662/c94822de-1135-45e1-af65-63e3129849cd)

Confirm Minimum Coverage logic/failure is unchanged:
![Screenshot 2023-09-22 22 35 14](https://github.com/nasa/cFE/assets/9024662/cac3b28e-6679-4a16-b1d9-005bc9dbfa97)

**Expected behavior changes**
Any PR that improves coverage will cause the workflow to fail now, unless the `MISSED_LINES_ALLOWED` and/or `MISSED_BRANCHES_ALLOWED` variables are updated (lowered) as well.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt