### PR TITLE
Fix #2451, minor reorg of message headers

### DIFF
--- a/docs/src/cfe_es.dox
+++ b/docs/src/cfe_es.dox
@@ -308,7 +308,7 @@
   the system resources are properly released.
 
   The format of the Stop Application command, is defined in the structure
-  #CFE_ES_AppNameCmd_t. The only parameter in the command is an application
+  #CFE_ES_StopAppCmd_t. The only parameter in the command is an application
   name.
 
   If the command fails for any reason, an error event will be sent stating

--- a/modules/es/CMakeLists.txt
+++ b/modules/es/CMakeLists.txt
@@ -35,6 +35,16 @@ if (ENABLE_UNIT_TESTS)
 endif (ENABLE_UNIT_TESTS)
 
 cfs_app_check_intf(${DEP}
-    cfe_es_msg.h
     cfe_es_eventids.h
-)
+    cfe_es_extern_typedefs.h
+    cfe_es_fcncodes.h
+    cfe_es_interface_cfg.h
+    cfe_es_internal_cfg.h
+    cfe_es_mission_cfg.h
+    cfe_es_msgdefs.h
+    cfe_es_msg.h
+    cfe_es_msgids.h
+    cfe_es_msgstruct.h
+    cfe_es_platform_cfg.h
+    cfe_es_topicids.h
+  )

--- a/modules/es/config/default_cfe_es_msgdefs.h
+++ b/modules/es/config/default_cfe_es_msgdefs.h
@@ -26,6 +26,321 @@
 #ifndef CFE_ES_MSGDEFS_H
 #define CFE_ES_MSGDEFS_H
 
+#include "common_types.h"
+#include "cfe_mission_cfg.h"
+#include "cfe_es_extern_typedefs.h"
 #include "cfe_es_fcncodes.h"
+
+/********************************/
+/* Command Message Data Formats */
+/********************************/
+
+/**
+** \brief Restart cFE Command Payload
+**
+** For command details, see #CFE_ES_RESTART_CC
+**
+**/
+typedef struct CFE_ES_RestartCmd_Payload
+{
+    uint16 RestartType; /**< \brief #CFE_PSP_RST_TYPE_PROCESSOR=Processor Reset
+                             or #CFE_PSP_RST_TYPE_POWERON=Power-On Reset        */
+} CFE_ES_RestartCmd_Payload_t;
+
+/**
+** \brief Generic file name command payload
+**
+** This format is shared by several executive services commands.
+** For command details, see #CFE_ES_QUERY_ALL_CC, #CFE_ES_QUERY_ALL_TASKS_CC,
+** #CFE_ES_WRITE_SYSLOG_CC, and #CFE_ES_WRITE_ER_LOG_CC
+**
+**/
+typedef struct CFE_ES_FileNameCmd_Payload
+{
+    char FileName[CFE_MISSION_MAX_PATH_LEN]; /**< \brief ASCII text string containing full path and
+                                                 filename of file in which Application data is to be dumped */
+} CFE_ES_FileNameCmd_Payload_t;
+
+/**
+** \brief Overwrite/Discard System Log Configuration Command Payload
+**
+** For command details, see #CFE_ES_OVER_WRITE_SYSLOG_CC
+**
+**/
+typedef struct CFE_ES_OverWriteSysLogCmd_Payload
+{
+    uint32 Mode; /**< \brief #CFE_ES_LogMode_DISCARD=Throw away most recent messages,
+                             #CFE_ES_LogMode_OVERWRITE=Overwrite oldest with most recent */
+} CFE_ES_OverWriteSysLogCmd_Payload_t;
+
+/**
+** \brief Start Application Command Payload
+**
+** For command details, see #CFE_ES_START_APP_CC
+**
+**/
+typedef struct CFE_ES_StartAppCmd_Payload
+{
+    char Application[CFE_MISSION_MAX_API_LEN];   /**< \brief Name of Application to be started */
+    char AppEntryPoint[CFE_MISSION_MAX_API_LEN]; /**< \brief Symbolic name of Application's entry point */
+    char AppFileName[CFE_MISSION_MAX_PATH_LEN];  /**< \brief Full path and filename of Application's
+                                                    executable image */
+
+    CFE_ES_MemOffset_t StackSize; /**< \brief Desired stack size for the new application */
+
+    CFE_ES_ExceptionAction_Enum_t ExceptionAction; /**< \brief #CFE_ES_ExceptionAction_RESTART_APP=On exception,
+                                                       restart Application,
+                                                       #CFE_ES_ExceptionAction_PROC_RESTART=On exception,
+                                                       perform a Processor Reset */
+    CFE_ES_TaskPriority_Atom_t Priority;           /**< \brief The new Applications runtime priority. */
+} CFE_ES_StartAppCmd_Payload_t;
+
+/**
+** \brief Generic application name command payload
+**
+** For command details, see #CFE_ES_STOP_APP_CC, #CFE_ES_RESTART_APP_CC, #CFE_ES_QUERY_ONE_CC
+**
+**/
+typedef struct CFE_ES_AppNameCmd_Payload
+{
+    char Application[CFE_MISSION_MAX_API_LEN]; /**< \brief ASCII text string containing Application or Library Name */
+} CFE_ES_AppNameCmd_Payload_t;
+
+/**
+** \brief Reload Application Command Payload
+**
+** For command details, see #CFE_ES_RELOAD_APP_CC
+**
+**/
+typedef struct CFE_ES_AppReloadCmd_Payload
+{
+    char Application[CFE_MISSION_MAX_API_LEN];  /**< \brief ASCII text string containing Application Name */
+    char AppFileName[CFE_MISSION_MAX_PATH_LEN]; /**< \brief Full path and filename of Application's
+                                                   executable image */
+} CFE_ES_AppReloadCmd_Payload_t;
+
+/**
+** \brief Set Maximum Processor Reset Count Command Payload
+**
+** For command details, see #CFE_ES_SET_MAX_PR_COUNT_CC
+**
+**/
+typedef struct CFE_ES_SetMaxPRCountCmd_Payload
+{
+    uint16 MaxPRCount; /**< \brief New maximum number of Processor Resets before
+                                   an automatic Power-On Reset is performed */
+} CFE_ES_SetMaxPRCountCmd_Payload_t;
+
+/**
+** \brief Delete Critical Data Store Command Payload
+**
+** For command details, see #CFE_ES_DELETE_CDS_CC
+**
+**/
+typedef struct CFE_ES_DeleteCDSCmd_Payload
+{
+    char
+        CdsName[CFE_MISSION_ES_CDS_MAX_FULL_NAME_LEN]; /**< \brief ASCII text string containing name of CDS to delete */
+} CFE_ES_DeleteCDSCmd_Payload_t;
+
+/**
+** \brief Start Performance Analyzer Command Payload
+**
+** For command details, see #CFE_ES_START_PERF_DATA_CC
+**
+**/
+typedef struct CFE_ES_StartPerfCmd_Payload
+{
+    uint32 TriggerMode; /**< \brief Desired trigger position (Start, Center, End) */
+} CFE_ES_StartPerfCmd_Payload_t;
+
+/**
+** \brief Stop Performance Analyzer Command Payload
+**
+** For command details, see #CFE_ES_STOP_PERF_DATA_CC
+**
+**/
+typedef struct CFE_ES_StopPerfCmd_Payload
+{
+    char DataFileName[CFE_MISSION_MAX_PATH_LEN]; /**< \brief ASCII text string of full path and filename
+                                                    of file Performance Analyzer data is to be written */
+} CFE_ES_StopPerfCmd_Payload_t;
+
+/**
+** \brief Set Performance Analyzer Filter Mask Command Payload
+**
+** For command details, see #CFE_ES_SET_PERF_FILTER_MASK_CC
+**
+**/
+typedef struct CFE_ES_SetPerfFilterMaskCmd_Payload
+{
+    uint32 FilterMaskNum; /**< \brief Index into array of Filter Masks */
+    uint32 FilterMask;    /**< \brief New Mask for specified entry in array of Filter Masks */
+} CFE_ES_SetPerfFilterMaskCmd_Payload_t;
+
+/**
+** \brief Set Performance Analyzer Trigger Mask Command Payload
+**
+** For command details, see #CFE_ES_SET_PERF_TRIGGER_MASK_CC
+**
+**/
+typedef struct CFE_ES_SetPerfTrigMaskCmd_Payload
+{
+    uint32 TriggerMaskNum; /**< \brief Index into array of Trigger Masks */
+    uint32 TriggerMask;    /**< \brief New Mask for specified entry in array of Trigger Masks */
+} CFE_ES_SetPerfTrigMaskCmd_Payload_t;
+
+/**
+** \brief Send Memory Pool Statistics Command Payload
+**
+** For command details, see #CFE_ES_SEND_MEM_POOL_STATS_CC
+**
+**/
+typedef struct CFE_ES_SendMemPoolStatsCmd_Payload
+{
+    char               Application[CFE_MISSION_MAX_API_LEN]; /**< \brief - RESERVED - should be all zeroes */
+    CFE_ES_MemHandle_t PoolHandle; /**< \brief Handle of Pool whose statistics are to be telemetered */
+} CFE_ES_SendMemPoolStatsCmd_Payload_t;
+
+/**
+** \brief Dump CDS Registry Command Payload
+**
+** For command details, see #CFE_ES_DUMP_CDS_REGISTRY_CC
+**
+**/
+typedef struct CFE_ES_DumpCDSRegistryCmd_Payload
+{
+    char DumpFilename[CFE_MISSION_MAX_PATH_LEN]; /**< \brief ASCII text string of full path and filename
+                                                    of file CDS Registry is to be written */
+} CFE_ES_DumpCDSRegistryCmd_Payload_t;
+
+/*************************************************************************/
+
+/************************************/
+/* Telemetry Interface Data Formats */
+/************************************/
+
+/**********************************/
+/* Telemetry Message Data Formats */
+/**********************************/
+/**
+**  \cfeestlm Single Application Information Packet
+**/
+typedef struct CFE_ES_OneAppTlm_Payload
+{
+    CFE_ES_AppInfo_t AppInfo; /**< \brief For more information, see #CFE_ES_AppInfo_t */
+} CFE_ES_OneAppTlm_Payload_t;
+
+/**
+**  \cfeestlm Memory Pool Statistics Packet
+**/
+typedef struct CFE_ES_PoolStatsTlm_Payload
+{
+    CFE_ES_MemHandle_t PoolHandle;   /**< \cfetlmmnemonic \ES_POOLHANDLE
+                                          \brief Handle of memory pool whose stats are being telemetered */
+    CFE_ES_MemPoolStats_t PoolStats; /**< \brief For more info, see #CFE_ES_MemPoolStats_t */
+} CFE_ES_PoolStatsTlm_Payload_t;
+
+/*************************************************************************/
+
+/**
+**  \cfeestlm Executive Services Housekeeping Packet
+**/
+typedef struct CFE_ES_HousekeepingTlm_Payload
+{
+    uint8 CommandCounter;      /**< \cfetlmmnemonic \ES_CMDPC
+                                \brief The ES Application Command Counter */
+    uint8 CommandErrorCounter; /**< \cfetlmmnemonic \ES_CMDEC
+                           \brief The ES Application Command Error Counter */
+
+    uint16 CFECoreChecksum;    /**< \cfetlmmnemonic \ES_CKSUM
+                                    \brief Checksum of cFE Core Code */
+    uint8 CFEMajorVersion;     /**< \cfetlmmnemonic \ES_CFEMAJORVER
+                                    \brief Major Version Number of cFE */
+    uint8 CFEMinorVersion;     /**< \cfetlmmnemonic \ES_CFEMINORVER
+                                    \brief Minor Version Number of cFE */
+    uint8 CFERevision;         /**< \cfetlmmnemonic \ES_CFEREVISION
+                                    \brief Sub-Minor Version Number of cFE */
+    uint8 CFEMissionRevision;  /**< \cfetlmmnemonic \ES_CFEMISSIONREV
+                                    \brief Mission Version Number of cFE */
+    uint8 OSALMajorVersion;    /**< \cfetlmmnemonic \ES_OSMAJORVER
+                                    \brief OS Abstraction Layer Major Version Number */
+    uint8 OSALMinorVersion;    /**< \cfetlmmnemonic \ES_OSMINORVER
+                                    \brief OS Abstraction Layer Minor Version Number */
+    uint8 OSALRevision;        /**< \cfetlmmnemonic \ES_OSREVISION
+                                    \brief OS Abstraction Layer Revision Number */
+    uint8 OSALMissionRevision; /**< \cfetlmmnemonic \ES_OSMISSIONREV
+                                    \brief OS Abstraction Layer MissionRevision Number */
+
+    uint8 PSPMajorVersion;    /**< \cfetlmmnemonic \ES_PSPMAJORVER
+                                   \brief Platform Support Package Major Version Number */
+    uint8 PSPMinorVersion;    /**< \cfetlmmnemonic \ES_PSPMINORVER
+                                   \brief Platform Support Package Minor Version Number */
+    uint8 PSPRevision;        /**< \cfetlmmnemonic \ES_PSPREVISION
+                                   \brief Platform Support Package Revision Number */
+    uint8 PSPMissionRevision; /**< \cfetlmmnemonic \ES_PSPMISSIONREV
+                                   \brief Platform Support Package MissionRevision Number */
+
+    CFE_ES_MemOffset_t SysLogBytesUsed; /**< \cfetlmmnemonic \ES_SYSLOGBYTEUSED
+                                             \brief Total number of bytes used in system log */
+    CFE_ES_MemOffset_t SysLogSize;      /**< \cfetlmmnemonic \ES_SYSLOGSIZE
+                                             \brief Total size of the system log */
+    uint32 SysLogEntries;               /**< \cfetlmmnemonic \ES_SYSLOGENTRIES
+                                             \brief Number of entries in the system log */
+    uint32 SysLogMode;                  /**< \cfetlmmnemonic \ES_SYSLOGMODE
+                                             \brief Write/Overwrite Mode */
+
+    uint32 ERLogIndex;   /**< \cfetlmmnemonic \ES_ERLOGINDEX
+                              \brief Current index of the ER Log (wraps around) */
+    uint32 ERLogEntries; /**< \cfetlmmnemonic \ES_ERLOGENTRIES
+                              \brief Number of entries made in the ER Log since the power on */
+
+    uint32 RegisteredCoreApps;     /**< \cfetlmmnemonic \ES_REGCOREAPPS
+                                        \brief Number of Applications registered with ES */
+    uint32 RegisteredExternalApps; /**< \cfetlmmnemonic \ES_REGEXTAPPS
+                                        \brief Number of Applications registered with ES */
+    uint32 RegisteredTasks;        /**< \cfetlmmnemonic \ES_REGTASKS
+                                        \brief Number of Tasks ( main AND child tasks ) registered with ES */
+    uint32 RegisteredLibs;         /**< \cfetlmmnemonic \ES_REGLIBS
+                                        \brief Number of Libraries registered with ES */
+
+    uint32 ResetType;          /**< \cfetlmmnemonic \ES_RESETTYPE
+                                    \brief Reset type ( PROCESSOR or POWERON ) */
+    uint32 ResetSubtype;       /**< \cfetlmmnemonic \ES_RESETSUBTYPE
+                                    \brief Reset Sub Type */
+    uint32 ProcessorResets;    /**< \cfetlmmnemonic \ES_PROCRESETCNT
+                                    \brief Number of processor resets since last power on */
+    uint32 MaxProcessorResets; /**< \cfetlmmnemonic \ES_MAXPROCRESETS
+                                    \brief Max processor resets before a power on is done */
+    uint32 BootSource;         /**< \cfetlmmnemonic \ES_BOOTSOURCE
+                                    \brief Boot source ( as provided from BSP ) */
+
+    uint32 PerfState;                                        /**< \cfetlmmnemonic \ES_PERFSTATE
+                                                                  \brief Current state of Performance Analyzer */
+    uint32 PerfMode;                                         /**< \cfetlmmnemonic \ES_PERFMODE
+                                                                  \brief Current mode of Performance Analyzer */
+    uint32 PerfTriggerCount;                                 /**< \cfetlmmnemonic \ES_PERFTRIGCNT
+                                                                  \brief Number of Times Performance Analyzer has Triggered */
+    uint32 PerfFilterMask[CFE_MISSION_ES_PERF_MAX_IDS / 32]; /**< \cfetlmmnemonic \ES_PERFFLTRMASK
+                                                          \brief Current Setting of Performance Analyzer Filter Masks */
+    uint32
+        PerfTriggerMask[CFE_MISSION_ES_PERF_MAX_IDS / 32]; /**< \cfetlmmnemonic \ES_PERFTRIGMASK
+                                                        \brief Current Setting of Performance Analyzer Trigger Masks */
+    uint32 PerfDataStart;                                  /**< \cfetlmmnemonic \ES_PERFDATASTART
+                                                                \brief Identifies First Stored Entry in Performance Analyzer Log */
+    uint32 PerfDataEnd;                                    /**< \cfetlmmnemonic \ES_PERFDATAEND
+                                                                \brief Identifies Last Stored Entry in Performance Analyzer Log */
+    uint32 PerfDataCount;                                  /**< \cfetlmmnemonic \ES_PERFDATACNT
+                                                                \brief Number of Entries Put Into the Performance Analyzer Log */
+    uint32
+        PerfDataToWrite;                 /**< \cfetlmmnemonic \ES_PERFDATA2WRITE
+                                              \brief Number of Performance Analyzer Log Entries Left to be Written to Log Dump File */
+    CFE_ES_MemOffset_t HeapBytesFree;    /**< \cfetlmmnemonic \ES_HEAPBYTESFREE
+                                            \brief Number of free bytes remaining in the OS heap */
+    CFE_ES_MemOffset_t HeapBlocksFree;   /**< \cfetlmmnemonic \ES_HEAPBLKSFREE
+                                            \brief Number of free blocks remaining in the OS heap */
+    CFE_ES_MemOffset_t HeapMaxBlockSize; /**< \cfetlmmnemonic \ES_HEAPMAXBLK
+                                            \brief Number of bytes in the largest free block */
+} CFE_ES_HousekeepingTlm_Payload_t;
 
 #endif

--- a/modules/es/config/default_cfe_es_msgstruct.h
+++ b/modules/es/config/default_cfe_es_msgstruct.h
@@ -42,19 +42,6 @@
 /********************************/
 /* Command Message Data Formats */
 /********************************/
-/**
-** \brief Generic "no arguments" command
-**
-** This command structure is used for commands that do not have any parameters.
-** This includes:
-** -# The Housekeeping Request Message
-** -# The No-Op Command (For details, see #CFE_ES_NOOP_CC)
-** -# The Reset Counters Command (For details, see #CFE_ES_RESET_COUNTERS_CC)
-*/
-typedef struct CFE_ES_NoArgsCmd
-{
-    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
-} CFE_ES_NoArgsCmd_t;
 
 /*
  * The following commands all share the "NoArgs" format
@@ -63,24 +50,35 @@ typedef struct CFE_ES_NoArgsCmd
  * allows them to change independently in the future without changing the prototype
  * of the handler function.
  */
-typedef CFE_ES_NoArgsCmd_t CFE_ES_NoopCmd_t;
-typedef CFE_ES_NoArgsCmd_t CFE_ES_ResetCountersCmd_t;
-typedef CFE_ES_NoArgsCmd_t CFE_ES_ClearSysLogCmd_t;
-typedef CFE_ES_NoArgsCmd_t CFE_ES_ClearERLogCmd_t;
-typedef CFE_ES_NoArgsCmd_t CFE_ES_ResetPRCountCmd_t;
-typedef CFE_ES_NoArgsCmd_t CFE_ES_SendHkCmd_t;
-
-/**
-** \brief Restart cFE Command Payload
-**
-** For command details, see #CFE_ES_RESTART_CC
-**
-**/
-typedef struct CFE_ES_RestartCmd_Payload
+typedef struct CFE_ES_NoopCmd
 {
-    uint16 RestartType; /**< \brief #CFE_PSP_RST_TYPE_PROCESSOR=Processor Reset
-                             or #CFE_PSP_RST_TYPE_POWERON=Power-On Reset        */
-} CFE_ES_RestartCmd_Payload_t;
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CFE_ES_NoopCmd_t;
+
+typedef struct CFE_ES_ResetCountersCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CFE_ES_ResetCountersCmd_t;
+
+typedef struct CFE_ES_ClearSysLogCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CFE_ES_ClearSysLogCmd_t;
+
+typedef struct CFE_ES_ClearERLogCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CFE_ES_ClearERLogCmd_t;
+
+typedef struct CFE_ES_ResetPRCountCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CFE_ES_ResetPRCountCmd_t;
+
+typedef struct CFE_ES_SendHkCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CFE_ES_SendHkCmd_t;
 
 /**
  * \brief Restart cFE Command
@@ -91,20 +89,7 @@ typedef struct CFE_ES_RestartCmd
     CFE_ES_RestartCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_ES_RestartCmd_t;
 
-/**
-** \brief Generic file name command payload
-**
-** This format is shared by several executive services commands.
-** For command details, see #CFE_ES_QUERY_ALL_CC, #CFE_ES_QUERY_ALL_TASKS_CC,
-** #CFE_ES_WRITE_SYSLOG_CC, and #CFE_ES_WRITE_ER_LOG_CC
-**
-**/
-typedef struct CFE_ES_FileNameCmd_Payload
-{
-    char FileName[CFE_MISSION_MAX_PATH_LEN]; /**< \brief ASCII text string containing full path and
-                                                 filename of file in which Application data is to be dumped */
-} CFE_ES_FileNameCmd_Payload_t;
-
+#ifndef jphfix
 /**
  * \brief Generic file name command
  */
@@ -113,27 +98,34 @@ typedef struct CFE_ES_FileNameCmd
     CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
     CFE_ES_FileNameCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_ES_FileNameCmd_t;
-
+#endif
 /*
  * Unique typedefs for each of the commands that utilize the FileNameCmd
  * packet format
  */
-typedef CFE_ES_FileNameCmd_t CFE_ES_QueryAllCmd_t;
-typedef CFE_ES_FileNameCmd_t CFE_ES_QueryAllTasksCmd_t;
-typedef CFE_ES_FileNameCmd_t CFE_ES_WriteSysLogCmd_t;
-typedef CFE_ES_FileNameCmd_t CFE_ES_WriteERLogCmd_t;
-
-/**
-** \brief Overwrite/Discard System Log Configuration Command Payload
-**
-** For command details, see #CFE_ES_OVER_WRITE_SYSLOG_CC
-**
-**/
-typedef struct CFE_ES_OverWriteSysLogCmd_Payload
+typedef struct CFE_ES_QueryAllCmd
 {
-    uint32 Mode; /**< \brief #CFE_ES_LogMode_DISCARD=Throw away most recent messages,
-                             #CFE_ES_LogMode_OVERWRITE=Overwrite oldest with most recent */
-} CFE_ES_OverWriteSysLogCmd_Payload_t;
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
+    CFE_ES_FileNameCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_ES_QueryAllCmd_t;
+
+typedef struct CFE_ES_QueryAllTasksCmd
+{
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
+    CFE_ES_FileNameCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_ES_QueryAllTasksCmd_t;
+
+typedef struct CFE_ES_WriteSysLogCmd
+{
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
+    CFE_ES_FileNameCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_ES_WriteSysLogCmd_t;
+
+typedef struct CFE_ES_WriteERLogCmd
+{
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
+    CFE_ES_FileNameCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_ES_WriteERLogCmd_t;
 
 /**
  * \brief Overwrite/Discard System Log Configuration Command Payload
@@ -145,28 +137,6 @@ typedef struct CFE_ES_OverWriteSysLogCmd
 } CFE_ES_OverWriteSysLogCmd_t;
 
 /**
-** \brief Start Application Command Payload
-**
-** For command details, see #CFE_ES_START_APP_CC
-**
-**/
-typedef struct CFE_ES_StartAppCmd_Payload
-{
-    char Application[CFE_MISSION_MAX_API_LEN];   /**< \brief Name of Application to be started */
-    char AppEntryPoint[CFE_MISSION_MAX_API_LEN]; /**< \brief Symbolic name of Application's entry point */
-    char AppFileName[CFE_MISSION_MAX_PATH_LEN];  /**< \brief Full path and filename of Application's
-                                                    executable image */
-
-    CFE_ES_MemOffset_t StackSize; /**< \brief Desired stack size for the new application */
-
-    CFE_ES_ExceptionAction_Enum_t ExceptionAction; /**< \brief #CFE_ES_ExceptionAction_RESTART_APP=On exception,
-                                                       restart Application,
-                                                       #CFE_ES_ExceptionAction_PROC_RESTART=On exception,
-                                                       perform a Processor Reset */
-    CFE_ES_TaskPriority_Atom_t Priority;           /**< \brief The new Applications runtime priority. */
-} CFE_ES_StartAppCmd_Payload_t;
-
-/**
  * \brief Start Application Command
  */
 typedef struct CFE_ES_StartApp
@@ -175,47 +145,28 @@ typedef struct CFE_ES_StartApp
     CFE_ES_StartAppCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_ES_StartAppCmd_t;
 
-/**
-** \brief Generic application name command payload
-**
-** For command details, see #CFE_ES_STOP_APP_CC, #CFE_ES_RESTART_APP_CC, #CFE_ES_QUERY_ONE_CC
-**
-**/
-typedef struct CFE_ES_AppNameCmd_Payload
-{
-    char Application[CFE_MISSION_MAX_API_LEN]; /**< \brief ASCII text string containing Application or Library Name */
-} CFE_ES_AppNameCmd_Payload_t;
-
-/**
- * \brief Generic application name command
- */
-typedef struct CFE_ES_AppNameCmd
-{
-    CFE_MSG_CommandHeader_t     CommandHeader; /**< \brief Command header */
-    CFE_ES_AppNameCmd_Payload_t Payload;       /**< \brief Command payload */
-} CFE_ES_AppNameCmd_t;
-
 /*
  * Like NoArgsCmd, this message definition is shared by multiple commands.
  * Create a separate typedef for each one so they can all evolve independently
  * without affecting the prototype.
  */
-typedef CFE_ES_AppNameCmd_t CFE_ES_StopAppCmd_t;
-typedef CFE_ES_AppNameCmd_t CFE_ES_RestartAppCmd_t;
-typedef CFE_ES_AppNameCmd_t CFE_ES_QueryOneCmd_t;
-
-/**
-** \brief Reload Application Command Payload
-**
-** For command details, see #CFE_ES_RELOAD_APP_CC
-**
-**/
-typedef struct CFE_ES_AppReloadCmd_Payload
+typedef struct CFE_ES_StopAppCmd
 {
-    char Application[CFE_MISSION_MAX_API_LEN];  /**< \brief ASCII text string containing Application Name */
-    char AppFileName[CFE_MISSION_MAX_PATH_LEN]; /**< \brief Full path and filename of Application's
-                                                   executable image */
-} CFE_ES_AppReloadCmd_Payload_t;
+    CFE_MSG_CommandHeader_t     CommandHeader; /**< \brief Command header */
+    CFE_ES_AppNameCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_ES_StopAppCmd_t;
+
+typedef struct CFE_ES_RestartAppCmd
+{
+    CFE_MSG_CommandHeader_t     CommandHeader; /**< \brief Command header */
+    CFE_ES_AppNameCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_ES_RestartAppCmd_t;
+
+typedef struct CFE_ES_QueryOneCmd
+{
+    CFE_MSG_CommandHeader_t     CommandHeader; /**< \brief Command header */
+    CFE_ES_AppNameCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_ES_QueryOneCmd_t;
 
 /**
  * \brief Reload Application Command
@@ -227,18 +178,6 @@ typedef struct CFE_ES_ReloadAppCmd
 } CFE_ES_ReloadAppCmd_t;
 
 /**
-** \brief Set Maximum Processor Reset Count Command Payload
-**
-** For command details, see #CFE_ES_SET_MAX_PR_COUNT_CC
-**
-**/
-typedef struct CFE_ES_SetMaxPRCountCmd_Payload
-{
-    uint16 MaxPRCount; /**< \brief New maximum number of Processor Resets before
-                                   an automatic Power-On Reset is performed */
-} CFE_ES_SetMaxPRCountCmd_Payload_t;
-
-/**
  * \brief Set Maximum Processor Reset Count Command
  */
 typedef struct CFE_ES_SetMaxPRCountCmd
@@ -246,18 +185,6 @@ typedef struct CFE_ES_SetMaxPRCountCmd
     CFE_MSG_CommandHeader_t           CommandHeader; /**< \brief Command header */
     CFE_ES_SetMaxPRCountCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_ES_SetMaxPRCountCmd_t;
-
-/**
-** \brief Delete Critical Data Store Command Payload
-**
-** For command details, see #CFE_ES_DELETE_CDS_CC
-**
-**/
-typedef struct CFE_ES_DeleteCDSCmd_Payload
-{
-    char
-        CdsName[CFE_MISSION_ES_CDS_MAX_FULL_NAME_LEN]; /**< \brief ASCII text string containing name of CDS to delete */
-} CFE_ES_DeleteCDSCmd_Payload_t;
 
 /**
  * \brief Delete Critical Data Store Command
@@ -269,17 +196,6 @@ typedef struct CFE_ES_DeleteCDSCmd
 } CFE_ES_DeleteCDSCmd_t;
 
 /**
-** \brief Start Performance Analyzer Command Payload
-**
-** For command details, see #CFE_ES_START_PERF_DATA_CC
-**
-**/
-typedef struct CFE_ES_StartPerfCmd_Payload
-{
-    uint32 TriggerMode; /**< \brief Desired trigger position (Start, Center, End) */
-} CFE_ES_StartPerfCmd_Payload_t;
-
-/**
  * \brief Start Performance Analyzer Command
  */
 typedef struct CFE_ES_StartPerfDataCmd
@@ -287,18 +203,6 @@ typedef struct CFE_ES_StartPerfDataCmd
     CFE_MSG_CommandHeader_t       CommandHeader; /**< \brief Command header */
     CFE_ES_StartPerfCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_ES_StartPerfDataCmd_t;
-
-/**
-** \brief Stop Performance Analyzer Command Payload
-**
-** For command details, see #CFE_ES_STOP_PERF_DATA_CC
-**
-**/
-typedef struct CFE_ES_StopPerfCmd_Payload
-{
-    char DataFileName[CFE_MISSION_MAX_PATH_LEN]; /**< \brief ASCII text string of full path and filename
-                                                    of file Performance Analyzer data is to be written */
-} CFE_ES_StopPerfCmd_Payload_t;
 
 /**
  * \brief Stop Performance Analyzer Command
@@ -310,18 +214,6 @@ typedef struct CFE_ES_StopPerfDataCmd
 } CFE_ES_StopPerfDataCmd_t;
 
 /**
-** \brief Set Performance Analyzer Filter Mask Command Payload
-**
-** For command details, see #CFE_ES_SET_PERF_FILTER_MASK_CC
-**
-**/
-typedef struct CFE_ES_SetPerfFilterMaskCmd_Payload
-{
-    uint32 FilterMaskNum; /**< \brief Index into array of Filter Masks */
-    uint32 FilterMask;    /**< \brief New Mask for specified entry in array of Filter Masks */
-} CFE_ES_SetPerfFilterMaskCmd_Payload_t;
-
-/**
  * \brief Set Performance Analyzer Filter Mask Command
  */
 typedef struct CFE_ES_SetPerfFilterMaskCmd
@@ -329,18 +221,6 @@ typedef struct CFE_ES_SetPerfFilterMaskCmd
     CFE_MSG_CommandHeader_t               CommandHeader; /**< \brief Command header */
     CFE_ES_SetPerfFilterMaskCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_ES_SetPerfFilterMaskCmd_t;
-
-/**
-** \brief Set Performance Analyzer Trigger Mask Command Payload
-**
-** For command details, see #CFE_ES_SET_PERF_TRIGGER_MASK_CC
-**
-**/
-typedef struct CFE_ES_SetPerfTrigMaskCmd_Payload
-{
-    uint32 TriggerMaskNum; /**< \brief Index into array of Trigger Masks */
-    uint32 TriggerMask;    /**< \brief New Mask for specified entry in array of Trigger Masks */
-} CFE_ES_SetPerfTrigMaskCmd_Payload_t;
 
 /**
  * \brief Set Performance Analyzer Trigger Mask Command
@@ -352,18 +232,6 @@ typedef struct CFE_ES_SetPerfTriggerMaskCmd
 } CFE_ES_SetPerfTriggerMaskCmd_t;
 
 /**
-** \brief Send Memory Pool Statistics Command Payload
-**
-** For command details, see #CFE_ES_SEND_MEM_POOL_STATS_CC
-**
-**/
-typedef struct CFE_ES_SendMemPoolStatsCmd_Payload
-{
-    char               Application[CFE_MISSION_MAX_API_LEN]; /**< \brief - RESERVED - should be all zeroes */
-    CFE_ES_MemHandle_t PoolHandle; /**< \brief Handle of Pool whose statistics are to be telemetered */
-} CFE_ES_SendMemPoolStatsCmd_Payload_t;
-
-/**
  * \brief Send Memory Pool Statistics Command
  */
 typedef struct CFE_ES_SendMemPoolStatsCmd
@@ -371,18 +239,6 @@ typedef struct CFE_ES_SendMemPoolStatsCmd
     CFE_MSG_CommandHeader_t              CommandHeader; /**< \brief Command header */
     CFE_ES_SendMemPoolStatsCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_ES_SendMemPoolStatsCmd_t;
-
-/**
-** \brief Dump CDS Registry Command Payload
-**
-** For command details, see #CFE_ES_DUMP_CDS_REGISTRY_CC
-**
-**/
-typedef struct CFE_ES_DumpCDSRegistryCmd_Payload
-{
-    char DumpFilename[CFE_MISSION_MAX_PATH_LEN]; /**< \brief ASCII text string of full path and filename
-                                                    of file CDS Registry is to be written */
-} CFE_ES_DumpCDSRegistryCmd_Payload_t;
 
 /**
  * \brief Dump CDS Registry Command
@@ -395,21 +251,13 @@ typedef struct CFE_ES_DumpCDSRegistryCmd
 
 /*************************************************************************/
 
-/************************************/
-/* Telemetry Interface Data Formats */
-/************************************/
-
 /**********************************/
 /* Telemetry Message Data Formats */
 /**********************************/
+
 /**
 **  \cfeestlm Single Application Information Packet
 **/
-typedef struct CFE_ES_OneAppTlm_Payload
-{
-    CFE_ES_AppInfo_t AppInfo; /**< \brief For more information, see #CFE_ES_AppInfo_t */
-} CFE_ES_OneAppTlm_Payload_t;
-
 typedef struct CFE_ES_OneAppTlm
 {
     CFE_MSG_TelemetryHeader_t  TelemetryHeader; /**< \brief Telemetry header */
@@ -419,121 +267,15 @@ typedef struct CFE_ES_OneAppTlm
 /**
 **  \cfeestlm Memory Pool Statistics Packet
 **/
-typedef struct CFE_ES_PoolStatsTlm_Payload
-{
-    CFE_ES_MemHandle_t PoolHandle;   /**< \cfetlmmnemonic \ES_POOLHANDLE
-                                          \brief Handle of memory pool whose stats are being telemetered */
-    CFE_ES_MemPoolStats_t PoolStats; /**< \brief For more info, see #CFE_ES_MemPoolStats_t */
-} CFE_ES_PoolStatsTlm_Payload_t;
-
 typedef struct CFE_ES_MemStatsTlm
 {
     CFE_MSG_TelemetryHeader_t     TelemetryHeader; /**< \brief Telemetry header */
     CFE_ES_PoolStatsTlm_Payload_t Payload;         /**< \brief Telemetry payload */
 } CFE_ES_MemStatsTlm_t;
 
-/*************************************************************************/
-
 /**
 **  \cfeestlm Executive Services Housekeeping Packet
 **/
-typedef struct CFE_ES_HousekeepingTlm_Payload
-{
-    uint8 CommandCounter;      /**< \cfetlmmnemonic \ES_CMDPC
-                                \brief The ES Application Command Counter */
-    uint8 CommandErrorCounter; /**< \cfetlmmnemonic \ES_CMDEC
-                           \brief The ES Application Command Error Counter */
-
-    uint16 CFECoreChecksum;    /**< \cfetlmmnemonic \ES_CKSUM
-                                    \brief Checksum of cFE Core Code */
-    uint8 CFEMajorVersion;     /**< \cfetlmmnemonic \ES_CFEMAJORVER
-                                    \brief Major Version Number of cFE */
-    uint8 CFEMinorVersion;     /**< \cfetlmmnemonic \ES_CFEMINORVER
-                                    \brief Minor Version Number of cFE */
-    uint8 CFERevision;         /**< \cfetlmmnemonic \ES_CFEREVISION
-                                    \brief Sub-Minor Version Number of cFE */
-    uint8 CFEMissionRevision;  /**< \cfetlmmnemonic \ES_CFEMISSIONREV
-                                    \brief Mission Version Number of cFE */
-    uint8 OSALMajorVersion;    /**< \cfetlmmnemonic \ES_OSMAJORVER
-                                    \brief OS Abstraction Layer Major Version Number */
-    uint8 OSALMinorVersion;    /**< \cfetlmmnemonic \ES_OSMINORVER
-                                    \brief OS Abstraction Layer Minor Version Number */
-    uint8 OSALRevision;        /**< \cfetlmmnemonic \ES_OSREVISION
-                                    \brief OS Abstraction Layer Revision Number */
-    uint8 OSALMissionRevision; /**< \cfetlmmnemonic \ES_OSMISSIONREV
-                                    \brief OS Abstraction Layer MissionRevision Number */
-
-    uint8 PSPMajorVersion;    /**< \cfetlmmnemonic \ES_PSPMAJORVER
-                                   \brief Platform Support Package Major Version Number */
-    uint8 PSPMinorVersion;    /**< \cfetlmmnemonic \ES_PSPMINORVER
-                                   \brief Platform Support Package Minor Version Number */
-    uint8 PSPRevision;        /**< \cfetlmmnemonic \ES_PSPREVISION
-                                   \brief Platform Support Package Revision Number */
-    uint8 PSPMissionRevision; /**< \cfetlmmnemonic \ES_PSPMISSIONREV
-                                   \brief Platform Support Package MissionRevision Number */
-
-    CFE_ES_MemOffset_t SysLogBytesUsed; /**< \cfetlmmnemonic \ES_SYSLOGBYTEUSED
-                                             \brief Total number of bytes used in system log */
-    CFE_ES_MemOffset_t SysLogSize;      /**< \cfetlmmnemonic \ES_SYSLOGSIZE
-                                             \brief Total size of the system log */
-    uint32 SysLogEntries;               /**< \cfetlmmnemonic \ES_SYSLOGENTRIES
-                                             \brief Number of entries in the system log */
-    uint32 SysLogMode;                  /**< \cfetlmmnemonic \ES_SYSLOGMODE
-                                             \brief Write/Overwrite Mode */
-
-    uint32 ERLogIndex;   /**< \cfetlmmnemonic \ES_ERLOGINDEX
-                              \brief Current index of the ER Log (wraps around) */
-    uint32 ERLogEntries; /**< \cfetlmmnemonic \ES_ERLOGENTRIES
-                              \brief Number of entries made in the ER Log since the power on */
-
-    uint32 RegisteredCoreApps;     /**< \cfetlmmnemonic \ES_REGCOREAPPS
-                                        \brief Number of Applications registered with ES */
-    uint32 RegisteredExternalApps; /**< \cfetlmmnemonic \ES_REGEXTAPPS
-                                        \brief Number of Applications registered with ES */
-    uint32 RegisteredTasks;        /**< \cfetlmmnemonic \ES_REGTASKS
-                                        \brief Number of Tasks ( main AND child tasks ) registered with ES */
-    uint32 RegisteredLibs;         /**< \cfetlmmnemonic \ES_REGLIBS
-                                        \brief Number of Libraries registered with ES */
-
-    uint32 ResetType;          /**< \cfetlmmnemonic \ES_RESETTYPE
-                                    \brief Reset type ( PROCESSOR or POWERON ) */
-    uint32 ResetSubtype;       /**< \cfetlmmnemonic \ES_RESETSUBTYPE
-                                    \brief Reset Sub Type */
-    uint32 ProcessorResets;    /**< \cfetlmmnemonic \ES_PROCRESETCNT
-                                    \brief Number of processor resets since last power on */
-    uint32 MaxProcessorResets; /**< \cfetlmmnemonic \ES_MAXPROCRESETS
-                                    \brief Max processor resets before a power on is done */
-    uint32 BootSource;         /**< \cfetlmmnemonic \ES_BOOTSOURCE
-                                    \brief Boot source ( as provided from BSP ) */
-
-    uint32 PerfState;                                        /**< \cfetlmmnemonic \ES_PERFSTATE
-                                                                  \brief Current state of Performance Analyzer */
-    uint32 PerfMode;                                         /**< \cfetlmmnemonic \ES_PERFMODE
-                                                                  \brief Current mode of Performance Analyzer */
-    uint32 PerfTriggerCount;                                 /**< \cfetlmmnemonic \ES_PERFTRIGCNT
-                                                                  \brief Number of Times Performance Analyzer has Triggered */
-    uint32 PerfFilterMask[CFE_MISSION_ES_PERF_MAX_IDS / 32]; /**< \cfetlmmnemonic \ES_PERFFLTRMASK
-                                                          \brief Current Setting of Performance Analyzer Filter Masks */
-    uint32
-        PerfTriggerMask[CFE_MISSION_ES_PERF_MAX_IDS / 32]; /**< \cfetlmmnemonic \ES_PERFTRIGMASK
-                                                        \brief Current Setting of Performance Analyzer Trigger Masks */
-    uint32 PerfDataStart;                                  /**< \cfetlmmnemonic \ES_PERFDATASTART
-                                                                \brief Identifies First Stored Entry in Performance Analyzer Log */
-    uint32 PerfDataEnd;                                    /**< \cfetlmmnemonic \ES_PERFDATAEND
-                                                                \brief Identifies Last Stored Entry in Performance Analyzer Log */
-    uint32 PerfDataCount;                                  /**< \cfetlmmnemonic \ES_PERFDATACNT
-                                                                \brief Number of Entries Put Into the Performance Analyzer Log */
-    uint32
-        PerfDataToWrite;                 /**< \cfetlmmnemonic \ES_PERFDATA2WRITE
-                                              \brief Number of Performance Analyzer Log Entries Left to be Written to Log Dump File */
-    CFE_ES_MemOffset_t HeapBytesFree;    /**< \cfetlmmnemonic \ES_HEAPBYTESFREE
-                                            \brief Number of free bytes remaining in the OS heap */
-    CFE_ES_MemOffset_t HeapBlocksFree;   /**< \cfetlmmnemonic \ES_HEAPBLKSFREE
-                                            \brief Number of free blocks remaining in the OS heap */
-    CFE_ES_MemOffset_t HeapMaxBlockSize; /**< \cfetlmmnemonic \ES_HEAPMAXBLK
-                                            \brief Number of bytes in the largest free block */
-} CFE_ES_HousekeepingTlm_Payload_t;
-
 typedef struct CFE_ES_HousekeepingTlm
 {
     CFE_MSG_TelemetryHeader_t        TelemetryHeader; /**< \brief Telemetry header */

--- a/modules/evs/CMakeLists.txt
+++ b/modules/evs/CMakeLists.txt
@@ -25,6 +25,16 @@ if(ENABLE_UNIT_TESTS)
 endif(ENABLE_UNIT_TESTS)
 
 cfs_app_check_intf(${DEP}
-    cfe_evs_msg.h
     cfe_evs_eventids.h
+    cfe_evs_extern_typedefs.h
+    cfe_evs_fcncodes.h
+    cfe_evs_interface_cfg.h
+    cfe_evs_internal_cfg.h
+    cfe_evs_mission_cfg.h
+    cfe_evs_msgdefs.h
+    cfe_evs_msg.h
+    cfe_evs_msgids.h
+    cfe_evs_msgstruct.h
+    cfe_evs_platform_cfg.h
+    cfe_evs_topicids.h
 )

--- a/modules/evs/config/default_cfe_evs_msgdefs.h
+++ b/modules/evs/config/default_cfe_evs_msgdefs.h
@@ -26,6 +26,10 @@
 #ifndef CFE_EVS_MSGDEFS_H
 #define CFE_EVS_MSGDEFS_H
 
+#include "common_types.h"
+#include "cfe_mission_cfg.h"
+#include "cfe_es_extern_typedefs.h"
+#include "cfe_evs_extern_typedefs.h"
 #include "cfe_evs_fcncodes.h"
 
 /* Event Type bit masks */
@@ -39,5 +43,216 @@
 #define CFE_EVS_PORT2_BIT 0x0002
 #define CFE_EVS_PORT3_BIT 0x0004
 #define CFE_EVS_PORT4_BIT 0x0008
+
+/***********************************/
+/*  Command Message Data Payloads  */
+/***********************************/
+
+/**
+** \brief Write Event Log to File Command Payload
+**
+** For command details, see #CFE_EVS_WRITE_LOG_DATA_FILE_CC
+**
+**/
+typedef struct CFE_EVS_LogFileCmd_Payload
+{
+    char LogFilename[CFE_MISSION_MAX_PATH_LEN]; /**< \brief Filename where log data is to be written */
+} CFE_EVS_LogFileCmd_Payload_t;
+
+/**
+** \brief Write Event Services Application Information to File Command Payload
+**
+** For command details, see #CFE_EVS_WRITE_APP_DATA_FILE_CC
+**
+**/
+typedef struct CFE_EVS_AppDataCmd_Payload
+{
+    char AppDataFilename[CFE_MISSION_MAX_PATH_LEN]; /**< \brief Filename where application data is to be written */
+} CFE_EVS_AppDataCmd_Payload_t;
+
+/**
+** \brief Set Log Mode Command Payload
+**
+** For command details, see #CFE_EVS_SET_LOG_MODE_CC
+**
+**/
+typedef struct CFE_EVS_SetLogMode_Payload
+{
+    CFE_EVS_LogMode_Enum_t LogMode; /**< \brief Mode to use in the command*/
+    uint8                  Spare;   /**< \brief Pad to even byte*/
+} CFE_EVS_SetLogMode_Payload_t;
+
+/**
+** \brief Set Event Format Mode Command Payload
+**
+** For command details, see #CFE_EVS_SET_EVENT_FORMAT_MODE_CC
+**
+**/
+typedef struct CFE_EVS_SetEventFormatCode_Payload
+{
+    CFE_EVS_MsgFormat_Enum_t MsgFormat; /**< \brief Mode to use in the command*/
+    uint8                    Spare;     /**< \brief Pad to even byte*/
+} CFE_EVS_SetEventFormatMode_Payload_t;
+
+/**
+** \brief Generic Bitmask Command Payload
+**
+** For command details, see #CFE_EVS_ENABLE_EVENT_TYPE_CC, #CFE_EVS_DISABLE_EVENT_TYPE_CC,
+**                          #CFE_EVS_ENABLE_PORTS_CC and/or #CFE_EVS_DISABLE_PORTS_CC
+**
+**/
+typedef struct CFE_EVS_BitMaskCmd_Payload
+{
+    uint8 BitMask; /**< \brief BitMask to use in the command */
+    uint8 Spare;   /**< \brief Pad to even byte*/
+} CFE_EVS_BitMaskCmd_Payload_t;
+
+/**
+** \brief Generic App Name Command Payload
+**
+** For command details, see #CFE_EVS_ENABLE_APP_EVENTS_CC, #CFE_EVS_DISABLE_APP_EVENTS_CC,
+**                          #CFE_EVS_RESET_APP_COUNTER_CC and/or #CFE_EVS_RESET_ALL_FILTERS_CC
+**
+**/
+typedef struct CFE_EVS_AppNameCmd_Payload
+{
+    char AppName[CFE_MISSION_MAX_API_LEN]; /**< \brief Application name to use in the command*/
+} CFE_EVS_AppNameCmd_Payload_t;
+
+/**
+** \brief Generic App Name and Event ID Command Payload
+**
+** For command details, see #CFE_EVS_RESET_FILTER_CC and #CFE_EVS_DELETE_EVENT_FILTER_CC
+**
+**/
+typedef struct CFE_EVS_AppNameEventIDCmd_Payload
+{
+    char   AppName[CFE_MISSION_MAX_API_LEN]; /**< \brief Application name to use in the command*/
+    uint16 EventID;                          /**< \brief Event ID  to use in the command*/
+} CFE_EVS_AppNameEventIDCmd_Payload_t;
+
+/**
+** \brief Generic App Name and Bitmask Command Payload
+**
+** For command details, see #CFE_EVS_ENABLE_APP_EVENT_TYPE_CC and/or #CFE_EVS_DISABLE_APP_EVENT_TYPE_CC
+**
+**/
+typedef struct CFE_EVS_AppNameBitMaskCmd_Payload
+{
+    char  AppName[CFE_MISSION_MAX_API_LEN]; /**< \brief Application name to use in the command*/
+    uint8 BitMask;                          /**< \brief BitMask to use in the command*/
+    uint8 Spare;                            /**< \brief Pad to even byte*/
+} CFE_EVS_AppNameBitMaskCmd_Payload_t;
+
+/**
+** \brief Generic App Name, Event ID, Mask Command Payload
+**
+** For command details, see #CFE_EVS_SET_FILTER_CC, #CFE_EVS_ADD_EVENT_FILTER_CC
+**                      and/or #CFE_EVS_DELETE_EVENT_FILTER_CC
+**
+**/
+typedef struct CFE_EVS_AppNameEventIDMaskCmd_Payload
+{
+    char   AppName[CFE_MISSION_MAX_API_LEN]; /**< \brief Application name to use in the command*/
+    uint16 EventID;                          /**< \brief Event ID  to use in the command*/
+    uint16 Mask;                             /**< \brief Mask to use in the command */
+} CFE_EVS_AppNameEventIDMaskCmd_Payload_t;
+
+/*************************************************************************/
+
+/***********************************/
+/* Telemetry Message Data Payloads */
+/***********************************/
+
+typedef struct CFE_EVS_AppTlmData
+{
+    CFE_ES_AppId_t AppID;             /**< \cfetlmmnemonic \EVS_APPID
+                                           \brief Numerical application identifier */
+    uint16 AppMessageSentCounter;     /**< \cfetlmmnemonic \EVS_APPMSGSENTC
+                                           \brief Application message sent counter */
+    uint8 AppEnableStatus;            /**< \cfetlmmnemonic \EVS_APPENASTAT
+                                           \brief Application event service enable status */
+    uint8 AppMessageSquelchedCounter; /**< \cfetlmmnemonic \EVS_SQUELCHEDC
+                                       \brief Number of events squelched */
+} CFE_EVS_AppTlmData_t;
+
+/**
+**  \cfeevstlm Event Services Housekeeping Telemetry Packet
+**/
+typedef struct CFE_EVS_HousekeepingTlm_Payload
+{
+    uint8 CommandCounter;      /**< \cfetlmmnemonic \EVS_CMDPC
+                                    \brief EVS Command Counter */
+    uint8 CommandErrorCounter; /**< \cfetlmmnemonic \EVS_CMDEC
+                                  \brief EVS Command Error Counter */
+    uint8 MessageFormatMode;   /**< \cfetlmmnemonic \EVS_MSGFMTMODE
+                                    \brief Event message format mode (short/long) */
+    uint8 MessageTruncCounter; /**< \cfetlmmnemonic \EVS_MSGTRUNC
+                                    \brief Event message truncation counter */
+
+    uint8 UnregisteredAppCounter; /**< \cfetlmmnemonic \EVS_UNREGAPPC
+                                       \brief Unregistered application message send counter */
+    uint8 OutputPort;             /**< \cfetlmmnemonic \EVS_OUTPUTPORT
+                                       \brief Output port mask */
+    uint8 LogFullFlag;            /**< \cfetlmmnemonic \EVS_LOGFULL
+                                       \brief Local event log full flag */
+    uint8 LogMode;                /**< \cfetlmmnemonic \EVS_LOGMODE
+                                       \brief Local event logging mode (overwrite/discard) */
+
+    uint16 MessageSendCounter; /**< \cfetlmmnemonic \EVS_MSGSENTC
+                                    \brief Event message send counter */
+    uint16 LogOverflowCounter; /**< \cfetlmmnemonic \EVS_LOGOVERFLOWC
+                                    \brief Local event log overflow counter */
+
+    uint8 LogEnabled; /**< \cfetlmmnemonic \EVS_LOGENABLED
+                           \brief Current event log enable/disable state */
+    uint8 Spare1;     /**< \cfetlmmnemonic \EVS_HK_SPARE1
+                           \brief Padding for 32 bit boundary */
+    uint8 Spare2;     /**< \cfetlmmnemonic \EVS_HK_SPARE2
+                           \brief Padding for 32 bit boundary */
+    uint8 Spare3;     /**< \cfetlmmnemonic \EVS_HK_SPARE3
+                           \brief Padding for 32 bit boundary */
+
+    CFE_EVS_AppTlmData_t AppData[CFE_MISSION_ES_MAX_APPLICATIONS]; /**< \cfetlmmnemonic \EVS_APP
+                                                                \brief Array of registered application table data */
+} CFE_EVS_HousekeepingTlm_Payload_t;
+
+/** Telemetry packet structures */
+
+typedef struct CFE_EVS_PacketID
+{
+    char AppName[CFE_MISSION_MAX_API_LEN]; /**< \cfetlmmnemonic \EVS_APPNAME
+                                        \brief Application name */
+    uint16 EventID;                        /**< \cfetlmmnemonic \EVS_EVENTID
+                                                \brief Numerical event identifier */
+    uint16 EventType;                      /**< \cfetlmmnemonic \EVS_EVENTTYPE
+                                                \brief Numerical event type identifier */
+    uint32 SpacecraftID;                   /**< \cfetlmmnemonic \EVS_SCID
+                                                \brief Spacecraft identifier */
+    uint32 ProcessorID;                    /**< \cfetlmmnemonic \EVS_PROCESSORID
+                                                \brief Numerical processor identifier */
+} CFE_EVS_PacketID_t;
+
+/**
+**  \cfeevstlm Event Message Telemetry Packet (Long format)
+**/
+typedef struct CFE_EVS_LongEventTlm_Payload
+{
+    CFE_EVS_PacketID_t PacketID;                                    /**< \brief Event packet information */
+    char               Message[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH]; /**< \cfetlmmnemonic \EVS_EVENT
+                                                                 \brief Event message string */
+    uint8 Spare1;                                                   /**< \cfetlmmnemonic \EVS_SPARE1
+                                                                         \brief Structure padding */
+    uint8 Spare2;                                                   /**< \cfetlmmnemonic \EVS_SPARE2
+                                                                     \brief Structure padding */
+} CFE_EVS_LongEventTlm_Payload_t;
+
+/**
+**  \cfeevstlm Event Message Telemetry Packet (Short format)
+**/
+typedef struct CFE_EVS_ShortEventTlm_Payload
+{
+    CFE_EVS_PacketID_t PacketID; /**< \brief Event packet information */
+} CFE_EVS_ShortEventTlm_Payload_t;
 
 #endif

--- a/modules/evs/config/default_cfe_evs_msgstruct.h
+++ b/modules/evs/config/default_cfe_evs_msgstruct.h
@@ -42,34 +42,30 @@
 
 /******************  Structure Definitions *********************/
 
-/**
-** \brief Command with no additional arguments
-**/
-typedef struct CFE_EVS_NoArgsCmd
-{
-    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
-} CFE_EVS_NoArgsCmd_t;
-
 /*
  * The NoArgsCmd is shared by several EVS command handlers.
  * Create a unique type for each one so the prototypes will follow the naming pattern,
  * allowing each command to evolve independently.
  */
-typedef CFE_EVS_NoArgsCmd_t CFE_EVS_NoopCmd_t;
-typedef CFE_EVS_NoArgsCmd_t CFE_EVS_ResetCountersCmd_t;
-typedef CFE_EVS_NoArgsCmd_t CFE_EVS_ClearLogCmd_t;
-typedef CFE_EVS_NoArgsCmd_t CFE_EVS_SendHkCmd_t;
-
-/**
-** \brief Write Event Log to File Command Payload
-**
-** For command details, see #CFE_EVS_WRITE_LOG_DATA_FILE_CC
-**
-**/
-typedef struct CFE_EVS_LogFileCmd_Payload
+typedef struct CFE_EVS_NoopCmd
 {
-    char LogFilename[CFE_MISSION_MAX_PATH_LEN]; /**< \brief Filename where log data is to be written */
-} CFE_EVS_LogFileCmd_Payload_t;
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CFE_EVS_NoopCmd_t;
+
+typedef struct CFE_EVS_ResetCountersCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CFE_EVS_ResetCountersCmd_t;
+
+typedef struct CFE_EVS_ClearLogCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CFE_EVS_ClearLogCmd_t;
+
+typedef struct CFE_EVS_SendHkCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CFE_EVS_SendHkCmd_t;
 
 /**
  * \brief Write Event Log to File Command
@@ -81,17 +77,6 @@ typedef struct CFE_EVS_WriteLogDataFileCmd
 } CFE_EVS_WriteLogDataFileCmd_t;
 
 /**
-** \brief Write Event Services Application Information to File Command Payload
-**
-** For command details, see #CFE_EVS_WRITE_APP_DATA_FILE_CC
-**
-**/
-typedef struct CFE_EVS_AppDataCmd_Payload
-{
-    char AppDataFilename[CFE_MISSION_MAX_PATH_LEN]; /**< \brief Filename where application data is to be written */
-} CFE_EVS_AppDataCmd_Payload_t;
-
-/**
  * \brief Write Event Services Application Information to File Command
  */
 typedef struct CFE_EVS_WriteAppDataFileCmd
@@ -99,18 +84,6 @@ typedef struct CFE_EVS_WriteAppDataFileCmd
     CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
     CFE_EVS_AppDataCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_EVS_WriteAppDataFileCmd_t;
-
-/**
-** \brief Set Log Mode Command Payload
-**
-** For command details, see #CFE_EVS_SET_LOG_MODE_CC
-**
-**/
-typedef struct CFE_EVS_SetLogMode_Payload
-{
-    CFE_EVS_LogMode_Enum_t LogMode; /**< \brief Mode to use in the command*/
-    uint8                  Spare;   /**< \brief Pad to even byte*/
-} CFE_EVS_SetLogMode_Payload_t;
 
 /**
  * \brief Set Log Mode Command
@@ -122,18 +95,6 @@ typedef struct CFE_EVS_SetLogModeCmd
 } CFE_EVS_SetLogModeCmd_t;
 
 /**
-** \brief Set Event Format Mode Command Payload
-**
-** For command details, see #CFE_EVS_SET_EVENT_FORMAT_MODE_CC
-**
-**/
-typedef struct CFE_EVS_SetEventFormatCode_Payload
-{
-    CFE_EVS_MsgFormat_Enum_t MsgFormat; /**< \brief Mode to use in the command*/
-    uint8                    Spare;     /**< \brief Pad to even byte*/
-} CFE_EVS_SetEventFormatMode_Payload_t;
-
-/**
  * \brief Set Event Format Mode Command
  */
 typedef struct CFE_EVS_SetEventFormatModeCmd
@@ -142,259 +103,126 @@ typedef struct CFE_EVS_SetEventFormatModeCmd
     CFE_EVS_SetEventFormatMode_Payload_t Payload;       /**< \brief Command payload */
 } CFE_EVS_SetEventFormatModeCmd_t;
 
-/**
-** \brief Generic Bitmask Command Payload
-**
-** For command details, see #CFE_EVS_ENABLE_EVENT_TYPE_CC, #CFE_EVS_DISABLE_EVENT_TYPE_CC,
-**                          #CFE_EVS_ENABLE_PORTS_CC and/or #CFE_EVS_DISABLE_PORTS_CC
-**
-**/
-typedef struct CFE_EVS_BitMaskCmd_Payload
-{
-    uint8 BitMask; /**< \brief BitMask to use in the command */
-    uint8 Spare;   /**< \brief Pad to even byte*/
-} CFE_EVS_BitMaskCmd_Payload_t;
-
-/**
- * \brief Generic Bitmask Command
- */
-typedef struct CFE_EVS_BitMaskCmd
-{
-    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
-    CFE_EVS_BitMaskCmd_Payload_t Payload;       /**< \brief Command payload */
-} CFE_EVS_BitMaskCmd_t;
-
 /*
  * The CFE_EVS_BitMaskCmd_t is shared by several EVS command handlers.
  * Create a unique type for each one so the prototypes will follow the naming pattern,
  * allowing each command to evolve independently.
  */
-typedef CFE_EVS_BitMaskCmd_t CFE_EVS_EnablePortsCmd_t;
-typedef CFE_EVS_BitMaskCmd_t CFE_EVS_DisablePortsCmd_t;
-typedef CFE_EVS_BitMaskCmd_t CFE_EVS_EnableEventTypeCmd_t;
-typedef CFE_EVS_BitMaskCmd_t CFE_EVS_DisableEventTypeCmd_t;
-
-/**
-** \brief Generic App Name Command Payload
-**
-** For command details, see #CFE_EVS_ENABLE_APP_EVENTS_CC, #CFE_EVS_DISABLE_APP_EVENTS_CC,
-**                          #CFE_EVS_RESET_APP_COUNTER_CC and/or #CFE_EVS_RESET_ALL_FILTERS_CC
-**
-**/
-typedef struct CFE_EVS_AppNameCmd_Payload
-{
-    char AppName[CFE_MISSION_MAX_API_LEN]; /**< \brief Application name to use in the command*/
-} CFE_EVS_AppNameCmd_Payload_t;
-
-/**
- * \brief Generic App Name Command
- */
-typedef struct CFE_EVS_AppNameCmd
+typedef struct CFE_EVS_EnablePortsCmd
 {
     CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
-    CFE_EVS_AppNameCmd_Payload_t Payload;       /**< \brief Command payload */
-} CFE_EVS_AppNameCmd_t;
+    CFE_EVS_BitMaskCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_EVS_EnablePortsCmd_t;
+
+typedef struct CFE_EVS_DisablePortsCmd
+{
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
+    CFE_EVS_BitMaskCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_EVS_DisablePortsCmd_t;
+
+typedef struct CFE_EVS_EnableEventTypeCmd
+{
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
+    CFE_EVS_BitMaskCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_EVS_EnableEventTypeCmd_t;
+
+typedef struct CFE_EVS_DisableEventTypeCmd
+{
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
+    CFE_EVS_BitMaskCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_EVS_DisableEventTypeCmd_t;
 
 /*
  * The CFE_EVS_AppNameCmd_t is shared by several EVS command handlers.
  * Create a unique type for each one so the prototypes will follow the naming pattern,
  * allowing each command to evolve independently.
  */
-typedef CFE_EVS_AppNameCmd_t CFE_EVS_EnableAppEventsCmd_t;
-typedef CFE_EVS_AppNameCmd_t CFE_EVS_DisableAppEventsCmd_t;
-typedef CFE_EVS_AppNameCmd_t CFE_EVS_ResetAppCounterCmd_t;
-typedef CFE_EVS_AppNameCmd_t CFE_EVS_ResetAllFiltersCmd_t;
-
-/**
-** \brief Generic App Name and Event ID Command Payload
-**
-** For command details, see #CFE_EVS_RESET_FILTER_CC and #CFE_EVS_DELETE_EVENT_FILTER_CC
-**
-**/
-typedef struct CFE_EVS_AppNameEventIDCmd_Payload
+typedef struct CFE_EVS_EnableAppEventsCmd
 {
-    char   AppName[CFE_MISSION_MAX_API_LEN]; /**< \brief Application name to use in the command*/
-    uint16 EventID;                          /**< \brief Event ID  to use in the command*/
-} CFE_EVS_AppNameEventIDCmd_Payload_t;
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
+    CFE_EVS_AppNameCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_EVS_EnableAppEventsCmd_t;
 
-/**
- * \brief Generic App Name and Event ID Command
- */
-typedef struct CFE_EVS_AppNameEventIDCmd
+typedef struct CFE_EVS_DisableAppEventsCmd
 {
-    CFE_MSG_CommandHeader_t             CommandHeader; /**< \brief Command header */
-    CFE_EVS_AppNameEventIDCmd_Payload_t Payload;       /**< \brief Command payload */
-} CFE_EVS_AppNameEventIDCmd_t;
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
+    CFE_EVS_AppNameCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_EVS_DisableAppEventsCmd_t;
+
+typedef struct CFE_EVS_ResetAppCounterCmd
+{
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
+    CFE_EVS_AppNameCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_EVS_ResetAppCounterCmd_t;
+
+typedef struct CFE_EVS_ResetAllFiltersCmd
+{
+    CFE_MSG_CommandHeader_t      CommandHeader; /**< \brief Command header */
+    CFE_EVS_AppNameCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_EVS_ResetAllFiltersCmd_t;
 
 /*
  * The CFE_EVS_AppNameEventIDCmd_t is shared by several EVS command handlers.
  * Create a unique type for each one so the prototypes will follow the naming pattern,
  * allowing each command to evolve independently.
  */
-typedef CFE_EVS_AppNameEventIDCmd_t CFE_EVS_ResetFilterCmd_t;
-typedef CFE_EVS_AppNameEventIDCmd_t CFE_EVS_DeleteEventFilterCmd_t;
-
-/**
-** \brief Generic App Name and Bitmask Command Payload
-**
-** For command details, see #CFE_EVS_ENABLE_APP_EVENT_TYPE_CC and/or #CFE_EVS_DISABLE_APP_EVENT_TYPE_CC
-**
-**/
-typedef struct CFE_EVS_AppNameBitMaskCmd_Payload
-{
-    char  AppName[CFE_MISSION_MAX_API_LEN]; /**< \brief Application name to use in the command*/
-    uint8 BitMask;                          /**< \brief BitMask to use in the command*/
-    uint8 Spare;                            /**< \brief Pad to even byte*/
-} CFE_EVS_AppNameBitMaskCmd_Payload_t;
-
-/**
- * \brief Generic App Name and Bitmask Command
- */
-typedef struct CFE_EVS_AppNameBitMaskCmd
+typedef struct CFE_EVS_ResetFilterCmd
 {
     CFE_MSG_CommandHeader_t             CommandHeader; /**< \brief Command header */
-    CFE_EVS_AppNameBitMaskCmd_Payload_t Payload;       /**< \brief Command payload */
-} CFE_EVS_AppNameBitMaskCmd_t;
+    CFE_EVS_AppNameEventIDCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_EVS_ResetFilterCmd_t;
+
+typedef struct CFE_EVS_DeleteEventFilterCmd
+{
+    CFE_MSG_CommandHeader_t             CommandHeader; /**< \brief Command header */
+    CFE_EVS_AppNameEventIDCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_EVS_DeleteEventFilterCmd_t;
 
 /*
  * The CFE_EVS_AppNameBitMaskCmd_t is shared by several EVS command handlers.
  * Create a unique type for each one so the prototypes will follow the naming pattern,
  * allowing each command to evolve independently.
  */
-typedef CFE_EVS_AppNameBitMaskCmd_t CFE_EVS_EnableAppEventTypeCmd_t;
-typedef CFE_EVS_AppNameBitMaskCmd_t CFE_EVS_DisableAppEventTypeCmd_t;
-
-/**
-** \brief Generic App Name, Event ID, Mask Command Payload
-**
-** For command details, see #CFE_EVS_SET_FILTER_CC, #CFE_EVS_ADD_EVENT_FILTER_CC
-**                      and/or #CFE_EVS_DELETE_EVENT_FILTER_CC
-**
-**/
-typedef struct CFE_EVS_AppNameEventIDMaskCmd_Payload
+typedef struct CFE_EVS_EnableAppEventTypeCmd
 {
-    char   AppName[CFE_MISSION_MAX_API_LEN]; /**< \brief Application name to use in the command*/
-    uint16 EventID;                          /**< \brief Event ID  to use in the command*/
-    uint16 Mask;                             /**< \brief Mask to use in the command */
-} CFE_EVS_AppNameEventIDMaskCmd_Payload_t;
+    CFE_MSG_CommandHeader_t             CommandHeader; /**< \brief Command header */
+    CFE_EVS_AppNameBitMaskCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_EVS_EnableAppEventTypeCmd_t;
 
-/**
- * \brief Generic App Name, Event ID, Mask Command
- */
-typedef struct CFE_EVS_AppNameEventIDMaskCmd
+typedef struct CFE_EVS_DisableAppEventTypeCmd
 {
-    CFE_MSG_CommandHeader_t                 CommandHeader; /**< \brief Command header */
-    CFE_EVS_AppNameEventIDMaskCmd_Payload_t Payload;       /**< \brief Command payload */
-} CFE_EVS_AppNameEventIDMaskCmd_t;
+    CFE_MSG_CommandHeader_t             CommandHeader; /**< \brief Command header */
+    CFE_EVS_AppNameBitMaskCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_EVS_DisableAppEventTypeCmd_t;
 
 /*
  * The CFE_EVS_AppNameEventIDMaskCmd_t is shared by several EVS command handlers.
  * Create a unique type for each one so the prototypes will follow the naming pattern,
  * allowing each command to evolve independently.
  */
-typedef CFE_EVS_AppNameEventIDMaskCmd_t CFE_EVS_AddEventFilterCmd_t;
-typedef CFE_EVS_AppNameEventIDMaskCmd_t CFE_EVS_SetFilterCmd_t;
+typedef struct CFE_EVS_AddEventFilterCmd
+{
+    CFE_MSG_CommandHeader_t                 CommandHeader; /**< \brief Command header */
+    CFE_EVS_AppNameEventIDMaskCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_EVS_AddEventFilterCmd_t;
+
+typedef struct CFE_EVS_SetFilterCmd
+{
+    CFE_MSG_CommandHeader_t                 CommandHeader; /**< \brief Command header */
+    CFE_EVS_AppNameEventIDMaskCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_EVS_SetFilterCmd_t;
 
 /*************************************************************************/
-/**********************************/
-/* Telemetry Message Data Formats */
-/**********************************/
-typedef struct CFE_EVS_AppTlmData
-{
-    CFE_ES_AppId_t AppID;             /**< \cfetlmmnemonic \EVS_APPID
-                                           \brief Numerical application identifier */
-    uint16 AppMessageSentCounter;     /**< \cfetlmmnemonic \EVS_APPMSGSENTC
-                                           \brief Application message sent counter */
-    uint8 AppEnableStatus;            /**< \cfetlmmnemonic \EVS_APPENASTAT
-                                           \brief Application event service enable status */
-    uint8 AppMessageSquelchedCounter; /**< \cfetlmmnemonic \EVS_SQUELCHEDC
-                                       \brief Number of events squelched */
-} CFE_EVS_AppTlmData_t;
 
-/**
-**  \cfeevstlm Event Services Housekeeping Telemetry Packet
-**/
-typedef struct CFE_EVS_HousekeepingTlm_Payload
-{
-    uint8 CommandCounter;      /**< \cfetlmmnemonic \EVS_CMDPC
-                                    \brief EVS Command Counter */
-    uint8 CommandErrorCounter; /**< \cfetlmmnemonic \EVS_CMDEC
-                                  \brief EVS Command Error Counter */
-    uint8 MessageFormatMode;   /**< \cfetlmmnemonic \EVS_MSGFMTMODE
-                                    \brief Event message format mode (short/long) */
-    uint8 MessageTruncCounter; /**< \cfetlmmnemonic \EVS_MSGTRUNC
-                                    \brief Event message truncation counter */
-
-    uint8 UnregisteredAppCounter; /**< \cfetlmmnemonic \EVS_UNREGAPPC
-                                       \brief Unregistered application message send counter */
-    uint8 OutputPort;             /**< \cfetlmmnemonic \EVS_OUTPUTPORT
-                                       \brief Output port mask */
-    uint8 LogFullFlag;            /**< \cfetlmmnemonic \EVS_LOGFULL
-                                       \brief Local event log full flag */
-    uint8 LogMode;                /**< \cfetlmmnemonic \EVS_LOGMODE
-                                       \brief Local event logging mode (overwrite/discard) */
-
-    uint16 MessageSendCounter; /**< \cfetlmmnemonic \EVS_MSGSENTC
-                                    \brief Event message send counter */
-    uint16 LogOverflowCounter; /**< \cfetlmmnemonic \EVS_LOGOVERFLOWC
-                                    \brief Local event log overflow counter */
-
-    uint8 LogEnabled; /**< \cfetlmmnemonic \EVS_LOGENABLED
-                           \brief Current event log enable/disable state */
-    uint8 Spare1;     /**< \cfetlmmnemonic \EVS_HK_SPARE1
-                           \brief Padding for 32 bit boundary */
-    uint8 Spare2;     /**< \cfetlmmnemonic \EVS_HK_SPARE2
-                           \brief Padding for 32 bit boundary */
-    uint8 Spare3;     /**< \cfetlmmnemonic \EVS_HK_SPARE3
-                           \brief Padding for 32 bit boundary */
-
-    CFE_EVS_AppTlmData_t AppData[CFE_MISSION_ES_MAX_APPLICATIONS]; /**< \cfetlmmnemonic \EVS_APP
-                                                                \brief Array of registered application table data */
-} CFE_EVS_HousekeepingTlm_Payload_t;
+/*******************************************/
+/* Telemetry Message Encapsulation Formats */
+/*******************************************/
 
 typedef struct CFE_EVS_HousekeepingTlm
 {
     CFE_MSG_TelemetryHeader_t         TelemetryHeader; /**< \brief Telemetry header */
     CFE_EVS_HousekeepingTlm_Payload_t Payload;         /**< \brief Telemetry payload */
 } CFE_EVS_HousekeepingTlm_t;
-
-/** Telemetry packet structures */
-
-typedef struct CFE_EVS_PacketID
-{
-    char AppName[CFE_MISSION_MAX_API_LEN]; /**< \cfetlmmnemonic \EVS_APPNAME
-                                        \brief Application name */
-    uint16 EventID;                        /**< \cfetlmmnemonic \EVS_EVENTID
-                                                \brief Numerical event identifier */
-    uint16 EventType;                      /**< \cfetlmmnemonic \EVS_EVENTTYPE
-                                                \brief Numerical event type identifier */
-    uint32 SpacecraftID;                   /**< \cfetlmmnemonic \EVS_SCID
-                                                \brief Spacecraft identifier */
-    uint32 ProcessorID;                    /**< \cfetlmmnemonic \EVS_PROCESSORID
-                                                \brief Numerical processor identifier */
-} CFE_EVS_PacketID_t;
-
-/**
-**  \cfeevstlm Event Message Telemetry Packet (Long format)
-**/
-typedef struct CFE_EVS_LongEventTlm_Payload
-{
-    CFE_EVS_PacketID_t PacketID;                                    /**< \brief Event packet information */
-    char               Message[CFE_MISSION_EVS_MAX_MESSAGE_LENGTH]; /**< \cfetlmmnemonic \EVS_EVENT
-                                                                 \brief Event message string */
-    uint8 Spare1;                                                   /**< \cfetlmmnemonic \EVS_SPARE1
-                                                                         \brief Structure padding */
-    uint8 Spare2;                                                   /**< \cfetlmmnemonic \EVS_SPARE2
-                                                                     \brief Structure padding */
-} CFE_EVS_LongEventTlm_Payload_t;
-
-/**
-**  \cfeevstlm Event Message Telemetry Packet (Short format)
-**/
-typedef struct CFE_EVS_ShortEventTlm_Payload
-{
-    CFE_EVS_PacketID_t PacketID; /**< \brief Event packet information */
-} CFE_EVS_ShortEventTlm_Payload_t;
 
 typedef struct CFE_EVS_LongEventTlm
 {

--- a/modules/evs/ut-coverage/evs_UT.c
+++ b/modules/evs/ut-coverage/evs_UT.c
@@ -272,8 +272,8 @@ void UtTest_Setup(void)
 */
 void Test_Init(void)
 {
-    CFE_EVS_BitMaskCmd_t        bitmaskcmd;
-    CFE_EVS_AppNameBitMaskCmd_t appbitcmd;
+    CFE_EVS_EnablePortsCmd_t        bitmaskcmd;
+    CFE_EVS_EnableAppEventTypeCmd_t appbitcmd;
     CFE_SB_MsgId_t              msgid = CFE_SB_INVALID_MSG_ID;
 
     UtPrintf("Begin Test Init");
@@ -695,7 +695,7 @@ void Test_Format(void)
 
     CFE_TIME_SysTime_t              time = {0, 0};
     CFE_EVS_SetEventFormatModeCmd_t modecmd;
-    CFE_EVS_AppNameBitMaskCmd_t     appbitcmd;
+    CFE_EVS_EnableAppEventTypeCmd_t     appbitcmd;
     CFE_EVS_PacketID_t              CapturedMsg;
     UT_SoftwareBusSnapshot_Entry_t  LongFmtSnapshotData = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_LONG_EVENT_MSG_MID),
                                                           .SnapshotBuffer = &CapturedMsg,
@@ -821,7 +821,7 @@ void Test_Format(void)
 */
 void Test_Ports(void)
 {
-    CFE_EVS_BitMaskCmd_t           bitmaskcmd;
+    CFE_EVS_EnablePortsCmd_t           bitmaskcmd;
     UT_SoftwareBusSnapshot_Entry_t LocalSnapshotData = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_LONG_EVENT_MSG_MID)};
     CFE_TIME_SysTime_t             PacketTime;
 
@@ -1076,7 +1076,7 @@ void Test_WriteApp(void)
     {
         CFE_EVS_ResetCountersCmd_t    ResetCountersCmd;
         CFE_EVS_WriteAppDataFileCmd_t AppDataCmd;
-        CFE_EVS_AppNameBitMaskCmd_t   appbitcmd;
+        CFE_EVS_EnableAppEventTypeCmd_t   appbitcmd;
     } CmdBuf;
 
     UtPrintf("Begin Test Write App");
@@ -1157,10 +1157,10 @@ void Test_WriteApp(void)
 */
 void Test_BadAppCmd(void)
 {
-    CFE_EVS_AppNameBitMaskCmd_t     appbitcmd;
-    CFE_EVS_AppNameCmd_t            appnamecmd;
-    CFE_EVS_AppNameEventIDMaskCmd_t appmaskcmd;
-    CFE_EVS_AppNameEventIDCmd_t     appcmdcmd;
+    CFE_EVS_EnableAppEventTypeCmd_t     appbitcmd;
+    CFE_EVS_EnableAppEventsCmd_t            appnamecmd;
+    CFE_EVS_AddEventFilterCmd_t appmaskcmd;
+    CFE_EVS_ResetFilterCmd_t     appcmdcmd;
     uint32                          TestAppIndex;
 
     UtPrintf("Begin Test Bad App Command");
@@ -1426,9 +1426,9 @@ void Test_BadAppCmd(void)
 void Test_EventCmd(void)
 {
     uint16                         EventCount[4];
-    CFE_EVS_BitMaskCmd_t           bitmaskcmd;
-    CFE_EVS_AppNameBitMaskCmd_t    appbitcmd;
-    CFE_EVS_AppNameCmd_t           appnamecmd;
+    CFE_EVS_EnablePortsCmd_t           bitmaskcmd;
+    CFE_EVS_EnableAppEventTypeCmd_t    appbitcmd;
+    CFE_EVS_EnableAppEventsCmd_t           appnamecmd;
     UT_SoftwareBusSnapshot_Entry_t LocalSnapshotData = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_LONG_EVENT_MSG_MID)};
 
     memset(&bitmaskcmd, 0, sizeof(bitmaskcmd));
@@ -1602,10 +1602,10 @@ void Test_EventCmd(void)
 void Test_FilterCmd(void)
 {
     int                             i;
-    CFE_EVS_AppNameCmd_t            appnamecmd;
-    CFE_EVS_AppNameEventIDMaskCmd_t appmaskcmd;
-    CFE_EVS_AppNameEventIDCmd_t     appcmdcmd;
-    CFE_EVS_AppNameBitMaskCmd_t     appbitcmd;
+    CFE_EVS_EnableAppEventsCmd_t            appnamecmd;
+    CFE_EVS_AddEventFilterCmd_t appmaskcmd;
+    CFE_EVS_ResetFilterCmd_t     appcmdcmd;
+    CFE_EVS_EnableAppEventTypeCmd_t     appbitcmd;
 
     UtPrintf("Begin Test Filter Command");
 

--- a/modules/sb/CMakeLists.txt
+++ b/modules/sb/CMakeLists.txt
@@ -28,6 +28,16 @@ if(ENABLE_UNIT_TESTS)
 endif(ENABLE_UNIT_TESTS)
 
 cfs_app_check_intf(${DEP}
-    cfe_sb_msg.h
     cfe_sb_eventids.h
+    cfe_sb_extern_typedefs.h
+    cfe_sb_fcncodes.h
+    cfe_sb_interface_cfg.h
+    cfe_sb_internal_cfg.h
+    cfe_sb_mission_cfg.h
+    cfe_sb_msgdefs.h
+    cfe_sb_msg.h
+    cfe_sb_msgids.h
+    cfe_sb_msgstruct.h
+    cfe_sb_platform_cfg.h
+    cfe_sb_topicids.h
 )

--- a/modules/sb/config/default_cfe_sb_msgdefs.h
+++ b/modules/sb/config/default_cfe_sb_msgdefs.h
@@ -26,6 +26,257 @@
 #ifndef CFE_SB_MSGDEFS_H
 #define CFE_SB_MSGDEFS_H
 
+#include "common_types.h"
+#include "cfe_mission_cfg.h"
+#include "cfe_es_extern_typedefs.h"
+#include "cfe_sb_extern_typedefs.h"
 #include "cfe_sb_fcncodes.h"
+
+/**
+**  \brief Write File Info Command Payload
+**
+**  This structure contains a generic definition used by SB commands that write to a file
+*/
+typedef struct CFE_SB_WriteFileInfoCmd_Payload
+{
+    char Filename[CFE_MISSION_MAX_PATH_LEN]; /**< \brief Path and Filename of data to be loaded */
+} CFE_SB_WriteFileInfoCmd_Payload_t;
+
+/**
+**  \brief Enable/Disable Route Command Payload
+**
+**  This structure contains a definition used by two SB commands,
+**  'Enable Route' #CFE_SB_ENABLE_ROUTE_CC and 'Disable Route' #CFE_SB_DISABLE_ROUTE_CC.
+**  A route is the destination pipe for a  particular message and is therefore defined
+**  as a MsgId and PipeId combination.
+*/
+typedef struct CFE_SB_RouteCmd_Payload
+{
+    CFE_SB_MsgId_t  MsgId; /**< \brief Message ID of route to be enabled or disabled #CFE_SB_MsgId_t */
+    CFE_SB_PipeId_t Pipe;  /**< \brief Pipe ID of route to be enabled or disabled #CFE_SB_PipeId_t */
+    uint8           Spare; /**<\brief Spare byte to make command even number of bytes */
+} CFE_SB_RouteCmd_Payload_t;
+
+/****************************
+**  SB Telemetry Formats   **
+*****************************/
+
+/**
+**  \cfesbtlm Software Bus task housekeeping Packet
+*/
+typedef struct CFE_SB_HousekeepingTlm_Payload
+{
+    uint8 CommandCounter;       /**< \cfetlmmnemonic \SB_CMDPC
+                                 \brief Count of valid commands received */
+    uint8 CommandErrorCounter;  /**< \cfetlmmnemonic \SB_CMDEC
+                           \brief Count of invalid commands received */
+    uint8 NoSubscribersCounter; /**< \cfetlmmnemonic \SB_NOSUBEC
+                                 \brief Count pkts sent with no subscribers */
+    uint8 MsgSendErrorCounter;  /**< \cfetlmmnemonic \SB_MSGSNDEC
+                               \brief Count of message send errors */
+
+    uint8 MsgReceiveErrorCounter;        /**< \cfetlmmnemonic \SB_MSGRECEC
+                                        \brief Count of message receive errors */
+    uint8 InternalErrorCounter;          /**< \cfetlmmnemonic \SB_INTERNALEC
+                                        \brief Count of queue read or write errors */
+    uint8 CreatePipeErrorCounter;        /**< \cfetlmmnemonic \SB_NEWPIPEEC
+                                        \brief Count of errors in create pipe API */
+    uint8 SubscribeErrorCounter;         /**< \cfetlmmnemonic \SB_SUBSCREC
+                                        \brief Count of errors in subscribe API */
+    uint8 PipeOptsErrorCounter;          /**< \cfetlmmnemonic \SB_PIPEOPTSEC
+                                       \brief Count of errors in set/get pipe options API */
+    uint8 DuplicateSubscriptionsCounter; /**< \cfetlmmnemonic \SB_DUPSUBCNT
+                                    \brief Count of duplicate subscriptions */
+    uint8 GetPipeIdByNameErrorCounter;   /**< \cfetlmmnemonic \SB_GETPIPEIDBYNAMEEC
+                                \brief Count of errors in get pipe id by name API */
+    uint8 Spare2Align[1];                /**< \cfetlmmnemonic \SB_SPARE2ALIGN
+                                              \brief Spare bytes to ensure alignment */
+
+    uint16 PipeOverflowErrorCounter; /**< \cfetlmmnemonic \SB_PIPEOVREC
+                                    \brief Count of pipe overflow errors */
+    uint16 MsgLimitErrorCounter;     /**< \cfetlmmnemonic \SB_MSGLIMEC
+                                       \brief Count of msg id to pipe errors */
+
+    CFE_ES_MemHandle_t MemPoolHandle; /**< \cfetlmmnemonic \SB_MEMPOOLHANDLE
+                                           \brief Handle to SB's Memory Pool */
+
+    uint32 MemInUse; /**< \cfetlmmnemonic \SB_MEMINUSE
+                                    \brief Memory in use */
+
+    uint32 UnmarkedMem; /**< \cfetlmmnemonic \SB_UNMARKEDMEM
+                             \brief cfg param CFE_PLATFORM_SB_BUF_MEMORY_BYTES minus Peak Memory in use */
+} CFE_SB_HousekeepingTlm_Payload_t;
+
+/**
+** \brief SB Pipe Depth Statistics
+**
+** Used in SB Statistics Telemetry Packet #CFE_SB_StatsTlm_t
+*/
+typedef struct CFE_SB_PipeDepthStats
+{
+    CFE_SB_PipeId_t PipeId;   /**< \cfetlmmnemonic \SB_PDPIPEID
+                                   \brief Pipe Id associated with the stats below */
+    uint16 MaxQueueDepth;     /**< \cfetlmmnemonic \SB_PDDEPTH
+                           \brief Number of messages the pipe can hold */
+    uint16 CurrentQueueDepth; /**< \cfetlmmnemonic \SB_PDINUSE
+                       \brief Number of messages currently on the pipe */
+    uint16 PeakQueueDepth;    /**< \cfetlmmnemonic \SB_PDPKINUSE
+                              \brief Peak number of messages that have been on the pipe */
+    uint16 Spare;             /**< \cfetlmmnemonic \SB_PDSPARE
+                                   \brief Spare word to ensure alignment */
+} CFE_SB_PipeDepthStats_t;
+
+/**
+** \brief SB Pipe Information File Entry
+**
+** This statistics structure is output as part of the CFE SB
+** "Send Pipe Info" command (CFE_SB_SEND_PIPE_INFO_CC).
+**
+** Previous versions of CFE simply wrote the internal CFE_SB_PipeD_t object
+** to the file, but this also contains information such as pointers which are
+** not relevant outside the running CFE process.
+**
+** By defining the pipe info structure separately, it also provides some
+** independence, such that the internal CFE_SB_PipeD_t definition
+** can evolve without changing the binary format of the information
+** file.
+*/
+typedef struct CFE_SB_PipeInfoEntry
+{
+    CFE_SB_PipeId_t PipeId;                            /**< The runtime ID of the pipe */
+    CFE_ES_AppId_t  AppId;                             /**< The runtime ID of the application that owns the pipe */
+    char            PipeName[CFE_MISSION_MAX_API_LEN]; /**< The Name of the pipe */
+    char            AppName[CFE_MISSION_MAX_API_LEN];  /**< The Name of the application that owns the pipe */
+    uint16          MaxQueueDepth;                     /**< The allocated depth of the pipe (max capacity) */
+    uint16          CurrentQueueDepth;                 /**< The current depth of the pipe */
+    uint16          PeakQueueDepth;                    /**< The peak depth of the pipe (high watermark) */
+    uint16          SendErrors;                        /**< Number of errors when writing to this pipe */
+    uint8           Opts;                              /**< Pipe options set (bitmask) */
+    uint8           Spare[3];                          /**< Padding to make this structure a multiple of 4 bytes */
+} CFE_SB_PipeInfoEntry_t;
+
+/**
+** \cfesbtlm SB Statistics Telemetry Packet
+**
+** SB Statistics packet sent in response to #CFE_SB_SEND_SB_STATS_CC
+*/
+typedef struct CFE_SB_StatsTlm_Payload
+{
+    uint32 MsgIdsInUse;      /**< \cfetlmmnemonic \SB_SMMIDIU
+                                  \brief Current number of MsgIds with a destination */
+    uint32 PeakMsgIdsInUse;  /**< \cfetlmmnemonic \SB_SMPMIDIU
+                                  \brief Peak number of MsgIds with a destination */
+    uint32 MaxMsgIdsAllowed; /**< \cfetlmmnemonic \SB_SMMMIDALW
+                                  \brief cFE Cfg Param \link #CFE_PLATFORM_SB_MAX_MSG_IDS \endlink */
+
+    uint32 PipesInUse;      /**< \cfetlmmnemonic \SB_SMPIU
+                                 \brief Number of pipes currently in use */
+    uint32 PeakPipesInUse;  /**< \cfetlmmnemonic \SB_SMPPIU
+                                 \brief Peak number of pipes since last reboot */
+    uint32 MaxPipesAllowed; /**< \cfetlmmnemonic \SB_SMMPALW
+                                 \brief cFE Cfg Param \link #CFE_PLATFORM_SB_MAX_PIPES \endlink */
+
+    uint32 MemInUse;      /**< \cfetlmmnemonic \SB_SMBMIU
+                                  \brief Memory bytes currently in use for SB msg transfers */
+    uint32 PeakMemInUse;  /**< \cfetlmmnemonic \SB_SMPBMIU
+                                  \brief Peak memory bytes in use for SB msg transfers */
+    uint32 MaxMemAllowed; /**< \cfetlmmnemonic \SB_SMMBMALW
+                                  \brief cFE Cfg Param \link #CFE_PLATFORM_SB_BUF_MEMORY_BYTES \endlink */
+
+    uint32 SubscriptionsInUse;      /**< \cfetlmmnemonic \SB_SMSIU
+                                         \brief Number of current subscriptions */
+    uint32 PeakSubscriptionsInUse;  /**< \cfetlmmnemonic \SB_SMPSIU
+                                         \brief Peak number of subscriptions */
+    uint32 MaxSubscriptionsAllowed; /**< \cfetlmmnemonic \SB_SMMSALW
+                                         \brief product of \link #CFE_PLATFORM_SB_MAX_MSG_IDS \endlink
+                                         and \link #CFE_PLATFORM_SB_MAX_DEST_PER_PKT \endlink */
+
+    uint32 SBBuffersInUse;     /**< \cfetlmmnemonic \SB_SMSBBIU
+                                    \brief Number of SB message buffers currently in use */
+    uint32 PeakSBBuffersInUse; /**< \cfetlmmnemonic \SB_SMPSBBIU
+                                    \brief Max number of SB message buffers in use */
+
+    uint32 MaxPipeDepthAllowed; /**< \cfetlmmnemonic \SB_SMMPDALW
+                                     \brief Maximum allowed pipe depth */
+    CFE_SB_PipeDepthStats_t
+        PipeDepthStats[CFE_MISSION_SB_MAX_PIPES]; /**< \cfetlmmnemonic \SB_SMPDS
+                                               \brief Pipe Depth Statistics #CFE_SB_PipeDepthStats_t*/
+} CFE_SB_StatsTlm_Payload_t;
+
+/**
+** \brief SB Routing File Entry
+**
+** Structure of one element of the routing information in response to #CFE_SB_WRITE_ROUTING_INFO_CC
+*/
+typedef struct CFE_SB_RoutingFileEntry
+{
+    CFE_SB_MsgId_t  MsgId;                             /**< \brief Message Id portion of the route */
+    CFE_SB_PipeId_t PipeId;                            /**< \brief Pipe Id portion of the route */
+    uint8           State;                             /**< \brief Route Enabled or Disabled */
+    uint16          MsgCnt;                            /**< \brief Number of msgs with this MsgId sent to this PipeId */
+    char            AppName[CFE_MISSION_MAX_API_LEN];  /**< \brief Pipe Depth Statistics */
+    char            PipeName[CFE_MISSION_MAX_API_LEN]; /**< \brief Pipe Depth Statistics */
+} CFE_SB_RoutingFileEntry_t;
+
+/**
+** \brief SB Map File Entry
+**
+** Structure of one element of the map information in response to #CFE_SB_WRITE_MAP_INFO_CC
+*/
+typedef struct CFE_SB_MsgMapFileEntry
+{
+    CFE_SB_MsgId_t        MsgId; /**< \brief Message Id which has been subscribed to */
+    CFE_SB_RouteId_Atom_t Index; /**< \brief Routing raw index value (0 based, not Route ID) */
+} CFE_SB_MsgMapFileEntry_t;
+
+/**
+** \cfesbtlm SB Subscription Report Packet
+**
+** This structure defines the pkt sent by SB when a subscription or
+** a request to unsubscribe is received while subscription reporting is enabled.
+** By default subscription reporting is disabled. This feature is intended to be
+** used primarily by Software Bus Networking Application (SBN)
+**
+** \sa #CFE_SB_ENABLE_SUB_REPORTING_CC, #CFE_SB_DISABLE_SUB_REPORTING_CC
+*/
+typedef struct CFE_SB_SingleSubscriptionTlm_Payload
+{
+    uint8           SubType; /**< \brief Subscription or Unsubscription */
+    CFE_SB_MsgId_t  MsgId;   /**< \brief MsgId subscribed or unsubscribe to */
+    CFE_SB_Qos_t    Qos;     /**< \brief Quality of Service, used only for interprocessor communication */
+    CFE_SB_PipeId_t Pipe;    /**< \brief Destination pipe id to send above msg id  */
+} CFE_SB_SingleSubscriptionTlm_Payload_t;
+
+/**
+** \brief SB Previous Subscriptions Entry
+**
+** This structure defines an entry used in the CFE_SB_PrevSubsPkt_t
+** Intended to be used primarily by Software Bus Networking Application (SBN)
+**
+** Used in structure definition #CFE_SB_AllSubscriptionsTlm_t
+*/
+typedef struct CFE_SB_SubEntries
+{
+    CFE_SB_MsgId_t  MsgId; /**< \brief MsgId portion of the subscription */
+    CFE_SB_Qos_t    Qos;   /**< \brief Qos portion of the subscription */
+    CFE_SB_PipeId_t Pipe;  /**< \brief PipeId portion of the subscription */
+} CFE_SB_SubEntries_t;
+
+/**
+** \cfesbtlm SB Previous Subscriptions Packet
+**
+** This structure defines the pkt(s) sent by SB that contains a list of all current
+** subscriptions. This pkt is generated on cmd and intended to be used primarily by
+** the Software Bus Networking Application (SBN). Typically, when the cmd is received
+** there are more subscriptions than can fit in one pkt. The complete list of
+** subscriptions is sent via a series of segmented pkts.
+*/
+typedef struct CFE_SB_AllSubscriptionsTlm_Payload
+{
+    uint32              PktSegment;    /**< \brief Pkt number(starts at 1) in the series */
+    uint32              TotalSegments; /**< \brief Total number of pkts needed to complete the request */
+    uint32              Entries;       /**< \brief Number of entries in the pkt */
+    CFE_SB_SubEntries_t Entry[CFE_SB_SUB_ENTRIES_PER_PKT]; /**< \brief Array of #CFE_SB_SubEntries_t entries */
+} CFE_SB_AllSubscriptionsTlm_Payload_t;
 
 #endif

--- a/modules/sb/config/default_cfe_sb_msgstruct.h
+++ b/modules/sb/config/default_cfe_sb_msgstruct.h
@@ -35,7 +35,7 @@
 /************************************************************************
  * Includes
  ************************************************************************/
-#include "cfe_sb_interface_cfg.h"
+#include "cfe_sb_msgdefs.h"
 #include "cfe_msg_hdr.h"
 
 /****************************
@@ -49,119 +49,80 @@
  * For the SB application these are mapped to the CFE_MSG_CommandHeader_t type,
  * as they contain only a primary + command header.
  */
-typedef CFE_MSG_CommandHeader_t CFE_SB_NoopCmd_t;
-typedef CFE_MSG_CommandHeader_t CFE_SB_ResetCountersCmd_t;
-typedef CFE_MSG_CommandHeader_t CFE_SB_EnableSubReportingCmd_t;
-typedef CFE_MSG_CommandHeader_t CFE_SB_DisableSubReportingCmd_t;
-typedef CFE_MSG_CommandHeader_t CFE_SB_SendSbStatsCmd_t;
-typedef CFE_MSG_CommandHeader_t CFE_SB_SendPrevSubsCmd_t;
-typedef CFE_MSG_CommandHeader_t CFE_SB_SendHkCmd_t;
-
-/**
-**  \brief Write File Info Command Payload
-**
-**  This structure contains a generic definition used by SB commands that write to a file
-*/
-typedef struct CFE_SB_WriteFileInfoCmd_Payload
+typedef struct CFE_SB_NoopCmd
 {
-    char Filename[CFE_MISSION_MAX_PATH_LEN]; /**< \brief Path and Filename of data to be loaded */
-} CFE_SB_WriteFileInfoCmd_Payload_t;
+    CFE_MSG_CommandHeader_t CommandHeader;
+} CFE_SB_NoopCmd_t;
 
-/**
- * \brief Write File Info Command
+typedef struct CFE_SB_ResetCountersCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader;
+} CFE_SB_ResetCountersCmd_t;
+
+typedef struct CFE_SB_EnableSubReportingCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader;
+} CFE_SB_EnableSubReportingCmd_t;
+
+typedef struct CFE_SB_DisableSubReportingCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader;
+} CFE_SB_DisableSubReportingCmd_t;
+
+typedef struct CFE_SB_SendSbStatsCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader;
+} CFE_SB_SendSbStatsCmd_t;
+
+typedef struct CFE_SB_SendPrevSubsCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader;
+} CFE_SB_SendPrevSubsCmd_t;
+
+typedef struct CFE_SB_SendHkCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader;
+} CFE_SB_SendHkCmd_t;
+
+/*
+ * Create a unique typedef for each of the commands that share this format.
  */
-typedef struct CFE_SB_WriteFileInfoCmd
+typedef struct CFE_SB_WriteRoutingInfoCmd
 {
     CFE_MSG_CommandHeader_t           CommandHeader; /**< \brief Command header */
     CFE_SB_WriteFileInfoCmd_Payload_t Payload;       /**< \brief Command payload */
-} CFE_SB_WriteFileInfoCmd_t;
+} CFE_SB_WriteRoutingInfoCmd_t;
+
+typedef struct CFE_SB_WritePipeInfoCmd
+{
+    CFE_MSG_CommandHeader_t           CommandHeader; /**< \brief Command header */
+    CFE_SB_WriteFileInfoCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_SB_WritePipeInfoCmd_t;
+
+typedef struct CFE_SB_WriteMapInfoCmd
+{
+    CFE_MSG_CommandHeader_t           CommandHeader; /**< \brief Command header */
+    CFE_SB_WriteFileInfoCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_SB_WriteMapInfoCmd_t;
 
 /*
  * Create a unique typedef for each of the commands that share this format.
  */
-typedef CFE_SB_WriteFileInfoCmd_t CFE_SB_WriteRoutingInfoCmd_t;
-typedef CFE_SB_WriteFileInfoCmd_t CFE_SB_WritePipeInfoCmd_t;
-typedef CFE_SB_WriteFileInfoCmd_t CFE_SB_WriteMapInfoCmd_t;
-
-/**
-**  \brief Enable/Disable Route Command Payload
-**
-**  This structure contains a definition used by two SB commands,
-**  'Enable Route' #CFE_SB_ENABLE_ROUTE_CC and 'Disable Route' #CFE_SB_DISABLE_ROUTE_CC.
-**  A route is the destination pipe for a  particular message and is therefore defined
-**  as a MsgId and PipeId combination.
-*/
-typedef struct CFE_SB_RouteCmd_Payload
-{
-    CFE_SB_MsgId_t  MsgId; /**< \brief Message ID of route to be enabled or disabled #CFE_SB_MsgId_t */
-    CFE_SB_PipeId_t Pipe;  /**< \brief Pipe ID of route to be enabled or disabled #CFE_SB_PipeId_t */
-    uint8           Spare; /**<\brief Spare byte to make command even number of bytes */
-} CFE_SB_RouteCmd_Payload_t;
-
-/**
- * \brief Enable/Disable Route Command
- */
-typedef struct CFE_SB_RouteCmd
+typedef struct CFE_SB_EnableRouteCmd
 {
     CFE_MSG_CommandHeader_t   CommandHeader; /**< \brief Command header */
     CFE_SB_RouteCmd_Payload_t Payload;       /**< \brief Command payload */
-} CFE_SB_RouteCmd_t;
+} CFE_SB_EnableRouteCmd_t;
 
-/*
- * Create a unique typedef for each of the commands that share this format.
- */
-typedef CFE_SB_RouteCmd_t CFE_SB_EnableRouteCmd_t;
-typedef CFE_SB_RouteCmd_t CFE_SB_DisableRouteCmd_t;
+typedef struct CFE_SB_DisableRouteCmd
+{
+    CFE_MSG_CommandHeader_t   CommandHeader; /**< \brief Command header */
+    CFE_SB_RouteCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_SB_DisableRouteCmd_t;
 
 /****************************
 **  SB Telemetry Formats   **
 *****************************/
-
-/**
-**  \cfesbtlm Software Bus task housekeeping Packet
-*/
-typedef struct CFE_SB_HousekeepingTlm_Payload
-{
-    uint8 CommandCounter;       /**< \cfetlmmnemonic \SB_CMDPC
-                                 \brief Count of valid commands received */
-    uint8 CommandErrorCounter;  /**< \cfetlmmnemonic \SB_CMDEC
-                           \brief Count of invalid commands received */
-    uint8 NoSubscribersCounter; /**< \cfetlmmnemonic \SB_NOSUBEC
-                                 \brief Count pkts sent with no subscribers */
-    uint8 MsgSendErrorCounter;  /**< \cfetlmmnemonic \SB_MSGSNDEC
-                               \brief Count of message send errors */
-
-    uint8 MsgReceiveErrorCounter;        /**< \cfetlmmnemonic \SB_MSGRECEC
-                                        \brief Count of message receive errors */
-    uint8 InternalErrorCounter;          /**< \cfetlmmnemonic \SB_INTERNALEC
-                                        \brief Count of queue read or write errors */
-    uint8 CreatePipeErrorCounter;        /**< \cfetlmmnemonic \SB_NEWPIPEEC
-                                        \brief Count of errors in create pipe API */
-    uint8 SubscribeErrorCounter;         /**< \cfetlmmnemonic \SB_SUBSCREC
-                                        \brief Count of errors in subscribe API */
-    uint8 PipeOptsErrorCounter;          /**< \cfetlmmnemonic \SB_PIPEOPTSEC
-                                       \brief Count of errors in set/get pipe options API */
-    uint8 DuplicateSubscriptionsCounter; /**< \cfetlmmnemonic \SB_DUPSUBCNT
-                                    \brief Count of duplicate subscriptions */
-    uint8 GetPipeIdByNameErrorCounter;   /**< \cfetlmmnemonic \SB_GETPIPEIDBYNAMEEC
-                                \brief Count of errors in get pipe id by name API */
-    uint8 Spare2Align[1];                /**< \cfetlmmnemonic \SB_SPARE2ALIGN
-                                              \brief Spare bytes to ensure alignment */
-
-    uint16 PipeOverflowErrorCounter; /**< \cfetlmmnemonic \SB_PIPEOVREC
-                                    \brief Count of pipe overflow errors */
-    uint16 MsgLimitErrorCounter;     /**< \cfetlmmnemonic \SB_MSGLIMEC
-                                       \brief Count of msg id to pipe errors */
-
-    CFE_ES_MemHandle_t MemPoolHandle; /**< \cfetlmmnemonic \SB_MEMPOOLHANDLE
-                                           \brief Handle to SB's Memory Pool */
-
-    uint32 MemInUse; /**< \cfetlmmnemonic \SB_MEMINUSE
-                                    \brief Memory in use */
-
-    uint32 UnmarkedMem; /**< \cfetlmmnemonic \SB_UNMARKEDMEM
-                             \brief cfg param CFE_PLATFORM_SB_BUF_MEMORY_BYTES minus Peak Memory in use */
-} CFE_SB_HousekeepingTlm_Payload_t;
 
 typedef struct CFE_SB_HousekeepingTlm
 {
@@ -169,189 +130,17 @@ typedef struct CFE_SB_HousekeepingTlm
     CFE_SB_HousekeepingTlm_Payload_t Payload;         /**< \brief Telemetry payload */
 } CFE_SB_HousekeepingTlm_t;
 
-/**
-** \brief SB Pipe Depth Statistics
-**
-** Used in SB Statistics Telemetry Packet #CFE_SB_StatsTlm_t
-*/
-typedef struct CFE_SB_PipeDepthStats
-{
-    CFE_SB_PipeId_t PipeId;   /**< \cfetlmmnemonic \SB_PDPIPEID
-                                   \brief Pipe Id associated with the stats below */
-    uint16 MaxQueueDepth;     /**< \cfetlmmnemonic \SB_PDDEPTH
-                           \brief Number of messages the pipe can hold */
-    uint16 CurrentQueueDepth; /**< \cfetlmmnemonic \SB_PDINUSE
-                       \brief Number of messages currently on the pipe */
-    uint16 PeakQueueDepth;    /**< \cfetlmmnemonic \SB_PDPKINUSE
-                              \brief Peak number of messages that have been on the pipe */
-    uint16 Spare;             /**< \cfetlmmnemonic \SB_PDSPARE
-                                   \brief Spare word to ensure alignment */
-} CFE_SB_PipeDepthStats_t;
-
-/**
-** \brief SB Pipe Information File Entry
-**
-** This statistics structure is output as part of the CFE SB
-** "Send Pipe Info" command (CFE_SB_SEND_PIPE_INFO_CC).
-**
-** Previous versions of CFE simply wrote the internal CFE_SB_PipeD_t object
-** to the file, but this also contains information such as pointers which are
-** not relevant outside the running CFE process.
-**
-** By defining the pipe info structure separately, it also provides some
-** independence, such that the internal CFE_SB_PipeD_t definition
-** can evolve without changing the binary format of the information
-** file.
-*/
-typedef struct CFE_SB_PipeInfoEntry
-{
-    CFE_SB_PipeId_t PipeId;                            /**< The runtime ID of the pipe */
-    CFE_ES_AppId_t  AppId;                             /**< The runtime ID of the application that owns the pipe */
-    char            PipeName[CFE_MISSION_MAX_API_LEN]; /**< The Name of the pipe */
-    char            AppName[CFE_MISSION_MAX_API_LEN];  /**< The Name of the application that owns the pipe */
-    uint16          MaxQueueDepth;                     /**< The allocated depth of the pipe (max capacity) */
-    uint16          CurrentQueueDepth;                 /**< The current depth of the pipe */
-    uint16          PeakQueueDepth;                    /**< The peak depth of the pipe (high watermark) */
-    uint16          SendErrors;                        /**< Number of errors when writing to this pipe */
-    uint8           Opts;                              /**< Pipe options set (bitmask) */
-    uint8           Spare[3];                          /**< Padding to make this structure a multiple of 4 bytes */
-} CFE_SB_PipeInfoEntry_t;
-
-/**
-** \cfesbtlm SB Statistics Telemetry Packet
-**
-** SB Statistics packet sent in response to #CFE_SB_SEND_SB_STATS_CC
-*/
-typedef struct CFE_SB_StatsTlm_Payload
-{
-    uint32 MsgIdsInUse;      /**< \cfetlmmnemonic \SB_SMMIDIU
-                                  \brief Current number of MsgIds with a destination */
-    uint32 PeakMsgIdsInUse;  /**< \cfetlmmnemonic \SB_SMPMIDIU
-                                  \brief Peak number of MsgIds with a destination */
-    uint32 MaxMsgIdsAllowed; /**< \cfetlmmnemonic \SB_SMMMIDALW
-                                  \brief cFE Cfg Param \link #CFE_PLATFORM_SB_MAX_MSG_IDS \endlink */
-
-    uint32 PipesInUse;      /**< \cfetlmmnemonic \SB_SMPIU
-                                 \brief Number of pipes currently in use */
-    uint32 PeakPipesInUse;  /**< \cfetlmmnemonic \SB_SMPPIU
-                                 \brief Peak number of pipes since last reboot */
-    uint32 MaxPipesAllowed; /**< \cfetlmmnemonic \SB_SMMPALW
-                                 \brief cFE Cfg Param \link #CFE_PLATFORM_SB_MAX_PIPES \endlink */
-
-    uint32 MemInUse;      /**< \cfetlmmnemonic \SB_SMBMIU
-                                  \brief Memory bytes currently in use for SB msg transfers */
-    uint32 PeakMemInUse;  /**< \cfetlmmnemonic \SB_SMPBMIU
-                                  \brief Peak memory bytes in use for SB msg transfers */
-    uint32 MaxMemAllowed; /**< \cfetlmmnemonic \SB_SMMBMALW
-                                  \brief cFE Cfg Param \link #CFE_PLATFORM_SB_BUF_MEMORY_BYTES \endlink */
-
-    uint32 SubscriptionsInUse;      /**< \cfetlmmnemonic \SB_SMSIU
-                                         \brief Number of current subscriptions */
-    uint32 PeakSubscriptionsInUse;  /**< \cfetlmmnemonic \SB_SMPSIU
-                                         \brief Peak number of subscriptions */
-    uint32 MaxSubscriptionsAllowed; /**< \cfetlmmnemonic \SB_SMMSALW
-                                         \brief product of \link #CFE_PLATFORM_SB_MAX_MSG_IDS \endlink
-                                         and \link #CFE_PLATFORM_SB_MAX_DEST_PER_PKT \endlink */
-
-    uint32 SBBuffersInUse;     /**< \cfetlmmnemonic \SB_SMSBBIU
-                                    \brief Number of SB message buffers currently in use */
-    uint32 PeakSBBuffersInUse; /**< \cfetlmmnemonic \SB_SMPSBBIU
-                                    \brief Max number of SB message buffers in use */
-
-    uint32 MaxPipeDepthAllowed; /**< \cfetlmmnemonic \SB_SMMPDALW
-                                     \brief Maximum allowed pipe depth */
-    CFE_SB_PipeDepthStats_t
-        PipeDepthStats[CFE_MISSION_SB_MAX_PIPES]; /**< \cfetlmmnemonic \SB_SMPDS
-                                               \brief Pipe Depth Statistics #CFE_SB_PipeDepthStats_t*/
-} CFE_SB_StatsTlm_Payload_t;
-
 typedef struct CFE_SB_StatsTlm
 {
     CFE_MSG_TelemetryHeader_t TelemetryHeader; /**< \brief Telemetry header */
     CFE_SB_StatsTlm_Payload_t Payload;         /**< \brief Telemetry payload */
 } CFE_SB_StatsTlm_t;
 
-/**
-** \brief SB Routing File Entry
-**
-** Structure of one element of the routing information in response to #CFE_SB_WRITE_ROUTING_INFO_CC
-*/
-typedef struct CFE_SB_RoutingFileEntry
-{
-    CFE_SB_MsgId_t  MsgId;                             /**< \brief Message Id portion of the route */
-    CFE_SB_PipeId_t PipeId;                            /**< \brief Pipe Id portion of the route */
-    uint8           State;                             /**< \brief Route Enabled or Disabled */
-    uint16          MsgCnt;                            /**< \brief Number of msgs with this MsgId sent to this PipeId */
-    char            AppName[CFE_MISSION_MAX_API_LEN];  /**< \brief Pipe Depth Statistics */
-    char            PipeName[CFE_MISSION_MAX_API_LEN]; /**< \brief Pipe Depth Statistics */
-} CFE_SB_RoutingFileEntry_t;
-
-/**
-** \brief SB Map File Entry
-**
-** Structure of one element of the map information in response to #CFE_SB_WRITE_MAP_INFO_CC
-*/
-typedef struct CFE_SB_MsgMapFileEntry
-{
-    CFE_SB_MsgId_t        MsgId; /**< \brief Message Id which has been subscribed to */
-    CFE_SB_RouteId_Atom_t Index; /**< \brief Routing raw index value (0 based, not Route ID) */
-} CFE_SB_MsgMapFileEntry_t;
-
-/**
-** \cfesbtlm SB Subscription Report Packet
-**
-** This structure defines the pkt sent by SB when a subscription or
-** a request to unsubscribe is received while subscription reporting is enabled.
-** By default subscription reporting is disabled. This feature is intended to be
-** used primarily by Software Bus Networking Application (SBN)
-**
-** \sa #CFE_SB_ENABLE_SUB_REPORTING_CC, #CFE_SB_DISABLE_SUB_REPORTING_CC
-*/
-typedef struct CFE_SB_SingleSubscriptionTlm_Payload
-{
-    uint8           SubType; /**< \brief Subscription or Unsubscription */
-    CFE_SB_MsgId_t  MsgId;   /**< \brief MsgId subscribed or unsubscribe to */
-    CFE_SB_Qos_t    Qos;     /**< \brief Quality of Service, used only for interprocessor communication */
-    CFE_SB_PipeId_t Pipe;    /**< \brief Destination pipe id to send above msg id  */
-} CFE_SB_SingleSubscriptionTlm_Payload_t;
-
 typedef struct CFE_SB_SingleSubscriptionTlm
 {
     CFE_MSG_TelemetryHeader_t              TelemetryHeader; /**< \brief Telemetry header */
     CFE_SB_SingleSubscriptionTlm_Payload_t Payload;         /**< \brief Telemetry payload */
 } CFE_SB_SingleSubscriptionTlm_t;
-
-/**
-** \brief SB Previous Subscriptions Entry
-**
-** This structure defines an entry used in the CFE_SB_PrevSubsPkt_t
-** Intended to be used primarily by Software Bus Networking Application (SBN)
-**
-** Used in structure definition #CFE_SB_AllSubscriptionsTlm_t
-*/
-typedef struct CFE_SB_SubEntries
-{
-    CFE_SB_MsgId_t  MsgId; /**< \brief MsgId portion of the subscription */
-    CFE_SB_Qos_t    Qos;   /**< \brief Qos portion of the subscription */
-    CFE_SB_PipeId_t Pipe;  /**< \brief PipeId portion of the subscription */
-} CFE_SB_SubEntries_t;
-
-/**
-** \cfesbtlm SB Previous Subscriptions Packet
-**
-** This structure defines the pkt(s) sent by SB that contains a list of all current
-** subscriptions. This pkt is generated on cmd and intended to be used primarily by
-** the Software Bus Networking Application (SBN). Typically, when the cmd is received
-** there are more subscriptions than can fit in one pkt. The complete list of
-** subscriptions is sent via a series of segmented pkts.
-*/
-typedef struct CFE_SB_AllSubscriptionsTlm_Payload
-{
-    uint32              PktSegment;    /**< \brief Pkt number(starts at 1) in the series */
-    uint32              TotalSegments; /**< \brief Total number of pkts needed to complete the request */
-    uint32              Entries;       /**< \brief Number of entries in the pkt */
-    CFE_SB_SubEntries_t Entry[CFE_SB_SUB_ENTRIES_PER_PKT]; /**< \brief Array of #CFE_SB_SubEntries_t entries */
-} CFE_SB_AllSubscriptionsTlm_Payload_t;
 
 typedef struct CFE_SB_AllSubscriptionsTlm
 {

--- a/modules/sb/fsw/src/cfe_sb_dispatch.c
+++ b/modules/sb/fsw/src/cfe_sb_dispatch.c
@@ -84,7 +84,7 @@ void CFE_SB_ProcessCmdPipePkt(const CFE_SB_Buffer_t *SBBufPtr)
     {
         case CFE_SB_SEND_HK_MID:
             /* Note: Command counter not incremented for this command */
-            CFE_SB_SendHKTlmCmd((const CFE_MSG_CommandHeader_t *)SBBufPtr);
+            CFE_SB_SendHKTlmCmd((const CFE_SB_SendHkCmd_t *)SBBufPtr);
             break;
 
         case CFE_SB_SUB_RPT_CTRL_MID:

--- a/modules/tbl/CMakeLists.txt
+++ b/modules/tbl/CMakeLists.txt
@@ -25,6 +25,16 @@ if(ENABLE_UNIT_TESTS)
 endif(ENABLE_UNIT_TESTS)
 
 cfs_app_check_intf(${DEP}
-    cfe_tbl_msg.h
     cfe_tbl_eventids.h
+    cfe_tbl_extern_typedefs.h
+    cfe_tbl_fcncodes.h
+    cfe_tbl_interface_cfg.h
+    cfe_tbl_internal_cfg.h
+    cfe_tbl_mission_cfg.h
+    cfe_tbl_msgdefs.h
+    cfe_tbl_msg.h
+    cfe_tbl_msgids.h
+    cfe_tbl_msgstruct.h
+    cfe_tbl_platform_cfg.h
+    cfe_tbl_topicids.h
 )

--- a/modules/tbl/config/default_cfe_tbl_msgdefs.h
+++ b/modules/tbl/config/default_cfe_tbl_msgdefs.h
@@ -26,6 +26,253 @@
 #ifndef CFE_TBL_MSGDEFS_H
 #define CFE_TBL_MSGDEFS_H
 
+#include "common_types.h"
+#include "cfe_mission_cfg.h"
+#include "cfe_es_extern_typedefs.h"
+#include "cfe_time_extern_typedefs.h"
 #include "cfe_tbl_fcncodes.h"
+
+/********************************/
+/* Command Message Data Formats */
+/********************************/
+
+/**
+** \brief Load Table Command Payload
+**
+** For command details, see #CFE_TBL_LOAD_CC
+**
+**/
+typedef struct CFE_TBL_LoadCmd_Payload
+{
+    char LoadFilename[CFE_MISSION_MAX_PATH_LEN]; /**< \brief Filename (and path) of data to be loaded */
+} CFE_TBL_LoadCmd_Payload_t;
+
+/**
+** \brief Dump Table Command Payload
+**
+** For command details, see #CFE_TBL_DUMP_CC
+*/
+typedef struct CFE_TBL_DumpCmd_Payload
+{
+    uint16 ActiveTableFlag;                            /**< \brief #CFE_TBL_BufferSelect_INACTIVE=Inactive Table,
+                                                                 #CFE_TBL_BufferSelect_ACTIVE=Active Table */
+                                                       /**< Selects either the "Inactive"
+                                                            (#CFE_TBL_BufferSelect_INACTIVE) buffer or the
+                                                            "Active" (#CFE_TBL_BufferSelect_ACTIVE) buffer
+                                                            to be dumped */
+    char TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \brief Full name of table to be dumped */
+                                                       /**< ASCII string containing full table name
+                                                            identifier of table to be dumped */
+    char DumpFilename[CFE_MISSION_MAX_PATH_LEN];       /**< \brief Full Filename where data is to be written */
+                                                       /**< ASCII string containing full path of filename
+                                                            where data is to be dumped */
+} CFE_TBL_DumpCmd_Payload_t;
+
+/**
+** \brief Validate Table Command Payload
+**
+** For command details, see #CFE_TBL_VALIDATE_CC
+*/
+typedef struct CFE_TBL_ValidateCmd_Payload
+{
+    uint16 ActiveTableFlag;                            /**< \brief #CFE_TBL_BufferSelect_INACTIVE=Inactive Table,
+                                                                 #CFE_TBL_BufferSelect_ACTIVE=Active Table */
+                                                       /**< Selects either the "Inactive"
+                                                            (#CFE_TBL_BufferSelect_INACTIVE) buffer or the
+                                                            "Active" (#CFE_TBL_BufferSelect_ACTIVE) buffer
+                                                            to be validated */
+    char TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \brief Full Name of Table to be validated */
+                                                       /**< ASCII string containing full table name
+                                                            identifier of table to be validated */
+} CFE_TBL_ValidateCmd_Payload_t;
+
+/**
+** \brief Activate Table Command Payload
+**
+** For command details, see #CFE_TBL_ACTIVATE_CC
+*/
+typedef struct CFE_TBL_ActivateCmd_Payload
+{
+    char TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \brief Full Name of Table to be activated */
+                                                       /**< ASCII string containing full table name
+                                                            identifier of table to be activated */
+} CFE_TBL_ActivateCmd_Payload_t;
+
+/**
+** \brief Dump Registry Command Payload
+**
+** For command details, see #CFE_TBL_DUMP_REGISTRY_CC
+*/
+typedef struct CFE_TBL_DumpRegistryCmd_Payload
+{
+    char DumpFilename[CFE_MISSION_MAX_PATH_LEN]; /**< \brief Full Filename where dumped data is to be
+                                             written */
+                                                 /**< ASCII string containing full path of filename
+                                                      where registry is to be dumped */
+} CFE_TBL_DumpRegistryCmd_Payload_t;
+
+/**
+** \brief Send Table Registry Command Payload
+**
+** For command details, see #CFE_TBL_SEND_REGISTRY_CC
+*/
+typedef struct CFE_TBL_SendRegistryCmd_Payload
+{
+    char TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \brief Full Name of Table whose registry entry
+                                                    is to be telemetered */
+                                                       /**< ASCII string containing full table name
+                                                            identifier of table whose registry entry is
+                                                            to be telemetered via #CFE_TBL_TableRegistryTlm_t */
+} CFE_TBL_SendRegistryCmd_Payload_t;
+
+/**
+** \brief Delete Critical Table CDS Command Payload
+**
+** For command details, see #CFE_TBL_DELETE_CDS_CC
+*/
+typedef struct CFE_TBL_DelCDSCmd_Payload
+{
+    char TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \brief Full Name of Table whose CDS is
+                                                    to be deleted */
+                                                       /**< ASCII string containing full table name
+                                                            identifier of a critical table whose
+                                                            CDS is to be deleted */
+} CFE_TBL_DelCDSCmd_Payload_t;
+
+/**
+** \brief Abort Load Command Payload
+**
+** For command details, see #CFE_TBL_ABORT_LOAD_CC
+*/
+typedef struct CFE_TBL_AbortLoadCmd_Payload
+{
+    char TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \brief Full Name of Table whose load is to be aborted */
+                                                       /**< ASCII string containing full table name
+                                                            identifier of a table whose load is to be aborted */
+} CFE_TBL_AbortLoadCmd_Payload_t;
+
+/*************************************************************************/
+
+/**
+** \brief Table Management Notification Command Payload
+**
+** \par Description
+**      Whenever an application that owns a table calls the #CFE_TBL_NotifyByMessage API
+**      following the table registration, Table services will generate the following
+**      command message with the application specified message ID, command code and
+**      parameter whenever the table requires management (e.g. - loads and validations).
+*/
+typedef struct CFE_TBL_NotifyCmd_Payload
+{
+    uint32 Parameter; /**< \brief Application specified command parameter */
+} CFE_TBL_NotifyCmd_Payload_t;
+
+/*************************************************************************/
+
+/**********************************/
+/* Telemetry Message Data Formats */
+/**********************************/
+/**
+**  \cfetbltlm Table Services Housekeeping Packet
+**/
+typedef struct CFE_TBL_HousekeepingTlm_Payload
+{
+    /*
+    ** Task command interface counters...
+    */
+    uint8 CommandCounter;      /**< \cfetlmmnemonic \TBL_CMDPC
+                                \brief Count of valid commands received */
+    uint8 CommandErrorCounter; /**< \cfetlmmnemonic \TBL_CMDEC
+                           \brief Count of invalid commands received */
+
+    /*
+    ** Table Registry Statistics
+    */
+    uint16 NumTables;      /**< \cfetlmmnemonic \TBL_NUMTABLES
+                                \brief Number of Tables Registered */
+    uint16 NumLoadPending; /**< \cfetlmmnemonic \TBL_NUMUPDATESPEND
+                                \brief Number of Tables pending on Applications for their update */
+
+    /*
+    ** Last Table Validation Results
+    */
+    uint16 ValidationCounter;                                 /**< \cfetlmmnemonic \TBL_VALCOMPLTDCTR
+                                                               \brief Number of completed table validations */
+    uint32 LastValCrc;                                        /**< \cfetlmmnemonic \TBL_LASTVALCRC
+                                                                   \brief Data Integrity Value computed for last table validated */
+    int32 LastValStatus;                                      /**< \cfetlmmnemonic \TBL_LASTVALS
+                                                                   \brief Returned status from validation function for last table validated */
+    bool ActiveBuffer;                                        /**< \cfetlmmnemonic \TBL_LASTVALBUF
+                                                                   \brief Indicator of whether table buffer validated was 0=Inactive, 1=Active */
+    char LastValTableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \cfetlmmnemonic \TBL_LASTVALTBLNAME
+                                                           \brief Name of last table validated */
+    uint8 SuccessValCounter;                                  /**< \cfetlmmnemonic \TBL_VALSUCCESSCTR
+                                                               \brief Total number of successful table validations */
+    uint8 FailedValCounter;                                   /**< \cfetlmmnemonic \TBL_VALFAILEDCTR
+                                                               \brief Total number of unsuccessful table validations */
+    uint8 NumValRequests;                                     /**< \cfetlmmnemonic \TBL_VALREQCTR
+                                                                   \brief Number of times Table Services has requested validations from Apps */
+
+    /*
+    ** Ground system interface information
+    */
+    uint8 NumFreeSharedBufs;                                  /**< \cfetlmmnemonic \TBL_NUMFREESHRBUF
+                                                                   \brief Number of free Shared Working Buffers */
+    uint8 ByteAlignPad1;                                      /**< \cfetlmmnemonic \TBL_BYTEALIGNPAD1
+                                                                   \brief Spare byte to ensure longword alignment */
+    CFE_ES_MemHandle_t MemPoolHandle;                         /**< \cfetlmmnemonic \TBL_MEMPOOLHANDLE
+                                                                   \brief Handle to TBL's memory pool */
+    CFE_TIME_SysTime_t LastUpdateTime;                        /**< \cfetlmmnemonic \TBL_LASTUPDTIME
+                                                                   \brief Time of last table update */
+    char LastUpdatedTable[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \cfetlmmnemonic \TBL_LASTUPDTBLNAME
+                                                         \brief Name of the last table updated */
+    char LastFileLoaded[CFE_MISSION_MAX_PATH_LEN];            /**< \cfetlmmnemonic \TBL_LASTFILELOADED
+                                                          \brief Path and Name of last table image file loaded */
+    char LastFileDumped[CFE_MISSION_MAX_PATH_LEN];            /**< \cfetlmmnemonic \TBL_LASTFILEDUMPED
+                                                          \brief Path and Name of last file dumped to */
+    char LastTableLoaded[CFE_MISSION_TBL_MAX_FULL_NAME_LEN];  /**< \cfetlmmnemonic \TBL_LASTTABLELOADED
+                                                          \brief Name of the last table loaded */
+} CFE_TBL_HousekeepingTlm_Payload_t;
+
+/**
+**  \cfetbltlm Table Registry Info Packet
+**/
+typedef struct CFE_TBL_TblRegPacket_Payload
+{
+    CFE_ES_MemOffset_t Size;                       /**< \cfetlmmnemonic \TBL_SIZE
+                                                        \brief Size, in bytes, of Table */
+    uint32 Crc;                                    /**< \cfetlmmnemonic \TBL_CRC
+                                                        \brief Most recently calculated CRC of Table */
+    CFE_ES_MemAddress_t ActiveBufferAddr;          /**< \cfetlmmnemonic \TBL_ACTBUFADD
+                                                        \brief Address of Active Buffer */
+    CFE_ES_MemAddress_t InactiveBufferAddr;        /**< \cfetlmmnemonic \TBL_IACTBUFADD
+                                                        \brief Address of Inactive Buffer */
+    CFE_ES_MemAddress_t ValidationFuncPtr;         /**< \cfetlmmnemonic \TBL_VALFUNCPTR
+                                                        \brief Ptr to Owner App's function that validates tbl contents */
+    CFE_TIME_SysTime_t TimeOfLastUpdate;           /**< \cfetlmmnemonic \TBL_TIMELASTUPD
+                                                        \brief Time when Table was last updated */
+    uint32 FileCreateTimeSecs;                     /**< \cfetlmmnemonic \TBL_FILECSECONDS
+                                                        \brief File creation time from last file loaded into table */
+    uint32 FileCreateTimeSubSecs;                  /**< \cfetlmmnemonic \TBL_FILECSUBSECONDS
+                                                        \brief File creation time from last file loaded into table */
+    bool TableLoadedOnce;                          /**< \cfetlmmnemonic \TBL_LOADEDONCE
+                                                        \brief Flag indicating whether table has been loaded once or not */
+    bool LoadPending;                              /**< \cfetlmmnemonic \TBL_UPDATEPNDNG
+                                                        \brief Flag indicating an inactive buffer is ready to be copied */
+    bool DumpOnly;                                 /**< \cfetlmmnemonic \TBL_DUMPONLY
+                                                        \brief Flag indicating Table is NOT to be loaded */
+    bool DoubleBuffered;                           /**< \cfetlmmnemonic \TBL_DBLBUFFERED
+                                                     \brief Flag indicating Table has a dedicated inactive buffer */
+    char Name[CFE_MISSION_TBL_MAX_FULL_NAME_LEN];  /**< \cfetlmmnemonic \TBL_NAME
+                                                \brief Processor specific table name */
+    char LastFileLoaded[CFE_MISSION_MAX_PATH_LEN]; /**< \cfetlmmnemonic \TBL_LASTFILEUPD
+                                               \brief Filename of last file loaded into table */
+    char OwnerAppName[CFE_MISSION_MAX_API_LEN];    /**< \cfetlmmnemonic \TBL_OWNERAPP
+                                                \brief Name of owning application */
+    bool Critical;                                 /**< \cfetlmmnemonic \TBL_CRITICAL
+                                                        \brief Indicates whether table is Critical or not */
+    uint8 ByteAlign4;                              /**< \cfetlmmnemonic \TBL_SPARE4
+                                                        \brief Spare byte to maintain byte alignment */
+} CFE_TBL_TblRegPacket_Payload_t;
 
 #endif

--- a/modules/tbl/config/default_cfe_tbl_msgstruct.h
+++ b/modules/tbl/config/default_cfe_tbl_msgstruct.h
@@ -35,46 +35,32 @@
 /************************************************************************
  * Includes
  ************************************************************************/
-#include "cfe_mission_cfg.h"
 #include "cfe_tbl_msgdefs.h"
 #include "cfe_msg_hdr.h"
 
 /********************************/
 /* Command Message Data Formats */
 /********************************/
-/**
-** \brief Generic "no arguments" command
-**
-** This command structure is used for commands that do not have any parameters.
-** This includes:
-** -# The Housekeeping Request Message
-** -# The No-Op Command (For details, see #CFE_TBL_NOOP_CC)
-** -# The Reset Counters Command (For details, see #CFE_TBL_RESET_COUNTERS_CC)
-*/
-typedef struct CFE_TBL_NoArgsCmd
-{
-    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
-} CFE_TBL_NoArgsCmd_t;
 
 /*
  * Typedefs for each of the messages that share the command format
  * Allows each command to evolve independently, while following the command
  * handler prototype convention
  */
-typedef CFE_TBL_NoArgsCmd_t CFE_TBL_NoopCmd_t;
-typedef CFE_TBL_NoArgsCmd_t CFE_TBL_ResetCountersCmd_t;
-typedef CFE_TBL_NoArgsCmd_t CFE_TBL_SendHkCmd_t;
-
-/**
-** \brief Load Table Command Payload
-**
-** For command details, see #CFE_TBL_LOAD_CC
-**
-**/
-typedef struct CFE_TBL_LoadCmd_Payload
+typedef struct CFE_TBL_NoopCmd
 {
-    char LoadFilename[CFE_MISSION_MAX_PATH_LEN]; /**< \brief Filename (and path) of data to be loaded */
-} CFE_TBL_LoadCmd_Payload_t;
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CFE_TBL_NoopCmd_t;
+
+typedef struct CFE_TBL_ResetCountersCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CFE_TBL_ResetCountersCmd_t;
+
+typedef struct CFE_TBL_SendHkCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CFE_TBL_SendHkCmd_t;
 
 /**
  * \brief Load Table Command
@@ -86,27 +72,6 @@ typedef struct CFE_TBL_LoadCmd
 } CFE_TBL_LoadCmd_t;
 
 /**
-** \brief Dump Table Command Payload
-**
-** For command details, see #CFE_TBL_DUMP_CC
-*/
-typedef struct CFE_TBL_DumpCmd_Payload
-{
-    uint16 ActiveTableFlag;                            /**< \brief #CFE_TBL_BufferSelect_INACTIVE=Inactive Table,
-                                                                 #CFE_TBL_BufferSelect_ACTIVE=Active Table */
-                                                       /**< Selects either the "Inactive"
-                                                            (#CFE_TBL_BufferSelect_INACTIVE) buffer or the
-                                                            "Active" (#CFE_TBL_BufferSelect_ACTIVE) buffer
-                                                            to be dumped */
-    char TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \brief Full name of table to be dumped */
-                                                       /**< ASCII string containing full table name
-                                                            identifier of table to be dumped */
-    char DumpFilename[CFE_MISSION_MAX_PATH_LEN];       /**< \brief Full Filename where data is to be written */
-                                                       /**< ASCII string containing full path of filename
-                                                            where data is to be dumped */
-} CFE_TBL_DumpCmd_Payload_t;
-
-/**
  * /brief Dump Table Command
  */
 typedef struct CFE_TBL_DumpCmd
@@ -114,24 +79,6 @@ typedef struct CFE_TBL_DumpCmd
     CFE_MSG_CommandHeader_t   CommandHeader; /**< \brief Command header */
     CFE_TBL_DumpCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_TBL_DumpCmd_t;
-
-/**
-** \brief Validate Table Command Payload
-**
-** For command details, see #CFE_TBL_VALIDATE_CC
-*/
-typedef struct CFE_TBL_ValidateCmd_Payload
-{
-    uint16 ActiveTableFlag;                            /**< \brief #CFE_TBL_BufferSelect_INACTIVE=Inactive Table,
-                                                                 #CFE_TBL_BufferSelect_ACTIVE=Active Table */
-                                                       /**< Selects either the "Inactive"
-                                                            (#CFE_TBL_BufferSelect_INACTIVE) buffer or the
-                                                            "Active" (#CFE_TBL_BufferSelect_ACTIVE) buffer
-                                                            to be validated */
-    char TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \brief Full Name of Table to be validated */
-                                                       /**< ASCII string containing full table name
-                                                            identifier of table to be validated */
-} CFE_TBL_ValidateCmd_Payload_t;
 
 /**
  * \brief Validate Table Command
@@ -143,18 +90,6 @@ typedef struct CFE_TBL_ValidateCmd
 } CFE_TBL_ValidateCmd_t;
 
 /**
-** \brief Activate Table Command Payload
-**
-** For command details, see #CFE_TBL_ACTIVATE_CC
-*/
-typedef struct CFE_TBL_ActivateCmd_Payload
-{
-    char TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \brief Full Name of Table to be activated */
-                                                       /**< ASCII string containing full table name
-                                                            identifier of table to be activated */
-} CFE_TBL_ActivateCmd_Payload_t;
-
-/**
  * \brief Activate Table Command
  */
 typedef struct CFE_TBL_ActivateCmd
@@ -162,19 +97,6 @@ typedef struct CFE_TBL_ActivateCmd
     CFE_MSG_CommandHeader_t       CommandHeader; /**< \brief Command header */
     CFE_TBL_ActivateCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_TBL_ActivateCmd_t;
-
-/**
-** \brief Dump Registry Command Payload
-**
-** For command details, see #CFE_TBL_DUMP_REGISTRY_CC
-*/
-typedef struct CFE_TBL_DumpRegistryCmd_Payload
-{
-    char DumpFilename[CFE_MISSION_MAX_PATH_LEN]; /**< \brief Full Filename where dumped data is to be
-                                             written */
-                                                 /**< ASCII string containing full path of filename
-                                                      where registry is to be dumped */
-} CFE_TBL_DumpRegistryCmd_Payload_t;
 
 /**
  * \brief Dump Registry Command
@@ -186,20 +108,6 @@ typedef struct CFE_TBL_DumpRegistryCmd
 } CFE_TBL_DumpRegistryCmd_t;
 
 /**
-** \brief Send Table Registry Command Payload
-**
-** For command details, see #CFE_TBL_SEND_REGISTRY_CC
-*/
-typedef struct CFE_TBL_SendRegistryCmd_Payload
-{
-    char TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \brief Full Name of Table whose registry entry
-                                                    is to be telemetered */
-                                                       /**< ASCII string containing full table name
-                                                            identifier of table whose registry entry is
-                                                            to be telemetered via #CFE_TBL_TableRegistryTlm_t */
-} CFE_TBL_SendRegistryCmd_Payload_t;
-
-/**
  * \brief Send Table Registry Command
  */
 typedef struct CFE_TBL_SendRegistryCmd
@@ -207,20 +115,6 @@ typedef struct CFE_TBL_SendRegistryCmd
     CFE_MSG_CommandHeader_t           CommandHeader; /**< \brief Command header */
     CFE_TBL_SendRegistryCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_TBL_SendRegistryCmd_t;
-
-/**
-** \brief Delete Critical Table CDS Command Payload
-**
-** For command details, see #CFE_TBL_DELETE_CDS_CC
-*/
-typedef struct CFE_TBL_DelCDSCmd_Payload
-{
-    char TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \brief Full Name of Table whose CDS is
-                                                    to be deleted */
-                                                       /**< ASCII string containing full table name
-                                                            identifier of a critical table whose
-                                                            CDS is to be deleted */
-} CFE_TBL_DelCDSCmd_Payload_t;
 
 /**
  * \brief Delete Critical Table CDS Command
@@ -232,18 +126,6 @@ typedef struct CFE_TBL_DeleteCDSCmd
 } CFE_TBL_DeleteCDSCmd_t;
 
 /**
-** \brief Abort Load Command Payload
-**
-** For command details, see #CFE_TBL_ABORT_LOAD_CC
-*/
-typedef struct CFE_TBL_AbortLoadCmd_Payload
-{
-    char TableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \brief Full Name of Table whose load is to be aborted */
-                                                       /**< ASCII string containing full table name
-                                                            identifier of a table whose load is to be aborted */
-} CFE_TBL_AbortLoadCmd_Payload_t;
-
-/**
  * \brief Abort Load Command
  */
 typedef struct CFE_TBL_AbortLoadCmd
@@ -253,22 +135,6 @@ typedef struct CFE_TBL_AbortLoadCmd
 } CFE_TBL_AbortLoadCmd_t;
 
 /*************************************************************************/
-/******************************************/
-/* Generated Command Message Data Formats */
-/******************************************/
-/**
-** \brief Table Management Notification Command Payload
-**
-** \par Description
-**      Whenever an application that owns a table calls the #CFE_TBL_NotifyByMessage API
-**      following the table registration, Table services will generate the following
-**      command message with the application specified message ID, command code and
-**      parameter whenever the table requires management (e.g. - loads and validations).
-*/
-typedef struct CFE_TBL_NotifyCmd_Payload
-{
-    uint32 Parameter; /**< \brief Application specified command parameter */
-} CFE_TBL_NotifyCmd_Payload_t;
 
 /**
  * /brief Table Management Notification Command
@@ -280,117 +146,16 @@ typedef struct CFE_TBL_NotifyCmd
 } CFE_TBL_NotifyCmd_t;
 
 /*************************************************************************/
+
 /**********************************/
 /* Telemetry Message Data Formats */
 /**********************************/
-/**
-**  \cfetbltlm Table Services Housekeeping Packet
-**/
-typedef struct CFE_TBL_HousekeepingTlm_Payload
-{
-    /*
-    ** Task command interface counters...
-    */
-    uint8 CommandCounter;      /**< \cfetlmmnemonic \TBL_CMDPC
-                                \brief Count of valid commands received */
-    uint8 CommandErrorCounter; /**< \cfetlmmnemonic \TBL_CMDEC
-                           \brief Count of invalid commands received */
-
-    /*
-    ** Table Registry Statistics
-    */
-    uint16 NumTables;      /**< \cfetlmmnemonic \TBL_NUMTABLES
-                                \brief Number of Tables Registered */
-    uint16 NumLoadPending; /**< \cfetlmmnemonic \TBL_NUMUPDATESPEND
-                                \brief Number of Tables pending on Applications for their update */
-
-    /*
-    ** Last Table Validation Results
-    */
-    uint16 ValidationCounter;                                 /**< \cfetlmmnemonic \TBL_VALCOMPLTDCTR
-                                                               \brief Number of completed table validations */
-    uint32 LastValCrc;                                        /**< \cfetlmmnemonic \TBL_LASTVALCRC
-                                                                   \brief Data Integrity Value computed for last table validated */
-    int32 LastValStatus;                                      /**< \cfetlmmnemonic \TBL_LASTVALS
-                                                                   \brief Returned status from validation function for last table validated */
-    bool ActiveBuffer;                                        /**< \cfetlmmnemonic \TBL_LASTVALBUF
-                                                                   \brief Indicator of whether table buffer validated was 0=Inactive, 1=Active */
-    char LastValTableName[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \cfetlmmnemonic \TBL_LASTVALTBLNAME
-                                                           \brief Name of last table validated */
-    uint8 SuccessValCounter;                                  /**< \cfetlmmnemonic \TBL_VALSUCCESSCTR
-                                                               \brief Total number of successful table validations */
-    uint8 FailedValCounter;                                   /**< \cfetlmmnemonic \TBL_VALFAILEDCTR
-                                                               \brief Total number of unsuccessful table validations */
-    uint8 NumValRequests;                                     /**< \cfetlmmnemonic \TBL_VALREQCTR
-                                                                   \brief Number of times Table Services has requested validations from Apps */
-
-    /*
-    ** Ground system interface information
-    */
-    uint8 NumFreeSharedBufs;                                  /**< \cfetlmmnemonic \TBL_NUMFREESHRBUF
-                                                                   \brief Number of free Shared Working Buffers */
-    uint8 ByteAlignPad1;                                      /**< \cfetlmmnemonic \TBL_BYTEALIGNPAD1
-                                                                   \brief Spare byte to ensure longword alignment */
-    CFE_ES_MemHandle_t MemPoolHandle;                         /**< \cfetlmmnemonic \TBL_MEMPOOLHANDLE
-                                                                   \brief Handle to TBL's memory pool */
-    CFE_TIME_SysTime_t LastUpdateTime;                        /**< \cfetlmmnemonic \TBL_LASTUPDTIME
-                                                                   \brief Time of last table update */
-    char LastUpdatedTable[CFE_MISSION_TBL_MAX_FULL_NAME_LEN]; /**< \cfetlmmnemonic \TBL_LASTUPDTBLNAME
-                                                         \brief Name of the last table updated */
-    char LastFileLoaded[CFE_MISSION_MAX_PATH_LEN];            /**< \cfetlmmnemonic \TBL_LASTFILELOADED
-                                                          \brief Path and Name of last table image file loaded */
-    char LastFileDumped[CFE_MISSION_MAX_PATH_LEN];            /**< \cfetlmmnemonic \TBL_LASTFILEDUMPED
-                                                          \brief Path and Name of last file dumped to */
-    char LastTableLoaded[CFE_MISSION_TBL_MAX_FULL_NAME_LEN];  /**< \cfetlmmnemonic \TBL_LASTTABLELOADED
-                                                          \brief Name of the last table loaded */
-} CFE_TBL_HousekeepingTlm_Payload_t;
 
 typedef struct CFE_TBL_HousekeepingTlm
 {
     CFE_MSG_TelemetryHeader_t         TelemetryHeader; /**< \brief Telemetry header */
     CFE_TBL_HousekeepingTlm_Payload_t Payload;         /**< \brief Telemetry payload */
 } CFE_TBL_HousekeepingTlm_t;
-
-/**
-**  \cfetbltlm Table Registry Info Packet
-**/
-typedef struct CFE_TBL_TblRegPacket_Payload
-{
-    CFE_ES_MemOffset_t Size;                       /**< \cfetlmmnemonic \TBL_SIZE
-                                                        \brief Size, in bytes, of Table */
-    uint32 Crc;                                    /**< \cfetlmmnemonic \TBL_CRC
-                                                        \brief Most recently calculated CRC of Table */
-    CFE_ES_MemAddress_t ActiveBufferAddr;          /**< \cfetlmmnemonic \TBL_ACTBUFADD
-                                                        \brief Address of Active Buffer */
-    CFE_ES_MemAddress_t InactiveBufferAddr;        /**< \cfetlmmnemonic \TBL_IACTBUFADD
-                                                        \brief Address of Inactive Buffer */
-    CFE_ES_MemAddress_t ValidationFuncPtr;         /**< \cfetlmmnemonic \TBL_VALFUNCPTR
-                                                        \brief Ptr to Owner App's function that validates tbl contents */
-    CFE_TIME_SysTime_t TimeOfLastUpdate;           /**< \cfetlmmnemonic \TBL_TIMELASTUPD
-                                                        \brief Time when Table was last updated */
-    uint32 FileCreateTimeSecs;                     /**< \cfetlmmnemonic \TBL_FILECSECONDS
-                                                        \brief File creation time from last file loaded into table */
-    uint32 FileCreateTimeSubSecs;                  /**< \cfetlmmnemonic \TBL_FILECSUBSECONDS
-                                                        \brief File creation time from last file loaded into table */
-    bool TableLoadedOnce;                          /**< \cfetlmmnemonic \TBL_LOADEDONCE
-                                                        \brief Flag indicating whether table has been loaded once or not */
-    bool LoadPending;                              /**< \cfetlmmnemonic \TBL_UPDATEPNDNG
-                                                        \brief Flag indicating an inactive buffer is ready to be copied */
-    bool DumpOnly;                                 /**< \cfetlmmnemonic \TBL_DUMPONLY
-                                                        \brief Flag indicating Table is NOT to be loaded */
-    bool DoubleBuffered;                           /**< \cfetlmmnemonic \TBL_DBLBUFFERED
-                                                     \brief Flag indicating Table has a dedicated inactive buffer */
-    char Name[CFE_MISSION_TBL_MAX_FULL_NAME_LEN];  /**< \cfetlmmnemonic \TBL_NAME
-                                                \brief Processor specific table name */
-    char LastFileLoaded[CFE_MISSION_MAX_PATH_LEN]; /**< \cfetlmmnemonic \TBL_LASTFILEUPD
-                                               \brief Filename of last file loaded into table */
-    char OwnerAppName[CFE_MISSION_MAX_API_LEN];    /**< \cfetlmmnemonic \TBL_OWNERAPP
-                                                \brief Name of owning application */
-    bool Critical;                                 /**< \cfetlmmnemonic \TBL_CRITICAL
-                                                        \brief Indicates whether table is Critical or not */
-    uint8 ByteAlign4;                              /**< \cfetlmmnemonic \TBL_SPARE4
-                                                        \brief Spare byte to maintain byte alignment */
-} CFE_TBL_TblRegPacket_Payload_t;
 
 typedef struct CFE_TBL_TableRegistryTlm
 {

--- a/modules/tbl/fsw/src/cfe_tbl_dispatch.c
+++ b/modules/tbl/fsw/src/cfe_tbl_dispatch.c
@@ -59,7 +59,7 @@ typedef struct
 
 const CFE_TBL_CmdHandlerTblRec_t CFE_TBL_CmdHandlerTbl[] = {
     /* SEND_HK Entry */
-    CFE_TBL_ENTRY(CFE_TBL_SEND_HK_MID, 0, CFE_TBL_NoArgsCmd_t, CFE_TBL_HousekeepingCmd, CFE_TBL_MSG_MSGTYPE),
+    CFE_TBL_ENTRY(CFE_TBL_SEND_HK_MID, 0, CFE_TBL_SendHkCmd_t, CFE_TBL_HousekeepingCmd, CFE_TBL_MSG_MSGTYPE),
 
     /* Everything else */
     CFE_TBL_ENTRY(CFE_TBL_CMD_MID, CFE_TBL_NOOP_CC, CFE_TBL_NoopCmd_t, CFE_TBL_NoopCmd, CFE_TBL_CMD_MSGTYPE),

--- a/modules/time/CMakeLists.txt
+++ b/modules/time/CMakeLists.txt
@@ -26,5 +26,15 @@ endif(ENABLE_UNIT_TESTS)
 
 cfs_app_check_intf(${DEP}
     cfe_time_eventids.h
+    cfe_time_extern_typedefs.h
+    cfe_time_fcncodes.h
+    cfe_time_interface_cfg.h
+    cfe_time_internal_cfg.h
+    cfe_time_mission_cfg.h
+    cfe_time_msgdefs.h
     cfe_time_msg.h
+    cfe_time_msgids.h
+    cfe_time_msgstruct.h
+    cfe_time_platform_cfg.h
+    cfe_time_topicids.h
 )

--- a/modules/time/config/default_cfe_time_msgdefs.h
+++ b/modules/time/config/default_cfe_time_msgdefs.h
@@ -26,6 +26,9 @@
 #ifndef CFE_TIME_MSGDEFS_H
 #define CFE_TIME_MSGDEFS_H
 
+#include "common_types.h"
+#include "cfe_mission_cfg.h"
+#include "cfe_time_extern_typedefs.h"
 #include "cfe_time_fcncodes.h"
 
 /** \defgroup CFETIMEClkStates cFE Clock State Flag Defines
@@ -46,5 +49,288 @@
     0x0010 /**< \brief GetReference read error, will be set if unable to get a consistent ref value */
 #define CFE_TIME_FLAG_UNUSED 0x000F /**< \brief Reserved flags - should be zero */
 /** \} */
+
+/**
+ * \brief Set leap seconds command payload
+ */
+typedef struct CFE_TIME_LeapsCmd_Payload
+{
+    int16 LeapSeconds;
+} CFE_TIME_LeapsCmd_Payload_t;
+
+/**
+ * \brief Set clock state command payload
+ */
+typedef struct CFE_TIME_StateCmd_Payload
+{
+    CFE_TIME_ClockState_Enum_t ClockState; /**< \brief #CFE_TIME_ClockState_INVALID=Spacecraft time has
+                                  not been accurately set, #CFE_TIME_ClockState_VALID=Spacecraft clock
+                                  has been accurately set, #CFE_TIME_ClockState_FLYWHEEL=Force into
+                                  FLYWHEEL mode   */
+                                           /**< Selects the current clock state */
+} CFE_TIME_StateCmd_Payload_t;
+
+/**
+ * \brief Set time data source command payload
+ */
+typedef struct CFE_TIME_SourceCmd_Payload
+{
+    int16 TimeSource; /**< \brief #CFE_TIME_SourceSelect_INTERNAL=Internal Source,
+                                  #CFE_TIME_SourceSelect_EXTERNAL=External Source   */
+                      /**< Selects either the "Internal" and "External" clock source */
+} CFE_TIME_SourceCmd_Payload_t;
+
+/**
+ * \brief Set tone signal source command payload
+ */
+typedef struct CFE_TIME_SignalCmd_Payload
+{
+    int16 ToneSource; /**< \brief #CFE_TIME_ToneSignalSelect_PRIMARY=Primary Source,
+                                  #CFE_TIME_ToneSignalSelect_REDUNDANT=Redundant Source   */
+                      /**< Selects either the "Primary" or "Redundant" tone signal source */
+} CFE_TIME_SignalCmd_Payload_t;
+
+/**
+ * \brief Generic seconds, microseconds command payload
+ */
+typedef struct CFE_TIME_TimeCmd_Payload
+{
+    uint32 Seconds;
+    uint32 MicroSeconds;
+} CFE_TIME_TimeCmd_Payload_t;
+
+/**
+ * \brief Generic seconds, subseconds command payload
+ */
+typedef struct CFE_TIME_OneHzAdjustmentCmd_Payload
+{
+    uint32 Seconds;
+    uint32 Subseconds;
+} CFE_TIME_OneHzAdjustmentCmd_Payload_t;
+
+/**
+ * \brief Time at tone data command payload
+ */
+typedef struct CFE_TIME_ToneDataCmd_Payload
+{
+    CFE_TIME_SysTime_t         AtToneMET;         /**< \brief MET at time of tone */
+    CFE_TIME_SysTime_t         AtToneSTCF;        /**< \brief STCF at time of tone */
+    int16                      AtToneLeapSeconds; /**< \brief Leap Seconds at time of tone */
+    CFE_TIME_ClockState_Enum_t AtToneState;       /**< \brief Clock state at time of tone */
+} CFE_TIME_ToneDataCmd_Payload_t;
+
+/*************************************************************************/
+
+/**
+**  \cfetimetlm Time Services Housekeeping Packet
+**/
+typedef struct CFE_TIME_HousekeepingTlm_Payload
+{
+    /*
+    ** Task command interface counters...
+    */
+    uint8 CommandCounter;      /**< \cfetlmmnemonic \TIME_CMDPC
+                                \brief Time Command Execution Counter */
+    uint8 CommandErrorCounter; /**< \cfetlmmnemonic \TIME_CMDEC
+                           \brief Time Command Error Counter */
+
+    /*
+    ** Clock state flags and "as calculated" clock state...
+    */
+    uint16 ClockStateFlags;                   /**< \cfetlmmnemonic \TIME_STATEFLG
+                                                   \brief State Flags */
+    CFE_TIME_ClockState_Enum_t ClockStateAPI; /**< \cfetlmmnemonic
+                              \TIME_APISTATE \brief API State */
+
+    /*
+    ** Leap Seconds...
+    */
+    int16 LeapSeconds; /**< \cfetlmmnemonic \TIME_LEAPSECS
+                            \brief Current Leaps Seconds */
+
+    /*
+    ** Current MET and STCF time values...
+    */
+    uint32 SecondsMET; /**< \cfetlmmnemonic \TIME_METSECS
+                            \brief Current MET (seconds) */
+    uint32 SubsecsMET; /**< \cfetlmmnemonic \TIME_METSUBSECS
+                            \brief Current MET (sub-seconds) */
+
+    uint32 SecondsSTCF; /**< \cfetlmmnemonic \TIME_STCFSECS
+                             \brief Current STCF (seconds) */
+    uint32 SubsecsSTCF; /**< \cfetlmmnemonic \TIME_STCFSUBSECS
+                             \brief Current STCF (sub-seconds) */
+
+/*
+** 1Hz STCF adjustment values (server only)...
+*/
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+    uint32 Seconds1HzAdj; /**< \cfetlmmnemonic \TIME_1HZADJSECS
+                               \brief Current 1 Hz SCTF adjustment (seconds) */
+    uint32 Subsecs1HzAdj; /**< \cfetlmmnemonic \TIME_1HZADJSSECS
+                               \brief Current 1 Hz SCTF adjustment (sub-seconds) */
+#endif
+
+/*
+** Time at tone delay values (client only)...
+*/
+#if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
+    uint32 SecondsDelay; /**< \cfetlmmnemonic \TIME_1HZDLYSECS
+                              \brief Current 1 Hz SCTF Delay (seconds) */
+    uint32 SubsecsDelay; /**< \cfetlmmnemonic \TIME_1HZDLYSSECS
+                              \brief Current 1 Hz SCTF Delay (sub-seconds) */
+#endif
+} CFE_TIME_HousekeepingTlm_Payload_t;
+
+/*************************************************************************/
+
+/**
+**  \cfetimetlm Time Services Diagnostics Packet
+**/
+typedef struct CFE_TIME_DiagnosticTlm_Payload
+{
+    /*
+     ** Data values used to compute time (in reference to "tone")...
+     */
+    CFE_TIME_SysTime_t AtToneMET;   /**< \cfetlmmnemonic \TIME_TMETS
+                                               \brief MET at time of tone */
+    CFE_TIME_SysTime_t AtToneSTCF;  /**< \cfetlmmnemonic \TIME_STCFS
+                                               \brief STCF at time of tone */
+    CFE_TIME_SysTime_t AtToneDelay; /**< \cfetlmmnemonic \TIME_LATENTS
+                                               \brief Adjustment for slow tone detection */
+    CFE_TIME_SysTime_t AtToneLatch; /**< \cfetlmmnemonic \TIME_TVALIDS
+                                               \brief Local clock latched at time of tone */
+
+    int16 AtToneLeapSeconds;                  /**< \cfetlmmnemonic \TIME_LEAPS
+                                                   \brief Leap Seconds at time of tone */
+    CFE_TIME_ClockState_Enum_t ClockStateAPI; /**< \cfetlmmnemonic \TIME_APISTATE
+                                    \brief Clock state as per API */
+
+    /*
+     ** Data values that reflect the time (right now)...
+     */
+    CFE_TIME_SysTime_t TimeSinceTone; /**< \cfetlmmnemonic \TIME_ELAPSEDS
+                                                 \brief Time elapsed since the tone */
+    CFE_TIME_SysTime_t CurrentLatch;  /**< \cfetlmmnemonic \TIME_LOCALS
+                                                 \brief Local clock latched just "now" */
+    CFE_TIME_SysTime_t CurrentMET;    /**< \cfetlmmnemonic \TIME_METS
+                                                 \brief MET at this instant */
+    CFE_TIME_SysTime_t CurrentTAI;    /**< \cfetlmmnemonic \TIME_TAIS
+                                                 \brief TAI at this instant */
+    CFE_TIME_SysTime_t CurrentUTC;    /**< \cfetlmmnemonic \TIME_UTCS
+                                                 \brief UTC at this instant */
+
+    /*
+     ** Data values used to define the current clock state...
+     */
+    int16 ClockSetState;  /**< \cfetlmmnemonic \TIME_VALID
+                                     \brief Time has been "set" */
+    int16 ClockFlyState;  /**< \cfetlmmnemonic \TIME_FLYWHEEL
+                                     \brief Current fly-wheel state */
+    int16 ClockSource;    /**< \cfetlmmnemonic \TIME_SOURCE
+                                     \brief Internal vs external, etc. */
+    int16 ClockSignal;    /**< \cfetlmmnemonic \TIME_SIGNAL
+                                     \brief Primary vs redundant, etc. */
+    int16 ServerFlyState; /**< \cfetlmmnemonic \TIME_SRVFLY
+                                     \brief Used by clients only */
+    int16 Forced2Fly;     /**< \cfetlmmnemonic \TIME_CMD2FLY
+                                     \brief Commanded into fly-wheel */
+
+    /*
+     ** Clock state flags...
+     */
+    uint16 ClockStateFlags; /**< \cfetlmmnemonic \TIME_STATEFLAGS
+                                       \brief Clock State Flags */
+
+    /*
+     ** STCF adjustment direction values...
+     */
+    int16 OneTimeDirection; /**< \cfetlmmnemonic \TIME_ADJUSTDIR
+                                       \brief One time STCF adjustment direction (Add = 1,  Sub = 2) */
+    int16 OneHzDirection;   /**< \cfetlmmnemonic \TIME_1HZADJDIR
+                                       \brief 1Hz STCF adjustment direction */
+    int16 DelayDirection;   /**< \cfetlmmnemonic \TIME_LATENTDIR
+                                       \brief Client latency adjustment direction */
+
+    /*
+     ** STCF adjustment values...
+     */
+    CFE_TIME_SysTime_t OneTimeAdjust; /**< \cfetlmmnemonic \TIME_ADJUSTS
+                                                 \brief Previous one-time STCF adjustment */
+    CFE_TIME_SysTime_t OneHzAdjust;   /**< \cfetlmmnemonic \TIME_1HZADJS
+                                                 \brief Current 1Hz STCF adjustment */
+
+    /*
+     ** Most recent local clock latch values...
+     */
+    CFE_TIME_SysTime_t ToneSignalLatch; /**< \cfetlmmnemonic \TIME_TTS
+                                                   \brief  Local Clock latched at most recent tone signal */
+    CFE_TIME_SysTime_t ToneDataLatch;   /**< \cfetlmmnemonic \TIME_TDS
+                                                   \brief  Local Clock latched at arrival of tone data */
+
+    /*
+     ** Miscellaneous counters (subject to reset command)...
+     */
+    uint32 ToneMatchCounter;      /**< \cfetlmmnemonic \TIME_VERIFYCNT
+                                           \brief  Tone signal / data verification count */
+    uint32 ToneMatchErrorCounter; /**< \cfetlmmnemonic \TIME_VERIFYER
+                                       \brief  Tone signal / data verification error count */
+    uint32 ToneSignalCounter;     /**< \cfetlmmnemonic \TIME_TSDETCNT
+                                           \brief  Tone signal detected SB message count */
+    uint32 ToneDataCounter;       /**< \cfetlmmnemonic \TIME_TATTCNT
+                                           \brief  Time at the tone data SB message count */
+    uint32 ToneIntCounter;        /**< \cfetlmmnemonic \TIME_TSISRCNT
+                                           \brief  Tone signal ISR execution count */
+    uint32 ToneIntErrorCounter;   /**< \cfetlmmnemonic \TIME_TSISRERR
+                                       \brief  Tone signal ISR error count */
+    uint32 ToneTaskCounter;       /**< \cfetlmmnemonic \TIME_TSTASKCNT
+                                           \brief  Tone task execution count */
+    uint32 VersionCounter;        /**< \cfetlmmnemonic \TIME_VERSIONCNT
+                                           \brief  Count of mods to time at tone reference data (version) */
+    uint32 LocalIntCounter;       /**< \cfetlmmnemonic \TIME_1HZISRCNT
+                                           \brief  Local 1Hz ISR execution count */
+    uint32 LocalTaskCounter;      /**< \cfetlmmnemonic \TIME_1HZTASKCNT
+                                           \brief  Local 1Hz task execution count */
+
+    /*
+     ** Miscellaneous counters (not subject to reset command)...
+     */
+    uint32 VirtualMET; /**< \cfetlmmnemonic \TIME_LOGICALMET
+                                  \brief  Software MET */
+
+    /*
+     ** Time window verification values (converted from micro-secs)...
+     **
+     ** Regardless of whether the tone follows the time packet, or vice
+     **    versa, these values define the acceptable window of time for
+     **    the second event to follow the first.  The minimum value may
+     **    be as little as zero, and the maximum must be something less
+     **    than a second.
+     */
+    uint32 MinElapsed; /**< \cfetlmmnemonic \TIME_MINWINDOW
+                                  \brief Min tone signal / data pkt arrival window (Sub-seconds) */
+    uint32 MaxElapsed; /**< \cfetlmmnemonic \TIME_MAXWINDOW
+                                  \brief Max tone signal / data pkt arrival window (Sub-seconds) */
+
+    /*
+     ** Maximum local clock value (before roll-over)...
+     */
+    CFE_TIME_SysTime_t MaxLocalClock; /**< \cfetlmmnemonic \TIME_WRAPS
+                                                 \brief Max local clock value before rollover */
+
+    /*
+     ** Tone signal tolerance limits...
+     */
+    uint32 ToneOverLimit;  /**< \cfetlmmnemonic \TIME_MAXSS
+                                      \brief Max between tone signal interrupts */
+    uint32 ToneUnderLimit; /**< \cfetlmmnemonic \TIME_MINSS
+                                      \brief Min between tone signal interrupts */
+
+    /*
+     ** Reset Area...
+     */
+    uint32 DataStoreStatus; /**< \cfetlmmnemonic \TIME_ATASTSTAT
+                                       \brief Data Store status (preserved across processor reset) */
+} CFE_TIME_DiagnosticTlm_Payload_t;
 
 #endif

--- a/modules/time/config/default_cfe_time_msgstruct.h
+++ b/modules/time/config/default_cfe_time_msgstruct.h
@@ -35,37 +35,48 @@
 /************************************************************************
  * Includes
  ************************************************************************/
-#include "cfe_mission_cfg.h"
+#include "cfe_time_msgdefs.h"
 #include "cfe_msg_hdr.h"
-
-/**
- * \brief Generic no argument command
- */
-typedef struct CFE_TIME_NoArgsCmd
-{
-    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
-} CFE_TIME_NoArgsCmd_t;
 
 /*
  * A separate typedef for each of the commands that share this definition
  * This follows the convention for command handler prototypes and allows
  * each one to independently evolve as necessary.
  */
-typedef CFE_TIME_NoArgsCmd_t CFE_TIME_NoopCmd_t;
-typedef CFE_TIME_NoArgsCmd_t CFE_TIME_ResetCountersCmd_t;
-typedef CFE_TIME_NoArgsCmd_t CFE_TIME_SendDiagnosticCmd_t;
-typedef CFE_TIME_NoArgsCmd_t CFE_TIME_1HzCmd_t;
-typedef CFE_TIME_NoArgsCmd_t CFE_TIME_ToneSignalCmd_t;
-typedef CFE_TIME_NoArgsCmd_t CFE_TIME_FakeToneCmd_t;
-typedef CFE_TIME_NoArgsCmd_t CFE_TIME_SendHkCmd_t;
-
-/**
- * \brief Set leap seconds command payload
- */
-typedef struct CFE_TIME_LeapsCmd_Payload
+typedef struct CFE_TIME_NoopCmd
 {
-    int16 LeapSeconds;
-} CFE_TIME_LeapsCmd_Payload_t;
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CFE_TIME_NoopCmd_t;
+
+typedef struct CFE_TIME_ResetCountersCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CFE_TIME_ResetCountersCmd_t;
+
+typedef struct CFE_TIME_SendDiagnosticCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CFE_TIME_SendDiagnosticCmd_t;
+
+typedef struct CFE_TIME_1HzCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CFE_TIME_1HzCmd_t;
+
+typedef struct CFE_TIME_ToneSignalCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CFE_TIME_ToneSignalCmd_t;
+
+typedef struct CFE_TIME_FakeToneCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CFE_TIME_FakeToneCmd_t;
+
+typedef struct CFE_TIME_SendHkCmd
+{
+    CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
+} CFE_TIME_SendHkCmd_t;
 
 /**
  * \brief Set leap seconds command
@@ -77,18 +88,6 @@ typedef struct CFE_TIME_SetLeapSecondsCmd
 } CFE_TIME_SetLeapSecondsCmd_t;
 
 /**
- * \brief Set clock state command payload
- */
-typedef struct CFE_TIME_StateCmd_Payload
-{
-    CFE_TIME_ClockState_Enum_t ClockState; /**< \brief #CFE_TIME_ClockState_INVALID=Spacecraft time has
-                                  not been accurately set, #CFE_TIME_ClockState_VALID=Spacecraft clock
-                                  has been accurately set, #CFE_TIME_ClockState_FLYWHEEL=Force into
-                                  FLYWHEEL mode   */
-                                           /**< Selects the current clock state */
-} CFE_TIME_StateCmd_Payload_t;
-
-/**
  * \brief Set clock state command
  */
 typedef struct CFE_TIME_SetStateCmd
@@ -96,16 +95,6 @@ typedef struct CFE_TIME_SetStateCmd
     CFE_MSG_CommandHeader_t     CommandHeader; /**< \brief Command header */
     CFE_TIME_StateCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_TIME_SetStateCmd_t;
-
-/**
- * \brief Set time data source command payload
- */
-typedef struct CFE_TIME_SourceCmd_Payload
-{
-    int16 TimeSource; /**< \brief #CFE_TIME_SourceSelect_INTERNAL=Internal Source,
-                                  #CFE_TIME_SourceSelect_EXTERNAL=External Source   */
-                      /**< Selects either the "Internal" and "External" clock source */
-} CFE_TIME_SourceCmd_Payload_t;
 
 /**
  * \brief Set time data source command
@@ -117,16 +106,6 @@ typedef struct CFE_TIME_SetSourceCmd
 } CFE_TIME_SetSourceCmd_t;
 
 /**
- * \brief Set tone signal source command payload
- */
-typedef struct CFE_TIME_SignalCmd_Payload
-{
-    int16 ToneSource; /**< \brief #CFE_TIME_ToneSignalSelect_PRIMARY=Primary Source,
-                                  #CFE_TIME_ToneSignalSelect_REDUNDANT=Redundant Source   */
-                      /**< Selects either the "Primary" or "Redundant" tone signal source */
-} CFE_TIME_SignalCmd_Payload_t;
-
-/**
  * \brief Set tone signal source command
  */
 typedef struct CFE_TIME_SetSignalCmd
@@ -135,73 +114,69 @@ typedef struct CFE_TIME_SetSignalCmd
     CFE_TIME_SignalCmd_Payload_t Payload;       /**< \brief Command payload */
 } CFE_TIME_SetSignalCmd_t;
 
-/**
- * \brief Generic seconds, microseconds command payload
+/*
+ * A separate typedef for each of the commands that share this definition
+ * This follows the convention for command handler prototypes and allows
+ * each one to independently evolve as necessary.
  */
-typedef struct CFE_TIME_TimeCmd_Payload
-{
-    uint32 Seconds;
-    uint32 MicroSeconds;
-} CFE_TIME_TimeCmd_Payload_t;
-
-/**
- * \brief Generic seconds, microseconds argument command
- */
-typedef struct CFE_TIME_TimeCmd
+typedef struct CFE_TIME_AddDelayCmd
 {
     CFE_MSG_CommandHeader_t    CommandHeader; /**< \brief Command header */
     CFE_TIME_TimeCmd_Payload_t Payload;       /**< \brief Command payload */
-} CFE_TIME_TimeCmd_t;
+} CFE_TIME_AddDelayCmd_t;
+
+typedef struct CFE_TIME_SubDelayCmd
+{
+    CFE_MSG_CommandHeader_t    CommandHeader; /**< \brief Command header */
+    CFE_TIME_TimeCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_TIME_SubDelayCmd_t;
+
+typedef struct CFE_TIME_SetMETCmd
+{
+    CFE_MSG_CommandHeader_t    CommandHeader; /**< \brief Command header */
+    CFE_TIME_TimeCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_TIME_SetMETCmd_t;
+
+typedef struct CFE_TIME_SetSTCFCmd
+{
+    CFE_MSG_CommandHeader_t    CommandHeader; /**< \brief Command header */
+    CFE_TIME_TimeCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_TIME_SetSTCFCmd_t;
+
+typedef struct CFE_TIME_AddAdjustCmd
+{
+    CFE_MSG_CommandHeader_t    CommandHeader; /**< \brief Command header */
+    CFE_TIME_TimeCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_TIME_AddAdjustCmd_t;
+
+typedef struct CFE_TIME_SubAdjustCmd
+{
+    CFE_MSG_CommandHeader_t    CommandHeader; /**< \brief Command header */
+    CFE_TIME_TimeCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_TIME_SubAdjustCmd_t;
+
+typedef struct CFE_TIME_SetTimeCmd
+{
+    CFE_MSG_CommandHeader_t    CommandHeader; /**< \brief Command header */
+    CFE_TIME_TimeCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_TIME_SetTimeCmd_t;
 
 /*
  * A separate typedef for each of the commands that share this definition
  * This follows the convention for command handler prototypes and allows
  * each one to independently evolve as necessary.
  */
-typedef CFE_TIME_TimeCmd_t CFE_TIME_AddDelayCmd_t;
-typedef CFE_TIME_TimeCmd_t CFE_TIME_SubDelayCmd_t;
-typedef CFE_TIME_TimeCmd_t CFE_TIME_SetMETCmd_t;
-typedef CFE_TIME_TimeCmd_t CFE_TIME_SetSTCFCmd_t;
-typedef CFE_TIME_TimeCmd_t CFE_TIME_AddAdjustCmd_t;
-typedef CFE_TIME_TimeCmd_t CFE_TIME_SubAdjustCmd_t;
-typedef CFE_TIME_TimeCmd_t CFE_TIME_SetTimeCmd_t;
-
-/**
- * \brief Generic seconds, subseconds command payload
- */
-typedef struct CFE_TIME_OneHzAdjustmentCmd_Payload
-{
-    uint32 Seconds;
-    uint32 Subseconds;
-} CFE_TIME_OneHzAdjustmentCmd_Payload_t;
-
-/**
- * \brief Generic seconds, subseconds adjustment command
- */
-typedef struct CFE_TIME_OneHzAdjustmentCmd
+typedef struct CFE_TIME_Add1HZAdjustmentCmd
 {
     CFE_MSG_CommandHeader_t               CommandHeader; /**< \brief Command header */
     CFE_TIME_OneHzAdjustmentCmd_Payload_t Payload;       /**< \brief Command payload */
-} CFE_TIME_OneHzAdjustmentCmd_t;
+} CFE_TIME_Add1HZAdjustmentCmd_t;
 
-/*
- * A separate typedef for each of the commands that share this definition
- * This follows the convention for command handler prototypes and allows
- * each one to independently evolve as necessary.
- */
-typedef CFE_TIME_OneHzAdjustmentCmd_t CFE_TIME_Add1HZAdjustmentCmd_t;
-typedef CFE_TIME_OneHzAdjustmentCmd_t CFE_TIME_Sub1HZAdjustmentCmd_t;
-
-/**
- * \brief Time at tone data command payload
- */
-typedef struct CFE_TIME_ToneDataCmd_Payload
+typedef struct CFE_TIME_Sub1HZAdjustmentCmd
 {
-    CFE_TIME_SysTime_t         AtToneMET;         /**< \brief MET at time of tone */
-    CFE_TIME_SysTime_t         AtToneSTCF;        /**< \brief STCF at time of tone */
-    int16                      AtToneLeapSeconds; /**< \brief Leap Seconds at time of tone */
-    CFE_TIME_ClockState_Enum_t AtToneState;       /**< \brief Clock state at time of tone */
-} CFE_TIME_ToneDataCmd_Payload_t;
+    CFE_MSG_CommandHeader_t               CommandHeader; /**< \brief Command header */
+    CFE_TIME_OneHzAdjustmentCmd_Payload_t Payload;       /**< \brief Command payload */
+} CFE_TIME_Sub1HZAdjustmentCmd_t;
 
 /**
  * \brief Time at tone data command
@@ -214,223 +189,11 @@ typedef struct CFE_TIME_ToneDataCmd
 
 /*************************************************************************/
 
-/**
-**  \cfetimetlm Time Services Housekeeping Packet
-**/
-typedef struct CFE_TIME_HousekeepingTlm_Payload
-{
-    /*
-    ** Task command interface counters...
-    */
-    uint8 CommandCounter;      /**< \cfetlmmnemonic \TIME_CMDPC
-                                \brief Time Command Execution Counter */
-    uint8 CommandErrorCounter; /**< \cfetlmmnemonic \TIME_CMDEC
-                           \brief Time Command Error Counter */
-
-    /*
-    ** Clock state flags and "as calculated" clock state...
-    */
-    uint16 ClockStateFlags;                   /**< \cfetlmmnemonic \TIME_STATEFLG
-                                                   \brief State Flags */
-    CFE_TIME_ClockState_Enum_t ClockStateAPI; /**< \cfetlmmnemonic
-                              \TIME_APISTATE \brief API State */
-
-    /*
-    ** Leap Seconds...
-    */
-    int16 LeapSeconds; /**< \cfetlmmnemonic \TIME_LEAPSECS
-                            \brief Current Leaps Seconds */
-
-    /*
-    ** Current MET and STCF time values...
-    */
-    uint32 SecondsMET; /**< \cfetlmmnemonic \TIME_METSECS
-                            \brief Current MET (seconds) */
-    uint32 SubsecsMET; /**< \cfetlmmnemonic \TIME_METSUBSECS
-                            \brief Current MET (sub-seconds) */
-
-    uint32 SecondsSTCF; /**< \cfetlmmnemonic \TIME_STCFSECS
-                             \brief Current STCF (seconds) */
-    uint32 SubsecsSTCF; /**< \cfetlmmnemonic \TIME_STCFSUBSECS
-                             \brief Current STCF (sub-seconds) */
-
-/*
-** 1Hz STCF adjustment values (server only)...
-*/
-#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
-    uint32 Seconds1HzAdj; /**< \cfetlmmnemonic \TIME_1HZADJSECS
-                               \brief Current 1 Hz SCTF adjustment (seconds) */
-    uint32 Subsecs1HzAdj; /**< \cfetlmmnemonic \TIME_1HZADJSSECS
-                               \brief Current 1 Hz SCTF adjustment (sub-seconds) */
-#endif
-
-/*
-** Time at tone delay values (client only)...
-*/
-#if (CFE_PLATFORM_TIME_CFG_CLIENT == true)
-    uint32 SecondsDelay; /**< \cfetlmmnemonic \TIME_1HZDLYSECS
-                              \brief Current 1 Hz SCTF Delay (seconds) */
-    uint32 SubsecsDelay; /**< \cfetlmmnemonic \TIME_1HZDLYSSECS
-                              \brief Current 1 Hz SCTF Delay (sub-seconds) */
-#endif
-} CFE_TIME_HousekeepingTlm_Payload_t;
-
 typedef struct CFE_TIME_HousekeepingTlm
 {
     CFE_MSG_TelemetryHeader_t          TelemetryHeader; /**< \brief Telemetry header */
     CFE_TIME_HousekeepingTlm_Payload_t Payload;         /**< \brief Telemetry payload */
 } CFE_TIME_HousekeepingTlm_t;
-
-/*************************************************************************/
-
-/**
-**  \cfetimetlm Time Services Diagnostics Packet
-**/
-typedef struct CFE_TIME_DiagnosticTlm_Payload
-{
-    /*
-     ** Data values used to compute time (in reference to "tone")...
-     */
-    CFE_TIME_SysTime_t AtToneMET;   /**< \cfetlmmnemonic \TIME_TMETS
-                                               \brief MET at time of tone */
-    CFE_TIME_SysTime_t AtToneSTCF;  /**< \cfetlmmnemonic \TIME_STCFS
-                                               \brief STCF at time of tone */
-    CFE_TIME_SysTime_t AtToneDelay; /**< \cfetlmmnemonic \TIME_LATENTS
-                                               \brief Adjustment for slow tone detection */
-    CFE_TIME_SysTime_t AtToneLatch; /**< \cfetlmmnemonic \TIME_TVALIDS
-                                               \brief Local clock latched at time of tone */
-
-    int16 AtToneLeapSeconds;                  /**< \cfetlmmnemonic \TIME_LEAPS
-                                                   \brief Leap Seconds at time of tone */
-    CFE_TIME_ClockState_Enum_t ClockStateAPI; /**< \cfetlmmnemonic \TIME_APISTATE
-                                    \brief Clock state as per API */
-
-    /*
-     ** Data values that reflect the time (right now)...
-     */
-    CFE_TIME_SysTime_t TimeSinceTone; /**< \cfetlmmnemonic \TIME_ELAPSEDS
-                                                 \brief Time elapsed since the tone */
-    CFE_TIME_SysTime_t CurrentLatch;  /**< \cfetlmmnemonic \TIME_LOCALS
-                                                 \brief Local clock latched just "now" */
-    CFE_TIME_SysTime_t CurrentMET;    /**< \cfetlmmnemonic \TIME_METS
-                                                 \brief MET at this instant */
-    CFE_TIME_SysTime_t CurrentTAI;    /**< \cfetlmmnemonic \TIME_TAIS
-                                                 \brief TAI at this instant */
-    CFE_TIME_SysTime_t CurrentUTC;    /**< \cfetlmmnemonic \TIME_UTCS
-                                                 \brief UTC at this instant */
-
-    /*
-     ** Data values used to define the current clock state...
-     */
-    int16 ClockSetState;  /**< \cfetlmmnemonic \TIME_VALID
-                                     \brief Time has been "set" */
-    int16 ClockFlyState;  /**< \cfetlmmnemonic \TIME_FLYWHEEL
-                                     \brief Current fly-wheel state */
-    int16 ClockSource;    /**< \cfetlmmnemonic \TIME_SOURCE
-                                     \brief Internal vs external, etc. */
-    int16 ClockSignal;    /**< \cfetlmmnemonic \TIME_SIGNAL
-                                     \brief Primary vs redundant, etc. */
-    int16 ServerFlyState; /**< \cfetlmmnemonic \TIME_SRVFLY
-                                     \brief Used by clients only */
-    int16 Forced2Fly;     /**< \cfetlmmnemonic \TIME_CMD2FLY
-                                     \brief Commanded into fly-wheel */
-
-    /*
-     ** Clock state flags...
-     */
-    uint16 ClockStateFlags; /**< \cfetlmmnemonic \TIME_STATEFLAGS
-                                       \brief Clock State Flags */
-
-    /*
-     ** STCF adjustment direction values...
-     */
-    int16 OneTimeDirection; /**< \cfetlmmnemonic \TIME_ADJUSTDIR
-                                       \brief One time STCF adjustment direction (Add = 1,  Sub = 2) */
-    int16 OneHzDirection;   /**< \cfetlmmnemonic \TIME_1HZADJDIR
-                                       \brief 1Hz STCF adjustment direction */
-    int16 DelayDirection;   /**< \cfetlmmnemonic \TIME_LATENTDIR
-                                       \brief Client latency adjustment direction */
-
-    /*
-     ** STCF adjustment values...
-     */
-    CFE_TIME_SysTime_t OneTimeAdjust; /**< \cfetlmmnemonic \TIME_ADJUSTS
-                                                 \brief Previous one-time STCF adjustment */
-    CFE_TIME_SysTime_t OneHzAdjust;   /**< \cfetlmmnemonic \TIME_1HZADJS
-                                                 \brief Current 1Hz STCF adjustment */
-
-    /*
-     ** Most recent local clock latch values...
-     */
-    CFE_TIME_SysTime_t ToneSignalLatch; /**< \cfetlmmnemonic \TIME_TTS
-                                                   \brief  Local Clock latched at most recent tone signal */
-    CFE_TIME_SysTime_t ToneDataLatch;   /**< \cfetlmmnemonic \TIME_TDS
-                                                   \brief  Local Clock latched at arrival of tone data */
-
-    /*
-     ** Miscellaneous counters (subject to reset command)...
-     */
-    uint32 ToneMatchCounter;      /**< \cfetlmmnemonic \TIME_VERIFYCNT
-                                           \brief  Tone signal / data verification count */
-    uint32 ToneMatchErrorCounter; /**< \cfetlmmnemonic \TIME_VERIFYER
-                                       \brief  Tone signal / data verification error count */
-    uint32 ToneSignalCounter;     /**< \cfetlmmnemonic \TIME_TSDETCNT
-                                           \brief  Tone signal detected SB message count */
-    uint32 ToneDataCounter;       /**< \cfetlmmnemonic \TIME_TATTCNT
-                                           \brief  Time at the tone data SB message count */
-    uint32 ToneIntCounter;        /**< \cfetlmmnemonic \TIME_TSISRCNT
-                                           \brief  Tone signal ISR execution count */
-    uint32 ToneIntErrorCounter;   /**< \cfetlmmnemonic \TIME_TSISRERR
-                                       \brief  Tone signal ISR error count */
-    uint32 ToneTaskCounter;       /**< \cfetlmmnemonic \TIME_TSTASKCNT
-                                           \brief  Tone task execution count */
-    uint32 VersionCounter;        /**< \cfetlmmnemonic \TIME_VERSIONCNT
-                                           \brief  Count of mods to time at tone reference data (version) */
-    uint32 LocalIntCounter;       /**< \cfetlmmnemonic \TIME_1HZISRCNT
-                                           \brief  Local 1Hz ISR execution count */
-    uint32 LocalTaskCounter;      /**< \cfetlmmnemonic \TIME_1HZTASKCNT
-                                           \brief  Local 1Hz task execution count */
-
-    /*
-     ** Miscellaneous counters (not subject to reset command)...
-     */
-    uint32 VirtualMET; /**< \cfetlmmnemonic \TIME_LOGICALMET
-                                  \brief  Software MET */
-
-    /*
-     ** Time window verification values (converted from micro-secs)...
-     **
-     ** Regardless of whether the tone follows the time packet, or vice
-     **    versa, these values define the acceptable window of time for
-     **    the second event to follow the first.  The minimum value may
-     **    be as little as zero, and the maximum must be something less
-     **    than a second.
-     */
-    uint32 MinElapsed; /**< \cfetlmmnemonic \TIME_MINWINDOW
-                                  \brief Min tone signal / data pkt arrival window (Sub-seconds) */
-    uint32 MaxElapsed; /**< \cfetlmmnemonic \TIME_MAXWINDOW
-                                  \brief Max tone signal / data pkt arrival window (Sub-seconds) */
-
-    /*
-     ** Maximum local clock value (before roll-over)...
-     */
-    CFE_TIME_SysTime_t MaxLocalClock; /**< \cfetlmmnemonic \TIME_WRAPS
-                                                 \brief Max local clock value before rollover */
-
-    /*
-     ** Tone signal tolerance limits...
-     */
-    uint32 ToneOverLimit;  /**< \cfetlmmnemonic \TIME_MAXSS
-                                      \brief Max between tone signal interrupts */
-    uint32 ToneUnderLimit; /**< \cfetlmmnemonic \TIME_MINSS
-                                      \brief Min between tone signal interrupts */
-
-    /*
-     ** Reset Area...
-     */
-    uint32 DataStoreStatus; /**< \cfetlmmnemonic \TIME_ATASTSTAT
-                                       \brief Data Store status (preserved across processor reset) */
-} CFE_TIME_DiagnosticTlm_Payload_t;
 
 typedef struct CFE_TIME_DiagnosticTlm
 {


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Puts the message encapsulation in a separate header from the message payload.  Also puts all headers into the "header-check" target as there were some inclusion dependencies noted.

Fixes #2451

**Testing performed**
Build and run all tests

**Expected behavior changes**
None

**System(s) tested on**
Debian

**Additional context**
This is primarily to improve maintainability and resolve inclusion issues in _other_ modules

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
