### PR TITLE
Fix #1502, Correct type of ActiveTableFlag variable

### DIFF
--- a/modules/tbl/config/default_cfe_tbl_msgdefs.h
+++ b/modules/tbl/config/default_cfe_tbl_msgdefs.h
@@ -54,8 +54,8 @@ typedef struct CFE_TBL_LoadCmd_Payload
 */
 typedef struct CFE_TBL_DumpCmd_Payload
 {
-    uint16 ActiveTableFlag;                            /**< \brief #CFE_TBL_BufferSelect_INACTIVE=Inactive Table,
-                                                                 #CFE_TBL_BufferSelect_ACTIVE=Active Table */
+    CFE_TBL_BufferSelect_Enum_t ActiveTableFlag;       /**< \brief #CFE_TBL_BufferSelect_INACTIVE=Inactive Table,
+                                                            #CFE_TBL_BufferSelect_ACTIVE=Active Table */
                                                        /**< Selects either the "Inactive"
                                                             (#CFE_TBL_BufferSelect_INACTIVE) buffer or the
                                                             "Active" (#CFE_TBL_BufferSelect_ACTIVE) buffer
@@ -75,8 +75,8 @@ typedef struct CFE_TBL_DumpCmd_Payload
 */
 typedef struct CFE_TBL_ValidateCmd_Payload
 {
-    uint16 ActiveTableFlag;                            /**< \brief #CFE_TBL_BufferSelect_INACTIVE=Inactive Table,
-                                                                 #CFE_TBL_BufferSelect_ACTIVE=Active Table */
+    CFE_TBL_BufferSelect_Enum_t ActiveTableFlag;       /**< \brief #CFE_TBL_BufferSelect_INACTIVE=Inactive Table,
+                                                            #CFE_TBL_BufferSelect_ACTIVE=Active Table */
                                                        /**< Selects either the "Inactive"
                                                             (#CFE_TBL_BufferSelect_INACTIVE) buffer or the
                                                             "Active" (#CFE_TBL_BufferSelect_ACTIVE) buffer


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1502
  - `ActiveTableFlag` has been converted from `uint16` to what it was intended to be typed as, namely a `CFE_TBL_BufferSelect_Enum_t` type (which is actually just a `typedef`'d alias for `uint16` anyway).

**Testing performed**
GitHub CI actions (incl. Build + Run, Unit Tests etc.) all passing successfully.

**Expected behavior changes**
No impact on behavior.

**Contributor Info**
Avi @thnkslprpt