### PR TITLE
Fix #2447, updating cFE to use new versioning system.

### DIFF
--- a/modules/config/fsw/src/cfe_config_get.c
+++ b/modules/config/fsw/src/cfe_config_get.c
@@ -29,8 +29,10 @@
 */
 #include "cfe_config_priv.h"
 #include "cfe_config_map.h"
+#include "cfe_version.h"
 
 #include <string.h>
+#include <stdio.h>
 
 /*----------------------------------------------------------------
  *
@@ -158,4 +160,18 @@ void CFE_Config_IterateAll(void *Arg, CFE_Config_Callback_t Callback)
         }
         ++NamePtr;
     }
+}
+
+/*----------------------------------------------------------------
+ *
+ * Defined per public API
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void CFE_Config_GetVersionString(char *Buf, size_t Size, const char *Component,
+  const char *SrcVersion, const char *CodeName, const char *LastOffcRel)
+{
+    snprintf(Buf, Size, "%s %s %s (Codename %s), Last Official Release: %s %s)",
+        Component, CFE_REVISION == 0 ? "Development Build" : "Release", SrcVersion,
+        CodeName, Component, LastOffcRel);
 }

--- a/modules/config/fsw/src/cfe_config_init.c
+++ b/modules/config/fsw/src/cfe_config_init.c
@@ -170,6 +170,7 @@ void CFE_Config_SetupModuleVersions(CFE_ConfigName_t *ModuleListSet[], size_t Se
 void CFE_Config_SetupBasicBuildInfo(void)
 {
     const char *KeyVal;
+    char       VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
 
     /* Global mission name */
     CFE_Config_SetString(CFE_CONFIGID_MISSION_NAME, GLOBAL_CONFIGDATA.MissionName);
@@ -184,7 +185,9 @@ void CFE_Config_SetupBasicBuildInfo(void)
     CFE_Config_SetValue(CFE_CONFIGID_CORE_VERSION_BUILDNUM, CFE_BUILD_NUMBER);
 
     CFE_Config_SetString(CFE_CONFIGID_CORE_VERSION_BASELINE, CFE_BUILD_BASELINE);
-    CFE_Config_SetString(CFE_CONFIGID_CORE_VERSION_DESCRIPTION, CFE_VERSION_STRING);
+    CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE",
+        CFE_SRC_VERSION, CFE_BUILD_CODENAME, CFE_LAST_OFFICIAL);
+    CFE_Config_SetString(CFE_CONFIGID_CORE_VERSION_DESCRIPTION, VersionString);
 
     /*
      * Initialize values from the "target_config" CFE internal object

--- a/modules/core_api/fsw/inc/cfe_config.h
+++ b/modules/core_api/fsw/inc/cfe_config.h
@@ -119,4 +119,26 @@ CFE_ConfigId_t CFE_Config_GetIdByName(const char *Name);
  */
 void CFE_Config_IterateAll(void *Arg, CFE_Config_Callback_t Callback);
 
+/**
+ * @brief Obtain the version string for a cFS component or app
+ *
+ * Assembles a standardized version string associated with the specified
+ * component/app.
+ *
+ * @param[in]   Buf         Buffer to place version string in. Will be populated
+ *                          with standard version string containing the provided
+                            parameters (i.e.:
+ *                          "cFE DEVELOPMENT BUILD equuleus-rc1+dev0 (Codename
+                            equueleus), Last Official Release: cFE 6.7.0"
+ * @param[in]   Size        Size of the provided buffer
+ * @param[in]   Component   Component for which to get version string
+ *                          (i.e. "cFE")
+ * @param[in]   SrcVersion  Source version identifier (i.e. "equuleus-rc1+dev0")
+ * @param[in]   CodeName    Code name for the build (i.e. "equuleus")
+ * @param[in]   LastOffcRel Last official release (i.e. "6.7.0")
+ */
+void CFE_Config_GetVersionString(char *Buf, size_t Size,
+  const char *Component, const char *SrcVersion,
+  const char *CodeName, const char *LastOffcRel);
+
 #endif /* CFE_CONFIG_H */

--- a/modules/core_api/fsw/inc/cfe_version.h
+++ b/modules/core_api/fsw/inc/cfe_version.h
@@ -27,12 +27,19 @@
 
 /* Development Build Macro Definitions */
 #define CFE_BUILD_NUMBER   434 /**< @brief Development: Number of development git commits since CFE_BUILD_BASELINE */
-#define CFE_BUILD_BASELINE "v7.0.0-rc4" /**< @brief Development: Reference git tag for build number */
+#define CFE_BUILD_BASELINE "equuleus-rc1" /**< @brief Development: Reference git tag for build number */
+#define CFE_BUILD_DEV_CYCLE 	"equuleus-rc2" /**< @brief Development: Release name for current development cycle */
+#define CFE_BUILD_CODENAME      "Equuleus" /**< @brief: Development: Code name for the current build */
 
 /* See \ref cfsversions for definitions */
 #define CFE_MAJOR_VERSION 6  /*!< @brief Major version number */
 #define CFE_MINOR_VERSION 7  /*!< @brief Minor version number */
-#define CFE_REVISION      99 /*!< @brief Revision version number. Value of 99 indicates a development version.*/
+#define CFE_REVISION      0  /*!< @brief Revision version number. Value of 0 indicates a development version.*/
+
+/**
+ * @brief Last official release.
+ */
+#define CFE_LAST_OFFICIAL "v6.7.0"
 
 /*!
  * @brief Mission revision.
@@ -55,12 +62,10 @@
 #define CFE_SRC_VERSION CFE_BUILD_BASELINE "+dev" CFE_STR(CFE_BUILD_NUMBER)
 
 /**
- * @brief Long Build Version String
- *
- * Long freeform string identifying the build, see @ref cfsversions for suggested format for development
- * and official releases.
+ * @brief Max Version String length.
+ * 
+ * Maximum length that a cFE version string can be.
  */
-#define CFE_VERSION_STRING \
-    " cFE DEVELOPMENT BUILD " CFE_SRC_VERSION " (Codename: Draco), Last Official Release: cfe v6.7.0"
+#define CFE_CFG_MAX_VERSION_STR_LEN 256
 
 #endif /* CFE_VERSION_H */

--- a/modules/core_api/ut-stubs/src/cfe_config_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_config_stubs.c
@@ -110,6 +110,23 @@ uint32 CFE_Config_GetValue(CFE_ConfigId_t ConfigId)
 
 /*
  * ----------------------------------------------------
+ * Generated stub function for CFE_Config_GetVersionString()
+ * ----------------------------------------------------
+ */
+void CFE_Config_GetVersionString(char *Buf, size_t Size, const char *Component, const char *SrcVersion, const char *CodeName, const char *LastOffcRel)
+{
+    UT_GenStub_AddParam(CFE_Config_GetVersionString, char *, Buf);
+    UT_GenStub_AddParam(CFE_Config_GetVersionString, size_t , Size);
+    UT_GenStub_AddParam(CFE_Config_GetVersionString, const char *, Component);
+    UT_GenStub_AddParam(CFE_Config_GetVersionString, const char *, SrcVersion);
+    UT_GenStub_AddParam(CFE_Config_GetVersionString, const char *, CodeName);
+    UT_GenStub_AddParam(CFE_Config_GetVersionString, const char *, LastOffcRel);
+
+    UT_GenStub_Execute(CFE_Config_GetVersionString, Basic, NULL);
+}
+
+/*
+ * ----------------------------------------------------
  * Generated stub function for CFE_Config_IterateAll()
  * ----------------------------------------------------
  */

--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -277,6 +277,7 @@ int32 CFE_ES_TaskInit(void)
     uint32  SizeofCfeSegment;
     cpuaddr CfeSegmentAddr;
     uint8   VersionNumber[4];
+    char    VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
 
     /*
     ** Initialize task command execution counters
@@ -394,8 +395,10 @@ int32 CFE_ES_TaskInit(void)
     /*
     ** Task startup event message.
     */
+    CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE",
+        CFE_SRC_VERSION, CFE_BUILD_CODENAME, CFE_LAST_OFFICIAL);
     Status = CFE_EVS_SendEvent(CFE_ES_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "cFE ES Initialized: %s",
-                               CFE_VERSION_STRING);
+                               VersionString);
     if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s: Error sending init event:RC=0x%08X\n", __func__, (unsigned int)Status);

--- a/modules/evs/fsw/src/cfe_evs_task.c
+++ b/modules/evs/fsw/src/cfe_evs_task.c
@@ -30,6 +30,7 @@
 /* Include Files */
 #include "cfe_evs_module_all.h" /* All EVS internal definitions and API */
 #include "cfe_version.h"        /* cFE version definitions */
+#include "cfe_config.h"         /* For version string construction */
 #include "cfe_evs_verify.h"
 
 #include <string.h>
@@ -260,6 +261,7 @@ int32 CFE_EVS_TaskInit(void)
 {
     int32          Status;
     CFE_ES_AppId_t AppID;
+    char           VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
 
     /* Query and verify the AppID */
     Status = CFE_ES_GetAppID(&AppID);
@@ -302,7 +304,9 @@ int32 CFE_EVS_TaskInit(void)
 
     /* Write the AppID to the global location, now that the rest of initialization is done */
     CFE_EVS_Global.EVS_AppID = AppID;
-    EVS_SendEvent(CFE_EVS_STARTUP_EID, CFE_EVS_EventType_INFORMATION, "cFE EVS Initialized: %s", CFE_VERSION_STRING);
+    CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE",
+        CFE_SRC_VERSION, CFE_BUILD_CODENAME, CFE_LAST_OFFICIAL);
+    EVS_SendEvent(CFE_EVS_STARTUP_EID, CFE_EVS_EventType_INFORMATION, "cFE EVS Initialized: %s", VersionString);
 
     return CFE_SUCCESS;
 }
@@ -315,7 +319,10 @@ int32 CFE_EVS_TaskInit(void)
  *-----------------------------------------------------------------*/
 int32 CFE_EVS_NoopCmd(const CFE_EVS_NoopCmd_t *data)
 {
-    EVS_SendEvent(CFE_EVS_NOOP_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", CFE_VERSION_STRING);
+    char VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
+    CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE",
+        CFE_SRC_VERSION, CFE_BUILD_CODENAME, CFE_LAST_OFFICIAL);
+    EVS_SendEvent(CFE_EVS_NOOP_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", VersionString);
     return CFE_SUCCESS;
 }
 

--- a/modules/sb/fsw/src/cfe_sb_task.c
+++ b/modules/sb/fsw/src/cfe_sb_task.c
@@ -30,6 +30,7 @@
 
 #include "cfe_sb_module_all.h"
 #include "cfe_version.h"
+#include "cfe_config.h" /* For version string construction */
 #include "cfe_es_msg.h" /* needed for local use of CFE_ES_RestartCmd_t */
 #include "cfe_sb_verify.h"
 
@@ -119,6 +120,7 @@ int32 CFE_SB_AppInit(void)
     uint32              CfgFileEventsToFilter = 0;
     CFE_ES_MemPoolBuf_t TmpPtr;
     int32               Status;
+    char                VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
 
     /* Get the assigned Application ID for the SB Task */
     CFE_ES_GetAppID(&CFE_SB_Global.AppId);
@@ -266,8 +268,10 @@ int32 CFE_SB_AppInit(void)
         return Status;
     }
 
+    CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE",
+        CFE_SRC_VERSION, CFE_BUILD_CODENAME, CFE_LAST_OFFICIAL);
     Status =
-        CFE_EVS_SendEvent(CFE_SB_INIT_EID, CFE_EVS_EventType_INFORMATION, "cFE SB Initialized: %s", CFE_VERSION_STRING);
+        CFE_EVS_SendEvent(CFE_SB_INIT_EID, CFE_EVS_EventType_INFORMATION, "cFE SB Initialized: %s", VersionString);
     if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s: Error sending init event:RC=0x%08X\n", __func__, (unsigned int)Status);
@@ -285,7 +289,10 @@ int32 CFE_SB_AppInit(void)
  *-----------------------------------------------------------------*/
 int32 CFE_SB_NoopCmd(const CFE_SB_NoopCmd_t *data)
 {
-    CFE_EVS_SendEvent(CFE_SB_CMD0_RCVD_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", CFE_VERSION_STRING);
+    char VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
+    CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE",
+        CFE_SRC_VERSION, CFE_BUILD_CODENAME, CFE_LAST_OFFICIAL);
+    CFE_EVS_SendEvent(CFE_SB_CMD0_RCVD_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", VersionString);
     CFE_SB_Global.HKTlmMsg.Payload.CommandCounter++;
 
     return CFE_SUCCESS;

--- a/modules/tbl/fsw/src/cfe_tbl_task.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task.c
@@ -32,6 +32,7 @@
 */
 #include "cfe_tbl_module_all.h"
 #include "cfe_version.h"
+#include "cfe_config.h" /* For version string construction */
 #include "cfe_tbl_verify.h"
 
 #include <string.h>
@@ -110,6 +111,7 @@ void CFE_TBL_TaskMain(void)
 int32 CFE_TBL_TaskInit(void)
 {
     int32 Status;
+    char  VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
 
     /*
     ** Initialize global Table Services data
@@ -162,8 +164,10 @@ int32 CFE_TBL_TaskInit(void)
     /*
     ** Task startup event message
     */
+    CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE",
+        CFE_SRC_VERSION, CFE_BUILD_CODENAME, CFE_LAST_OFFICIAL);
     Status = CFE_EVS_SendEvent(CFE_TBL_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "cFE TBL Initialized: %s",
-                               CFE_VERSION_STRING);
+                               VersionString);
 
     if (Status != CFE_SUCCESS)
     {

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
@@ -32,6 +32,7 @@
 */
 #include "cfe_tbl_module_all.h"
 #include "cfe_version.h"
+#include "cfe_config.h" /* For version string construction */
 
 #include <string.h>
 
@@ -310,8 +311,12 @@ void CFE_TBL_GetTblRegData(void)
  *-----------------------------------------------------------------*/
 int32 CFE_TBL_NoopCmd(const CFE_TBL_NoopCmd_t *data)
 {
+    char VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
+
     /* Acknowledge receipt of NOOP with Event Message */
-    CFE_EVS_SendEvent(CFE_TBL_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", CFE_VERSION_STRING);
+    CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE",
+        CFE_SRC_VERSION, CFE_BUILD_CODENAME, CFE_LAST_OFFICIAL);
+    CFE_EVS_SendEvent(CFE_TBL_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", VersionString);
 
     return CFE_TBL_INC_CMD_CTR;
 }

--- a/modules/time/fsw/src/cfe_time_task.c
+++ b/modules/time/fsw/src/cfe_time_task.c
@@ -32,6 +32,7 @@
 */
 #include "cfe_time_module_all.h"
 #include "cfe_version.h"
+#include "cfe_config.h" /* For version string construction */
 #include "cfe_time_verify.h"
 
 /*
@@ -127,6 +128,7 @@ int32 CFE_TIME_TaskInit(void)
     int32     OsStatus;
     osal_id_t TimeBaseId;
     osal_id_t TimerId;
+    char      VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
 
     Status = CFE_EVS_Register(NULL, 0, 0);
     if (Status != CFE_SUCCESS)
@@ -259,8 +261,10 @@ int32 CFE_TIME_TaskInit(void)
         return Status;
     }
 
+    CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE",
+        CFE_SRC_VERSION, CFE_BUILD_CODENAME, CFE_LAST_OFFICIAL);
     Status = CFE_EVS_SendEvent(CFE_TIME_INIT_EID, CFE_EVS_EventType_INFORMATION, "cFE TIME Initialized: %s",
-                               CFE_VERSION_STRING);
+                               VersionString);
     if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s: Error sending init event:RC=0x%08X\n", __func__, (unsigned int)Status);
@@ -443,9 +447,13 @@ int32 CFE_TIME_ToneSendCmd(const CFE_TIME_FakeToneCmd_t *data)
  *-----------------------------------------------------------------*/
 int32 CFE_TIME_NoopCmd(const CFE_TIME_NoopCmd_t *data)
 {
+    char VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
+
     CFE_TIME_Global.CommandCounter++;
 
-    CFE_EVS_SendEvent(CFE_TIME_NOOP_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", CFE_VERSION_STRING);
+    CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE",
+        CFE_SRC_VERSION, CFE_BUILD_CODENAME, CFE_LAST_OFFICIAL);
+    CFE_EVS_SendEvent(CFE_TIME_NOOP_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", VersionString);
 
     return CFE_SUCCESS;
 }


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #2447.

**Testing performed**
Workflows were run.

**Expected behavior changes**
No behavior changes, however the following changes were made to the versioning system:
1. Build Baseline is set to "equuleus-rc1"
2. Mission Revision is set to to 00
3. "CFE_BUILD_DEV_CYCLE" macro has been defined
4. Version String has been removed, and all references to it replaced with the Build Baseline/Codename

**System(s) tested on**
Ubuntu 20.04

**Contributor Info - All information REQUIRED for consideration of pull request**
Dylan Z. Baker/NASA GSFC
