### PR TITLE
Fix #2469, change workflow to use output on failure option

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -83,18 +83,18 @@ jobs:
       - name: Test
         run: |
           lcov --capture --initial --directory build --output-file coverage_base.info
-          make -C build/native/default_cpu1/config test
-          make -C build/native/default_cpu1/core_api test
-          make -C build/native/default_cpu1/core_private test
-          make -C build/native/default_cpu1/es test
-          make -C build/native/default_cpu1/evs test
-          make -C build/native/default_cpu1/fs test
-          make -C build/native/default_cpu1/msg test
-          make -C build/native/default_cpu1/resourceid test
-          make -C build/native/default_cpu1/sb test
-          make -C build/native/default_cpu1/sbr test
-          make -C build/native/default_cpu1/tbl test
-          make -C build/native/default_cpu1/time test
+          (cd build/native/default_cpu1/config && ctest --output-on-failure)
+          (cd build/native/default_cpu1/core_api && ctest --output-on-failure)
+          (cd build/native/default_cpu1/core_private && ctest --output-on-failure)
+          (cd build/native/default_cpu1/es && ctest --output-on-failure)
+          (cd build/native/default_cpu1/evs && ctest --output-on-failure)
+          (cd build/native/default_cpu1/fs && ctest --output-on-failure)
+          (cd build/native/default_cpu1/msg && ctest --output-on-failure)
+          (cd build/native/default_cpu1/resourceid && ctest --output-on-failure)
+          (cd build/native/default_cpu1/sb && ctest --output-on-failure)
+          (cd build/native/default_cpu1/sbr && ctest --output-on-failure)
+          (cd build/native/default_cpu1/tbl && ctest --output-on-failure)
+          (cd build/native/default_cpu1/time && ctest --output-on-failure)
 
       - name: Calculate Coverage
         run: |


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Instead of using "make test" target, call ctest directly and pass the --output-on-failure option. If a test fails, then the workflow log will contain the details of the test

Fixes #2469

**Testing performed**
Run workflows

**Expected behavior changes**
If a test fails, then the entire test log is shown in the workflow log

**System(s) tested on**
Github

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
