### PR TITLE
Fix #2478, Add missing `default`/`break` to `switch` statements

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   codeql:
     uses: nasa/cFS/.github/workflows/codeql-reusable.yml@main
-    with: 
+    with:
       component-path: cfe
       make: make -j8
       test: true

--- a/.github/workflows/icbundle.yml
+++ b/.github/workflows/icbundle.yml
@@ -59,7 +59,7 @@ jobs:
           done
           changelog_entry="${changelog_entry}\n${see_entry}\n"
           sed -ir "s|# Changelog|$changelog_entry|" CHANGELOG.md
-          
+
           buildnumber_entry=$'#define CFE_BUILD_NUMBER   '${rev_num}$' /**< @brief Development: Number of development git commits since CFE_BUILD_BASELINE */'
           sed -ir "s|#define CFE_BUILD_NUMBER.*|$buildnumber_entry|" modules/core_api/fsw/inc/cfe_version.h
       - name: Commit and Push Updates to IC Branch

--- a/docs/cFS_IdentifierNamingConvention.md
+++ b/docs/cFS_IdentifierNamingConvention.md
@@ -247,7 +247,7 @@ Common command/event descriptions include:
 | `LEN_ERR`      | Incorrect Message Length                 | Error         |
 | `CC_ERR`       | Invalid Command Code Received            | Error         |
 | `NOOP_INF`     | No-op Command Success                    | Informational |
-| `INIT_INF`     | Applicaiton Initialization Success       | Informational |
+| `INIT_INF`     | Application Initialization Success       | Informational |
 | `RESET_INF`    | Reset Command Counters Command Success   | Informational |
 
 # Appendix: Abbreviation Guide

--- a/modules/cfe_assert/src/cfe_assert_runner.c
+++ b/modules/cfe_assert/src/cfe_assert_runner.c
@@ -138,7 +138,7 @@ bool CFE_Assert_Status_DeferredCheck(CFE_Status_t Status, UtAssert_CaseType_t Ca
         }
         else
         {
-            /* if condition was false add an exta marker so user does not necessarily need to decode the string */
+            /* if condition was false add an extra marker so user does not necessarily need to decode the string */
             ExtraTag = " [false]";
         }
 

--- a/modules/cfe_testcase/src/cfe_test.c
+++ b/modules/cfe_testcase/src/cfe_test.c
@@ -58,7 +58,7 @@ void CFE_TestMain(void)
      * Register test cases in UtAssert
      */
     ESApplicationControlTestSetup();
-    ESBehaviorestSetup();
+    ESBehaviorTestSetup();
     ESCDSTestSetup();
     ESCounterTestSetup();
     ESErrorTestSetup();

--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -72,7 +72,7 @@ void TimeInRange(CFE_TIME_SysTime_t Start, CFE_TIME_SysTime_t Time, CFE_TIME_Sys
 
 void CFE_TestMain(void);
 void ESApplicationControlTestSetup(void);
-void ESBehaviorestSetup(void);
+void ESBehaviorTestSetup(void);
 void ESCDSTestSetup(void);
 void ESCounterTestSetup(void);
 void ESErrorTestSetup(void);

--- a/modules/cfe_testcase/src/es_behavior_test.c
+++ b/modules/cfe_testcase/src/es_behavior_test.c
@@ -82,7 +82,7 @@ void TestWaitBehavior(void)
     UtAssert_UINT32_EQ(CFE_TIME_Compare(TimePassed, TimeExpected), CFE_TIME_A_LT_B);
 }
 
-void ESBehaviorestSetup(void)
+void ESBehaviorTestSetup(void)
 {
     UtTest_Add(TestRunCounter, NULL, NULL, "Test Run Counter");
     UtTest_Add(TestWaitBehavior, NULL, NULL, "Test Wait Behavior");

--- a/modules/cfe_testcase/src/sb_pipe_mang_test.c
+++ b/modules/cfe_testcase/src/sb_pipe_mang_test.c
@@ -74,7 +74,7 @@ void TestPipeCreateMax(void)
          * Normally, this will return CFE_SUCCESS, until the max number of pipes is reached.
          * Confirm that the last creation attempt returned CFE_SB_MAX_PIPES_MET
          *
-         * NOTE: this also mimics the same format as UtAssert_INT32_EQ so that any post-procesing
+         * NOTE: this also mimics the same format as UtAssert_INT32_EQ so that any post-processing
          * test log analysis tools will see this call as well.
          */
         if (CFE_Assert_STATUS_MAY_BE(CFE_SB_MAX_PIPES_MET))

--- a/modules/cfe_testcase/tables/cfe_test_tbl.c
+++ b/modules/cfe_testcase/tables/cfe_test_tbl.c
@@ -30,7 +30,7 @@
 
 /*
  * The test table data should contain some identifiable numeric values,
- * so any issues with paritial loading/byteswapping are morely likely
+ * so any issues with partial loading/byteswapping are more likely
  * to be detected.
  */
 CFE_TEST_TestTable_t TestTable = {0xf007, 0xba11};

--- a/modules/core_api/config/default_cfe_core_api_interface_cfg.h
+++ b/modules/core_api/config/default_cfe_core_api_interface_cfg.h
@@ -129,4 +129,4 @@
 */
 #define CFE_MISSION_MAX_NUM_FILES 50
 
-#endif /* SAMPLE_MISSION_CFG_H */
+#endif /* CFE_CORE_API_INTERFACE_CFG_H */

--- a/modules/core_private/ut-stubs/inc/ut_support.h
+++ b/modules/core_private/ut-stubs/inc/ut_support.h
@@ -96,7 +96,7 @@ extern const char *UT_OSP_MESSAGES[];
  */
 #define UT_LITTLE_ENDIAN 1
 #define UT_BIG_ENDIAN    2
-extern uint8 UT_Endianess;
+extern uint8 UT_Endianness;
 
 typedef struct
 {

--- a/modules/core_private/ut-stubs/src/ut_support.c
+++ b/modules/core_private/ut-stubs/src/ut_support.c
@@ -38,7 +38,7 @@
 /*
 ** Global variables
 */
-uint8 UT_Endianess;
+uint8 UT_Endianness;
 
 static char           UT_appname[80];
 static char           UT_subsys[5];
@@ -110,11 +110,11 @@ void UT_Init(const char *subsys)
 
     if ((*(char *)&EndianCheck) == 0x04)
     {
-        UT_Endianess = UT_LITTLE_ENDIAN;
+        UT_Endianness = UT_LITTLE_ENDIAN;
     }
     else
     {
-        UT_Endianess = UT_BIG_ENDIAN;
+        UT_Endianness = UT_BIG_ENDIAN;
     }
 }
 

--- a/modules/es/fsw/src/cfe_es_erlog.c
+++ b/modules/es/fsw/src/cfe_es_erlog.c
@@ -295,7 +295,7 @@ bool CFE_ES_RunExceptionScan(uint32 ElapsedTime, void *Arg)
     if (PspStatus != CFE_PSP_SUCCESS)
     {
         /* reason string is not available - populate with something for the PspStatus*/
-        snprintf(ReasonString, sizeof(ReasonString), "Unknown - CFE_PSP_ExceptionGetSummary() error %ld",
+        snprintf(ReasonString, sizeof(ReasonString), "Unknown - CFE_PSP_Exception_GetSummary() error %ld",
                  (long)PspStatus);
         PspContextId    = 0;
         ExceptionTaskID = OS_OBJECT_ID_UNDEFINED;

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -4241,7 +4241,7 @@ void TestAPI(void)
     AppId = CFE_ES_AppRecordGetID(UtAppRecPtr);
     CFE_UtAssert_SUCCESS(CFE_ES_GetAppName(AppName, AppId, sizeof(AppName)));
 
-    /* Bad arguement calls */
+    /* Bad argument calls */
     UtAssert_INT32_EQ(CFE_ES_GetAppName(NULL, AppId, sizeof(AppName)), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetAppName(AppName, AppId, 0), CFE_ES_BAD_ARGUMENT);
 

--- a/modules/evs/ut-coverage/evs_UT.c
+++ b/modules/evs/ut-coverage/evs_UT.c
@@ -160,7 +160,7 @@ void UT_InitData_EVS(void)
     UT_SetHandlerFunction(UT_KEY(CFE_MSG_GetMsgTime), UT_CFE_MSG_GetMsgTime_CustomHandler, NULL);
 }
 
-/* Message init hook to stora last MsgId passed in */
+/* Message init hook to store last MsgId passed in */
 static int32 UT_EVS_MSGInitHook(void *UserObj, int32 StubRetcode, uint32 CallCount, const UT_StubContext_t *Context)
 {
     UT_EVS_MSGInitData_t *msgdataptr = UserObj;

--- a/modules/fs/config/default_cfe_fs_filedef.h
+++ b/modules/fs/config/default_cfe_fs_filedef.h
@@ -195,4 +195,4 @@ typedef struct CFE_FS_Header
     char Description[CFE_FS_HDR_DESC_MAX_LEN]; /**< \brief File description */
 } CFE_FS_Header_t;
 
-#endif /* CFE_FS_EXTERN_TYPEDEFS_H */
+#endif /* CFE_FS_FILEHDR_H */

--- a/modules/msg/fsw/src/cfe_msg_ccsdspri.c
+++ b/modules/msg/fsw/src/cfe_msg_ccsdspri.c
@@ -262,6 +262,7 @@ CFE_Status_t CFE_MSG_GetSegmentationFlag(const CFE_MSG_Message_t *MsgPtr, CFE_MS
         case CFE_MSG_SEGFLG_UNSEG:
         default:
             *SegFlag = CFE_MSG_SegFlag_Unsegmented;
+            break;
     }
 
     return CFE_SUCCESS;
@@ -300,6 +301,7 @@ CFE_Status_t CFE_MSG_SetSegmentationFlag(CFE_MSG_Message_t *MsgPtr, CFE_MSG_Segm
         case CFE_MSG_SegFlag_Invalid:
         default:
             status = CFE_MSG_BAD_ARGUMENT;
+            break;
     }
 
     if (status == CFE_SUCCESS)

--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -1062,6 +1062,8 @@ int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_
         case CFE_SB_DUP_SUBSCRIP_EID:
             CFE_SB_Global.HKTlmMsg.Payload.DuplicateSubscriptionsCounter++;
             break;
+        default:
+            break;
     }
 
     CFE_SB_UnlockSharedData(__func__, __LINE__);

--- a/modules/sb/fsw/src/cfe_sb_task.c
+++ b/modules/sb/fsw/src/cfe_sb_task.c
@@ -442,6 +442,7 @@ int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data)
             CFE_EVS_SendEvent(CFE_SB_ENBL_RTE2_EID, CFE_EVS_EventType_DEBUG, "Enabling Route,Msg 0x%x,Pipe %lu",
                               (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(CmdPtr->Pipe));
             break;
+        // No default case - unreachable with current implementation
     }
 
     return CFE_SUCCESS;
@@ -509,6 +510,7 @@ int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data)
             CFE_EVS_SendEvent(CFE_SB_DSBL_RTE2_EID, CFE_EVS_EventType_DEBUG, "Route Disabled,Msg 0x%x,Pipe %lu",
                               (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(CmdPtr->Pipe));
             break;
+        // No default case - unreachable with current implementation
     }
 
     return CFE_SUCCESS;

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -1614,7 +1614,7 @@ void Test_SB_EarlyInit_NoErrors(void)
     CFE_SB_EarlyInit();
     CFE_UtAssert_SUCCESS(CFE_SB_EarlyInit());
 
-    /* Confirm reset of values to cover reset requirements that are challenging operationaly */
+    /* Confirm reset of values to cover reset requirements that are challenging operationally */
     UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.CommandErrorCounter);
     UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.NoSubscribersCounter);
     UtAssert_ZERO(CFE_SB_Global.HKTlmMsg.Payload.MsgSendErrorCounter);
@@ -4138,7 +4138,7 @@ static void SB_UT_PipeIdModifyHandler(void *UserObj, UT_EntryKey_t FuncKey, cons
     PipeDscPtr->PipeId = CFE_SB_INVALID_PIPE;
 }
 
-/* Special handler to hit OS_QueueGet error casses */
+/* Special handler to hit OS_QueueGet error cases */
 static void SB_UT_QueueGetHandler(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
 {
     size_t **data        = (size_t **)UT_Hook_GetArgValueByName(Context, "data", void *);
@@ -4792,14 +4792,14 @@ void Test_SB_SpecialCases(void)
 }
 
 /*
- * Test the use count rollover prevetion
+ * Test the use count rollover prevention
  */
 void Test_UseCount_Rollover_Prevention(void)
 {
     CFE_SB_BufferD_t bd;
     uint16           usecount_expected = 0x7FFF;
 
-    /* Note this is just for coverage, limit can not be reached in nomal ops (would be a bug) */
+    /* Note this is just for coverage, limit can not be reached in normal ops (would be a bug) */
     bd.UseCount = usecount_expected;
     UtAssert_VOIDCALL(CFE_SB_IncrBufUseCnt(&bd));
     UtAssert_UINT32_EQ(bd.UseCount, usecount_expected);

--- a/modules/tbl/fsw/src/cfe_tbl_api.c
+++ b/modules/tbl/fsw/src/cfe_tbl_api.c
@@ -492,6 +492,7 @@ CFE_Status_t CFE_TBL_Load(CFE_TBL_Handle_t TblHandle, CFE_TBL_SrcEnum_t SrcType,
                                        "%s: Attempted to load from illegal source type=%d", AppName, (int)SrcType);
 
             Status = CFE_TBL_ERR_ILLEGAL_SRC_TYPE;
+            break;
     }
 
     /* If the data was successfully loaded, then validate its contents */

--- a/modules/tbl/ut-coverage/tbl_UT.c
+++ b/modules/tbl/ut-coverage/tbl_UT.c
@@ -106,7 +106,7 @@ void UT_TBL_SetupHeader(CFE_TBL_File_Hdr_t *TblFileHeader, size_t Offset, size_t
     TblFileHeader->Offset   = Offset;
     TblFileHeader->NumBytes = NumBytes;
 
-    if (UT_Endianess == UT_LITTLE_ENDIAN)
+    if (UT_Endianness == UT_LITTLE_ENDIAN)
     {
         CFE_TBL_ByteSwapUint32(&TblFileHeader->Offset);
         CFE_TBL_ByteSwapUint32(&TblFileHeader->NumBytes);
@@ -1353,7 +1353,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_TBL_INC_ERR_CTR);
 
-    /* Test with interal CFE_TBL_GetWorkingBuffer error (memcpy with matching address */
+    /* Test with internal CFE_TBL_GetWorkingBuffer error (memcpy with matching address */
     UT_InitData();
     CFE_TBL_Global.Registry[0].LoadInProgress                                        = CFE_TBL_NO_LOAD_IN_PROGRESS;
     CFE_TBL_Global.Registry[0].TableLoadedOnce                                       = true;
@@ -2522,7 +2522,7 @@ void Test_CFE_TBL_ReleaseAddresses(void)
     File.TblHeader.TableName[sizeof(File.TblHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&File.TblHeader, 0, sizeof(UT_Table1_t));
 
-    if (UT_Endianess == UT_LITTLE_ENDIAN)
+    if (UT_Endianness == UT_LITTLE_ENDIAN)
     {
         File.TblData.TblElement1 = 0x04030201;
         File.TblData.TblElement2 = 0x08070605;
@@ -3131,7 +3131,7 @@ void Test_CFE_TBL_TblMod(void)
     File.TblHeader.TableName[sizeof(File.TblHeader.TableName) - 1] = '\0';
     UT_TBL_SetupHeader(&File.TblHeader, 0, sizeof(UT_Table1_t));
 
-    if (UT_Endianess == UT_LITTLE_ENDIAN)
+    if (UT_Endianness == UT_LITTLE_ENDIAN)
     {
         File.TblData.TblElement1 = 0x04030201;
         File.TblData.TblElement2 = 0x08070605;
@@ -3484,7 +3484,7 @@ void Test_CFE_TBL_Internal(void)
     TblFileHeader.NumBytes                                       = sizeof(UT_Table1_t) - 1;
     TblFileHeader.Offset                                         = 0;
 
-    if (UT_Endianess == UT_LITTLE_ENDIAN)
+    if (UT_Endianness == UT_LITTLE_ENDIAN)
     {
         CFE_TBL_ByteSwapUint32(&TblFileHeader.NumBytes);
         CFE_TBL_ByteSwapUint32(&TblFileHeader.Offset);
@@ -3967,7 +3967,7 @@ void Test_CFE_TBL_Internal(void)
     TblFileHeader.NumBytes                                       = sizeof(UT_Table1_t) - 1;
     TblFileHeader.Offset                                         = 0;
 
-    if (UT_Endianess == UT_LITTLE_ENDIAN)
+    if (UT_Endianness == UT_LITTLE_ENDIAN)
     {
         CFE_TBL_ByteSwapUint32(&TblFileHeader.NumBytes);
         CFE_TBL_ByteSwapUint32(&TblFileHeader.Offset);
@@ -3997,7 +3997,7 @@ void Test_CFE_TBL_Internal(void)
     TblFileHeader.NumBytes                                       = sizeof(UT_Table1_t) - 1;
     TblFileHeader.Offset                                         = 0;
 
-    if (UT_Endianess == UT_LITTLE_ENDIAN)
+    if (UT_Endianness == UT_LITTLE_ENDIAN)
     {
         CFE_TBL_ByteSwapUint32(&TblFileHeader.NumBytes);
         CFE_TBL_ByteSwapUint32(&TblFileHeader.Offset);


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe 2the contribution**
- Fixes #2478 
  - `switch` blocks that were missing `default` and/or `break` statements have been corrected
  - a few minor typo-type corrections were added in here as well

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).
Note: Most of the added `default` case lines are not tested (impossible to test given that all cases are handled explicitly) so the number of missed lines has grown larger.

**Expected behavior changes**
Effectively no change to current behavior.
Ensuring switch statements are well-formed is good defensive coding for future code changes and improves consistency across cFE.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt