### PR TITLE
Fix #2481, correct loop variable

### DIFF
--- a/cmake/arch_build.cmake
+++ b/cmake/arch_build.cmake
@@ -666,7 +666,7 @@ function(setup_platform_msgids)
       list(APPEND OUTPUT_VAR_LIST ${CFGSRC}_cfe_${DEP_NAME}_msgids)
     endforeach(DEP_NAME ${MISSION_CORE_MODULES})
 
-    foreach(DEP_NAME ${TGTSYS_${SYSVAR}_APPS} ${TGTSYS_${SYSVAR}_STATICAPPS})
+    foreach(DEP_NAME ${MISSION_APPS})
       string(TOUPPER "${DEP_NAME}_CFGFILE_SRC" CFGSRC)
       list(APPEND OUTPUT_VAR_LIST ${CFGSRC}_${DEP_NAME}_msgids)
     endforeach(DEP_NAME ${MISSION_APPS})


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
This CMake loop is supposed to run for every app.  Unfortunately at this point the SYSVAR is not yet defined, so the result is it does nothing and none of the overrides get configured.

With this loop, it should set up the override directive correctly.

Fixes #2481

**Testing performed**
Build with override msgids.h file

**Expected behavior changes**
Global msgids.h will be used by every app

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
