### PR TITLE
Fix #2493, Relative prefix exclusion for cfe implementation file search

### DIFF
--- a/cmake/global_functions.cmake
+++ b/cmake/global_functions.cmake
@@ -54,10 +54,13 @@ function(cfe_locate_implementation_file OUTPUT_VAR FILE_NAME)
   foreach(BASEDIR ${IMPL_SEARCH_BASEDIRS})
     list(APPEND IMPL_SEARCH_PATH "${BASEDIR}${FILE_NAME}")
 
+    # Get relative directory
+    string(REPLACE ${MISSION_SOURCE_DIR} "" RELATIVEDIR ${BASEDIR})
+
     # A target-specific prefixed filename gets priority over a direct filename match
-    # But do not include this variant if the prefix is already part of the basedir
+    # But do not include this variant if the prefix is already part of the relative search path 
     foreach (PREFIX ${LOCATEIMPL_ARG_PREFIX})
-      if (NOT "${BASEDIR}" MATCHES "/${PREFIX}/")
+      if (NOT "${RELATIVEDIR}" MATCHES "/${PREFIX}/")
         list(APPEND IMPL_SEARCH_PATH "${BASEDIR}${PREFIX}_${FILE_NAME}")
       endif()
     endforeach()


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #2493 

**Testing performed**
Standard build w/ setup described in https://github.com/nasa/cFS/issues/709, where bundle directory matches *_defs name

**Expected behavior changes**
Finds prefixed files as expected

**System(s) tested on**
 - Hardware: docker
 - OS: Ubuntu 22.04
 - Versions: Main bundle + this commit

**Additional context**
None

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC