### PR TITLE
Fix #2495, Remove superfluous status assignment in `CFE_SB_CreatePipe`

### DIFF
--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -161,12 +161,7 @@ CFE_Status_t CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16 Depth, const c
     {
         /* create the queue */
         OsStatus = OS_QueueCreate(&SysQueueId, PipeName, Depth, sizeof(CFE_SB_BufferD_t *), 0);
-        if (OsStatus == OS_SUCCESS)
-        {
-            /* just translate the RC to CFE */
-            Status = CFE_SUCCESS;
-        }
-        else
+        if (OsStatus != OS_SUCCESS)
         {
             if (OsStatus == OS_ERR_NAME_TAKEN)
             {


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2495
  - Removes the assignment of `Status` after successful return from `OS_QueueCreate()` (`Status` is already, and can only be, set to `CFE_SUCCESS` at this point in the logical flow).

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Behavior unchanged because this assignment was superfluous.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt