### PR TITLE
Fix #1543, Rename `CFE_TIME_QueryResetVars` to `CFE_TIME_RestoreFromTimeResetVars`

### DIFF
--- a/modules/time/fsw/src/cfe_time_utils.c
+++ b/modules/time/fsw/src/cfe_time_utils.c
@@ -104,7 +104,7 @@ CFE_TIME_SysTime_t CFE_TIME_LatchClock(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-void CFE_TIME_QueryResetVars(void)
+void CFE_TIME_RestoreFromTimeResetVars(void)
 {
     CFE_TIME_ResetVars_t                LocalResetVars;
     uint32                              DefSubsMET;
@@ -247,7 +247,7 @@ void CFE_TIME_InitData(void)
     /*
     ** Try to get values used to compute time from Reset Area...
     */
-    CFE_TIME_QueryResetVars();
+    CFE_TIME_RestoreFromTimeResetVars();
 
     RefState = CFE_TIME_StartReferenceUpdate();
 

--- a/modules/time/fsw/src/cfe_time_utils.h
+++ b/modules/time/fsw/src/cfe_time_utils.h
@@ -341,7 +341,7 @@ void CFE_TIME_InitData(void);
 /**
  * @brief query contents of Reset Variables
  */
-void CFE_TIME_QueryResetVars(void);
+void CFE_TIME_RestoreFromTimeResetVars(void);
 
 /*---------------------------------------------------------------------------------------*/
 /**

--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -1955,31 +1955,31 @@ void Test_ResetArea(void)
     /* Tests existing and good Reset Area */
     UT_InitData();
     UT_SetStatusBSPResetArea(OS_SUCCESS, CFE_TIME_RESET_SIGNATURE, CFE_TIME_ToneSignalSelect_PRIMARY);
-    CFE_TIME_QueryResetVars();
+    CFE_TIME_RestoreFromTimeResetVars();
     UtAssert_INT32_EQ(CFE_TIME_Global.DataStoreStatus, CFE_TIME_RESET_AREA_EXISTING);
 
     /* Tests existing and good Reset Area */
     UT_InitData();
     UT_SetStatusBSPResetArea(OS_SUCCESS, CFE_TIME_RESET_SIGNATURE, CFE_TIME_ToneSignalSelect_REDUNDANT);
-    CFE_TIME_QueryResetVars();
+    CFE_TIME_RestoreFromTimeResetVars();
     UtAssert_INT32_EQ(CFE_TIME_Global.DataStoreStatus, CFE_TIME_RESET_AREA_EXISTING);
 
     /* Test response to a bad reset area */
     UT_InitData();
     UT_SetStatusBSPResetArea(OS_ERROR, CFE_TIME_RESET_SIGNATURE, CFE_TIME_ToneSignalSelect_PRIMARY);
-    CFE_TIME_QueryResetVars();
+    CFE_TIME_RestoreFromTimeResetVars();
     UtAssert_INT32_EQ(CFE_TIME_Global.DataStoreStatus, CFE_TIME_RESET_AREA_BAD);
 
     /* Test initializing to default time values */
     UT_InitData();
     UT_SetStatusBSPResetArea(OS_SUCCESS, CFE_TIME_RESET_SIGNATURE + 1, CFE_TIME_ToneSignalSelect_PRIMARY);
-    CFE_TIME_QueryResetVars();
+    CFE_TIME_RestoreFromTimeResetVars();
     UtAssert_INT32_EQ(CFE_TIME_Global.DataStoreStatus, CFE_TIME_RESET_AREA_NEW);
 
     /* Test response to a bad clock signal selection parameter */
     UT_InitData();
     UT_SetStatusBSPResetArea(OS_SUCCESS, CFE_TIME_RESET_SIGNATURE, CFE_TIME_ToneSignalSelect_REDUNDANT + 1);
-    CFE_TIME_QueryResetVars();
+    CFE_TIME_RestoreFromTimeResetVars();
     UtAssert_INT32_EQ(CFE_TIME_Global.DataStoreStatus, CFE_TIME_RESET_AREA_NEW);
 
     /* Test response to a reset area error */


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1543
  - Rename `CFE_TIME_QueryResetVars` to `CFE_TIME_RestoreFromTimeResetVars` given that the function does not just 'query' the time variables, but rather it actually uses them to restore and set the `CFE_TIME_ReferenceState_t` members (or initialize from scratch if there is no valid reset data).

**Note:** Could also go with `CFE_TIME_RestoreFromResetVars` (not including the extra `Time` qualifier in the name) but that may be less clear given the current names of the reset variables:
https://github.com/nasa/cFE/blob/7f5ebcd15032fe31e7ef0e5ff4ef624d51d66e16/modules/core_private/fsw/inc/cfe_es_resetdata_typedef.h#L79-L88

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
No change.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt