### PR TITLE
Fix #1360, Limit HK Commands to 1 in pipe + replace hand-written function names with `__func__`

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,7 +10,7 @@ A clear and concise description of what the contribution is.
 **Testing performed**
 Steps taken to test the contribution:
 1. Build steps '...'
-1. Execution steps '...'
+2. Execution steps '...'
 
 **Expected behavior changes**
 A clear and concise description of how this contribution will change behavior and level of impact.

--- a/docs/cFE Application Developers Guide.md
+++ b/docs/cFE Application Developers Guide.md
@@ -1251,7 +1251,7 @@ with the allocated memory.
 The intention is for an Application to use a working copy of the CDS
 data during Application execution. Periodically, the Application is then
 responsible for calling `CFE_ES_CopyToCDS` API to copy the working image
-back into the CDS The cFE then computes a data integrity value for the
+back into the CDS. The cFE then computes a data integrity value for the
 block of data and stores it in the allocated CDS block. It should be
 noted that although the cFE will validate the integrity of the contents
 of the Application's CDS, the Application is responsible for determining

--- a/modules/core_private/ut-stubs/src/ut_osprintf_stubs.c
+++ b/modules/core_private/ut-stubs/src/ut_osprintf_stubs.c
@@ -79,7 +79,7 @@ const char *UT_OSP_MESSAGES[] = {
     [UT_OSP_APP_CREATE]                 = "%s: AppCreate Error: TaskCreate %s Failed. EC = %ld!\n",
     [UT_OSP_CREATE_VOLATILE]            = "%s: Error Creating Volatile(RAM) Volume. EC = %ld\n",
     [UT_OSP_MODULE_UNLOAD_FAILED]       = "%s: Failed to unload: %s. EC = %ld\n",
-    [UT_OSP_POR_COMMANDED]              = "%s: POWERON RESET called from CFE_ES_ResetCFE (Commanded).\n",
+    [UT_OSP_POR_COMMANDED]              = "POWERON RESET called from %s (Commanded).\n",
     [UT_OSP_REMOUNT_VOLATILE]           = "%s: Error Re-Mounting Volatile(RAM) Volume. EC = %ld\n",
     [UT_OSP_CORE_APP_EXIT]              = "%s: Cannot Exit CORE Application %s\n",
     [UT_OSP_ES_APP_STARTUP_OPEN]        = "%s: Opened ES App Startup file: %s\n",

--- a/modules/es/fsw/src/cfe_es_api.c
+++ b/modules/es/fsw/src/cfe_es_api.c
@@ -95,7 +95,7 @@ CFE_Status_t CFE_ES_ResetCFE(uint32 ResetType)
         }
         else
         {
-            CFE_ES_WriteToSysLog("%s: PROCESSOR RESET called from CFE_ES_ResetCFE (Commanded).\n", __func__);
+            CFE_ES_WriteToSysLog("PROCESSOR RESET called from %s (Commanded).\n", __func__);
 
             /*
             ** Update the reset variables
@@ -121,7 +121,7 @@ CFE_Status_t CFE_ES_ResetCFE(uint32 ResetType)
     }
     else if (ResetType == CFE_PSP_RST_TYPE_POWERON)
     {
-        CFE_ES_WriteToSysLog("%s: POWERON RESET called from CFE_ES_ResetCFE (Commanded).\n", __func__);
+        CFE_ES_WriteToSysLog("POWERON RESET called from %s (Commanded).\n", __func__);
 
         /*
         ** Log the reset in the ER Log. The log will be wiped out, but it's good to have

--- a/modules/es/fsw/src/cfe_es_start.c
+++ b/modules/es/fsw/src/cfe_es_start.c
@@ -154,7 +154,7 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const cha
     /*
     ** Announce the startup
     */
-    CFE_ES_WriteToSysLog("%s: CFE_ES_Main in EARLY_INIT state\n", __func__);
+    CFE_ES_WriteToSysLog("%s: In EARLY_INIT state\n", __func__);
 
     /*
     ** Create and Mount the filesystems needed
@@ -177,7 +177,7 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const cha
     /*
     ** Indicate that the CFE core is now starting up / going multi-threaded
     */
-    CFE_ES_WriteToSysLog("%s: CFE_ES_Main entering CORE_STARTUP state\n", __func__);
+    CFE_ES_WriteToSysLog("%s: Entering CORE_STARTUP state\n", __func__);
     CFE_ES_Global.SystemState = CFE_ES_SystemState_CORE_STARTUP;
 
     /*
@@ -188,7 +188,7 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const cha
     /*
     ** Indicate that the CFE core is ready
     */
-    CFE_ES_WriteToSysLog("%s: CFE_ES_Main entering CORE_READY state\n", __func__);
+    CFE_ES_WriteToSysLog("%s: Entering CORE_READY state\n", __func__);
     CFE_ES_Global.SystemState = CFE_ES_SystemState_CORE_READY;
 
     /*
@@ -210,7 +210,7 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const cha
         CFE_ES_WriteToSysLog("%s: Startup Sync failed - Applications may not have all initialized\n", __func__);
     }
 
-    CFE_ES_WriteToSysLog("%s: CFE_ES_Main entering APPS_INIT state\n", __func__);
+    CFE_ES_WriteToSysLog("%s: Entering APPS_INIT state\n", __func__);
     CFE_ES_Global.SystemState = CFE_ES_SystemState_APPS_INIT;
 
     /*
@@ -228,7 +228,7 @@ void CFE_ES_Main(uint32 StartType, uint32 StartSubtype, uint32 ModeId, const cha
     /*
     ** Startup is fully complete
     */
-    CFE_ES_WriteToSysLog("%s: CFE_ES_Main entering OPERATIONAL state\n", __func__);
+    CFE_ES_WriteToSysLog("%s: Entering OPERATIONAL state\n", __func__);
     CFE_ES_Global.SystemState = CFE_ES_SystemState_OPERATIONAL;
 }
 

--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -336,9 +336,10 @@ int32 CFE_ES_TaskInit(void)
     }
 
     /*
-    ** Subscribe to Housekeeping request commands
+    ** Subscribe to Housekeeping request commands (limit to 1 in the pipe at a time)
     */
-    Status = CFE_SB_Subscribe(CFE_SB_ValueToMsgId(CFE_ES_SEND_HK_MID), CFE_ES_Global.TaskData.CmdPipe);
+    Status = CFE_SB_SubscribeEx(CFE_SB_ValueToMsgId(CFE_ES_SEND_HK_MID), CFE_ES_Global.TaskData.CmdPipe,
+                                CFE_SB_DEFAULT_QOS, 1);
     if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s: Cannot Subscribe to HK packet, RC = 0x%08X\n", __func__, (unsigned int)Status);
@@ -660,32 +661,32 @@ int32 CFE_ES_StartAppCmd(const CFE_ES_StartAppCmd_t *data)
     {
         CFE_ES_Global.TaskData.CommandErrorCounter++;
         CFE_EVS_SendEvent(CFE_ES_START_INVALID_FILENAME_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "CFE_ES_StartAppCmd: invalid filename, status=%lx", (unsigned long)Result);
+                          "%s: invalid filename, status=%lx", __func__, (unsigned long)Result);
     }
     else if (AppEntryLen <= 0)
     {
         CFE_ES_Global.TaskData.CommandErrorCounter++;
         CFE_EVS_SendEvent(CFE_ES_START_INVALID_ENTRY_POINT_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "CFE_ES_StartAppCmd: App Entry Point is empty.");
+                          "%s: App Entry Point is empty.", __func__);
     }
     else if (AppNameLen <= 0)
     {
         CFE_ES_Global.TaskData.CommandErrorCounter++;
         CFE_EVS_SendEvent(CFE_ES_START_NULL_APP_NAME_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "CFE_ES_StartAppCmd: App Name is empty.");
+                          "%s: App Name is empty.", __func__);
     }
     else if (cmd->Priority > OS_MAX_PRIORITY)
     {
         CFE_ES_Global.TaskData.CommandErrorCounter++;
         CFE_EVS_SendEvent(CFE_ES_START_PRIORITY_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "CFE_ES_StartAppCmd: Priority is too large: %d.", (int)cmd->Priority);
+                          "%s: Priority is too large: %d.", __func__, (int)cmd->Priority);
     }
     else if ((cmd->ExceptionAction != CFE_ES_ExceptionAction_RESTART_APP) &&
              (cmd->ExceptionAction != CFE_ES_ExceptionAction_PROC_RESTART))
     {
         CFE_ES_Global.TaskData.CommandErrorCounter++;
         CFE_EVS_SendEvent(CFE_ES_START_EXC_ACTION_ERR_EID, CFE_EVS_EventType_ERROR,
-                          "CFE_ES_StartAppCmd: Invalid Exception Action: %d.", (int)cmd->ExceptionAction);
+                          "%s: Invalid Exception Action: %d.", __func__, (int)cmd->ExceptionAction);
     }
     else
     {

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -2582,7 +2582,7 @@ void TestTask(void)
 
     /* Test task main process loop with a ground command subscribe failure */
     ES_ResetUnitTest();
-    UT_SetDeferredRetcode(UT_KEY(CFE_SB_Subscribe), 2, -4);
+    UT_SetDeferredRetcode(UT_KEY(CFE_SB_SubscribeEx), 1, -4);
     UtAssert_INT32_EQ(CFE_ES_TaskInit(), -4);
 
     /* Test task main process loop with an init event send failure */

--- a/modules/sb/eds/cfe_sb.xml
+++ b/modules/sb/eds/cfe_sb.xml
@@ -329,7 +329,7 @@
               \cfetlmmnemonic  \SB_SMPSBBIU
             </LongDescription>
           </Entry>
-          <Entry name="MaxPipeDepthAllowed" type="BASE_TYPES/uint32" shortDescription="cFE Cfg Param #CFE_PLATFORM_SB_MAX_PIPE_DEPTH">
+          <Entry name="MaxPipeDepthAllowed" type="BASE_TYPES/uint32" shortDescription="cFE Cfg Param #OS_QUEUE_MAX_DEPTH">
             <LongDescription>
               \cfetlmmnemonic  \SB_SMMPDALW
             </LongDescription>

--- a/modules/sb/fsw/src/cfe_sb_priv.c
+++ b/modules/sb/fsw/src/cfe_sb_priv.c
@@ -1343,7 +1343,7 @@ void CFE_SB_ReceiveTxn_ExportReference(CFE_SB_MessageTxn_State_t *TxnPtr, CFE_SB
     if (CFE_SB_PipeDescIsMatch(PipeDscPtr, ContextPtr->PipeId))
     {
         /*
-        ** Load the pipe tables 'CurrentBuff' with the buffer descriptor
+        ** Load the pipe table's 'LastBuffer' with the buffer descriptor
         ** ptr corresponding to the message just read. This is done so that
         ** the buffer can be released on the next receive call for this pipe.
         **
@@ -1353,7 +1353,7 @@ void CFE_SB_ReceiveTxn_ExportReference(CFE_SB_MessageTxn_State_t *TxnPtr, CFE_SB
         PipeDscPtr->LastBuffer = BufDscPtr;
 
         /*
-         * Also set the Receivers pointer to the address of the actual message
+         * Also set the Receiver's pointer to the address of the actual message
          * (currently this is "borrowing" the ref above, not its own ref)
          */
         *ParentBufDscPtrP = BufDscPtr;


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1360
  - Limits Send HK MIDs in the ES command pipe to 1 at a time using `CFE_SB_SubscribeEx()`
  - Also piggy-backing on this PR are a few typo fixes, updates to out-of-date identifiers, and replacing hand-written function names with `__func__` (to reduce chances of these coming out of sync in the future)

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Send HK MIDs in ES command pipe will be explicitly limited to 1 at a time instead of whatever the default is set to (currently 4).

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt