### PR TITLE
Fix #2502, correct name mismatches in ES

### DIFF
--- a/docs/src/cfe_es.dox
+++ b/docs/src/cfe_es.dox
@@ -693,13 +693,13 @@
   The System Log is an array of bytes that contains back-to-back printf type
   messages from applications. The cFE internal applications use this log when
   errors are encountered during initialization before the Event Manager is fully
-  initialized. To view the information the #CFE_ES_WRITE_SYSLOG_CC command must
+  initialized. To view the information the #CFE_ES_WRITE_SYS_LOG_CC command must
   be sent. This command will write the log to a binary file. The path and
   filename may be specified in the command. If the filename command field
   contains an empty string, the configuration parameter
   #CFE_PLATFORM_ES_DEFAULT_SYSLOG_FILE is used to specify the path and filename.  Use the
   ground system to get the file and display the contents.  The
-  #CFE_ES_CLEAR_SYSLOG_CC is used to clear the System log.
+  #CFE_ES_CLEAR_SYS_LOG_CC is used to clear the System log.
 
   The size of the System log is defined by the platform configuration parameter
   #CFE_PLATFORM_ES_SYSTEM_LOG_SIZE. This log is preserved after a processor reset and

--- a/modules/core_api/eds/cfe_fs.xml
+++ b/modules/core_api/eds/cfe_fs.xml
@@ -38,7 +38,7 @@
             <Enumeration label="ES_SYSLOG" value="2" shortDescription="Executive Services System Log Type">
               <LongDescription>
                 Executive Services System Log File which is generated in response to a
-                \link #CFE_ES_WRITE_SYSLOG_CC \ES_WRITESYSLOG2FILE \endlink
+                \link #CFE_ES_WRITE_SYS_LOG_CC \ES_WRITESYSLOG2FILE \endlink
                 command.
               </LongDescription>
             </Enumeration>

--- a/modules/es/config/default_cfe_es_fcncodes.h
+++ b/modules/es/config/default_cfe_es_fcncodes.h
@@ -457,10 +457,10 @@
 **       This command is not dangerous.  However, any previously logged data
 **       will be lost.
 **
-**  \sa #CFE_ES_WRITE_SYSLOG_CC, #CFE_ES_CLEAR_ER_LOG_CC, #CFE_ES_WRITE_ER_LOG_CC,
-**      #CFE_ES_OVER_WRITE_SYSLOG_CC
+**  \sa #CFE_ES_WRITE_SYS_LOG_CC, #CFE_ES_CLEAR_ER_LOG_CC, #CFE_ES_WRITE_ER_LOG_CC,
+**      #CFE_ES_OVER_WRITE_SYS_LOG_CC
 */
-#define CFE_ES_CLEAR_SYSLOG_CC 10
+#define CFE_ES_CLEAR_SYS_LOG_CC 10
 
 /** \cfeescmd Writes contents of Executive Services System Log to a File
 **
@@ -500,10 +500,10 @@
 **       if performed repeatedly without sufficient file management by the
 **       operator, fill the file system.
 **
-**  \sa #CFE_ES_CLEAR_SYSLOG_CC, #CFE_ES_CLEAR_ER_LOG_CC, #CFE_ES_WRITE_ER_LOG_CC,
-**      #CFE_ES_OVER_WRITE_SYSLOG_CC
+**  \sa #CFE_ES_CLEAR_SYS_LOG_CC, #CFE_ES_CLEAR_ER_LOG_CC, #CFE_ES_WRITE_ER_LOG_CC,
+**      #CFE_ES_OVER_WRITE_SYS_LOG_CC
 */
-#define CFE_ES_WRITE_SYSLOG_CC 11
+#define CFE_ES_WRITE_SYS_LOG_CC 11
 
 /** \cfeescmd Clears the contents of the Exception and Reset Log
 **
@@ -535,7 +535,7 @@
 **       This command is not dangerous.  However, any previously logged data
 **       will be lost.
 **
-**  \sa #CFE_ES_CLEAR_SYSLOG_CC, #CFE_ES_WRITE_SYSLOG_CC, #CFE_ES_WRITE_ER_LOG_CC
+**  \sa #CFE_ES_CLEAR_SYS_LOG_CC, #CFE_ES_WRITE_SYS_LOG_CC, #CFE_ES_WRITE_ER_LOG_CC
 */
 #define CFE_ES_CLEAR_ER_LOG_CC 12
 
@@ -578,7 +578,7 @@
 **       if performed repeatedly without sufficient file management by the
 **       operator, fill the file system.
 **
-**  \sa #CFE_ES_CLEAR_SYSLOG_CC, #CFE_ES_WRITE_SYSLOG_CC, #CFE_ES_CLEAR_ER_LOG_CC
+**  \sa #CFE_ES_CLEAR_SYS_LOG_CC, #CFE_ES_WRITE_SYS_LOG_CC, #CFE_ES_CLEAR_ER_LOG_CC
 */
 #define CFE_ES_WRITE_ER_LOG_CC 13
 
@@ -787,9 +787,9 @@
 **       identifying the cause of a problem to be lost by a subsequent flood of
 **       additional messages).
 **
-**  \sa #CFE_ES_CLEAR_SYSLOG_CC, #CFE_ES_WRITE_SYSLOG_CC
+**  \sa #CFE_ES_CLEAR_SYS_LOG_CC, #CFE_ES_WRITE_SYS_LOG_CC
 */
-#define CFE_ES_OVER_WRITE_SYSLOG_CC 18
+#define CFE_ES_OVER_WRITE_SYS_LOG_CC 18
 
 /** \cfeescmd Resets the Processor Reset Counter to Zero
 **

--- a/modules/es/config/default_cfe_es_msgdefs.h
+++ b/modules/es/config/default_cfe_es_msgdefs.h
@@ -52,7 +52,7 @@ typedef struct CFE_ES_RestartCmd_Payload
 **
 ** This format is shared by several executive services commands.
 ** For command details, see #CFE_ES_QUERY_ALL_CC, #CFE_ES_QUERY_ALL_TASKS_CC,
-** #CFE_ES_WRITE_SYSLOG_CC, and #CFE_ES_WRITE_ER_LOG_CC
+** #CFE_ES_WRITE_SYS_LOG_CC, and #CFE_ES_WRITE_ER_LOG_CC
 **
 **/
 typedef struct CFE_ES_FileNameCmd_Payload
@@ -64,7 +64,7 @@ typedef struct CFE_ES_FileNameCmd_Payload
 /**
 ** \brief Overwrite/Discard System Log Configuration Command Payload
 **
-** For command details, see #CFE_ES_OVER_WRITE_SYSLOG_CC
+** For command details, see #CFE_ES_OVER_WRITE_SYS_LOG_CC
 **
 **/
 typedef struct CFE_ES_OverWriteSysLogCmd_Payload
@@ -146,13 +146,12 @@ typedef struct CFE_ES_DeleteCDSCmd_Payload
 /**
  * @brief Labels for values to use in #CFE_ES_StartPerfCmd_Payload.TriggerMode
  * @sa CFE_ES_StartPerfCmd_Payload
-*/
+ */
 enum CFE_ES_PerfMode
 {
-    CFE_ES_PERF_TRIGGER_START = 0,
-    CFE_ES_PERF_TRIGGER_CENTER,
-    CFE_ES_PERF_TRIGGER_END,
-    CFE_ES_PERF_MAX_MODES
+    CFE_ES_PerfTrigger_START = 0,
+    CFE_ES_PerfTrigger_CENTER,
+    CFE_ES_PerfTrigger_END
 };
 
 typedef uint32 CFE_ES_PerfMode_Enum_t;
@@ -165,7 +164,8 @@ typedef uint32 CFE_ES_PerfMode_Enum_t;
 **/
 typedef struct CFE_ES_StartPerfCmd_Payload
 {
-    CFE_ES_PerfMode_Enum_t TriggerMode; /**< \brief Desired trigger position (Start, Center, End). Values defined by #CFE_ES_PerfMode. */
+    CFE_ES_PerfMode_Enum_t
+        TriggerMode; /**< \brief Desired trigger position (Start, Center, End). Values defined by #CFE_ES_PerfMode. */
 } CFE_ES_StartPerfCmd_Payload_t;
 
 /**

--- a/modules/es/eds/cfe_es.xml
+++ b/modules/es/eds/cfe_es.xml
@@ -116,6 +116,15 @@
         </EnumerationList>
       </EnumeratedDataType>
 
+      <EnumeratedDataType name="PerfTrigger" shortDescription="Performance Monitor trigger modes">
+        <IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+        <EnumerationList>
+          <Enumeration label="START"  value="0" shortDescription="Trigger at start" />
+          <Enumeration label="CENTER" value="1" shortDescription="Trigger at center" />
+          <Enumeration label="END"    value="2" shortDescription="Trigger at end" />
+        </EnumerationList>
+      </EnumeratedDataType>
+
       <ContainerDataType name="AppId" baseType="CFE_RESOURCEID/BaseType" shortDescription="A type for Application IDs">
         <LongDescription>
           This is the type that is used for any API accepting or returning an App ID
@@ -165,7 +174,7 @@
         </Range>
       </IntegerDataType>
 
-      <IntegerDataType name="MemOffset" shortDescription="Integer type used for CPU memory addresses, sizes and offsets">
+      <AliasDataType name="MemOffset" type="BASE_TYPES/MemReference" shortDescription="Integer type used for CPU memory addresses, sizes and offsets">
         <LongDescription>
           For backward compatibility with existing CFS code this should be uint32,
           but all telemetry information will be limited to 4GB in size as a result.
@@ -177,13 +186,9 @@
           In either case this must be an unsigned type, and should be large enough
           to represent the largest memory address/size in use in the CFS system.
         </LongDescription>
-        <IntegerDataEncoding sizeInBits="${CFE_MISSION/MEM_REFERENCE_SIZE_BITS}" encoding="unsigned" />
-        <Range>
-          <MinMaxRange max="2 ^ ${CFE_MISSION/MEM_REFERENCE_SIZE_BITS}" min="0" rangeType="inclusiveMinExclusiveMax"/>
-        </Range>
-      </IntegerDataType>
+      </AliasDataType>
 
-      <IntegerDataType name="MemAddress" shortDescription="Integer type used for CPU memory addresses, sizes and offsets">
+      <AliasDataType name="MemAddress" type="BASE_TYPES/MemReference" shortDescription="Integer type used for CPU memory addresses, sizes and offsets">
         <LongDescription>
           For backward compatibility with existing CFS code this should be uint32,
           but all telemetry information will be limited to 4GB in size as a result.
@@ -195,11 +200,7 @@
           In either case this must be an unsigned type, and should be large enough
           to represent the largest memory address/size in use in the CFS system.
         </LongDescription>
-        <IntegerDataEncoding sizeInBits="${CFE_MISSION/MEM_REFERENCE_SIZE_BITS}" encoding="unsigned" />
-        <Range>
-          <MinMaxRange max="2 ^ ${CFE_MISSION/MEM_REFERENCE_SIZE_BITS}" min="0" rangeType="inclusiveMinExclusiveMax"/>
-        </Range>
-      </IntegerDataType>
+      </AliasDataType>
 
       <StringDataType name="char_x_CFE_ES_CDS_MAX_FULL_NAME_LEN" length="${CFE_MISSION/ES_CDS_MAX_FULL_NAME_LEN}" />
 
@@ -402,7 +403,7 @@
 
       <ContainerDataType name="OverWriteSysLogCmd_Payload" shortDescription="Overwrite/Discard System Log Configuration Command">
         <LongDescription>
-          For command details, see #CFE_ES_OVERWRITE_SYSLOG_CC
+          For command details, see #CFE_ES_OVERWRITE_SYS_LOG_CC
         </LongDescription>
         <EntryList>
           <Entry name="Mode" type="LogMode">
@@ -475,7 +476,7 @@
           For command details, see #CFE_ES_PERF_STARTDATA_CC
         </LongDescription>
         <EntryList>
-          <Entry name="TriggerMode" type="BASE_TYPES/uint32" shortDescription="Desired trigger position (Start, Center, End)" />
+          <Entry name="TriggerMode" type="PerfTrigger" shortDescription="Desired trigger position (Start, Center, End)" />
         </EntryList>
       </ContainerDataType>
 
@@ -1300,8 +1301,8 @@
           This command is not dangerous.  However, any previously logged data
           will be lost.
 
-          \sa  #CFE_ES_WRITE_SYSLOG_CC, #CFE_ES_CLEAR_ERLOG_CC, #CFE_ES_WRITE_ERLOG_CC,
-          #CFE_ES_OVERWRITE_SYSLOG_CC
+          \sa  #CFE_ES_WRITE_SYS_LOG_CC, #CFE_ES_CLEAR_ERLOG_CC, #CFE_ES_WRITE_ERLOG_CC,
+          #CFE_ES_OVERWRITE_SYS_LOG_CC
         </LongDescription>
         <ConstraintSet>
           <ValueConstraint entry="Sec.FunctionCode" value="10" />
@@ -1351,8 +1352,8 @@
           if performed repeatedly without sufficient file management by the
           operator, fill the file system.
 
-          \sa  #CFE_ES_CLEAR_SYSLOG_CC, #CFE_ES_CLEAR_ERLOG_CC, #CFE_ES_WRITE_ERLOG_CC,
-          #CFE_ES_OVERWRITE_SYSLOG_CC
+          \sa  #CFE_ES_CLEAR_SYS_LOG_CC, #CFE_ES_CLEAR_ERLOG_CC, #CFE_ES_WRITE_ERLOG_CC,
+          #CFE_ES_OVERWRITE_SYS_LOG_CC
         </LongDescription>
         <ConstraintSet>
           <ValueConstraint entry="Sec.FunctionCode" value="11" />
@@ -1400,7 +1401,7 @@
           This command is not dangerous.  However, any previously logged data
           will be lost.
 
-          \sa  #CFE_ES_CLEAR_SYSLOG_CC, #CFE_ES_WRITE_SYSLOG_CC, #CFE_ES_WRITE_ERLOG_CC
+          \sa  #CFE_ES_CLEAR_SYS_LOG_CC, #CFE_ES_WRITE_SYS_LOG_CC, #CFE_ES_WRITE_ERLOG_CC
         </LongDescription>
         <ConstraintSet>
           <ValueConstraint entry="Sec.FunctionCode" value="12" />
@@ -1450,7 +1451,7 @@
           if performed repeatedly without sufficient file management by the
           operator, fill the file system.
 
-          \sa  #CFE_ES_CLEAR_SYSLOG_CC, #CFE_ES_WRITE_SYSLOG_CC, #CFE_ES_CLEAR_ERLOG_CC
+          \sa  #CFE_ES_CLEAR_SYS_LOG_CC, #CFE_ES_WRITE_SYS_LOG_CC, #CFE_ES_CLEAR_ERLOG_CC
         </LongDescription>
         <ConstraintSet>
           <ValueConstraint entry="Sec.FunctionCode" value="13" />
@@ -1710,7 +1711,7 @@
           identifying the cause of a problem to be lost by a subsequent flood of
           additional messages).
 
-          \sa  #CFE_ES_CLEAR_SYSLOG_CC, #CFE_ES_WRITE_SYSLOG_CC
+          \sa  #CFE_ES_CLEAR_SYS_LOG_CC, #CFE_ES_WRITE_SYS_LOG_CC
         </LongDescription>
         <ConstraintSet>
           <ValueConstraint entry="Sec.FunctionCode" value="18" />

--- a/modules/es/fsw/inc/cfe_es_eventids.h
+++ b/modules/es/fsw/inc/cfe_es_eventids.h
@@ -212,7 +212,7 @@
  *
  *  \par Cause:
  *
- *  \link #CFE_ES_CLEAR_SYSLOG_CC ES Clear System Log Command \endlink success.
+ *  \link #CFE_ES_CLEAR_SYS_LOG_CC ES Clear System Log Command \endlink success.
  */
 #define CFE_ES_SYSLOG1_INF_EID 17
 
@@ -223,7 +223,7 @@
  *
  *  \par Cause:
  *
- *  \link #CFE_ES_CLEAR_SYSLOG_CC ES Write System Log Command \endlink success.
+ *  \link #CFE_ES_CLEAR_SYS_LOG_CC ES Write System Log Command \endlink success.
  */
 #define CFE_ES_SYSLOG2_EID 18
 
@@ -608,7 +608,7 @@
  *
  *  \par Cause:
  *
- *  \link #CFE_ES_WRITE_SYSLOG_CC ES Write System Log Command \endlink failed parsing file
+ *  \link #CFE_ES_WRITE_SYS_LOG_CC ES Write System Log Command \endlink failed parsing file
  *  name or creating the file. OVERLOADED
  */
 #define CFE_ES_SYSLOG2_ERR_EID 55
@@ -772,7 +772,7 @@
  *
  *  \par Cause:
  *
- *  \link #CFE_ES_OVER_WRITE_SYSLOG_CC ES Set System Log Overwrite Mode Command \endlink success.
+ *  \link #CFE_ES_OVER_WRITE_SYS_LOG_CC ES Set System Log Overwrite Mode Command \endlink success.
  */
 #define CFE_ES_SYSLOGMODE_EID 70
 
@@ -783,7 +783,7 @@
  *
  *  \par Cause:
  *
- *  \link #CFE_ES_OVER_WRITE_SYSLOG_CC ES Set System Log Overwrite Mode Command \endlink failed
+ *  \link #CFE_ES_OVER_WRITE_SYS_LOG_CC ES Set System Log Overwrite Mode Command \endlink failed
  *  due to invalid mode requested.
  */
 #define CFE_ES_ERR_SYSLOGMODE_EID 71

--- a/modules/es/fsw/src/cfe_es_dispatch.c
+++ b/modules/es/fsw/src/cfe_es_dispatch.c
@@ -168,21 +168,21 @@ void CFE_ES_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
                     }
                     break;
 
-                case CFE_ES_CLEAR_SYSLOG_CC:
+                case CFE_ES_CLEAR_SYS_LOG_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_ClearSysLogCmd_t)))
                     {
                         CFE_ES_ClearSysLogCmd((const CFE_ES_ClearSysLogCmd_t *)SBBufPtr);
                     }
                     break;
 
-                case CFE_ES_WRITE_SYSLOG_CC:
+                case CFE_ES_WRITE_SYS_LOG_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_WriteSysLogCmd_t)))
                     {
                         CFE_ES_WriteSysLogCmd((const CFE_ES_WriteSysLogCmd_t *)SBBufPtr);
                     }
                     break;
 
-                case CFE_ES_OVER_WRITE_SYSLOG_CC:
+                case CFE_ES_OVER_WRITE_SYS_LOG_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_OverWriteSysLogCmd_t)))
                     {
                         CFE_ES_OverWriteSysLogCmd((const CFE_ES_OverWriteSysLogCmd_t *)SBBufPtr);

--- a/modules/es/fsw/src/cfe_es_perf.c
+++ b/modules/es/fsw/src/cfe_es_perf.c
@@ -74,7 +74,7 @@ void CFE_ES_SetupPerfVariables(uint32 ResetType)
 
         /* set data collection state to waiting for command state */
         Perf->MetaData.State                 = CFE_ES_PERF_IDLE;
-        Perf->MetaData.Mode                  = CFE_ES_PERF_TRIGGER_START;
+        Perf->MetaData.Mode                  = CFE_ES_PerfTrigger_START;
         Perf->MetaData.TriggerCount          = 0;
         Perf->MetaData.DataStart             = 0;
         Perf->MetaData.DataEnd               = 0;
@@ -155,7 +155,7 @@ int32 CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfDataCmd_t *data)
         PerfDumpState->PendingState == CFE_ES_PerfDumpState_IDLE)
     {
         /* Make sure Trigger Mode is valid */
-        if (CmdPtr->TriggerMode < CFE_ES_PERF_MAX_MODES)
+        if (CmdPtr->TriggerMode <= CFE_ES_PerfTrigger_END)
         {
             CFE_ES_Global.TaskData.CommandCounter++;
 
@@ -180,7 +180,7 @@ int32 CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfDataCmd_t *data)
             CFE_ES_Global.TaskData.CommandErrorCounter++;
             CFE_EVS_SendEvent(CFE_ES_PERF_STARTCMD_TRIG_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Cannot start collecting performance data, trigger mode (%d) out of range (%d to %d)",
-                              (int)CmdPtr->TriggerMode, (int)CFE_ES_PERF_TRIGGER_START, (int)CFE_ES_PERF_TRIGGER_END);
+                              (int)CmdPtr->TriggerMode, (int)CFE_ES_PerfTrigger_START, (int)CFE_ES_PerfTrigger_END);
         }
     }
     else
@@ -668,21 +668,21 @@ void CFE_ES_PerfLogAdd(uint32 Marker, uint32 EntryExit)
         if (Perf->MetaData.State == CFE_ES_PERF_TRIGGERED)
         {
             Perf->MetaData.TriggerCount++;
-            if (Perf->MetaData.Mode == CFE_ES_PERF_TRIGGER_START)
+            if (Perf->MetaData.Mode == CFE_ES_PerfTrigger_START)
             {
                 if (Perf->MetaData.TriggerCount >= CFE_PLATFORM_ES_PERF_DATA_BUFFER_SIZE)
                 {
                     Perf->MetaData.State = CFE_ES_PERF_IDLE;
                 }
             }
-            else if (Perf->MetaData.Mode == CFE_ES_PERF_TRIGGER_CENTER)
+            else if (Perf->MetaData.Mode == CFE_ES_PerfTrigger_CENTER)
             {
                 if (Perf->MetaData.TriggerCount >= CFE_PLATFORM_ES_PERF_DATA_BUFFER_SIZE / 2)
                 {
                     Perf->MetaData.State = CFE_ES_PERF_IDLE;
                 }
             }
-            else if (Perf->MetaData.Mode == CFE_ES_PERF_TRIGGER_END)
+            else if (Perf->MetaData.Mode == CFE_ES_PerfTrigger_END)
             {
                 Perf->MetaData.State = CFE_ES_PERF_IDLE;
             }

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -111,12 +111,12 @@ static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_QUERY_ALL_CC = {
     .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_QUERY_ALL_CC};
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_QUERY_ALL_TASKS_CC = {
     .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_QUERY_ALL_TASKS_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_CLEAR_SYSLOG_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_CLEAR_SYSLOG_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_WRITE_SYSLOG_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_OVER_WRITE_SYSLOG_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_OVER_WRITE_SYSLOG_CC};
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_CLEAR_SYS_LOG_CC = {
+    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_CLEAR_SYS_LOG_CC};
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_WRITE_SYS_LOG_CC = {
+    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_WRITE_SYS_LOG_CC};
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_OVER_WRITE_SYS_LOG_CC = {
+    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_OVER_WRITE_SYS_LOG_CC};
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_CLEAR_ER_LOG_CC = {
     .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_CLEAR_ER_LOG_CC};
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_WRITE_ER_LOG_CC = {
@@ -2466,7 +2466,6 @@ void TestGenericPool(void)
     ES_ResetUnitTest();
     UtAssert_INT32_EQ(CFE_ES_GenPoolRecyclePoolBlock(&Pool1, 0, Pool1.Buckets[0].BlockSize, &Offset1),
                       CFE_ES_BUFFER_NOT_IN_POOL);
-
 }
 
 void TestTask(void)
@@ -3027,7 +3026,7 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.ClearSysLogCmd),
-                    UT_TPID_CFE_ES_CMD_CLEAR_SYSLOG_CC);
+                    UT_TPID_CFE_ES_CMD_CLEAR_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOG1_INF_EID);
 
     /* Test successful overwriting of the system log using overwrite mode */
@@ -3035,7 +3034,7 @@ void TestTask(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.OverwriteSysLogCmd.Payload.Mode = CFE_ES_LogMode_OVERWRITE;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.OverwriteSysLogCmd),
-                    UT_TPID_CFE_ES_CMD_OVER_WRITE_SYSLOG_CC);
+                    UT_TPID_CFE_ES_CMD_OVER_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOGMODE_EID);
 
     /* Test successful overwriting of the system log using discard mode */
@@ -3043,7 +3042,7 @@ void TestTask(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.OverwriteSysLogCmd.Payload.Mode = CFE_ES_LogMode_DISCARD;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.OverwriteSysLogCmd),
-                    UT_TPID_CFE_ES_CMD_OVER_WRITE_SYSLOG_CC);
+                    UT_TPID_CFE_ES_CMD_OVER_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOGMODE_EID);
 
     /* Test overwriting the system log using an invalid mode */
@@ -3051,7 +3050,7 @@ void TestTask(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.OverwriteSysLogCmd.Payload.Mode = 255;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.OverwriteSysLogCmd),
-                    UT_TPID_CFE_ES_CMD_OVER_WRITE_SYSLOG_CC);
+                    UT_TPID_CFE_ES_CMD_OVER_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_ERR_SYSLOGMODE_EID);
 
     /* Test successful writing of the system log */
@@ -3061,7 +3060,7 @@ void TestTask(void)
     CmdBuf.WriteSysLogCmd.Payload.FileName[sizeof(CmdBuf.WriteSysLogCmd.Payload.FileName) - 1] = '\0';
     CFE_ES_Global.TaskData.HkPacket.Payload.SysLogEntries                                      = 123;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.WriteSysLogCmd),
-                    UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
+                    UT_TPID_CFE_ES_CMD_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOG2_EID);
 
     /* Test writing the system log using a bad file name */
@@ -3069,7 +3068,7 @@ void TestTask(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_ParseInputFileNameEx), 1, CFE_FS_INVALID_PATH);
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.WriteSysLogCmd),
-                    UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
+                    UT_TPID_CFE_ES_CMD_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOG2_ERR_EID);
 
     /* Test writing the system log using a null file name */
@@ -3077,7 +3076,7 @@ void TestTask(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.WriteSysLogCmd.Payload.FileName[0] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.WriteSysLogCmd),
-                    UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
+                    UT_TPID_CFE_ES_CMD_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOG2_EID);
 
     /* Test writing the system log with an OS create failure */
@@ -3086,7 +3085,7 @@ void TestTask(void)
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
     CmdBuf.WriteSysLogCmd.Payload.FileName[0] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.WriteSysLogCmd),
-                    UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
+                    UT_TPID_CFE_ES_CMD_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOG2_ERR_EID);
 
     /* Test writing the system log with an OS write failure */
@@ -3099,14 +3098,14 @@ void TestTask(void)
     CFE_ES_Global.ResetDataPtr->SystemLogEndIdx = CFE_ES_Global.ResetDataPtr->SystemLogWriteIdx;
     CmdBuf.WriteSysLogCmd.Payload.FileName[0]   = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.WriteSysLogCmd),
-                    UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
+                    UT_TPID_CFE_ES_CMD_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_FILEWRITE_ERR_EID);
 
     /* Test writing the system log with a write header failure */
     ES_ResetUnitTest();
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_WriteHeader), 1, OS_ERROR);
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.WriteSysLogCmd),
-                    UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
+                    UT_TPID_CFE_ES_CMD_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_FILEWRITE_ERR_EID);
 
     /* Test successful clearing of the E&R log */
@@ -3466,21 +3465,21 @@ void TestTask(void)
      * invalid command length
      */
     ES_ResetUnitTest();
-    UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_CLEAR_SYSLOG_CC);
+    UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_CLEAR_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
 
     /* Test sending a request to overwrite the system log with an
      * invalid command length
      */
     ES_ResetUnitTest();
-    UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_OVER_WRITE_SYSLOG_CC);
+    UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_OVER_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
 
     /* Test sending a request to write the system log with an
      * invalid command length
      */
     ES_ResetUnitTest();
-    UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
+    UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
 
     /* Test successful overwriting of the system log using overwrite mode */
@@ -3488,7 +3487,7 @@ void TestTask(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.OverwriteSysLogCmd.Payload.Mode = CFE_ES_LogMode_OVERWRITE;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.OverwriteSysLogCmd),
-                    UT_TPID_CFE_ES_CMD_OVER_WRITE_SYSLOG_CC);
+                    UT_TPID_CFE_ES_CMD_OVER_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOGMODE_EID);
 
     /* Test sending a request to write the error log with an
@@ -3598,7 +3597,7 @@ void TestPerf(void)
      */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CmdBuf.PerfStartCmd.Payload.TriggerMode = CFE_ES_PERF_TRIGGER_START;
+    CmdBuf.PerfStartCmd.Payload.TriggerMode = CFE_ES_PerfTrigger_START;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.PerfStartCmd),
                     UT_TPID_CFE_ES_CMD_START_PERF_DATA_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_PERF_STARTCMD_EID);
@@ -3608,7 +3607,7 @@ void TestPerf(void)
      */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CmdBuf.PerfStartCmd.Payload.TriggerMode = CFE_ES_PERF_TRIGGER_CENTER;
+    CmdBuf.PerfStartCmd.Payload.TriggerMode = CFE_ES_PerfTrigger_CENTER;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.PerfStartCmd),
                     UT_TPID_CFE_ES_CMD_START_PERF_DATA_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_PERF_STARTCMD_EID);
@@ -3618,7 +3617,7 @@ void TestPerf(void)
      */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CmdBuf.PerfStartCmd.Payload.TriggerMode = CFE_ES_PERF_TRIGGER_END;
+    CmdBuf.PerfStartCmd.Payload.TriggerMode = CFE_ES_PerfTrigger_END;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.PerfStartCmd),
                     UT_TPID_CFE_ES_CMD_START_PERF_DATA_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_PERF_STARTCMD_EID);
@@ -3628,7 +3627,7 @@ void TestPerf(void)
      */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CmdBuf.PerfStartCmd.Payload.TriggerMode = (CFE_ES_PERF_TRIGGER_END + 1);
+    CmdBuf.PerfStartCmd.Payload.TriggerMode = (CFE_ES_PerfTrigger_END + 1);
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.PerfStartCmd),
                     UT_TPID_CFE_ES_CMD_START_PERF_DATA_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_PERF_STARTCMD_TRIG_ERR_EID);
@@ -3649,7 +3648,7 @@ void TestPerf(void)
     /* clearing the BackgroundPerfDumpState will fully reset to initial state */
     memset(&CFE_ES_Global.BackgroundPerfDumpState, 0, sizeof(CFE_ES_Global.BackgroundPerfDumpState));
     CFE_ES_Global.BackgroundPerfDumpState.CurrentState = CFE_ES_PerfDumpState_INIT;
-    CmdBuf.PerfStartCmd.Payload.TriggerMode            = CFE_ES_PERF_TRIGGER_START;
+    CmdBuf.PerfStartCmd.Payload.TriggerMode            = CFE_ES_PerfTrigger_START;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.PerfStartCmd),
                     UT_TPID_CFE_ES_CMD_START_PERF_DATA_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_PERF_STARTCMD_ERR_EID);
@@ -3667,7 +3666,7 @@ void TestPerf(void)
     ES_ResetUnitTest();
     memset(&CFE_ES_Global.BackgroundPerfDumpState, 0, sizeof(CFE_ES_Global.BackgroundPerfDumpState));
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CmdBuf.PerfStartCmd.Payload.TriggerMode = CFE_ES_PERF_TRIGGER_START;
+    CmdBuf.PerfStartCmd.Payload.TriggerMode = CFE_ES_PerfTrigger_START;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.PerfStartCmd),
                     UT_TPID_CFE_ES_CMD_START_PERF_DATA_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_PERF_STARTCMD_EID);
@@ -3775,11 +3774,11 @@ void TestPerf(void)
      */
     ES_ResetUnitTest();
     Perf->MetaData.InvalidMarkerReported = true;
-    Perf->MetaData.Mode                  = CFE_ES_PERF_TRIGGER_START;
+    Perf->MetaData.Mode                  = CFE_ES_PerfTrigger_START;
     Perf->MetaData.DataCount             = CFE_PLATFORM_ES_PERF_DATA_BUFFER_SIZE + 1;
     Perf->MetaData.TriggerMask[0]        = 0xFFFF;
     CFE_ES_PerfLogAdd(1, 0);
-    UtAssert_UINT32_EQ(Perf->MetaData.Mode, CFE_ES_PERF_TRIGGER_START);
+    UtAssert_UINT32_EQ(Perf->MetaData.Mode, CFE_ES_PerfTrigger_START);
     UtAssert_UINT32_EQ(Perf->MetaData.State, CFE_ES_PERF_IDLE);
 
     /* Test addition of a new entry to the performance log with CENTER
@@ -3787,10 +3786,10 @@ void TestPerf(void)
      */
     ES_ResetUnitTest();
     Perf->MetaData.State        = CFE_ES_PERF_TRIGGERED;
-    Perf->MetaData.Mode         = CFE_ES_PERF_TRIGGER_CENTER;
+    Perf->MetaData.Mode         = CFE_ES_PerfTrigger_CENTER;
     Perf->MetaData.TriggerCount = CFE_PLATFORM_ES_PERF_DATA_BUFFER_SIZE / 2 + 1;
     CFE_ES_PerfLogAdd(1, 0);
-    UtAssert_UINT32_EQ(Perf->MetaData.Mode, CFE_ES_PERF_TRIGGER_CENTER);
+    UtAssert_UINT32_EQ(Perf->MetaData.Mode, CFE_ES_PerfTrigger_CENTER);
     UtAssert_UINT32_EQ(Perf->MetaData.State, CFE_ES_PERF_IDLE);
 
     /* Test addition of a new entry to the performance log with END
@@ -3798,9 +3797,9 @@ void TestPerf(void)
      */
     ES_ResetUnitTest();
     Perf->MetaData.State = CFE_ES_PERF_TRIGGERED;
-    Perf->MetaData.Mode  = CFE_ES_PERF_TRIGGER_END;
+    Perf->MetaData.Mode  = CFE_ES_PerfTrigger_END;
     CFE_ES_PerfLogAdd(1, 0);
-    UtAssert_UINT32_EQ(Perf->MetaData.Mode, CFE_ES_PERF_TRIGGER_END);
+    UtAssert_UINT32_EQ(Perf->MetaData.Mode, CFE_ES_PerfTrigger_END);
     UtAssert_UINT32_EQ(Perf->MetaData.State, CFE_ES_PERF_IDLE);
 
     /* Test addition where state goes to idle after first check */
@@ -3853,7 +3852,7 @@ void TestPerf(void)
     ES_ResetUnitTest();
     Perf->MetaData.TriggerCount   = 0;
     Perf->MetaData.State          = CFE_ES_PERF_TRIGGERED;
-    Perf->MetaData.Mode           = CFE_ES_PERF_TRIGGER_START;
+    Perf->MetaData.Mode           = CFE_ES_PerfTrigger_START;
     Perf->MetaData.TriggerMask[0] = 0xffff;
     CFE_ES_PerfLogAdd(0x1, 0);
     UtAssert_UINT32_EQ(Perf->MetaData.TriggerCount, 1);
@@ -3864,7 +3863,7 @@ void TestPerf(void)
     ES_ResetUnitTest();
     Perf->MetaData.TriggerCount = CFE_PLATFORM_ES_PERF_DATA_BUFFER_SIZE / 2 - 2;
     Perf->MetaData.State        = CFE_ES_PERF_TRIGGERED;
-    Perf->MetaData.Mode         = CFE_ES_PERF_TRIGGER_CENTER;
+    Perf->MetaData.Mode         = CFE_ES_PerfTrigger_CENTER;
     CFE_ES_PerfLogAdd(0x1, 0);
     UtAssert_UINT32_EQ(Perf->MetaData.State, CFE_ES_PERF_TRIGGERED);
 

--- a/modules/fs/config/default_cfe_fs_filedef.h
+++ b/modules/fs/config/default_cfe_fs_filedef.h
@@ -52,7 +52,7 @@ enum CFE_FS_SubType
      * @brief Executive Services System Log Type
      *
      * Executive Services System Log File which is generated in response to a
-     * \link #CFE_ES_WRITE_SYSLOG_CC \ES_WRITESYSLOG2FILE \endlink
+     * \link #CFE_ES_WRITE_SYS_LOG_CC \ES_WRITESYSLOG2FILE \endlink
      * command.
      *
      */

--- a/modules/fs/eds/cfe_fs.xml
+++ b/modules/fs/eds/cfe_fs.xml
@@ -38,7 +38,7 @@
             <Enumeration label="ES_SYSLOG" value="2" shortDescription="Executive Services System Log Type">
               <LongDescription>
                 Executive Services System Log File which is generated in response to a
-                \link #CFE_ES_WRITE_SYSLOG_CC \ES_WRITESYSLOG2FILE \endlink
+                \link #CFE_ES_WRITE_SYS_LOG_CC \ES_WRITESYSLOG2FILE \endlink
                 command.
               </LongDescription>
             </Enumeration>

--- a/modules/time/config/default_cfe_time_fcncodes.h
+++ b/modules/time/config/default_cfe_time_fcncodes.h
@@ -142,7 +142,7 @@
 **
 **  \sa
 */
-#define CFE_TIME_SEND_DIAGNOSTIC_TLM_CC 2 /* request diagnostic hk telemetry */
+#define CFE_TIME_SEND_DIAGNOSTIC_CC 2 /* request diagnostic hk telemetry */
 
 /** \cfetimecmd Set Time Source
 **
@@ -515,8 +515,8 @@
 **       Inappropriately setting the clock may result in other sub-systems performing incorrect
 **       time based calculations.  The specific risk is dependent upon the behavior of those sub-systems.
 **
-**  \sa #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_SUB_ADJUST_CC, #CFE_TIME_ADD_ONEHZ_ADJUSTMENT_CC,
-*#CFE_TIME_SUB_ONEHZ_ADJUSTMENT_CC
+**  \sa #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_SUB_ADJUST_CC, #CFE_TIME_ADD_ONE_HZ_ADJUSTMENT_CC,
+*#CFE_TIME_SUB_ONE_HZ_ADJUSTMENT_CC
 */
 #define CFE_TIME_ADD_ADJUST_CC 11 /* add one time STCF adjustment */
 
@@ -550,7 +550,7 @@
 **       Inappropriately setting the clock may result in other sub-systems performing incorrect
 **       time based calculations.  The specific risk is dependent upon the behavior of those sub-systems.
 **
-**  \sa #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_ADD_ONEHZ_ADJUSTMENT_CC, #CFE_TIME_SUB_ONEHZ_ADJUSTMENT_CC
+**  \sa #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_ADD_ONE_HZ_ADJUSTMENT_CC, #CFE_TIME_SUB_ONE_HZ_ADJUSTMENT_CC
 */
 #define CFE_TIME_SUB_ADJUST_CC 12 /* subtract one time STCF adjustment */
 
@@ -596,9 +596,9 @@
 **       Inappropriately setting the clock may result in other sub-systems performing incorrect
 **       time based calculations.  The specific risk is dependent upon the behavior of those sub-systems.
 **
-**  \sa #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_SUB_ADJUST_CC, #CFE_TIME_SUB_ONEHZ_ADJUSTMENT_CC
+**  \sa #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_SUB_ADJUST_CC, #CFE_TIME_SUB_ONE_HZ_ADJUSTMENT_CC
 */
-#define CFE_TIME_ADD_ONEHZ_ADJUSTMENT_CC 13 /* add 1Hz STCF adjustment */
+#define CFE_TIME_ADD_ONE_HZ_ADJUSTMENT_CC 13 /* add 1Hz STCF adjustment */
 
 /** \cfetimecmd Subtract Delta from Spacecraft Time Correlation Factor each 1Hz
 **
@@ -644,9 +644,9 @@
 **       Inappropriately setting the clock may result in other sub-systems performing incorrect
 **       time based calculations.  The specific risk is dependent upon the behavior of those sub-systems.
 **
-**  \sa #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_SUB_ADJUST_CC, #CFE_TIME_ADD_ONEHZ_ADJUSTMENT_CC
+**  \sa #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_SUB_ADJUST_CC, #CFE_TIME_ADD_ONE_HZ_ADJUSTMENT_CC
 */
-#define CFE_TIME_SUB_ONEHZ_ADJUSTMENT_CC 14 /* subtract 1Hz STCF adjustment */
+#define CFE_TIME_SUB_ONE_HZ_ADJUSTMENT_CC 14 /* subtract 1Hz STCF adjustment */
 
 /** \cfetimecmd Set Tone Signal Source
 **

--- a/modules/time/config/default_cfe_time_msgstruct.h
+++ b/modules/time/config/default_cfe_time_msgstruct.h
@@ -58,10 +58,10 @@ typedef struct CFE_TIME_SendDiagnosticCmd
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 } CFE_TIME_SendDiagnosticCmd_t;
 
-typedef struct CFE_TIME_1HzCmd
+typedef struct CFE_TIME_OneHzCmd
 {
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
-} CFE_TIME_1HzCmd_t;
+} CFE_TIME_OneHzCmd_t;
 
 typedef struct CFE_TIME_ToneSignalCmd
 {

--- a/modules/time/eds/cfe_time.xml
+++ b/modules/time/eds/cfe_time.xml
@@ -460,7 +460,7 @@
         </EntryList>
       </ContainerDataType>
 
-      <ContainerDataType name="1HzCmd" baseType="CFE_HDR/CommandHeader">
+      <ContainerDataType name="OneHzCmd" baseType="CFE_HDR/CommandHeader">
       </ContainerDataType>
 
       <ContainerDataType name="FakeToneCmd" baseType="CFE_HDR/CommandHeader">
@@ -1305,7 +1305,7 @@
           </Interface>
           <Interface name="ONEHZ_CMD" type="CFE_SB/Telecommand">
             <GenericTypeMapSet>
-              <GenericTypeMap name="TelecommandDataType" type="1HzCmd" />
+              <GenericTypeMap name="TelecommandDataType" type="OneHzCmd" />
             </GenericTypeMapSet>
           </Interface>
           <Interface name="DATA_CMD" type="CFE_SB/Telecommand">

--- a/modules/time/fsw/inc/cfe_time_eventids.h
+++ b/modules/time/fsw/inc/cfe_time_eventids.h
@@ -70,7 +70,7 @@
  *
  *  \par Cause:
  *
- *  \link #CFE_TIME_SEND_DIAGNOSTIC_TLM_CC TIME Request Diagnostics Command \endlink success.
+ *  \link #CFE_TIME_SEND_DIAGNOSTIC_CC TIME Request Diagnostics Command \endlink success.
  */
 #define CFE_TIME_DIAG_EID 6
 
@@ -171,8 +171,8 @@
  *
  *  \par Cause:
  *
- *  \link #CFE_TIME_ADD_ONEHZ_ADJUSTMENT_CC TIME Add STCF Adjustment Each Second Command \endlink OR
- *  \link #CFE_TIME_SUB_ONEHZ_ADJUSTMENT_CC TIME Subtract STCF Adjustment Each Second Command \endlink success.
+ *  \link #CFE_TIME_ADD_ONE_HZ_ADJUSTMENT_CC TIME Add STCF Adjustment Each Second Command \endlink OR
+ *  \link #CFE_TIME_SUB_ONE_HZ_ADJUSTMENT_CC TIME Subtract STCF Adjustment Each Second Command \endlink success.
  */
 #define CFE_TIME_ONEHZ_EID 16
 
@@ -431,8 +431,8 @@
  *
  *  \par Cause:
  *
- *  \link #CFE_TIME_ADD_ONEHZ_ADJUSTMENT_CC TIME Add STCF Adjustment Each Second Command \endlink OR
- *  \link #CFE_TIME_SUB_ONEHZ_ADJUSTMENT_CC TIME Subtract STCF Adjustment Each Second Command \endlink
+ *  \link #CFE_TIME_ADD_ONE_HZ_ADJUSTMENT_CC TIME Add STCF Adjustment Each Second Command \endlink OR
+ *  \link #CFE_TIME_SUB_ONE_HZ_ADJUSTMENT_CC TIME Subtract STCF Adjustment Each Second Command \endlink
  *  failure due to being in an incompatible mode.
  */
 #define CFE_TIME_ONEHZ_CFG_EID 48

--- a/modules/time/fsw/src/cfe_time_dispatch.c
+++ b/modules/time/fsw/src/cfe_time_dispatch.c
@@ -81,7 +81,7 @@ void CFE_TIME_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
         ** Housekeeping telemetry request...
         */
         case CFE_TIME_SEND_HK_MID:
-            CFE_TIME_HousekeepingCmd((const CFE_TIME_SendHkCmd_t *)SBBufPtr);
+            CFE_TIME_SendHkCmd((const CFE_TIME_SendHkCmd_t *)SBBufPtr);
             break;
 
         /*
@@ -102,7 +102,7 @@ void CFE_TIME_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
         ** Run time state machine at 1Hz...
         */
         case CFE_TIME_ONEHZ_CMD_MID:
-            CFE_TIME_OneHzCmd((const CFE_TIME_1HzCmd_t *)SBBufPtr);
+            CFE_TIME_OneHzCmd((const CFE_TIME_OneHzCmd_t *)SBBufPtr);
             break;
 
 /*
@@ -136,7 +136,7 @@ void CFE_TIME_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
                     }
                     break;
 
-                case CFE_TIME_SEND_DIAGNOSTIC_TLM_CC:
+                case CFE_TIME_SEND_DIAGNOSTIC_CC:
                     if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SendDiagnosticCmd_t)))
                     {
                         CFE_TIME_SendDiagnosticTlm((const CFE_TIME_SendDiagnosticCmd_t *)SBBufPtr);
@@ -226,14 +226,14 @@ void CFE_TIME_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
                     }
                     break;
 
-                case CFE_TIME_ADD_ONEHZ_ADJUSTMENT_CC:
+                case CFE_TIME_ADD_ONE_HZ_ADJUSTMENT_CC:
                     if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_Add1HZAdjustmentCmd_t)))
                     {
                         CFE_TIME_Add1HZAdjustmentCmd((const CFE_TIME_Add1HZAdjustmentCmd_t *)SBBufPtr);
                     }
                     break;
 
-                case CFE_TIME_SUB_ONEHZ_ADJUSTMENT_CC:
+                case CFE_TIME_SUB_ONE_HZ_ADJUSTMENT_CC:
                     if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_Sub1HZAdjustmentCmd_t)))
                     {
                         CFE_TIME_Sub1HZAdjustmentCmd((const CFE_TIME_Sub1HZAdjustmentCmd_t *)SBBufPtr);

--- a/modules/time/fsw/src/cfe_time_task.c
+++ b/modules/time/fsw/src/cfe_time_task.c
@@ -315,7 +315,7 @@ int32 CFE_TIME_TaskInit(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_HousekeepingCmd(const CFE_TIME_SendHkCmd_t *data)
+int32 CFE_TIME_SendHkCmd(const CFE_TIME_SendHkCmd_t *data)
 {
     CFE_TIME_Reference_t Reference;
 
@@ -393,7 +393,7 @@ int32 CFE_TIME_ToneDataCmd(const CFE_TIME_ToneDataCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_OneHzCmd(const CFE_TIME_1HzCmd_t *data)
+int32 CFE_TIME_OneHzCmd(const CFE_TIME_OneHzCmd_t *data)
 {
     /*
      * Run the state machine updates required at 1Hz.

--- a/modules/time/fsw/src/cfe_time_tone.c
+++ b/modules/time/fsw/src/cfe_time_tone.c
@@ -1287,7 +1287,7 @@ void CFE_TIME_Local1HzTask(void)
         ** This used to be optional in previous CFE versions, but it is now required
         ** as TIME subscribes to this itself to do state machine tasks.
         */
-        CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TIME_Global.Local1HzCmd.CommandHeader), true);
+        CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TIME_Global.LocalOneHzCmd.CommandHeader), true);
 
         CFE_TIME_Global.LocalTaskCounter++;
 

--- a/modules/time/fsw/src/cfe_time_utils.c
+++ b/modules/time/fsw/src/cfe_time_utils.c
@@ -351,8 +351,8 @@ void CFE_TIME_InitData(void)
     /*
     ** Initialize local 1Hz "wake-up" command packet (optional)...
     */
-    CFE_MSG_Init(CFE_MSG_PTR(CFE_TIME_Global.Local1HzCmd.CommandHeader), CFE_SB_ValueToMsgId(CFE_TIME_ONEHZ_CMD_MID),
-                 sizeof(CFE_TIME_Global.Local1HzCmd));
+    CFE_MSG_Init(CFE_MSG_PTR(CFE_TIME_Global.LocalOneHzCmd.CommandHeader), CFE_SB_ValueToMsgId(CFE_TIME_ONEHZ_CMD_MID),
+                 sizeof(CFE_TIME_Global.LocalOneHzCmd));
 }
 
 /*----------------------------------------------------------------

--- a/modules/time/fsw/src/cfe_time_utils.h
+++ b/modules/time/fsw/src/cfe_time_utils.h
@@ -259,7 +259,7 @@ typedef struct
     /*
     ** Local 1Hz wake-up command packet (not related to time at tone)...
     */
-    CFE_TIME_1HzCmd_t Local1HzCmd;
+    CFE_TIME_OneHzCmd_t LocalOneHzCmd;
 
     /*
     ** Time at the tone command packets (sent by time servers)...
@@ -666,7 +666,7 @@ void CFE_TIME_Local1HzTimerCallback(osal_id_t TimerId, void *Arg);
 /**
  * @brief  Onboard command (HK request)
  */
-int32 CFE_TIME_HousekeepingCmd(const CFE_TIME_SendHkCmd_t *data);
+int32 CFE_TIME_SendHkCmd(const CFE_TIME_SendHkCmd_t *data);
 
 /*
 ** Command handler for "tone signal detected"...
@@ -702,7 +702,7 @@ int32 CFE_TIME_ToneDataCmd(const CFE_TIME_ToneDataCmd_t *data);
  * This also implements the "fake tone" functionality when that is enabled,
  * as we do not need a separate MID for this job.
  */
-int32 CFE_TIME_OneHzCmd(const CFE_TIME_1HzCmd_t *data);
+int32 CFE_TIME_OneHzCmd(const CFE_TIME_OneHzCmd_t *data);
 
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
 

--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -68,7 +68,7 @@ static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_NOOP_CC = {.MsgId = CF
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_RESET_COUNTERS_CC = {
     .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_RESET_COUNTERS_CC};
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SEND_DIAGNOSTIC_TLM_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SEND_DIAGNOSTIC_TLM_CC};
+    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SEND_DIAGNOSTIC_CC};
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_STATE_CC = {
     .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SET_STATE_CC};
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_SOURCE_CC = {
@@ -92,9 +92,9 @@ static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_ADD_ADJUST_CC = {
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SUB_ADJUST_CC = {
     .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SUB_ADJUST_CC};
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_ADD_ONEHZ_ADJUSTMENT_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_ADD_ONEHZ_ADJUSTMENT_CC};
+    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_ADD_ONE_HZ_ADJUSTMENT_CC};
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SUB_ONEHZ_ADJUSTMENT_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SUB_ONEHZ_ADJUSTMENT_CC};
+    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SUB_ONE_HZ_ADJUSTMENT_CC};
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_INVALID_MID = {.MsgId = CFE_SB_MSGID_RESERVED, .CommandCode = 0};
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_INVALID_CC = {
     .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = 0x7F};
@@ -1317,7 +1317,7 @@ void Test_PipeCmds(void)
         CFE_TIME_ToneSignalCmd_t       tonesignalcmd;
         CFE_TIME_FakeToneCmd_t         timesendcmd;
         CFE_TIME_SendHkCmd_t           sendhkcmd;
-        CFE_TIME_1HzCmd_t              onehzcmd;
+        CFE_TIME_OneHzCmd_t              onehzcmd;
         CFE_TIME_NoopCmd_t             noopcmd;
         CFE_TIME_ResetCountersCmd_t    resetcounterscmd;
         CFE_TIME_SendDiagnosticCmd_t   diagtlmcmd;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Corrects cases where ES symbol names did not exactly match expected conventions.

Fixes #2502

**Testing performed**
Build and run all tests

**Expected behavior changes**
None - symbols are internal only.  But source will be (more) compatible with generated header files.

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
