### PR TITLE
Fix #2502, #2504, CFE updates needed for generated header compatibility (EDS)

### DIFF
--- a/docs/src/cfe_es.dox
+++ b/docs/src/cfe_es.dox
@@ -693,13 +693,13 @@
   The System Log is an array of bytes that contains back-to-back printf type
   messages from applications. The cFE internal applications use this log when
   errors are encountered during initialization before the Event Manager is fully
-  initialized. To view the information the #CFE_ES_WRITE_SYSLOG_CC command must
+  initialized. To view the information the #CFE_ES_WRITE_SYS_LOG_CC command must
   be sent. This command will write the log to a binary file. The path and
   filename may be specified in the command. If the filename command field
   contains an empty string, the configuration parameter
   #CFE_PLATFORM_ES_DEFAULT_SYSLOG_FILE is used to specify the path and filename.  Use the
   ground system to get the file and display the contents.  The
-  #CFE_ES_CLEAR_SYSLOG_CC is used to clear the System log.
+  #CFE_ES_CLEAR_SYS_LOG_CC is used to clear the System log.
 
   The size of the System log is defined by the platform configuration parameter
   #CFE_PLATFORM_ES_SYSTEM_LOG_SIZE. This log is preserved after a processor reset and

--- a/docs/src/cfe_time.dox
+++ b/docs/src/cfe_time.dox
@@ -657,7 +657,7 @@
   TIME provides the ability to command a one time adjustment
   (#CFE_TIME_ADD_ADJUST_CC and #CFE_TIME_SUB_ADJUST_CC)
   to the current STCF.  In addition there is a 1Hz adjustment
-  (#CFE_TIME_ADD_ONEHZ_ADJUSTMENT_CC and #CFE_TIME_SUB_ONEHZ_ADJUSTMENT_CC)
+  (#CFE_TIME_ADD_ONE_HZ_ADJUSTMENT_CC and #CFE_TIME_SUB_ONE_HZ_ADJUSTMENT_CC)
   that can be made to the STCF to compensate for oscillator drift.
   Mission specific ground correlation should be used to assist in
   determining the proper values to use. The Leap Seconds should be
@@ -671,7 +671,7 @@
   to by the other systems.
 
   \sa #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_SUB_ADJUST_CC, #CFE_TIME_SET_STCF_CC,
-  #CFE_TIME_ADD_ONEHZ_ADJUSTMENT_CC, #CFE_TIME_SUB_ONEHZ_ADJUSTMENT_CC, #CFE_TIME_SET_LEAP_SECONDS_CC
+  #CFE_TIME_ADD_ONE_HZ_ADJUSTMENT_CC, #CFE_TIME_SUB_ONE_HZ_ADJUSTMENT_CC, #CFE_TIME_SET_LEAP_SECONDS_CC
 **/
 
 

--- a/modules/core_api/fsw/inc/cfe_fs_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_fs_api_typedefs.h
@@ -33,6 +33,7 @@
 */
 #include "common_types.h"
 #include "osconfig.h"
+#include "cfe_mission_cfg.h"
 #include "cfe_fs_extern_typedefs.h"
 
 /**
@@ -124,7 +125,7 @@ typedef struct CFE_FS_FileWriteMetaData
 {
     volatile bool IsPending; /**< Whether request is pending (volatile as it may be checked outside lock) */
 
-    char FileName[OS_MAX_PATH_LEN]; /**< Name of file to write */
+    char FileName[CFE_MISSION_MAX_PATH_LEN]; /**< Name of file to write */
 
     /* Data for FS header */
     uint32 FileSubType;                          /**< Type of file to write (for FS header) */

--- a/modules/core_private/ut-stubs/src/ut_support.c
+++ b/modules/core_private/ut-stubs/src/ut_support.c
@@ -69,6 +69,8 @@ static uint16 UT_SendEventAppIDHistory[UT_EVENT_HISTORY_SIZE * 10];
 
 int32 dummy_function(void);
 
+static const UT_EntryKey_t UT_TABLE_DISPATCHER = 0;
+
 /*
 ** Functions
 */
@@ -195,6 +197,38 @@ void UT_ResetPoolBufferIndex(void)
     UT_SetDataBuffer(UT_KEY(CFE_ES_GetPoolBuf), &UT_CFE_ES_MemoryPool, sizeof(UT_CFE_ES_MemoryPool), false);
 }
 
+void UT_DispatchTableHandler(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+{
+    UT_TaskPipeDispatchId_t *DispatchId    = UserObj;
+    const CFE_SB_Buffer_t *  Buffer        = UT_Hook_GetArgValueByName(Context, "Buffer", const CFE_SB_Buffer_t *);
+    const void *             DispatchTable = UT_Hook_GetArgValueByName(Context, "DispatchTable", const void *);
+    const uint8 *            Addr;
+    CFE_Status_t (*MsgHandler)(const CFE_SB_Buffer_t *);
+    CFE_Status_t Status;
+
+    MsgHandler = NULL;
+    UT_Stub_GetInt32StatusCode(Context, &Status);
+
+    if (Status == 0 && DispatchId != NULL)
+    {
+        Status = DispatchId->DispatchError;
+
+        if (DispatchId->Method == UT_TaskPipeDispatchMethod_TABLE_OFFSET && DispatchTable != NULL)
+        {
+            Addr = DispatchTable;
+            Addr += DispatchId->TableOffset;
+            memcpy(&MsgHandler, Addr, sizeof(void *));
+        }
+    }
+
+    if (MsgHandler != NULL)
+    {
+        Status = MsgHandler(Buffer);
+    }
+
+    UT_Stub_SetReturnValue(FuncKey, Status);
+}
+
 /*
 ** Sets up the MSG stubs in preparation to invoke a "TaskPipe" dispatch function
 **
@@ -204,21 +238,58 @@ void UT_ResetPoolBufferIndex(void)
 void UT_SetupBasicMsgDispatch(const UT_TaskPipeDispatchId_t *DispatchReq, CFE_MSG_Size_t MsgSize,
                               bool ExpectFailureEvent)
 {
+    CFE_Status_t ErrorCode;
+
     if (DispatchReq != NULL)
     {
-        /* Set up for the typical task pipe related calls */
-        UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), (void *)&DispatchReq->MsgId, sizeof(DispatchReq->MsgId), true);
-        UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), true);
-        UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), (void *)&DispatchReq->CommandCode,
-                         sizeof(DispatchReq->CommandCode), true);
-
-        /* If a failure event is being set up, also set for MsgId/FcnCode retrieval as part of failure event reporting
-         */
-        if (ExpectFailureEvent)
+        if (DispatchReq->Method == UT_TaskPipeDispatchMethod_MSG_ID_CC)
         {
+            /* Set up for the typical task pipe related calls */
             UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), (void *)&DispatchReq->MsgId, sizeof(DispatchReq->MsgId), true);
+            UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), true);
             UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), (void *)&DispatchReq->CommandCode,
                              sizeof(DispatchReq->CommandCode), true);
+        }
+
+        if (DispatchReq->Method == UT_TaskPipeDispatchMethod_TABLE_OFFSET)
+        {
+            /* If the code uses EDS dispatch, this will invoke the right member function from the table (based on
+             * offset).  This requires setting up the function used for table dispatching first. */
+            if (UT_TABLE_DISPATCHER == 0)
+            {
+                UtAssert_Failed(
+                    "Setup error: Method set to TABLE_OFFSET but table dispatcher function is not configured");
+            }
+            else
+            {
+                UT_SetHandlerFunction(UT_TABLE_DISPATCHER, UT_DispatchTableHandler, (void *)DispatchReq);
+            }
+        }
+
+        /* If a failure event is being set up, set for MsgId/FcnCode retrieval as part of failure event reporting  */
+        if (ExpectFailureEvent || DispatchReq->DispatchError != CFE_SUCCESS)
+        {
+            UT_SetDataBuffer(UT_KEY(CFE_MSG_GetMsgId), (void *)&DispatchReq->MsgId, sizeof(DispatchReq->MsgId), true);
+            UT_SetDataBuffer(UT_KEY(CFE_MSG_GetSize), &MsgSize, sizeof(MsgSize), true);
+            UT_SetDataBuffer(UT_KEY(CFE_MSG_GetFcnCode), (void *)&DispatchReq->CommandCode,
+                             sizeof(DispatchReq->CommandCode), true);
+
+            if (UT_TABLE_DISPATCHER != 0)
+            {
+                /* If the code uses EDS dispatch, this will cause it to return the specified error */
+                if (DispatchReq->DispatchError != CFE_SUCCESS)
+                {
+                    ErrorCode = DispatchReq->DispatchError;
+                }
+                else
+                {
+                    /* If not specified, default to WRONG_MSG_LENGTH as this feature was historically used for testing
+                     * bad length */
+                    ErrorCode = CFE_STATUS_WRONG_MSG_LENGTH;
+                }
+
+                UT_SetDefaultReturnValue(UT_TABLE_DISPATCHER, ErrorCode);
+            }
         }
     }
     else
@@ -227,6 +298,10 @@ void UT_SetupBasicMsgDispatch(const UT_TaskPipeDispatchId_t *DispatchReq, CFE_MS
         UT_ResetState(UT_KEY(CFE_MSG_GetMsgId));
         UT_ResetState(UT_KEY(CFE_MSG_GetSize));
         UT_ResetState(UT_KEY(CFE_MSG_GetFcnCode));
+        if (UT_TABLE_DISPATCHER != 0)
+        {
+            UT_ResetState(UT_TABLE_DISPATCHER);
+        }
     }
 }
 

--- a/modules/es/config/default_cfe_es_fcncodes.h
+++ b/modules/es/config/default_cfe_es_fcncodes.h
@@ -457,10 +457,10 @@
 **       This command is not dangerous.  However, any previously logged data
 **       will be lost.
 **
-**  \sa #CFE_ES_WRITE_SYSLOG_CC, #CFE_ES_CLEAR_ER_LOG_CC, #CFE_ES_WRITE_ER_LOG_CC,
-**      #CFE_ES_OVER_WRITE_SYSLOG_CC
+**  \sa #CFE_ES_WRITE_SYS_LOG_CC, #CFE_ES_CLEAR_ER_LOG_CC, #CFE_ES_WRITE_ER_LOG_CC,
+**      #CFE_ES_OVER_WRITE_SYS_LOG_CC
 */
-#define CFE_ES_CLEAR_SYSLOG_CC 10
+#define CFE_ES_CLEAR_SYS_LOG_CC 10
 
 /** \cfeescmd Writes contents of Executive Services System Log to a File
 **
@@ -500,10 +500,10 @@
 **       if performed repeatedly without sufficient file management by the
 **       operator, fill the file system.
 **
-**  \sa #CFE_ES_CLEAR_SYSLOG_CC, #CFE_ES_CLEAR_ER_LOG_CC, #CFE_ES_WRITE_ER_LOG_CC,
-**      #CFE_ES_OVER_WRITE_SYSLOG_CC
+**  \sa #CFE_ES_CLEAR_SYS_LOG_CC, #CFE_ES_CLEAR_ER_LOG_CC, #CFE_ES_WRITE_ER_LOG_CC,
+**      #CFE_ES_OVER_WRITE_SYS_LOG_CC
 */
-#define CFE_ES_WRITE_SYSLOG_CC 11
+#define CFE_ES_WRITE_SYS_LOG_CC 11
 
 /** \cfeescmd Clears the contents of the Exception and Reset Log
 **
@@ -535,7 +535,7 @@
 **       This command is not dangerous.  However, any previously logged data
 **       will be lost.
 **
-**  \sa #CFE_ES_CLEAR_SYSLOG_CC, #CFE_ES_WRITE_SYSLOG_CC, #CFE_ES_WRITE_ER_LOG_CC
+**  \sa #CFE_ES_CLEAR_SYS_LOG_CC, #CFE_ES_WRITE_SYS_LOG_CC, #CFE_ES_WRITE_ER_LOG_CC
 */
 #define CFE_ES_CLEAR_ER_LOG_CC 12
 
@@ -578,7 +578,7 @@
 **       if performed repeatedly without sufficient file management by the
 **       operator, fill the file system.
 **
-**  \sa #CFE_ES_CLEAR_SYSLOG_CC, #CFE_ES_WRITE_SYSLOG_CC, #CFE_ES_CLEAR_ER_LOG_CC
+**  \sa #CFE_ES_CLEAR_SYS_LOG_CC, #CFE_ES_WRITE_SYS_LOG_CC, #CFE_ES_CLEAR_ER_LOG_CC
 */
 #define CFE_ES_WRITE_ER_LOG_CC 13
 
@@ -787,9 +787,9 @@
 **       identifying the cause of a problem to be lost by a subsequent flood of
 **       additional messages).
 **
-**  \sa #CFE_ES_CLEAR_SYSLOG_CC, #CFE_ES_WRITE_SYSLOG_CC
+**  \sa #CFE_ES_CLEAR_SYS_LOG_CC, #CFE_ES_WRITE_SYS_LOG_CC
 */
-#define CFE_ES_OVER_WRITE_SYSLOG_CC 18
+#define CFE_ES_OVER_WRITE_SYS_LOG_CC 18
 
 /** \cfeescmd Resets the Processor Reset Counter to Zero
 **

--- a/modules/es/config/default_cfe_es_msg.h
+++ b/modules/es/config/default_cfe_es_msg.h
@@ -32,6 +32,7 @@
 #define CFE_ES_MSG_H
 
 #include "cfe_mission_cfg.h"
+#include "cfe_es_fcncodes.h"
 #include "cfe_es_msgdefs.h"
 #include "cfe_es_msgstruct.h"
 

--- a/modules/es/config/default_cfe_es_msgdefs.h
+++ b/modules/es/config/default_cfe_es_msgdefs.h
@@ -52,7 +52,7 @@ typedef struct CFE_ES_RestartCmd_Payload
 **
 ** This format is shared by several executive services commands.
 ** For command details, see #CFE_ES_QUERY_ALL_CC, #CFE_ES_QUERY_ALL_TASKS_CC,
-** #CFE_ES_WRITE_SYSLOG_CC, and #CFE_ES_WRITE_ER_LOG_CC
+** #CFE_ES_WRITE_SYS_LOG_CC, and #CFE_ES_WRITE_ER_LOG_CC
 **
 **/
 typedef struct CFE_ES_FileNameCmd_Payload
@@ -64,7 +64,7 @@ typedef struct CFE_ES_FileNameCmd_Payload
 /**
 ** \brief Overwrite/Discard System Log Configuration Command Payload
 **
-** For command details, see #CFE_ES_OVER_WRITE_SYSLOG_CC
+** For command details, see #CFE_ES_OVER_WRITE_SYS_LOG_CC
 **
 **/
 typedef struct CFE_ES_OverWriteSysLogCmd_Payload
@@ -146,13 +146,12 @@ typedef struct CFE_ES_DeleteCDSCmd_Payload
 /**
  * @brief Labels for values to use in #CFE_ES_StartPerfCmd_Payload.TriggerMode
  * @sa CFE_ES_StartPerfCmd_Payload
-*/
+ */
 enum CFE_ES_PerfMode
 {
-    CFE_ES_PERF_TRIGGER_START = 0,
-    CFE_ES_PERF_TRIGGER_CENTER,
-    CFE_ES_PERF_TRIGGER_END,
-    CFE_ES_PERF_MAX_MODES
+    CFE_ES_PerfTrigger_START = 0,
+    CFE_ES_PerfTrigger_CENTER,
+    CFE_ES_PerfTrigger_END
 };
 
 typedef uint32 CFE_ES_PerfMode_Enum_t;
@@ -165,7 +164,8 @@ typedef uint32 CFE_ES_PerfMode_Enum_t;
 **/
 typedef struct CFE_ES_StartPerfCmd_Payload
 {
-    CFE_ES_PerfMode_Enum_t TriggerMode; /**< \brief Desired trigger position (Start, Center, End). Values defined by #CFE_ES_PerfMode. */
+    CFE_ES_PerfMode_Enum_t
+        TriggerMode; /**< \brief Desired trigger position (Start, Center, End). Values defined by #CFE_ES_PerfMode. */
 } CFE_ES_StartPerfCmd_Payload_t;
 
 /**

--- a/modules/es/eds/cfe_es.xml
+++ b/modules/es/eds/cfe_es.xml
@@ -116,6 +116,15 @@
         </EnumerationList>
       </EnumeratedDataType>
 
+      <EnumeratedDataType name="PerfTrigger" shortDescription="Performance Monitor trigger modes">
+        <IntegerDataEncoding sizeInBits="32" encoding="unsigned" />
+        <EnumerationList>
+          <Enumeration label="START"  value="0" shortDescription="Trigger at start" />
+          <Enumeration label="CENTER" value="1" shortDescription="Trigger at center" />
+          <Enumeration label="END"    value="2" shortDescription="Trigger at end" />
+        </EnumerationList>
+      </EnumeratedDataType>
+
       <ContainerDataType name="AppId" baseType="CFE_RESOURCEID/BaseType" shortDescription="A type for Application IDs">
         <LongDescription>
           This is the type that is used for any API accepting or returning an App ID
@@ -165,7 +174,7 @@
         </Range>
       </IntegerDataType>
 
-      <IntegerDataType name="MemOffset" shortDescription="Integer type used for CPU memory addresses, sizes and offsets">
+      <AliasDataType name="MemOffset" type="BASE_TYPES/MemReference" shortDescription="Integer type used for CPU memory addresses, sizes and offsets">
         <LongDescription>
           For backward compatibility with existing CFS code this should be uint32,
           but all telemetry information will be limited to 4GB in size as a result.
@@ -177,13 +186,9 @@
           In either case this must be an unsigned type, and should be large enough
           to represent the largest memory address/size in use in the CFS system.
         </LongDescription>
-        <IntegerDataEncoding sizeInBits="${CFE_MISSION/MEM_REFERENCE_SIZE_BITS}" encoding="unsigned" />
-        <Range>
-          <MinMaxRange max="2 ^ ${CFE_MISSION/MEM_REFERENCE_SIZE_BITS}" min="0" rangeType="inclusiveMinExclusiveMax"/>
-        </Range>
-      </IntegerDataType>
+      </AliasDataType>
 
-      <IntegerDataType name="MemAddress" shortDescription="Integer type used for CPU memory addresses, sizes and offsets">
+      <AliasDataType name="MemAddress" type="BASE_TYPES/MemReference" shortDescription="Integer type used for CPU memory addresses, sizes and offsets">
         <LongDescription>
           For backward compatibility with existing CFS code this should be uint32,
           but all telemetry information will be limited to 4GB in size as a result.
@@ -195,11 +200,7 @@
           In either case this must be an unsigned type, and should be large enough
           to represent the largest memory address/size in use in the CFS system.
         </LongDescription>
-        <IntegerDataEncoding sizeInBits="${CFE_MISSION/MEM_REFERENCE_SIZE_BITS}" encoding="unsigned" />
-        <Range>
-          <MinMaxRange max="2 ^ ${CFE_MISSION/MEM_REFERENCE_SIZE_BITS}" min="0" rangeType="inclusiveMinExclusiveMax"/>
-        </Range>
-      </IntegerDataType>
+      </AliasDataType>
 
       <StringDataType name="char_x_CFE_ES_CDS_MAX_FULL_NAME_LEN" length="${CFE_MISSION/ES_CDS_MAX_FULL_NAME_LEN}" />
 
@@ -402,7 +403,7 @@
 
       <ContainerDataType name="OverWriteSysLogCmd_Payload" shortDescription="Overwrite/Discard System Log Configuration Command">
         <LongDescription>
-          For command details, see #CFE_ES_OVERWRITE_SYSLOG_CC
+          For command details, see #CFE_ES_OVERWRITE_SYS_LOG_CC
         </LongDescription>
         <EntryList>
           <Entry name="Mode" type="LogMode">
@@ -475,7 +476,7 @@
           For command details, see #CFE_ES_PERF_STARTDATA_CC
         </LongDescription>
         <EntryList>
-          <Entry name="TriggerMode" type="BASE_TYPES/uint32" shortDescription="Desired trigger position (Start, Center, End)" />
+          <Entry name="TriggerMode" type="PerfTrigger" shortDescription="Desired trigger position (Start, Center, End)" />
         </EntryList>
       </ContainerDataType>
 
@@ -1300,8 +1301,8 @@
           This command is not dangerous.  However, any previously logged data
           will be lost.
 
-          \sa  #CFE_ES_WRITE_SYSLOG_CC, #CFE_ES_CLEAR_ERLOG_CC, #CFE_ES_WRITE_ERLOG_CC,
-          #CFE_ES_OVERWRITE_SYSLOG_CC
+          \sa  #CFE_ES_WRITE_SYS_LOG_CC, #CFE_ES_CLEAR_ERLOG_CC, #CFE_ES_WRITE_ERLOG_CC,
+          #CFE_ES_OVERWRITE_SYS_LOG_CC
         </LongDescription>
         <ConstraintSet>
           <ValueConstraint entry="Sec.FunctionCode" value="10" />
@@ -1351,8 +1352,8 @@
           if performed repeatedly without sufficient file management by the
           operator, fill the file system.
 
-          \sa  #CFE_ES_CLEAR_SYSLOG_CC, #CFE_ES_CLEAR_ERLOG_CC, #CFE_ES_WRITE_ERLOG_CC,
-          #CFE_ES_OVERWRITE_SYSLOG_CC
+          \sa  #CFE_ES_CLEAR_SYS_LOG_CC, #CFE_ES_CLEAR_ERLOG_CC, #CFE_ES_WRITE_ERLOG_CC,
+          #CFE_ES_OVERWRITE_SYS_LOG_CC
         </LongDescription>
         <ConstraintSet>
           <ValueConstraint entry="Sec.FunctionCode" value="11" />
@@ -1400,7 +1401,7 @@
           This command is not dangerous.  However, any previously logged data
           will be lost.
 
-          \sa  #CFE_ES_CLEAR_SYSLOG_CC, #CFE_ES_WRITE_SYSLOG_CC, #CFE_ES_WRITE_ERLOG_CC
+          \sa  #CFE_ES_CLEAR_SYS_LOG_CC, #CFE_ES_WRITE_SYS_LOG_CC, #CFE_ES_WRITE_ERLOG_CC
         </LongDescription>
         <ConstraintSet>
           <ValueConstraint entry="Sec.FunctionCode" value="12" />
@@ -1450,7 +1451,7 @@
           if performed repeatedly without sufficient file management by the
           operator, fill the file system.
 
-          \sa  #CFE_ES_CLEAR_SYSLOG_CC, #CFE_ES_WRITE_SYSLOG_CC, #CFE_ES_CLEAR_ERLOG_CC
+          \sa  #CFE_ES_CLEAR_SYS_LOG_CC, #CFE_ES_WRITE_SYS_LOG_CC, #CFE_ES_CLEAR_ERLOG_CC
         </LongDescription>
         <ConstraintSet>
           <ValueConstraint entry="Sec.FunctionCode" value="13" />
@@ -1710,7 +1711,7 @@
           identifying the cause of a problem to be lost by a subsequent flood of
           additional messages).
 
-          \sa  #CFE_ES_CLEAR_SYSLOG_CC, #CFE_ES_WRITE_SYSLOG_CC
+          \sa  #CFE_ES_CLEAR_SYS_LOG_CC, #CFE_ES_WRITE_SYS_LOG_CC
         </LongDescription>
         <ConstraintSet>
           <ValueConstraint entry="Sec.FunctionCode" value="18" />

--- a/modules/es/fsw/inc/cfe_es_eventids.h
+++ b/modules/es/fsw/inc/cfe_es_eventids.h
@@ -212,7 +212,7 @@
  *
  *  \par Cause:
  *
- *  \link #CFE_ES_CLEAR_SYSLOG_CC ES Clear System Log Command \endlink success.
+ *  \link #CFE_ES_CLEAR_SYS_LOG_CC ES Clear System Log Command \endlink success.
  */
 #define CFE_ES_SYSLOG1_INF_EID 17
 
@@ -223,7 +223,7 @@
  *
  *  \par Cause:
  *
- *  \link #CFE_ES_CLEAR_SYSLOG_CC ES Write System Log Command \endlink success.
+ *  \link #CFE_ES_CLEAR_SYS_LOG_CC ES Write System Log Command \endlink success.
  */
 #define CFE_ES_SYSLOG2_EID 18
 
@@ -608,7 +608,7 @@
  *
  *  \par Cause:
  *
- *  \link #CFE_ES_WRITE_SYSLOG_CC ES Write System Log Command \endlink failed parsing file
+ *  \link #CFE_ES_WRITE_SYS_LOG_CC ES Write System Log Command \endlink failed parsing file
  *  name or creating the file. OVERLOADED
  */
 #define CFE_ES_SYSLOG2_ERR_EID 55
@@ -772,7 +772,7 @@
  *
  *  \par Cause:
  *
- *  \link #CFE_ES_OVER_WRITE_SYSLOG_CC ES Set System Log Overwrite Mode Command \endlink success.
+ *  \link #CFE_ES_OVER_WRITE_SYS_LOG_CC ES Set System Log Overwrite Mode Command \endlink success.
  */
 #define CFE_ES_SYSLOGMODE_EID 70
 
@@ -783,7 +783,7 @@
  *
  *  \par Cause:
  *
- *  \link #CFE_ES_OVER_WRITE_SYSLOG_CC ES Set System Log Overwrite Mode Command \endlink failed
+ *  \link #CFE_ES_OVER_WRITE_SYS_LOG_CC ES Set System Log Overwrite Mode Command \endlink failed
  *  due to invalid mode requested.
  */
 #define CFE_ES_ERR_SYSLOGMODE_EID 71

--- a/modules/es/fsw/src/cfe_es_dispatch.c
+++ b/modules/es/fsw/src/cfe_es_dispatch.c
@@ -168,21 +168,21 @@ void CFE_ES_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
                     }
                     break;
 
-                case CFE_ES_CLEAR_SYSLOG_CC:
+                case CFE_ES_CLEAR_SYS_LOG_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_ClearSysLogCmd_t)))
                     {
                         CFE_ES_ClearSysLogCmd((const CFE_ES_ClearSysLogCmd_t *)SBBufPtr);
                     }
                     break;
 
-                case CFE_ES_WRITE_SYSLOG_CC:
+                case CFE_ES_WRITE_SYS_LOG_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_WriteSysLogCmd_t)))
                     {
                         CFE_ES_WriteSysLogCmd((const CFE_ES_WriteSysLogCmd_t *)SBBufPtr);
                     }
                     break;
 
-                case CFE_ES_OVER_WRITE_SYSLOG_CC:
+                case CFE_ES_OVER_WRITE_SYS_LOG_CC:
                     if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_OverWriteSysLogCmd_t)))
                     {
                         CFE_ES_OverWriteSysLogCmd((const CFE_ES_OverWriteSysLogCmd_t *)SBBufPtr);

--- a/modules/es/fsw/src/cfe_es_perf.c
+++ b/modules/es/fsw/src/cfe_es_perf.c
@@ -74,7 +74,7 @@ void CFE_ES_SetupPerfVariables(uint32 ResetType)
 
         /* set data collection state to waiting for command state */
         Perf->MetaData.State                 = CFE_ES_PERF_IDLE;
-        Perf->MetaData.Mode                  = CFE_ES_PERF_TRIGGER_START;
+        Perf->MetaData.Mode                  = CFE_ES_PerfTrigger_START;
         Perf->MetaData.TriggerCount          = 0;
         Perf->MetaData.DataStart             = 0;
         Perf->MetaData.DataEnd               = 0;
@@ -155,7 +155,7 @@ int32 CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfDataCmd_t *data)
         PerfDumpState->PendingState == CFE_ES_PerfDumpState_IDLE)
     {
         /* Make sure Trigger Mode is valid */
-        if (CmdPtr->TriggerMode < CFE_ES_PERF_MAX_MODES)
+        if (CmdPtr->TriggerMode <= CFE_ES_PerfTrigger_END)
         {
             CFE_ES_Global.TaskData.CommandCounter++;
 
@@ -180,7 +180,7 @@ int32 CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfDataCmd_t *data)
             CFE_ES_Global.TaskData.CommandErrorCounter++;
             CFE_EVS_SendEvent(CFE_ES_PERF_STARTCMD_TRIG_ERR_EID, CFE_EVS_EventType_ERROR,
                               "Cannot start collecting performance data, trigger mode (%d) out of range (%d to %d)",
-                              (int)CmdPtr->TriggerMode, (int)CFE_ES_PERF_TRIGGER_START, (int)CFE_ES_PERF_TRIGGER_END);
+                              (int)CmdPtr->TriggerMode, (int)CFE_ES_PerfTrigger_START, (int)CFE_ES_PerfTrigger_END);
         }
     }
     else
@@ -668,21 +668,21 @@ void CFE_ES_PerfLogAdd(uint32 Marker, uint32 EntryExit)
         if (Perf->MetaData.State == CFE_ES_PERF_TRIGGERED)
         {
             Perf->MetaData.TriggerCount++;
-            if (Perf->MetaData.Mode == CFE_ES_PERF_TRIGGER_START)
+            if (Perf->MetaData.Mode == CFE_ES_PerfTrigger_START)
             {
                 if (Perf->MetaData.TriggerCount >= CFE_PLATFORM_ES_PERF_DATA_BUFFER_SIZE)
                 {
                     Perf->MetaData.State = CFE_ES_PERF_IDLE;
                 }
             }
-            else if (Perf->MetaData.Mode == CFE_ES_PERF_TRIGGER_CENTER)
+            else if (Perf->MetaData.Mode == CFE_ES_PerfTrigger_CENTER)
             {
                 if (Perf->MetaData.TriggerCount >= CFE_PLATFORM_ES_PERF_DATA_BUFFER_SIZE / 2)
                 {
                     Perf->MetaData.State = CFE_ES_PERF_IDLE;
                 }
             }
-            else if (Perf->MetaData.Mode == CFE_ES_PERF_TRIGGER_END)
+            else if (Perf->MetaData.Mode == CFE_ES_PerfTrigger_END)
             {
                 Perf->MetaData.State = CFE_ES_PERF_IDLE;
             }

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -111,12 +111,12 @@ static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_QUERY_ALL_CC = {
     .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_QUERY_ALL_CC};
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_QUERY_ALL_TASKS_CC = {
     .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_QUERY_ALL_TASKS_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_CLEAR_SYSLOG_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_CLEAR_SYSLOG_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_WRITE_SYSLOG_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_OVER_WRITE_SYSLOG_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_OVER_WRITE_SYSLOG_CC};
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_CLEAR_SYS_LOG_CC = {
+    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_CLEAR_SYS_LOG_CC};
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_WRITE_SYS_LOG_CC = {
+    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_WRITE_SYS_LOG_CC};
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_OVER_WRITE_SYS_LOG_CC = {
+    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_OVER_WRITE_SYS_LOG_CC};
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_CLEAR_ER_LOG_CC = {
     .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_CLEAR_ER_LOG_CC};
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_WRITE_ER_LOG_CC = {
@@ -2466,7 +2466,6 @@ void TestGenericPool(void)
     ES_ResetUnitTest();
     UtAssert_INT32_EQ(CFE_ES_GenPoolRecyclePoolBlock(&Pool1, 0, Pool1.Buckets[0].BlockSize, &Offset1),
                       CFE_ES_BUFFER_NOT_IN_POOL);
-
 }
 
 void TestTask(void)
@@ -3027,7 +3026,7 @@ void TestTask(void)
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.ClearSysLogCmd),
-                    UT_TPID_CFE_ES_CMD_CLEAR_SYSLOG_CC);
+                    UT_TPID_CFE_ES_CMD_CLEAR_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOG1_INF_EID);
 
     /* Test successful overwriting of the system log using overwrite mode */
@@ -3035,7 +3034,7 @@ void TestTask(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.OverwriteSysLogCmd.Payload.Mode = CFE_ES_LogMode_OVERWRITE;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.OverwriteSysLogCmd),
-                    UT_TPID_CFE_ES_CMD_OVER_WRITE_SYSLOG_CC);
+                    UT_TPID_CFE_ES_CMD_OVER_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOGMODE_EID);
 
     /* Test successful overwriting of the system log using discard mode */
@@ -3043,7 +3042,7 @@ void TestTask(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.OverwriteSysLogCmd.Payload.Mode = CFE_ES_LogMode_DISCARD;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.OverwriteSysLogCmd),
-                    UT_TPID_CFE_ES_CMD_OVER_WRITE_SYSLOG_CC);
+                    UT_TPID_CFE_ES_CMD_OVER_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOGMODE_EID);
 
     /* Test overwriting the system log using an invalid mode */
@@ -3051,7 +3050,7 @@ void TestTask(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.OverwriteSysLogCmd.Payload.Mode = 255;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.OverwriteSysLogCmd),
-                    UT_TPID_CFE_ES_CMD_OVER_WRITE_SYSLOG_CC);
+                    UT_TPID_CFE_ES_CMD_OVER_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_ERR_SYSLOGMODE_EID);
 
     /* Test successful writing of the system log */
@@ -3061,7 +3060,7 @@ void TestTask(void)
     CmdBuf.WriteSysLogCmd.Payload.FileName[sizeof(CmdBuf.WriteSysLogCmd.Payload.FileName) - 1] = '\0';
     CFE_ES_Global.TaskData.HkPacket.Payload.SysLogEntries                                      = 123;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.WriteSysLogCmd),
-                    UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
+                    UT_TPID_CFE_ES_CMD_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOG2_EID);
 
     /* Test writing the system log using a bad file name */
@@ -3069,7 +3068,7 @@ void TestTask(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_ParseInputFileNameEx), 1, CFE_FS_INVALID_PATH);
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.WriteSysLogCmd),
-                    UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
+                    UT_TPID_CFE_ES_CMD_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOG2_ERR_EID);
 
     /* Test writing the system log using a null file name */
@@ -3077,7 +3076,7 @@ void TestTask(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.WriteSysLogCmd.Payload.FileName[0] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.WriteSysLogCmd),
-                    UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
+                    UT_TPID_CFE_ES_CMD_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOG2_EID);
 
     /* Test writing the system log with an OS create failure */
@@ -3086,7 +3085,7 @@ void TestTask(void)
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
     CmdBuf.WriteSysLogCmd.Payload.FileName[0] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.WriteSysLogCmd),
-                    UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
+                    UT_TPID_CFE_ES_CMD_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOG2_ERR_EID);
 
     /* Test writing the system log with an OS write failure */
@@ -3099,14 +3098,14 @@ void TestTask(void)
     CFE_ES_Global.ResetDataPtr->SystemLogEndIdx = CFE_ES_Global.ResetDataPtr->SystemLogWriteIdx;
     CmdBuf.WriteSysLogCmd.Payload.FileName[0]   = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.WriteSysLogCmd),
-                    UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
+                    UT_TPID_CFE_ES_CMD_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_FILEWRITE_ERR_EID);
 
     /* Test writing the system log with a write header failure */
     ES_ResetUnitTest();
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_WriteHeader), 1, OS_ERROR);
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.WriteSysLogCmd),
-                    UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
+                    UT_TPID_CFE_ES_CMD_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_FILEWRITE_ERR_EID);
 
     /* Test successful clearing of the E&R log */
@@ -3466,21 +3465,21 @@ void TestTask(void)
      * invalid command length
      */
     ES_ResetUnitTest();
-    UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_CLEAR_SYSLOG_CC);
+    UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_CLEAR_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
 
     /* Test sending a request to overwrite the system log with an
      * invalid command length
      */
     ES_ResetUnitTest();
-    UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_OVER_WRITE_SYSLOG_CC);
+    UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_OVER_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
 
     /* Test sending a request to write the system log with an
      * invalid command length
      */
     ES_ResetUnitTest();
-    UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_WRITE_SYSLOG_CC);
+    UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
 
     /* Test successful overwriting of the system log using overwrite mode */
@@ -3488,7 +3487,7 @@ void TestTask(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     CmdBuf.OverwriteSysLogCmd.Payload.Mode = CFE_ES_LogMode_OVERWRITE;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.OverwriteSysLogCmd),
-                    UT_TPID_CFE_ES_CMD_OVER_WRITE_SYSLOG_CC);
+                    UT_TPID_CFE_ES_CMD_OVER_WRITE_SYS_LOG_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOGMODE_EID);
 
     /* Test sending a request to write the error log with an
@@ -3598,7 +3597,7 @@ void TestPerf(void)
      */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CmdBuf.PerfStartCmd.Payload.TriggerMode = CFE_ES_PERF_TRIGGER_START;
+    CmdBuf.PerfStartCmd.Payload.TriggerMode = CFE_ES_PerfTrigger_START;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.PerfStartCmd),
                     UT_TPID_CFE_ES_CMD_START_PERF_DATA_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_PERF_STARTCMD_EID);
@@ -3608,7 +3607,7 @@ void TestPerf(void)
      */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CmdBuf.PerfStartCmd.Payload.TriggerMode = CFE_ES_PERF_TRIGGER_CENTER;
+    CmdBuf.PerfStartCmd.Payload.TriggerMode = CFE_ES_PerfTrigger_CENTER;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.PerfStartCmd),
                     UT_TPID_CFE_ES_CMD_START_PERF_DATA_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_PERF_STARTCMD_EID);
@@ -3618,7 +3617,7 @@ void TestPerf(void)
      */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CmdBuf.PerfStartCmd.Payload.TriggerMode = CFE_ES_PERF_TRIGGER_END;
+    CmdBuf.PerfStartCmd.Payload.TriggerMode = CFE_ES_PerfTrigger_END;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.PerfStartCmd),
                     UT_TPID_CFE_ES_CMD_START_PERF_DATA_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_PERF_STARTCMD_EID);
@@ -3628,7 +3627,7 @@ void TestPerf(void)
      */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CmdBuf.PerfStartCmd.Payload.TriggerMode = (CFE_ES_PERF_TRIGGER_END + 1);
+    CmdBuf.PerfStartCmd.Payload.TriggerMode = (CFE_ES_PerfTrigger_END + 1);
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.PerfStartCmd),
                     UT_TPID_CFE_ES_CMD_START_PERF_DATA_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_PERF_STARTCMD_TRIG_ERR_EID);
@@ -3649,7 +3648,7 @@ void TestPerf(void)
     /* clearing the BackgroundPerfDumpState will fully reset to initial state */
     memset(&CFE_ES_Global.BackgroundPerfDumpState, 0, sizeof(CFE_ES_Global.BackgroundPerfDumpState));
     CFE_ES_Global.BackgroundPerfDumpState.CurrentState = CFE_ES_PerfDumpState_INIT;
-    CmdBuf.PerfStartCmd.Payload.TriggerMode            = CFE_ES_PERF_TRIGGER_START;
+    CmdBuf.PerfStartCmd.Payload.TriggerMode            = CFE_ES_PerfTrigger_START;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.PerfStartCmd),
                     UT_TPID_CFE_ES_CMD_START_PERF_DATA_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_PERF_STARTCMD_ERR_EID);
@@ -3667,7 +3666,7 @@ void TestPerf(void)
     ES_ResetUnitTest();
     memset(&CFE_ES_Global.BackgroundPerfDumpState, 0, sizeof(CFE_ES_Global.BackgroundPerfDumpState));
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CmdBuf.PerfStartCmd.Payload.TriggerMode = CFE_ES_PERF_TRIGGER_START;
+    CmdBuf.PerfStartCmd.Payload.TriggerMode = CFE_ES_PerfTrigger_START;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.PerfStartCmd),
                     UT_TPID_CFE_ES_CMD_START_PERF_DATA_CC);
     CFE_UtAssert_EVENTSENT(CFE_ES_PERF_STARTCMD_EID);
@@ -3775,11 +3774,11 @@ void TestPerf(void)
      */
     ES_ResetUnitTest();
     Perf->MetaData.InvalidMarkerReported = true;
-    Perf->MetaData.Mode                  = CFE_ES_PERF_TRIGGER_START;
+    Perf->MetaData.Mode                  = CFE_ES_PerfTrigger_START;
     Perf->MetaData.DataCount             = CFE_PLATFORM_ES_PERF_DATA_BUFFER_SIZE + 1;
     Perf->MetaData.TriggerMask[0]        = 0xFFFF;
     CFE_ES_PerfLogAdd(1, 0);
-    UtAssert_UINT32_EQ(Perf->MetaData.Mode, CFE_ES_PERF_TRIGGER_START);
+    UtAssert_UINT32_EQ(Perf->MetaData.Mode, CFE_ES_PerfTrigger_START);
     UtAssert_UINT32_EQ(Perf->MetaData.State, CFE_ES_PERF_IDLE);
 
     /* Test addition of a new entry to the performance log with CENTER
@@ -3787,10 +3786,10 @@ void TestPerf(void)
      */
     ES_ResetUnitTest();
     Perf->MetaData.State        = CFE_ES_PERF_TRIGGERED;
-    Perf->MetaData.Mode         = CFE_ES_PERF_TRIGGER_CENTER;
+    Perf->MetaData.Mode         = CFE_ES_PerfTrigger_CENTER;
     Perf->MetaData.TriggerCount = CFE_PLATFORM_ES_PERF_DATA_BUFFER_SIZE / 2 + 1;
     CFE_ES_PerfLogAdd(1, 0);
-    UtAssert_UINT32_EQ(Perf->MetaData.Mode, CFE_ES_PERF_TRIGGER_CENTER);
+    UtAssert_UINT32_EQ(Perf->MetaData.Mode, CFE_ES_PerfTrigger_CENTER);
     UtAssert_UINT32_EQ(Perf->MetaData.State, CFE_ES_PERF_IDLE);
 
     /* Test addition of a new entry to the performance log with END
@@ -3798,9 +3797,9 @@ void TestPerf(void)
      */
     ES_ResetUnitTest();
     Perf->MetaData.State = CFE_ES_PERF_TRIGGERED;
-    Perf->MetaData.Mode  = CFE_ES_PERF_TRIGGER_END;
+    Perf->MetaData.Mode  = CFE_ES_PerfTrigger_END;
     CFE_ES_PerfLogAdd(1, 0);
-    UtAssert_UINT32_EQ(Perf->MetaData.Mode, CFE_ES_PERF_TRIGGER_END);
+    UtAssert_UINT32_EQ(Perf->MetaData.Mode, CFE_ES_PerfTrigger_END);
     UtAssert_UINT32_EQ(Perf->MetaData.State, CFE_ES_PERF_IDLE);
 
     /* Test addition where state goes to idle after first check */
@@ -3853,7 +3852,7 @@ void TestPerf(void)
     ES_ResetUnitTest();
     Perf->MetaData.TriggerCount   = 0;
     Perf->MetaData.State          = CFE_ES_PERF_TRIGGERED;
-    Perf->MetaData.Mode           = CFE_ES_PERF_TRIGGER_START;
+    Perf->MetaData.Mode           = CFE_ES_PerfTrigger_START;
     Perf->MetaData.TriggerMask[0] = 0xffff;
     CFE_ES_PerfLogAdd(0x1, 0);
     UtAssert_UINT32_EQ(Perf->MetaData.TriggerCount, 1);
@@ -3864,7 +3863,7 @@ void TestPerf(void)
     ES_ResetUnitTest();
     Perf->MetaData.TriggerCount = CFE_PLATFORM_ES_PERF_DATA_BUFFER_SIZE / 2 - 2;
     Perf->MetaData.State        = CFE_ES_PERF_TRIGGERED;
-    Perf->MetaData.Mode         = CFE_ES_PERF_TRIGGER_CENTER;
+    Perf->MetaData.Mode         = CFE_ES_PerfTrigger_CENTER;
     CFE_ES_PerfLogAdd(0x1, 0);
     UtAssert_UINT32_EQ(Perf->MetaData.State, CFE_ES_PERF_TRIGGERED);
 

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -88,62 +88,72 @@ CFE_ES_GMP_IndirectBuffer_t UT_MemPoolIndirectBuffer;
 /* Create a startup script buffer for a maximum of 5 lines * 80 chars/line */
 char StartupScript[MAX_STARTUP_SCRIPT];
 
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_NOOP_CC = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
-                                                                   .CommandCode = CFE_ES_NOOP_CC};
+/* Normal dispatching registers the MsgID+CC in order to follow a
+ * certain path through a series of switch statements */
+#define ES_UT_MID_DISPATCH(intf) \
+    .Method = UT_TaskPipeDispatchMethod_MSG_ID_CC, .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_##intf##_MID)
 
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_RESET_COUNTERS_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_RESET_COUNTERS_CC};
+#define ES_UT_MSG_DISPATCH(intf, cmd)       ES_UT_MID_DISPATCH(intf), UT_TPD_SETSIZE(CFE_ES_##cmd)
+#define ES_UT_CC_DISPATCH(intf, cc, cmd)    ES_UT_MSG_DISPATCH(intf, cmd), UT_TPD_SETCC(cc)
+#define ES_UT_ERROR_DISPATCH(intf, cc, err) ES_UT_MID_DISPATCH(intf), UT_TPD_SETCC(cc), UT_TPD_SETERR(err)
 
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_RESTART_CC = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
-                                                                      .CommandCode = CFE_ES_RESTART_CC};
-
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_START_APP_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_START_APP_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_STOP_APP_CC = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
-                                                                       .CommandCode = CFE_ES_STOP_APP_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_RESTART_APP_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_RESTART_APP_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_RELOAD_APP_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_RELOAD_APP_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_QUERY_ONE_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_QUERY_ONE_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_QUERY_ALL_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_QUERY_ALL_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_QUERY_ALL_TASKS_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_QUERY_ALL_TASKS_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_CLEAR_SYS_LOG_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_CLEAR_SYS_LOG_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_WRITE_SYS_LOG_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_WRITE_SYS_LOG_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_OVER_WRITE_SYS_LOG_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_OVER_WRITE_SYS_LOG_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_CLEAR_ER_LOG_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_CLEAR_ER_LOG_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_WRITE_ER_LOG_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_WRITE_ER_LOG_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_START_PERF_DATA_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_START_PERF_DATA_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_STOP_PERF_DATA_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_STOP_PERF_DATA_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_SET_PERF_FILTER_MASK_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_SET_PERF_FILTER_MASK_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_SET_PERF_TRIGGER_MASK_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_SET_PERF_TRIGGER_MASK_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_RESET_PR_COUNT_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_RESET_PR_COUNT_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_SET_MAX_PR_COUNT_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_SET_MAX_PR_COUNT_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_DELETE_CDS_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_DELETE_CDS_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_SEND_MEM_POOL_STATS_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_SEND_MEM_POOL_STATS_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_DUMP_CDS_REGISTRY_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID), .CommandCode = CFE_ES_DUMP_CDS_REGISTRY_CC};
-
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_INVALID_CC = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_CMD_MID),
-                                                                      .CommandCode = CFE_ES_DUMP_CDS_REGISTRY_CC + 2};
-
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_SEND_HK = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_ES_SEND_HK_MID)};
+/* NOTE: Automatic formatting of this table tends to make it harder to read. */
+/* clang-format off */
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_NOOP_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_NOOP_CC, NoopCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_RESET_COUNTERS_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_RESET_COUNTERS_CC, ResetCountersCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_RESTART_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_RESTART_CC, RestartCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_START_APP_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_START_APP_CC, StartAppCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_STOP_APP_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_STOP_APP_CC, StopAppCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_RESTART_APP_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_RESTART_APP_CC, RestartAppCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_RELOAD_APP_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_RELOAD_APP_CC, ReloadAppCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_QUERY_ONE_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_QUERY_ONE_CC, QueryOneCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_QUERY_ALL_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_QUERY_ALL_CC, QueryAllCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_QUERY_ALL_TASKS_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_QUERY_ALL_TASKS_CC, QueryAllTasksCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_CLEAR_SYS_LOG_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_CLEAR_SYS_LOG_CC, ClearSysLogCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_WRITE_SYS_LOG_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_WRITE_SYS_LOG_CC, WriteSysLogCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_OVER_WRITE_SYS_LOG_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_OVER_WRITE_SYS_LOG_CC, OverWriteSysLogCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_CLEAR_ER_LOG_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_CLEAR_ER_LOG_CC, ClearERLogCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_WRITE_ER_LOG_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_WRITE_ER_LOG_CC, WriteERLogCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_START_PERF_DATA_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_START_PERF_DATA_CC, StartPerfDataCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_STOP_PERF_DATA_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_STOP_PERF_DATA_CC, StopPerfDataCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_SET_PERF_FILTER_MASK_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_SET_PERF_FILTER_MASK_CC, SetPerfFilterMaskCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_SET_PERF_TRIGGER_MASK_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_SET_PERF_TRIGGER_MASK_CC, SetPerfTriggerMaskCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_RESET_PR_COUNT_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_RESET_PR_COUNT_CC, ResetPRCountCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_SET_MAX_PR_COUNT_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_SET_MAX_PR_COUNT_CC, SetMaxPRCountCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_DELETE_CDS_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_DELETE_CDS_CC, DeleteCDSCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_SEND_MEM_POOL_STATS_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_SEND_MEM_POOL_STATS_CC, SendMemPoolStatsCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_DUMP_CDS_REGISTRY_CC =
+    { ES_UT_CC_DISPATCH(CMD, CFE_ES_DUMP_CDS_REGISTRY_CC, DumpCDSRegistryCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_SEND_HK =
+    { ES_UT_MSG_DISPATCH(SEND_HK, SendHkCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_INVALID_LENGTH =
+    { ES_UT_ERROR_DISPATCH(CMD, 0, CFE_STATUS_WRONG_MSG_LENGTH) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_ES_CMD_INVALID_CC =
+    { ES_UT_ERROR_DISPATCH(CMD, -1, CFE_STATUS_BAD_COMMAND_CODE) };
+/* clang-format on */
 
 /*
 ** Functions
@@ -3248,7 +3258,7 @@ void TestTask(void)
      * length call
      */
     ES_ResetUnitTest();
-    UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_CLEAR_ER_LOG_CC);
+    UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_INVALID_LENGTH);
     CFE_UtAssert_EVENTSENT(CFE_ES_LEN_ERR_EID);
 
     /* Test resetting and setting the max for the processor reset count */

--- a/modules/evs/config/default_cfe_evs_msg.h
+++ b/modules/evs/config/default_cfe_evs_msg.h
@@ -33,6 +33,7 @@
 
 #include "cfe_mission_cfg.h"
 #include "cfe_evs_fcncodes.h"
+#include "cfe_evs_msgdefs.h"
 #include "cfe_evs_msgstruct.h"
 
 #endif

--- a/modules/evs/ut-coverage/evs_UT.c
+++ b/modules/evs/ut-coverage/evs_UT.c
@@ -57,52 +57,66 @@ static const char *EVS_SYSLOG_MSGS[] = {
     "%s: Subscribing to Cmds Failed:RC=0x%08X\n",
     "%s: Subscribing to HK Request Failed:RC=0x%08X\n"};
 
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_NOOP_CC = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID),
-                                                                    .CommandCode = CFE_EVS_NOOP_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_RESET_COUNTERS_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID), .CommandCode = CFE_EVS_RESET_COUNTERS_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_ENABLE_EVENT_TYPE_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID), .CommandCode = CFE_EVS_ENABLE_EVENT_TYPE_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_DISABLE_EVENT_TYPE_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID), .CommandCode = CFE_EVS_DISABLE_EVENT_TYPE_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_SET_EVENT_FORMAT_MODE_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID), .CommandCode = CFE_EVS_SET_EVENT_FORMAT_MODE_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_ENABLE_APP_EVENT_TYPE_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID), .CommandCode = CFE_EVS_ENABLE_APP_EVENT_TYPE_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_DISABLE_APP_EVENT_TYPE_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID), .CommandCode = CFE_EVS_DISABLE_APP_EVENT_TYPE_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_ENABLE_APP_EVENTS_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID), .CommandCode = CFE_EVS_ENABLE_APP_EVENTS_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_DISABLE_APP_EVENTS_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID), .CommandCode = CFE_EVS_DISABLE_APP_EVENTS_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_RESET_APP_COUNTER_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID), .CommandCode = CFE_EVS_RESET_APP_COUNTER_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_SET_FILTER_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID), .CommandCode = CFE_EVS_SET_FILTER_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_ENABLE_PORTS_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID), .CommandCode = CFE_EVS_ENABLE_PORTS_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_DISABLE_PORTS_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID), .CommandCode = CFE_EVS_DISABLE_PORTS_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_RESET_FILTER_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID), .CommandCode = CFE_EVS_RESET_FILTER_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_RESET_ALL_FILTERS_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID), .CommandCode = CFE_EVS_RESET_ALL_FILTERS_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_ADD_EVENT_FILTER_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID), .CommandCode = CFE_EVS_ADD_EVENT_FILTER_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_DELETE_EVENT_FILTER_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID), .CommandCode = CFE_EVS_DELETE_EVENT_FILTER_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_WRITE_APP_DATA_FILE_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID), .CommandCode = CFE_EVS_WRITE_APP_DATA_FILE_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_WRITE_LOG_DATA_FILE_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID), .CommandCode = CFE_EVS_WRITE_LOG_DATA_FILE_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_SET_LOG_MODE_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID), .CommandCode = CFE_EVS_SET_LOG_MODE_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_CLEAR_LOG_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID), .CommandCode = CFE_EVS_CLEAR_LOG_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_INVALID_MID = {.MsgId = CFE_SB_MSGID_RESERVED, .CommandCode = 0};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_INVALID_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_CMD_MID), .CommandCode = 0x7F};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_SEND_HK = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_SEND_HK_MID)};
+/* Normal dispatching registers the MsgID+CC in order to follow a
+ * certain path through a series of switch statements */
+#define EVS_UT_MID_DISPATCH(intf) \
+    .Method = UT_TaskPipeDispatchMethod_MSG_ID_CC, .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_EVS_##intf##_MID)
+
+#define EVS_UT_MSG_DISPATCH(intf, cmd)       EVS_UT_MID_DISPATCH(intf), UT_TPD_SETSIZE(CFE_EVS_##cmd)
+#define EVS_UT_CC_DISPATCH(intf, cc, cmd)    EVS_UT_MSG_DISPATCH(intf, cmd), UT_TPD_SETCC(cc)
+#define EVS_UT_ERROR_DISPATCH(intf, cc, err) EVS_UT_MID_DISPATCH(intf), UT_TPD_SETCC(cc), UT_TPD_SETERR(err)
+
+/* NOTE: Automatic formatting of this table tends to make it harder to read. */
+/* clang-format off */
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_NOOP_CC =
+    { EVS_UT_CC_DISPATCH(CMD, CFE_EVS_NOOP_CC, NoopCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_RESET_COUNTERS_CC =
+    { EVS_UT_CC_DISPATCH(CMD, CFE_EVS_RESET_COUNTERS_CC, ResetCountersCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_ENABLE_EVENT_TYPE_CC =
+    { EVS_UT_CC_DISPATCH(CMD, CFE_EVS_ENABLE_EVENT_TYPE_CC, EnableEventTypeCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_DISABLE_EVENT_TYPE_CC =
+    { EVS_UT_CC_DISPATCH(CMD, CFE_EVS_DISABLE_EVENT_TYPE_CC, DisableEventTypeCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_SET_EVENT_FORMAT_MODE_CC =
+    { EVS_UT_CC_DISPATCH(CMD, CFE_EVS_SET_EVENT_FORMAT_MODE_CC, SetEventFormatModeCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_ENABLE_APP_EVENT_TYPE_CC =
+    { EVS_UT_CC_DISPATCH(CMD, CFE_EVS_ENABLE_APP_EVENT_TYPE_CC, EnableAppEventTypeCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_DISABLE_APP_EVENT_TYPE_CC =
+    { EVS_UT_CC_DISPATCH(CMD, CFE_EVS_DISABLE_APP_EVENT_TYPE_CC, DisableAppEventTypeCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_ENABLE_APP_EVENTS_CC =
+    { EVS_UT_CC_DISPATCH(CMD, CFE_EVS_ENABLE_APP_EVENTS_CC, EnableAppEventsCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_DISABLE_APP_EVENTS_CC =
+    { EVS_UT_CC_DISPATCH(CMD, CFE_EVS_DISABLE_APP_EVENTS_CC, DisableAppEventsCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_RESET_APP_COUNTER_CC =
+    { EVS_UT_CC_DISPATCH(CMD, CFE_EVS_RESET_APP_COUNTER_CC, ResetAppCounterCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_SET_FILTER_CC =
+    { EVS_UT_CC_DISPATCH(CMD, CFE_EVS_SET_FILTER_CC, SetFilterCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_ENABLE_PORTS_CC =
+    { EVS_UT_CC_DISPATCH(CMD, CFE_EVS_ENABLE_PORTS_CC, EnablePortsCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_DISABLE_PORTS_CC =
+    { EVS_UT_CC_DISPATCH(CMD, CFE_EVS_DISABLE_PORTS_CC, DisablePortsCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_RESET_FILTER_CC =
+    { EVS_UT_CC_DISPATCH(CMD, CFE_EVS_RESET_FILTER_CC, ResetFilterCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_RESET_ALL_FILTERS_CC =
+    { EVS_UT_CC_DISPATCH(CMD, CFE_EVS_RESET_ALL_FILTERS_CC, ResetAllFiltersCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_ADD_EVENT_FILTER_CC =
+    { EVS_UT_CC_DISPATCH(CMD, CFE_EVS_ADD_EVENT_FILTER_CC, AddEventFilterCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_DELETE_EVENT_FILTER_CC =
+    { EVS_UT_CC_DISPATCH(CMD, CFE_EVS_DELETE_EVENT_FILTER_CC, DeleteEventFilterCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_WRITE_APP_DATA_FILE_CC =
+    { EVS_UT_CC_DISPATCH(CMD, CFE_EVS_WRITE_APP_DATA_FILE_CC, WriteAppDataFileCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_WRITE_LOG_DATA_FILE_CC =
+    { EVS_UT_CC_DISPATCH(CMD, CFE_EVS_WRITE_LOG_DATA_FILE_CC, WriteLogDataFileCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_SET_LOG_MODE_CC =
+    { EVS_UT_CC_DISPATCH(CMD, CFE_EVS_SET_LOG_MODE_CC, SetLogModeCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_CLEAR_LOG_CC =
+    { EVS_UT_CC_DISPATCH(CMD, CFE_EVS_CLEAR_LOG_CC, ClearLogCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_SEND_HK =
+    { EVS_UT_MSG_DISPATCH(SEND_HK, SendHkCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_INVALID_MID =
+    { .Method = UT_TaskPipeDispatchMethod_MSG_ID_CC, UT_TPD_SETERR(CFE_STATUS_UNKNOWN_MSG_ID) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_EVS_CMD_INVALID_CC =
+    { EVS_UT_ERROR_DISPATCH(CMD, -1, CFE_STATUS_BAD_COMMAND_CODE) };
+/* clang-format on */
 
 static UT_SoftwareBusSnapshot_Entry_t UT_EVS_LONGFMT_SNAPSHOTDATA = {
     .MsgId          = CFE_SB_MSGID_WRAP_VALUE(0),

--- a/modules/fs/config/default_cfe_fs_filedef.h
+++ b/modules/fs/config/default_cfe_fs_filedef.h
@@ -52,7 +52,7 @@ enum CFE_FS_SubType
      * @brief Executive Services System Log Type
      *
      * Executive Services System Log File which is generated in response to a
-     * \link #CFE_ES_WRITE_SYSLOG_CC \ES_WRITESYSLOG2FILE \endlink
+     * \link #CFE_ES_WRITE_SYS_LOG_CC \ES_WRITESYSLOG2FILE \endlink
      * command.
      *
      */

--- a/modules/fs/eds/cfe_fs.xml
+++ b/modules/fs/eds/cfe_fs.xml
@@ -38,7 +38,7 @@
             <Enumeration label="ES_SYSLOG" value="2" shortDescription="Executive Services System Log Type">
               <LongDescription>
                 Executive Services System Log File which is generated in response to a
-                \link #CFE_ES_WRITE_SYSLOG_CC \ES_WRITESYSLOG2FILE \endlink
+                \link #CFE_ES_WRITE_SYS_LOG_CC \ES_WRITESYSLOG2FILE \endlink
                 command.
               </LongDescription>
             </Enumeration>

--- a/modules/sb/config/default_cfe_sb_msg.h
+++ b/modules/sb/config/default_cfe_sb_msg.h
@@ -32,6 +32,7 @@
 #define CFE_SB_MSG_H
 
 #include "cfe_mission_cfg.h"
+#include "cfe_sb_fcncodes.h"
 #include "cfe_sb_msgdefs.h"
 #include "cfe_sb_msgstruct.h"
 

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -75,48 +75,48 @@ const CFE_SB_MsgId_t SB_UT_TLM_MID4 = CFE_SB_MSGID_WRAP_VALUE(SB_UT_TLM_MID_VALU
 const CFE_SB_MsgId_t SB_UT_TLM_MID5 = CFE_SB_MSGID_WRAP_VALUE(SB_UT_TLM_MID_VALUE_BASE + 5);
 const CFE_SB_MsgId_t SB_UT_TLM_MID6 = CFE_SB_MSGID_WRAP_VALUE(SB_UT_TLM_MID_VALUE_BASE + 6);
 
-const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_NOOP_CC = {.MsgId       = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_CMD_MID),
-                                                            .CommandCode = CFE_SB_NOOP_CC};
+/* Normal dispatching registers the MsgID+CC in order to follow a
+ * certain path through a series of switch statements */
+#define SB_UT_MID_DISPATCH(intf) \
+    .Method = UT_TaskPipeDispatchMethod_MSG_ID_CC, .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_##intf##_MID)
 
-const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_RESET_COUNTERS_CC = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_CMD_MID),
-                                                                      .CommandCode = CFE_SB_RESET_COUNTERS_CC};
+#define SB_UT_MSG_DISPATCH(intf, cmd)       SB_UT_MID_DISPATCH(intf), UT_TPD_SETSIZE(CFE_SB_##cmd)
+#define SB_UT_CC_DISPATCH(intf, cc, cmd)    SB_UT_MSG_DISPATCH(intf, cmd), UT_TPD_SETCC(cc)
+#define SB_UT_ERROR_DISPATCH(intf, cc, err) SB_UT_MID_DISPATCH(intf), UT_TPD_SETCC(cc), UT_TPD_SETERR(err)
 
-const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_SEND_SB_STATS_CC = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_CMD_MID),
-                                                                     .CommandCode = CFE_SB_SEND_SB_STATS_CC};
-
-const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_WRITE_ROUTING_INFO_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_CMD_MID), .CommandCode = CFE_SB_WRITE_ROUTING_INFO_CC};
-
-const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_WRITE_PIPE_INFO_CC = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_CMD_MID),
-                                                                       .CommandCode = CFE_SB_WRITE_PIPE_INFO_CC};
-
-const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_WRITE_MAP_INFO_CC = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_CMD_MID),
-                                                                      .CommandCode = CFE_SB_WRITE_MAP_INFO_CC};
-
-const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_ENABLE_ROUTE_CC = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_CMD_MID),
-                                                                    .CommandCode = CFE_SB_ENABLE_ROUTE_CC};
-
-const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_DISABLE_ROUTE_CC = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_CMD_MID),
-                                                                     .CommandCode = CFE_SB_DISABLE_ROUTE_CC};
-
-const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_SEND_HK = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_SEND_HK_MID)};
-
-const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_SUB_RPT_CTL_SEND_PREV_SUBS_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_SUB_RPT_CTRL_MID), .CommandCode = CFE_SB_SEND_PREV_SUBS_CC};
-
-const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_SUB_RPT_CTL_ENABLE_SUB_REPORTING_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_SUB_RPT_CTRL_MID), .CommandCode = CFE_SB_ENABLE_SUB_REPORTING_CC};
-
-const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_SUB_RPT_CTL_DISABLE_SUB_REPORTING_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_SUB_RPT_CTRL_MID), .CommandCode = CFE_SB_DISABLE_SUB_REPORTING_CC};
-
-const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_BAD_FCNCODE = {.MsgId       = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_CMD_MID),
-                                                                .CommandCode = 99};
-
-const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_SUB_RPT_CTRL_BAD_FCNCODE = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_SB_SUB_RPT_CTRL_MID), .CommandCode = 99};
-
-const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_BAD_MSGID = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(SB_UT_TLM_MID_VALUE_BASE)};
+/* NOTE: Automatic formatting of this table tends to make it harder to read. */
+/* clang-format off */
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_NOOP_CC =
+    { SB_UT_CC_DISPATCH(CMD,CFE_SB_NOOP_CC,NoopCmd) };
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_RESET_COUNTERS_CC =
+    { SB_UT_CC_DISPATCH(CMD,CFE_SB_RESET_COUNTERS_CC,ResetCountersCmd) };
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_SEND_SB_STATS_CC =
+    { SB_UT_CC_DISPATCH(CMD,CFE_SB_SEND_SB_STATS_CC,SendSbStatsCmd) };
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_WRITE_ROUTING_INFO_CC =
+    { SB_UT_CC_DISPATCH(CMD,CFE_SB_WRITE_ROUTING_INFO_CC,WriteRoutingInfoCmd) };
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_WRITE_PIPE_INFO_CC =
+    { SB_UT_CC_DISPATCH(CMD,CFE_SB_WRITE_PIPE_INFO_CC,WritePipeInfoCmd) };
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_WRITE_MAP_INFO_CC =
+    { SB_UT_CC_DISPATCH(CMD,CFE_SB_WRITE_MAP_INFO_CC,WriteMapInfoCmd) };
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_ENABLE_ROUTE_CC =
+    { SB_UT_CC_DISPATCH(CMD,CFE_SB_ENABLE_ROUTE_CC,EnableRouteCmd) };
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_DISABLE_ROUTE_CC =
+    { SB_UT_CC_DISPATCH(CMD,CFE_SB_DISABLE_ROUTE_CC,DisableRouteCmd) };
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_SEND_HK =
+    { SB_UT_MSG_DISPATCH(SEND_HK,SendHkCmd) };
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_SUB_RPT_CTL_SEND_PREV_SUBS_CC =
+    { SB_UT_CC_DISPATCH(SUB_RPT_CTRL,CFE_SB_SEND_PREV_SUBS_CC,SendPrevSubsCmd) };
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_SUB_RPT_CTL_ENABLE_SUB_REPORTING_CC =
+    { SB_UT_CC_DISPATCH(SUB_RPT_CTRL,CFE_SB_ENABLE_SUB_REPORTING_CC,DisableSubReportingCmd) };
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_SUB_RPT_CTL_DISABLE_SUB_REPORTING_CC =
+    { SB_UT_CC_DISPATCH(SUB_RPT_CTRL,CFE_SB_DISABLE_SUB_REPORTING_CC,EnableSubReportingCmd) };
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_CMD_BAD_FCNCODE =
+    { SB_UT_ERROR_DISPATCH(CMD, -1, CFE_STATUS_BAD_COMMAND_CODE) };
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_SUB_RPT_CTRL_BAD_FCNCODE =
+    { SB_UT_ERROR_DISPATCH(SUB_RPT_CTRL, -1, CFE_STATUS_BAD_COMMAND_CODE) };
+const UT_TaskPipeDispatchId_t UT_TPID_CFE_SB_BAD_MSGID =
+    { .Method = UT_TaskPipeDispatchMethod_MSG_ID_CC, UT_TPD_SETERR(CFE_STATUS_UNKNOWN_MSG_ID) };
+/* clang-format on */
 
 /*
  * A MsgId value which still qualifies as valid

--- a/modules/tbl/config/default_cfe_tbl_msg.h
+++ b/modules/tbl/config/default_cfe_tbl_msg.h
@@ -32,6 +32,7 @@
 #define CFE_TBL_MSG_H
 
 #include "cfe_mission_cfg.h"
+#include "cfe_tbl_fcncodes.h"
 #include "cfe_tbl_msgdefs.h"
 #include "cfe_tbl_msgstruct.h"
 

--- a/modules/tbl/ut-coverage/tbl_UT.c
+++ b/modules/tbl/ut-coverage/tbl_UT.c
@@ -72,14 +72,29 @@ void * Tbl1Ptr = NULL;
 void * Tbl2Ptr = NULL;
 void **ArrayOfPtrsToTblPtrs[2];
 
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TBL_MSG_HK = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_SEND_HK_MID)};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TBL_CMD_NOOP_CC = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_CMD_MID),
-                                                                    .CommandCode = CFE_TBL_NOOP_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TBL_CMD_RESET_COUNTERS_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_CMD_MID), .CommandCode = CFE_TBL_RESET_COUNTERS_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TBL_INVALID_MID = {.MsgId = CFE_SB_MSGID_RESERVED, .CommandCode = 0};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TBL_CMD_INVALID_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_CMD_MID), .CommandCode = 0x7F};
+/* Normal dispatching registers the MsgID+CC in order to follow a
+ * certain path through a series of switch statements */
+#define TBL_UT_MID_DISPATCH(intf) \
+    .Method = UT_TaskPipeDispatchMethod_MSG_ID_CC, .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TBL_##intf##_MID)
+
+#define TBL_UT_MSG_DISPATCH(intf, cmd)       TBL_UT_MID_DISPATCH(intf), UT_TPD_SETSIZE(CFE_TBL_##cmd)
+#define TBL_UT_CC_DISPATCH(intf, cc, cmd)    TBL_UT_MSG_DISPATCH(intf, cmd), UT_TPD_SETCC(cc)
+#define TBL_UT_ERROR_DISPATCH(intf, cc, err) TBL_UT_MID_DISPATCH(intf), UT_TPD_SETCC(cc), UT_TPD_SETERR(err)
+
+/* NOTE: Automatic formatting of this table tends to make it harder to read. */
+/* clang-format off */
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TBL_MSG_HK =
+    { TBL_UT_MSG_DISPATCH(SEND_HK, SendHkCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TBL_CMD_NOOP_CC =
+    { TBL_UT_CC_DISPATCH(CMD, CFE_TBL_NOOP_CC, NoopCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TBL_CMD_RESET_COUNTERS_CC =
+    { TBL_UT_CC_DISPATCH(CMD, CFE_TBL_RESET_COUNTERS_CC, ResetCountersCmd) };
+
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TBL_INVALID_MID =
+    { .Method = UT_TaskPipeDispatchMethod_MSG_ID_CC, UT_TPD_SETERR(CFE_STATUS_UNKNOWN_MSG_ID) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TBL_CMD_INVALID_CC =
+    { TBL_UT_ERROR_DISPATCH(CMD, -1, CFE_STATUS_BAD_COMMAND_CODE) };
+
 
 CFE_TBL_RegistryRec_t Original[CFE_PLATFORM_TBL_MAX_NUM_TABLES];
 

--- a/modules/time/config/default_cfe_time_fcncodes.h
+++ b/modules/time/config/default_cfe_time_fcncodes.h
@@ -142,7 +142,7 @@
 **
 **  \sa
 */
-#define CFE_TIME_SEND_DIAGNOSTIC_TLM_CC 2 /* request diagnostic hk telemetry */
+#define CFE_TIME_SEND_DIAGNOSTIC_CC 2 /* request diagnostic hk telemetry */
 
 /** \cfetimecmd Set Time Source
 **
@@ -515,8 +515,8 @@
 **       Inappropriately setting the clock may result in other sub-systems performing incorrect
 **       time based calculations.  The specific risk is dependent upon the behavior of those sub-systems.
 **
-**  \sa #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_SUB_ADJUST_CC, #CFE_TIME_ADD_ONEHZ_ADJUSTMENT_CC,
-*#CFE_TIME_SUB_ONEHZ_ADJUSTMENT_CC
+**  \sa #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_SUB_ADJUST_CC, #CFE_TIME_ADD_ONE_HZ_ADJUSTMENT_CC,
+*#CFE_TIME_SUB_ONE_HZ_ADJUSTMENT_CC
 */
 #define CFE_TIME_ADD_ADJUST_CC 11 /* add one time STCF adjustment */
 
@@ -550,7 +550,7 @@
 **       Inappropriately setting the clock may result in other sub-systems performing incorrect
 **       time based calculations.  The specific risk is dependent upon the behavior of those sub-systems.
 **
-**  \sa #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_ADD_ONEHZ_ADJUSTMENT_CC, #CFE_TIME_SUB_ONEHZ_ADJUSTMENT_CC
+**  \sa #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_ADD_ONE_HZ_ADJUSTMENT_CC, #CFE_TIME_SUB_ONE_HZ_ADJUSTMENT_CC
 */
 #define CFE_TIME_SUB_ADJUST_CC 12 /* subtract one time STCF adjustment */
 
@@ -576,7 +576,7 @@
 **  \cfecmdmnemonic \TIME_ADD1HZSTCF
 **
 **  \par Command Structure
-**       #CFE_TIME_Add1HZAdjustmentCmd_t
+**       #CFE_TIME_AddOneHzAdjustmentCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the
@@ -596,9 +596,9 @@
 **       Inappropriately setting the clock may result in other sub-systems performing incorrect
 **       time based calculations.  The specific risk is dependent upon the behavior of those sub-systems.
 **
-**  \sa #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_SUB_ADJUST_CC, #CFE_TIME_SUB_ONEHZ_ADJUSTMENT_CC
+**  \sa #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_SUB_ADJUST_CC, #CFE_TIME_SUB_ONE_HZ_ADJUSTMENT_CC
 */
-#define CFE_TIME_ADD_ONEHZ_ADJUSTMENT_CC 13 /* add 1Hz STCF adjustment */
+#define CFE_TIME_ADD_ONE_HZ_ADJUSTMENT_CC 13 /* add 1Hz STCF adjustment */
 
 /** \cfetimecmd Subtract Delta from Spacecraft Time Correlation Factor each 1Hz
 **
@@ -622,7 +622,7 @@
 **  \cfecmdmnemonic \TIME_SUB1HZSTCF
 **
 **  \par Command Structure
-**       #CFE_TIME_Sub1HZAdjustmentCmd_t
+**       #CFE_TIME_SubOneHzAdjustmentCmd_t
 **
 **  \par Command Verification
 **       Successful execution of this command may be verified with the
@@ -644,9 +644,9 @@
 **       Inappropriately setting the clock may result in other sub-systems performing incorrect
 **       time based calculations.  The specific risk is dependent upon the behavior of those sub-systems.
 **
-**  \sa #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_SUB_ADJUST_CC, #CFE_TIME_ADD_ONEHZ_ADJUSTMENT_CC
+**  \sa #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_SUB_ADJUST_CC, #CFE_TIME_ADD_ONE_HZ_ADJUSTMENT_CC
 */
-#define CFE_TIME_SUB_ONEHZ_ADJUSTMENT_CC 14 /* subtract 1Hz STCF adjustment */
+#define CFE_TIME_SUB_ONE_HZ_ADJUSTMENT_CC 14 /* subtract 1Hz STCF adjustment */
 
 /** \cfetimecmd Set Tone Signal Source
 **

--- a/modules/time/config/default_cfe_time_msg.h
+++ b/modules/time/config/default_cfe_time_msg.h
@@ -32,6 +32,7 @@
 #define CFE_TIME_MSG_H
 
 #include "cfe_mission_cfg.h"
+#include "cfe_time_fcncodes.h"
 #include "cfe_time_msgdefs.h"
 #include "cfe_time_msgstruct.h"
 

--- a/modules/time/config/default_cfe_time_msgstruct.h
+++ b/modules/time/config/default_cfe_time_msgstruct.h
@@ -58,10 +58,10 @@ typedef struct CFE_TIME_SendDiagnosticCmd
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
 } CFE_TIME_SendDiagnosticCmd_t;
 
-typedef struct CFE_TIME_1HzCmd
+typedef struct CFE_TIME_OneHzCmd
 {
     CFE_MSG_CommandHeader_t CommandHeader; /**< \brief Command header */
-} CFE_TIME_1HzCmd_t;
+} CFE_TIME_OneHzCmd_t;
 
 typedef struct CFE_TIME_ToneSignalCmd
 {
@@ -166,17 +166,17 @@ typedef struct CFE_TIME_SetTimeCmd
  * This follows the convention for command handler prototypes and allows
  * each one to independently evolve as necessary.
  */
-typedef struct CFE_TIME_Add1HZAdjustmentCmd
+typedef struct CFE_TIME_AddOneHzAdjustmentCmd
 {
     CFE_MSG_CommandHeader_t               CommandHeader; /**< \brief Command header */
     CFE_TIME_OneHzAdjustmentCmd_Payload_t Payload;       /**< \brief Command payload */
-} CFE_TIME_Add1HZAdjustmentCmd_t;
+} CFE_TIME_AddOneHzAdjustmentCmd_t;
 
-typedef struct CFE_TIME_Sub1HZAdjustmentCmd
+typedef struct CFE_TIME_SubOneHzAdjustmentCmd
 {
     CFE_MSG_CommandHeader_t               CommandHeader; /**< \brief Command header */
     CFE_TIME_OneHzAdjustmentCmd_Payload_t Payload;       /**< \brief Command payload */
-} CFE_TIME_Sub1HZAdjustmentCmd_t;
+} CFE_TIME_SubOneHzAdjustmentCmd_t;
 
 /**
  * \brief Time at tone data command

--- a/modules/time/eds/cfe_time.xml
+++ b/modules/time/eds/cfe_time.xml
@@ -460,7 +460,7 @@
         </EntryList>
       </ContainerDataType>
 
-      <ContainerDataType name="1HzCmd" baseType="CFE_HDR/CommandHeader">
+      <ContainerDataType name="OneHzCmd" baseType="CFE_HDR/CommandHeader">
       </ContainerDataType>
 
       <ContainerDataType name="FakeToneCmd" baseType="CFE_HDR/CommandHeader">
@@ -1041,7 +1041,7 @@
           Inappropriately setting the clock may result in other sub-systems performing incorrect
           time based calculations.  The specific risk is dependent upon the behavior of those sub-systems.
 
-          \sa  #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_SUB_ADJUST_CC, #CFE_TIME_ADD_1HZADJ_CC, #CFE_TIME_SUB_1HZADJ_CC
+          \sa  #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_SUB_ADJUST_CC, #CFE_TIME_ADD_ONEHZADJ_CC, #CFE_TIME_SUB_ONEHZADJ_CC
         </LongDescription>
         <ConstraintSet>
           <ValueConstraint entry="Sec.FunctionCode" value="11" />
@@ -1083,7 +1083,7 @@
           Inappropriately setting the clock may result in other sub-systems performing incorrect
           time based calculations.  The specific risk is dependent upon the behavior of those sub-systems.
 
-          \sa  #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_ADD_1HZADJ_CC, #CFE_TIME_SUB_1HZADJ_CC
+          \sa  #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_ADD_ONEHZADJ_CC, #CFE_TIME_SUB_ONEHZADJ_CC
         </LongDescription>
         <ConstraintSet>
           <ValueConstraint entry="Sec.FunctionCode" value="12" />
@@ -1093,7 +1093,7 @@
         </EntryList>
       </ContainerDataType>
 
-      <ContainerDataType name="Add1HZAdjustmentCmd" baseType="CommandBase">
+      <ContainerDataType name="AddOneHzAdjustmentCmd" baseType="CommandBase">
         <LongDescription>
           \cfetimecmd  Add Delta to Spacecraft Time Correlation Factor each 1Hz
 
@@ -1139,7 +1139,7 @@
           Inappropriately setting the clock may result in other sub-systems performing incorrect
           time based calculations.  The specific risk is dependent upon the behavior of those sub-systems.
 
-          \sa  #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_SUB_ADJUST_CC, #CFE_TIME_SUB_1HZADJ_CC
+          \sa  #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_SUB_ADJUST_CC, #CFE_TIME_SUB_ONEHZADJ_CC
         </LongDescription>
         <ConstraintSet>
           <ValueConstraint entry="Sec.FunctionCode" value="13" />
@@ -1149,7 +1149,7 @@
         </EntryList>
       </ContainerDataType>
 
-      <ContainerDataType name="Sub1HZAdjustmentCmd" baseType="CommandBase">
+      <ContainerDataType name="SubOneHzAdjustmentCmd" baseType="CommandBase">
         <LongDescription>
           \cfetimecmd  Subtract Delta from Spacecraft Time Correlation Factor each 1Hz
 
@@ -1195,7 +1195,7 @@
           Inappropriately setting the clock may result in other sub-systems performing incorrect
           time based calculations.  The specific risk is dependent upon the behavior of those sub-systems.
 
-          \sa  #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_SUB_ADJUST_CC, #CFE_TIME_ADD_1HZADJ_CC
+          \sa  #CFE_TIME_ADD_ADJUST_CC, #CFE_TIME_SUB_ADJUST_CC, #CFE_TIME_ADD_ONEHZADJ_CC
         </LongDescription>
         <ConstraintSet>
           <ValueConstraint entry="Sec.FunctionCode" value="14" />
@@ -1305,7 +1305,7 @@
           </Interface>
           <Interface name="ONEHZ_CMD" type="CFE_SB/Telecommand">
             <GenericTypeMapSet>
-              <GenericTypeMap name="TelecommandDataType" type="1HzCmd" />
+              <GenericTypeMap name="TelecommandDataType" type="OneHzCmd" />
             </GenericTypeMapSet>
           </Interface>
           <Interface name="DATA_CMD" type="CFE_SB/Telecommand">

--- a/modules/time/fsw/inc/cfe_time_eventids.h
+++ b/modules/time/fsw/inc/cfe_time_eventids.h
@@ -70,7 +70,7 @@
  *
  *  \par Cause:
  *
- *  \link #CFE_TIME_SEND_DIAGNOSTIC_TLM_CC TIME Request Diagnostics Command \endlink success.
+ *  \link #CFE_TIME_SEND_DIAGNOSTIC_CC TIME Request Diagnostics Command \endlink success.
  */
 #define CFE_TIME_DIAG_EID 6
 
@@ -171,8 +171,8 @@
  *
  *  \par Cause:
  *
- *  \link #CFE_TIME_ADD_ONEHZ_ADJUSTMENT_CC TIME Add STCF Adjustment Each Second Command \endlink OR
- *  \link #CFE_TIME_SUB_ONEHZ_ADJUSTMENT_CC TIME Subtract STCF Adjustment Each Second Command \endlink success.
+ *  \link #CFE_TIME_ADD_ONE_HZ_ADJUSTMENT_CC TIME Add STCF Adjustment Each Second Command \endlink OR
+ *  \link #CFE_TIME_SUB_ONE_HZ_ADJUSTMENT_CC TIME Subtract STCF Adjustment Each Second Command \endlink success.
  */
 #define CFE_TIME_ONEHZ_EID 16
 
@@ -431,8 +431,8 @@
  *
  *  \par Cause:
  *
- *  \link #CFE_TIME_ADD_ONEHZ_ADJUSTMENT_CC TIME Add STCF Adjustment Each Second Command \endlink OR
- *  \link #CFE_TIME_SUB_ONEHZ_ADJUSTMENT_CC TIME Subtract STCF Adjustment Each Second Command \endlink
+ *  \link #CFE_TIME_ADD_ONE_HZ_ADJUSTMENT_CC TIME Add STCF Adjustment Each Second Command \endlink OR
+ *  \link #CFE_TIME_SUB_ONE_HZ_ADJUSTMENT_CC TIME Subtract STCF Adjustment Each Second Command \endlink
  *  failure due to being in an incompatible mode.
  */
 #define CFE_TIME_ONEHZ_CFG_EID 48

--- a/modules/time/fsw/src/cfe_time_dispatch.c
+++ b/modules/time/fsw/src/cfe_time_dispatch.c
@@ -81,7 +81,7 @@ void CFE_TIME_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
         ** Housekeeping telemetry request...
         */
         case CFE_TIME_SEND_HK_MID:
-            CFE_TIME_HousekeepingCmd((const CFE_TIME_SendHkCmd_t *)SBBufPtr);
+            CFE_TIME_SendHkCmd((const CFE_TIME_SendHkCmd_t *)SBBufPtr);
             break;
 
         /*
@@ -102,7 +102,7 @@ void CFE_TIME_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
         ** Run time state machine at 1Hz...
         */
         case CFE_TIME_ONEHZ_CMD_MID:
-            CFE_TIME_OneHzCmd((const CFE_TIME_1HzCmd_t *)SBBufPtr);
+            CFE_TIME_OneHzCmd((const CFE_TIME_OneHzCmd_t *)SBBufPtr);
             break;
 
 /*
@@ -136,7 +136,7 @@ void CFE_TIME_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
                     }
                     break;
 
-                case CFE_TIME_SEND_DIAGNOSTIC_TLM_CC:
+                case CFE_TIME_SEND_DIAGNOSTIC_CC:
                     if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SendDiagnosticCmd_t)))
                     {
                         CFE_TIME_SendDiagnosticTlm((const CFE_TIME_SendDiagnosticCmd_t *)SBBufPtr);
@@ -226,17 +226,17 @@ void CFE_TIME_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
                     }
                     break;
 
-                case CFE_TIME_ADD_ONEHZ_ADJUSTMENT_CC:
-                    if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_Add1HZAdjustmentCmd_t)))
+                case CFE_TIME_ADD_ONE_HZ_ADJUSTMENT_CC:
+                    if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_AddOneHzAdjustmentCmd_t)))
                     {
-                        CFE_TIME_Add1HZAdjustmentCmd((const CFE_TIME_Add1HZAdjustmentCmd_t *)SBBufPtr);
+                        CFE_TIME_AddOneHzAdjustmentCmd((const CFE_TIME_AddOneHzAdjustmentCmd_t *)SBBufPtr);
                     }
                     break;
 
-                case CFE_TIME_SUB_ONEHZ_ADJUSTMENT_CC:
-                    if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_Sub1HZAdjustmentCmd_t)))
+                case CFE_TIME_SUB_ONE_HZ_ADJUSTMENT_CC:
+                    if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SubOneHzAdjustmentCmd_t)))
                     {
-                        CFE_TIME_Sub1HZAdjustmentCmd((const CFE_TIME_Sub1HZAdjustmentCmd_t *)SBBufPtr);
+                        CFE_TIME_SubOneHzAdjustmentCmd((const CFE_TIME_SubOneHzAdjustmentCmd_t *)SBBufPtr);
                     }
                     break;
 

--- a/modules/time/fsw/src/cfe_time_task.c
+++ b/modules/time/fsw/src/cfe_time_task.c
@@ -261,10 +261,10 @@ int32 CFE_TIME_TaskInit(void)
         return Status;
     }
 
-    CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE",
-        CFE_SRC_VERSION, CFE_BUILD_CODENAME, CFE_LAST_OFFICIAL);
-    Status = CFE_EVS_SendEvent(CFE_TIME_INIT_EID, CFE_EVS_EventType_INFORMATION, "cFE TIME Initialized: %s",
-                               VersionString);
+    CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE", CFE_SRC_VERSION, CFE_BUILD_CODENAME,
+                                CFE_LAST_OFFICIAL);
+    Status =
+        CFE_EVS_SendEvent(CFE_TIME_INIT_EID, CFE_EVS_EventType_INFORMATION, "cFE TIME Initialized: %s", VersionString);
     if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s: Error sending init event:RC=0x%08X\n", __func__, (unsigned int)Status);
@@ -315,7 +315,7 @@ int32 CFE_TIME_TaskInit(void)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_HousekeepingCmd(const CFE_TIME_SendHkCmd_t *data)
+int32 CFE_TIME_SendHkCmd(const CFE_TIME_SendHkCmd_t *data)
 {
     CFE_TIME_Reference_t Reference;
 
@@ -393,7 +393,7 @@ int32 CFE_TIME_ToneDataCmd(const CFE_TIME_ToneDataCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_OneHzCmd(const CFE_TIME_1HzCmd_t *data)
+int32 CFE_TIME_OneHzCmd(const CFE_TIME_OneHzCmd_t *data)
 {
     /*
      * Run the state machine updates required at 1Hz.
@@ -451,8 +451,8 @@ int32 CFE_TIME_NoopCmd(const CFE_TIME_NoopCmd_t *data)
 
     CFE_TIME_Global.CommandCounter++;
 
-    CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE",
-        CFE_SRC_VERSION, CFE_BUILD_CODENAME, CFE_LAST_OFFICIAL);
+    CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE", CFE_SRC_VERSION, CFE_BUILD_CODENAME,
+                                CFE_LAST_OFFICIAL);
     CFE_EVS_SendEvent(CFE_TIME_NOOP_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", VersionString);
 
     return CFE_SUCCESS;
@@ -1081,7 +1081,7 @@ void CFE_TIME_1HzAdjImpl(const CFE_TIME_OneHzAdjustmentCmd_Payload_t *CommandPtr
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_Add1HZAdjustmentCmd(const CFE_TIME_Add1HZAdjustmentCmd_t *data)
+int32 CFE_TIME_AddOneHzAdjustmentCmd(const CFE_TIME_AddOneHzAdjustmentCmd_t *data)
 {
     CFE_TIME_1HzAdjImpl(&data->Payload, CFE_TIME_AdjustDirection_ADD);
     return CFE_SUCCESS;
@@ -1093,7 +1093,7 @@ int32 CFE_TIME_Add1HZAdjustmentCmd(const CFE_TIME_Add1HZAdjustmentCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_Sub1HZAdjustmentCmd(const CFE_TIME_Sub1HZAdjustmentCmd_t *data)
+int32 CFE_TIME_SubOneHzAdjustmentCmd(const CFE_TIME_SubOneHzAdjustmentCmd_t *data)
 {
     CFE_TIME_1HzAdjImpl(&data->Payload, CFE_TIME_AdjustDirection_SUBTRACT);
     return CFE_SUCCESS;

--- a/modules/time/fsw/src/cfe_time_tone.c
+++ b/modules/time/fsw/src/cfe_time_tone.c
@@ -1287,7 +1287,7 @@ void CFE_TIME_Local1HzTask(void)
         ** This used to be optional in previous CFE versions, but it is now required
         ** as TIME subscribes to this itself to do state machine tasks.
         */
-        CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TIME_Global.Local1HzCmd.CommandHeader), true);
+        CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TIME_Global.LocalOneHzCmd.CommandHeader), true);
 
         CFE_TIME_Global.LocalTaskCounter++;
 

--- a/modules/time/fsw/src/cfe_time_utils.c
+++ b/modules/time/fsw/src/cfe_time_utils.c
@@ -351,8 +351,8 @@ void CFE_TIME_InitData(void)
     /*
     ** Initialize local 1Hz "wake-up" command packet (optional)...
     */
-    CFE_MSG_Init(CFE_MSG_PTR(CFE_TIME_Global.Local1HzCmd.CommandHeader), CFE_SB_ValueToMsgId(CFE_TIME_ONEHZ_CMD_MID),
-                 sizeof(CFE_TIME_Global.Local1HzCmd));
+    CFE_MSG_Init(CFE_MSG_PTR(CFE_TIME_Global.LocalOneHzCmd.CommandHeader), CFE_SB_ValueToMsgId(CFE_TIME_ONEHZ_CMD_MID),
+                 sizeof(CFE_TIME_Global.LocalOneHzCmd));
 }
 
 /*----------------------------------------------------------------

--- a/modules/time/fsw/src/cfe_time_utils.h
+++ b/modules/time/fsw/src/cfe_time_utils.h
@@ -259,7 +259,7 @@ typedef struct
     /*
     ** Local 1Hz wake-up command packet (not related to time at tone)...
     */
-    CFE_TIME_1HzCmd_t Local1HzCmd;
+    CFE_TIME_OneHzCmd_t LocalOneHzCmd;
 
     /*
     ** Time at the tone command packets (sent by time servers)...
@@ -666,7 +666,7 @@ void CFE_TIME_Local1HzTimerCallback(osal_id_t TimerId, void *Arg);
 /**
  * @brief  Onboard command (HK request)
  */
-int32 CFE_TIME_HousekeepingCmd(const CFE_TIME_SendHkCmd_t *data);
+int32 CFE_TIME_SendHkCmd(const CFE_TIME_SendHkCmd_t *data);
 
 /*
 ** Command handler for "tone signal detected"...
@@ -702,7 +702,7 @@ int32 CFE_TIME_ToneDataCmd(const CFE_TIME_ToneDataCmd_t *data);
  * This also implements the "fake tone" functionality when that is enabled,
  * as we do not need a separate MID for this job.
  */
-int32 CFE_TIME_OneHzCmd(const CFE_TIME_1HzCmd_t *data);
+int32 CFE_TIME_OneHzCmd(const CFE_TIME_OneHzCmd_t *data);
 
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
 
@@ -760,7 +760,7 @@ void CFE_TIME_AdjustImpl(const CFE_TIME_TimeCmd_Payload_t *CommandPtr, CFE_TIME_
  *
  * This is a wrapper around CFE_TIME_1HzAdjImpl()
  */
-int32 CFE_TIME_Add1HZAdjustmentCmd(const CFE_TIME_Add1HZAdjustmentCmd_t *data);
+int32 CFE_TIME_AddOneHzAdjustmentCmd(const CFE_TIME_AddOneHzAdjustmentCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -857,7 +857,7 @@ int32 CFE_TIME_SetTimeCmd(const CFE_TIME_SetTimeCmd_t *data);
  *
  * This is a wrapper around CFE_TIME_1HzAdjImpl()
  */
-int32 CFE_TIME_Sub1HZAdjustmentCmd(const CFE_TIME_Sub1HZAdjustmentCmd_t *data);
+int32 CFE_TIME_SubOneHzAdjustmentCmd(const CFE_TIME_SubOneHzAdjustmentCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**

--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -68,7 +68,7 @@ static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_NOOP_CC = {.MsgId = CF
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_RESET_COUNTERS_CC = {
     .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_RESET_COUNTERS_CC};
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SEND_DIAGNOSTIC_TLM_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SEND_DIAGNOSTIC_TLM_CC};
+    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SEND_DIAGNOSTIC_CC};
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_STATE_CC = {
     .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SET_STATE_CC};
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_SOURCE_CC = {
@@ -92,9 +92,9 @@ static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_ADD_ADJUST_CC = {
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SUB_ADJUST_CC = {
     .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SUB_ADJUST_CC};
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_ADD_ONEHZ_ADJUSTMENT_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_ADD_ONEHZ_ADJUSTMENT_CC};
+    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_ADD_ONE_HZ_ADJUSTMENT_CC};
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SUB_ONEHZ_ADJUSTMENT_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SUB_ONEHZ_ADJUSTMENT_CC};
+    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SUB_ONE_HZ_ADJUSTMENT_CC};
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_INVALID_MID = {.MsgId = CFE_SB_MSGID_RESERVED, .CommandCode = 0};
 static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_INVALID_CC = {
     .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = 0x7F};
@@ -1312,28 +1312,28 @@ void Test_PipeCmds(void)
 {
     union
     {
-        CFE_MSG_Message_t              message;
-        CFE_TIME_ToneDataCmd_t         tonedatacmd;
-        CFE_TIME_ToneSignalCmd_t       tonesignalcmd;
-        CFE_TIME_FakeToneCmd_t         timesendcmd;
-        CFE_TIME_SendHkCmd_t           sendhkcmd;
-        CFE_TIME_1HzCmd_t              onehzcmd;
-        CFE_TIME_NoopCmd_t             noopcmd;
-        CFE_TIME_ResetCountersCmd_t    resetcounterscmd;
-        CFE_TIME_SendDiagnosticCmd_t   diagtlmcmd;
-        CFE_TIME_SetStateCmd_t         statecmd;
-        CFE_TIME_SetSourceCmd_t        sourcecmd;
-        CFE_TIME_SetSignalCmd_t        signalcmd;
-        CFE_TIME_AddDelayCmd_t         adddelaycmd;
-        CFE_TIME_SubDelayCmd_t         subdelaycmd;
-        CFE_TIME_SetTimeCmd_t          settimecmd;
-        CFE_TIME_SetMETCmd_t           setmetcmd;
-        CFE_TIME_SetSTCFCmd_t          setstcfcmd;
-        CFE_TIME_SetLeapSecondsCmd_t   leapscmd;
-        CFE_TIME_AddAdjustCmd_t        addadjcmd;
-        CFE_TIME_SubAdjustCmd_t        subadjcmd;
-        CFE_TIME_Add1HZAdjustmentCmd_t add1hzadjcmd;
-        CFE_TIME_Sub1HZAdjustmentCmd_t sub1hzadjcmd;
+        CFE_MSG_Message_t                message;
+        CFE_TIME_ToneDataCmd_t           tonedatacmd;
+        CFE_TIME_ToneSignalCmd_t         tonesignalcmd;
+        CFE_TIME_FakeToneCmd_t           timesendcmd;
+        CFE_TIME_SendHkCmd_t             sendhkcmd;
+        CFE_TIME_OneHzCmd_t              onehzcmd;
+        CFE_TIME_NoopCmd_t               noopcmd;
+        CFE_TIME_ResetCountersCmd_t      resetcounterscmd;
+        CFE_TIME_SendDiagnosticCmd_t     diagtlmcmd;
+        CFE_TIME_SetStateCmd_t           statecmd;
+        CFE_TIME_SetSourceCmd_t          sourcecmd;
+        CFE_TIME_SetSignalCmd_t          signalcmd;
+        CFE_TIME_AddDelayCmd_t           adddelaycmd;
+        CFE_TIME_SubDelayCmd_t           subdelaycmd;
+        CFE_TIME_SetTimeCmd_t            settimecmd;
+        CFE_TIME_SetMETCmd_t             setmetcmd;
+        CFE_TIME_SetSTCFCmd_t            setstcfcmd;
+        CFE_TIME_SetLeapSecondsCmd_t     leapscmd;
+        CFE_TIME_AddAdjustCmd_t          addadjcmd;
+        CFE_TIME_SubAdjustCmd_t          subadjcmd;
+        CFE_TIME_AddOneHzAdjustmentCmd_t add1hzadjcmd;
+        CFE_TIME_SubOneHzAdjustmentCmd_t sub1hzadjcmd;
     } CmdBuf;
 
     UT_SoftwareBusSnapshot_Entry_t LocalSnapshotData = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_HK_TLM_MID)};

--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -49,55 +49,68 @@ const char *TIME_SYSLOG_MSGS[] = {NULL,
                                   "%s: Application Init Failed,RC=0x%08X\n",
                                   "%s: Failed invalid arguments\n"};
 
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_SEND_HK   = {.MsgId =
-                                                                     CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_SEND_HK_MID)};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_TONE_CMD  = {.MsgId =
-                                                                      CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_TONE_CMD_MID)};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_DATA_CMD  = {.MsgId =
-                                                                      CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_DATA_CMD_MID)};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_ONEHZ_CMD = {.MsgId =
-                                                                       CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_ONEHZ_CMD_MID)};
+/* Normal dispatching registers the MsgID+CC in order to follow a
+ * certain path through a series of switch statements */
+#define TIME_UT_MID_DISPATCH(intf) \
+    .Method = UT_TaskPipeDispatchMethod_MSG_ID_CC, .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_##intf##_MID)
+
+#define TIME_UT_MSG_DISPATCH(intf, cmd)       TIME_UT_MID_DISPATCH(intf), UT_TPD_SETSIZE(CFE_TIME_##cmd)
+#define TIME_UT_CC_DISPATCH(intf, cc, cmd)    TIME_UT_MSG_DISPATCH(intf, cmd), UT_TPD_SETCC(cc)
+#define TIME_UT_ERROR_DISPATCH(intf, cc, err) TIME_UT_MID_DISPATCH(intf), UT_TPD_SETCC(cc), UT_TPD_SETERR(err)
+
+/* NOTE: Automatic formatting of this table tends to make it harder to read. */
+/* clang-format off */
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_SEND_HK =
+    { TIME_UT_MSG_DISPATCH(SEND_HK,SendHkCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_TONE_CMD =
+    { TIME_UT_MSG_DISPATCH(TONE_CMD,ToneSignalCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_DATA_CMD =
+    { TIME_UT_MSG_DISPATCH(DATA_CMD,ToneDataCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_ONEHZ_CMD =
+    { TIME_UT_MSG_DISPATCH(ONEHZ_CMD,OneHzCmd) };
 
 #if (CFE_PLATFORM_TIME_CFG_SERVER == true)
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_SEND_CMD = {.MsgId =
-                                                                      CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_SEND_CMD_MID)};
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_SEND_CMD =
+    { TIME_UT_MSG_DISPATCH(SEND_CMD,FakeToneCmd) };
 #endif
 
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_NOOP_CC = {.MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID),
-                                                                     .CommandCode = CFE_TIME_NOOP_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_RESET_COUNTERS_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_RESET_COUNTERS_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SEND_DIAGNOSTIC_TLM_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SEND_DIAGNOSTIC_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_STATE_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SET_STATE_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_SOURCE_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SET_SOURCE_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_SIGNAL_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SET_SIGNAL_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_ADD_DELAY_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_ADD_DELAY_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SUB_DELAY_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SUB_DELAY_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_TIME_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SET_TIME_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_MET_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SET_MET_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_STCF_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SET_STCF_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_LEAP_SECONDS_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SET_LEAP_SECONDS_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_ADD_ADJUST_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_ADD_ADJUST_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SUB_ADJUST_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SUB_ADJUST_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_ADD_ONEHZ_ADJUSTMENT_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_ADD_ONE_HZ_ADJUSTMENT_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SUB_ONEHZ_ADJUSTMENT_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = CFE_TIME_SUB_ONE_HZ_ADJUSTMENT_CC};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_INVALID_MID = {.MsgId = CFE_SB_MSGID_RESERVED, .CommandCode = 0};
-static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_INVALID_CC = {
-    .MsgId = CFE_SB_MSGID_WRAP_VALUE(CFE_TIME_CMD_MID), .CommandCode = 0x7F};
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_NOOP_CC =
+    { TIME_UT_CC_DISPATCH(CMD, CFE_TIME_NOOP_CC, NoopCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_RESET_COUNTERS_CC =
+    { TIME_UT_CC_DISPATCH(CMD, CFE_TIME_RESET_COUNTERS_CC, ResetCountersCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SEND_DIAGNOSTIC_TLM_CC =
+    { TIME_UT_CC_DISPATCH(CMD, CFE_TIME_SEND_DIAGNOSTIC_CC, SendDiagnosticCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_STATE_CC =
+    { TIME_UT_CC_DISPATCH(CMD, CFE_TIME_SET_STATE_CC, SetStateCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_SOURCE_CC =
+    { TIME_UT_CC_DISPATCH(CMD, CFE_TIME_SET_SOURCE_CC, SetSourceCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_SIGNAL_CC =
+    { TIME_UT_CC_DISPATCH(CMD, CFE_TIME_SET_SIGNAL_CC, SetSignalCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_ADD_DELAY_CC =
+    { TIME_UT_CC_DISPATCH(CMD, CFE_TIME_ADD_DELAY_CC, AddDelayCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SUB_DELAY_CC =
+    { TIME_UT_CC_DISPATCH(CMD, CFE_TIME_SUB_DELAY_CC, SubDelayCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_TIME_CC =
+    { TIME_UT_CC_DISPATCH(CMD, CFE_TIME_SET_TIME_CC, SetTimeCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_MET_CC =
+    { TIME_UT_CC_DISPATCH(CMD, CFE_TIME_SET_MET_CC, SetMETCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_STCF_CC =
+    { TIME_UT_CC_DISPATCH(CMD, CFE_TIME_SET_STCF_CC, SetSTCFCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SET_LEAP_SECONDS_CC =
+    { TIME_UT_CC_DISPATCH(CMD, CFE_TIME_SET_LEAP_SECONDS_CC, SetLeapSecondsCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_ADD_ADJUST_CC =
+    { TIME_UT_CC_DISPATCH(CMD, CFE_TIME_ADD_ADJUST_CC, AddAdjustCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SUB_ADJUST_CC =
+    { TIME_UT_CC_DISPATCH(CMD, CFE_TIME_SUB_ADJUST_CC, SubAdjustCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_ADD_ONEHZ_ADJUSTMENT_CC =
+    { TIME_UT_CC_DISPATCH(CMD, CFE_TIME_ADD_ONE_HZ_ADJUSTMENT_CC, AddOneHzAdjustmentCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_SUB_ONEHZ_ADJUSTMENT_CC =
+    { TIME_UT_CC_DISPATCH(CMD, CFE_TIME_SUB_ONE_HZ_ADJUSTMENT_CC, SubOneHzAdjustmentCmd) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_INVALID_MID =
+    { .Method = UT_TaskPipeDispatchMethod_MSG_ID_CC, UT_TPD_SETERR(CFE_STATUS_UNKNOWN_MSG_ID) };
+static const UT_TaskPipeDispatchId_t UT_TPID_CFE_TIME_CMD_INVALID_CC =
+    { TIME_UT_ERROR_DISPATCH(CMD, -1, CFE_STATUS_BAD_COMMAND_CODE) };
+/* clang-format on */
 
 /*
 ** Global variables


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Addresses the listed issues which related to compatibility with the generated header files:

Fixes #2502 
Corrects name mismatches / deviations from standard naming conventions

Fixes #2504 
Updates Unit Tests to be include a "TABLE_OFFSET" dispatch option which is needed when the entire task pipe function is a stub that uses a dispatch table.

**Testing performed**
Build and run all tests

**Expected behavior changes**
Compatibility with generated files/headers.

**System(s) tested on**
Debian

**Additional context**
All FSW updates are global name change only, no logic change.
Other updates (in 2504) are only unit test

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
