### PR TITLE
Fix #2514, change CFE_MSG_Message from union to struct

### DIFF
--- a/modules/core_api/fsw/inc/cfe_msg_api_typedefs.h
+++ b/modules/core_api/fsw/inc/cfe_msg_api_typedefs.h
@@ -99,7 +99,7 @@ typedef enum CFE_MSG_PlaybackFlag
 /**
  * \brief cFS generic base message
  */
-typedef union CFE_MSG_Message CFE_MSG_Message_t;
+typedef struct CFE_MSG_Message CFE_MSG_Message_t;
 
 /**
  * \brief cFS command header

--- a/modules/core_api/ut-stubs/src/cfe_sb_handlers.c
+++ b/modules/core_api/ut-stubs/src/cfe_sb_handlers.c
@@ -348,7 +348,7 @@ void UT_DefaultHandler_CFE_SB_GetUserData(void *UserObj, UT_EntryKey_t FuncKey, 
     if (UT_Stub_CopyToLocal(UT_KEY(CFE_SB_GetUserData), &Result, sizeof(Result)) != sizeof(Result))
     {
         BytePtr = (uint8 *)MsgPtr;
-        if ((MsgPtr->Byte[0] & 0x10) != 0)
+        if ((*BytePtr & 0x10) != 0)
         {
             HdrSize = sizeof(CFE_MSG_CommandHeader_t);
         }

--- a/modules/core_private/ut-stubs/src/ut_support.c
+++ b/modules/core_private/ut-stubs/src/ut_support.c
@@ -342,13 +342,15 @@ int32 UT_SoftwareBusSnapshotHook(void *UserObj, int32 StubRetcode, uint32 CallCo
 {
     UT_SoftwareBusSnapshot_Entry_t *Snapshot = UserObj;
     const CFE_MSG_Message_t *       MsgPtr   = UT_Hook_GetArgValueByName(Context, "MsgPtr", CFE_MSG_Message_t *);
+    const uint8_t *                 BytePtr;
 
     if (MsgPtr != NULL && Snapshot != NULL)
     {
         ++Snapshot->Count;
         if (Snapshot->SnapshotSize > 0 && Snapshot->SnapshotBuffer != NULL)
         {
-            memcpy(Snapshot->SnapshotBuffer, &MsgPtr->Byte[Snapshot->SnapshotOffset], Snapshot->SnapshotSize);
+            BytePtr = (const uint8 *)MsgPtr;
+            memcpy(Snapshot->SnapshotBuffer, &BytePtr[Snapshot->SnapshotOffset], Snapshot->SnapshotSize);
         }
     }
 
@@ -535,7 +537,7 @@ uint16 UT_GetNumEventsSent(void)
 */
 void UT_DisplayPkt(CFE_MSG_Message_t *MsgPtr, size_t size)
 {
-    uint8 *BytePtr = MsgPtr->Byte;
+    uint8 *BytePtr = (uint8 *)MsgPtr;
     size_t i;
     size_t BufSize = UT_MAX_MESSAGE_LENGTH;
     char   DisplayMsg[UT_MAX_MESSAGE_LENGTH];

--- a/modules/msg/fsw/src/cfe_msg_sechdr_checksum.c
+++ b/modules/msg/fsw/src/cfe_msg_sechdr_checksum.c
@@ -34,7 +34,7 @@
 CFE_MSG_Checksum_t CFE_MSG_ComputeCheckSum(const CFE_MSG_Message_t *MsgPtr)
 {
     CFE_MSG_Size_t     PktLen  = 0;
-    const uint8 *      BytePtr = MsgPtr->Byte;
+    const uint8 *      BytePtr = (const uint8 *)MsgPtr;
     CFE_MSG_Checksum_t chksum  = 0xFF;
 
     /* Message already checked, no error case reachable */

--- a/modules/msg/option_inc/default_cfe_msg_hdr_pri.h
+++ b/modules/msg/option_inc/default_cfe_msg_hdr_pri.h
@@ -89,10 +89,9 @@ typedef struct
  *
  * This provides the definition of CFE_MSG_Message_t
  */
-union CFE_MSG_Message
+struct CFE_MSG_Message
 {
-    CCSDS_SpacePacket_t CCSDS;                             /**< \brief CCSDS Header (Pri or Pri + Ext) */
-    uint8               Byte[sizeof(CCSDS_SpacePacket_t)]; /**< \brief Byte level access */
+    CCSDS_SpacePacket_t CCSDS; /**< \brief CCSDS Header (Pri or Pri + Ext) */
 };
 
 /**

--- a/modules/msg/option_inc/default_cfe_msg_hdr_priext.h
+++ b/modules/msg/option_inc/default_cfe_msg_hdr_priext.h
@@ -96,10 +96,9 @@ typedef struct
 /**
  * \brief cFS generic base message
  */
-union CFE_MSG_Message
+struct CFE_MSG_Message
 {
-    CCSDS_SpacePacket_t CCSDS;                             /**< \brief CCSDS Header (Pri or Pri + Ext) */
-    uint8               Byte[sizeof(CCSDS_SpacePacket_t)]; /**< \brief Byte level access */
+    CCSDS_SpacePacket_t CCSDS; /**< \brief CCSDS Header (Pri or Pri + Ext) */
 };
 
 /**


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Having this abstract type as a "struct" makes it match the Command and Telemetry abstract types.  Futhermore, it better conveys the intent that this is an abstract object and should not be directly used or accessed in other ways.

It may still be implemented as a union underneath (depending on how MSG module chooses to implement) but that is hidden from public API.  In the case of the default MSG module implementation, there are just a handful of cases where it is accessed internally as bytes, and those are simple enough to do with a cast.

Fixes #2514

**Testing performed**
Build and run all tests

**Expected behavior changes**
API simplification

**System(s) tested on**
Debian

**Additional context**
There is a (very slight) possibility that some app code has used the `union CFE_MSG_Message` directly, and the change from union to struct will cause an error if any such code exists (but that could should be fixed anyway).  None of the current CFS apps appear to do this, so its OK in that domain.

If any users have implemented a custom MSG module, this will require a matching/corresponding update in that implementation.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
