### PR TITLE
Fix #2516, propagate stack pointer for child tasks

### DIFF
--- a/modules/core_api/fsw/inc/cfe_version.h
+++ b/modules/core_api/fsw/inc/cfe_version.h
@@ -29,12 +29,12 @@
 #define CFE_BUILD_NUMBER    96 /**< @brief Development: Number of development git commits since CFE_BUILD_BASELINE */
 #define CFE_BUILD_BASELINE  "equuleus-rc1" /**< @brief Development: Reference git tag for build number */
 #define CFE_BUILD_DEV_CYCLE "equuleus-rc2" /**< @brief Development: Release name for current development cycle */
-#define CFE_BUILD_CODENAME  "Equuleus" /**< @brief: Development: Code name for the current build */
+#define CFE_BUILD_CODENAME  "Equuleus"     /**< @brief: Development: Code name for the current build */
 
 /* See \ref cfsversions for definitions */
-#define CFE_MAJOR_VERSION 6  /*!< @brief Major version number */
-#define CFE_MINOR_VERSION 7  /*!< @brief Minor version number */
-#define CFE_REVISION      0  /*!< @brief Revision version number. Value of 0 indicates a development version.*/
+#define CFE_MAJOR_VERSION 6 /*!< @brief Major version number */
+#define CFE_MINOR_VERSION 7 /*!< @brief Minor version number */
+#define CFE_REVISION      0 /*!< @brief Revision version number. Value of 0 indicates a development version.*/
 
 /**
  * @brief Last official release.
@@ -63,7 +63,7 @@
 
 /**
  * @brief Max Version String length.
- * 
+ *
  * Maximum length that a cFE version string can be.
  */
 #define CFE_CFG_MAX_VERSION_STR_LEN 256

--- a/modules/es/fsw/src/cfe_es_api.c
+++ b/modules/es/fsw/src/cfe_es_api.c
@@ -1259,6 +1259,7 @@ CFE_Status_t CFE_ES_CreateChildTask(CFE_ES_TaskId_t *TaskIdPtr, const char *Task
     memset(&Params, 0, sizeof(Params));
     Params.Priority  = Priority;
     Params.StackSize = StackSize;
+    Params.StackPtr  = StackPtr;
 
     /*
     ** Validate some of the arguments

--- a/modules/es/fsw/src/cfe_es_apps.c
+++ b/modules/es/fsw/src/cfe_es_apps.c
@@ -585,13 +585,13 @@ int32 CFE_ES_StartAppTask(CFE_ES_TaskId_t *TaskIdPtr, const char *TaskName, CFE_
     /*
      * Create the primary task for the newly loaded task
      */
-    OsStatus = OS_TaskCreate(&OsalTaskId,              /* task id */
-                             TaskName,                 /* task name matches app name for main task */
-                             CFE_ES_TaskEntryPoint,    /* task function pointer */
-                             OSAL_TASK_STACK_ALLOCATE, /* stack pointer (allocate) */
-                             Params->StackSize,        /* stack size */
-                             Params->Priority,         /* task priority */
-                             OS_FP_ENABLED);           /* task options */
+    OsStatus = OS_TaskCreate(&OsalTaskId,           /* task id */
+                             TaskName,              /* task name matches app name for main task */
+                             CFE_ES_TaskEntryPoint, /* task function pointer */
+                             Params->StackPtr,      /* stack pointer (allocate if NULL) */
+                             Params->StackSize,     /* stack size */
+                             Params->Priority,      /* task priority */
+                             OS_FP_ENABLED);        /* task options */
 
     CFE_ES_LockSharedData(__func__, __LINE__);
 

--- a/modules/es/fsw/src/cfe_es_apps.h
+++ b/modules/es/fsw/src/cfe_es_apps.h
@@ -99,6 +99,7 @@ typedef struct
 typedef struct
 {
     size_t                     StackSize;
+    CFE_ES_StackPointer_t      StackPtr;
     CFE_ES_TaskPriority_Atom_t Priority;
 } CFE_ES_TaskStartParams_t;
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Update CFE_ES_CreateChildTask to propagate the user-supplied stack pointer to the underlying OS_TaskCreate call.  Also adds a functional test to check that the memory address of a local variable within a child task resides within the expected stack buffer.

NOTE: this requires an additional fix to POSIX OSAL to make it work on that platform.

Fixes #2516

**Testing performed**
Build and run all tests

**Expected behavior changes**
CFE Child tasks created will adhere to passed-in stack pointer.

**System(s) tested on**
Debian, RTEMS

**Additional context**
The newly added functional test will fail on POSIX due to a similar bug in the OS_TaskCreate() implementation.  This didn't propagate the stack pointer, either.

The biggest risk with "fixing" this is that it might expose stack size problems that were otherwise hidden.  Many apps use very small stack sizes for child tasks, and on POSIX (at least Linux/Glibc) it puts TLS storage in the stack buffer.  This TLS takes about 10kB off the top of the stack.  If the entire stack was only 4kB, this is now a problem.  It was hidden because POSIX created a stack anyway, and when it created the stack it was at least 16kB.  But by fixing that problem, the stack size really will be only 4kB, and thus not be big enough, and memory corruption will result.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.