### PR TITLE
Fix #2519, Add runtime TopicId conversion routines to SB

### DIFF
--- a/modules/core_api/fsw/inc/cfe_sb.h
+++ b/modules/core_api/fsw/inc/cfe_sb.h
@@ -853,6 +853,133 @@ static inline CFE_SB_MsgId_t CFE_SB_ValueToMsgId(CFE_SB_MsgId_Atom_t MsgIdValue)
     CFE_SB_MsgId_t Result = CFE_SB_MSGID_C(MsgIdValue);
     return Result;
 }
+
+/*****************************************************************************/
+/**
+ * \brief Converts a topic ID and instance number combination into a MsgID value integer
+ *
+ * \par Description
+ *    This function accepts a data pair of topic ID + instance number and returns the
+ *    corresponding MsgID Value (integer) for commands.
+ *
+ * \par Assumptions and Notes:
+ *    A topic ID identifies a certain data stream from an application, for example
+ *    the CFE Software bus ground commands (CFE_MISSION_SB_CMD_TOPICID).  In
+ *    contrast to MsgID, the topic ID is consistent across all CPUs in a system, whereas
+ *    each CPU instance will have a unique MsgID.
+ *
+ *    CPU instance numbers are 1-based.  The instance number of 0 is reserved
+ *    for "global" MsgID values that are the same on all CPUs.  The PSP function
+ *    may be used to obtain the current CPU number for the host processor.
+ *
+ * \sa CFE_SB_TlmTopicIdToMsgId(), CFE_PSP_GetProcessorId()
+ *
+ * \return Integer representation of the #CFE_SB_MsgId_t
+ */
+CFE_SB_MsgId_Atom_t CFE_SB_CmdTopicIdToMsgId(uint16 TopicId, uint16 InstanceNum);
+
+/*****************************************************************************/
+/**
+ * \brief Converts a topic ID and instance number combination into a MsgID value integer
+ *
+ * \par Description
+ *    This function accepts a data pair of topic ID + instance number and returns the
+ *    corresponding MsgID Value (integer) for telemetry.
+ *
+ * \par Assumptions and Notes:
+ *    A topic ID identifies a certain data stream from an application, for example
+ *    the CFE Software bus housekeeping telemetry (CFE_MISSION_SB_HK_TLM_TOPICID).  In
+ *    contrast to MsgID, the topic ID is consistent across all CPUs in a system, whereas
+ *    each CPU instance will have a unique MsgID.
+ *
+ *    CPU instance numbers are 1-based.  The instance number of 0 is reserved
+ *    for "global" MsgID values that are the same on all CPUs.  The PSP function
+ *    may be used to obtain the current CPU number for the host processor.
+ *
+ * \sa CFE_SB_CmdTopicIdToMsgId(), CFE_PSP_GetProcessorId()
+ *
+ * \return Integer representation of the #CFE_SB_MsgId_t
+ */
+CFE_SB_MsgId_Atom_t CFE_SB_TlmTopicIdToMsgId(uint16 TopicId, uint16 InstanceNum);
+
+/*****************************************************************************/
+/**
+ * \brief Converts a topic ID to a MsgID value integer for Global commands
+ *
+ * \par Description
+ *    This is a wrapper around CFE_SB_CmdTopicIdToMsgId() for topic IDs which
+ *    are the same on all CPUs within a system (i.e. not specific to a certain
+ *    processor)
+ *
+ * \par Assumptions and Notes:
+ *    Global MsgIDs may be used when only a single instance of a service exists
+ *    within the system.  The CFE framework does not use this feature for commands,
+ *    but is defined for future use.
+ *
+ * \sa CFE_SB_CmdTopicIdToMsgId(), CFE_SB_LocalCmdTopicIdToMsgId()
+ *
+ * \return Integer representation of the #CFE_SB_MsgId_t
+ */
+CFE_SB_MsgId_Atom_t CFE_SB_GlobalCmdTopicIdToMsgId(uint16 TopicId);
+
+/*****************************************************************************/
+/**
+ * \brief Converts a topic ID to a MsgID value integer for Global telemetry
+ *
+ * \par Description
+ *    This is a wrapper around CFE_SB_TlmTopicIdToMsgId() for topic IDs which
+ *    are the same on all CPUs within a system (i.e. not specific to a certain
+ *    processor)
+ *
+ * \par Assumptions and Notes:
+ *    Global MsgIDs may be used when only a single instance of a service exists
+ *    within the system.  An example for such telemetry is the time synchronization
+ *    service published by CFE_TIME.
+ *
+ * \sa CFE_SB_TlmTopicIdToMsgId(), CFE_SB_LocalTlmTopicIdToMsgId()
+ *
+ * \return Integer representation of the #CFE_SB_MsgId_t
+ */
+CFE_SB_MsgId_Atom_t CFE_SB_GlobalTlmTopicIdToMsgId(uint16 TopicId);
+
+/*****************************************************************************/
+/**
+ * \brief Converts a topic ID to a MsgID value integer for local commands
+ *
+ * \par Description
+ *    This is a wrapper around CFE_SB_CmdTopicIdToMsgId() for topic IDs which
+ *    are unique on all CPUs within a system (i.e. specific to a certain
+ *    processor)
+ *
+ * \par Assumptions and Notes:
+ *    This assumes the caller is referring to a service running on the same
+ *    processor instance as itself.
+ *
+ * \sa CFE_SB_CmdTopicIdToMsgId(), CFE_SB_LocalTlmTopicIdToMsgId()
+ *
+ * \return Integer representation of the #CFE_SB_MsgId_t
+ */
+CFE_SB_MsgId_Atom_t CFE_SB_LocalCmdTopicIdToMsgId(uint16 TopicId);
+
+/*****************************************************************************/
+/**
+ * \brief Converts a topic ID to a MsgID value integer for local telemetry
+ *
+ * \par Description
+ *    This is a wrapper around CFE_SB_TlmTopicIdToMsgId() for topic IDs which
+ *    are unique on all CPUs within a system (i.e. specific to a certain
+ *    processor)
+ *
+ * \par Assumptions and Notes:
+ *    This assumes the caller is referring to a service running on the same
+ *    processor instance as itself.
+ *
+ * \sa CFE_SB_TlmTopicIdToMsgId(), CFE_SB_LocalCmdTopicIdToMsgId()
+ *
+ * \return Integer representation of the #CFE_SB_MsgId_t
+ */
+CFE_SB_MsgId_Atom_t CFE_SB_LocalTlmTopicIdToMsgId(uint16 TopicId);
+
 /** @} */
 
 #endif /* CFE_SB_H */

--- a/modules/core_api/ut-stubs/src/cfe_config_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_config_stubs.c
@@ -113,10 +113,11 @@ uint32 CFE_Config_GetValue(CFE_ConfigId_t ConfigId)
  * Generated stub function for CFE_Config_GetVersionString()
  * ----------------------------------------------------
  */
-void CFE_Config_GetVersionString(char *Buf, size_t Size, const char *Component, const char *SrcVersion, const char *CodeName, const char *LastOffcRel)
+void CFE_Config_GetVersionString(char *Buf, size_t Size, const char *Component, const char *SrcVersion,
+                                 const char *CodeName, const char *LastOffcRel)
 {
     UT_GenStub_AddParam(CFE_Config_GetVersionString, char *, Buf);
-    UT_GenStub_AddParam(CFE_Config_GetVersionString, size_t , Size);
+    UT_GenStub_AddParam(CFE_Config_GetVersionString, size_t, Size);
     UT_GenStub_AddParam(CFE_Config_GetVersionString, const char *, Component);
     UT_GenStub_AddParam(CFE_Config_GetVersionString, const char *, SrcVersion);
     UT_GenStub_AddParam(CFE_Config_GetVersionString, const char *, CodeName);

--- a/modules/core_api/ut-stubs/src/cfe_sb_handlers.c
+++ b/modules/core_api/ut-stubs/src/cfe_sb_handlers.c
@@ -66,9 +66,148 @@ static CFE_SB_StubMsg_MetaData_t *CFE_SB_StubMsg_GetMetaData(const CFE_MSG_Messa
 
     return MetaPtr;
 }
+
+/*------------------------------------------------------------
+ *
+ * Helper function to fabricate a MsgID value for testing purposes
+ *
+ * Note this is not intended to match a real MsgID value used in flight
+ * software builds, it is just for UT.  The fabricated value just needs
+ * to pass the "CFE_SB_IsValidMsgId()" test.
+ *
+ *------------------------------------------------------------*/
+static void UT_CFE_SB_FabricateMsgIdValue(UT_EntryKey_t FuncKey, bool IsCmd, uint16 TopicId, uint16 InstanceNum)
+{
+    CFE_SB_MsgId_Atom_t MsgIdValue;
+
+    /* This makes the bits line up with the "traditional" use of the first 16
+     * bits of a CCSDS space packet as a MsgId */
+    MsgIdValue = 1;
+    if (IsCmd)
+    {
+        MsgIdValue |= 2;
+    }
+    MsgIdValue <<= 4;
+    MsgIdValue |= InstanceNum & 0xF;
+    MsgIdValue <<= 7;
+    MsgIdValue |= TopicId & 0x7F;
+
+    UT_Stub_SetReturnValue(FuncKey, MsgIdValue);
+}
+
 /*
 ** Functions
 */
+
+/*------------------------------------------------------------
+ *
+ * Default handler for CFE_SB_LocalCmdTopicIdToMsgId coverage stub function
+ *
+ *------------------------------------------------------------*/
+void UT_DefaultHandler_CFE_SB_LocalCmdTopicIdToMsgId(void *UserObj, UT_EntryKey_t FuncKey,
+                                                     const UT_StubContext_t *Context)
+{
+    uint16 TopicId;
+
+    if (!UT_Stub_GetInt32StatusCode(Context, NULL))
+    {
+        TopicId = UT_Hook_GetArgValueByName(Context, "TopicId", uint16);
+
+        UT_CFE_SB_FabricateMsgIdValue(FuncKey, true, TopicId, 1);
+    }
+}
+
+/*------------------------------------------------------------
+ *
+ * Default handler for CFE_SB_LocalTlmTopicIdToMsgId coverage stub function
+ *
+ *------------------------------------------------------------*/
+void UT_DefaultHandler_CFE_SB_LocalTlmTopicIdToMsgId(void *UserObj, UT_EntryKey_t FuncKey,
+                                                     const UT_StubContext_t *Context)
+{
+    uint16 TopicId;
+
+    if (!UT_Stub_GetInt32StatusCode(Context, NULL))
+    {
+        TopicId = UT_Hook_GetArgValueByName(Context, "TopicId", uint16);
+
+        UT_CFE_SB_FabricateMsgIdValue(FuncKey, false, TopicId, 1);
+    }
+}
+
+/*------------------------------------------------------------
+ *
+ * Default handler for CFE_SB_GlobalCmdTopicIdToMsgId coverage stub function
+ *
+ *------------------------------------------------------------*/
+void UT_DefaultHandler_CFE_SB_GlobalCmdTopicIdToMsgId(void *UserObj, UT_EntryKey_t FuncKey,
+                                                      const UT_StubContext_t *Context)
+{
+    uint16 TopicId;
+
+    if (!UT_Stub_GetInt32StatusCode(Context, NULL))
+    {
+        TopicId = UT_Hook_GetArgValueByName(Context, "TopicId", uint16);
+
+        UT_CFE_SB_FabricateMsgIdValue(FuncKey, true, TopicId, 0);
+    }
+}
+
+/*------------------------------------------------------------
+ *
+ * Default handler for CFE_SB_GlobalTlmTopicIdToMsgId coverage stub function
+ *
+ *------------------------------------------------------------*/
+void UT_DefaultHandler_CFE_SB_GlobalTlmTopicIdToMsgId(void *UserObj, UT_EntryKey_t FuncKey,
+                                                      const UT_StubContext_t *Context)
+{
+    uint16 TopicId;
+
+    if (!UT_Stub_GetInt32StatusCode(Context, NULL))
+    {
+        TopicId = UT_Hook_GetArgValueByName(Context, "TopicId", uint16);
+
+        UT_CFE_SB_FabricateMsgIdValue(FuncKey, false, TopicId, 0);
+    }
+}
+
+/*------------------------------------------------------------
+ *
+ * Default handler for CFE_SB_CmdTopicIdToMsgId coverage stub function
+ *
+ *------------------------------------------------------------*/
+void UT_DefaultHandler_CFE_SB_CmdTopicIdToMsgId(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+{
+    uint16 TopicId;
+    uint16 InstanceNum;
+
+    if (!UT_Stub_GetInt32StatusCode(Context, NULL))
+    {
+        TopicId     = UT_Hook_GetArgValueByName(Context, "TopicId", uint16);
+        InstanceNum = UT_Hook_GetArgValueByName(Context, "InstanceNum", uint16);
+
+        UT_CFE_SB_FabricateMsgIdValue(FuncKey, true, TopicId, InstanceNum);
+    }
+}
+
+/*------------------------------------------------------------
+ *
+ * Default handler for CFE_SB_TlmTopicIdToMsgId coverage stub function
+ *
+ *------------------------------------------------------------*/
+void UT_DefaultHandler_CFE_SB_TlmTopicIdToMsgId(void *UserObj, UT_EntryKey_t FuncKey, const UT_StubContext_t *Context)
+{
+    uint16 TopicId;
+    uint16 InstanceNum;
+
+    if (!UT_Stub_GetInt32StatusCode(Context, NULL))
+    {
+        TopicId     = UT_Hook_GetArgValueByName(Context, "TopicId", uint16);
+        InstanceNum = UT_Hook_GetArgValueByName(Context, "InstanceNum", uint16);
+
+        UT_CFE_SB_FabricateMsgIdValue(FuncKey, false, TopicId, InstanceNum);
+    }
+}
 
 /*------------------------------------------------------------
  *

--- a/modules/core_api/ut-stubs/src/cfe_sb_stubs.c
+++ b/modules/core_api/ut-stubs/src/cfe_sb_stubs.c
@@ -26,18 +26,24 @@
 #include "utgenstub.h"
 
 void UT_DefaultHandler_CFE_SB_AllocateMessageBuffer(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_SB_CmdTopicIdToMsgId(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CFE_SB_CreatePipe(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CFE_SB_DeletePipe(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CFE_SB_GetPipeIdByName(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CFE_SB_GetPipeName(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CFE_SB_GetUserData(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CFE_SB_GetUserDataLength(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_SB_GlobalCmdTopicIdToMsgId(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_SB_GlobalTlmTopicIdToMsgId(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CFE_SB_IsValidMsgId(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_SB_LocalCmdTopicIdToMsgId(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_SB_LocalTlmTopicIdToMsgId(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CFE_SB_MessageStringGet(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CFE_SB_MessageStringSet(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CFE_SB_ReceiveBuffer(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CFE_SB_SetUserDataLength(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CFE_SB_TimeStampMsg(void *, UT_EntryKey_t, const UT_StubContext_t *);
+void UT_DefaultHandler_CFE_SB_TlmTopicIdToMsgId(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CFE_SB_TransmitBuffer(void *, UT_EntryKey_t, const UT_StubContext_t *);
 void UT_DefaultHandler_CFE_SB_TransmitMsg(void *, UT_EntryKey_t, const UT_StubContext_t *);
 
@@ -55,6 +61,23 @@ CFE_SB_Buffer_t *CFE_SB_AllocateMessageBuffer(size_t MsgSize)
     UT_GenStub_Execute(CFE_SB_AllocateMessageBuffer, Basic, UT_DefaultHandler_CFE_SB_AllocateMessageBuffer);
 
     return UT_GenStub_GetReturnValue(CFE_SB_AllocateMessageBuffer, CFE_SB_Buffer_t *);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CFE_SB_CmdTopicIdToMsgId()
+ * ----------------------------------------------------
+ */
+CFE_SB_MsgId_Atom_t CFE_SB_CmdTopicIdToMsgId(uint16 TopicId, uint16 InstanceNum)
+{
+    UT_GenStub_SetupReturnBuffer(CFE_SB_CmdTopicIdToMsgId, CFE_SB_MsgId_Atom_t);
+
+    UT_GenStub_AddParam(CFE_SB_CmdTopicIdToMsgId, uint16, TopicId);
+    UT_GenStub_AddParam(CFE_SB_CmdTopicIdToMsgId, uint16, InstanceNum);
+
+    UT_GenStub_Execute(CFE_SB_CmdTopicIdToMsgId, Basic, UT_DefaultHandler_CFE_SB_CmdTopicIdToMsgId);
+
+    return UT_GenStub_GetReturnValue(CFE_SB_CmdTopicIdToMsgId, CFE_SB_MsgId_Atom_t);
 }
 
 /*
@@ -177,6 +200,38 @@ size_t CFE_SB_GetUserDataLength(const CFE_MSG_Message_t *MsgPtr)
 
 /*
  * ----------------------------------------------------
+ * Generated stub function for CFE_SB_GlobalCmdTopicIdToMsgId()
+ * ----------------------------------------------------
+ */
+CFE_SB_MsgId_Atom_t CFE_SB_GlobalCmdTopicIdToMsgId(uint16 TopicId)
+{
+    UT_GenStub_SetupReturnBuffer(CFE_SB_GlobalCmdTopicIdToMsgId, CFE_SB_MsgId_Atom_t);
+
+    UT_GenStub_AddParam(CFE_SB_GlobalCmdTopicIdToMsgId, uint16, TopicId);
+
+    UT_GenStub_Execute(CFE_SB_GlobalCmdTopicIdToMsgId, Basic, UT_DefaultHandler_CFE_SB_GlobalCmdTopicIdToMsgId);
+
+    return UT_GenStub_GetReturnValue(CFE_SB_GlobalCmdTopicIdToMsgId, CFE_SB_MsgId_Atom_t);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CFE_SB_GlobalTlmTopicIdToMsgId()
+ * ----------------------------------------------------
+ */
+CFE_SB_MsgId_Atom_t CFE_SB_GlobalTlmTopicIdToMsgId(uint16 TopicId)
+{
+    UT_GenStub_SetupReturnBuffer(CFE_SB_GlobalTlmTopicIdToMsgId, CFE_SB_MsgId_Atom_t);
+
+    UT_GenStub_AddParam(CFE_SB_GlobalTlmTopicIdToMsgId, uint16, TopicId);
+
+    UT_GenStub_Execute(CFE_SB_GlobalTlmTopicIdToMsgId, Basic, UT_DefaultHandler_CFE_SB_GlobalTlmTopicIdToMsgId);
+
+    return UT_GenStub_GetReturnValue(CFE_SB_GlobalTlmTopicIdToMsgId, CFE_SB_MsgId_Atom_t);
+}
+
+/*
+ * ----------------------------------------------------
  * Generated stub function for CFE_SB_IsValidMsgId()
  * ----------------------------------------------------
  */
@@ -189,6 +244,38 @@ bool CFE_SB_IsValidMsgId(CFE_SB_MsgId_t MsgId)
     UT_GenStub_Execute(CFE_SB_IsValidMsgId, Basic, UT_DefaultHandler_CFE_SB_IsValidMsgId);
 
     return UT_GenStub_GetReturnValue(CFE_SB_IsValidMsgId, bool);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CFE_SB_LocalCmdTopicIdToMsgId()
+ * ----------------------------------------------------
+ */
+CFE_SB_MsgId_Atom_t CFE_SB_LocalCmdTopicIdToMsgId(uint16 TopicId)
+{
+    UT_GenStub_SetupReturnBuffer(CFE_SB_LocalCmdTopicIdToMsgId, CFE_SB_MsgId_Atom_t);
+
+    UT_GenStub_AddParam(CFE_SB_LocalCmdTopicIdToMsgId, uint16, TopicId);
+
+    UT_GenStub_Execute(CFE_SB_LocalCmdTopicIdToMsgId, Basic, UT_DefaultHandler_CFE_SB_LocalCmdTopicIdToMsgId);
+
+    return UT_GenStub_GetReturnValue(CFE_SB_LocalCmdTopicIdToMsgId, CFE_SB_MsgId_Atom_t);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CFE_SB_LocalTlmTopicIdToMsgId()
+ * ----------------------------------------------------
+ */
+CFE_SB_MsgId_Atom_t CFE_SB_LocalTlmTopicIdToMsgId(uint16 TopicId)
+{
+    UT_GenStub_SetupReturnBuffer(CFE_SB_LocalTlmTopicIdToMsgId, CFE_SB_MsgId_Atom_t);
+
+    UT_GenStub_AddParam(CFE_SB_LocalTlmTopicIdToMsgId, uint16, TopicId);
+
+    UT_GenStub_Execute(CFE_SB_LocalTlmTopicIdToMsgId, Basic, UT_DefaultHandler_CFE_SB_LocalTlmTopicIdToMsgId);
+
+    return UT_GenStub_GetReturnValue(CFE_SB_LocalTlmTopicIdToMsgId, CFE_SB_MsgId_Atom_t);
 }
 
 /*
@@ -377,6 +464,23 @@ void CFE_SB_TimeStampMsg(CFE_MSG_Message_t *MsgPtr)
     UT_GenStub_AddParam(CFE_SB_TimeStampMsg, CFE_MSG_Message_t *, MsgPtr);
 
     UT_GenStub_Execute(CFE_SB_TimeStampMsg, Basic, UT_DefaultHandler_CFE_SB_TimeStampMsg);
+}
+
+/*
+ * ----------------------------------------------------
+ * Generated stub function for CFE_SB_TlmTopicIdToMsgId()
+ * ----------------------------------------------------
+ */
+CFE_SB_MsgId_Atom_t CFE_SB_TlmTopicIdToMsgId(uint16 TopicId, uint16 InstanceNum)
+{
+    UT_GenStub_SetupReturnBuffer(CFE_SB_TlmTopicIdToMsgId, CFE_SB_MsgId_Atom_t);
+
+    UT_GenStub_AddParam(CFE_SB_TlmTopicIdToMsgId, uint16, TopicId);
+    UT_GenStub_AddParam(CFE_SB_TlmTopicIdToMsgId, uint16, InstanceNum);
+
+    UT_GenStub_Execute(CFE_SB_TlmTopicIdToMsgId, Basic, UT_DefaultHandler_CFE_SB_TlmTopicIdToMsgId);
+
+    return UT_GenStub_GetReturnValue(CFE_SB_TlmTopicIdToMsgId, CFE_SB_MsgId_Atom_t);
 }
 
 /*

--- a/modules/sb/fsw/src/cfe_sb_msg_id_util.c
+++ b/modules/sb/fsw/src/cfe_sb_msg_id_util.c
@@ -25,6 +25,171 @@
 ** Include Files
 */
 #include "cfe_sb_module_all.h"
+#include "cfe_core_api_base_msgids.h"
+
+/*
+ * IMPORTANT:
+ * The "core_api_base_msgids.h" header should have defined the following macros:
+ *   CFE_PLATFORM_CMD_TOPICID_TO_MIDV
+ *   CFE_PLATFORM_TLM_TOPICID_TO_MIDV
+ *   CFE_GLOBAL_CMD_TOPICID_TO_MIDV
+ *   CFE_GLOBAL_TLM_TOPICID_TO_MIDV
+ *
+ * However, historically in CFE, MsgIDs were directly defined at compile-time (not run-time)
+ * and not based on a topic ID.  It is possible that when using an older CFE configuration
+ * that it does not define these macros, and thus run-time conversion cannot be performed.
+ *
+ * If that is the case, then all these functions will return the invalid MsgID value (0).
+ * The coverage tests will fail (which should let the user know the feature is not working
+ * correctly) but CFE and related apps will still execute just fine so long as nothing
+ * relies on the run-time conversions.
+ */
+
+#ifndef CFE_PLATFORM_CMD_TOPICID_TO_MIDV
+#define CFE_PLATFORM_CMD_TOPICID_TO_MIDV(x) 0
+#endif
+
+#ifndef CFE_PLATFORM_TLM_TOPICID_TO_MIDV
+#define CFE_PLATFORM_TLM_TOPICID_TO_MIDV(x) 0
+#endif
+
+#ifndef CFE_GLOBAL_CMD_TOPICID_TO_MIDV
+#define CFE_GLOBAL_CMD_TOPICID_TO_MIDV(x) 0
+#endif
+
+#ifndef CFE_GLOBAL_TLM_TOPICID_TO_MIDV
+#define CFE_GLOBAL_TLM_TOPICID_TO_MIDV(x) 0
+#endif
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+size_t CFE_SB_MsgHdrSize(const CFE_MSG_Message_t *MsgPtr)
+{
+    size_t         size      = 0;
+    bool           hassechdr = false;
+    CFE_MSG_Type_t type      = CFE_MSG_Type_Invalid;
+
+    if (MsgPtr == NULL)
+    {
+        return size;
+    }
+
+    CFE_MSG_GetHasSecondaryHeader(MsgPtr, &hassechdr);
+    CFE_MSG_GetType(MsgPtr, &type);
+
+    /* if secondary hdr is not present... */
+    /* Since all cFE messages must have a secondary hdr this check is not needed */
+    if (!hassechdr)
+    {
+        size = sizeof(CFE_MSG_Message_t);
+    }
+    else if (type == CFE_MSG_Type_Cmd)
+    {
+        size = sizeof(CFE_MSG_CommandHeader_t);
+    }
+    else if (type == CFE_MSG_Type_Tlm)
+    {
+        size = sizeof(CFE_MSG_TelemetryHeader_t);
+    }
+
+    return size;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Implemented per public API
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+CFE_SB_MsgId_Atom_t CFE_SB_CmdTopicIdToMsgId(uint16 TopicId, uint16 InstanceNum)
+{
+    CFE_SB_MsgId_Atom_t MsgIdValue;
+
+    /* Instance Number 0 is reserved for globals */
+    if (InstanceNum == 0)
+    {
+        MsgIdValue = CFE_SB_GlobalTlmTopicIdToMsgId(TopicId);
+    }
+    else
+    {
+        MsgIdValue = CFE_PLATFORM_CMD_TOPICID_TO_MIDV(TopicId);
+    }
+
+    return MsgIdValue;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Implemented per public API
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+CFE_SB_MsgId_Atom_t CFE_SB_TlmTopicIdToMsgId(uint16 TopicId, uint16 InstanceNum)
+{
+    CFE_SB_MsgId_Atom_t MsgIdValue;
+
+    /* Instance Number 0 is reserved for globals */
+    if (InstanceNum == 0)
+    {
+        MsgIdValue = CFE_SB_GlobalTlmTopicIdToMsgId(TopicId);
+    }
+    else
+    {
+        MsgIdValue = CFE_PLATFORM_TLM_TOPICID_TO_MIDV(TopicId);
+    }
+
+    return MsgIdValue;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Implemented per public API
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+CFE_SB_MsgId_Atom_t CFE_SB_GlobalCmdTopicIdToMsgId(uint16 TopicId)
+{
+    return CFE_GLOBAL_CMD_TOPICID_TO_MIDV(TopicId);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Implemented per public API
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+CFE_SB_MsgId_Atom_t CFE_SB_GlobalTlmTopicIdToMsgId(uint16 TopicId)
+{
+    return CFE_GLOBAL_TLM_TOPICID_TO_MIDV(TopicId);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Implemented per public API
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+CFE_SB_MsgId_Atom_t CFE_SB_LocalCmdTopicIdToMsgId(uint16 TopicId)
+{
+    /* PSP-reported Instance number is used for locals */
+    return CFE_SB_CmdTopicIdToMsgId(TopicId, CFE_PSP_GetProcessorId());
+}
+
+/*----------------------------------------------------------------
+ *
+ * Implemented per public API
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+CFE_SB_MsgId_Atom_t CFE_SB_LocalTlmTopicIdToMsgId(uint16 TopicId)
+{
+    /* PSP-reported Instance number is used for locals */
+    return CFE_SB_TlmTopicIdToMsgId(TopicId, CFE_PSP_GetProcessorId());
+}
 
 /*----------------------------------------------------------------
  *

--- a/modules/sb/fsw/src/cfe_sb_util.c
+++ b/modules/sb/fsw/src/cfe_sb_util.c
@@ -37,44 +37,6 @@
 
 /*----------------------------------------------------------------
  *
- * Application-scope internal function
- * See description in header file for argument/return detail
- *
- *-----------------------------------------------------------------*/
-size_t CFE_SB_MsgHdrSize(const CFE_MSG_Message_t *MsgPtr)
-{
-    size_t         size      = 0;
-    bool           hassechdr = false;
-    CFE_MSG_Type_t type      = CFE_MSG_Type_Invalid;
-
-    if (MsgPtr == NULL)
-    {
-        return size;
-    }
-
-    CFE_MSG_GetHasSecondaryHeader(MsgPtr, &hassechdr);
-    CFE_MSG_GetType(MsgPtr, &type);
-
-    /* if secondary hdr is not present... */
-    /* Since all cFE messages must have a secondary hdr this check is not needed */
-    if (!hassechdr)
-    {
-        size = sizeof(CFE_MSG_Message_t);
-    }
-    else if (type == CFE_MSG_Type_Cmd)
-    {
-        size = sizeof(CFE_MSG_CommandHeader_t);
-    }
-    else if (type == CFE_MSG_Type_Tlm)
-    {
-        size = sizeof(CFE_MSG_TelemetryHeader_t);
-    }
-
-    return size;
-}
-
-/*----------------------------------------------------------------
- *
  * Implemented per public API
  * See description in header file for argument/return detail
  *

--- a/modules/sb/ut-coverage/sb_UT.h
+++ b/modules/sb/ut-coverage/sb_UT.h
@@ -2514,4 +2514,14 @@ void Test_SB_CCSDSPriHdr_Macros(void);
 void Test_SB_CCSDSSecHdr_Macros(void);
 void Test_SB_IdxPushPop(void);
 
+/*
+ * TopicID <-> MsgID conversion test routines
+ */
+void Test_CFE_SB_CmdTopicIdToMsgId(void);
+void Test_CFE_SB_TlmTopicIdToMsgId(void);
+void Test_CFE_SB_GlobalCmdTopicIdToMsgId(void);
+void Test_CFE_SB_GlobalTlmTopicIdToMsgId(void);
+void Test_CFE_SB_LocalCmdTopicIdToMsgId(void);
+void Test_CFE_SB_LocalTlmTopicIdToMsgId(void);
+
 #endif /* SB_UT_H */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Adds the following APIs to convert TopicID to MsgID values at runtime:

 - CFE_SB_CmdTopicIdToMsgId()
 - CFE_SB_TlmTopicIdToMsgId()
 - CFE_SB_GlobalCmdTopicIdToMsgId()
 - CFE_SB_GlobalTlmTopicIdToMsgId()
 - CFE_SB_LocalCmdTopicIdToMsgId()
 - CFE_SB_LocalTlmTopicIdToMsgId()

This includes coverage tests and stubs.  If the config does not define the conversions, then these return the invalid msgID value.

Fixes #2519

**Testing performed**
Build and run all tests

**Expected behavior changes**
None  (new APIs are not actively called by FSW, yet)

**System(s) tested on**
Debian

**Additional context**
EDS-based builds generally deal only in Topic IDs and convert to Msg IDs at runtime.  These APIs are needed as a prerequisite to that model.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
