### PR TITLE
Fix #2561, send CMake message to stdout instead of stderr

### DIFF
--- a/cmake/arch_build.cmake
+++ b/cmake/arch_build.cmake
@@ -820,7 +820,7 @@ function(process_arch SYSVAR)
       if (FILESRC)
         # In case the file is a symlink, follow it to get to the actual file
         get_filename_component(FILESRC "${FILESRC}" REALPATH)
-        message("NOTE: Selected ${FILESRC} as source for ${INSTFILE} on ${TGTNAME}")
+        message(STATUS "NOTE: Selected ${FILESRC} as source for ${INSTFILE} on ${TGTNAME}")
         install(FILES ${FILESRC} DESTINATION ${TGTNAME}/${INSTALL_SUBDIR} RENAME ${INSTFILE})
       else(FILESRC)
         message("WARNING: Install file ${INSTFILE} for ${TGTNAME} not found")


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fix #2561.

While executing the drac0-rc5 training exercises, I noticed on the first `make prep` call that the following message is printed to stderr
```
NOTE: Selected /home/cmartin/code/cFS/sample_defs/cpu1_cfe_es_startup.scr as source for cfe_es_startup.scr on cpu1
```
This seems like an informational message that would be more appropriate for stdout than stderr, so I added the [`STATUS` keyword](https://cmake.org/cmake/help/v3.26/command/message.html) to the cmake `message` call.

**Testing performed**
Before change
```
make prep > stdout.log # observe NOTE printed to screen despite passing stdout to file
```
After change
```
rm -rf build
make prep > stdout.log # observe nothing printed to screen 🎉
```

**Expected behavior changes**
 - API Change: None
 - Behavior Change: One message that used to go to stderr now goes to stdout

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu 22.04
 - Versions: draco-rc5

**Additional context**
This is a bit of a trial balloon to feel out the cFS contribution process. I won't be offended if you close this Pull Request with no action. Thank you for your hard work on this product and its outstanding documentation!

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
- Cody Martin (Personal contributor)