### PR TITLE
Hotfix #2526, add missing memset() for stack variables

### DIFF
--- a/modules/es/fsw/src/cfe_es_apps.c
+++ b/modules/es/fsw/src/cfe_es_apps.c
@@ -295,6 +295,8 @@ int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens)
     int32                   Status;
     CFE_ES_AppStartParams_t ParamBuf;
 
+    memset(&ParamBuf, 0, sizeof(ParamBuf));
+
     /*
     ** Check to see if the correct number of items were parsed
     */

--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -639,6 +639,8 @@ int32 CFE_ES_StartAppCmd(const CFE_ES_StartAppCmd_t *data)
     char                                LocalAppName[OS_MAX_API_NAME];
     CFE_ES_AppStartParams_t             StartParams;
 
+    memset(&StartParams, 0, sizeof(StartParams));
+
     /* Create local copies of all input strings and ensure null termination */
     Result = CFE_FS_ParseInputFileNameEx(StartParams.BasicInfo.FileName, cmd->AppFileName,
                                          sizeof(StartParams.BasicInfo.FileName), sizeof(cmd->AppFileName), NULL,


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Correct two cases where struct variables on the stack were not being properly cleared before use.

Hot Fix for PR #2526 - addresses issues when running workflows

**Testing performed**
Run workflows

**Expected behavior changes**
Workflows succeed, no seg faults

**System(s) tested on**
Github Hosted Runner

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
