### PR TITLE
Fix #2534, Switch pc rtems toolchains to use osal generic-rtems bsp

### DIFF
--- a/cmake/sample_defs/toolchain-i686-rtems4.11.cmake
+++ b/cmake/sample_defs/toolchain-i686-rtems4.11.cmake
@@ -20,7 +20,7 @@ set(RTEMS_BSP               "pc686")
 # these settings are specific to cFE/OSAL and determines which
 # abstraction layers are built when using this toolchain
 SET(CFE_SYSTEM_PSPNAME      pc-rtems)
-SET(OSAL_SYSTEM_BSPTYPE     pc-rtems)
+SET(OSAL_SYSTEM_BSPTYPE     generic-rtems)
 SET(OSAL_SYSTEM_OSTYPE      rtems)
 
 # This is for version specific RTEMS ifdefs needed by the OSAL and PSP

--- a/cmake/sample_defs/toolchain-i686-rtems5.cmake
+++ b/cmake/sample_defs/toolchain-i686-rtems5.cmake
@@ -20,7 +20,7 @@ set(RTEMS_BSP               "pc686")
 # these settings are specific to cFE/OSAL and determines which
 # abstraction layers are built when using this toolchain
 SET(CFE_SYSTEM_PSPNAME      pc-rtems)
-SET(OSAL_SYSTEM_BSPTYPE     pc-rtems)
+SET(OSAL_SYSTEM_BSPTYPE     generic-rtems)
 SET(OSAL_SYSTEM_OSTYPE      rtems)
 
 # This is for version specific RTEMS ifdefs needed by the OSAL and PSP

--- a/cmake/sample_defs/toolchain-i686-rtems6.cmake
+++ b/cmake/sample_defs/toolchain-i686-rtems6.cmake
@@ -20,7 +20,7 @@ set(RTEMS_BSP               "pc686")
 # these settings are specific to cFE/OSAL and determines which
 # abstraction layers are built when using this toolchain
 SET(CFE_SYSTEM_PSPNAME      pc-rtems)
-SET(OSAL_SYSTEM_BSPTYPE     pc-rtems)
+SET(OSAL_SYSTEM_BSPTYPE     generic-rtems)
 SET(OSAL_SYSTEM_OSTYPE      rtems)
 
 # This is for version specific RTEMS ifdefs needed by the OSAL and PSP


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fix #2534 

**Testing performed**
See passing workflows for rtems 4.11 and 5 here (on a test cFS branch):
https://github.com/skliper/cFS/actions/runs/8381881063
https://github.com/skliper/cFS/actions/runs/8381881063

**Expected behavior changes**
None, just more fully featured osal bsp

**System(s) tested on**
CI (also tested with a leon3 build)

**Additional context**
Depends on https://github.com/nasa/osal/pull/1350

**Third party code**
None

**Contributor Info - All information REQUIRED for consideration of pull request**
Jacob Hageman - NASA/GSFC