### PR TITLE
Fix #2546, add handle list operation routines

### DIFF
--- a/modules/tbl/fsw/src/cfe_tbl_internal.h
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.h
@@ -48,6 +48,17 @@
 #define CFE_TBL_NOT_FOUND   (-1)
 #define CFE_TBL_END_OF_LIST (CFE_TBL_Handle_t)0xFFFF
 
+/**
+ * Function type used with access descriptor iterator
+ *
+ * The access descriptor iterator will invoke the supplied function
+ * for every descriptor associated with the table registry entry
+ *
+ * \param AccDescPtr Pointer to the current access descriptor
+ * \param Arg Opaque argument from caller (passed through)
+ */
+typedef void (* const CFE_TBL_AccessDescFunc_t)(CFE_TBL_AccessDescriptor_t *AccDescPtr, void *Arg);
+
 /*****************************  Function Prototypes   **********************************/
 
 /*---------------------------------------------------------------------------------------*/
@@ -536,6 +547,105 @@ CFE_Status_t CFE_TBL_RestoreTableDataFromCDS(CFE_TBL_RegistryRec_t *RegRecPtr, c
 */
 void CFE_TBL_RegisterWithCriticalTableRegistry(CFE_TBL_CritRegRec_t *CritRegRecPtr, CFE_TBL_RegistryRec_t *RegRecPtr,
                                                const char *TblName);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+** \brief Generic iterator for access descriptors associated with a Table Registry
+**
+** \par Description
+**        This function iterates through the list of access descriptors that are associated
+**        with the given table registry entry.  The user-supplied callback function will be
+**        invoked for each access descriptor, with the opaque pointer argument passed as a
+**        parameter.
+**
+** \par Assumptions, External Events, and Notes:
+**        The caller should ensure that the list is not modified by other threads during this call
+**
+** \param RegRecPtr The pointer to the registry record
+** \param Func The function to invoke for each access descriptor
+** \param Arg Opaque argument, passed through to function
+*/
+void CFE_TBL_ForeachAccessDescriptor(CFE_TBL_RegistryRec_t *RegRecPtr, CFE_TBL_AccessDescFunc_t Func, void *Arg);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+** \brief Handle iterator function that increments a counter
+**
+** \par Description
+**        When used with CFE_TBL_ForeachAccessDescriptor() this will count the number of entries
+**
+** \par Assumptions, External Events, and Notes:
+**        This is declared here so it can be used in several places that count descriptors
+**
+** \param AccDescPtr Pointer to descriptor entry, not used
+** \param Arg a pointer to a uint32 value that is incremented on each call
+*/
+void CFE_TBL_CountAccessDescHelper(CFE_TBL_AccessDescriptor_t *AccDescPtr, void *Arg);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+** \brief Initializes a handle link
+**
+** \par Description
+**        Sets the handle link to initial condition, where it is not a member of any list
+**        After this call, CFE_TBL_HandleLinkIsAttached() on this link will always return false
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \param LinkPtr Pointer to link entry to initialize
+*/
+void CFE_TBL_HandleLinkInit(CFE_TBL_HandleLink_t *LinkPtr);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+** \brief Checks if a handle link is attached to another entry
+**
+** \par Description
+**        This will return true if the passed-in link is attached to another list node,
+**        indicating it is part of a list.  Conversely, this will return false if the
+**        link is not attached to another node, indicating a singleton or empty list.
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \param LinkPtr Pointer to link entry to check
+** \retval true if the link node is part of a list (attached)
+** \retval false if the link node is not part of a list (detached)
+*/
+bool CFE_TBL_HandleLinkIsAttached(CFE_TBL_HandleLink_t *LinkPtr);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+** \brief Removes the given access descriptor from the registry list
+**
+** \par Description
+**        This will disassociate the access descriptor from the table registry record by
+**        removing/extracting the access descriptor from the linked list
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \param RegRecPtr The table registry record that is associated with the access descriptor
+** \param AccessDescPtr The access descriptor that is to be removed from the list
+*/
+void CFE_TBL_HandleListRemoveLink(CFE_TBL_RegistryRec_t *RegRecPtr, CFE_TBL_AccessDescriptor_t *AccessDescPtr);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+** \brief Inserts the given access descriptor into the registry list
+**
+** \par Description
+**        This will associate the access descriptor with the table registry record by
+**        inserting the access descriptor into the linked list
+**
+** \par Assumptions, External Events, and Notes:
+**        None
+**
+** \param RegRecPtr The table registry record that should be associated with the access descriptor
+** \param AccessDescPtr The access descriptor that is to be added to the list
+*/
+void CFE_TBL_HandleListInsertLink(CFE_TBL_RegistryRec_t *RegRecPtr, CFE_TBL_AccessDescriptor_t *AccessDescPtr);
 
 /*
 ** Globals specific to the TBL module

--- a/modules/tbl/fsw/src/cfe_tbl_resource.c
+++ b/modules/tbl/fsw/src/cfe_tbl_resource.c
@@ -35,7 +35,7 @@
 
 /*----------------------------------------------------------------
  *
- * Implemented per public API
+ * Application-scope internal function
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
@@ -50,9 +50,10 @@ CFE_Status_t CFE_TBL_Handle_ToIndex(CFE_TBL_Handle_t TblHandle, uint32 *Idx)
 
     return CFE_SUCCESS;
 }
+
 /*----------------------------------------------------------------
  *
- * Implemented per public API
+ * Application-scope internal function
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
@@ -97,6 +98,18 @@ CFE_TBL_RegistryRec_t *CFE_TBL_LocateRegistryRecordByID(CFE_TBL_RegId_t RegId)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
+CFE_TBL_RegId_t CFE_TBL_RegistryRecordGetID(const CFE_TBL_RegistryRec_t *RegRecPtr)
+{
+    /* The pointer should be to an entry within the Registry array */
+    return (RegRecPtr - CFE_TBL_Global.Registry);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
 CFE_TBL_AccessDescriptor_t *CFE_TBL_LocateAccessDescriptorByHandle(CFE_TBL_Handle_t TblHandle)
 {
     CFE_TBL_AccessDescriptor_t *AccessDescPtr;
@@ -112,4 +125,16 @@ CFE_TBL_AccessDescriptor_t *CFE_TBL_LocateAccessDescriptorByHandle(CFE_TBL_Handl
     }
 
     return AccessDescPtr;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+CFE_TBL_Handle_t CFE_TBL_AccessDescriptorGetHandle(const CFE_TBL_AccessDescriptor_t *AccessDescPtr)
+{
+    /* The pointer should be to an entry within the Handles array */
+    return (AccessDescPtr - CFE_TBL_Global.Handles);
 }

--- a/modules/tbl/fsw/src/cfe_tbl_resource.h
+++ b/modules/tbl/fsw/src/cfe_tbl_resource.h
@@ -38,7 +38,7 @@
 
 /*---------------------------------------------------------------------------------------*/
 /**
- * @brief Locate the app table entry correlating with a given app ID.
+ * @brief Locate the registry table entry correlating with a given registry ID.
  *
  * This only returns a pointer to the table entry where the record
  * should reside, but does _not_ actually check/validate the entry.
@@ -47,7 +47,7 @@
  * values for applications, such that it could never be valid under
  * any circumstances, then NULL is returned.  Otherwise, a pointer to the
  * corresponding table entry is returned, indicating the location where
- * that ID _should_ reside, if it is currently in use.
+ * that ID should reside, if it is currently in use.
  *
  * @note This only returns where the ID should reside, not that it actually
  * resides there.  If looking up an existing ID, then caller must additionally
@@ -59,67 +59,45 @@
  *
  * @sa CFE_TBL_RegistryRecordIsMatch()
  *
- * @param[in]   RegId   the app ID to locate
- * @return pointer to App Table entry for the given app ID, or NULL if out of range
+ * @param[in]   RegId   the registry ID to locate
+ * @return pointer to Registry Table entry for the given registry ID, or NULL if out of range
  */
 CFE_TBL_RegistryRec_t *CFE_TBL_LocateRegistryRecordByID(CFE_TBL_RegId_t RegId);
 
 /*---------------------------------------------------------------------------------------*/
 /**
- * @brief Locate the task table entry correlating with a given task ID.
+ * @brief Locate the access descriptor entry correlating with a given table handle.
  *
- * This only returns a pointer to the table entry where the record
+ * This only returns a pointer to the table entry where the descriptor
  * should reside, but does _not_ actually check/validate the entry.
  *
  * If the passed-in ID parameter is not within the acceptable range of ID
  * values for tasks, such that it could never be valid under
  * any circumstances, then NULL is returned.  Otherwise, a pointer to the
  * corresponding table entry is returned, indicating the location where
- * that ID _should_ reside, if it is currently in use.
+ * that ID should reside, if it is currently in use.
  *
  * @note This only returns where the ID should reside, not that it actually
  * resides there.  If looking up an existing ID, then caller must additionally
- * confirm that the returned record is a match to the expected ID before using
- * or modifying the data within the returned record pointer.
+ * confirm that the returned descriptor is a match to the expected ID before using
+ * or modifying the data within the returned descriptor pointer.
  *
  * The CFE_TBL_AccessDescriptorIsMatch() function can be used to check/confirm
  * if the returned table entry is a positive match for the given ID.
  *
  * @sa CFE_TBL_AccessDescriptorIsMatch()
  *
- * @param[in]   TblHandle   the task ID to locate
- * @return pointer to Task Table entry for the given task ID, or NULL if out of range
+ * @param[in]   TblHandle   the table handle to locate
+ * @return pointer to decriptor table entry for the given table handle, or NULL if out of range
  */
 CFE_TBL_AccessDescriptor_t *CFE_TBL_LocateAccessDescriptorByHandle(CFE_TBL_Handle_t TblHandle);
 
-#ifdef jphfix
 /*---------------------------------------------------------------------------------------*/
 /**
- * @brief Check if an app record is in use or free/empty
+ * @brief Check if a registry record is a match for the given RegId
  *
- * This routine checks if the App table entry is in use or if it is free
- *
- * As this dereferences fields within the record, global data must be
- * locked prior to invoking this function.
- *
- * @note This internal helper function must only be used on record pointers
- * that are known to refer to an actual table location (i.e. non-null).
- *
- * @param[in]   RegRecPtr   pointer to app table entry
- * @returns true if the entry is in use/configured, or false if it is free/empty
- */
-static inline bool CFE_TBL_RegistryRecordIsUsed(const CFE_TBL_RegistryRec_t *RegRecPtr)
-{
-    return RegRecPtr->Taken;
-}
-#endif
-
-/*---------------------------------------------------------------------------------------*/
-/**
- * @brief Check if an app record is a match for the given RegId
- *
- * This routine confirms that the previously-located record is valid
- * and matches the expected app ID.
+ * This routine confirms that the previously-located registry record is valid
+ * and matches the expected registry ID.
  *
  * As this dereferences fields within the record, global data must be
  * locked prior to invoking this function.
@@ -134,9 +112,9 @@ static inline bool CFE_TBL_RegistryRecordIsUsed(const CFE_TBL_RegistryRec_t *Reg
  *
  * @sa CFE_TBL_LocateRegistryRecordByID
  *
- * @param[in]   RegRecPtr   pointer to app table entry, or NULL
- * @param[in]   RegId       expected app ID
- * @returns true if the entry matches the given app ID
+ * @param[in]   RegRecPtr   pointer to registry table entry, or NULL
+ * @param[in]   RegId       expected registry ID
+ * @returns true if the entry matches the given registry ID
  */
 static inline bool CFE_TBL_RegistryRecordIsMatch(const CFE_TBL_RegistryRec_t *RegRecPtr, CFE_TBL_RegId_t RegId)
 {
@@ -164,92 +142,23 @@ static inline const char *CFE_TBL_RegistryRecordGetName(const CFE_TBL_RegistryRe
     return RegRecPtr->Name;
 }
 
-#ifdef jphfix
 /*---------------------------------------------------------------------------------------*/
 /**
- * @brief Get the ID value from a Task table entry
+ * @brief Get the Handle ID from an an access descriptor pointer
  *
- * This routine converts the table entry back to an abstract ID.
- *
- * As this dereferences fields within the record, global data must be
- * locked prior to invoking this function.
+ * This routine converts a pointer to a handle table entry to an ID
  *
  * @note This internal helper function must only be used on record pointers
  * that are known to refer to an actual table location (i.e. non-null).
  *
- * @param[in]   AccessDescPtr   pointer to Task table entry
+ * @param[in]   AccessDescPtr   pointer to access descriptor
  * @returns TblHandle of entry
  */
-static inline CFE_TBL_Handle_t CFE_TBL_AccessDescriptorGetID(const CFE_TBL_AccessDescriptor_t *AccessDescPtr)
-{
-    return AccessDescPtr->TblHandle;
-}
+CFE_TBL_Handle_t CFE_TBL_AccessDescriptorGetHandle(const CFE_TBL_AccessDescriptor_t *AccessDescPtr);
 
 /*---------------------------------------------------------------------------------------*/
 /**
- * @brief Check if a Task record is in use or free/empty
- *
- * This routine checks if the Task table entry is in use or if it is free
- *
- * As this dereferences fields within the record, global data must be
- * locked prior to invoking this function.
- *
- * @note This internal helper function must only be used on record pointers
- * that are known to refer to an actual table location (i.e. non-null).
- *
- * @param[in]   AccessDescPtr   pointer to task table entry
- * @returns true if the entry is in use/configured, or false if it is free/empty
- */
-static inline bool CFE_TBL_AccessDescriptorIsUsed(const CFE_TBL_AccessDescriptor_t *AccessDescPtr)
-{
-    return CFE_RESOURCEID_TEST_DEFINED(AccessDescPtr->TblHandle);
-}
-
-/*---------------------------------------------------------------------------------------*/
-/**
- * @brief Marks a Task table entry as used (not free)
- *
- * This sets the internal field(s) within this entry, and marks
- * it as being associated with the given Task ID.
- *
- * As this dereferences fields within the record, global data must be
- * locked prior to invoking this function.
- *
- * @note This internal helper function must only be used on record pointers
- * that are known to refer to an actual table location (i.e. non-null).
- *
- * @param[in]   AccessDescPtr   pointer to Task table entry
- * @param[in]   PendingId    the Task ID of this entry
- */
-static inline void CFE_TBL_AccessDescriptorSetUsed(CFE_TBL_AccessDescriptor_t *AccessDescPtr,
-                                                   CFE_ResourceId_t            PendingId)
-{
-    AccessDescPtr->TblHandle = CFE_TBL_ACCESSID_C(PendingId);
-}
-
-/*---------------------------------------------------------------------------------------*/
-/**
- * @brief Set a Task record table entry free
- *
- * This allows the table entry to be re-used by another Task.
- *
- * As this dereferences fields within the record, global data must be
- * locked prior to invoking this function.
- *
- * @note This internal helper function must only be used on record pointers
- * that are known to refer to an actual table location (i.e. non-null).
- *
- * @param[in]   AccessDescPtr   pointer to task table entry
- */
-static inline void CFE_TBL_AccessDescriptorSetFree(CFE_TBL_AccessDescriptor_t *AccessDescPtr)
-{
-    AccessDescPtr->TblHandle = CFE_TBL_ACCESSID_UNDEFINED;
-}
-#endif
-
-/*---------------------------------------------------------------------------------------*/
-/**
- * @brief Check if a Task record is a match for the given TblHandle
+ * @brief Check if an Access Descriptor is a match for the given TblHandle
  *
  * This routine confirms that the previously-located record is valid
  * and matches the expected Task ID.
@@ -257,7 +166,7 @@ static inline void CFE_TBL_AccessDescriptorSetFree(CFE_TBL_AccessDescriptor_t *A
  * As this dereferences fields within the record, global data must be
  * locked prior to invoking this function.
  *
- * This function may be used in conjunction with CFE_TBL_LocateTaskRecordByID()
+ * This function may be used in conjunction with CFE_TBL_LocateAccessDescriptorByHandle()
  * to confirm that the located record is a positive match to the expected ID.
  * As such, the record pointer is also permitted to be NULL, to alleviate the
  * need for the caller to handle this possibility explicitly.
@@ -265,252 +174,16 @@ static inline void CFE_TBL_AccessDescriptorSetFree(CFE_TBL_AccessDescriptor_t *A
  * Once a record pointer has been successfully validated using this routine,
  * it may be safely passed to all other internal functions.
  *
- * @sa CFE_TBL_LocateTaskRecordByID
+ * @sa CFE_TBL_LocateAccessDescriptorByHandle
  *
- * @param[in]   AccessDescPtr   pointer to task table entry
- * @param[in]   TblHandle       The expected task ID to verify
- * @returns true if the entry matches the given task ID
+ * @param[in]   AccessDescPtr   pointer to access descriptor table entry
+ * @param[in]   TblHandle       The expected table handle to verify
+ * @returns true if the descriptor entry matches the given table handle
  */
 static inline bool CFE_TBL_AccessDescriptorIsMatch(const CFE_TBL_AccessDescriptor_t *AccessDescPtr,
                                                    CFE_TBL_Handle_t                  TblHandle)
 {
     return (AccessDescPtr != NULL && AccessDescPtr->UsedFlag);
 }
-
-#ifdef jphfix
-/*---------------------------------------------------------------------------------------*/
-/**
- * @brief Obtain the name associated with the Task record
- *
- * Returns the name field from within the Task record
- *
- * @note This internal helper function must only be used on record pointers
- * that are known to refer to an actual table location (i.e. non-null).
- *
- * @param[in]   AccessDescPtr   pointer to Task table entry
- * @returns Pointer to Task name
- */
-static inline const char *CFE_TBL_AccessDescriptorGetName(const CFE_TBL_AccessDescriptor_t *AccessDescPtr)
-{
-    return AccessDescPtr->TaskName;
-}
-
-/*---------------------------------------------------------------------------------------*/
-/**
- * @brief Check if a Counter record is in use or free/empty
- *
- * This routine checks if the Counter table entry is in use or if it is free
- *
- * As this dereferences fields within the record, global data must be
- * locked prior to invoking this function.
- *
- * @note This internal helper function must only be used on record pointers
- * that are known to refer to an actual table location (i.e. non-null).
- *
- * @param[in]   CounterRecPtr   pointer to Counter table entry
- * @returns true if the entry is in use/configured, or false if it is free/empty
- */
-static inline bool CFE_TBL_CounterRecordIsUsed(const CFE_TBL_GenCounterRecord_t *CounterRecPtr)
-{
-    return CFE_RESOURCEID_TEST_DEFINED(CounterRecPtr->CounterId);
-}
-
-/*---------------------------------------------------------------------------------------*/
-/**
- * @brief Get the ID value from a Counter table entry
- *
- * This routine converts the table entry back to an abstract ID.
- *
- * @note This internal helper function must only be used on record pointers
- * that are known to refer to an actual table location (i.e. non-null).
- *
- * @param[in]   CounterRecPtr   pointer to Counter table entry
- * @returns CounterID of entry
- */
-static inline CFE_TBL_CounterId_t CFE_TBL_CounterRecordGetID(const CFE_TBL_GenCounterRecord_t *CounterRecPtr)
-{
-    return CounterRecPtr->CounterId;
-}
-
-/*---------------------------------------------------------------------------------------*/
-/**
- * @brief Marks a Counter table entry as used (not free)
- *
- * This sets the internal field(s) within this entry, and marks
- * it as being associated with the given Counter ID.
- *
- * As this dereferences fields within the record, global data must be
- * locked prior to invoking this function.
- *
- * @note This internal helper function must only be used on record pointers
- * that are known to refer to an actual table location (i.e. non-null).
- *
- * @param[in]   CounterRecPtr   pointer to Counter table entry
- * @param[in]   PendingId       the Counter ID of this entry
- */
-static inline void CFE_TBL_CounterRecordSetUsed(CFE_TBL_GenCounterRecord_t *CounterRecPtr, CFE_ResourceId_t PendingId)
-{
-    CounterRecPtr->CounterId = CFE_TBL_COUNTERID_C(PendingId);
-}
-
-/*---------------------------------------------------------------------------------------*/
-/**
- * @brief Set a Counter record table entry free (not used)
- *
- * This clears the internal field(s) within this entry, and allows the
- * memory to be re-used in the future.
- *
- * As this dereferences fields within the record, global data must be
- * locked prior to invoking this function.
- *
- * @note This internal helper function must only be used on record pointers
- * that are known to refer to an actual table location (i.e. non-null).
- *
- * @param[in]   CounterRecPtr   pointer to Counter table entry
- */
-static inline void CFE_TBL_CounterRecordSetFree(CFE_TBL_GenCounterRecord_t *CounterRecPtr)
-{
-    CounterRecPtr->CounterId = CFE_TBL_COUNTERID_UNDEFINED;
-}
-
-/*---------------------------------------------------------------------------------------*/
-/**
- * @brief Check if a Counter record is a match for the given CounterID
- *
- * This routine confirms that the previously-located record is valid
- * and matches the expected Counter ID.
- *
- * As this dereferences fields within the record, global data must be
- * locked prior to invoking this function.
- *
- * This function may be used in conjunction with CFE_TBL_LocateCounterRecordByID()
- * to confirm that the located record is a positive match to the expected ID.
- * As such, the record pointer is also permitted to be NULL, to alleviate the
- * need for the caller to handle this possibility explicitly.
- *
- * Once a record pointer has been successfully validated using this routine,
- * it may be safely passed to all other internal functions.
- *
- * @sa CFE_TBL_LocateCounterRecordByID
- *
- * @param[in]   CounterRecPtr   pointer to Counter table entry
- * @param[in]   CounterID       expected Counter ID
- * @returns true if the entry matches the given Counter ID
- */
-static inline bool CFE_TBL_CounterRecordIsMatch(const CFE_TBL_GenCounterRecord_t *CounterRecPtr,
-                                                CFE_TBL_CounterId_t               CounterID)
-{
-    return (CounterRecPtr != NULL && CFE_RESOURCEID_TEST_EQUAL(CounterRecPtr->CounterId, CounterID));
-}
-
-/*---------------------------------------------------------------------------------------*/
-/**
- * @brief Obtain the name associated with the counter record
- *
- * Returns the name field from within the counter record
- *
- * @note This internal helper function must only be used on record pointers
- * that are known to refer to an actual table location (i.e. non-null).
- *
- * @param[in]   CounterRecPtr   pointer to Counter table entry
- * @returns Pointer to counter name
- */
-static inline const char *CFE_TBL_CounterRecordGetName(const CFE_TBL_GenCounterRecord_t *CounterRecPtr)
-{
-    return CounterRecPtr->CounterName;
-}
-#endif
-
-/*
- * Internal functions to perform name based resource lookups
- *
- * These functions do not lock, they must only be used internally by ES when
- * the lock is already held.
- */
-
-/*---------------------------------------------------------------------------------------*/
-/**
- * @brief Finds an application table record matching the given name
- *
- * Helper function, aids in finding an application record from a name string.
- * Must be called while locked.
- *
- * @returns pointer to table entry matching name, or NULL if not found
- */
-CFE_TBL_RegistryRec_t *CFE_TBL_LocateRegistryRecordByName(const char *Name);
-
-#ifdef jphfix
-/*---------------------------------------------------------------------------------------*/
-/**
- * @brief Finds a library table record matching the given name
- *
- * Helper function, aids in finding a library record from a name string.
- * Must be called while locked.
- *
- * @returns pointer to table entry matching name, or NULL if not found
- */
-CFE_TBL_LoadBuff_t *CFE_TBL_LocateLibRecordByName(const char *Name);
-
-/*---------------------------------------------------------------------------------------*/
-/**
- * @brief Finds a task table record matching the given name
- *
- * Helper function, aids in finding a task record from a name string.
- * Must be called while locked.
- *
- * @returns pointer to table entry matching name, or NULL if not found
- */
-CFE_TBL_AccessDescriptor_t *CFE_TBL_LocateTaskRecordByName(const char *Name);
-
-/*---------------------------------------------------------------------------------------*/
-/**
- * @brief Finds a counter table record matching the given name
- *
- * Helper function, aids in finding a counter record from a name string.
- * Must be called while locked.
- *
- * @returns pointer to table entry matching name, or NULL if not found
- */
-CFE_TBL_GenCounterRecord_t *CFE_TBL_LocateCounterRecordByName(const char *Name);
-#endif
-
-/*
- * Availability check functions used in conjunction with CFE_ResourceId_FindNext()
- */
-
-/*---------------------------------------------------------------------------------------*/
-/**
- * @brief Checks if Application slot is currently used
- *
- * Helper function, Aids in allocating a new ID by checking if
- * a given ID is available.  Must be called while locked.
- *
- * @returns false if slot is unused/available, true if used/unavailable
- */
-bool CFE_TBL_CheckRegIdSlotUsed(CFE_ResourceId_t CheckId);
-
-/*---------------------------------------------------------------------------------------*/
-/**
- * @brief Checks if Library slot is currently used
- *
- * Helper function, Aids in allocating a new ID by checking if
- * a given ID is available.  Must be called while locked.
- *
- * @returns false if slot is unused/available, true if used/unavailable
- */
-bool CFE_TBL_CheckSharedBufferSlotUsed(CFE_ResourceId_t CheckId);
-
-#ifdef jphfix
-/*---------------------------------------------------------------------------------------*/
-/**
- * @brief Checks if Counter slot is currently used
- *
- * Helper function, Aids in allocating a new ID by checking if
- * a given ID is available.  Must be called while locked.
- *
- * @returns false if slot is unused/available, true if used/unavailable
- */
-bool CFE_TBL_CheckCounterIdSlotUsed(CFE_ResourceId_t CheckId);
-#endif
 
 #endif /* CFE_TBL_RESOURCE_H */

--- a/modules/tbl/fsw/src/cfe_tbl_task.h
+++ b/modules/tbl/fsw/src/cfe_tbl_task.h
@@ -145,6 +145,15 @@ typedef struct
  */
 typedef int16 CFE_TBL_RegId_t;
 
+/**
+ * A structure to facilitate a linked-list of table handles
+ */
+typedef struct CFE_TBL_HandleLink
+{
+    CFE_TBL_Handle_t Next; /**< Next table handle in list */
+    CFE_TBL_Handle_t Prev; /**< Previous table handle in list */
+} CFE_TBL_HandleLink_t;
+
 /*******************************************************************************/
 /**   \brief Application to Table Access Descriptor
 **
@@ -155,14 +164,13 @@ typedef int16 CFE_TBL_RegId_t;
 */
 typedef struct
 {
-    CFE_ES_AppId_t   AppId;       /**< \brief Application ID to verify access */
-    CFE_TBL_RegId_t  RegIndex;    /**< \brief Index into Table Registry (a.k.a. - Global Table #) */
-    CFE_TBL_Handle_t PrevLink;    /**< \brief Index of previous access descriptor in linked list */
-    CFE_TBL_Handle_t NextLink;    /**< \brief Index of next access descriptor in linked list */
-    bool             UsedFlag;    /**< \brief Indicates whether this descriptor is being used or not  */
-    bool             LockFlag;    /**< \brief Indicates whether thread is currently accessing table data */
-    bool             Updated;     /**< \brief Indicates table has been updated since last GetAddress call */
-    uint8            BufferIndex; /**< \brief Index of buffer currently being used */
+    CFE_ES_AppId_t       AppId;       /**< \brief Application ID to verify access */
+    CFE_TBL_RegId_t      RegIndex;    /**< \brief Index into Table Registry (a.k.a. - Global Table #) */
+    CFE_TBL_HandleLink_t Link;        /**< \brief Linkage into list of access descriptors for the table */
+    bool                 UsedFlag;    /**< \brief Indicates whether this descriptor is being used or not  */
+    bool                 LockFlag;    /**< \brief Indicates whether thread is currently accessing table data */
+    bool                 Updated;     /**< \brief Indicates table has been updated since last GetAddress call */
+    uint8                BufferIndex; /**< \brief Index of buffer currently being used */
 } CFE_TBL_AccessDescriptor_t;
 
 /*******************************************************************************/
@@ -180,7 +188,7 @@ typedef struct
     CFE_TBL_LoadBuff_t Buffers[2];        /**< \brief Active and Inactive Buffer Pointers */
     CFE_TBL_CallbackFuncPtr_t ValidationFuncPtr; /**< \brief Ptr to Owner App's function that validates tbl contents */
     CFE_TIME_SysTime_t        TimeOfLastUpdate;  /**< \brief Time when Table was last updated */
-    CFE_TBL_Handle_t          HeadOfAccessList;  /**< \brief Index into Handles Array that starts Access Linked List */
+    CFE_TBL_HandleLink_t      AccessList;        /**< \brief Linked List of associated access descriptors */
     int32              LoadInProgress;      /**< \brief Flag identifies inactive buffer and whether load in progress */
     int32              ValidateActiveIndex; /**< \brief Index to Validation Request on Active Table Result data */
     int32              ValidateInactiveIndex; /**< \brief Index to Validation Request on Inactive Table Result data */


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Adds a "HandleLink" structure to encapsulate the linked list functionality and add generic routines to initialize and test/check this structure, along with list insert/remove functions for access descriptors that use this link struct interally.

This also cleans up documentation of the table resource ID functions defined in cfe_tbl_resource.h

Fixes #2546 

**Testing performed**
Build and run all tests

**Expected behavior changes**
None (code clean up)

**System(s) tested on**
Debian

**Additional context**
Improves maintainability of code by moving linked list ops into common routines

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
