### PR TITLE
Fix #2553, null value in vsnprintf

### DIFF
--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -4554,9 +4554,9 @@ void TestAPI(void)
     UT_SetHandlerFunction(UT_KEY(CFE_TIME_Print), ES_UT_FillBuffer, &SysLogBufSize);
     UtAssert_VOIDCALL(ES_UT_SysLog_snprintf(SysLogBuf, sizeof(SysLogBuf), "b"));
 
-    /* Force a vsnprintf failure */
+    /* Force a vsnprintf to return 0 */
     ES_ResetUnitTest();
-    UtAssert_VOIDCALL(ES_UT_SysLog_snprintf(SysLogBuf, sizeof(SysLogBuf), NULL));
+    UtAssert_VOIDCALL(ES_UT_SysLog_snprintf(SysLogBuf, sizeof(SysLogBuf), ""));
 
     /* Test run loop with an application error status */
     ES_ResetUnitTest();


### PR DESCRIPTION
Fix #2553, fix test that was passing null value
into vsnprintf

**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
A clear and concise description of what the contribution is.
- Include explicitly what issue it addresses [e.g. Fixes #X]

Fixes #2553, address issue that occur when running with address sanitizer. One of the coverage test was trying to pass an 
null value to force an return code of 0 or less to an vsnprintf. Passing an null value as an input is an undefine behavior but you can achieve the same result by passing in an empty string which will force the return code to be 0. 

**Testing performed**
Steps taken to test the contribution:
add the following options:
add_compile_options(-fsanitize=address -g)
add_link_options(-fsanitize=address)

1. make ENABLE_UNIT_TESTS=true SIMULATION=native prep
2. make install
3. make test
4. make lcov


**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.

no more error when running with fsanitize. 
Still 100% coverage.
![Capture](https://github.com/nasa/cFE/assets/26749312/12aed636-a288-49bc-928a-42f539c77788)
![Capture1](https://github.com/nasa/cFE/assets/26749312/cad9b545-9308-4fd6-b6b3-193dcd2fb01e)

**System(s) tested on**
 - Hardware: [e.g. PC, SP0, MCP750]
 - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
 - Note CLAs apply to only software contributions.
Anh Van, GSFC
