### PR TITLE
cfe_es_start: fix CFE_ES_MainTaskSyncDelay() parameter

### DIFF
--- a/modules/es/fsw/src/cfe_es_start.c
+++ b/modules/es/fsw/src/cfe_es_start.c
@@ -808,7 +808,7 @@ void CFE_ES_CreateObjects(void)
                      * newly-started thread calls CFE_ES_WaitForSystemState()
                      */
                     ReturnCode =
-                        CFE_ES_MainTaskSyncDelay(CFE_ES_AppState_RUNNING, CFE_PLATFORM_CORE_MAX_STARTUP_MSEC * 1000);
+                        CFE_ES_MainTaskSyncDelay(CFE_ES_AppState_RUNNING, CFE_PLATFORM_CORE_MAX_STARTUP_MSEC);
                 }
 
                 if (ReturnCode != CFE_SUCCESS)


### PR DESCRIPTION
CFE_ES_MainTaskSyncDelay() expects a `TimeOutMilliseconds` parameter.

**Checklist (Please check before submitting)**

* [ ] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
A clear and concise description of what the contribution is.
- Include explicitly what issue it addresses [e.g. Fixes #X]

**Testing performed**
Steps taken to test the contribution:
1. Build steps '...'
1. Execution steps '...'

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - API Change: xxx (if applicable)
 - Behavior Change: xxx (if applicable)
 - Or no impact to behavior

**System(s) tested on**
 - Hardware: [e.g. PC, SP0, MCP750]
 - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
 - Note CLAs apply to only software contributions.
