### PR TITLE
Fix #2529, Reduces CFE_EVS_MAX_PORT_MSG_LENGTH to prevent new line character truncation

### DIFF
--- a/modules/evs/fsw/src/cfe_evs_task.h
+++ b/modules/evs/fsw/src/cfe_evs_task.h
@@ -60,14 +60,17 @@
 #define CFE_EVS_MAX_FILTER_COUNT     65535
 #define CFE_EVS_MAX_SQUELCH_COUNT    255
 #define CFE_EVS_PIPE_NAME            "EVS_CMD_PIPE"
-#define CFE_EVS_MAX_PORT_MSG_LENGTH  (CFE_MISSION_EVS_MAX_MESSAGE_LENGTH + OS_MAX_API_NAME + 30)
+#define CFE_EVS_MAX_PORT_MSG_LENGTH  (CFE_MISSION_EVS_MAX_MESSAGE_LENGTH + OS_MAX_API_NAME + 19)
 
 /* Since CFE_EVS_MAX_PORT_MSG_LENGTH is the size of the buffer that is sent to
  * print out (using OS_printf), we need to check to make sure that the buffer
- * size the OS uses is big enough. This check has to be made here because it is
- * the first spot after CFE_EVS_MAX_PORT_MSG_LENGTH is defined */
-#if OS_BUFFER_SIZE < CFE_EVS_MAX_PORT_MSG_LENGTH
-#error CFE_EVS_MAX_PORT_MSG_LENGTH cannot be greater than OS_BUFFER_SIZE!
+ * size the OS uses is big enough. The buffer needs to have at least 11 extra
+ * characters to accommodate the format string "EVS Port%u %s\n" used in
+ * downstream processing for sending messages via ports. This check has to be
+ * made here because it is the first spot after CFE_EVS_MAX_PORT_MSG_LENGTH
+ * is defined. */
+#if OS_BUFFER_SIZE < CFE_EVS_MAX_PORT_MSG_LENGTH + 11
+#error CFE_EVS_MAX_PORT_MSG_LENGTH cannot be greater than OS_BUFFER_SIZE - 11!
 #endif
 
 /************************  Internal Structure Definitions  *****************************/


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
A clear and concise description of what the contribution is.
- Fixes #2529, Adds snprintf check return value and buffer to PortMessage within `EVS_SendViaPorts()` to ensure enough space for format string characters in the downstream `EVS_OutputPort()` printing.

**Testing performed**
Started cFS and reviewed startup messages.

**Expected behavior changes**
Enough space should now be allocated to PortMessage such that it is null terminated and ends with a new line character when printed out via ports.

**System(s) tested on**
 - OS: Ubuntu 22.04

**Additional context**
_Alternative solutions considered_

- Enlarging `CFE_EVS_MAX_PORT_MSG_LENGTH` to allow for more space to PortMessage and therefore no unintended truncation
    - Thoughts: Trying not to use more resources if its not necessary
- Reducing the size of the messages passed in by CI_LAB_APP,  CI_LAB_APP, and TO_LAB_APP (VS_PktPtr->Payload.Message) as these were the messages causing truncated strings on every cFS build and run.
     - Thoughts: Would work but wouldn't prevent future app message changes that are too long from truncating

[cFS_startup_cpu1_PrePR.txt](https://github.com/nasa/cFE/files/15419404/cFS_startup_cpu1_PrePR.txt)

This is what the startup messages look like after including this PR. 
[cFS_startup_cpu1_19buf.txt](https://github.com/user-attachments/files/15809489/cFS_startup_cpu1_19buf.txt)


This is what the startup messages look like after including code to check for `snprintf()` return value.
This Note that CI_LAB_APP,  CI_LAB_APP, and TO_LAB_APP all now have Truncation warnings and the message isn't concatenated to the next discrete message but ends with a `*\0`
[cFS_startup_cpu1_PostPR.txt](https://github.com/nasa/cFE/files/15419364/cFS_startup_cpu1_PostPR.txt)



**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, Vantage Systems
