### PR TITLE
Fix 2572, CFE_TIME unit test failure when CFE_MISSION_TIME_AT_TONE_WI…

### DIFF
--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -1081,7 +1081,7 @@ void Test_External(void)
     /* Test setting time data from MET (external source, state set) */
     UT_InitData();
     CFE_TIME_Global.ClockSource              = CFE_TIME_SourceSelect_EXTERNAL;
-    CFE_TIME_Global.ClockSetState            = CFE_TIME_SetState_WAS_SET;
+    CFE_TIME_Global.ClockSetState            = CFE_TIME_SetState_NOT_SET;
     settime.Seconds                          = 10;
     settime.Subseconds                       = 0;
     CFE_TIME_Global.ExternalCount            = 0;
@@ -1179,7 +1179,7 @@ void Test_External(void)
     /* Test setting time data from GPS (external source, state set) */
     UT_InitData();
     CFE_TIME_Global.ClockSource              = CFE_TIME_SourceSelect_EXTERNAL;
-    CFE_TIME_Global.ClockSetState            = CFE_TIME_SetState_WAS_SET;
+    CFE_TIME_Global.ClockSetState            = CFE_TIME_SetState_NOT_SET;
     settime.Seconds                          = 10;
     settime.Subseconds                       = 0;
     CFE_TIME_Global.ExternalCount            = 0;
@@ -1279,7 +1279,7 @@ void Test_External(void)
     /* Test setting time data from Time (external source, state set) */
     UT_InitData();
     CFE_TIME_Global.ClockSource                              = CFE_TIME_SourceSelect_EXTERNAL;
-    CFE_TIME_Global.ReferenceState[0].ClockSetState          = CFE_TIME_SetState_WAS_SET;
+    CFE_TIME_Global.ReferenceState[0].ClockSetState          = CFE_TIME_SetState_NOT_SET;
     settime.Seconds                                          = 10;
     settime.Subseconds                                       = 0;
     CFE_TIME_Global.ExternalCount                            = 0;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x ] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fix #2572 

Sets the clock state to CFE_TIME_SetState_NOT_SET for the external clock source tests such that they complete successfully/provide coverage testing.

**Testing performed**
Successfully executed unit test.

**Contributor Info - All information REQUIRED for consideration of pull request**
Dan Knutsen
NASA Goddard
