### PR TITLE
Fix #1712, Make successful command events INFO type

### DIFF
--- a/modules/es/config/default_cfe_es_fcncodes.h
+++ b/modules/es/config/default_cfe_es_fcncodes.h
@@ -365,7 +365,7 @@
 **       the following telemetry:
 **       - \b \c \ES_CMDPC - command execution counter will
 **         increment
-**       - The #CFE_ES_ONE_APP_EID debug event message will be
+**       - The #CFE_ES_ONE_APP_INF_EID informational event message will be
 **         generated.
 **       - Receipt of the #CFE_ES_OneAppTlm_t telemetry packet
 **
@@ -401,7 +401,7 @@
 **       the following telemetry:
 **       - \b \c \ES_CMDPC - command execution counter will
 **         increment
-**       - The #CFE_ES_ALL_APPS_EID debug event message will be
+**       - The #CFE_ES_ALL_APPS_INF_EID informational event message will be
 **         generated.
 **       - The file specified in the command (or the default specified
 **         by the #CFE_PLATFORM_ES_DEFAULT_APP_LOG_FILE configuration parameter) will be
@@ -478,7 +478,7 @@
 **       the following telemetry:
 **       - \b \c \ES_CMDPC - command execution counter will
 **         increment
-**       - The #CFE_ES_SYSLOG2_EID debug event message will be
+**       - The #CFE_ES_SYSLOG2_INF_EID informational event message will be
 **         generated.
 **       - The file specified in the command (or the default specified
 **         by the #CFE_PLATFORM_ES_DEFAULT_SYSLOG_FILE configuration parameter) will be
@@ -555,7 +555,7 @@
 **       the following telemetry:
 **       - \b \c \ES_CMDPC - command execution counter will
 **         increment
-**       - The #CFE_ES_ERLOG2_EID debug event message will be
+**       - The #CFE_ES_ERLOG2_INF_EID informational event message will be
 **         generated.
 **       - The file specified in the command (or the default specified
 **         by the #CFE_PLATFORM_ES_DEFAULT_ER_LOG_FILE configuration parameter) will be
@@ -606,7 +606,7 @@
 **       - \b \c \ES_PERFDATASTART - Data Start Index will go to zero
 **       - \b \c \ES_PERFDATAEND - Data End Index will go to zero
 **       - \b \c \ES_PERFDATACNT - Performance Data Counter will go to zero
-**       - The #CFE_ES_PERF_STARTCMD_EID debug event message will be
+**       - The #CFE_ES_PERF_STARTCMD_INF_EID informational event message will be
 **         generated.
 **
 **  \par Error Conditions
@@ -694,7 +694,7 @@
 **         increment
 **       - \b \c \ES_PERFFLTRMASK - the current performance filter mask
 **         value(s) should reflect the commanded value
-**       - The #CFE_ES_PERF_FILTMSKCMD_EID debug event message will be
+**       - The #CFE_ES_PERF_FILTMSKCMD_INF_EID informational event message will be
 **         generated.
 **
 **  \par Error Conditions
@@ -731,7 +731,7 @@
 **         increment
 **       - \b \c \ES_PERFTRIGMASK - the current performance trigger mask
 **         value(s) should reflect the commanded value
-**       - The #CFE_ES_PERF_TRIGMSKCMD_EID debug event message will be
+**       - The #CFE_ES_PERF_TRIGMSKCMD_INF_EID informational event message will be
 **         generated.
 **
 **  \par Error Conditions
@@ -770,7 +770,7 @@
 **         increment
 **       - \b \c \ES_SYSLOGMODE - Current System Log Mode should reflect
 **         the commanded value
-**       - The #CFE_ES_SYSLOGMODE_EID debug event message will be
+**       - The #CFE_ES_SYSLOGMODE_INF_EID informational event message will be
 **         generated.
 **
 **  \par Error Conditions
@@ -924,7 +924,7 @@
 **       the following telemetry:
 **       - \b \c \ES_CMDPC - command execution counter will
 **         increment
-**       - The #CFE_ES_TLM_POOL_STATS_INFO_EID debug event message will be
+**       - The #CFE_ES_TLM_POOL_STATS_INF_EID informational event message will be
 **         generated.
 **       - The \link #CFE_ES_MemStatsTlm_t Memory Pool Statistics Telemetry Packet \endlink
 **         is produced
@@ -963,7 +963,7 @@
 **       the following telemetry:
 **       - \b \c \ES_CMDPC - command execution counter will
 **         increment
-**       - The #CFE_ES_CDS_REG_DUMP_INF_EID debug event message will be
+**       - The #CFE_ES_CDS_REG_DUMP_INF_EID informational event message will be
 **         generated.
 **       - The file specified in the command (or the default specified
 **         by the #CFE_PLATFORM_ES_DEFAULT_CDS_REG_DUMP_FILE configuration parameter) will be
@@ -1005,7 +1005,7 @@
 **       the following telemetry:
 **       - \b \c \ES_CMDPC - command execution counter will
 **         increment
-**       - The #CFE_ES_TASKINFO_EID debug event message will be
+**       - The #CFE_ES_TASKINFO_INF_EID informational event message will be
 **         generated.
 **       - The file specified in the command (or the default specified
 **         by the #CFE_PLATFORM_ES_DEFAULT_TASK_LOG_FILE configuration parameter) will be

--- a/modules/es/eds/cfe_es.xml
+++ b/modules/es/eds/cfe_es.xml
@@ -1181,7 +1181,7 @@
           the following telemetry:
           - \b \c \ES_CMDPC - command execution counter will
           increment
-          - The #CFE_ES_ONE_APP_EID debug event message will be
+          - The #CFE_ES_ONE_APP_INF_EID informational event message will be
           generated. NOTE: This event message only identifies that the
           act of stopping the application has begun, not that it has completed.
           - Receipt of the #CFE_ES_APP_TLM_t telemetry packet
@@ -1229,7 +1229,7 @@
           the following telemetry:
           - \b \c \ES_CMDPC - command execution counter will
           increment
-          - The #CFE_ES_ALL_APPS_EID debug event message will be
+          - The #CFE_ES_ALL_APPS_INF_EID informational event message will be
           generated.
           - The file specified in the command (or the default specified
           by the #CFE_ES_DEFAULT_APP_LOG_FILE configuration parameter) will be
@@ -1328,7 +1328,7 @@
           the following telemetry:
           - \b \c \ES_CMDPC - command execution counter will
           increment
-          - The #CFE_ES_SYSLOG2_EID debug event message will be
+          - The #CFE_ES_SYSLOG2_INF_EID informational event message will be
           generated.
           - The file specified in the command (or the default specified
           by the #CFE_ES_DEFAULT_SYSLOG_FILE configuration parameter) will be
@@ -1427,7 +1427,7 @@
           the following telemetry:
           - \b \c \ES_CMDPC - command execution counter will
           increment
-          - The #CFE_ES_ERLOG2_EID debug event message will be
+          - The #CFE_ES_ERLOG2_INF_EID informational event message will be
           generated.
           - The file specified in the command (or the default specified
           by the #CFE_ES_DEFAULT_ER_LOG_FILE configuration parameter) will be
@@ -1488,7 +1488,7 @@
           - \b \c \ES_PERFDATASTART - Data Start Index will go to zero
           - \b \c \ES_PERFDATAEND - Data End Index will go to zero
           - \b \c \ES_PERFDATACNT - Performance Data Counter will go to zero
-          - The #CFE_ES_PERF_STARTCMD_EID debug event message will be
+          - The #CFE_ES_PERF_STARTCMD_INF_EID informational event message will be
           generated.
 
           \par  Error Conditions
@@ -1592,7 +1592,7 @@
           increment
           - \B \C \ES_PERFFLTRMASK - the current performance filter mask
           value(s) should reflect the commanded value
-          - The #CFE_ES_PERF_FILTMSKCMD_EID debug event message will be
+          - The #CFE_ES_PERF_FILTMSKCMD_INF_EID informational event message will be
           generated.
 
           \par  Error Conditions
@@ -1640,7 +1640,7 @@
           increment
           - \b \c \ES_PERFTRIGMASK - the current performance trigger mask
           value(s) should reflect the commanded value
-          - The #CFE_ES_PERF_TRIGMSKCMD_EID debug event message will be
+          - The #CFE_ES_PERF_TRIGMSKCMD_INF_EID informational event message will be
           generated.
 
           \par  Error Conditions
@@ -1691,7 +1691,7 @@
           increment
           - \b \c \ES_SYSLOGMODE - Current System Log Mode should reflect
           the commanded value
-          - The #CFE_ES_SYSLOGMODE_EID debug event message will be
+          - The #CFE_ES_SYSLOGMODE_INF_EID informational event message will be
           generated.
 
           \par  Error Conditions
@@ -1894,7 +1894,7 @@
           the following telemetry:
           - \b \c \ES_CMDPC - command execution counter will
           increment
-          - The #CFE_ES_TLM_POOL_STATS_INFO_EID debug event message will be
+          - The #CFE_ES_TLM_POOL_STATS_INF_EID informational event message will be
           generated.
           - The \link #CFE_ES_MEMSTATS_TLM_t Memory Pool Statistics Telemetry Packet \endlink
           is produced
@@ -1945,7 +1945,7 @@
           the following telemetry:
           - \b \c \ES_CMDPC - command execution counter will
           increment
-          - The #CFE_ES_CDS_REG_DUMP_INF_EID debug event message will be
+          - The #CFE_ES_CDS_REG_DUMP_INF_EID informational event message will be
           generated.
           - The file specified in the command (or the default specified
           by the #CFE_ES_DEFAULT_CDS_REG_DUMP_FILE configuration parameter) will be
@@ -1997,7 +1997,7 @@
           the following telemetry:
           - \b \c \ES_CMDPC - command execution counter will
           increment
-          - The #CFE_ES_TASKINFO_EID debug event message will be
+          - The #CFE_ES_TASKINFO_INF_EID informational event message will be
           generated.
           - The file specified in the command (or the default specified
           by the #CFE_ES_DEFAULT_TASK_LOG_FILE configuration parameter) will be

--- a/modules/es/fsw/inc/cfe_es_eventids.h
+++ b/modules/es/fsw/inc/cfe_es_eventids.h
@@ -186,24 +186,24 @@
 /**
  * \brief ES Query One Application Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_ES_QUERY_ONE_CC ES Query One Application Command \endlink success.
  */
-#define CFE_ES_ONE_APP_EID 15
+#define CFE_ES_ONE_APP_INF_EID 15
 
 /**
  * \brief ES Query All Applications Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_ES_QUERY_ALL_CC ES Query All Applications Command \endlink success.
  */
-#define CFE_ES_ALL_APPS_EID 16
+#define CFE_ES_ALL_APPS_INF_EID 16
 
 /**
  * \brief ES Clear System Log Command Success Event ID
@@ -219,13 +219,13 @@
 /**
  * \brief ES Write System Log Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_ES_CLEAR_SYS_LOG_CC ES Write System Log Command \endlink success.
  */
-#define CFE_ES_SYSLOG2_EID 18
+#define CFE_ES_SYSLOG2_INF_EID 18
 
 /**
  * \brief ES Clear Exception Reset Log Command Success Event ID
@@ -241,13 +241,13 @@
 /**
  * \brief ES Write Exception Reset Log Complete Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  Request to write the Exception Reset log successfully completed.
  */
-#define CFE_ES_ERLOG2_EID 20
+#define CFE_ES_ERLOG2_INF_EID 20
 
 /**
  * \brief ES Invalid Message ID Received Event ID
@@ -628,13 +628,13 @@
 /**
  * \brief ES Start Performance Analyzer Data Collection Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_ES_START_PERF_DATA_CC ES Start Performance Analyzer Data Collection Command \endlink success.
  */
-#define CFE_ES_PERF_STARTCMD_EID 57
+#define CFE_ES_PERF_STARTCMD_INF_EID 57
 
 /**
  * \brief ES Start Performance Analyzer Data Collection Command Idle Check Failed Event ID
@@ -688,13 +688,13 @@
 /**
  * \brief ES Set Performance Analyzer Filter Mask Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_ES_SET_PERF_FILTER_MASK_CC ES Set Performance Analyzer Filter Mask Command \endlink success.
  */
-#define CFE_ES_PERF_FILTMSKCMD_EID 63
+#define CFE_ES_PERF_FILTMSKCMD_INF_EID 63
 
 /**
  * \brief ES Set Performance Analyzer Filter Mask Command Invalid Index Event ID
@@ -711,13 +711,13 @@
 /**
  * \brief ES Set Performance Analyzer Trigger Mask Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_ES_SET_PERF_TRIGGER_MASK_CC ES Set Performance Analyzer Trigger Mask Command \endlink success.
  */
-#define CFE_ES_PERF_TRIGMSKCMD_EID 65
+#define CFE_ES_PERF_TRIGMSKCMD_INF_EID 65
 
 /**
  * \brief ES Set Performance Analyzer Trigger Mask Command Invalid Mask Event ID
@@ -768,13 +768,13 @@
 /**
  * \brief ES Set System Log Overwrite Mode Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_ES_OVER_WRITE_SYS_LOG_CC ES Set System Log Overwrite Mode Command \endlink success.
  */
-#define CFE_ES_SYSLOGMODE_EID 70
+#define CFE_ES_SYSLOGMODE_INF_EID 70
 
 /**
  * \brief ES Set System Log Overwrite Mode Command Failed Event ID
@@ -885,13 +885,13 @@
 /**
  * \brief ES Telemeter Memory Statistics Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_ES_SEND_MEM_POOL_STATS_CC ES Telemeter Memory Statistics Command \endlink success.
  */
-#define CFE_ES_TLM_POOL_STATS_INFO_EID 81
+#define CFE_ES_TLM_POOL_STATS_INF_EID 81
 
 /**
  * \brief ES Telemeter Memory Statistics Command Invalid Handle Event ID
@@ -908,7 +908,7 @@
 /**
  * \brief ES Write Critical Data Store Registry Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
@@ -955,13 +955,13 @@
 /**
  * \brief ES Write All Task Data Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_ES_QUERY_ALL_TASKS_CC ES Write All Task Data Command \endlink success.
  */
-#define CFE_ES_TASKINFO_EID 87
+#define CFE_ES_TASKINFO_INF_EID 87
 
 /**
  * \brief ES Write All Task Data Command Filename Parse or File Create Failed Event ID

--- a/modules/es/fsw/src/cfe_es_erlog.c
+++ b/modules/es/fsw/src/cfe_es_erlog.c
@@ -239,7 +239,7 @@ void CFE_ES_BackgroundERLogFileEventHandler(void *Meta, CFE_FS_FileWriteEvent_t 
     switch (Event)
     {
         case CFE_FS_FileWriteEvent_COMPLETE:
-            CFE_EVS_SendEvent(CFE_ES_ERLOG2_EID, CFE_EVS_EventType_DEBUG, "%s written:Size=%lu",
+            CFE_EVS_SendEvent(CFE_ES_ERLOG2_INF_EID, CFE_EVS_EventType_INFORMATION, "%s written:Size=%lu",
                               BgFilePtr->FileWrite.FileName, (unsigned long)Position);
             break;
 

--- a/modules/es/fsw/src/cfe_es_perf.c
+++ b/modules/es/fsw/src/cfe_es_perf.c
@@ -171,7 +171,7 @@ int32 CFE_ES_StartPerfDataCmd(const CFE_ES_StartPerfDataCmd_t *data)
             Perf->MetaData.State                 = CFE_ES_PERF_WAITING_FOR_TRIGGER; /* this must be done last */
             OS_MutSemGive(CFE_ES_Global.PerfDataMutex);
 
-            CFE_EVS_SendEvent(CFE_ES_PERF_STARTCMD_EID, CFE_EVS_EventType_DEBUG,
+            CFE_EVS_SendEvent(CFE_ES_PERF_STARTCMD_INF_EID, CFE_EVS_EventType_INFORMATION,
                               "Start collecting performance data cmd received, trigger mode = %d",
                               (int)CmdPtr->TriggerMode);
         }
@@ -499,7 +499,7 @@ int32 CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMaskCmd_t *data)
     {
         Perf->MetaData.FilterMask[cmd->FilterMaskNum] = cmd->FilterMask;
 
-        CFE_EVS_SendEvent(CFE_ES_PERF_FILTMSKCMD_EID, CFE_EVS_EventType_DEBUG,
+        CFE_EVS_SendEvent(CFE_ES_PERF_FILTMSKCMD_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "Set Performance Filter Mask Cmd rcvd, num %u, val 0x%08X", (unsigned int)cmd->FilterMaskNum,
                           (unsigned int)cmd->FilterMask);
 
@@ -537,7 +537,7 @@ int32 CFE_ES_SetPerfTriggerMaskCmd(const CFE_ES_SetPerfTriggerMaskCmd_t *data)
     {
         Perf->MetaData.TriggerMask[cmd->TriggerMaskNum] = cmd->TriggerMask;
 
-        CFE_EVS_SendEvent(CFE_ES_PERF_TRIGMSKCMD_EID, CFE_EVS_EventType_DEBUG,
+        CFE_EVS_SendEvent(CFE_ES_PERF_TRIGMSKCMD_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "Set Performance Trigger Mask Cmd rcvd,num %u, val 0x%08X", (unsigned int)cmd->TriggerMaskNum,
                           (unsigned int)cmd->TriggerMask);
 

--- a/modules/es/fsw/src/cfe_es_syslog.c
+++ b/modules/es/fsw/src/cfe_es_syslog.c
@@ -525,8 +525,8 @@ int32 CFE_ES_SysLogDump(const char *Filename)
     }
     else
     {
-        CFE_EVS_SendEvent(CFE_ES_SYSLOG2_EID, CFE_EVS_EventType_DEBUG, "%s written:Size=%lu,Entries=%u", Filename,
-                          (unsigned long)TotalSize,
+        CFE_EVS_SendEvent(CFE_ES_SYSLOG2_INF_EID, CFE_EVS_EventType_INFORMATION, "%s written:Size=%lu,Entries=%u",
+                          Filename, (unsigned long)TotalSize,
                           (unsigned int)CFE_ES_Global.TaskData.HkPacket.Payload.SysLogEntries);
         Status = CFE_SUCCESS;
     }

--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -924,7 +924,8 @@ int32 CFE_ES_QueryOneCmd(const CFE_ES_QueryOneCmd_t *data)
         if (Result == CFE_SUCCESS)
         {
             CFE_ES_Global.TaskData.CommandCounter++;
-            CFE_EVS_SendEvent(CFE_ES_ONE_APP_EID, CFE_EVS_EventType_DEBUG, "Sent %s application data", LocalApp);
+            CFE_EVS_SendEvent(CFE_ES_ONE_APP_INF_EID, CFE_EVS_EventType_INFORMATION, "Sent %s application data",
+                              LocalApp);
         }
         else
         {
@@ -1092,7 +1093,7 @@ int32 CFE_ES_QueryAllCmd(const CFE_ES_QueryAllCmd_t *data)
 
         OS_close(FileDescriptor);
         CFE_ES_Global.TaskData.CommandCounter++;
-        CFE_EVS_SendEvent(CFE_ES_ALL_APPS_EID, CFE_EVS_EventType_DEBUG,
+        CFE_EVS_SendEvent(CFE_ES_ALL_APPS_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "App Info file written to %s, Entries=%d, FileSize=%lu", QueryAllFilename, (int)EntryCount,
                           (unsigned long)FileSize);
     }
@@ -1244,7 +1245,7 @@ int32 CFE_ES_QueryAllTasksCmd(const CFE_ES_QueryAllTasksCmd_t *data)
 
         OS_close(FileDescriptor);
         CFE_ES_Global.TaskData.CommandCounter++;
-        CFE_EVS_SendEvent(CFE_ES_TASKINFO_EID, CFE_EVS_EventType_DEBUG,
+        CFE_EVS_SendEvent(CFE_ES_TASKINFO_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "Task Info file written to %s, Entries=%d, FileSize=%lu", QueryAllFilename, (int)EntryCount,
                           (unsigned long)FileSize);
     }
@@ -1303,7 +1304,7 @@ int32 CFE_ES_OverWriteSysLogCmd(const CFE_ES_OverWriteSysLogCmd_t *data)
     }
     else
     {
-        CFE_EVS_SendEvent(CFE_ES_SYSLOGMODE_EID, CFE_EVS_EventType_DEBUG,
+        CFE_EVS_SendEvent(CFE_ES_SYSLOGMODE_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "Set OverWriteSysLog Command Received with Mode setting = %d", (int)CmdPtr->Mode);
 
         CFE_ES_Global.TaskData.CommandCounter++;
@@ -1604,7 +1605,7 @@ int32 CFE_ES_SendMemPoolStatsCmd(const CFE_ES_SendMemPoolStatsCmd_t *data)
         CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_ES_Global.TaskData.MemStatsPacket.TelemetryHeader), true);
 
         CFE_ES_Global.TaskData.CommandCounter++;
-        CFE_EVS_SendEvent(CFE_ES_TLM_POOL_STATS_INFO_EID, CFE_EVS_EventType_DEBUG,
+        CFE_EVS_SendEvent(CFE_ES_TLM_POOL_STATS_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "Successfully telemetered memory pool stats for 0x%08lX",
                           CFE_RESOURCEID_TO_ULONG(Cmd->PoolHandle));
     }
@@ -1707,7 +1708,7 @@ int32 CFE_ES_DumpCDSRegistryCmd(const CFE_ES_DumpCDSRegistryCmd_t *data)
 
             if (OsStatus == sizeof(CFE_ES_CDSRegDumpRec_t))
             {
-                CFE_EVS_SendEvent(CFE_ES_CDS_REG_DUMP_INF_EID, CFE_EVS_EventType_DEBUG,
+                CFE_EVS_SendEvent(CFE_ES_CDS_REG_DUMP_INF_EID, CFE_EVS_EventType_INFORMATION,
                                   "Successfully dumped CDS Registry to '%s':Size=%d,Entries=%d", DumpFilename,
                                   (int)FileSize, (int)NumEntries);
 

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -2137,7 +2137,7 @@ void TestERLog(void)
     /* Test ER log background write event handling */
     UT_ClearEventHistory();
     CFE_ES_BackgroundERLogFileEventHandler(&State, CFE_FS_FileWriteEvent_COMPLETE, CFE_SUCCESS, 10, 0, 100);
-    CFE_UtAssert_EVENTSENT(CFE_ES_ERLOG2_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_ERLOG2_INF_EID);
 
     UT_ClearEventHistory();
     CFE_ES_BackgroundERLogFileEventHandler(&State, CFE_FS_FileWriteEvent_HEADER_WRITE_ERROR, -1, 10, 10, 100);
@@ -2905,7 +2905,7 @@ void TestTask(void)
     strncpy(CmdBuf.QueryOneCmd.Payload.Application, "CFE_ES", sizeof(CmdBuf.QueryOneCmd.Payload.Application) - 1);
     CmdBuf.QueryOneCmd.Payload.Application[sizeof(CmdBuf.QueryOneCmd.Payload.Application) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.QueryOneCmd), UT_TPID_CFE_ES_CMD_QUERY_ONE_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_ONE_APP_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_ONE_APP_INF_EID);
 
     /* Test telemetry packet request for single app data with send message failure */
     ES_ResetUnitTest();
@@ -2933,7 +2933,7 @@ void TestTask(void)
     strncpy(CmdBuf.QueryAllCmd.Payload.FileName, "AllFilename", sizeof(CmdBuf.QueryAllCmd.Payload.FileName) - 1);
     CmdBuf.QueryAllCmd.Payload.FileName[sizeof(CmdBuf.QueryAllCmd.Payload.FileName) - 1] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.QueryAllCmd), UT_TPID_CFE_ES_CMD_QUERY_ALL_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_ALL_APPS_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_ALL_APPS_INF_EID);
 
     /* Test Query tasks command with valid lib ID */
     ES_ResetUnitTest();
@@ -2941,13 +2941,13 @@ void TestTask(void)
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
     CFE_ES_Global.LibTable[0].LibId = CFE_ES_LIBID_C(ES_UT_MakeLibIdForIndex(1));
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.QueryAllCmd), UT_TPID_CFE_ES_CMD_QUERY_ALL_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_ALL_APPS_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_ALL_APPS_INF_EID);
 
     /* Test write of all app data to file with a null file name */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.QueryAllCmd), UT_TPID_CFE_ES_CMD_QUERY_ALL_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_ALL_APPS_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_ALL_APPS_INF_EID);
 
     /* Test write of all app data to file with a bad file name */
     ES_ResetUnitTest();
@@ -2985,7 +2985,7 @@ void TestTask(void)
     ES_UT_SetupSingleAppId(CFE_ES_AppType_CORE, CFE_ES_AppState_RUNNING, "CFE_ES", NULL, NULL);
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.QueryAllTasksCmd),
                     UT_TPID_CFE_ES_CMD_QUERY_ALL_TASKS_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_TASKINFO_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_TASKINFO_INF_EID);
 
     /* Test write of all task data with a task that becomes unused after first scan */
     ES_ResetUnitTest();
@@ -2995,7 +2995,7 @@ void TestTask(void)
     UT_SetHandlerFunction(UT_KEY(CFE_FS_InitHeader), ES_UT_UnusedAppTask, &TaskId);
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.QueryAllTasksCmd),
                     UT_TPID_CFE_ES_CMD_QUERY_ALL_TASKS_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_TASKINFO_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_TASKINFO_INF_EID);
 
     /* Test write of all task data to a file with file name validation failure */
     ES_ResetUnitTest();
@@ -3045,7 +3045,7 @@ void TestTask(void)
     CmdBuf.OverwriteSysLogCmd.Payload.Mode = CFE_ES_LogMode_OVERWRITE;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.OverwriteSysLogCmd),
                     UT_TPID_CFE_ES_CMD_OVER_WRITE_SYS_LOG_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOGMODE_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOGMODE_INF_EID);
 
     /* Test successful overwriting of the system log using discard mode */
     ES_ResetUnitTest();
@@ -3053,7 +3053,7 @@ void TestTask(void)
     CmdBuf.OverwriteSysLogCmd.Payload.Mode = CFE_ES_LogMode_DISCARD;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.OverwriteSysLogCmd),
                     UT_TPID_CFE_ES_CMD_OVER_WRITE_SYS_LOG_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOGMODE_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOGMODE_INF_EID);
 
     /* Test overwriting the system log using an invalid mode */
     ES_ResetUnitTest();
@@ -3071,7 +3071,7 @@ void TestTask(void)
     CFE_ES_Global.TaskData.HkPacket.Payload.SysLogEntries                                      = 123;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.WriteSysLogCmd),
                     UT_TPID_CFE_ES_CMD_WRITE_SYS_LOG_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOG2_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOG2_INF_EID);
 
     /* Test writing the system log using a bad file name */
     ES_ResetUnitTest();
@@ -3087,7 +3087,7 @@ void TestTask(void)
     CmdBuf.WriteSysLogCmd.Payload.FileName[0] = '\0';
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.WriteSysLogCmd),
                     UT_TPID_CFE_ES_CMD_WRITE_SYS_LOG_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOG2_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOG2_INF_EID);
 
     /* Test writing the system log with an OS create failure */
     ES_ResetUnitTest();
@@ -3375,7 +3375,7 @@ void TestTask(void)
     CmdBuf.SendMemPoolStatsCmd.Payload.PoolHandle = CFE_ES_MemPoolRecordGetID(UtPoolRecPtr);
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.SendMemPoolStatsCmd),
                     UT_TPID_CFE_ES_CMD_SEND_MEM_POOL_STATS_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_TLM_POOL_STATS_INFO_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_TLM_POOL_STATS_INF_EID);
 
     /* Test the command pipe message process with an invalid command */
     ES_ResetUnitTest();
@@ -3498,7 +3498,7 @@ void TestTask(void)
     CmdBuf.OverwriteSysLogCmd.Payload.Mode = CFE_ES_LogMode_OVERWRITE;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.OverwriteSysLogCmd),
                     UT_TPID_CFE_ES_CMD_OVER_WRITE_SYS_LOG_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOGMODE_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_SYSLOGMODE_INF_EID);
 
     /* Test sending a request to write the error log with an
      * invalid command length
@@ -3610,7 +3610,7 @@ void TestPerf(void)
     CmdBuf.PerfStartCmd.Payload.TriggerMode = CFE_ES_PerfTrigger_START;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.PerfStartCmd),
                     UT_TPID_CFE_ES_CMD_START_PERF_DATA_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_PERF_STARTCMD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_PERF_STARTCMD_INF_EID);
 
     /* Test successful performance data collection start in CENTER
      * trigger mode
@@ -3620,7 +3620,7 @@ void TestPerf(void)
     CmdBuf.PerfStartCmd.Payload.TriggerMode = CFE_ES_PerfTrigger_CENTER;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.PerfStartCmd),
                     UT_TPID_CFE_ES_CMD_START_PERF_DATA_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_PERF_STARTCMD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_PERF_STARTCMD_INF_EID);
 
     /* Test successful performance data collection start in END
      * trigger mode
@@ -3630,7 +3630,7 @@ void TestPerf(void)
     CmdBuf.PerfStartCmd.Payload.TriggerMode = CFE_ES_PerfTrigger_END;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.PerfStartCmd),
                     UT_TPID_CFE_ES_CMD_START_PERF_DATA_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_PERF_STARTCMD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_PERF_STARTCMD_INF_EID);
 
     /* Test performance data collection start with an invalid trigger mode
      * (too high)
@@ -3679,7 +3679,7 @@ void TestPerf(void)
     CmdBuf.PerfStartCmd.Payload.TriggerMode = CFE_ES_PerfTrigger_START;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.PerfStartCmd),
                     UT_TPID_CFE_ES_CMD_START_PERF_DATA_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_PERF_STARTCMD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_PERF_STARTCMD_INF_EID);
 
     /* Test successful performance data collection stop */
     ES_ResetUnitTest();
@@ -3739,7 +3739,7 @@ void TestPerf(void)
     CmdBuf.PerfSetFilterMaskCmd.Payload.FilterMaskNum = CFE_ES_PERF_32BIT_WORDS_IN_MASK / 2;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.PerfSetFilterMaskCmd),
                     UT_TPID_CFE_ES_CMD_SET_PERF_FILTER_MASK_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_PERF_FILTMSKCMD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_PERF_FILTMSKCMD_INF_EID);
 
     /* Test successful performance filter mask command with minimum filter
          mask value */
@@ -3748,7 +3748,7 @@ void TestPerf(void)
     CmdBuf.PerfSetTrigMaskCmd.Payload.TriggerMaskNum = 0;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.PerfSetTrigMaskCmd),
                     UT_TPID_CFE_ES_CMD_SET_PERF_TRIGGER_MASK_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_PERF_TRIGMSKCMD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_PERF_TRIGMSKCMD_INF_EID);
 
     /* Test successful performance filter mask command with maximum filter
      * mask value
@@ -3758,7 +3758,7 @@ void TestPerf(void)
     CmdBuf.PerfSetTrigMaskCmd.Payload.TriggerMaskNum = CFE_ES_PERF_32BIT_WORDS_IN_MASK - 1;
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), sizeof(CmdBuf.PerfSetTrigMaskCmd),
                     UT_TPID_CFE_ES_CMD_SET_PERF_TRIGGER_MASK_CC);
-    CFE_UtAssert_EVENTSENT(CFE_ES_PERF_TRIGMSKCMD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_PERF_TRIGMSKCMD_INF_EID);
 
     /* Test successful performance filter mask command with a greater than the
      * maximum filter mask value
@@ -3890,7 +3890,7 @@ void TestPerf(void)
     /* Test performance data collection start with an invalid message length */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_START_PERF_DATA_CC);
-    CFE_UtAssert_EVENTNOTSENT(CFE_ES_PERF_STARTCMD_EID);
+    CFE_UtAssert_EVENTNOTSENT(CFE_ES_PERF_STARTCMD_INF_EID);
 
     /* Test performance data collection stop with an invalid message length */
     ES_ResetUnitTest();
@@ -3900,12 +3900,12 @@ void TestPerf(void)
     /* Test performance data filter mask with an invalid message length */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_SET_PERF_FILTER_MASK_CC);
-    CFE_UtAssert_EVENTNOTSENT(CFE_ES_PERF_FILTMSKCMD_EID);
+    CFE_UtAssert_EVENTNOTSENT(CFE_ES_PERF_FILTMSKCMD_INF_EID);
 
     /* Test performance data trigger mask with an invalid message length */
     ES_ResetUnitTest();
     UT_CallTaskPipe(CFE_ES_TaskPipe, CFE_MSG_PTR(CmdBuf), 0, UT_TPID_CFE_ES_CMD_SET_PERF_TRIGGER_MASK_CC);
-    CFE_UtAssert_EVENTNOTSENT(CFE_ES_PERF_TRIGMSKCMD_EID);
+    CFE_UtAssert_EVENTNOTSENT(CFE_ES_PERF_TRIGMSKCMD_INF_EID);
 
     /* Test perf log dump state machine */
     /* Nominal call 1 - should go through up to the DELAY state */

--- a/modules/evs/config/default_cfe_evs_fcncodes.h
+++ b/modules/evs/config/default_cfe_evs_fcncodes.h
@@ -48,7 +48,7 @@
 **       following telemetry:
 **       - \b \c \EVS_CMDPC - command execution counter will
 **         increment
-**       - The #CFE_EVS_NOOP_EID informational event message will
+**       - The #CFE_EVS_NOOP_INF_EID informational event message will
 **         be generated
 **
 **  \par Error Conditions
@@ -84,7 +84,7 @@
 **         will be reset to 0
 **       - \b \c \EVS_CMDEC - command error counter
 **         will be reset to 0
-**       - The #CFE_EVS_RSTCNT_EID debug event message will be
+**       - The #CFE_EVS_RESET_INF_EID informational event message will be
 **         generated
 **
 **  \par Error Conditions
@@ -130,7 +130,7 @@
 **
 **        - \b \c \EVS_CMDPC - command execution counter will
 **         increment
-**        - The generation of  #CFE_EVS_ENAEVTTYPE_EID debug message
+**        - The generation of  #CFE_EVS_ENAEVTTYPE_INF_EID informational message
 **
 **  \par Error Conditions
 **        This command may fail for the following reason(s):
@@ -178,7 +178,7 @@
 **
 **       - \b \c \EVS_CMDPC - command execution counter will
 **       increment
-         - The generation of #CFE_EVS_DISEVTTYPE_EID debug message
+         - The generation of #CFE_EVS_DISEVTTYPE_INF_EID informational message
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):
@@ -228,7 +228,7 @@
 **
 **       - \b \c \EVS_CMDPC - command execution counter will
 **       increment
-**       - The generation of #CFE_EVS_SETEVTFMTMOD_EID debug message
+**       - The generation of #CFE_EVS_SETEVTFMTMOD_INF_EID informational message
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):
@@ -277,7 +277,7 @@
 **       the following telemetry:
 **       - \b \c \EVS_CMDPC - command execution counter will
 **       increment
-**       - The generation of #CFE_EVS_ENAAPPEVTTYPE_EID debug event message
+**       - The generation of #CFE_EVS_ENAAPPEVTTYPE_INF_EID informational event message
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):
@@ -328,7 +328,7 @@
 **       the following telemetry:
 **       - \b \c \EVS_CMDPC - command execution counter will
 **       increment
-**       - The generation of #CFE_EVS_DISAPPENTTYPE_EID debug event message
+**       - The generation of #CFE_EVS_DISAPPENTTYPE_INF_EID informational event message
 **       - The clearing of the Event Type Active Flag in The Event Type Active Flag in EVS App Data File
 **
 **  \par Error Conditions
@@ -369,7 +369,7 @@
 **       the following telemetry:
 **       - \b \c \EVS_CMDPC - command execution counter will
 **       increment
-**       - The generation of #CFE_EVS_ENAAPPEVT_EID debug event message
+**       - The generation of #CFE_EVS_ENAAPPEVT_INF_EID informational event message
 **       - The setting of the Active Flag in The Active Flag in EVS App Data File
 **
 **  \par Error Conditions
@@ -408,7 +408,7 @@
 **       the following telemetry:
 **       - \b \c \EVS_CMDPC - command execution counter will
 **       increment
-**       - The generation of #CFE_EVS_DISAPPEVT_EID debug event message
+**       - The generation of #CFE_EVS_DISAPPEVT_INF_EID informational event message
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):
@@ -447,7 +447,7 @@
 **       the following telemetry:
 **       - \b \c \EVS_CMDPC - command execution counter will
 **       increment
-**       - The generation of #CFE_EVS_RSTEVTCNT_EID debug event message
+**       - The generation of #CFE_EVS_RSTEVTCNT_EID informational event message
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):
@@ -484,7 +484,7 @@
 **       the following telemetry:
 **       - \b \c \EVS_CMDPC - command execution counter will
 **       increment
-**       - The generation of #CFE_EVS_SETFILTERMSK_EID debug event message
+**       - The generation of #CFE_EVS_SETFILTERMSK_INF_EID informational event message
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):
@@ -530,7 +530,7 @@
 **       the following telemetry:
 **       - \b \c \EVS_CMDPC - command execution counter will
 **       increment
-**       - The generation of #CFE_EVS_ENAPORT_EID debug event message
+**       - The generation of #CFE_EVS_ENAPORT_INF_EID informational event message
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):
@@ -569,7 +569,7 @@
 **       the following telemetry:
 **       - \b \c \EVS_CMDPC - command execution counter will
 **       increment
-**       - The generation of #CFE_EVS_DISPORT_EID debug event message
+**       - The generation of #CFE_EVS_DISPORT_INF_EID informational event message
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):
@@ -603,7 +603,7 @@
 **       the following telemetry:
 **       - \b \c \EVS_CMDPC - command execution counter will
 **       increment
-**       - The generation of #CFE_EVS_RSTFILTER_EID debug event message
+**       - The generation of #CFE_EVS_RSTFILTER_INF_EID informational event message
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):
@@ -639,7 +639,7 @@
 **       the following telemetry:
 **       - \b \c \EVS_CMDPC - command execution counter will
 **       increment
-**       - The generation of #CFE_EVS_RSTALLFILTER_EID debug event message
+**       - The generation of #CFE_EVS_RSTALLFILTER_INF_EID informational event message
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):
@@ -673,7 +673,7 @@
 **       the following telemetry:
 **       - \b \c \EVS_CMDPC - command execution counter will
 **       increment
-**       - The generation of #CFE_EVS_ADDFILTER_EID debug event message
+**       - The generation of #CFE_EVS_ADDFILTER_INF_EID informational event message
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):
@@ -709,7 +709,7 @@
 **       the following telemetry:
 **       - \b \c \EVS_CMDPC - command execution counter will
 **       increment
-**       - The generation of #CFE_EVS_DELFILTER_EID debug event message
+**       - The generation of #CFE_EVS_DELFILTER_INF_EID informational event message
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):
@@ -744,7 +744,7 @@
 **       the following telemetry:
 **       - \b \c \EVS_CMDPC - command execution counter will
 **       increment
-**       - The generation of #CFE_EVS_WRDAT_EID debug event message
+**       - The generation of #CFE_EVS_WRDAT_INF_EID informational event message
 **       - The file specified in the command (or the default specified
 **         by the #CFE_PLATFORM_EVS_DEFAULT_APP_DATA_FILE configuration parameter) will be
 **         updated with the latest information.
@@ -782,7 +782,7 @@
 **       the following telemetry:
 **       - \b \c \EVS_CMDPC - command execution counter will
 **       increment
-**       - The generation of #CFE_EVS_WRLOG_EID debug event message
+**       - The generation of #CFE_EVS_WRLOG_INF_EID informational event message
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):
@@ -816,7 +816,7 @@
 **       the following telemetry:
 **       - \b \c \EVS_CMDPC - command execution counter will
 **       increment
-**       - The generation of #CFE_EVS_LOGMODE_EID debug event message
+**       - The generation of #CFE_EVS_LOGMODE_INF_EID informational event message
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):

--- a/modules/evs/eds/cfe_evs.xml
+++ b/modules/evs/eds/cfe_evs.xml
@@ -349,7 +349,7 @@
           \par  Command Verification
           Successful execution of this command may be verified with the following telemetry:
           - \b \c \EVS_CMDPC - command execution counter will increment
-          - The #CFE_EVS_NOOP_EID informational event message will be generated
+          - The #CFE_EVS_NOOP_INF_EID informational event message will be generated
 
           \par  Error Conditions
           There are no error conditions for this command. If the Event
@@ -384,7 +384,7 @@
           the following telemetry:
           - \b \c \EVS_CMDPC - command execution counter will
           increment
-          - The #CFE_EVS_RSTCNT_EID debug event message will be
+          - The #CFE_EVS_RESET_INF_EID informational event message will be
           generated
 
           \par  Error Conditions
@@ -433,7 +433,7 @@
           the following telemetry:
           - \b \c \EVS_CMDPC - command execution counter will
           increment
-          - The generation of  #CFE_EVS_ENAEVTTYPE_EID debug message
+          - The generation of  #CFE_EVS_ENAEVTTYPE_INF_EID informational message
 
           \par  Error Conditions
           This command may fail for the following reason(s):
@@ -486,7 +486,7 @@
           the following telemetry:
           - \b \c \EVS_CMDPC - command execution counter will
           increment
-          - The generation of #CFE_EVS_DISEVTTYPE_EID debug message
+          - The generation of #CFE_EVS_DISEVTTYPE_INF_EID informational message
 
           \par  Error Conditions
           This command may fail for the following reason(s):
@@ -541,7 +541,7 @@
           the following telemetry:
           - \b \c \EVS_CMDPC - command execution counter will
           increment
-          - The generation of #CFE_EVS_SETEVTFMTMOD_EID debug message
+          - The generation of #CFE_EVS_SETEVTFMTMOD_INF_EID informational message
 
           \par  Error Conditions
           This command may fail for the following reason(s):
@@ -597,7 +597,7 @@
           the following telemetry:
           - \b \c \EVS_CMDPC - command execution counter will
           increment
-          - The generation of #CFE_EVS_ENAAPPEVTTYPE_EID debug event message
+          - The generation of #CFE_EVS_ENAAPPEVTTYPE_INF_EID informational event message
 
           \par  Error Conditions
           This command may fail for the following reason(s):
@@ -652,7 +652,7 @@
           Successful execution of this command may be verified with
           the following telemetry:
           - \b \c \EVS_CMDPC - command execution counter will increment
-          - The generation of #CFE_EVS_DISAPPENTTYPE_EID debug event message
+          - The generation of #CFE_EVS_DISAPPENTTYPE_INF_EID informational event message
           - The clearing of the Active Flag in \link #CFE_EVS_AppDataFile_t::ActiveFlag \endlink The Active Flag in EVS App Data File
 
           \par  Error Conditions
@@ -698,7 +698,7 @@
           the following telemetry:
           - \b \c \EVS_CMDPC - command execution counter will
           increment
-          - The generation of #CFE_EVS_ENAAPPEVT_EID debug event message
+          - The generation of #CFE_EVS_ENAAPPEVT_INF_EID informational event message
           - The setting of the Active Flag in \link #CFE_EVS_AppDataFile_t::ActiveFlag \endlink The Active Flag in EVS App Data File
 
           \par  Error Conditions
@@ -745,7 +745,7 @@
           the following telemetry:
           - \b \c \EVS_CMDPC - command execution counter will
           increment
-          - The generation of #CFE_EVS_DISAPPEVT_EID debug event message
+          - The generation of #CFE_EVS_DISAPPEVT_INF_EID informational event message
 
           \par  Error Conditions
           This command may fail for the following reason(s):
@@ -791,7 +791,7 @@
           Successful execution of this command may be verified with
           the following telemetry:
           - \b \c \EVS_CMDPC - command execution counter will increment
-          - The generation of #CFE_EVS_RSTEVTCNT_EID debug event message
+          - The generation of #CFE_EVS_RSTEVTCNT_EID informational event message
 
           \par  Error Conditions
           This command may fail for the following reason(s):
@@ -835,7 +835,7 @@
           Successful execution of this command may be verified with
           the following telemetry:
           - \b \c \EVS_CMDPC - command execution counter will increment
-          - The generation of #CFE_EVS_SETFILTERMSK_EID debug event message
+          - The generation of #CFE_EVS_SETFILTERMSK_INF_EID informational event message
 
           \par  Error Conditions
           This command may fail for the following reason(s):
@@ -886,7 +886,7 @@
           Successful execution of this command may be verified with
           the following telemetry:
           - \b \c \EVS_CMDPC - command execution counter will increment
-          - The generation of #CFE_EVS_ENAPORT_EID debug event message
+          - The generation of #CFE_EVS_ENAPORT_INF_EID informational event message
 
           \par  Error Conditions
           This command may fail for the following reason(s):
@@ -932,7 +932,7 @@
           the following telemetry:
           - \b \c \EVS_CMDPC - command execution counter will
           increment
-          - The generation of #CFE_EVS_DISPORT_EID debug event message
+          - The generation of #CFE_EVS_DISPORT_INF_EID informational event message
 
           \par  Error Conditions
           This command may fail for the following reason(s):
@@ -972,7 +972,7 @@
           Successful execution of this command may be verified with
           the following telemetry:
           - \b \c \EVS_CMDPC - command execution counter will increment
-          - The generation of #CFE_EVS_RSTFILTER_EID debug event message
+          - The generation of #CFE_EVS_RSTFILTER_INF_EID informational event message
 
           \par  Error Conditions
           This command may fail for the following reason(s):
@@ -1014,7 +1014,7 @@
           the following telemetry:
           - \b \c \EVS_CMDPC - command execution counter will
           increment
-          - The generation of #CFE_EVS_RSTALLFILTER_EID debug event message
+          - The generation of #CFE_EVS_RSTALLFILTER_INF_EID informational event message
 
           \par  Error Conditions
           This command may fail for the following reason(s):
@@ -1056,7 +1056,7 @@
           the following telemetry:
           - \b \c \EVS_CMDPC - command execution counter will
           increment
-          - The generation of #CFE_EVS_ADDFILTER_EID debug event message
+          - The generation of #CFE_EVS_ADDFILTER_INF_EID informational event message
 
           \par  Error Conditions
           This command may fail for the following reason(s):
@@ -1098,7 +1098,7 @@
           the following telemetry:
           - \b \c \EVS_CMDPC - command execution counter will
           increment
-          - The generation of #CFE_EVS_DELFILTER_EID debug event message
+          - The generation of #CFE_EVS_DELFILTER_INF_EID informational event message
 
           \par  Error Conditions
           This command may fail for the following reason(s):
@@ -1140,7 +1140,7 @@
           the following telemetry:
           - \b \c \EVS_CMDPC - command execution counter will
           increment
-          - The generation of #CFE_EVS_WRDAT_EID debug event message
+          - The generation of #CFE_EVS_WRDAT_INF_EID informational event message
           - The generation of the file written to
 
           \par  Error Conditions
@@ -1181,7 +1181,7 @@
           the following telemetry:
           - \b \c \EVS_CMDPC - command execution counter will
           increment
-          - The generation of #CFE_EVS_WRLOG_EID debug event message
+          - The generation of #CFE_EVS_WRLOG_INF_EID informational event message
 
           \par  Error Conditions
           This command may fail for the following reason(s):
@@ -1220,7 +1220,7 @@
           the following telemetry:
           - \b \c \EVS_CMDPC - command execution counter will
           increment
-          - The generation of #CFE_EVS_LOGMODE_EID debug event message
+          - The generation of #CFE_EVS_LOGMODE_INF_EID informational event message
 
           \par  Error Conditions
           This command may fail for the following reason(s):

--- a/modules/evs/fsw/inc/cfe_evs_eventids.h
+++ b/modules/evs/fsw/inc/cfe_evs_eventids.h
@@ -39,7 +39,7 @@
  *
  *  \link #CFE_EVS_NOOP_CC EVS NO-OP command \endlink success.
  */
-#define CFE_EVS_NOOP_EID 0
+#define CFE_EVS_NOOP_INF_EID 0
 
 /**
  * \brief EVS Initialization Event ID
@@ -50,7 +50,7 @@
  *
  *  Event Services Task initialization complete.
  */
-#define CFE_EVS_STARTUP_EID 1
+#define CFE_EVS_INIT_INF_EID 1
 
 /**
  * \brief EVS Write Event Log Command File Write Entry Failed Event ID
@@ -204,128 +204,128 @@
 /**
  * \brief EVS Reset Counters Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_EVS_RESET_COUNTERS_CC EVS Reset Counters Command \endlink success.
  */
-#define CFE_EVS_RSTCNT_EID 16
+#define CFE_EVS_RESET_INF_EID 16
 
 /**
  * \brief EVS Set Filter Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_EVS_SET_FILTER_CC EVS Set Filter Command \endlink success.
  */
-#define CFE_EVS_SETFILTERMSK_EID 17
+#define CFE_EVS_SETFILTERMSK_INF_EID 17
 
 /**
  * \brief EVS Enable Ports Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_EVS_ENABLE_PORTS_CC EVS Enable Ports Command \endlink success.
  */
-#define CFE_EVS_ENAPORT_EID 18
+#define CFE_EVS_ENAPORT_INF_EID 18
 
 /**
  * \brief EVS Disable Ports Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_EVS_DISABLE_PORTS_CC EVS Disable Ports Command \endlink success.
  */
-#define CFE_EVS_DISPORT_EID 19
+#define CFE_EVS_DISPORT_INF_EID 19
 
 /**
  * \brief EVS Enable Event Type Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_EVS_ENABLE_EVENT_TYPE_CC EVS Enable Event Type Command \endlink success.
  */
-#define CFE_EVS_ENAEVTTYPE_EID 20
+#define CFE_EVS_ENAEVTTYPE_INF_EID 20
 
 /**
  * \brief EVS Disable Event Type Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_EVS_DISABLE_EVENT_TYPE_CC EVS Disable Event Type Command \endlink success.
  */
-#define CFE_EVS_DISEVTTYPE_EID 21
+#define CFE_EVS_DISEVTTYPE_INF_EID 21
 
 /**
  * \brief EVS Set Event Format Mode Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_EVS_SET_EVENT_FORMAT_MODE_CC EVS Set Event Format Mode Command \endlink success.
  */
-#define CFE_EVS_SETEVTFMTMOD_EID 22
+#define CFE_EVS_SETEVTFMTMOD_INF_EID 22
 
 /**
  * \brief EVS Enable App Event Type Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_EVS_ENABLE_APP_EVENT_TYPE_CC EVS Enable App Event Type Command \endlink success.
  */
-#define CFE_EVS_ENAAPPEVTTYPE_EID 23
+#define CFE_EVS_ENAAPPEVTTYPE_INF_EID 23
 
 /**
  * \brief EVS Disable App Event Type Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_EVS_DISABLE_APP_EVENT_TYPE_CC EVS Disable App Event Type Command \endlink success.
  */
-#define CFE_EVS_DISAPPENTTYPE_EID 24
+#define CFE_EVS_DISAPPENTTYPE_INF_EID 24
 
 /**
  * \brief EVS Enable App Events Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_EVS_ENABLE_APP_EVENTS_CC EVS Enable App Events Command \endlink success.
  */
-#define CFE_EVS_ENAAPPEVT_EID 25
+#define CFE_EVS_ENAAPPEVT_INF_EID 25
 
 /**
  * \brief EVS Disable App Events Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_EVS_DISABLE_APP_EVENTS_CC EVS Disable App Events Command \endlink success.
  */
-#define CFE_EVS_DISAPPEVT_EID 26
+#define CFE_EVS_DISAPPEVT_INF_EID 26
 
 /**
  * \brief EVS Reset App Event Counter Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
@@ -336,68 +336,68 @@
 /**
  * \brief EVS Reset App Event Filter Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_EVS_RESET_FILTER_CC EVS Reset App Event Filter Command \endlink success.
  */
-#define CFE_EVS_RSTFILTER_EID 28
+#define CFE_EVS_RSTFILTER_INF_EID 28
 
 /**
  * \brief EVS Reset All Filters Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_EVS_RESET_ALL_FILTERS_CC EVS Reset All FIlters Command \endlink success.
  */
-#define CFE_EVS_RSTALLFILTER_EID 29
+#define CFE_EVS_RSTALLFILTER_INF_EID 29
 
 /**
  * \brief EVS Add Event Filter Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_EVS_ADD_EVENT_FILTER_CC EVS Add Event Filter Command \endlink success.
  */
-#define CFE_EVS_ADDFILTER_EID 30
+#define CFE_EVS_ADDFILTER_INF_EID 30
 
 /**
  * \brief EVS Delete Event Filter Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_EVS_DELETE_EVENT_FILTER_CC EVS Delete Event Filter Command \endlink success.
  */
-#define CFE_EVS_DELFILTER_EID 31
+#define CFE_EVS_DELFILTER_INF_EID 31
 
 /**
  * \brief EVS Write Application Data Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_EVS_WRITE_APP_DATA_FILE_CC EVS Write Application Data Command \endlink success.
  */
-#define CFE_EVS_WRDAT_EID 32
+#define CFE_EVS_WRDAT_INF_EID 32
 
 /**
  * \brief EVS Write Event Log Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_EVS_WRITE_LOG_DATA_FILE_CC EVS Write Event Log Command \endlink success.
  */
-#define CFE_EVS_WRLOG_EID 33
+#define CFE_EVS_WRLOG_INF_EID 33
 
 /**
  * \brief EVS Add Filter Command Duplicate Registration Event ID
@@ -414,13 +414,13 @@
 /**
  * \brief EVS Set Log Mode Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_EVS_SET_LOG_MODE_CC EVS Set Log Mode Command \endlink success.
  */
-#define CFE_EVS_LOGMODE_EID 38
+#define CFE_EVS_LOGMODE_INF_EID 38
 
 /**
  * \brief EVS Set Log Mode Command Invalid Mode Event ID

--- a/modules/evs/fsw/src/cfe_evs_log.c
+++ b/modules/evs/fsw/src/cfe_evs_log.c
@@ -204,7 +204,7 @@ int32 CFE_EVS_WriteLogDataFileCmd(const CFE_EVS_WriteLogDataFileCmd_t *data)
             /* Process command handler success result */
             if (i == CFE_EVS_Global.EVS_LogPtr->LogCount)
             {
-                EVS_SendEvent(CFE_EVS_WRLOG_EID, CFE_EVS_EventType_DEBUG,
+                EVS_SendEvent(CFE_EVS_WRLOG_INF_EID, CFE_EVS_EventType_INFORMATION,
                               "Write Log File Command: %d event log entries written to %s",
                               (int)CFE_EVS_Global.EVS_LogPtr->LogCount, LogFilename);
                 Result = CFE_SUCCESS;
@@ -247,7 +247,7 @@ int32 CFE_EVS_SetLogModeCmd(const CFE_EVS_SetLogModeCmd_t *data)
         CFE_EVS_Global.EVS_LogPtr->LogMode = CmdPtr->LogMode;
         OS_MutSemGive(CFE_EVS_Global.EVS_SharedDataMutexID);
 
-        EVS_SendEvent(CFE_EVS_LOGMODE_EID, CFE_EVS_EventType_DEBUG, "Set Log Mode Command: Log Mode = %d",
+        EVS_SendEvent(CFE_EVS_LOGMODE_INF_EID, CFE_EVS_EventType_INFORMATION, "Set Log Mode Command: Log Mode = %d",
                       (int)CmdPtr->LogMode);
 
         Status = CFE_SUCCESS;

--- a/modules/evs/fsw/src/cfe_evs_task.c
+++ b/modules/evs/fsw/src/cfe_evs_task.c
@@ -300,7 +300,7 @@ int32 CFE_EVS_TaskInit(void)
     CFE_EVS_Global.EVS_AppID = AppID;
     CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE", CFE_SRC_VERSION, CFE_BUILD_CODENAME,
                                 CFE_LAST_OFFICIAL);
-    EVS_SendEvent(CFE_EVS_STARTUP_EID, CFE_EVS_EventType_INFORMATION, "cFE EVS Initialized: %s", VersionString);
+    EVS_SendEvent(CFE_EVS_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "cFE EVS Initialized: %s", VersionString);
 
     return CFE_SUCCESS;
 }
@@ -316,7 +316,7 @@ int32 CFE_EVS_NoopCmd(const CFE_EVS_NoopCmd_t *data)
     char VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
     CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE", CFE_SRC_VERSION, CFE_BUILD_CODENAME,
                                 CFE_LAST_OFFICIAL);
-    EVS_SendEvent(CFE_EVS_NOOP_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", VersionString);
+    EVS_SendEvent(CFE_EVS_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", VersionString);
     return CFE_SUCCESS;
 }
 
@@ -400,7 +400,7 @@ int32 CFE_EVS_ResetCountersCmd(const CFE_EVS_ResetCountersCmd_t *data)
     CFE_EVS_Global.EVS_TlmPkt.Payload.MessageTruncCounter    = 0;
     CFE_EVS_Global.EVS_TlmPkt.Payload.UnregisteredAppCounter = 0;
 
-    EVS_SendEvent(CFE_EVS_RSTCNT_EID, CFE_EVS_EventType_DEBUG, "Reset Counters Command Received");
+    EVS_SendEvent(CFE_EVS_RESET_INF_EID, CFE_EVS_EventType_INFORMATION, "Reset Counters Command Received");
 
     /* NOTE: Historically the reset counters command does _NOT_ increment the command counter */
 
@@ -436,7 +436,7 @@ int32 CFE_EVS_SetFilterCmd(const CFE_EVS_SetFilterCmd_t *data)
             /* Set application filter mask */
             FilterPtr->Mask = CmdPtr->Mask;
 
-            EVS_SendEvent(CFE_EVS_SETFILTERMSK_EID, CFE_EVS_EventType_DEBUG,
+            EVS_SendEvent(CFE_EVS_SETFILTERMSK_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "Set Filter Mask Command Received with AppName=%s, EventID=0x%08x, Mask=0x%04x", LocalName,
                           (unsigned int)CmdPtr->EventID, (unsigned int)CmdPtr->Mask);
         }
@@ -494,7 +494,7 @@ int32 CFE_EVS_EnablePortsCmd(const CFE_EVS_EnablePortsCmd_t *data)
         /* Process command data */
         CFE_EVS_Global.EVS_TlmPkt.Payload.OutputPort |= CmdPtr->BitMask;
 
-        EVS_SendEvent(CFE_EVS_ENAPORT_EID, CFE_EVS_EventType_DEBUG,
+        EVS_SendEvent(CFE_EVS_ENAPORT_INF_EID, CFE_EVS_EventType_INFORMATION,
                       "Enable Ports Command Received with Port Bit Mask = 0x%02x", (unsigned int)CmdPtr->BitMask);
         ReturnCode = CFE_SUCCESS;
     }
@@ -526,7 +526,7 @@ int32 CFE_EVS_DisablePortsCmd(const CFE_EVS_DisablePortsCmd_t *data)
         /* Process command data */
         CFE_EVS_Global.EVS_TlmPkt.Payload.OutputPort &= ~CmdPtr->BitMask;
 
-        EVS_SendEvent(CFE_EVS_DISPORT_EID, CFE_EVS_EventType_DEBUG,
+        EVS_SendEvent(CFE_EVS_DISPORT_INF_EID, CFE_EVS_EventType_INFORMATION,
                       "Disable Ports Command Received with Port Bit Mask = 0x%02x", (unsigned int)CmdPtr->BitMask);
 
         ReturnCode = CFE_SUCCESS;
@@ -569,7 +569,7 @@ int32 CFE_EVS_EnableEventTypeCmd(const CFE_EVS_EnableEventTypeCmd_t *data)
             ++AppDataPtr;
         }
 
-        EVS_SendEvent(CFE_EVS_ENAEVTTYPE_EID, CFE_EVS_EventType_DEBUG,
+        EVS_SendEvent(CFE_EVS_ENAEVTTYPE_INF_EID, CFE_EVS_EventType_INFORMATION,
                       "Enable Event Type Command Received with Event Type Bit Mask = 0x%02x",
                       (unsigned int)CmdPtr->BitMask);
 
@@ -614,7 +614,7 @@ int32 CFE_EVS_DisableEventTypeCmd(const CFE_EVS_DisableEventTypeCmd_t *data)
             ++AppDataPtr;
         }
 
-        EVS_SendEvent(CFE_EVS_DISEVTTYPE_EID, CFE_EVS_EventType_DEBUG,
+        EVS_SendEvent(CFE_EVS_DISEVTTYPE_INF_EID, CFE_EVS_EventType_INFORMATION,
                       "Disable Event Type Command Received with Event Type Bit Mask = 0x%02x",
                       (unsigned int)CmdPtr->BitMask);
 
@@ -639,7 +639,7 @@ int32 CFE_EVS_SetEventFormatModeCmd(const CFE_EVS_SetEventFormatModeCmd_t *data)
     {
         CFE_EVS_Global.EVS_TlmPkt.Payload.MessageFormatMode = CmdPtr->MsgFormat;
 
-        EVS_SendEvent(CFE_EVS_SETEVTFMTMOD_EID, CFE_EVS_EventType_DEBUG,
+        EVS_SendEvent(CFE_EVS_SETEVTFMTMOD_INF_EID, CFE_EVS_EventType_INFORMATION,
                       "Set Event Format Mode Command Received with Mode = 0x%02x", (unsigned int)CmdPtr->MsgFormat);
         Status = CFE_SUCCESS;
     }
@@ -708,7 +708,7 @@ int32 CFE_EVS_EnableAppEventTypeCmd(const CFE_EVS_EnableAppEventTypeCmd_t *data)
 
     if (Status == CFE_SUCCESS)
     {
-        EVS_SendEvent(CFE_EVS_ENAAPPEVTTYPE_EID, CFE_EVS_EventType_DEBUG,
+        EVS_SendEvent(CFE_EVS_ENAAPPEVTTYPE_INF_EID, CFE_EVS_EventType_INFORMATION,
                       "Enable App Event Type Command Received with AppName = %s, EventType Bit Mask = 0x%02x",
                       LocalName, CmdPtr->BitMask);
     }
@@ -770,7 +770,7 @@ int32 CFE_EVS_DisableAppEventTypeCmd(const CFE_EVS_DisableAppEventTypeCmd_t *dat
 
     if (Status == CFE_SUCCESS)
     {
-        EVS_SendEvent(CFE_EVS_DISAPPENTTYPE_EID, CFE_EVS_EventType_DEBUG,
+        EVS_SendEvent(CFE_EVS_DISAPPENTTYPE_INF_EID, CFE_EVS_EventType_INFORMATION,
                       "Disable App Event Type Command Received with AppName = %s, EventType Bit Mask = 0x%02x",
                       LocalName, (unsigned int)CmdPtr->BitMask);
     }
@@ -801,7 +801,7 @@ int32 CFE_EVS_EnableAppEventsCmd(const CFE_EVS_EnableAppEventsCmd_t *data)
     {
         AppDataPtr->ActiveFlag = true;
 
-        EVS_SendEvent(CFE_EVS_ENAAPPEVT_EID, CFE_EVS_EventType_DEBUG,
+        EVS_SendEvent(CFE_EVS_ENAAPPEVT_INF_EID, CFE_EVS_EventType_INFORMATION,
                       "Enable App Events Command Received with AppName = %s", LocalName);
     }
     else if (Status == CFE_EVS_APP_NOT_REGISTERED)
@@ -848,7 +848,7 @@ int32 CFE_EVS_DisableAppEventsCmd(const CFE_EVS_DisableAppEventsCmd_t *data)
     {
         AppDataPtr->ActiveFlag = false;
 
-        EVS_SendEvent(CFE_EVS_DISAPPEVT_EID, CFE_EVS_EventType_DEBUG,
+        EVS_SendEvent(CFE_EVS_DISAPPEVT_INF_EID, CFE_EVS_EventType_INFORMATION,
                       "Disable App Events Command Received with AppName = %s", LocalName);
     }
     else if (Status == CFE_EVS_APP_NOT_REGISTERED)
@@ -896,7 +896,7 @@ int32 CFE_EVS_ResetAppCounterCmd(const CFE_EVS_ResetAppCounterCmd_t *data)
         AppDataPtr->EventCount     = 0;
         AppDataPtr->SquelchedCount = 0;
 
-        EVS_SendEvent(CFE_EVS_RSTEVTCNT_EID, CFE_EVS_EventType_DEBUG,
+        EVS_SendEvent(CFE_EVS_RSTEVTCNT_EID, CFE_EVS_EventType_INFORMATION,
                       "Reset Event Counter Command Received with AppName = %s", LocalName);
     }
     else if (Status == CFE_EVS_APP_NOT_REGISTERED)
@@ -948,7 +948,7 @@ int32 CFE_EVS_ResetFilterCmd(const CFE_EVS_ResetFilterCmd_t *data)
         {
             FilterPtr->Count = 0;
 
-            EVS_SendEvent(CFE_EVS_RSTFILTER_EID, CFE_EVS_EventType_DEBUG,
+            EVS_SendEvent(CFE_EVS_RSTFILTER_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "Reset Filter Command Received with AppName = %s, EventID = 0x%08x", LocalName,
                           (unsigned int)CmdPtr->EventID);
         }
@@ -1009,7 +1009,7 @@ int32 CFE_EVS_ResetAllFiltersCmd(const CFE_EVS_ResetAllFiltersCmd_t *data)
             AppDataPtr->BinFilters[i].Count = 0;
         }
 
-        EVS_SendEvent(CFE_EVS_RSTALLFILTER_EID, CFE_EVS_EventType_DEBUG,
+        EVS_SendEvent(CFE_EVS_RSTALLFILTER_INF_EID, CFE_EVS_EventType_INFORMATION,
                       "Reset All Filters Command Received with AppName = %s", LocalName);
     }
     else if (Status == CFE_EVS_APP_NOT_REGISTERED)
@@ -1079,7 +1079,7 @@ int32 CFE_EVS_AddEventFilterCmd(const CFE_EVS_AddEventFilterCmd_t *data)
                 FilterPtr->Mask    = CmdPtr->Mask;
                 FilterPtr->Count   = 0;
 
-                EVS_SendEvent(CFE_EVS_ADDFILTER_EID, CFE_EVS_EventType_DEBUG,
+                EVS_SendEvent(CFE_EVS_ADDFILTER_INF_EID, CFE_EVS_EventType_INFORMATION,
                               "Add Filter Command Received with AppName = %s, EventID = 0x%08x, Mask = 0x%04x",
                               LocalName, (unsigned int)CmdPtr->EventID, (unsigned int)CmdPtr->Mask);
             }
@@ -1146,7 +1146,7 @@ int32 CFE_EVS_DeleteEventFilterCmd(const CFE_EVS_DeleteEventFilterCmd_t *data)
             FilterPtr->Mask    = CFE_EVS_NO_MASK;
             FilterPtr->Count   = 0;
 
-            EVS_SendEvent(CFE_EVS_DELFILTER_EID, CFE_EVS_EventType_DEBUG,
+            EVS_SendEvent(CFE_EVS_DELFILTER_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "Delete Filter Command Received with AppName = %s, EventID = 0x%08x", LocalName,
                           (unsigned int)CmdPtr->EventID);
         }
@@ -1280,7 +1280,7 @@ int32 CFE_EVS_WriteAppDataFileCmd(const CFE_EVS_WriteAppDataFileCmd_t *data)
             /* Process command handler success result */
             if (i == CFE_PLATFORM_ES_MAX_APPLICATIONS)
             {
-                EVS_SendEvent(CFE_EVS_WRDAT_EID, CFE_EVS_EventType_DEBUG,
+                EVS_SendEvent(CFE_EVS_WRDAT_INF_EID, CFE_EVS_EventType_INFORMATION,
                               "Write App Data Command: %d application data entries written to %s", (int)EntryCount,
                               LocalName);
                 Result = CFE_SUCCESS;

--- a/modules/evs/ut-coverage/evs_UT.c
+++ b/modules/evs/ut-coverage/evs_UT.c
@@ -428,14 +428,14 @@ void Test_Init(void)
     appbitcmd.Payload.BitMask = CFE_EVS_DEBUG_BIT | CFE_EVS_INFORMATION_BIT | CFE_EVS_ERROR_BIT | CFE_EVS_CRITICAL_BIT;
     UT_EVS_DoDispatchCheckEvents(&appbitcmd, sizeof(appbitcmd), UT_TPID_CFE_EVS_CMD_ENABLE_APP_EVENT_TYPE_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ENAAPPEVTTYPE_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ENAAPPEVTTYPE_INF_EID);
 
     /* Disable ports */
     UT_InitData_EVS();
     bitmaskcmd.Payload.BitMask = CFE_EVS_PORT1_BIT | CFE_EVS_PORT2_BIT | CFE_EVS_PORT3_BIT | CFE_EVS_PORT4_BIT;
     UT_EVS_DoDispatchCheckEvents(&bitmaskcmd, sizeof(bitmaskcmd), UT_TPID_CFE_EVS_CMD_DISABLE_PORTS_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_DISPORT_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_DISPORT_INF_EID);
 
     UT_EVS_DisableSquelch();
 }
@@ -745,7 +745,7 @@ void Test_Format(void)
     appbitcmd.Payload.BitMask = CFE_EVS_DEBUG_BIT | CFE_EVS_INFORMATION_BIT | CFE_EVS_ERROR_BIT | CFE_EVS_CRITICAL_BIT;
     UT_EVS_DoDispatchCheckEvents(&appbitcmd, sizeof(appbitcmd), UT_TPID_CFE_EVS_CMD_ENABLE_APP_EVENT_TYPE_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ENAAPPEVTTYPE_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ENAAPPEVTTYPE_INF_EID);
 
     /* Test set event format mode command using an invalid mode */
     UT_InitData_EVS();
@@ -761,7 +761,7 @@ void Test_Format(void)
     modecmd.Payload.MsgFormat = CFE_EVS_MsgFormat_SHORT;
     UT_EVS_DoDispatchCheckEventsShort(&modecmd, sizeof(modecmd), UT_TPID_CFE_EVS_CMD_SET_EVENT_FORMAT_MODE_CC,
                                       &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_SETEVTFMTMOD_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_SETEVTFMTMOD_INF_EID);
 
     UtPrintf("Test for short event sent when configured to do so ");
     UT_InitData_EVS();
@@ -785,7 +785,7 @@ void Test_Format(void)
     modecmd.Payload.MsgFormat = CFE_EVS_MsgFormat_LONG;
     UT_EVS_DoDispatchCheckEvents(&modecmd, sizeof(modecmd), UT_TPID_CFE_EVS_CMD_SET_EVENT_FORMAT_MODE_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_SETEVTFMTMOD_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_SETEVTFMTMOD_INF_EID);
 
     /* Test event long format mode command was successful (the following
      * messages are output if long format selection is successful)
@@ -853,7 +853,7 @@ void Test_Ports(void)
     bitmaskcmd.Payload.BitMask = CFE_EVS_PORT1_BIT | CFE_EVS_PORT2_BIT | CFE_EVS_PORT3_BIT | CFE_EVS_PORT4_BIT;
     UT_EVS_DoDispatchCheckEvents(&bitmaskcmd, sizeof(bitmaskcmd), UT_TPID_CFE_EVS_CMD_ENABLE_PORTS_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ENAPORT_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ENAPORT_INF_EID);
 
     /* Test that ports are enabled by sending a message */
     UT_InitData_EVS();
@@ -868,7 +868,7 @@ void Test_Ports(void)
     bitmaskcmd.Payload.BitMask = CFE_EVS_PORT1_BIT | CFE_EVS_PORT2_BIT | CFE_EVS_PORT3_BIT | CFE_EVS_PORT4_BIT;
     UT_EVS_DoDispatchCheckEvents(&bitmaskcmd, sizeof(bitmaskcmd), UT_TPID_CFE_EVS_CMD_DISABLE_PORTS_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_DISPORT_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_DISPORT_INF_EID);
 
     /* Test enabling a port using a bitmask that is out of range (high) */
     UT_InitData_EVS();
@@ -895,14 +895,14 @@ void Test_Ports(void)
     bitmaskcmd.Payload.BitMask = CFE_EVS_PORT1_BIT | CFE_EVS_PORT2_BIT;
     UT_EVS_DoDispatchCheckEvents(&bitmaskcmd, sizeof(bitmaskcmd), UT_TPID_CFE_EVS_CMD_ENABLE_PORTS_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ENAPORT_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ENAPORT_INF_EID);
 
     /* Test enabling a port 3 and 4, but not 1 and 2 (branch path coverage) */
     UT_InitData_EVS();
     bitmaskcmd.Payload.BitMask = CFE_EVS_PORT3_BIT | CFE_EVS_PORT4_BIT;
     UT_EVS_DoDispatchCheckEvents(&bitmaskcmd, sizeof(bitmaskcmd), UT_TPID_CFE_EVS_CMD_ENABLE_PORTS_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ENAPORT_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ENAPORT_INF_EID);
 
     /* Test disabling a port using a bitmask that is out of range (low) */
     UT_InitData_EVS();
@@ -916,14 +916,14 @@ void Test_Ports(void)
     bitmaskcmd.Payload.BitMask = CFE_EVS_PORT1_BIT | CFE_EVS_PORT2_BIT;
     UT_EVS_DoDispatchCheckEvents(&bitmaskcmd, sizeof(bitmaskcmd), UT_TPID_CFE_EVS_CMD_DISABLE_PORTS_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_DISPORT_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_DISPORT_INF_EID);
 
     /* Test disabling a port 3 and 4, but not 1 and 2 (branch path coverage) */
     UT_InitData_EVS();
     bitmaskcmd.Payload.BitMask = CFE_EVS_PORT3_BIT | CFE_EVS_PORT4_BIT;
     UT_EVS_DoDispatchCheckEvents(&bitmaskcmd, sizeof(bitmaskcmd), UT_TPID_CFE_EVS_CMD_DISABLE_PORTS_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_DISPORT_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_DISPORT_INF_EID);
 }
 
 /*
@@ -974,7 +974,7 @@ void Test_Logging(void)
     CmdBuf.modecmd.Payload.LogMode = CFE_EVS_LogMode_DISCARD;
     UT_EVS_DoDispatchCheckEvents(&CmdBuf.modecmd, sizeof(CmdBuf.modecmd), UT_TPID_CFE_EVS_CMD_SET_LOG_MODE_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LOGMODE_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LOGMODE_INF_EID);
 
     /* Test overfilling the log in discard mode */
     UT_InitData_EVS();
@@ -1010,7 +1010,7 @@ void Test_Logging(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_EVS_DoDispatchCheckEvents(&CmdBuf.noopcmd, sizeof(CmdBuf.noopcmd), UT_TPID_CFE_EVS_CMD_NOOP_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_NOOP_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_NOOP_INF_EID);
 
     /* Clear log for next test */
     UT_InitData_EVS();
@@ -1108,13 +1108,13 @@ void Test_WriteApp(void)
         CFE_EVS_DEBUG_BIT | CFE_EVS_INFORMATION_BIT | CFE_EVS_ERROR_BIT | CFE_EVS_CRITICAL_BIT;
     UT_EVS_DoDispatchCheckEvents(&CmdBuf.appbitcmd, sizeof(CmdBuf.appbitcmd),
                                  UT_TPID_CFE_EVS_CMD_ENABLE_APP_EVENT_TYPE_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ENAAPPEVTTYPE_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ENAAPPEVTTYPE_INF_EID);
 
     /* Test resetting counters */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&CmdBuf.ResetCountersCmd, sizeof(CmdBuf.ResetCountersCmd),
                                  UT_TPID_CFE_EVS_CMD_RESET_COUNTERS_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_RSTCNT_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_RESET_INF_EID);
 
     /* Test writing application data with a create failure using default
      * file name
@@ -1147,7 +1147,7 @@ void Test_WriteApp(void)
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&CmdBuf.AppDataCmd, sizeof(CmdBuf.AppDataCmd),
                                  UT_TPID_CFE_EVS_CMD_WRITE_APP_DATA_FILE_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_WRDAT_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_WRDAT_INF_EID);
 
     /* Test writing application data with a create failure using specified
      * file name
@@ -1496,7 +1496,7 @@ void Test_EventCmd(void)
     EventCount[2] = LocalSnapshotData.Count;
     CFE_EVS_SendEvent(0, CFE_EVS_EventType_CRITICAL, "Critical message enabled");
     EventCount[3] = LocalSnapshotData.Count;
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ENAAPPEVTTYPE_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ENAAPPEVTTYPE_INF_EID);
     UtAssert_UINT32_EQ(EventCount[0], 1);
     UtAssert_UINT32_EQ(EventCount[1], 2);
     UtAssert_UINT32_EQ(EventCount[2], 3);
@@ -1526,20 +1526,20 @@ void Test_EventCmd(void)
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&appnamecmd, sizeof(appnamecmd), UT_TPID_CFE_EVS_CMD_ENABLE_APP_EVENTS_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ENAAPPEVT_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ENAAPPEVT_INF_EID);
 
-    /* Test disabling event types (leave debug enabled) */
+    /* Test disabling event types (leave information enabled) */
     UT_InitData_EVS();
-    bitmaskcmd.Payload.BitMask = CFE_EVS_INFORMATION_BIT | CFE_EVS_ERROR_BIT | CFE_EVS_CRITICAL_BIT;
+    bitmaskcmd.Payload.BitMask = CFE_EVS_DEBUG_BIT | CFE_EVS_ERROR_BIT | CFE_EVS_CRITICAL_BIT;
     UT_EVS_DoDispatchCheckEvents(&bitmaskcmd, sizeof(bitmaskcmd), UT_TPID_CFE_EVS_CMD_DISABLE_EVENT_TYPE_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_DISEVTTYPE_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_DISEVTTYPE_INF_EID);
 
-    /* Test enabling all event types (debug already enabled) */
+    /* Test enabling all event types (information already enabled) */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&bitmaskcmd, sizeof(bitmaskcmd), UT_TPID_CFE_EVS_CMD_ENABLE_EVENT_TYPE_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ENAEVTTYPE_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ENAEVTTYPE_INF_EID);
 
     /* Test successfully resetting the application event counter */
     UT_InitData_EVS();
@@ -1648,7 +1648,7 @@ void Test_FilterCmd(void)
     appbitcmd.Payload.BitMask = CFE_EVS_DEBUG_BIT | CFE_EVS_INFORMATION_BIT | CFE_EVS_ERROR_BIT | CFE_EVS_CRITICAL_BIT;
     UT_EVS_DoDispatchCheckEvents(&appbitcmd, sizeof(appbitcmd), UT_TPID_CFE_EVS_CMD_ENABLE_APP_EVENT_TYPE_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ENAAPPEVTTYPE_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ENAAPPEVTTYPE_INF_EID);
 
     /* Ensure there is no filter for the next tests */
     UT_InitData_EVS();
@@ -1674,13 +1674,13 @@ void Test_FilterCmd(void)
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&appnamecmd, sizeof(appnamecmd), UT_TPID_CFE_EVS_CMD_RESET_ALL_FILTERS_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_RSTALLFILTER_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_RSTALLFILTER_INF_EID);
 
     /* Test successfully adding an event filter */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&appmaskcmd, sizeof(appmaskcmd), UT_TPID_CFE_EVS_CMD_ADD_EVENT_FILTER_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ADDFILTER_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ADDFILTER_INF_EID);
 
     /* Test adding an event filter to an event already registered
      * for filtering
@@ -1693,24 +1693,24 @@ void Test_FilterCmd(void)
     /* Test successfully setting a filter mask */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&appmaskcmd, sizeof(appmaskcmd), UT_TPID_CFE_EVS_CMD_SET_FILTER_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_SETFILTERMSK_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_SETFILTERMSK_INF_EID);
 
     /* Test successfully resetting a filter mask */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&appcmdcmd, sizeof(appcmdcmd), UT_TPID_CFE_EVS_CMD_RESET_FILTER_CC, &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_RSTFILTER_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_RSTFILTER_INF_EID);
 
     /* Test successfully resetting all filters */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&appnamecmd, sizeof(appnamecmd), UT_TPID_CFE_EVS_CMD_RESET_ALL_FILTERS_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_RSTALLFILTER_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_RSTALLFILTER_INF_EID);
 
     /* Test successfully deleting an event filter */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&appcmdcmd, sizeof(appcmdcmd), UT_TPID_CFE_EVS_CMD_DELETE_EVENT_FILTER_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_DELFILTER_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_DELFILTER_INF_EID);
 
     /* Test filling the event filters */
     UT_InitData_EVS();
@@ -1723,7 +1723,7 @@ void Test_FilterCmd(void)
         appmaskcmd.Payload.EventID++;
     }
 
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ADDFILTER_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ADDFILTER_INF_EID);
     UtAssert_UINT32_EQ(UT_EVS_EventBuf.Count, CFE_PLATFORM_EVS_MAX_EVENT_FILTERS);
 
     /* Test overfilling the event filters */
@@ -1742,13 +1742,13 @@ void Test_FilterCmd(void)
     appbitcmd.Payload.BitMask = CFE_EVS_DEBUG_BIT | CFE_EVS_INFORMATION_BIT | CFE_EVS_ERROR_BIT | CFE_EVS_CRITICAL_BIT;
     UT_EVS_DoDispatchCheckEvents(&appbitcmd, sizeof(appbitcmd), UT_TPID_CFE_EVS_CMD_ENABLE_APP_EVENT_TYPE_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ENAAPPEVTTYPE_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ENAAPPEVTTYPE_INF_EID);
 
     /* Set-up to test filtering the same event twice */
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&appmaskcmd, sizeof(appmaskcmd), UT_TPID_CFE_EVS_CMD_ADD_EVENT_FILTER_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ADDFILTER_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_ADDFILTER_INF_EID);
 
     /* Test filtering the same event again */
     UT_InitData_EVS();
@@ -1760,7 +1760,7 @@ void Test_FilterCmd(void)
     UT_InitData_EVS();
     UT_EVS_DoDispatchCheckEvents(&appcmdcmd, sizeof(appcmdcmd), UT_TPID_CFE_EVS_CMD_DELETE_EVENT_FILTER_CC,
                                  &UT_EVS_EventBuf);
-    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_DELFILTER_EID);
+    UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_DELFILTER_INF_EID);
 
     /* Return application to original state, re-register application */
     UT_InitData_EVS();
@@ -2064,7 +2064,7 @@ void Test_Misc(void)
     }
     else
     {
-        UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_WRLOG_EID);
+        UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_WRLOG_INF_EID);
     }
 
     /* Test successfully setting the logging mode */
@@ -2077,7 +2077,7 @@ void Test_Misc(void)
     }
     else
     {
-        UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LOGMODE_EID);
+        UtAssert_UINT32_EQ(UT_EVS_EventBuf.EventID, CFE_EVS_LOGMODE_INF_EID);
     }
 
     /* Test housekeeping report with log enabled */

--- a/modules/sb/config/default_cfe_sb_fcncodes.h
+++ b/modules/sb/config/default_cfe_sb_fcncodes.h
@@ -49,7 +49,7 @@
 **       following telemetry:
 **       - \b \c \SB_CMDPC - command execution counter will
 **         increment
-**       - The #CFE_SB_CMD0_RCVD_EID informational event message will
+**       - The #CFE_SB_NOOP_INF_EID informational event message will
 **         be generated
 **
 **  \par Error Conditions
@@ -93,7 +93,7 @@
 **       - \b \c \SB_CMDPC - command execution counter will
 **         be reset to 0
 **       - All other counters listed in description will be reset to 0
-**       - The #CFE_SB_CMD1_RCVD_EID informational event message will
+**       - The #CFE_SB_RESET_INF_EID informational event message will
 **         be generated
 **
 **  \par Error Conditions
@@ -130,7 +130,7 @@
 **       following telemetry:
 **       - \b \c \SB_CMDPC - command execution counter will increment
 **       - Receipt of statistics packet with MsgId #CFE_SB_STATS_TLM_MID
-**       - The #CFE_SB_SND_STATS_EID debug event message will be generated
+**       - The #CFE_SB_SND_STATS_INF_EID informational event message will be generated
 **
 **  \par Error Conditions
 **       There are no error conditions for this command. If the Software
@@ -211,7 +211,7 @@
 **       - \b \c \SB_CMDPC - command execution counter will increment
 **       - View routing information #CFE_SB_WRITE_ROUTING_INFO_CC to verify
 **         enable/disable state change
-**       - The #CFE_SB_ENBL_RTE2_EID debug event message will be generated
+**       - The #CFE_SB_ENBL_RTE2_INF_EID informational event message will be generated
 **       - Destination will begin receiving messages
 **
 **  \par Error Conditions
@@ -247,7 +247,7 @@
 **       - \b \c \SB_CMDPC - command execution counter will increment
 **       - View routing information #CFE_SB_WRITE_ROUTING_INFO_CC to verify
 **         enable/disable state change
-**       - The #CFE_SB_DSBL_RTE2_EID debug event message will be generated
+**       - The #CFE_SB_DSBL_RTE2_INF_EID informational event message will be generated
 **       - Destination will stop receiving messages
 **
 **  \par Error Conditions

--- a/modules/sb/eds/cfe_sb.xml
+++ b/modules/sb/eds/cfe_sb.xml
@@ -475,7 +475,7 @@
           Successful execution of this command may be verified with the
           following telemetry:
           - \b \c \SB_CMDPC - command execution counter will increment
-          - The #CFE_SB_CMD0_RCVD_EID informational event message will be generated
+          - The #CFE_SB_NOOP_INF_EID informational event message will be generated
 
           \par  Error Conditions
           There are no error conditions for this command. If the Software
@@ -509,7 +509,7 @@
           Successful execution of this command may be verified with the
           following telemetry:
           - \b \c \SB_CMDPC - command execution counter will increment
-          - The #CFE_SB_CMD1_RCVD_EID informational event message will be generated
+          - The #CFE_SB_RESET_INF_EID informational event message will be generated
 
           \par  Error Conditions
           There are no error conditions for this command. If the Software
@@ -547,7 +547,7 @@
           following telemetry:
           - \b \c \SB_CMDPC - command execution counter will increment
           - Receipt of statistics packet with MsgId #CFE_SB_STATS_TLM_MID
-          - The #CFE_SB_SND_STATS_EID debug event message will be generated. All
+          - The #CFE_SB_SND_STATS_INF_EID informational event message will be generated. All
           debug events are filtered by default.
 
           \par  Error Conditions
@@ -637,7 +637,7 @@
           - \b \c \SB_CMDPC - command execution counter will increment
           - View routing information #CFE_SB_SEND_ROUTING_INFO_CC to verify
           enable/disable state change
-          - The #CFE_SB_ENBL_RTE2_EID debug event message will be generated. All
+          - The #CFE_SB_ENBL_RTE2_INF_EID informational event message will be generated. All
           debug events are filtered by default.
           - Destination will begin receiving messages.
 
@@ -681,7 +681,7 @@
           - \b \c \SB_CMDPC - command execution counter will increment
           - View routing information #CFE_SB_SEND_ROUTING_INFO_CC to verify
           enable/disable state change
-          - The #CFE_SB_DSBL_RTE2_EID debug event message will be generated. All
+          - The #CFE_SB_DSBL_RTE2_INF_EID informational event message will be generated. All
           debug events are filtered by default.
           - Destination will stop receiving messages.
 

--- a/modules/sb/fsw/inc/cfe_sb_eventids.h
+++ b/modules/sb/fsw/inc/cfe_sb_eventids.h
@@ -39,7 +39,7 @@
  *
  *  Software Bus Services Task initialization complete.
  */
-#define CFE_SB_INIT_EID 1
+#define CFE_SB_INIT_INF_EID 1
 
 /**
  * \brief SB Create Pipe API Bad Argument Event ID
@@ -77,13 +77,13 @@
 /**
  * \brief SB Create Pipe API Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  #CFE_SB_CreatePipe API successfully completed.
  */
-#define CFE_SB_PIPE_ADDED_EID 5
+#define CFE_SB_PIPE_ADDED_INF_EID 5
 
 /**
  * \brief SB Subscribe API Bad Argument Event ID
@@ -135,13 +135,13 @@
 /**
  * \brief SB Subscribe API Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  An SB Subscribe API completed successfully.
  */
-#define CFE_SB_SUBSCRIPTION_RCVD_EID 10
+#define CFE_SB_SUBSCRIPTION_RCVD_INF_EID 10
 
 /**
  * \brief SB Unsubscribe API Bad Argument Event ID
@@ -332,29 +332,29 @@
  *
  *  \link #CFE_SB_NOOP_CC SB NO-OP Command \endlink success.
  */
-#define CFE_SB_CMD0_RCVD_EID 28
+#define CFE_SB_NOOP_INF_EID 28
 
 /**
  * \brief SB Reset Counters Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_SB_RESET_COUNTERS_CC SB Reset Counters Command \endlink success.
  */
-#define CFE_SB_CMD1_RCVD_EID 29
+#define CFE_SB_RESET_INF_EID 29
 
 /**
  * \brief SB Send Statistics Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_SB_SEND_SB_STATS_CC SB Send Statistics Command \endlink success.
  */
-#define CFE_SB_SND_STATS_EID 32
+#define CFE_SB_SND_STATS_INF_EID 32
 
 /**
  * \brief SB Enable Route Command Invalid MsgId/PipeID Pair Event ID
@@ -371,13 +371,13 @@
 /**
  * \brief SB Enable Route Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_SB_ENABLE_ROUTE_CC SB Enable Route Command \endlink success.
  */
-#define CFE_SB_ENBL_RTE2_EID 34
+#define CFE_SB_ENBL_RTE2_INF_EID 34
 
 /**
  * \brief SB Enable Route Command Invalid MsgId or Pipe Event ID
@@ -406,13 +406,13 @@
 /**
  * \brief SB Disable Route Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_SB_DISABLE_ROUTE_CC SB Disable Route Command \endlink success.
  */
-#define CFE_SB_DSBL_RTE2_EID 37
+#define CFE_SB_DSBL_RTE2_INF_EID 37
 
 /**
  * \brief SB Disable Route Command Invalid MsgId or Pipe Event ID
@@ -509,24 +509,24 @@
 /**
  * \brief SB Pipe Delete API Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  An SB Delete Pipe API successfully completed.
  */
-#define CFE_SB_PIPE_DELETED_EID 47
+#define CFE_SB_PIPE_DELETED_INF_EID 47
 
 /**
  * \brief SB Unsubscribe API Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  An SB Unsubscribe API successfully completed.
  */
-#define CFE_SB_SUBSCRIPTION_REMOVED_EID 48
+#define CFE_SB_SUBSCRIPTION_REMOVED_INF_EID 48
 
 /**
  * \brief SB File Write Failed Event ID
@@ -619,13 +619,13 @@
 /**
  * \brief SB Set Pipe Opts API Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  #CFE_SB_SetPipeOpts success.
  */
-#define CFE_SB_SETPIPEOPTS_EID 57
+#define CFE_SB_SETPIPEOPTS_INF_EID 57
 
 /**
  * \brief SB Get Pipe Opts API Invalid Pipe Event ID
@@ -652,24 +652,24 @@
 /**
  * \brief SB Get Pipe Opts API Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  #CFE_SB_GetPipeOpts success.
  */
-#define CFE_SB_GETPIPEOPTS_EID 60
+#define CFE_SB_GETPIPEOPTS_INF_EID 60
 
 /**
  * \brief SB Get Pipe Name API Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  #CFE_SB_GetPipeName success.
  */
-#define CFE_SB_GETPIPENAME_EID 62
+#define CFE_SB_GETPIPENAME_INF_EID 62
 
 /**
  * \brief SB Get Pipe Name API Invalid Pointer Event ID
@@ -696,13 +696,13 @@
 /**
  * \brief SB Get Pipe ID By Name API Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  #CFE_SB_GetPipeIdByName success.
  */
-#define CFE_SB_GETPIPEIDBYNAME_EID 65
+#define CFE_SB_GETPIPEIDBYNAME_INF_EID 65
 
 /**
  * \brief SB Get Pipe ID By Name API Invalid Pointer Event ID

--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -256,8 +256,8 @@ CFE_Status_t CFE_SB_CreatePipe(CFE_SB_PipeId_t *PipeIdPtr, uint16 Depth, const c
 
     if (Status == CFE_SUCCESS)
     {
-        /* send debug event */
-        CFE_EVS_SendEventWithAppID(CFE_SB_PIPE_ADDED_EID, CFE_EVS_EventType_DEBUG, CFE_SB_Global.AppId,
+        /* send informational event */
+        CFE_EVS_SendEventWithAppID(CFE_SB_PIPE_ADDED_INF_EID, CFE_EVS_EventType_INFORMATION, CFE_SB_Global.AppId,
                                    "Pipe Created:name %s,id %d,app %s", PipeName,
                                    (int)CFE_ResourceId_ToInteger(PendingPipeId), CFE_SB_GetAppTskName(TskId, FullName));
 
@@ -474,7 +474,7 @@ int32 CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId)
          */
         CFE_ES_GetAppName(FullName, AppId, sizeof(FullName));
 
-        CFE_EVS_SendEventWithAppID(CFE_SB_PIPE_DELETED_EID, CFE_EVS_EventType_DEBUG, CFE_SB_Global.AppId,
+        CFE_EVS_SendEventWithAppID(CFE_SB_PIPE_DELETED_INF_EID, CFE_EVS_EventType_INFORMATION, CFE_SB_Global.AppId,
                                    "Pipe Deleted:id %d,owner %s", (int)CFE_RESOURCEID_TO_ULONG(PipeId), FullName);
     }
 
@@ -567,7 +567,7 @@ CFE_Status_t CFE_SB_SetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 Opts)
         /* get AppID of caller for events */
         CFE_ES_GetAppName(FullName, AppID, sizeof(FullName));
 
-        CFE_EVS_SendEventWithAppID(CFE_SB_SETPIPEOPTS_EID, CFE_EVS_EventType_DEBUG, CFE_SB_Global.AppId,
+        CFE_EVS_SendEventWithAppID(CFE_SB_SETPIPEOPTS_INF_EID, CFE_EVS_EventType_INFORMATION, CFE_SB_Global.AppId,
                                    "Pipe opts set:id %lu,owner %s, opts=0x%02x", CFE_RESOURCEID_TO_ULONG(PipeId),
                                    FullName, (unsigned int)Opts);
     }
@@ -649,7 +649,7 @@ CFE_Status_t CFE_SB_GetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 *OptsPtr)
 
     if (Status == CFE_SUCCESS)
     {
-        CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPEOPTS_EID, CFE_EVS_EventType_DEBUG, CFE_SB_Global.AppId,
+        CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPEOPTS_INF_EID, CFE_EVS_EventType_INFORMATION, CFE_SB_Global.AppId,
                                    "Pipe opts get:id %lu, opts=0x%02x", CFE_RESOURCEID_TO_ULONG(PipeId),
                                    (unsigned int)*OptsPtr);
     }
@@ -747,7 +747,7 @@ CFE_Status_t CFE_SB_GetPipeName(char *PipeNameBuf, size_t PipeNameSize, CFE_SB_P
 
     if (Status == CFE_SUCCESS)
     {
-        CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPENAME_EID, CFE_EVS_EventType_DEBUG, CFE_SB_Global.AppId,
+        CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPENAME_INF_EID, CFE_EVS_EventType_INFORMATION, CFE_SB_Global.AppId,
                                    "GetPipeName name=%s id=%lu", PipeNameBuf, CFE_RESOURCEID_TO_ULONG(PipeId));
     }
     else
@@ -866,7 +866,7 @@ CFE_Status_t CFE_SB_GetPipeIdByName(CFE_SB_PipeId_t *PipeIdPtr, const char *Pipe
 
     if (Status == CFE_SUCCESS)
     {
-        CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPEIDBYNAME_EID, CFE_EVS_EventType_DEBUG, CFE_SB_Global.AppId,
+        CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPEIDBYNAME_INF_EID, CFE_EVS_EventType_INFORMATION, CFE_SB_Global.AppId,
                                    "PipeIdByName name=%s id=%lu", PipeName, CFE_RESOURCEID_TO_ULONG(*PipeIdPtr));
     }
 
@@ -1130,10 +1130,10 @@ int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, CFE_SB_
             break;
     }
 
-    /* If no other event pending, send a debug event indicating success */
+    /* If no other event pending, send an informational event indicating success */
     if (Status == CFE_SUCCESS && PendingEventID == 0)
     {
-        CFE_EVS_SendEventWithAppID(CFE_SB_SUBSCRIPTION_RCVD_EID, CFE_EVS_EventType_DEBUG, CFE_SB_Global.AppId,
+        CFE_EVS_SendEventWithAppID(CFE_SB_SUBSCRIPTION_RCVD_INF_EID, CFE_EVS_EventType_INFORMATION, CFE_SB_Global.AppId,
                                    "Subscription Rcvd:MsgId 0x%x on PipeId %lu,app %s",
                                    (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(PipeId),
                                    CFE_SB_GetAppTskName(TskId, FullName));
@@ -1318,11 +1318,11 @@ int32 CFE_SB_UnsubscribeFull(CFE_SB_MsgId_t MsgId, CFE_SB_PipeId_t PipeId, uint8
             break;
     }
 
-    /* if no other event pending, send a debug event for successful unsubscribe */
+    /* if no other event pending, send an informational event for successful unsubscribe */
     if (Status == CFE_SUCCESS && PendingEventID == 0)
     {
-        CFE_EVS_SendEventWithAppID(CFE_SB_SUBSCRIPTION_REMOVED_EID, CFE_EVS_EventType_DEBUG, CFE_SB_Global.AppId,
-                                   "Subscription Removed:Msg 0x%x on pipe %lu,app %s",
+        CFE_EVS_SendEventWithAppID(CFE_SB_SUBSCRIPTION_REMOVED_INF_EID, CFE_EVS_EventType_INFORMATION,
+                                   CFE_SB_Global.AppId, "Subscription Removed:Msg 0x%x on pipe %lu,app %s",
                                    (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(PipeId),
                                    CFE_SB_GetAppTskName(TskId, FullName));
     }

--- a/modules/sb/fsw/src/cfe_sb_task.c
+++ b/modules/sb/fsw/src/cfe_sb_task.c
@@ -271,7 +271,7 @@ int32 CFE_SB_AppInit(void)
     CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE",
         CFE_SRC_VERSION, CFE_BUILD_CODENAME, CFE_LAST_OFFICIAL);
     Status =
-        CFE_EVS_SendEvent(CFE_SB_INIT_EID, CFE_EVS_EventType_INFORMATION, "cFE SB Initialized: %s", VersionString);
+        CFE_EVS_SendEvent(CFE_SB_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "cFE SB Initialized: %s", VersionString);
     if (Status != CFE_SUCCESS)
     {
         CFE_ES_WriteToSysLog("%s: Error sending init event:RC=0x%08X\n", __func__, (unsigned int)Status);
@@ -292,7 +292,7 @@ int32 CFE_SB_NoopCmd(const CFE_SB_NoopCmd_t *data)
     char VersionString[CFE_CFG_MAX_VERSION_STR_LEN];
     CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE",
         CFE_SRC_VERSION, CFE_BUILD_CODENAME, CFE_LAST_OFFICIAL);
-    CFE_EVS_SendEvent(CFE_SB_CMD0_RCVD_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", VersionString);
+    CFE_EVS_SendEvent(CFE_SB_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", VersionString);
     CFE_SB_Global.HKTlmMsg.Payload.CommandCounter++;
 
     return CFE_SUCCESS;
@@ -306,7 +306,7 @@ int32 CFE_SB_NoopCmd(const CFE_SB_NoopCmd_t *data)
  *-----------------------------------------------------------------*/
 int32 CFE_SB_ResetCountersCmd(const CFE_SB_ResetCountersCmd_t *data)
 {
-    CFE_EVS_SendEvent(CFE_SB_CMD1_RCVD_EID, CFE_EVS_EventType_DEBUG, "Reset Counters Cmd Rcvd");
+    CFE_EVS_SendEvent(CFE_SB_RESET_INF_EID, CFE_EVS_EventType_INFORMATION, "Reset Counters Cmd Rcvd");
 
     CFE_SB_ResetCounters();
 
@@ -419,7 +419,7 @@ int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data)
         else
         {
             DestPtr->Active = CFE_SB_ACTIVE;
-            PendingEventID  = CFE_SB_ENBL_RTE2_EID;
+            PendingEventID  = CFE_SB_ENBL_RTE2_INF_EID;
             CFE_SB_Global.HKTlmMsg.Payload.CommandCounter++;
         }
     }
@@ -438,9 +438,10 @@ int32 CFE_SB_EnableRouteCmd(const CFE_SB_EnableRouteCmd_t *data)
                               "Enbl Route Cmd:Invalid Param.Msg 0x%x,Pipe %lu",
                               (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(CmdPtr->Pipe));
             break;
-        case CFE_SB_ENBL_RTE2_EID:
-            CFE_EVS_SendEvent(CFE_SB_ENBL_RTE2_EID, CFE_EVS_EventType_DEBUG, "Enabling Route,Msg 0x%x,Pipe %lu",
-                              (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(CmdPtr->Pipe));
+        case CFE_SB_ENBL_RTE2_INF_EID:
+            CFE_EVS_SendEvent(CFE_SB_ENBL_RTE2_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Enabling Route,Msg 0x%x,Pipe %lu", (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+                              CFE_RESOURCEID_TO_ULONG(CmdPtr->Pipe));
             break;
     }
 
@@ -486,7 +487,7 @@ int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data)
         else
         {
             DestPtr->Active = CFE_SB_INACTIVE;
-            PendingEventID  = CFE_SB_DSBL_RTE2_EID;
+            PendingEventID  = CFE_SB_DSBL_RTE2_INF_EID;
             CFE_SB_Global.HKTlmMsg.Payload.CommandCounter++;
         }
     }
@@ -505,9 +506,10 @@ int32 CFE_SB_DisableRouteCmd(const CFE_SB_DisableRouteCmd_t *data)
                               "Disable Route Cmd:Invalid Param.Msg 0x%x,Pipe %lu",
                               (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(CmdPtr->Pipe));
             break;
-        case CFE_SB_DSBL_RTE2_EID:
-            CFE_EVS_SendEvent(CFE_SB_DSBL_RTE2_EID, CFE_EVS_EventType_DEBUG, "Route Disabled,Msg 0x%x,Pipe %lu",
-                              (unsigned int)CFE_SB_MsgIdToValue(MsgId), CFE_RESOURCEID_TO_ULONG(CmdPtr->Pipe));
+        case CFE_SB_DSBL_RTE2_INF_EID:
+            CFE_EVS_SendEvent(CFE_SB_DSBL_RTE2_INF_EID, CFE_EVS_EventType_INFORMATION,
+                              "Route Disabled,Msg 0x%x,Pipe %lu", (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+                              CFE_RESOURCEID_TO_ULONG(CmdPtr->Pipe));
             break;
     }
 
@@ -567,7 +569,7 @@ int32 CFE_SB_SendStatsCmd(const CFE_SB_SendSbStatsCmd_t *data)
     CFE_SB_TimeStampMsg(CFE_MSG_PTR(CFE_SB_Global.StatTlmMsg.TelemetryHeader));
     CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_SB_Global.StatTlmMsg.TelemetryHeader), true);
 
-    CFE_EVS_SendEvent(CFE_SB_SND_STATS_EID, CFE_EVS_EventType_DEBUG, "Software Bus Statistics packet sent");
+    CFE_EVS_SendEvent(CFE_SB_SND_STATS_INF_EID, CFE_EVS_EventType_INFORMATION, "Software Bus Statistics packet sent");
 
     CFE_SB_Global.HKTlmMsg.Payload.CommandCounter++;
 

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -392,7 +392,7 @@ void Test_SB_Main_RcvErr(void)
 
     CFE_UtAssert_EVENTCOUNT(7);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_INIT_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_INIT_INF_EID);
 
     CFE_UtAssert_EVENTSENT(CFE_SB_Q_RD_ERR_EID);
 
@@ -443,8 +443,8 @@ void Test_SB_Main_Nominal(void)
 
     CFE_UtAssert_EVENTCOUNT(6);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_INIT_EID);
-    CFE_UtAssert_EVENTSENT(CFE_SB_CMD0_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_INIT_INF_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_NOOP_INF_EID);
 
     /* remove the handler so the pipe can be deleted */
     UT_SetHandlerFunction(UT_KEY(OS_QueueGet), NULL, NULL);
@@ -518,7 +518,7 @@ void Test_SB_Cmds_Noop(void)
 
     CFE_UtAssert_EVENTCOUNT(1);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_CMD0_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_NOOP_INF_EID);
 
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, CFE_MSG_PTR(Noop.SBBuf), 0, UT_TPID_CFE_SB_CMD_NOOP_CC);
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
@@ -542,7 +542,7 @@ void Test_SB_Cmds_RstCtrs(void)
 
     CFE_UtAssert_EVENTCOUNT(1);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_CMD1_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_RESET_INF_EID);
 
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, CFE_MSG_PTR(ResetCounters.SBBuf), 0,
                     UT_TPID_CFE_SB_CMD_RESET_COUNTERS_CC);
@@ -586,7 +586,7 @@ void Test_SB_Cmds_Stats(void)
     /* No subs event and command processing event */
     CFE_UtAssert_EVENTCOUNT(5);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_SND_STATS_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SND_STATS_INF_EID);
 
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, CFE_MSG_PTR(SendSbStats.SBBuf), 0, UT_TPID_CFE_SB_CMD_SEND_SB_STATS_CC);
     CFE_UtAssert_EVENTSENT(CFE_SB_LEN_ERR_EID);
@@ -617,9 +617,9 @@ void Test_SB_Cmds_RoutingInfoDef(void)
 
     CFE_UtAssert_EVENTCOUNT(5);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_INIT_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_INIT_INF_EID);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_INF_EID);
 
     /* Also test with a bad file name - should generate CFE_SB_SND_RTG_ERR1_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_ParseInputFileNameEx), 1, CFE_FS_INVALID_PATH);
@@ -765,7 +765,7 @@ void Test_SB_Cmds_PipeInfoDef(void)
 
     CFE_UtAssert_EVENTCOUNT(3);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_INF_EID);
 
     /* Also test with a bad file name - should generate CFE_SB_SND_RTG_ERR1_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_ParseInputFileNameEx), 1, CFE_FS_INVALID_PATH);
@@ -968,9 +968,9 @@ void Test_SB_Cmds_MapInfoDef(void)
 
     CFE_UtAssert_EVENTCOUNT(10);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_INF_EID);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_INF_EID);
 
     /* Also test with a bad file name - should generate CFE_SB_SND_RTG_ERR1_EID */
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_ParseInputFileNameEx), 1, CFE_FS_INVALID_PATH);
@@ -1039,11 +1039,11 @@ void Test_SB_Cmds_EnRouteValParam(void)
 
     CFE_UtAssert_EVENTCOUNT(3);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_INF_EID);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_INF_EID);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_ENBL_RTE2_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_ENBL_RTE2_INF_EID);
 
     /* Bad Size */
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, CFE_MSG_PTR(EnableRoute.SBBuf), 0, UT_TPID_CFE_SB_CMD_ENABLE_ROUTE_CC);
@@ -1080,8 +1080,8 @@ void Test_SB_Cmds_EnRouteNonExist(void)
 
     CFE_UtAssert_EVENTCOUNT(4);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_INF_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_INF_EID);
     CFE_UtAssert_EVENTSENT(CFE_SB_ENBL_RTE1_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId1));
@@ -1187,11 +1187,11 @@ void Test_SB_Cmds_DisRouteValParam(void)
 
     CFE_UtAssert_EVENTCOUNT(3);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_INF_EID);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_INF_EID);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_DSBL_RTE2_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_DSBL_RTE2_INF_EID);
 
     /* Bad Size */
     UT_CallTaskPipe(CFE_SB_ProcessCmdPipePkt, CFE_MSG_PTR(DisableRoute.SBBuf), 0, UT_TPID_CFE_SB_CMD_DISABLE_ROUTE_CC);
@@ -1228,8 +1228,8 @@ void Test_SB_Cmds_DisRouteNonExist(void)
 
     CFE_UtAssert_EVENTCOUNT(4);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_INF_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_INF_EID);
     CFE_UtAssert_EVENTSENT(CFE_SB_DSBL_RTE1_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId1));
@@ -1453,7 +1453,7 @@ void Test_SB_Cmds_SendPrevSubs(void)
         CFE_UtAssert_EVENTCOUNT(NumEvts);
     }
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_INF_EID);
     CFE_UtAssert_EVENTSENT(CFE_SB_SEND_NO_SUBS_EID);
     CFE_UtAssert_EVENTSENT(CFE_SB_FULL_SUB_PKT_EID);
     CFE_UtAssert_EVENTSENT(CFE_SB_PART_SUB_PKT_EID);
@@ -1683,7 +1683,7 @@ void Test_CreatePipe_ValPipeDepth(void)
 
     CFE_UtAssert_EVENTCOUNT(2);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_INF_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeIdReturned[0]));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeIdReturned[1]));
@@ -1865,8 +1865,8 @@ void Test_DeletePipe_NoSubs(void)
 
     CFE_UtAssert_EVENTCOUNT(2);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
-    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_DELETED_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_INF_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_DELETED_INF_EID);
 }
 
 /*
@@ -1890,8 +1890,8 @@ void Test_DeletePipe_WithSubs(void)
 
     CFE_UtAssert_EVENTCOUNT(6);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
-    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_DELETED_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_INF_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_DELETED_INF_EID);
 }
 
 /*
@@ -2034,7 +2034,7 @@ void Test_GetPipeName(void)
 
     CFE_UtAssert_SUCCESS(CFE_SB_GetPipeName(PipeName, sizeof(PipeName), PipeId));
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_GETPIPENAME_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_GETPIPENAME_INF_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
 }
@@ -2103,7 +2103,7 @@ void Test_GetPipeIdByName(void)
                      sizeof(CFE_SB_Global.PipeTbl[0].SysQueueId), false);
 
     CFE_UtAssert_SUCCESS(CFE_SB_GetPipeIdByName(&PipeIdOut, "TestPipe1"));
-    CFE_UtAssert_EVENTSENT(CFE_SB_GETPIPEIDBYNAME_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_GETPIPEIDBYNAME_INF_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
 }
@@ -2154,7 +2154,7 @@ void Test_SetPipeOpts(void)
 
     CFE_UtAssert_SUCCESS(CFE_SB_SetPipeOpts(PipeID, 0));
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_SETPIPEOPTS_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SETPIPEOPTS_INF_EID);
 
     UT_SetDeferredRetcode(UT_KEY(CFE_ES_GetAppID), 1, CFE_ES_ERR_RESOURCEID_NOT_VALID);
     UtAssert_INT32_EQ(CFE_SB_SetPipeOpts(PipeID, 0), CFE_ES_ERR_RESOURCEID_NOT_VALID);
@@ -2202,7 +2202,7 @@ void Test_GetPipeOpts(void)
 
     CFE_UtAssert_SUCCESS(CFE_SB_GetPipeOpts(PipeID, &Opts));
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_GETPIPEOPTS_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_GETPIPEOPTS_INF_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeID));
 }
@@ -2243,8 +2243,8 @@ void Test_Subscribe_SubscribeEx(void)
 
     CFE_UtAssert_EVENTCOUNT(2);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_INF_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_INF_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
 }
@@ -2302,7 +2302,7 @@ void Test_Subscribe_MaxMsgLim(void)
 
     CFE_UtAssert_EVENTCOUNT(2);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_INF_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
 }
@@ -2323,7 +2323,7 @@ void Test_Subscribe_DuplicateSubscription(void)
 
     CFE_UtAssert_EVENTCOUNT(4);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_INF_EID);
     CFE_UtAssert_EVENTSENT(CFE_SB_DUP_SUBSCRIP_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
@@ -2345,8 +2345,8 @@ void Test_Subscribe_LocalSubscription(void)
 
     CFE_UtAssert_EVENTCOUNT(2);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_INF_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_INF_EID);
 
     /* Test_Subscribe_LocalSubscription with message
      * limit greater than CFE_PLATFORM_SB_DEFAULT_MSG_LIMIT
@@ -2390,7 +2390,7 @@ void Test_Subscribe_MaxDestCount(void)
 
     CFE_UtAssert_EVENTCOUNT((2 * CFE_PLATFORM_SB_MAX_DEST_PER_PKT) + 3);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_INF_EID);
     CFE_UtAssert_EVENTSENT(CFE_SB_MAX_DESTS_MET_EID);
 
     /* Delete pipes */
@@ -2610,7 +2610,7 @@ void Test_Unsubscribe_Basic(void)
 
     CFE_UtAssert_EVENTCOUNT(3);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_INF_EID);
 
     /* Check unsubscribe after unsubscribe produces event */
     UT_ClearEventHistory();
@@ -2640,7 +2640,7 @@ void Test_Unsubscribe_AppId(void)
 
     CFE_UtAssert_EVENTCOUNT(3);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_INF_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe));
 }
@@ -2661,7 +2661,7 @@ void Test_Unsubscribe_Local(void)
 
     CFE_UtAssert_EVENTCOUNT(4);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_INF_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe));
 }
@@ -2813,8 +2813,8 @@ void Test_Unsubscribe_FirstDestWithMany(void)
 
     CFE_UtAssert_EVENTCOUNT(7);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_REMOVED_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_INF_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_REMOVED_INF_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe2));
@@ -2844,8 +2844,8 @@ void Test_Unsubscribe_MiddleDestWithMany(void)
 
     CFE_UtAssert_EVENTCOUNT(7);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_REMOVED_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_INF_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_REMOVED_INF_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe2));
@@ -2876,8 +2876,8 @@ void Test_Unsubscribe_GetDestPtr(void)
 
     CFE_UtAssert_EVENTCOUNT(5);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_REMOVED_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_INF_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_REMOVED_INF_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe1));
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(TestPipe2));
@@ -3416,7 +3416,7 @@ void Test_MessageTxn_ReportSingleEvent(void)
     UtAssert_BOOL_TRUE(CFE_SB_MessageTxn_ReportSingleEvent(&Txn, &Entry, CFE_SB_Q_WR_ERR_EID));
     CFE_UtAssert_EVENTCOUNT(2);
     CFE_UtAssert_EVENTSENT(CFE_SB_Q_WR_ERR_EID);
-    CFE_UtAssert_EVENTSENT(CFE_SB_GETPIPENAME_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_GETPIPENAME_INF_EID);
 
     /* Check that the loop-avoidance works */
     CFE_SB_RequestToSendEvent(MyTskId, CFE_SB_MSG_TOO_BIG_EID_BIT);
@@ -3654,7 +3654,7 @@ void Test_TransmitMsg_UpdateHeader(void)
     UtAssert_STUB_COUNT(CFE_MSG_GetNextSequenceCount, 2);
 
     CFE_UtAssert_EVENTCOUNT(2);
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_INF_EID);
 
     CFE_UtAssert_SETUP(CFE_SB_Unsubscribe(MsgId, PipeId)); /* should have no subscribers now */
 
@@ -3956,7 +3956,7 @@ void Test_TransmitBuffer_IncrementSeqCnt(void)
 
     CFE_UtAssert_EVENTCOUNT(2);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_INF_EID);
 
     /* Test again with message validation failure */
     SendPtr = CFE_SB_AllocateMessageBuffer(sizeof(SB_UT_Test_Tlm_t));
@@ -4018,7 +4018,7 @@ void Test_TransmitBuffer_NoIncrement(void)
 
     CFE_UtAssert_EVENTCOUNT(2);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_INF_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
 }
@@ -4091,7 +4091,7 @@ void Test_TransmitMsg_DisabledDestination(void)
 
     CFE_UtAssert_EVENTCOUNT(2);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_INF_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
 }
@@ -4239,7 +4239,7 @@ void Test_ReceiveBuffer_Poll(void)
 
     CFE_UtAssert_EVENTCOUNT(1);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_INF_EID);
     UtAssert_UINT8_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgReceiveErrorCounter, 0);
     UtAssert_UINT8_EQ(CFE_SB_Global.HKTlmMsg.Payload.InternalErrorCounter, 0);
 
@@ -4263,7 +4263,7 @@ void Test_ReceiveBuffer_Timeout(void)
 
     CFE_UtAssert_EVENTCOUNT(1);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_INF_EID);
     UtAssert_UINT8_EQ(CFE_SB_Global.HKTlmMsg.Payload.MsgReceiveErrorCounter, 0);
     UtAssert_UINT8_EQ(CFE_SB_Global.HKTlmMsg.Payload.InternalErrorCounter, 0);
 
@@ -4330,7 +4330,7 @@ void Test_ReceiveBuffer_PendForever(void)
     UtAssert_ADDRESS_EQ(&PipeDscPtr->LastBuffer->Content, SBBufPtr);
 
     CFE_UtAssert_EVENTCOUNT(2);
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_INF_EID);
 
     /* Ensure that calling a second time with no message clears the LastBuffer reference */
     UtAssert_INT32_EQ(CFE_SB_ReceiveBuffer(&SBBufPtr, PipeId, CFE_SB_PEND_FOREVER), CFE_SB_NO_MESSAGE);
@@ -4397,9 +4397,9 @@ void Test_CleanupApp_API(void)
 
     CFE_UtAssert_EVENTCOUNT(2);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_INF_EID);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_DELETED_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_DELETED_INF_EID);
 }
 
 /*
@@ -4754,8 +4754,8 @@ void Test_OS_MutSem_ErrLogic(void)
 
     CFE_UtAssert_EVENTCOUNT(2);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_EID);
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_PIPE_ADDED_INF_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_INF_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
 }
@@ -4919,8 +4919,8 @@ void Test_ReceiveBuffer_UnsubResubPath(void)
 
     CFE_UtAssert_EVENTCOUNT(4);
 
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_EID);
-    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_REMOVED_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_RCVD_INF_EID);
+    CFE_UtAssert_EVENTSENT(CFE_SB_SUBSCRIPTION_REMOVED_INF_EID);
 
     CFE_UtAssert_TEARDOWN(CFE_SB_DeletePipe(PipeId));
 }

--- a/modules/tbl/config/default_cfe_tbl_fcncodes.h
+++ b/modules/tbl/config/default_cfe_tbl_fcncodes.h
@@ -89,7 +89,7 @@
 **       the following telemetry:
 **       - \b \c \TBL_CMDPC - command execution counter will
 **         be reset to 0
-**       - The #CFE_TBL_RESET_INF_EID debug event message will be
+**       - The #CFE_TBL_RESET_INF_EID informational event message will be
 **         generated
 **
 **  \par Error Conditions
@@ -317,7 +317,7 @@
 **       - \b \c \TBL_CMDPC -  command execution counter will
 **         increment
 **       - The generation of either #CFE_TBL_OVERWRITE_REG_DUMP_INF_EID
-**         or #CFE_TBL_WRITE_REG_DUMP_INF_EID debug event messages
+**         or #CFE_TBL_WRITE_REG_DUMP_INF_EID informational event messages
 **       - The specified file should appear (or be updated) at the
 **         specified location in the file system
 **
@@ -358,7 +358,7 @@
 **       following telemetry:
 **       - \b \c \TBL_CMDPC -  command execution counter will increment
 **       - Receipt of a Table Registry Info Packet (see #CFE_TBL_TableRegistryTlm_t)
-**       - The #CFE_TBL_TLM_REG_CMD_INF_EID debug event message will
+**       - The #CFE_TBL_TLM_REG_CMD_INF_EID informational event message will
 **         be generated
 **
 **  \par Error Conditions

--- a/modules/tbl/eds/cfe_tbl.xml
+++ b/modules/tbl/eds/cfe_tbl.xml
@@ -416,7 +416,7 @@
           \par  Command Verification
           Successful execution of this command may be verified with the following telemetry:
           - \b \c \TBL_CMDPC - command execution counter will increment
-          - The #CFE_TBL_RESET_INF_EID debug event message will be generated
+          - The #CFE_TBL_RESET_INF_EID informational event message will be generated
 
           \par  Error Conditions
           There are no error conditions for this command. If the Table
@@ -660,7 +660,7 @@
           following telemetry:
           - \b \c \TBL_CMDPC -  command execution counter will increment
           - The generation of either #CFE_TBL_OVERWRITE_REG_DUMP_INF_EID
-          or #CFE_TBL_WRITE_REG_DUMP_INF_EID debug event messages
+          or #CFE_TBL_WRITE_REG_DUMP_INF_EID informational event messages
           - The specified file should appear (or be updated) at the
           specified location in the file system
 
@@ -705,7 +705,7 @@
           following telemetry:
           - \b \c \TBL_CMDPC -  command execution counter will increment
           - Receipt of a Table Registry Info Packet (see #CFE_TBL_TblRegPacket_t)
-          - The #CFE_TBL_TLM_REG_CMD_INF_EID debug event message will
+          - The #CFE_TBL_TLM_REG_CMD_INF_EID informational event message will
           be generated
 
           \par  Error Conditions

--- a/modules/tbl/fsw/inc/cfe_tbl_eventids.h
+++ b/modules/tbl/fsw/inc/cfe_tbl_eventids.h
@@ -55,7 +55,7 @@
 /**
  * \brief TBL Reset Counters Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
@@ -100,7 +100,7 @@
 /**
  * \brief TBL Write Table Registry To Existing File Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
@@ -131,12 +131,12 @@
  *
  *  TBL load table pending notification successfully sent.
  */
-#define CFE_TBL_LOAD_PEND_REQ_INF_EID 17
+#define CFE_TBL_LOAD_PEND_REQ_DBG_EID 17
 
 /**
  * \brief TBL Telemeter Table Registry Entry Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
@@ -159,7 +159,7 @@
 /**
  * \brief TBL Write Table Registry To New File Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *

--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
@@ -339,7 +339,7 @@ int32 CFE_TBL_ResetCountersCmd(const CFE_TBL_ResetCountersCmd_t *data)
     CFE_TBL_Global.NumValRequests      = 0;
     CFE_TBL_Global.ValidationCounter   = 0;
 
-    CFE_EVS_SendEvent(CFE_TBL_RESET_INF_EID, CFE_EVS_EventType_DEBUG, "Reset Counters command");
+    CFE_EVS_SendEvent(CFE_TBL_RESET_INF_EID, CFE_EVS_EventType_INFORMATION, "Reset Counters command");
 
     return CFE_TBL_DONT_INC_CTR;
 }
@@ -940,7 +940,7 @@ int32 CFE_TBL_ActivateCmd(const CFE_TBL_ActivateCmd_t *data)
                 /* If application requested notification by message, then do so */
                 if (CFE_TBL_SendNotificationMsg(RegRecPtr) == CFE_SUCCESS)
                 {
-                    CFE_EVS_SendEvent(CFE_TBL_LOAD_PEND_REQ_INF_EID, CFE_EVS_EventType_DEBUG,
+                    CFE_EVS_SendEvent(CFE_TBL_LOAD_PEND_REQ_DBG_EID, CFE_EVS_EventType_DEBUG,
                                       "Tbl Services notifying App that '%s' has a load pending", TableName);
                 }
 
@@ -1103,14 +1103,14 @@ void CFE_TBL_DumpRegistryEventHandler(void *Meta, CFE_FS_FileWriteEvent_t Event,
         case CFE_FS_FileWriteEvent_COMPLETE:
             if (StatePtr->FileExisted)
             {
-                CFE_EVS_SendEventWithAppID(CFE_TBL_OVERWRITE_REG_DUMP_INF_EID, CFE_EVS_EventType_DEBUG,
+                CFE_EVS_SendEventWithAppID(CFE_TBL_OVERWRITE_REG_DUMP_INF_EID, CFE_EVS_EventType_INFORMATION,
                                            CFE_TBL_Global.TableTaskAppId,
                                            "Successfully overwrote '%s' with Table Registry:Size=%d,Entries=%d",
                                            StatePtr->FileWrite.FileName, (int)Position, (int)RecordNum);
             }
             else
             {
-                CFE_EVS_SendEventWithAppID(CFE_TBL_WRITE_REG_DUMP_INF_EID, CFE_EVS_EventType_DEBUG,
+                CFE_EVS_SendEventWithAppID(CFE_TBL_WRITE_REG_DUMP_INF_EID, CFE_EVS_EventType_INFORMATION,
                                            CFE_TBL_Global.TableTaskAppId,
                                            "Successfully dumped Table Registry to '%s':Size=%d,Entries=%d",
                                            StatePtr->FileWrite.FileName, (int)Position, (int)RecordNum);
@@ -1227,7 +1227,7 @@ int32 CFE_TBL_SendRegistryCmd(const CFE_TBL_SendRegistryCmd_t *data)
         /* Change the index used to identify what data is to be telemetered */
         CFE_TBL_Global.HkTlmTblRegIndex = RegIndex;
 
-        CFE_EVS_SendEvent(CFE_TBL_TLM_REG_CMD_INF_EID, CFE_EVS_EventType_DEBUG,
+        CFE_EVS_SendEvent(CFE_TBL_TLM_REG_CMD_INF_EID, CFE_EVS_EventType_INFORMATION,
                           "Table Registry entry for '%s' will be telemetered", TableName);
 
         /* Increment Successful Command Counter */

--- a/modules/time/config/default_cfe_time_fcncodes.h
+++ b/modules/time/config/default_cfe_time_fcncodes.h
@@ -50,7 +50,7 @@
 **       Successful execution of this command may be verified with the
 **       following telemetry:
 **       - \b \c \TIME_CMDPC - command execution counter will increment
-**       - The #CFE_TIME_NOOP_EID informational event message will be generated
+**       - The #CFE_TIME_NOOP_INF_EID informational event message will be generated
 **
 **  \par Error Conditions
 **       There are no error conditions for this command. If the Time
@@ -95,7 +95,7 @@
 **       following telemetry:
 **       - \b \c \TIME_CMDPC - command execution counter will reset to 0
 **       - \b \c \TIME_CMDEC - command error counter will reset to 0
-**       - The #CFE_TIME_RESET_EID informational event message will be generated
+**       - The #CFE_TIME_RESET_INF_EID informational event message will be generated
 **
 **  \par Error Conditions
 **       There are no error conditions for this command. If the Time
@@ -129,7 +129,7 @@
 **       following telemetry:
 **       - \b \c \TIME_CMDPC - command execution counter will increment
 **       - Sequence Counter for #CFE_TIME_DiagnosticTlm_t will increment
-**       - The #CFE_TIME_DIAG_EID debug event message will be generated
+**       - The #CFE_TIME_DIAG_INF_EID informational event message will be generated
 **
 **  \par Error Conditions
 **       There are no error conditions for this command. If the Time

--- a/modules/time/eds/cfe_time.xml
+++ b/modules/time/eds/cfe_time.xml
@@ -495,7 +495,7 @@
           Successful execution of this command may be verified with the
           following telemetry:
           - \b \c \TIME_CMDPC - command execution counter will increment
-          - The #CFE_TIME_NOOP_EID informational event message will be generated
+          - The #CFE_TIME_NOOP_INF_EID informational event message will be generated
 
           \par  Error Conditions
           There are no error conditions for this command. If the Time
@@ -541,7 +541,7 @@
           Successful execution of this command may be verified with the
           following telemetry:
           - \b \c \TIME_CMDPC - command execution counter will increment
-          - The #CFE_TIME_RESET_EID informational event message will be generated
+          - The #CFE_TIME_RESET_INF_EID informational event message will be generated
 
           \par  Error Conditions
           There are no error conditions for this command. If the Time
@@ -577,7 +577,7 @@
           following telemetry:
           - \b \c \TIME_CMDPC - command execution counter will increment
           - Sequence Counter for #CFE_TIME_DiagPacket_t will increment
-          - The #CFE_TIME_DIAG_EID debug event message will be generated
+          - The #CFE_TIME_DIAG_INF_EID informational event message will be generated
 
           \par  Error Conditions
           There are no error conditions for this command. If the Time

--- a/modules/time/fsw/inc/cfe_time_eventids.h
+++ b/modules/time/fsw/inc/cfe_time_eventids.h
@@ -50,29 +50,29 @@
  *
  *  \link #CFE_TIME_NOOP_CC TIME NO-OP Command \endlink success.
  */
-#define CFE_TIME_NOOP_EID 4
+#define CFE_TIME_NOOP_INF_EID 4
 
 /**
  * \brief TIME Reset Counters Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_TIME_RESET_COUNTERS_CC TIME Reset Counters Command \endlink success.
  */
-#define CFE_TIME_RESET_EID 5
+#define CFE_TIME_RESET_INF_EID 5
 
 /**
  * \brief TIME Request Diagnostics Command Success Event ID
  *
- *  \par Type: DEBUG
+ *  \par Type: INFORMATION
  *
  *  \par Cause:
  *
  *  \link #CFE_TIME_SEND_DIAGNOSTIC_CC TIME Request Diagnostics Command \endlink success.
  */
-#define CFE_TIME_DIAG_EID 6
+#define CFE_TIME_DIAG_INF_EID 6
 
 /**
  * \brief TIME Set Time State Command Success Event ID

--- a/modules/time/fsw/src/cfe_time_dispatch.c
+++ b/modules/time/fsw/src/cfe_time_dispatch.c
@@ -139,7 +139,7 @@ void CFE_TIME_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
                 case CFE_TIME_SEND_DIAGNOSTIC_CC:
                     if (CFE_TIME_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_TIME_SendDiagnosticCmd_t)))
                     {
-                        CFE_TIME_SendDiagnosticTlm((const CFE_TIME_SendDiagnosticCmd_t *)SBBufPtr);
+                        CFE_TIME_SendDiagnosticTlmCmd((const CFE_TIME_SendDiagnosticCmd_t *)SBBufPtr);
                     }
                     break;
 

--- a/modules/time/fsw/src/cfe_time_task.c
+++ b/modules/time/fsw/src/cfe_time_task.c
@@ -453,7 +453,7 @@ int32 CFE_TIME_NoopCmd(const CFE_TIME_NoopCmd_t *data)
 
     CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE", CFE_SRC_VERSION, CFE_BUILD_CODENAME,
                                 CFE_LAST_OFFICIAL);
-    CFE_EVS_SendEvent(CFE_TIME_NOOP_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", VersionString);
+    CFE_EVS_SendEvent(CFE_TIME_NOOP_INF_EID, CFE_EVS_EventType_INFORMATION, "No-op Cmd Rcvd: %s", VersionString);
 
     return CFE_SUCCESS;
 }
@@ -491,7 +491,7 @@ int32 CFE_TIME_ResetCountersCmd(const CFE_TIME_ResetCountersCmd_t *data)
     CFE_TIME_Global.InternalCount = 0;
     CFE_TIME_Global.ExternalCount = 0;
 
-    CFE_EVS_SendEvent(CFE_TIME_RESET_EID, CFE_EVS_EventType_DEBUG, "Reset Counters command");
+    CFE_EVS_SendEvent(CFE_TIME_RESET_INF_EID, CFE_EVS_EventType_INFORMATION, "Reset Counters command");
 
     return CFE_SUCCESS;
 }
@@ -502,7 +502,7 @@ int32 CFE_TIME_ResetCountersCmd(const CFE_TIME_ResetCountersCmd_t *data)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
-int32 CFE_TIME_SendDiagnosticTlm(const CFE_TIME_SendDiagnosticCmd_t *data)
+int32 CFE_TIME_SendDiagnosticTlmCmd(const CFE_TIME_SendDiagnosticCmd_t *data)
 {
     CFE_TIME_Global.CommandCounter++;
 
@@ -517,7 +517,7 @@ int32 CFE_TIME_SendDiagnosticTlm(const CFE_TIME_SendDiagnosticCmd_t *data)
     CFE_SB_TimeStampMsg(CFE_MSG_PTR(CFE_TIME_Global.DiagPacket.TelemetryHeader));
     CFE_SB_TransmitMsg(CFE_MSG_PTR(CFE_TIME_Global.DiagPacket.TelemetryHeader), true);
 
-    CFE_EVS_SendEvent(CFE_TIME_DIAG_EID, CFE_EVS_EventType_DEBUG, "Request diagnostics command");
+    CFE_EVS_SendEvent(CFE_TIME_DIAG_INF_EID, CFE_EVS_EventType_INFORMATION, "Request diagnostics command");
 
     return CFE_SUCCESS;
 }

--- a/modules/time/fsw/src/cfe_time_utils.h
+++ b/modules/time/fsw/src/cfe_time_utils.h
@@ -790,7 +790,7 @@ int32 CFE_TIME_SubDelayCmd(const CFE_TIME_SubDelayCmd_t *data);
 /**
  * @brief  Time task ground command (diagnostics)
  */
-int32 CFE_TIME_SendDiagnosticTlm(const CFE_TIME_SendDiagnosticCmd_t *data);
+int32 CFE_TIME_SendDiagnosticTlmCmd(const CFE_TIME_SendDiagnosticCmd_t *data);
 
 /*---------------------------------------------------------------------------------------*/
 /**

--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -1409,7 +1409,7 @@ void Test_PipeCmds(void)
     UT_InitData();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.noopcmd), UT_TPID_CFE_TIME_CMD_NOOP_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TIME_NOOP_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_NOOP_INF_EID);
 
     /* Noop with bad size */
     UT_InitData();
@@ -1435,7 +1435,7 @@ void Test_PipeCmds(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.resetcounterscmd),
                     UT_TPID_CFE_TIME_CMD_RESET_COUNTERS_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TIME_RESET_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_RESET_INF_EID);
 
     /* Confirm error counters get reset to help cover requirements that are difficult operationally */
     UtAssert_ZERO(CFE_TIME_Global.ToneMatchCounter);
@@ -1463,7 +1463,7 @@ void Test_PipeCmds(void)
     memset(&CmdBuf, 0, sizeof(CmdBuf));
     UT_CallTaskPipe(CFE_TIME_TaskPipe, &CmdBuf.message, sizeof(CmdBuf.diagtlmcmd),
                     UT_TPID_CFE_TIME_CMD_SEND_DIAGNOSTIC_TLM_CC);
-    CFE_UtAssert_EVENTSENT(CFE_TIME_DIAG_EID);
+    CFE_UtAssert_EVENTSENT(CFE_TIME_DIAG_INF_EID);
 
     /* Request diagnostics with bad size */
     UT_InitData();


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1712
  - Converts successful command EIDs to `INFO` type
  - Couple of event-type related typos etc. fixed along the way

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
As above.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt