### PR TITLE
Fix #2576, Runtime Error in coverage-es-ALL, TestApps

### DIFF
--- a/modules/es/fsw/src/cfe_es_apps.c
+++ b/modules/es/fsw/src/cfe_es_apps.c
@@ -207,7 +207,7 @@ void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath)
                     BuffLen++;
 
                     ++NumTokens;
-                    if (NumTokens < CFE_ES_STARTSCRIPT_MAX_TOKENS_PER_LINE)
+                    if (NumTokens < CFE_ES_STARTSCRIPT_MAX_TOKENS_PER_LINE && !LineTooLong)
                     {
                         /*
                          * NOTE: pointer never dereferenced unless "LineTooLong" is false.


### PR DESCRIPTION
Fix #2576, Runtime Error was detected when running coverage-es-ALL-testrunner in TestApps. Resolved buffer overflow.

**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
A clear and concise description of what the contribution is.
- Include explicitly what issue it addresses [e.g. Fixes #X]
Fix #2576, Resolved buffer overflow in CFE_ES_StartApplications

**Testing performed**
Steps taken to test the contribution:
Running with the following options:

add_compile_options(
-fsanitize=address
-fsanitize=undefined
-fsanitize-recover=all
-g
)
add_link_options(
-fsanitize=address
-fsanitize=undefined
-fsanitize-recover=all
)

1. make SIMULATION=native ENABLE_UNIT_TESTS=true prep
2. make install
3. Run Test
4. make test
5. make lcov

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - API Change: xxx (if applicable)
 - Behavior Change: xxx (if applicable)
 - Or no impact to behavior

**System(s) tested on**
 - Hardware: [e.g. PC, SP0, MCP750]
 - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
 - Note CLAs apply to only software contributions.
Anh Van, GSFC
