### PR TITLE
Fix #2581, Adding bytes read check

### DIFF
--- a/modules/fs/fsw/src/cfe_fs_api.c
+++ b/modules/fs/fsw/src/cfe_fs_api.c
@@ -138,6 +138,12 @@ CFE_Status_t CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, osal_id_t FileDes)
         */
         OsStatus = OS_read(FileDes, Hdr, sizeof(CFE_FS_Header_t));
 
+        /* Check if the read was successful */
+        if (OsStatus != sizeof(CFE_FS_Header_t)) 
+        {
+            return CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
+        }
+
         /* Determine if this processor is a little endian processor */
         /* cppcheck-suppress knownConditionTrueFalse */
         if ((*(char *)(&EndianCheck)) == 0x04)

--- a/modules/fs/fsw/src/cfe_fs_api.c
+++ b/modules/fs/fsw/src/cfe_fs_api.c
@@ -152,11 +152,7 @@ CFE_Status_t CFE_FS_ReadHeader(CFE_FS_Header_t *Hdr, osal_id_t FileDes)
             /* its standard big-endian format into a little endian format to ease user access    */
             CFE_FS_ByteSwapCFEHeader(Hdr);
         }
-    }
 
-    if (OsStatus >= OS_SUCCESS)
-    {
-        /* The "OsStatus" reflects size actually read */
         Result = (long)OsStatus;
     }
     else

--- a/modules/fs/ut-coverage/fs_UT.c
+++ b/modules/fs/ut-coverage/fs_UT.c
@@ -122,6 +122,11 @@ void Test_CFE_FS_ReadHeader(void)
     UT_SetDefaultReturnValue(UT_KEY(OS_read), OS_ERROR);
     UtAssert_INT32_EQ(CFE_FS_ReadHeader(&Hdr, FileDes), CFE_STATUS_EXTERNAL_RESOURCE_FAIL);
 
+    /* Test partial success with reading header */
+    UT_InitData();
+    UT_SetDefaultReturnValue(UT_KEY(OS_read), 1);
+    UtAssert_INT32_EQ(CFE_FS_ReadHeader(&Hdr, FileDes), CFE_STATUS_EXTERNAL_RESOURCE_FAIL);
+
     /* Test successfully reading the header */
     UT_InitData();
     UtAssert_INT32_EQ(CFE_FS_ReadHeader(&Hdr, FileDes), sizeof(Hdr));


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**

Fixes #2581
- Checks the return value of the read operation done in cfe_fs_api.c to make sure the correct number of bytes was read.
- Handles cases where the read operation fails or reads fewer bytes than expected, preventing the use of uninitialized or partially initialized data.

**Testing performed**

Added a unit test to simulate scenario where the file read operation reads fewer bytes than expected.

**Expected behavior changes**

When a read operation fails, the system now exits the function early, preventing potential undefined behavior.

**System(s) tested on**
 
OS: Ubuntu 18.04

**Contributor Info - All information REQUIRED for consideration of pull request**

Tvisha Andharia - GSFC 582 intern
