### PR TITLE
Fix #2582, Cast to unsigned int

### DIFF
--- a/modules/msg/fsw/src/cfe_msg_sechdr_time.c
+++ b/modules/msg/fsw/src/cfe_msg_sechdr_time.c
@@ -92,8 +92,8 @@ CFE_Status_t CFE_MSG_GetMsgTime(const CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTim
     }
 
     /* Get big endian time fields with default 32/16 layout */
-    Time->Subseconds = (tlm->Sec.Time[4] << 24) + (tlm->Sec.Time[5] << 16);
-    Time->Seconds    = (tlm->Sec.Time[0] << 24) + (tlm->Sec.Time[1] << 16) + (tlm->Sec.Time[2] << 8) + tlm->Sec.Time[3];
+    Time->Subseconds = ((unsigned int)tlm->Sec.Time[4] << 24) + ((unsigned int)tlm->Sec.Time[5] << 16);
+    Time->Seconds    = ((unsigned int)tlm->Sec.Time[0] << 24) + ((unsigned int)tlm->Sec.Time[1] << 16) + ((unsigned int)tlm->Sec.Time[2] << 8) + (unsigned int)tlm->Sec.Time[3];
 
     return CFE_SUCCESS;
 }

--- a/modules/msg/fsw/src/cfe_msg_sechdr_time.c
+++ b/modules/msg/fsw/src/cfe_msg_sechdr_time.c
@@ -92,8 +92,8 @@ CFE_Status_t CFE_MSG_GetMsgTime(const CFE_MSG_Message_t *MsgPtr, CFE_TIME_SysTim
     }
 
     /* Get big endian time fields with default 32/16 layout */
-    Time->Subseconds = ((unsigned int)tlm->Sec.Time[4] << 24) + ((unsigned int)tlm->Sec.Time[5] << 16);
-    Time->Seconds    = ((unsigned int)tlm->Sec.Time[0] << 24) + ((unsigned int)tlm->Sec.Time[1] << 16) + ((unsigned int)tlm->Sec.Time[2] << 8) + (unsigned int)tlm->Sec.Time[3];
+    Time->Subseconds = ((uint32)tlm->Sec.Time[4] << 24) + ((uint32)tlm->Sec.Time[5] << 16);
+    Time->Seconds    = ((uint32)tlm->Sec.Time[0] << 24) + ((uint32)tlm->Sec.Time[1] << 16) + ((uint32)tlm->Sec.Time[2] << 8) + (uint32)tlm->Sec.Time[3];
 
     return CFE_SUCCESS;
 }


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**

Fixes #2582
- cfe_msg_sechdr_time.c promotes the byte (unsigned char) to a signed integer before the shift operation, which can cause overflow on a 32-bit machine.
- Modified the code to cast the bytes to unsigned integers before performing the shift operations to avoid overflow issues.

**Testing performed**

Unit Testing

**Expected behavior changes**

Reduced risk of overflow-related bugs.

**System(s) tested on**
 
OS: Ubuntu 18.04

**Contributor Info - All information REQUIRED for consideration of pull request**

Tvisha Andharia - GSFC 582 intern