### PR TITLE
Fix #2588, Split up CFE_TBL_Load and remove early returns

### DIFF
--- a/modules/tbl/fsw/src/cfe_tbl_internal.h
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.h
@@ -717,7 +717,7 @@ CFE_TBL_LoadBuff_t *CFE_TBL_GetInactiveBuffer(CFE_TBL_RegistryRec_t *RegRecPtr);
 ** \param BufferSelect The buffer to obtain (active or inactive)
 ** \returns Pointer to the selected table buffer
 */
-CFE_TBL_LoadBuff_t *CFE_TBL_GetSelectedBuffer(CFE_TBL_RegistryRec_t *     RegRecPtr,
+CFE_TBL_LoadBuff_t *CFE_TBL_GetSelectedBuffer(CFE_TBL_RegistryRec_t      *RegRecPtr,
                                               CFE_TBL_BufferSelect_Enum_t BufferSelect);
 
 /*---------------------------------------------------------------------------------------*/
@@ -745,6 +745,90 @@ CFE_TBL_LoadBuff_t *CFE_TBL_GetSelectedBuffer(CFE_TBL_RegistryRec_t *     RegRec
 */
 CFE_TBL_ValidationResult_t *CFE_TBL_CheckValidationRequest(CFE_TBL_ValidationResultId_t *ValIdPtr);
 
+/*---------------------------------------------------------------------------------------*/
+/**
+** \brief Load data into a Dump-Only Table
+**
+** \par Description
+** This function loads data into a Dump-Only Table. It ensures that the table is only loaded once
+** and that the address is defined by the application. If the table has already been loaded or
+** the address is not user-defined, an error event is sent.
+**
+** \param RegRecPtr  Pointer to Table Registry Record for table to be loaded.
+** \param AppName    The name of the application attempting to load the table.
+** \param SrcDataPtr Pointer to the source data to be loaded into the table.
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS           \copybrief CFE_SUCCESS
+** \retval #CFE_TBL_ERR_DUMP_ONLY \copybrief CFE_TBL_ERR_DUMP_ONLY
+*/
+CFE_Status_t CFE_TBL_LoadDumpOnlyTable(CFE_TBL_RegistryRec_t *RegRecPtr, const char *AppName, const void *SrcDataPtr);
+
+/**
+** \brief Load data into a working buffer for a table
+**
+** \par Description
+** This function loads data into a working buffer from a specified source type (file or memory address).
+** The function also handles partial loads and computes the CRC for the loaded data.
+**
+** \param SrcType          The type of source (file or memory address).
+** \param AppName          The name of the application attempting to load the buffer.
+** \param WorkingBufferPtr Pointer to the working buffer where data will be loaded.
+** \param RegRecPtr        Pointer to the table registry record.
+** \param SrcDataPtr       Pointer to the source data (file name or memory address).
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS               \copybrief CFE_SUCCESS
+** \retval #CFE_TBL_WARN_PARTIAL_LOAD \copybrief CFE_TBL_WARN_PARTIAL_LOAD
+** \retval #CFE_TBL_ERR_PARTIAL_LOAD  \copybrief CFE_TBL_ERR_PARTIAL_LOAD
+** \retval #CFE_TBL_ERR_ILLEGAL_SRC_TYPE \copybrief CFE_TBL_ERR_ILLEGAL_SRC_TYPE
+*/
+CFE_Status_t CFE_TBL_LoadWorkingBuffer(const CFE_TBL_SrcEnum_t SrcType, const char *AppName,
+                                       CFE_TBL_LoadBuff_t *WorkingBufferPtr, CFE_TBL_RegistryRec_t *RegRecPtr,
+                                       const void *SrcDataPtr);
+
+/**
+** \brief Validate the contents of a working buffer for a table
+**
+** \par Description
+** This function validates the contents of a working buffer using the validation function
+** specified in the table registry record.
+**
+** \param RegRecPtr        Pointer to the Table Registry record.
+** \param WorkingBufferPtr Pointer to the working buffer to be validated.
+** \param AppName          The name of the application attempting to validate the buffer.
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS                    \copybrief CFE_SUCCESS
+** \retval #CFE_STATUS_VALIDATION_FAILURE  \copybrief CFE_STATUS_VALIDATION_FAILURE
+*/
+CFE_Status_t CFE_TBL_ValidateWorkingBufferContents(CFE_TBL_RegistryRec_t *RegRecPtr,
+                                                   CFE_TBL_LoadBuff_t *WorkingBufferPtr, const char *AppName);
+
+/**
+** \brief Perform the update of a table's working buffer
+**
+** \par Description
+** This function performs the update of a table's working buffer. If this is the first load, the
+** data is directly loaded into the active buffer. If not the first load, the data is moved from
+** the inactive buffer to the active buffer.
+** For first-time loads, the function also updates the table registry with the data source information
+** and notifies table users of the update. If the table is a critical table, the CDS is also updated.
+**
+** \param RegRecPtr        Pointer to the Table Registry record.
+** \param TblHandle        Handle of the table to be updated.
+** \param AccessDescPtr    Pointer to the access descriptor for the table.
+** \param AppName          The name of the application performing the update.
+** \param WorkingBufferPtr Pointer to the working buffer containing the data to be loaded.
+** \param IsFirstTime      Boolean indicating if this is the first load of the table.
+**
+** \return Execution status, see \ref CFEReturnCodes
+** \retval #CFE_SUCCESS                    \copybrief CFE_SUCCESS
+** \retval #CFE_TBL_UPDATE_ERR_EID         \copybrief CFE_TBL_UPDATE_ERR_EID
+*/
+CFE_Status_t CFE_TBL_PerformUpdate(CFE_TBL_RegistryRec_t *RegRecPtr, const CFE_TBL_Handle_t TblHandle,
+                                   CFE_TBL_AccessDescriptor_t *AccessDescPtr, const char *AppName,
+                                   const CFE_TBL_LoadBuff_t *WorkingBufferPtr, const bool IsFirstTime);
 /*
 ** Globals specific to the TBL module
 */

--- a/modules/tbl/ut-coverage/tbl_UT.c
+++ b/modules/tbl/ut-coverage/tbl_UT.c
@@ -2273,7 +2273,7 @@ void Test_CFE_TBL_Load(void)
      */
     UT_InitData();
     UT_SetDeferredRetcode(UT_KEY(Test_CFE_TBL_ValidationFunc), 1, 1);
-    UtAssert_INT32_EQ(CFE_TBL_Load(App1TblHandle1, CFE_TBL_SRC_ADDRESS, &TestTable1), -1);
+    UtAssert_INT32_EQ(CFE_TBL_Load(App1TblHandle1, CFE_TBL_SRC_ADDRESS, &TestTable1), CFE_STATUS_VALIDATION_FAILURE);
     CFE_UtAssert_EVENTSENT(CFE_TBL_LOAD_VAL_ERR_EID);
     CFE_UtAssert_EVENTCOUNT(2);
 


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2588
  - Splits the functionality of `CFE_TBL_Load()` into 4 helper functions
  - Removes all except the first 2 early returns (by introducing a new boolean status guard `StillProcessing`) - allowing us to move `CFE_TBL_TxnFinish()` to the end of the function
  - `CFE_TBL_Load()` reduced from 223 -> 123 lines (and cyclomatic complexity roughly halved)

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.) + some basic sanity checking with a cFS suite run, loading of a table etc.

**Expected behavior changes**
This PR minimises complexity of `CFE_TBL_Load()` thereby easing future maintenance/testing/refactoring. Logic is largely unchanged here, other than the points mentioned above.

**System(s) tested on**
Debian GNU/Linux 12 (bookworm)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt