### PR TITLE
Fix #2592, Yield cpu to other tasks in SB Perf Test

### DIFF
--- a/modules/cfe_testcase/src/sb_performance_test.c
+++ b/modules/cfe_testcase/src/sb_performance_test.c
@@ -402,7 +402,7 @@ void UT_CommandTransmitterTask(void)
     BulkCmd.XmitFinished = true;
 }
 
-void UT_TelemtryTransmitterTask(void)
+void UT_TelemetryTransmitterTask(void)
 {
     CFE_SB_Buffer_t *            BufPtr;
     CFE_TEST_TestTlmMessage32_t *TlmMsgPtr;
@@ -533,7 +533,7 @@ void TestBulkTransferMulti4(void)
         CFE_ES_CreateChildTask(&BulkCmd.TaskIdXmit, "CmdXmit", UT_CommandTransmitterTask, NULL, 32768, 150, 0),
         CFE_SUCCESS);
     UtAssert_INT32_EQ(
-        CFE_ES_CreateChildTask(&BulkTlm.TaskIdXmit, "TlmXmit", UT_TelemtryTransmitterTask, NULL, 32768, 150, 0),
+        CFE_ES_CreateChildTask(&BulkTlm.TaskIdXmit, "TlmXmit", UT_TelemetryTransmitterTask, NULL, 32768, 150, 0),
         CFE_SUCCESS);
     UtAssert_INT32_EQ(
         CFE_ES_CreateChildTask(&BulkCmd.TaskIdRecv, "CmdRecv", UT_CommandReceiverTask, NULL, 32768, 100, 0),

--- a/modules/cfe_testcase/src/sb_performance_test.c
+++ b/modules/cfe_testcase/src/sb_performance_test.c
@@ -209,6 +209,9 @@ void RunSingleCmdSendRecv(void)
             UtAssert_UINT32_EQ(CmdPtr->Payload.Value, CmdMsg.Payload.Value);
             break;
         }
+
+        /* Yield cpu to other task with same priority */
+        OS_TaskDelay(0);
     }
 
     CFE_PSP_GetTime(&BulkCmd.EndTime);
@@ -255,6 +258,9 @@ void RunSingleTlmSendRecv(void)
             UtAssert_UINT32_EQ(TlmPtr->Payload.Value, TlmMsg.Payload.Value);
             break;
         }
+
+        /* Yield cpu to other task with same priority */
+        OS_TaskDelay(0);
     }
 
     CFE_PSP_GetTime(&BulkTlm.EndTime);
@@ -388,6 +394,9 @@ void UT_CommandTransmitterTask(void)
             CFE_Assert_STATUS_MUST_BE(CFE_SUCCESS);
             break;
         }
+
+        /* Yield cpu to other task with same priority */
+        OS_TaskDelay(0);
     }
 
     BulkCmd.XmitFinished = true;
@@ -424,6 +433,9 @@ void UT_TelemtryTransmitterTask(void)
             CFE_Assert_STATUS_MUST_BE(CFE_SUCCESS);
             break;
         }
+
+        /* Yield cpu to other task with same priority */
+        OS_TaskDelay(0);
     }
 
     BulkTlm.XmitFinished = true;

--- a/modules/cfe_testcase/src/sb_performance_test.c
+++ b/modules/cfe_testcase/src/sb_performance_test.c
@@ -37,6 +37,9 @@
 /* Number of messages to send during test */
 uint32_t UT_BulkTestDuration = 1000;
 
+/* Number of SB messages sent before yielding CPU (has to be power of 2 minus 1)*/
+static uint32_t UT_CpuYieldMask = 1024 - 1;
+
 /* State structure for multicore test - shared between threads */
 typedef struct UT_BulkMultiCoreSharedState
 {
@@ -210,8 +213,12 @@ void RunSingleCmdSendRecv(void)
             break;
         }
 
-        /* Yield cpu to other task with same priority */
-        OS_TaskDelay(0);
+        /* Only yield CPU once in a while to avoid slowing down the test with too many context switches */
+        if ((BulkCmd.SendCount & UT_CpuYieldMask) == 0)
+        {
+            /* Yield cpu to other task with same priority */
+            OS_TaskDelay(0);
+        }
     }
 
     CFE_PSP_GetTime(&BulkCmd.EndTime);
@@ -259,8 +266,12 @@ void RunSingleTlmSendRecv(void)
             break;
         }
 
-        /* Yield cpu to other task with same priority */
-        OS_TaskDelay(0);
+        /* Only yield CPU once in a while to avoid slowing down the test with too many context switches */
+        if ((BulkTlm.SendCount & UT_CpuYieldMask) == 0)
+        {
+            /* Yield cpu to other task with same priority */
+            OS_TaskDelay(0);
+        }
     }
 
     CFE_PSP_GetTime(&BulkTlm.EndTime);
@@ -395,8 +406,12 @@ void UT_CommandTransmitterTask(void)
             break;
         }
 
-        /* Yield cpu to other task with same priority */
-        OS_TaskDelay(0);
+        /* Only yield CPU once in a while to avoid slowing down the test with too many context switches */
+        if ((BulkCmd.SendCount & UT_CpuYieldMask) == 0)
+        {
+            /* Yield cpu to other task with same priority */
+            OS_TaskDelay(0);
+        }
     }
 
     BulkCmd.XmitFinished = true;
@@ -434,8 +449,12 @@ void UT_TelemetryTransmitterTask(void)
             break;
         }
 
-        /* Yield cpu to other task with same priority */
-        OS_TaskDelay(0);
+        /* Only yield CPU once in a while to avoid slowing down the test with too many context switches */
+        if ((BulkTlm.SendCount & UT_CpuYieldMask) == 0)
+        {
+            /* Yield cpu to other task with same priority */
+            OS_TaskDelay(0);
+        }
     }
 
     BulkTlm.XmitFinished = true;


### PR DESCRIPTION
Depends on #2591 and #2996

**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2592 Greatly increase timeout on SB Perf test to give command tasks enough time to finish before exiting the telemetry receiver task.
- Fix a typo in Telemetry task name

**Testing performed**
Steps taken to test the contribution:
1. Ran functional test using RTEMS on MUSTANG processor card

**Expected behavior changes**
SB performance tests runs to completion

**System(s) tested on**
 - Hardware: MUSTANG Proc card
 - OS: RTEMS 5
 - Versions: latest on main as of today

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Jose F Martinez Pedraza / GSFC 582
