### PR TITLE
Fix #2610, Enforce keeping coverage minimums up-to-date in Code Coverage CI workflow

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -13,7 +13,9 @@ env:
   ENABLE_UNIT_TESTS: true
   OMIT_DEPRECATED: true
   BUILDTYPE: debug
-
+  ALLOWED_MISSED_BRANCHES: 39
+  ALLOWED_MISSED_LINES: 17
+  ALLOWED_MISSED_FUNCTIONS: 0
 jobs:
 
   #Check for duplicate actions. Skips push actions if there is a matching or duplicate pull-request action.
@@ -105,17 +107,64 @@ jobs:
 
       - name: Confirm Minimum Coverage
         run: |
-          missed_branches=39
-          missed_lines=19
           branch_nums=$(grep -A 3 "Overall coverage rate" lcov_out.txt | grep branches | grep -oP "[0-9]+[0-9]*")
           line_nums=$(grep -A 3 "Overall coverage rate" lcov_out.txt | grep lines | grep -oP "[0-9]+[0-9]*")
+          function_nums=$(grep -A 3 "Overall coverage rate" lcov_out.txt | grep functions | grep -oP "[0-9]+[0-9]*")
 
           branch_diff=$(echo $branch_nums | awk '{ print $4 - $3 }')
+          echo "branch_diff=$branch_diff" >> $GITHUB_ENV
           line_diff=$(echo $line_nums | awk '{ print $4 - $3 }')
-          if [ $branch_diff -gt $missed_branches ] || [ $line_diff -gt $missed_lines ]
+          echo "line_diff=$line_diff" >> $GITHUB_ENV
+          function_diff=$(echo $function_nums | awk '{ print $4 - $3 }')
+          echo "function_diff=$function_diff" >> $GITHUB_ENV
+
+          if [ $branch_diff -gt ${{ env.ALLOWED_MISSED_BRANCHES }} ]
           then
             grep -A 3 "Overall coverage rate" lcov_out.txt
-            echo "$branch_diff branches missed, $missed_branches allowed"
-            echo "$line_diff lines missed, $missed_lines allowed"
+            echo "::error::$branch_diff uncovered branch$([ $branch_diff -ne 1 ] && echo 'es') reported, but only ${{ env.ALLOWED_MISSED_BRANCHES }} ${{ env.ALLOWED_MISSED_BRANCHES == 1 && 'is' || 'are' }} allowed."
+            exit -1
+          fi
+
+          if [ $line_diff -gt ${{ env.ALLOWED_MISSED_LINES }} ]
+          then
+            grep -A 3 "Overall coverage rate" lcov_out.txt
+            echo "::error::$line_diff uncovered line$([ $line_diff -ne 1 ] && echo 's') reported, but only ${{ env.ALLOWED_MISSED_LINES }} ${{ env.ALLOWED_MISSED_LINES == 1 && 'is' || 'are' }} allowed."
+            exit -1
+          fi
+
+          if [ $function_diff -gt ${{ env.ALLOWED_MISSED_FUNCTIONS }} ]
+          then
+            grep -A 3 "Overall coverage rate" lcov_out.txt
+            echo "::error::$function_diff uncovered function$([ $function_diff -ne 1 ] && echo 's') reported, but only ${{ env.ALLOWED_MISSED_FUNCTIONS }} ${{ env.ALLOWED_MISSED_FUNCTIONS == 1 && 'is' || 'are' }} allowed."
+            exit -1
+          fi
+
+      - name: Enforce Keeping Branch Coverage Minimum Up-To-Date
+        run: |
+          if [ $branch_diff -lt ${{ env.ALLOWED_MISSED_BRANCHES }} ]
+          then
+            grep -A 3 "Overall coverage rate" lcov_out.txt
+            echo "::error::$branch_diff uncovered branch$([ $branch_diff -ne 1 ] && echo 'es') reported, but ${{ env.ALLOWED_MISSED_BRANCHES }} ${{ env.ALLOWED_MISSED_BRANCHES == 1 && 'is' || 'are' }} allowed."
+            echo "::error::Please update (lower) the 'ALLOWED_MISSED_BRANCHES' variable to $branch_diff in order to match the new coverage level."
+            exit -1
+          fi
+
+      - name: Enforce Keeping Line Coverage Minimum Up-To-Date
+        run: |
+          if [ $line_diff -lt ${{ env.ALLOWED_MISSED_LINES }} ]
+          then
+            grep -A 3 "Overall coverage rate" lcov_out.txt
+            echo "::error::$line_diff uncovered line$([ $line_diff -ne 1 ] && echo 's') reported, but ${{ env.ALLOWED_MISSED_LINES }} ${{ env.ALLOWED_MISSED_LINES == 1 && 'is' || 'are' }} allowed."
+            echo "::error::Please update (lower) the 'ALLOWED_MISSED_LINES' variable to $line_diff in order to match the new coverage level."
+            exit -1
+          fi
+
+      - name: Enforce Keeping Function Coverage Minimum Up-To-Date
+        run: |
+          if [ $function_diff -lt ${{ env.ALLOWED_MISSED_FUNCTIONS }} ]
+          then
+            grep -A 3 "Overall coverage rate" lcov_out.txt
+            echo "::error::$function_diff uncovered function$([ $function_diff -ne 1 ] && echo 's') reported, but ${{ env.ALLOWED_MISSED_FUNCTIONS }} ${{ env.ALLOWED_MISSED_FUNCTIONS == 1 && 'is' || 'are' }} allowed."
+            echo "::error::Please update (lower) the 'ALLOWED_MISSED_FUNCTIONS' variable to $function_diff in order to match the new coverage level."
             exit -1
           fi


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Lowers `allowed_missed_lines` to 17 (from 19)
- Fixes #2610 
  - Adds additional steps in the code coverage workflow to check that the missed functions/lines/branches variables are kept up-to-date.

**Testing performed**
Tested all variations of coverage thresholds (above, below, split between functions/lines/branches etc.) to confirm expected behavior.

New checks:
![Screenshot 2024-10-11 18 28 42](https://github.com/user-attachments/assets/595e0f20-2756-48fd-8fd5-9ccaf78736a7)

**Expected behavior changes**
Any PR that improves coverage will cause the workflow to fail now unless the `ALLOWED_MISSED_BRANCHES`, `ALLOWED_MISSED_LINES` and/or `ALLOWED_MISSED_FUNCTIONS` variables are updated as part of the same PR. This will avoid cases like the present, where there is a gap, and a new PR could theoretically reduce coverage but give no warning of the fact.

**System(s) tested on**
Debian GNU/Linux 11 (bullseye)
Current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt