### PR TITLE
Fix #2618, Correct syntax for variable APP_NAME in arch_build.cmake

### DIFF
--- a/cmake/arch_build.cmake
+++ b/cmake/arch_build.cmake
@@ -109,7 +109,7 @@ function(add_cfe_app APP_NAME APP_SRC_FILES)
   # By linking with the respective application like this, the net result is that
   # only the _referenced_ EDS DBs (i.e. those for loaded apps) are held in memory.
   if (CFE_EDS_ENABLED_BUILD AND CFE_EDS_LINK_MODE STREQUAL LOCAL)
-    target_link_libraries($(APP_NAME) cfe_edsdb_static)
+    target_link_libraries(${APP_NAME} cfe_edsdb_static)
   endif()
 
   # An "install" step is only needed for dynamic/runtime loaded apps

--- a/cmake/mission_build.cmake
+++ b/cmake/mission_build.cmake
@@ -22,7 +22,7 @@
 # FUNCTION: initialize_globals
 #
 # Set up global mission configuration variables.
-# In the top level mode (this file)t reads extracts  state info from
+# In the top level mode (this file) reads and extracts state info from
 # configuration files within the project source tree (the _defs directory)
 #
 function(initialize_globals)


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2618
  - fix variable `APP_NAME` to be referenced using braces instead of parentheses

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Correct CMake syntax - I'm actually not sure if this worked somehow anyway beforehand or not.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt