### PR TITLE
Fix #2620, Correct cfe_testcase typos + minor bugs

### DIFF
--- a/modules/cfe_assert/src/cfe_assert_runner.c
+++ b/modules/cfe_assert/src/cfe_assert_runner.c
@@ -138,7 +138,7 @@ bool CFE_Assert_Status_DeferredCheck(CFE_Status_t Status, UtAssert_CaseType_t Ca
         }
         else
         {
-            /* if condition was false add an exta marker so user does not necessarily need to decode the string */
+            /* if condition was false, add an extra marker so user does not necessarily need to decode the string */
             ExtraTag = " [false]";
         }
 

--- a/modules/cfe_testcase/src/cfe_test.c
+++ b/modules/cfe_testcase/src/cfe_test.c
@@ -58,7 +58,7 @@ void CFE_TestMain(void)
      * Register test cases in UtAssert
      */
     ESApplicationControlTestSetup();
-    ESBehaviorestSetup();
+    ESBehaviorTestSetup();
     ESCDSTestSetup();
     ESCounterTestSetup();
     ESErrorTestSetup();

--- a/modules/cfe_testcase/src/cfe_test.h
+++ b/modules/cfe_testcase/src/cfe_test.h
@@ -72,7 +72,7 @@ void TimeInRange(CFE_TIME_SysTime_t Start, CFE_TIME_SysTime_t Time, CFE_TIME_Sys
 
 void CFE_TestMain(void);
 void ESApplicationControlTestSetup(void);
-void ESBehaviorestSetup(void);
+void ESBehaviorTestSetup(void);
 void ESCDSTestSetup(void);
 void ESCounterTestSetup(void);
 void ESErrorTestSetup(void);

--- a/modules/cfe_testcase/src/es_behavior_test.c
+++ b/modules/cfe_testcase/src/es_behavior_test.c
@@ -82,7 +82,7 @@ void TestWaitBehavior(void)
     UtAssert_UINT32_EQ(CFE_TIME_Compare(TimePassed, TimeExpected), CFE_TIME_A_LT_B);
 }
 
-void ESBehaviorestSetup(void)
+void ESBehaviorTestSetup(void)
 {
     UtTest_Add(TestRunCounter, NULL, NULL, "Test Run Counter");
     UtTest_Add(TestWaitBehavior, NULL, NULL, "Test Wait Behavior");

--- a/modules/cfe_testcase/src/es_mempool_test.c
+++ b/modules/cfe_testcase/src/es_mempool_test.c
@@ -174,7 +174,7 @@ void TestMemPoolPutBuf(void)
 
 void TestMemPoolDelete(void)
 {
-    CFE_ES_MemHandle_t    PoolID = CFE_ES_MEMHANDLE_UNDEFINED; /* Poo1 1 handle, no mutex */
+    CFE_ES_MemHandle_t    PoolID = CFE_ES_MEMHANDLE_UNDEFINED; /* Pool 1 handle, no mutex */
     uint8                 Buffer[1024];
     CFE_ES_MemPoolStats_t Stats;
 

--- a/modules/cfe_testcase/src/es_misc_test.c
+++ b/modules/cfe_testcase/src/es_misc_test.c
@@ -60,7 +60,7 @@ void TestCalculateCRC(void)
     UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(CRC_OTHER_INPUT, sizeof(CRC_OTHER_INPUT) - 1, 0, CFE_ES_CrcType_16_ARC),
                        0x11E3);
 
-    /* Test of nonzero initial value, this is used for checking CRC in across non-contiguous chunks or across multiple
+    /* Test of nonzero initial value, this is used for checking CRC across non-contiguous chunks or across multiple
      * cycles */
     UtAssert_UINT32_EQ(CFE_ES_CalculateCRC(CRC_CHECK_INPUT, sizeof(CRC_CHECK_INPUT) - 1, 345353, CFE_ES_CrcType_16_ARC),
                        0xE493);

--- a/modules/cfe_testcase/src/sb_pipe_mang_test.c
+++ b/modules/cfe_testcase/src/sb_pipe_mang_test.c
@@ -132,7 +132,7 @@ void TestPipeOptions(void)
 
     UtAssert_INT32_EQ(CFE_SB_SetPipeOpts(PipeId, Opts), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_SB_GetPipeOpts(PipeId, &OptsBuff), CFE_SUCCESS);
-    UtAssert_UINT32_EQ(Opts, OptsBuff);
+    UtAssert_UINT8_EQ(Opts, OptsBuff);
 
     UtAssert_INT32_EQ(CFE_SB_SetPipeOpts(CFE_SB_INVALID_PIPE, Opts), CFE_SB_BAD_ARGUMENT);
 

--- a/modules/cfe_testcase/src/tbl_content_access_test.c
+++ b/modules/cfe_testcase/src/tbl_content_access_test.c
@@ -77,7 +77,7 @@ void TestGetAddress(void)
 
 void TestReleaseAddress(void)
 {
-    UtPrintf("Testing: CFE_TBL_GetAddress");
+    UtPrintf("Testing: CFE_TBL_ReleaseAddress");
     void *               TblPtr;
     CFE_TEST_TestTable_t TestTable = {1, 2};
     /* Never loaded */

--- a/modules/cfe_testcase/src/tbl_content_mang_test.c
+++ b/modules/cfe_testcase/src/tbl_content_mang_test.c
@@ -405,7 +405,7 @@ void TblTest_GenerateTblFiles(void)
 
     /* write content, but make it identifiable/unique */
     buf.Content.Int1 = 0x1111;
-    buf.Content.Int1 = 0x2222;
+    buf.Content.Int2 = 0x2222;
     UtAssert_INT32_EQ(OS_write(fh2, &buf, sizeof(buf.Content)), sizeof(buf.Content));
 
     /* Write extra byte at the end */


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2620 
  - fix typos
  - correct `ESBehaviorestSetup` test name (should be `ESBehaviorTestSetup`)
  - correct `TblTest_GenerateTblFiles` test which initialized `buf.Content.Int1` twice, instead of `buf.Content.Int2`

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Bugs + typos corrected, improving code quality and easing future maintenance.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt