### PR TITLE
Fix #2623, Clean up command and event string typos

### DIFF
--- a/modules/core_api/fsw/inc/cfe_config.h
+++ b/modules/core_api/fsw/inc/cfe_config.h
@@ -42,7 +42,7 @@
 /**
  * @brief Obtain an integer value correlating to an CFE configuration ID
  *
- * Retreives the integer value associated with the specified key.
+ * Retrieves the integer value associated with the specified key.
  *
  * If no value has been set, or the key is not valid, this returns 0.
  *
@@ -56,7 +56,7 @@ uint32 CFE_Config_GetValue(CFE_ConfigId_t ConfigId);
 /**
  * @brief Obtain a pointer value correlating to an CFE configuration ID
  *
- * Retreives the pointer value associated with the specified key.
+ * Retrieves the pointer value associated with the specified key.
  *
  * If no value has been set, or the key is not valid, this returns NULL.
  *
@@ -70,7 +70,7 @@ const void *CFE_Config_GetObjPointer(CFE_ConfigId_t ConfigId);
 /**
  * @brief Obtain an array correlating to an CFE configuration ID
  *
- * Retreives the CFE_Config_ArrayValue_t value associated with the specified key.
+ * Retrieves the CFE_Config_ArrayValue_t value associated with the specified key.
  * This combines an array length (number of elements) and a pointer to the first element.
  *
  * If no value has been set, or the key is not valid, this returns 0 / NULL.
@@ -85,7 +85,7 @@ CFE_Config_ArrayValue_t CFE_Config_GetArrayValue(CFE_ConfigId_t ConfigId);
 /**
  * @brief Obtain a string value correlating to an CFE configuration ID
  *
- * Retreives the string value associated with the specified key.
+ * Retrieves the string value associated with the specified key.
  *
  * If no value has been set, or the key is not valid, this returns the
  * special string "UNDEFINED"
@@ -102,7 +102,7 @@ const char *CFE_Config_GetString(CFE_ConfigId_t ConfigId);
 /**
  * @brief Obtain the name of a CFE configuration ID
  *
- * Retreives the printable name associated with the specified key.
+ * Retrieves the printable name associated with the specified key.
  *
  * @note  This function does not return NULL.
  *
@@ -144,7 +144,7 @@ void CFE_Config_IterateAll(void *Arg, CFE_Config_Callback_t Callback);
  *                          with standard version string containing the provided
                             parameters (i.e.:
  *                          "cFE DEVELOPMENT BUILD equuleus-rc1+dev0 (Codename
-                            equueleus), Last Official Release: cFE 6.7.0"
+                            equuleus), Last Official Release: cFE 6.7.0"
  * @param[in]   Size        Size of the provided buffer
  * @param[in]   Component   Component for which to get version string
  *                          (i.e. "cFE")

--- a/modules/es/fsw/src/cfe_es_api.c
+++ b/modules/es/fsw/src/cfe_es_api.c
@@ -393,7 +393,7 @@ void CFE_ES_ExitApp(uint32 ExitStatus)
             }
         }
 
-    } /* end if ReturnCode == CFE_SUCCESS */
+    }
 
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 }
@@ -480,7 +480,7 @@ bool CFE_ES_RunLoop(uint32 *RunStatus)
         CFE_ES_SysLogWrite_Unsync("%s: Error getting AppID for the caller\n", __func__);
         ReturnCode = false;
 
-    } /* end if Status == CFE_SUCCESS */
+    }
 
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
@@ -1577,7 +1577,7 @@ CFE_Status_t CFE_ES_RegisterCDS(CFE_ES_CDSHandle_t *CDSHandlePtr, size_t BlockSi
 
             strncpy(CDSName, Name, sizeof(CDSName) - 1);
             CDSName[sizeof(CDSName) - 1] = '\0';
-            CFE_ES_WriteToSysLog("%s: CDS Name (%s) is too long\n", __func__, CDSName);
+            CFE_ES_WriteToSysLog("%s: CDS Name (%s) is either too long, or an empty string\n", __func__, CDSName);
         }
         else
         {

--- a/modules/es/fsw/src/cfe_es_cds.h
+++ b/modules/es/fsw/src/cfe_es_cds.h
@@ -474,22 +474,6 @@ int32 CFE_ES_ValidateCDS(void);
 
 /*---------------------------------------------------------------------------------------*/
 /**
-** \brief Initializes the CDS Registry
-**
-** \par Description
-**        Initializes the data structure used to keep track of CDS blocks and
-**        who they belong to.
-**
-** \par Assumptions, External Events, and Notes:
-**          None
-**
-** \retval #CFE_SUCCESS         \copydoc CFE_SUCCESS
-**
-******************************************************************************/
-int32 CFE_ES_InitCDSRegistry(void);
-
-/*---------------------------------------------------------------------------------------*/
-/**
 ** \brief Rebuilds memory pool for CDS and recovers existing registry
 **
 ** \par Description
@@ -599,23 +583,6 @@ int32 CFE_ES_UnlockCDS(void);
 
 /*---------------------------------------------------------------------------------------*/
 /**
-** \brief Rebuilds memory pool for CDS and recovers existing registry
-**
-** \par Description
-**        Scans memory for existing CDS and initializes memory pool and registry
-**        settings accordingly
-**
-** \par Assumptions, External Events, and Notes:
-**        -# Assumes the validity of the CDS has already been determined
-**
-** \return #CFE_SUCCESS         \copydoc CFE_SUCCESS
-** \return Any of the return values from #CFE_PSP_ReadFromCDS
-**
-******************************************************************************/
-int32 CFE_ES_RebuildCDS(void);
-
-/*---------------------------------------------------------------------------------------*/
-/**
 ** \brief Initializes the CDS Registry
 **
 ** \par Description
@@ -629,25 +596,6 @@ int32 CFE_ES_RebuildCDS(void);
 **
 ******************************************************************************/
 int32 CFE_ES_InitCDSRegistry(void);
-
-/*---------------------------------------------------------------------------------------*/
-/**
-** \brief Determines whether a CDS currently exists
-**
-** \par Description
-**        Reads a set of bytes from the beginning and end of the CDS memory
-**        area and determines if a fixed pattern is present, thus determining
-**        whether the CDS still likely contains valid data or not.
-**
-** \par Assumptions, External Events, and Notes:
-**          None
-**
-** \return #CFE_SUCCESS         \copydoc CFE_SUCCESS
-** \return #CFE_ES_CDS_INVALID  \copydoc CFE_ES_CDS_INVALID
-** \return Any of the return values from #CFE_PSP_ReadFromCDS
-**
-******************************************************************************/
-int32 CFE_ES_ValidateCDS(void);
 
 /*---------------------------------------------------------------------------------------*/
 /**

--- a/modules/evs/config/default_cfe_evs_fcncodes.h
+++ b/modules/evs/config/default_cfe_evs_fcncodes.h
@@ -329,7 +329,7 @@
 **       - \b \c \EVS_CMDPC - command execution counter will
 **       increment
 **       - The generation of #CFE_EVS_DISAPPENTTYPE_EID debug event message
-**       - The clearing of the Event Type Active Flag in The Event Type Active Flag in EVS App Data File
+**       - The clearing of the Event Type Active Flag in EVS App Data File
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):
@@ -370,7 +370,7 @@
 **       - \b \c \EVS_CMDPC - command execution counter will
 **       increment
 **       - The generation of #CFE_EVS_ENAAPPEVT_EID debug event message
-**       - The setting of the Active Flag in The Active Flag in EVS App Data File
+**       - The setting of the Active Flag in EVS App Data File
 **
 **  \par Error Conditions
 **       This command may fail for the following reason(s):

--- a/modules/evs/eds/cfe_evs.xml
+++ b/modules/evs/eds/cfe_evs.xml
@@ -50,7 +50,7 @@
         <EnumerationList>
           <Enumeration label="DEBUG" value="1" shortDescription="Events that are intended only for debugging, not nominal operations" />
           <Enumeration label="INFORMATION" value="2" shortDescription="Events that identify a state change or action that is not an error" />
-          <Enumeration label="ERROR" value="3" shortDescription="Events that identify an error but are not catastrophic (e.g. - bad command" />
+          <Enumeration label="ERROR" value="3" shortDescription="Events that identify an error but are not catastrophic (e.g. - bad command)" />
           <Enumeration label="CRITICAL" value="4" shortDescription="Events that identify errors that are unrecoverable autonomously" />
         </EnumerationList>
       </EnumeratedDataType>
@@ -846,8 +846,8 @@
           - \b \c \EVS_CMDEC - command error counter will increment
           - An Error specific event message
 
-          \par  Criticality
-          Setting an application¿s event filter mask is not particularly hazardous,
+          \par  Criticality               
+          Setting an application's event filter mask is not particularly hazardous,
           as the result may be shutting off unnecessary event messages and possible
           event flooding of the system.  However, inappropriately setting an
           application's event filter mask could result in a loss of critical

--- a/modules/evs/fsw/inc/cfe_evs_eventids.h
+++ b/modules/evs/fsw/inc/cfe_evs_eventids.h
@@ -351,7 +351,7 @@
  *
  *  \par Cause:
  *
- *  \link #CFE_EVS_RESET_ALL_FILTERS_CC EVS Reset All FIlters Command \endlink success.
+ *  \link #CFE_EVS_RESET_ALL_FILTERS_CC EVS Reset All Filters Command \endlink success.
  */
 #define CFE_EVS_RSTALLFILTER_EID 29
 

--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -640,7 +640,7 @@ CFE_Status_t CFE_SB_GetPipeOpts(CFE_SB_PipeId_t PipeId, uint8 *OptsPtr)
             break;
         case CFE_SB_GETPIPEOPTS_ID_ERR_EID:
             CFE_EVS_SendEventWithAppID(CFE_SB_GETPIPEOPTS_ID_ERR_EID, CFE_EVS_EventType_ERROR, CFE_SB_Global.AppId,
-                                       "Pipe Opts Error:Bad Argument,PipedId %lu,Requestor %s",
+                                       "Pipe Opts Error:Bad Argument,PipeId %lu,Requestor %s",
                                        CFE_RESOURCEID_TO_ULONG(PipeId), CFE_SB_GetAppTskName(TskId, FullName));
             break;
         default:


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2623
  - Clean up a few typos, duplicate header guards and event string corrections.

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
Improved clarity.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt