### PR TITLE
Fix nasa/cFS#812, Update Upload Artifact Version

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -96,7 +96,7 @@ jobs:
         working-directory: ./build/exe/cpu1/
 
       - name: Archive cFS Startup Artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: cFS-startup-log-deprecate-true-${{ matrix.buildtype }}
           path: ./build/exe/cpu1/cf/cfe_test.log


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes nasa/cFS#812

**Testing performed**
https://github.com/arielswalker/cFE/actions/runs/12916125161

**Expected behavior changes**
Functional tests workflow will not fail due to outdated upload artifacts version.

**System(s) tested on**
GitHub Actions

**Additional context**
This article, https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/, states:

"This deprecation will not impact any existing versions of GitHub Enterprise Server being used by customers."

Only the opensource workflows should be updated to use the latest version, v4. The internal workflows will fail if using v4 as seen below so it should continue to use v3.

This wiki, https://github.com/actions/upload-artifact, states:

"upload-artifact@v4+ is not currently supported on GHES yet. If you are on GHES, you must use [v3](https://github.com/actions/upload-artifact/releases/tag/v3)."

**Third party code**

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH. 
