### PR TITLE
Fix #2625, add initialization of table indices

### DIFF
--- a/modules/tbl/fsw/src/cfe_tbl_task.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task.c
@@ -164,8 +164,8 @@ int32 CFE_TBL_TaskInit(void)
     /*
     ** Task startup event message
     */
-    CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE",
-        CFE_SRC_VERSION, CFE_BUILD_CODENAME, CFE_LAST_OFFICIAL);
+    CFE_Config_GetVersionString(VersionString, CFE_CFG_MAX_VERSION_STR_LEN, "cFE", CFE_SRC_VERSION, CFE_BUILD_CODENAME,
+                                CFE_LAST_OFFICIAL);
     Status = CFE_EVS_SendEvent(CFE_TBL_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "cFE TBL Initialized: %s",
                                VersionString);
 
@@ -199,4 +199,7 @@ void CFE_TBL_InitData(void)
     /* Message ID is set when sent, so OK as 0 here */
     CFE_MSG_Init(CFE_MSG_PTR(CFE_TBL_Global.NotifyMsg.CommandHeader), CFE_SB_INVALID_MSG_ID,
                  sizeof(CFE_TBL_Global.NotifyMsg));
+
+    CFE_TBL_Global.LastValidationResultId = CFE_ResourceId_FromInteger(CFE_TBL_VALRESULTID_BASE);
+    CFE_TBL_Global.LastDumpCtrlBlockId    = CFE_ResourceId_FromInteger(CFE_TBL_DUMPCTRLID_BASE);
 }


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
The "Last" ID values that are tracked in the CFE_TBL_Global were not initialized correctly, thus making it fail to get a record.  This in turn caused the "Too many validations" issue, because it could not get a result buffer.

Fixes #2625 

**Testing performed**
- Reproduce bug as described in issue, then apply patch and confirm that the validation is now triggered successfully 
- Build and run all tests

**Expected behavior changes**
Sending the validate table command now works as expected, does not always reply with too many validations error.

**System(s) tested on**
Debian

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
