### PR TITLE
Issue #2641, Fixed Null Pointer in ES Application Control API test

### DIFF
--- a/modules/cfe_testcase/src/es_application_control_test.c
+++ b/modules/cfe_testcase/src/es_application_control_test.c
@@ -45,7 +45,7 @@ void TestApplicationControl(void)
      * error is ignored in CFE_ES_ReloadApp and file io error is returned
      * most other functions return a CFE_ES_BAD_ARGUMENT in this situation
      */
-    UtAssert_UINT32_EQ(CFE_ES_ReloadApp(TestAppId, NULL), CFE_ES_FILE_IO_ERR);
+    UtAssert_UINT32_EQ(CFE_ES_ReloadApp(TestAppId, ""), CFE_ES_FILE_IO_ERR);
     UtAssert_UINT32_EQ(CFE_ES_ReloadApp(TestAppId, "/cf/NOT_cfe_testcase.so"), CFE_ES_FILE_IO_ERR);
     UtAssert_UINT32_EQ(CFE_ES_ReloadApp(CFE_ES_APPID_UNDEFINED, "/cf/cfe_testcase.so"),
                        CFE_ES_ERR_RESOURCEID_NOT_VALID);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**

Updated the ES application control functional test for the CFE_ES_ReloadApp API to use an empty string instead of using a null pointer. 

Fixes #2641 

**Testing performed**

Built and executed the functional test and verified no failures detected in cfe_test.log file. 

**Expected behavior changes**

No impact to behavior, functional test will execute as normal.

**System(s) tested on**
 - Hardware: PC
 - OS: RedHat 8
 
**Contributor Info - All information REQUIRED for consideration of pull request**
Dwaine Molock, NASA/GSFC