### PR TITLE
Fix #2580, address sanitizer issue in coverage-evs-ALL

### DIFF
--- a/modules/evs/ut-coverage/evs_UT.c
+++ b/modules/evs/ut-coverage/evs_UT.c
@@ -292,6 +292,9 @@ void Test_Init(void)
     CFE_EVS_EnablePortsCmd_t        bitmaskcmd;
     CFE_EVS_EnableAppEventTypeCmd_t appbitcmd;
 
+    CFE_SB_Buffer_t *bufPtr;
+    CFE_EVS_NoopCmd_t testMsg;
+
     UtPrintf("Begin Test Init");
 
     memset(&bitmaskcmd, 0, sizeof(bitmaskcmd));
@@ -321,6 +324,9 @@ void Test_Init(void)
 
     /* Set unexpected message ID */
     UT_SetupBasicMsgDispatch(&UT_TPID_CFE_EVS_INVALID_MID, 0, true);
+
+    bufPtr = (CFE_SB_Buffer_t *)&testMsg; /* Fake Test Message */
+    UT_SetDataBuffer(UT_KEY(CFE_SB_ReceiveBuffer), &bufPtr, sizeof(bufPtr), false);
 
     UT_EVS_DoGenericCheckEvents(CFE_EVS_TaskMain, &UT_EVS_EventBuf);
     CFE_UtAssert_SYSLOG(EVS_SYSLOG_MSGS[8]);


### PR DESCRIPTION
Fix #2580, add in fake message to SBptr.

**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
A clear and concise description of what the contribution is.
Fix  #2580, add in fake message for software bus pointer. 

**Testing performed**
Steps taken to test the contribution:
Add in the the following options:
add_compile_options(
-fsanitize=address
-fsanitize=undefined
-fsanitize-recover=all
-g
)
add_link_options(
-fsanitize=address
-fsanitize=undefined
-fsanitize-recover=all
)

1. make SIMULATION=native ENABLE_UNIT_TESTS=true prep
2. make install
3. Run test

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - API Change: xxx (if applicable)
 - Behavior Change: xxx (if applicable)
 - Or no impact to behavior

no impact to behavior

**System(s) tested on**
 - Hardware: [e.g. PC, SP0, MCP750]
 - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
 - Note CLAs apply to only software contributions.
Anh Van, GSFC
