### PR TITLE
Fix #1399, Refactor common code out of EVS_ResetFilter functions

### DIFF
--- a/modules/evs/fsw/src/cfe_evs_utils.c
+++ b/modules/evs/fsw/src/cfe_evs_utils.c
@@ -621,3 +621,27 @@ int32 EVS_SendEvent(uint16 EventID, CFE_EVS_EventType_Enum_t EventType, const ch
 
     return CFE_SUCCESS;
 }
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 EVS_VerifyRegisteredApp(EVS_AppData_t **AppDataPtr)
+{
+    int32          Status;
+    CFE_ES_AppId_t AppID;
+
+    /* Query and verify the caller's AppID */
+    Status = EVS_GetCurrentContext(AppDataPtr, &AppID);
+    if (Status == CFE_SUCCESS)
+    {
+        if (!EVS_AppDataIsMatch(*AppDataPtr, AppID))
+        {
+            Status = CFE_EVS_APP_NOT_REGISTERED;
+        }
+    }
+
+    return Status;
+}

--- a/modules/evs/fsw/src/cfe_evs_utils.h
+++ b/modules/evs/fsw/src/cfe_evs_utils.h
@@ -252,4 +252,18 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, CFE_E
  */
 int32 EVS_SendEvent(uint16 EventID, CFE_EVS_EventType_Enum_t EventType, const char *Spec, ...);
 
+/*---------------------------------------------------------------------------------------*/
+/**
+ * @brief Verify that the calling app is registered with EVS
+ *
+ * This routine gets the current app context and verifies that the app
+ * is properly registered with EVS.
+ *
+ * @param[out]  AppDataPtr   Pointer to store the app data pointer
+ * @returns CFE_SUCCESS if app is registered
+ *          CFE_EVS_APP_ILLEGAL_APP_ID if app ID cannot be obtained
+ *          CFE_EVS_APP_NOT_REGISTERED if app is not registered with EVS
+ */
+int32 EVS_VerifyRegisteredApp(EVS_AppData_t **AppDataPtr);
+
 #endif /* CFE_EVS_UTILS_H */


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #1399
  - helper function created which pulls out the common verifications in `CFE_EVS_ResetFilter` and `CFE_EVS_ResetAllFilters`
  - can be used in other functions now as well
  - simplifies the code, and eases future maintenance

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).

**Expected behavior changes**
None.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt