### PR TITLE
Fix #2657, Remove duplication in CFE_TIME_ToneSendGPS/Time functions

### DIFF
--- a/modules/time/fsw/src/cfe_time_utils.h
+++ b/modules/time/fsw/src/cfe_time_utils.h
@@ -499,7 +499,7 @@ int32 CFE_TIME_ToneSendMET(CFE_TIME_SysTime_t NewMET);
  * "time at the tone" data command will arrive within the
  * specified window for tone and data packet verification.
  */
-int32 CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps);
+CFE_Status_t CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps);
 #endif
 
 #if (CFE_PLATFORM_TIME_CFG_SRC_TIME == true)
@@ -512,7 +512,7 @@ int32 CFE_TIME_ToneSendGPS(CFE_TIME_SysTime_t NewTime, int16 NewLeaps);
  * "time at the tone" data command will arrive within the
  * specified window for tone and data packet verification.
  */
-int32 CFE_TIME_ToneSendTime(CFE_TIME_SysTime_t NewTime);
+CFE_Status_t CFE_TIME_ToneSendTime(CFE_TIME_SysTime_t NewTime);
 #endif
 
 /*---------------------------------------------------------------------------------------*/


### PR DESCRIPTION
**Checklist**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/osal/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2657 
  - Removes 130 lines of identical code (except for 3 single identifiers) at the cost of 3 additional `#ifdef`'s (so it doesn't come for free).
  - Nevertheless, this improves future maintainability and simplifies the file.

**Testing performed**
GitHub CI actions all passing successfully (incl. Build + Run, Unit/Functional Tests etc.).
Coverage is maintained as the same level as before these changes.

**Expected behavior changes**
No change.

**System(s) tested on**
Debian 12 using the current main branch of cFS bundle.

**Contributor Info**
Avi Weiss &nbsp; @thnkslprpt