### PR TITLE
Fix #2523, add mutex around EVS counter increment

### DIFF
--- a/modules/evs/fsw/src/cfe_evs_utils.c
+++ b/modules/evs/fsw/src/cfe_evs_utils.c
@@ -455,6 +455,7 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, CFE_E
     CFE_EVS_LongEventTlm_t  LongEventTlm;  /* The "long" flavor is always generated, as this is what is logged */
     CFE_EVS_ShortEventTlm_t ShortEventTlm; /* The "short" flavor is only generated if selected */
     int                     ExpandedLength;
+    bool                    IsTruncated;
 
     memset(&LongEventTlm, 0, sizeof(LongEventTlm));
     memset(&ShortEventTlm, 0, sizeof(ShortEventTlm));
@@ -478,7 +479,11 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, CFE_E
     {
         /* Mark character before zero terminator to indicate truncation */
         LongEventTlm.Payload.Message[sizeof(LongEventTlm.Payload.Message) - 2] = CFE_EVS_MSG_TRUNCATED;
-        CFE_EVS_Global.EVS_TlmPkt.Payload.MessageTruncCounter++;
+        IsTruncated = true;
+    }
+    else
+    {
+        IsTruncated = false;
     }
 
     /* Obtain task and system information */
@@ -528,6 +533,11 @@ void EVS_GenerateEventTelemetry(EVS_AppData_t *AppDataPtr, uint16 EventID, CFE_E
     if (AppDataPtr->EventCount < CFE_EVS_MAX_EVENT_SEND_COUNT)
     {
         AppDataPtr->EventCount++;
+    }
+
+    if (IsTruncated)
+    {
+        CFE_EVS_Global.EVS_TlmPkt.Payload.MessageTruncCounter++;
     }
 
     OS_MutSemGive(CFE_EVS_Global.EVS_SharedDataMutexID);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Adds a mutex to protect the EVS counter increments, thus avoiding a potential race condition here.

Fixes #2523

**Testing performed**
Build and run all tests

**Expected behavior changes**
None

**System(s) tested on**
Linux

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
