### PR TITLE
Fix #2655, add counter locks

### DIFF
--- a/modules/es/fsw/src/cfe_es_api.c
+++ b/modules/es/fsw/src/cfe_es_api.c
@@ -1825,11 +1825,13 @@ CFE_Status_t CFE_ES_IncrementGenCounter(CFE_ES_CounterId_t CounterId)
     CFE_ES_GenCounterRecord_t *CountRecPtr;
 
     CountRecPtr = CFE_ES_LocateCounterRecordByID(CounterId);
+    CFE_ES_LockSharedData(__func__, __LINE__);
     if (CFE_ES_CounterRecordIsMatch(CountRecPtr, CounterId))
     {
         ++CountRecPtr->Counter;
         Status = CFE_SUCCESS;
     }
+    CFE_ES_UnlockSharedData(__func__, __LINE__);
     return Status;
 }
 
@@ -1845,11 +1847,13 @@ CFE_Status_t CFE_ES_SetGenCount(CFE_ES_CounterId_t CounterId, uint32 Count)
     CFE_ES_GenCounterRecord_t *CountRecPtr;
 
     CountRecPtr = CFE_ES_LocateCounterRecordByID(CounterId);
+    CFE_ES_LockSharedData(__func__, __LINE__);
     if (CFE_ES_CounterRecordIsMatch(CountRecPtr, CounterId))
     {
         CountRecPtr->Counter = Count;
         Status               = CFE_SUCCESS;
     }
+    CFE_ES_UnlockSharedData(__func__, __LINE__);
     return Status;
 }
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Add lock around counter increment and set.

NOTE: Generic counters are not widely used, so there is less concern about making this performant or ideal.

Fixes #2655

**Testing performed**
Build and run all validation tests

**Expected behavior changes**
No race condition in counter increments

**System(s) tested on**
Linux

**Additional context**
Just uses the same lock as the rest of ES.  This should be fine because the generic counters are not widely used.  For any app with performance concerns, that app probably has its own counter implemented in a thread-safe manner and does not use this API.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
