### PR TITLE
Fix nasa/cFS#703, Reduce stack usage in UT_CallTaskPipe

### DIFF
--- a/modules/core_private/ut-stubs/src/ut_support.c
+++ b/modules/core_private/ut-stubs/src/ut_support.c
@@ -63,6 +63,12 @@ static union
     CFE_ES_ResetData_t ResetData;
 } UT_CFE_ES_ResetData;
 
+static union
+{
+    CFE_SB_Buffer_t Buf;
+    uint8           Bytes[CFE_MISSION_SB_MAX_SB_MSG_SIZE];
+} UT_SBBuf;
+
 static uint16 UT_SendEventHistory[UT_EVENT_HISTORY_SIZE];
 static uint16 UT_SendTimedEventHistory[UT_EVENT_HISTORY_SIZE];
 static uint16 UT_SendEventAppIDHistory[UT_EVENT_HISTORY_SIZE * 10];
@@ -314,14 +320,8 @@ void UT_SetupBasicMsgDispatch(const UT_TaskPipeDispatchId_t *DispatchReq, CFE_MS
 void UT_CallTaskPipe(void (*TaskPipeFunc)(const CFE_SB_Buffer_t *), const CFE_MSG_Message_t *MsgPtr, size_t MsgSize,
                      UT_TaskPipeDispatchId_t DispatchId)
 {
-    union
-    {
-        CFE_SB_Buffer_t Buf;
-        uint8           Bytes[CFE_MISSION_SB_MAX_SB_MSG_SIZE];
-    } SBBuf;
-
     /* Copy message into aligned SB buffer */
-    memcpy(SBBuf.Bytes, MsgPtr, MsgSize);
+    memcpy(UT_SBBuf.Bytes, MsgPtr, MsgSize);
 
     /* Passing MsgSize == 0 indicates intent to perform a size validation failure */
     UT_SetupBasicMsgDispatch(&DispatchId, MsgSize, (MsgSize == 0));
@@ -329,7 +329,7 @@ void UT_CallTaskPipe(void (*TaskPipeFunc)(const CFE_SB_Buffer_t *), const CFE_MS
     /*
      * Finally, call the actual task pipe requested.
      */
-    TaskPipeFunc(&SBBuf.Buf);
+    TaskPipeFunc(&UT_SBBuf.Buf);
 
     /*
      * UN-set the stub config, as some values may point to values on stack.


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Moves the large message buffer in `UT_CallTaskPipe()` from stack to static storage. The buffer is `CFE_MISSION_SB_MAX_SB_MSG_SIZE` bytes (32KB by default), which exceeds the default RTEMS task stack size of 20KB configured in `bsp_start.c`.

Fixes nasa/cFS#703

**Testing performed**
Code review and verification that the change follows existing patterns in the file (other static buffers like `UT_CFE_ES_ResetData`).

**Expected behavior changes**
Unit tests will no longer overflow the stack on systems with constrained stack sizes (e.g., RTEMS with default 20KB stacks).

**System(s) tested on**
Code review only (macOS development environment does not support cFS build)

**Contributor Info - All information REQUIRED for consideration of pull request**
Heath Dutton