### PR TITLE
Fix #2678, do not use "target_link_libraries" with object lib

### DIFF
--- a/modules/config/tool/CMakeLists.txt
+++ b/modules/config/tool/CMakeLists.txt
@@ -39,12 +39,11 @@ foreach(SYSVAR ${TGTSYS_LIST})
   )
   target_compile_definitions(${OBJLIB_NAME} PRIVATE
     MAP_ENTRY_LIST=${OBJECT_NAME}
+    $<TARGET_PROPERTY:core_api,INTERFACE_COMPILE_DEFINITIONS>
   )
   target_include_directories(${OBJLIB_NAME} PRIVATE
     ${TEMP_ARCH_BINARY_DIR}/inc
-  )
-  target_link_libraries(${OBJLIB_NAME} PRIVATE
-    core_api
+    $<TARGET_PROPERTY:core_api,INTERFACE_INCLUDE_DIRECTORIES>
   )
 
   # If this is an EDS build, this needs to be built after the EDS tool runs


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Instead of using the target_link_libraries, use generator expressions to specify the compile definitions and include dirs

Fixes #2678

**Testing performed**
Build with CMake v3.10

**Expected behavior changes**
Builds successfully

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
