### PR TITLE
Fix #2637, write perf log data in raw buffer order

### DIFF
--- a/modules/es/fsw/src/cfe_es_perf.c
+++ b/modules/es/fsw/src/cfe_es_perf.c
@@ -348,7 +348,7 @@ bool CFE_ES_RunPerfLogDump(uint32 ElapsedTime, void *Arg)
                     break;
 
                 case CFE_ES_PerfDumpState_WRITE_PERF_ENTRIES:
-                    State->DataPos      = Perf->MetaData.DataStart;
+                    State->DataPos      = 0;
                     State->StateCounter = Perf->MetaData.DataCount;
                     break;
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
The perf log dump reorders data entries by starting the write loop from `MetaData.DataStart`, but the metadata written to the file still contains the original `DataStart`/`DataEnd` indices. Consumers that use those indices to parse the file end up skipping entries.

- Fixes #2637

**Testing performed**
1. Built within cFS bundle with `SIMULATION=native ENABLE_UNIT_TESTS=true`
2. Ran ES unit tests -- all 1346 pass, including all 122 perf-specific tests

**Expected behavior changes**
- Behavior Change: Perf log file now contains data in raw circular buffer order (index 0 through N) instead of reordered from DataStart. The metadata indices are now consistent with the data layout, so existing perf log tools will correctly process all entries.

**System(s) tested on**
- OS: Ubuntu 22.04 (via cFS bundle build)

**Additional context**
One-line fix: changed `State->DataPos = Perf->MetaData.DataStart` to `State->DataPos = 0` in `CFE_ES_RunPerfLogDump`. This stops the reordering so the raw buffer layout matches the metadata that was already being written as-is.

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Heath Dutton / Personal