### PR TITLE
Fix #2638, Use unsigned format specifier for perf marker log

### DIFF
--- a/modules/es/fsw/src/cfe_es_perf.c
+++ b/modules/es/fsw/src/cfe_es_perf.c
@@ -586,7 +586,7 @@ void CFE_ES_PerfLogAdd(uint32 Marker, uint32 EntryExit)
         /* if marker has not been reported previously ... */
         if (Perf->MetaData.InvalidMarkerReported == false)
         {
-            CFE_ES_WriteToSysLog("%s: Invalid performance marker %d,max is %d\n", __func__, (unsigned int)Marker,
+            CFE_ES_WriteToSysLog("%s: Invalid performance marker %u,max is %u\n", __func__, (unsigned int)Marker,
                                  (CFE_MISSION_ES_PERF_MAX_IDS - 1));
             Perf->MetaData.InvalidMarkerReported = true;
         }


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #2638

The `CFE_ES_WriteToSysLog` call in `CFE_ES_PerfLogAdd` uses `%d` to format `Marker` (which is `uint32`, cast to `unsigned int`) and `CFE_MISSION_ES_PERF_MAX_IDS - 1`. Changed both format specifiers to `%u` so the format string matches the actual argument types.

**Testing performed**
Code review. Verified the existing unit test in `es_UT.c` covers the invalid marker path and does not assert on message text, so no test changes needed.

**Expected behavior changes**
Marker values with bit 31 set will now print as the correct unsigned value instead of a misleading negative number. No other behavior change.

**System(s) tested on**
Code review only (macOS does not support cFS native build)

**Contributor Info**
Heath Dutton