### PR TITLE
Fix #2650, Correct input buffer size in fs_UT

### DIFF
--- a/modules/fs/ut-coverage/fs_UT.c
+++ b/modules/fs/ut-coverage/fs_UT.c
@@ -336,7 +336,7 @@ void Test_CFE_FS_ParseInputFileNameEx(void)
 
     /* Cases where the file name itself is actually an empty string */
     UtAssert_INT32_EQ(
-        CFE_FS_ParseInputFileNameEx(OutBuffer, "", sizeof(OutBuffer), 10, NULL, NULL, TEST_DEFAULT_EXTENSION),
+        CFE_FS_ParseInputFileNameEx(OutBuffer, "", sizeof(OutBuffer), sizeof(""), NULL, NULL, TEST_DEFAULT_EXTENSION),
         CFE_FS_INVALID_PATH);
     UtAssert_INT32_EQ(CFE_FS_ParseInputFileNameEx(OutBuffer, "/path/", sizeof(OutBuffer), 7, NULL, TEST_DEFAULT_PATH,
                                                   TEST_DEFAULT_EXTENSION),


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**

The `Test_CFE_FS_ParseInputFileNameEx` test passes an `InputBufSize` of `10` for an empty string literal `""` which is only 1 byte. Address Sanitizer flags this as a read buffer overflow since the function is told it can read 10 bytes from a 1-byte buffer.

Fixes #2650

**Testing performed**

Code inspection. The empty string causes the function to take the early-out path at the `InputBuffer[0] != 0` check, so the expected result `CFE_FS_INVALID_PATH` is unchanged regardless of the size value. The fix simply makes the declared size match reality.

**Expected behavior changes**

No behavior change. Test exercises the same code path and expects the same result.

**System(s) tested on**

N/A -- test-only change, verified by inspection

**Additional context**

N/A

**Third party code**

N/A

**Contributor Info - All information REQUIRED for consideration of pull request**

Heath Dutton / Personal