### PR TITLE
Fix #2692, add size check for each header field

### DIFF
--- a/modules/tbl/fsw/src/cfe_tbl_eds_codec.c
+++ b/modules/tbl/fsw/src/cfe_tbl_eds_codec.c
@@ -421,7 +421,7 @@ CFE_Status_t CFE_TBL_ValidateCodecLoadSize(CFE_TBL_TxnState_t *Txn, const CFE_TB
     if (Status == CFE_SUCCESS)
     {
         ProjectedSize = HeaderPtr->Offset + HeaderPtr->NumBytes;
-        if (ProjectedSize > ActualSize)
+        if (ProjectedSize < HeaderPtr->Offset || ProjectedSize > ActualSize)
         {
             Status = CFE_TBL_ERR_FILE_TOO_LARGE;
             CFE_TBL_TxnAddEvent(Txn, CFE_TBL_LOAD_EXCEEDS_SIZE_ERR_EID, ProjectedSize, ActualSize);

--- a/modules/tbl/fsw/src/cfe_tbl_passthru_codec.c
+++ b/modules/tbl/fsw/src/cfe_tbl_passthru_codec.c
@@ -161,7 +161,7 @@ CFE_Status_t CFE_TBL_ValidateCodecLoadSize(CFE_TBL_TxnState_t *Txn, const CFE_TB
     /* Because the file sizes and in-memory size is the same, this check is simple */
     ActualSize    = CFE_TBL_RegRecGetSize(CFE_TBL_TxnRegRec(Txn));
     ProjectedSize = HeaderPtr->Offset + HeaderPtr->NumBytes;
-    if (ProjectedSize > ActualSize)
+    if (ProjectedSize < HeaderPtr->Offset || ProjectedSize > ActualSize)
     {
         Status = CFE_TBL_ERR_FILE_TOO_LARGE;
         CFE_TBL_TxnAddEvent(Txn, CFE_TBL_LOAD_EXCEEDS_SIZE_ERR_EID, ProjectedSize, ActualSize);

--- a/modules/tbl/ut-coverage/tbl_ut_support_eds.c
+++ b/modules/tbl/ut-coverage/tbl_ut_support_eds.c
@@ -357,8 +357,40 @@ void UT_TBL_ValidateCodecLoadSize_Test(void)
     UtAssert_ZERO(Txn.NumPendingEvents);
 
     Txn.RegRecPtr = &RegRec;
+
+    /* Case where the load exactly will fill the buffer */
+    RegRec.Config.Size = 100;
+    Header.NumBytes    = RegRec.Config.Size;
     UtAssert_INT32_EQ(CFE_TBL_ValidateCodecLoadSize(&Txn, &Header), CFE_SUCCESS);
     UtAssert_ZERO(Txn.NumPendingEvents);
+
+    /* Case where the numbytes is OK but offset is too large */
+    Header.NumBytes = RegRec.Config.Size / 2;
+    Header.Offset   = RegRec.Config.Size * 2;
+    UtAssert_INT32_EQ(CFE_TBL_ValidateCodecLoadSize(&Txn, &Header), CFE_TBL_ERR_FILE_TOO_LARGE);
+    UT_TBL_EVENT_PENDING(&Txn, CFE_TBL_LOAD_EXCEEDS_SIZE_ERR_EID);
+    CFE_TBL_TxnClearEvents(&Txn);
+
+    /* Case where the offset is OK but numbytes is too large */
+    Header.NumBytes = RegRec.Config.Size * 2;
+    Header.Offset   = RegRec.Config.Size / 2;
+    UtAssert_INT32_EQ(CFE_TBL_ValidateCodecLoadSize(&Txn, &Header), CFE_TBL_ERR_FILE_TOO_LARGE);
+    UT_TBL_EVENT_PENDING(&Txn, CFE_TBL_LOAD_EXCEEDS_SIZE_ERR_EID);
+    CFE_TBL_TxnClearEvents(&Txn);
+
+    /* Case where the offset is OK but numbytes causes uint32 overflow */
+    Header.NumBytes = UINT32_MAX - (RegRec.Config.Size / 2);
+    Header.Offset   = RegRec.Config.Size - 1;
+    UtAssert_INT32_EQ(CFE_TBL_ValidateCodecLoadSize(&Txn, &Header), CFE_TBL_ERR_FILE_TOO_LARGE);
+    UT_TBL_EVENT_PENDING(&Txn, CFE_TBL_LOAD_EXCEEDS_SIZE_ERR_EID);
+    CFE_TBL_TxnClearEvents(&Txn);
+
+    /* Case where the offset and numbytes are individually OK but sum is too large */
+    Header.NumBytes = RegRec.Config.Size - 1;
+    Header.Offset   = RegRec.Config.Size - 1;
+    UtAssert_INT32_EQ(CFE_TBL_ValidateCodecLoadSize(&Txn, &Header), CFE_TBL_ERR_FILE_TOO_LARGE);
+    UT_TBL_EVENT_PENDING(&Txn, CFE_TBL_LOAD_EXCEEDS_SIZE_ERR_EID);
+    CFE_TBL_TxnClearEvents(&Txn);
 }
 
 void UT_TBL_CodecGetFinalStatus_Test(void)

--- a/modules/tbl/ut-coverage/tbl_ut_support_passthru.c
+++ b/modules/tbl/ut-coverage/tbl_ut_support_passthru.c
@@ -81,7 +81,59 @@ void UT_TBL_SetupCodec(size_t ByteSize)
     /* classic build has a passthru layer here, this is a no-op */
 }
 
+void UT_TBL_ValidateCodecLoadSize_Test(void)
+{
+    /* Test Case for:
+     * CFE_Status_t CFE_TBL_ValidateCodecLoadSize(CFE_TBL_TxnState_t *Txn, const CFE_TBL_File_Hdr_t *HeaderPtr);
+     */
+
+    CFE_TBL_TxnState_t    Txn;
+    CFE_TBL_File_Hdr_t    Header;
+    CFE_TBL_RegistryRec_t RegRec;
+
+    memset(&Txn, 0, sizeof(Txn));
+    memset(&Header, 0, sizeof(Header));
+    memset(&RegRec, 0, sizeof(RegRec));
+
+    Txn.RegRecPtr = &RegRec;
+
+    /* Case where the load exactly will fill the buffer */
+    RegRec.Config.Size = 100;
+    Header.NumBytes = RegRec.Config.Size;
+    UtAssert_INT32_EQ(CFE_TBL_ValidateCodecLoadSize(&Txn, &Header), CFE_SUCCESS);
+    UtAssert_ZERO(Txn.NumPendingEvents);
+
+    /* Case where the numbytes is OK but offset is too large */
+    Header.NumBytes = RegRec.Config.Size / 2;
+    Header.Offset = RegRec.Config.Size * 2;
+    UtAssert_INT32_EQ(CFE_TBL_ValidateCodecLoadSize(&Txn, &Header), CFE_TBL_ERR_FILE_TOO_LARGE);
+    UT_TBL_EVENT_PENDING(&Txn, CFE_TBL_LOAD_EXCEEDS_SIZE_ERR_EID);
+    CFE_TBL_TxnClearEvents(&Txn);
+
+    /* Case where the offset is OK but numbytes is too large */
+    Header.NumBytes = RegRec.Config.Size * 2;
+    Header.Offset = RegRec.Config.Size / 2;
+    UtAssert_INT32_EQ(CFE_TBL_ValidateCodecLoadSize(&Txn, &Header), CFE_TBL_ERR_FILE_TOO_LARGE);
+    UT_TBL_EVENT_PENDING(&Txn, CFE_TBL_LOAD_EXCEEDS_SIZE_ERR_EID);
+    CFE_TBL_TxnClearEvents(&Txn);
+
+    /* Case where the offset is OK but numbytes causes uint32 overflow */
+    Header.NumBytes = UINT32_MAX - (RegRec.Config.Size / 2);
+    Header.Offset = RegRec.Config.Size - 1;
+    UtAssert_INT32_EQ(CFE_TBL_ValidateCodecLoadSize(&Txn, &Header), CFE_TBL_ERR_FILE_TOO_LARGE);
+    UT_TBL_EVENT_PENDING(&Txn, CFE_TBL_LOAD_EXCEEDS_SIZE_ERR_EID);
+    CFE_TBL_TxnClearEvents(&Txn);
+
+    /* Case where the offset and numbytes are individually OK but sum is too large */
+    Header.NumBytes = RegRec.Config.Size - 1;
+    Header.Offset = RegRec.Config.Size - 1;
+    UtAssert_INT32_EQ(CFE_TBL_ValidateCodecLoadSize(&Txn, &Header), CFE_TBL_ERR_FILE_TOO_LARGE);
+    UT_TBL_EVENT_PENDING(&Txn, CFE_TBL_LOAD_EXCEEDS_SIZE_ERR_EID);
+    CFE_TBL_TxnClearEvents(&Txn);
+}
+
 void UT_TBL_RegisterCodecTests(void)
 {
-    /* classic build has a passthru layer here, this is a no-op */
+    UtTest_Add(UT_TBL_ValidateCodecLoadSize_Test, UT_TBL_GlobalDataReset, NULL, "Test CFE_TBL_ValidateCodecLoadSize()");
+
 }


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Adds a size check on each of the table header size fields.  Previously only the sum (offset + numbytes) was checked against the size limit but if that sum overflows a uint32, then the check could pass when it should have failed.

Fixes nasa/cFE#2692

**Testing performed**
Build and run tests, confirm described case is now caught with error code (test added)

**Expected behavior changes**
Described condition is caught and error event sent

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
