### PR TITLE
Fix #2417, add size check in CFE_MSG_Init

### DIFF
--- a/modules/msg/fsw/src/cfe_msg_init.c
+++ b/modules/msg/fsw/src/cfe_msg_init.c
@@ -35,7 +35,7 @@ CFE_Status_t CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_M
 {
     int32 status;
 
-    if (MsgPtr == NULL)
+    if (MsgPtr == NULL || Size < sizeof(*MsgPtr))
     {
         return CFE_MSG_BAD_ARGUMENT;
     }

--- a/modules/msg/ut-coverage/test_cfe_msg_init.c
+++ b/modules/msg/ut-coverage/test_cfe_msg_init.c
@@ -57,6 +57,7 @@ void Test_MSG_Init(void)
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_IsValidMsgId), true);
     UtAssert_INT32_EQ(CFE_MSG_Init(NULL, msgid_act, sizeof(cmd)), CFE_MSG_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_MSG_Init(CFE_MSG_PTR(cmd), msgid_act, 0), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_Init(CFE_MSG_PTR(cmd), msgid_act, sizeof(CFE_MSG_Message_t) - 1), CFE_MSG_BAD_ARGUMENT);
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_IsValidMsgId), false);
     UtAssert_INT32_EQ(CFE_MSG_Init(CFE_MSG_PTR(cmd), msgid_act, sizeof(cmd)), CFE_MSG_BAD_ARGUMENT);
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #2417

`CFE_MSG_Init` only NULL-checks `MsgPtr`, then calls `CFE_MSG_InitDefaultHdr` and `CFE_MSG_SetMsgId` before `CFE_MSG_SetSize` performs any size validation. If the caller passes `Size` smaller than the header, those earlier calls have already written out-of-bounds by the time `SetSize` returns `CFE_MSG_BAD_ARGUMENT`.

Extended the existing guard to also reject `Size < sizeof(*MsgPtr)`. Using `sizeof(*MsgPtr)` naturally covers both the pri-only (6 bytes) and priext (10 bytes) header configurations without any ifdef.

**Testing performed**
Added one assertion in `test_cfe_msg_init.c` for `Size = sizeof(CFE_MSG_Message_t) - 1`, exercising the new branch. The pre-existing `Size = 0` assertion also now exits via this guard instead of coincidentally via `SetSize`. `clang-format --dry-run --Werror` clean.

**Expected behavior changes**
Callers passing a buffer smaller than the CCSDS header will now receive `CFE_MSG_BAD_ARGUMENT` with no writes to the buffer. Previously the same callers received `CFE_MSG_BAD_ARGUMENT` but only after the function had already corrupted memory past the end of their buffer. The downstream `SetSize` range check (`Size < CFE_MSG_SIZE_OFFSET` and upper bound) is unchanged.

The related downstream bug in CF (nasa/CF#401) that relied on this behavior is already closed.

**System(s) tested on**
Code review and clang-format only (macOS does not support cFS native build). Upstream CI will exercise the unit tests on Linux.

**Contributor Info**
Heath Dutton / Personal