### PR TITLE
Fix #2698: Add lower-bound validation on CCSDS Length field in SB transmit path

### DIFF
--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -1352,7 +1352,7 @@ CFE_SB_Buffer_t *CFE_SB_AllocateMessageBuffer(size_t MsgSize)
 
     Status = CFE_ES_GetAppID(&AppId);
 
-    if (MsgSize > CFE_MISSION_SB_MAX_SB_MSG_SIZE)
+    if (MsgSize < sizeof(CFE_MSG_Message_t) || MsgSize > CFE_MISSION_SB_MAX_SB_MSG_SIZE)
     {
         CFE_ES_GetAppName(AppName, AppId, sizeof(AppName));
         CFE_ES_WriteToSysLog("%s %s: Failed, requested size %zu larger than allowed %d\n",

--- a/modules/sb/fsw/src/cfe_sb_priv.c
+++ b/modules/sb/fsw/src/cfe_sb_priv.c
@@ -842,7 +842,7 @@ void CFE_SB_MessageTxn_SetRoutingMsgId(CFE_SB_MessageTxn_State_t *TxnPtr, CFE_SB
  *-----------------------------------------------------------------*/
 void CFE_SB_MessageTxn_SetContentSize(CFE_SB_MessageTxn_State_t *TxnPtr, size_t ContentSize)
 {
-    if (ContentSize > CFE_MISSION_SB_MAX_SB_MSG_SIZE)
+    if (ContentSize < sizeof(CFE_MSG_Message_t) || ContentSize > CFE_MISSION_SB_MAX_SB_MSG_SIZE)
     {
         CFE_SB_MessageTxn_SetEventAndStatus(TxnPtr, CFE_SB_MSG_TOO_BIG_EID, CFE_SB_MSG_TOO_BIG);
     }


### PR DESCRIPTION
Closes #2698
Related: CVE-2026-5474, CVE-2026-5475

- Added lower-bound check in CFE_SB_MessageTxn_SetContentSize
- Added lower-bound check in CFE_SB_AllocateMessageBuffer
- Prevents 32 KiB heap exfiltration via 8-byte UDP datagram