### PR TITLE
Fix #2697: Prevent unsigned integer underflow in CFE_SB_GetUserDataLength

### DIFF
--- a/modules/sb/fsw/src/cfe_sb_util.c
+++ b/modules/sb/fsw/src/cfe_sb_util.c
@@ -71,11 +71,20 @@ size_t CFE_SB_GetUserDataLength(const CFE_MSG_Message_t *MsgPtr)
 
     if (MsgPtr == NULL)
     {
-        return TotalMsgSize;
+        return 0;
     }
 
-    CFE_MSG_GetSize(MsgPtr, &TotalMsgSize);
+    if (CFE_MSG_GetSize(MsgPtr, &TotalMsgSize) != CFE_SUCCESS)
+    {
+        return 0;
+    }
+
     HdrSize = CFE_SB_MsgHdrSize(MsgPtr);
+
+    if (TotalMsgSize < HdrSize)
+    {
+        return 0;
+    }
 
     return TotalMsgSize - HdrSize;
 }


### PR DESCRIPTION
Closes #2697

- Check CFE_MSG_GetSize return value
- Return 0 when TotalMsgSize < HdrSize to prevent unsigned underflow
- Matches documented contract: return 0 on error