### PR TITLE
Fix #2710, update to snprintf

### DIFF
--- a/modules/es/fsw/src/cfe_es_cds.c
+++ b/modules/es/fsw/src/cfe_es_cds.c
@@ -685,7 +685,7 @@ void CFE_ES_FormCDSName(char *FullCDSName, const char *CDSName, CFE_ES_AppId_t T
     AppName[OS_MAX_API_NAME - 1] = '\0';
 
     /* Complete formation of processor specific table name */
-    sprintf(FullCDSName, "%s.%s", AppName, CDSName);
+    snprintf(FullCDSName, CFE_MISSION_ES_CDS_MAX_FULL_NAME_LEN, "%s.%s", AppName, CDSName);
 }
 
 /*----------------------------------------------------------------

--- a/modules/sb/fsw/src/cfe_sb_priv.c
+++ b/modules/sb/fsw/src/cfe_sb_priv.c
@@ -290,7 +290,7 @@ char *CFE_SB_GetAppTskName(CFE_ES_TaskId_t TaskId, char *FullName)
         strncpy(TskName, (char *)ptr->TaskName, sizeof(TskName) - 1);
         TskName[sizeof(TskName) - 1] = '\0';
 
-        sprintf(FullName, "%s.%s", AppName, TskName);
+        snprintf(FullName, OS_MAX_API_NAME * 2, "%s.%s", AppName, TskName);
     }
 
     return FullName;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Change remaining 2 calls to sprintf into snprintf.

These had been excused since the input string lengths were already of known length and could not overflow.  This is only updating to avoid future concerns or confusion.

Fixes #2710

**Testing performed**
Build and run all tests

**Expected behavior changes**
No impact

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
