### PR TITLE
Fix #2728, limit tags used by git describe

### DIFF
--- a/cmake/generate_git_module_version.cmake
+++ b/cmake/generate_git_module_version.cmake
@@ -33,7 +33,7 @@ function(get_version DEP)
     endif()
 
     execute_process(
-        COMMAND ${GIT_EXECUTABLE} describe --tags --always --dirty
+        COMMAND ${GIT_EXECUTABLE} describe --tags --always --dirty --match v[0-9].[0-9].[0-9]
         WORKING_DIRECTORY ${DIR}
         OUTPUT_VARIABLE GIT_DESC_OUTPUT
         RESULT_VARIABLE GIT_RESULT


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
When determining which tag to use for self reporting, limit tags to the style used for official release versions.

Fixes #2728

**Testing performed**
Confirm correct tag is being used/reported (e.g. `v7.0.0` or `v7.0.1`)

**Expected behavior changes**
A special/testing tag like the "multitarget-demo" will not be used

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
