### PR TITLE
ci: declare workflow-level `contents: read` on 5 build/test workflows

### DIFF
--- a/.github/workflows/build-documentation.yml
+++ b/.github/workflows/build-documentation.yml
@@ -18,6 +18,9 @@ on:
 env:
   WORK_PATH: ${{ github.workspace }}
 
+permissions:
+  contents: read
+
 jobs:
   checkout-and-cache:
     name: Custom checkout and cache for cFS documents

--- a/.github/workflows/code-coverage-eds.yml
+++ b/.github/workflows/code-coverage-eds.yml
@@ -22,6 +22,9 @@ env:
   CFE_EDS_ENABLED: true
   BUILDTYPE: debug
 
+permissions:
+  contents: read
+
 jobs:
 
   Execute-Unit-Tests:

--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -21,6 +21,9 @@ env:
   OMIT_DEPRECATED: false
   BUILDTYPE: debug
 
+permissions:
+  contents: read
+
 jobs:
  Execute-Unit-Tests:
     name: Build and Execute CFE unit tests

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -12,6 +12,9 @@ on:
       - synchronize
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   format-check:
     name: Run format check

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -15,6 +15,9 @@ on:
     # 11:59 PM UTC every Sunday
     - cron:  '59 23 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   static-analysis:
     name: Run Static Analysis


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on the 5 workflows in `.github/workflows/` that don't actually need any write scope:

- `build-documentation.yml`: doxygen build, uploads as workflow artifact.
- `code-coverage-eds.yml`, `code-coverage.yml`: lcov coverage runs, no GitHub API.
- `format-check.yml`: clang-format check.
- `static-analysis.yml`: scan-build / cppcheck.

Left implicit on purpose:

- `add-to-project.yml` is on `pull_request_target` with `actions/add-to-project`, which needs `projects: write`.
- `icbundle.yml` does `git merge` + push of PR sets via `GITHUB_TOKEN`.
- `mcdc.yml` uses `dawidd6/action-download-artifact`, which needs `actions: read`.
- `codeql-build.yml` needs `security-events: write` for SARIF upload.

All four are best declared by maintainers who know the right scope per workflow.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs and the leaked token retained whatever scope was issued at the workflow level. Pinning per workflow caps that runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.