### PR TITLE
Fix nasa#2731, Used CFE_SB_GetAppTaskName() function directly in call…

### DIFF
--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -456,14 +456,12 @@ int32 CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId)
     /* Send Events */
     if (PendingEventID != 0)
     {
-        /* get TaskId and name of caller for events */
+        /* get TaskId of caller for events */
         CFE_ES_GetTaskID(&TskId);
-        CFE_SB_GetAppTskName(TskId, FullName);
     }
     else
     {
-        TskId       = CFE_ES_TASKID_UNDEFINED;
-        FullName[0] = 0;
+        TskId = CFE_ES_TASKID_UNDEFINED;
     }
 
     switch (PendingEventID)
@@ -474,14 +472,14 @@ int32 CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId)
                                        CFE_SB_Global.AppId,
                                        "Pipe Delete Error:Bad Argument,PipedId %ld,Requestor %s",
                                        CFE_RESOURCEID_TO_ULONG(PipeId),
-                                       FullName);
+                                       CFE_SB_GetAppTskName(TskId, FullName));
             break;
         case CFE_SB_DEL_PIPE_ERR2_EID:
             CFE_EVS_SendEventWithAppID(CFE_SB_DEL_PIPE_ERR2_EID,
                                        CFE_EVS_EventType_ERROR,
                                        CFE_SB_Global.AppId,
                                        "Pipe Delete Error:Caller(%s) is not the owner of pipe %ld",
-                                       FullName,
+                                       CFE_SB_GetAppTskName(TskId, FullName),
                                        CFE_RESOURCEID_TO_ULONG(PipeId));
             break;
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Used CFE_SB_GetAppTaskName() function directly in calls to CFE_EVS_SendEventWithAppID() in CFE_SB_DeletePipeFull() in order to avoid having a standalone call to CFE_SB_GetAppTskName() where the return value is ignored.  Fixes nasa#2731.

**Testing performed**
Ran the unit tests and the build test on COSMOS.

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu 18.04
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Michael Yang NASA/GSFC
