### PR TITLE
fix nasa#2740, return value of OS_write() called by UT_BSP_WriteLogFi…

### DIFF
--- a/modules/cfe_assert/src/cfe_assert_io.c
+++ b/modules/cfe_assert/src/cfe_assert_io.c
@@ -88,7 +88,10 @@ void UT_BSP_WriteLogFile(osal_id_t FileDesc, uint8 MessageType, const char *Pref
     if (MsgEnabled & 1)
     {
         snprintf(LogFileBuffer, sizeof(LogFileBuffer), "[%5s] %s\n", Prefix, OutputMessage);
-        OS_write(FileDesc, LogFileBuffer, strlen(LogFileBuffer));
+
+        /* SAD: Suppress Ignored Return Value warning from CodeSonar.  There is no alternative action to take if
+         * OS_write fails  */
+        (void)OS_write(FileDesc, LogFileBuffer, strlen(LogFileBuffer));
     }
 }
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [ ] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [ ] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes nasa#2740 - return value of OS_write() called by UT_BSP_WriteLogFile() in modules/cfe_assert/src/cfe_assert_io.c casted to `(void)` in order to suppress warning.

**Testing performed**

**Expected behavior changes**
 - None

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu 18.04
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Michael Yang NASA/GSFC
