### PR TITLE
ci: declare workflow-level `contents: read` on 4 check workflows

### DIFF
--- a/.github/workflows/codeql-build.yml
+++ b/.github/workflows/codeql-build.yml
@@ -15,6 +15,9 @@ on:
     # 11:15 PM UTC every Sunday
     - cron:  '15 23 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   codeql:
     uses: nasa/cFS/.github/workflows/codeql-reusable.yml@dev

--- a/.github/workflows/format-check.yml
+++ b/.github/workflows/format-check.yml
@@ -12,6 +12,9 @@ on:
       - synchronize
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   format-check:
     name: Run format check

--- a/.github/workflows/mcdc.yml
+++ b/.github/workflows/mcdc.yml
@@ -24,6 +24,9 @@ env:
   BUILDTYPE: debug
   TESTS_RAN: false
 
+permissions:
+  contents: read
+
 jobs:
   mcdc:
     name: Build and Run MCDC

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -15,6 +15,9 @@ on:
     # 11:59 PM UTC every Sunday
     - cron:  '59 23 * * 0'
 
+permissions:
+  contents: read
+
 jobs:
   static-analysis:
     name: Run Static Analysis


### PR DESCRIPTION
Four lint/analysis workflows (`format-check`, `codeql-build`, `static-analysis`, `mcdc`) just run pure checks. No GitHub API writes from the workflows, so workflow-level `contents: read` is the right cap.

Note: `codeql-build` writes via `security-events: write` on the analyze job, so I left that job-level permissions alone (this PR only adds the workflow-level cap, jobs can still override upward where they need to).

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.