### PR TITLE
ci: pin third-party Actions to commit SHAs (CWE-829)

### DIFF
--- a/.github/workflows/mcdc.yml
+++ b/.github/workflows/mcdc.yml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Download latest main branch artifact
         continue-on-error: true
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@268677152d06ba59fcec7a7f0b5d961b6ccd7e1e # v2
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: mcdc-internal.yml


### PR DESCRIPTION
## Summary

Pin third-party GitHub Actions in `.github/workflows/` to immutable
40-character commit SHAs, addressing [CWE-829: Inclusion of Functionality
from Untrusted Control Sphere](https://cwe.mitre.org/data/definitions/829.html).

This is a follow-up to the sibling PR against the parent cFS bundle
([nasa/cFS#1040](https://github.com/nasa/cFS/pull/1040)) covering the
same supply-chain hygiene class — the parent PR could only touch the
workflows that live in the cFS root; this PR covers the ones inside
the submodule.

## Why

A third-party Action pinned to a mutable tag (`@v2`) or a moving branch
(`@master`) executes whatever the upstream maintainer pushes to that ref
at workflow run time. A maintainer compromise or a tag/branch rewrite
causes the action to run attacker code with `${{ secrets.* }}` in scope.

The [March 2025 `tj-actions/changed-files` supply-chain incident
(CVE-2025-30066)](https://nvd.nist.gov/vuln/detail/CVE-2025-30066) was
exactly this shape: 23,000+ workflows compromised because they used
`@v45` instead of a SHA. GitHub's hardening guidance recommends SHA
pinning for third-party Actions in its
[security hardening reference](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

Branch-pinned references (`@master`) are the higher-risk subset because
the branch HEAD moves on every push to the upstream repo.

## Changes

Each `@<tag-or-branch>` was resolved to its 40-character commit SHA via
`gh api` against the live GitHub refs. The human-readable ref is
preserved as a `# <ref>` inline comment so future Dependabot bumps and
human reviewers can see the intended version. NASA / GitHub first-party
actions (`actions/*`, `github/*`, `nasa/*`) are out of scope and not
touched.

## Test plan

- [ ] CI workflows still run successfully against the pinned SHAs.
- [ ] Action behavior is identical (the pinned SHAs correspond to the
      tag/branch HEAD previously in use; nothing functionally changes).

## Provenance

Discovered by [Kulvex Code (KCode)](https://github.com/AstrolexisAI/KCode),
a deterministic SAST scanner. Pattern: `cloud-006-gha-third-party-no-sha`.
Same audit campaign that produced [nasa/CryptoLib#511](https://github.com/nasa/CryptoLib/pull/511),
[nasa/cFS#1040](https://github.com/nasa/cFS/pull/1040), and
[nasa/trick#2132](https://github.com/nasa/trick/pull/2132).

Per common AI-assist disclosure practice: **AI tooling was used.** Discovery
via KCode (deterministic regex+AST patterns + LLM verifier). Fix generation
via KCode agentic mode. Each SHA resolution was done by `gh api` calls,
not invented.

— Bruno Aiub · AstroLexis · Kulvex Code · contact@astrolexis.space
