### PR TITLE
Fix nasa#2742, Suppressed ignored return value warning of OS_QueueDelete() in CFE_SB_DeletePipeFull() in modules/sb/fsw/src/cfe_sb_api.c

### DIFF
--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -433,7 +433,9 @@ int32 CFE_SB_DeletePipeFull(CFE_SB_PipeId_t PipeId, CFE_ES_AppId_t AppId)
         }
 
         /* Delete the underlying OS queue */
-        OS_QueueDelete(SysQueueId);
+        /* SAD: Suppress Ignored Return Value warning from CodeSonar.  If OS_QueueDelete() returns an error, nothing the
+         * user can do. */
+        (void)OS_QueueDelete(SysQueueId);
     }
 
     /*


### PR DESCRIPTION
**Describe the contribution**
Fixes nasa#2742 by suppressing ignored return value warning of OS_QueueDelete() in CFE_SB_DeletePipeFull() in modules/sb/fsw/src/cfe_sb_api.c

**Testing performed**

**Expected behavior changes**
- None

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu 18.04
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**

**Third party code**

**Contributor Info - All information REQUIRED for consideration of pull request**
Michael Yang NASA/GSFC
