### PR TITLE
fix: zero-init struct tm before gmtime_r; replace strcpy with memcpy

### DIFF
--- a/modules/cfe_assert/src/cfe_assert_init.c
+++ b/modules/cfe_assert/src/cfe_assert_init.c
@@ -70,7 +70,7 @@ int32 CFE_Assert_OpenLogFile(const char *Filename)
     {
         NameLen = sizeof(CFE_Assert_Global.LogFileTemp) - 5;
     }
-    strcpy(&CFE_Assert_Global.LogFileTemp[NameLen], ".tmp");
+    memcpy(&CFE_Assert_Global.LogFileTemp[NameLen], ".tmp", sizeof(".tmp"));
 
     OsStatus = OS_OpenCreate(&CFE_Assert_Global.LogFileDesc,
                              CFE_Assert_Global.LogFileTemp,

--- a/modules/tbl/fsw/src/cfe_tbl_internal.c
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.c
@@ -902,7 +902,7 @@ void CFE_TBL_MarkNameAsModified(char *NameBufPtr, size_t NameBufSize)
         EndPtr = &NameBufPtr[NameBufSize - 4];
     }
 
-    strcpy(EndPtr, "(*)");
+    memcpy(EndPtr, "(*)", sizeof("(*)"));
 }
 
 /*----------------------------------------------------------------

--- a/modules/time/fsw/src/cfe_time_api.c
+++ b/modules/time/fsw/src/cfe_time_api.c
@@ -577,7 +577,13 @@ CFE_Status_t CFE_TIME_Print(char *PrintBuffer, CFE_TIME_SysTime_t TimeToPrint)
     }
 
     time_t sec = TimeToPrint.Seconds + CFE_MISSION_TIME_EPOCH_SECONDS; // epoch is Jan 1, 1980
+
+    /* gmtime_r returns NULL for times outside the representable range.
+     * Zero-initialise tm so strftime produces a defined (epoch) string
+     * rather than reading uninitialised stack memory. */
+    memset(&tm, 0, sizeof(tm));
     gmtime_r(&sec, &tm);
+
     FmtLen            = strftime(PrintBuffer, CFE_TIME_PRINTED_STRING_SIZE - 6, "%Y-%j-%H:%M:%S", &tm);
     PrintBuffer      += FmtLen;
     *(PrintBuffer++)  = '.';


### PR DESCRIPTION
Fixes #2735 and #2737.

**#2735** — `gmtime_r()` returns NULL for out-of-range `time_t` values, leaving `struct tm` uninitialised. `strftime()` on uninitialised memory is UB. Zero-initialise `tm` with `memset()` before calling `gmtime_r()` so a failed conversion produces a deterministic epoch-like string.

**#2737** — Both `strcpy` sites in `cfe_assert_init.c` and `cfe_tbl_internal.c` append a fixed-length literal into a buffer where space was already verified. Replace with `memcpy(dst, literal, sizeof(literal))` to copy exactly the required bytes including the NUL terminator.