### PR TITLE
fix: guard CFE_SB_GetUserDataLength against unsigned underflow

### DIFF
--- a/modules/sb/fsw/src/cfe_sb_util.c
+++ b/modules/sb/fsw/src/cfe_sb_util.c
@@ -77,6 +77,15 @@ size_t CFE_SB_GetUserDataLength(const CFE_MSG_Message_t *MsgPtr)
     CFE_MSG_GetSize(MsgPtr, &TotalMsgSize);
     HdrSize = CFE_SB_MsgHdrSize(MsgPtr);
 
+    /* Guard against unsigned underflow: a malformed message whose CCSDS
+     * Length field encodes a total smaller than the header size would wrap
+     * the subtraction to SIZE_MAX, causing downstream OOB reads in every
+     * caller that uses the returned length as a buffer size or loop bound. */
+    if (TotalMsgSize <= HdrSize)
+    {
+        return 0;
+    }
+
     return TotalMsgSize - HdrSize;
 }
 


### PR DESCRIPTION
Fixes #2697. When a SB message's CCSDS Length field encodes a total smaller than the header size, the unsigned subtraction `TotalMsgSize - HdrSize` wraps to SIZE_MAX. Every downstream caller using this value as a buffer size or loop bound then performs an unbounded OOB read. Adds a `TotalMsgSize <= HdrSize` guard returning 0 for malformed messages, consistent with the existing NULL-pointer guard.