### PR TITLE
fix: add VerifyCmdLength before SEND_HK_MID cast in EVS and ES dispatch

### DIFF
--- a/modules/es/fsw/src/cfe_es_dispatch.c
+++ b/modules/es/fsw/src/cfe_es_dispatch.c
@@ -287,10 +287,12 @@ void CFE_ES_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
 
     if (CFE_SB_MsgId_Equal(MessageID, SEND_HK_MID))
     {
-        /*
-        ** Housekeeping telemetry request
-        */
-        CFE_ES_SendHkCmd((const CFE_ES_SendHkCmd_t *)SBBufPtr);
+        /* Housekeeping telemetry request — verify length before casting,
+         * consistent with every command code in CFE_ES_ProcessGroundCmd(). */
+        if (CFE_ES_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_ES_SendHkCmd_t)))
+        {
+            CFE_ES_SendHkCmd((const CFE_ES_SendHkCmd_t *)SBBufPtr);
+        }
     }
     else if (CFE_SB_MsgId_Equal(MessageID, CMD_MID))
     {

--- a/modules/evs/fsw/src/cfe_evs_dispatch.c
+++ b/modules/evs/fsw/src/cfe_evs_dispatch.c
@@ -58,8 +58,12 @@ void CFE_EVS_ProcessCommandPacket(const CFE_SB_Buffer_t *SBBufPtr)
     /* Process all SB messages */
     if (CFE_SB_MsgId_Equal(MessageID, SEND_HK_MID))
     {
-        /* Housekeeping request */
-        CFE_EVS_SendHkCmd((const CFE_EVS_SendHkCmd_t *)SBBufPtr);
+        /* Housekeeping request — verify length before casting, consistent
+         * with every command code in CFE_EVS_ProcessGroundCommand(). */
+        if (CFE_EVS_VerifyCmdLength(&SBBufPtr->Msg, sizeof(CFE_EVS_SendHkCmd_t)))
+        {
+            CFE_EVS_SendHkCmd((const CFE_EVS_SendHkCmd_t *)SBBufPtr);
+        }
     }
     else if (CFE_SB_MsgId_Equal(MessageID, CMD_MID))
     {


### PR DESCRIPTION
Fixes nasa/cFS#987 (EVS) and nasa/cFS#986 (ES).

Both `CFE_EVS_ProcessCommandPacket()` and `CFE_ES_TaskPipe()` cast the SB buffer directly to `*SendHkCmd_t` without calling `VerifyCmdLength` first. Every other command code in the respective `ProcessGroundCommand`/`ProcessGroundCmd` switches is guarded by `VerifyCmdLength` before the cast. A truncated `SEND_HK_MID` packet silently bypasses validation and causes an OOB struct-field read.

Adds the missing `VerifyCmdLength` guard in both dispatch functions, matching the existing pattern for all ground commands.