### PR TITLE
fix: clamp PktLen in CFE_MSG_ComputeCheckSum to MAX_SB_MSG_SIZE

### DIFF
--- a/modules/msg/fsw/src/cfe_msg_sechdr_checksum.c
+++ b/modules/msg/fsw/src/cfe_msg_sechdr_checksum.c
@@ -38,8 +38,16 @@ CFE_MSG_Checksum_t CFE_MSG_ComputeCheckSum(const CFE_MSG_Message_t *MsgPtr)
     const uint8       *BytePtr = (const uint8 *)MsgPtr;
     CFE_MSG_Checksum_t chksum  = 0xFF;
 
-    /* Message already checked, no error case reachable */
     CFE_MSG_GetSize(MsgPtr, &PktLen);
+
+    /* Clamp PktLen to the maximum valid message size before iterating.
+     * The CCSDS Length field is attacker-controlled; without this bound
+     * the loop reads PktLen bytes regardless of the actual buffer size,
+     * enabling an OOB heap read of up to (PktLen - actual_size) bytes. */
+    if (PktLen > CFE_MISSION_SB_MAX_SB_MSG_SIZE)
+    {
+        PktLen = 0;
+    }
 
     while (PktLen--)
     {


### PR DESCRIPTION
Fixes nasa/cFS#2699. `CFE_MSG_GetSize()` reads the loop bound from the attacker-controlled CCSDS Length field. Without an upper-bound check, `while(PktLen--)` iterates over an attacker-chosen number of bytes regardless of the actual buffer, enabling an OOB heap read. Clamps PktLen to `CFE_MISSION_SB_MAX_SB_MSG_SIZE` before the loop; a larger value indicates a malformed message and is treated as zero.