### PR TITLE
Fix #2736, Initialize Variables Passed to Functions

### DIFF
--- a/modules/cfe_testcase/src/es_cds_test.c
+++ b/modules/cfe_testcase/src/es_cds_test.c
@@ -88,7 +88,7 @@ void TestCDSName(void)
     const char        *CDSName      = "CFE_TEST.CDS_Test";
     const char        *INVALID_NAME = "INVALID_NAME";
 
-    CFE_ES_CDSHandle_t IdByName;
+    CFE_ES_CDSHandle_t IdByName = CFE_ES_CDS_BAD_HANDLE;
     char               CDSNameBuf[CFE_MISSION_ES_CDS_MAX_FULL_NAME_LEN];
 
     memset(CDSNameBuf, 0, sizeof(CDSNameBuf));

--- a/modules/cfe_testcase/src/es_resource_id_test.c
+++ b/modules/cfe_testcase/src/es_resource_id_test.c
@@ -33,7 +33,7 @@ void TestAppIDToIndex(void)
 {
     UtPrintf("Testing: CFE_ES_AppID_ToIndex");
     CFE_ES_AppId_t TestAppId;
-    uint32         TestAppIdx;
+    uint32         TestAppIdx = 0;
     uint32         idx;
     UtAssert_INT32_EQ(CFE_ES_GetAppID(&TestAppId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_AppID_ToIndex(TestAppId, &TestAppIdx), CFE_SUCCESS);
@@ -86,7 +86,7 @@ void TestCounterIDToIndex(void)
     UtPrintf("Testing: CFE_ES_CounterID_ToIndex");
     const char        *CounterName = "TEST_COUNTER";
     CFE_ES_CounterId_t CounterId;
-    uint32             CounterIdx;
+    uint32             CounterIdx = 0;
     uint32             idx;
     UtAssert_UINT32_EQ(CFE_ES_RegisterGenCounter(&CounterId, CounterName), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_CounterID_ToIndex(CounterId, &CounterIdx), CFE_SUCCESS);

--- a/modules/cfe_testcase/src/sb_pipe_mang_test.c
+++ b/modules/cfe_testcase/src/sb_pipe_mang_test.c
@@ -151,6 +151,8 @@ void TestPipeName(void)
     CFE_SB_PipeId_t PipeIdBuff        = CFE_SB_INVALID_PIPE;
     const char      InvalidPipeName[] = "Invalid Pipe";
 
+    memset(PipeNameBuf, 0, sizeof(PipeNameBuf));
+
     UtPrintf("Testing: CFE_SB_GetPipeName, CFE_SB_GetPipeIdByName");
 
     UtAssert_INT32_EQ(CFE_SB_CreatePipe(&PipeId, PipeDepth, PipeName), CFE_SUCCESS);

--- a/modules/sb/fsw/src/cfe_sb_priv.c
+++ b/modules/sb/fsw/src/cfe_sb_priv.c
@@ -1465,7 +1465,7 @@ void CFE_SB_ReceiveTxn_ExportReference(CFE_SB_MessageTxn_State_t *TxnPtr,
  *-----------------------------------------------------------------*/
 bool CFE_SB_ReceiveTxn_PipeHandler(CFE_SB_MessageTxn_State_t *TxnPtr, CFE_SB_PipeSetEntry_t *ContextPtr, void *Arg)
 {
-    CFE_SB_BufferD_t  *BufDscPtr;
+    CFE_SB_BufferD_t  *BufDscPtr = NULL;
     CFE_SB_BufferD_t **ParentBufDscPtrP;
     size_t             BufDscSize;
 

--- a/modules/tbl/fsw/src/cfe_tbl_dump.c
+++ b/modules/tbl/fsw/src/cfe_tbl_dump.c
@@ -88,7 +88,7 @@ CFE_Status_t CFE_TBL_TxnOpenTableDumpFile(CFE_TBL_TxnState_t              *Txn,
 {
     CFE_Status_t ReturnCode;
     int32        OsStatus;
-    osal_id_t    FileDescriptor;
+    osal_id_t    FileDescriptor = OS_OBJECT_ID_UNDEFINED;
 
     /* Create a new dump file, overwriting anything that may have existed previously */
     OsStatus = OS_OpenCreate(&FileDescriptor, Filename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
@@ -126,7 +126,7 @@ CFE_Status_t CFE_TBL_WriteSnapshotToFile(const CFE_TBL_DumpControl_t *DumpCtlPtr
     int32                     OsStatus;
     bool                      FileExistedPrev;
     CFE_TBL_CombinedFileHdr_t FileHeader;
-    osal_id_t                 FileDescriptor;
+    osal_id_t                 FileDescriptor = OS_OBJECT_ID_UNDEFINED;
     const char               *DumpFilename;
     const void               *DumpDataAddr;
     size_t                    DumpDataSize;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Fixes #2736 

**Testing performed**
GitHub Actions

**Expected behavior changes**
Resolve CodeSonar warnings on uninitialized variables 

**System(s) tested on**
GitHub Actions and CodeSonar. CodeSonar results will be posted on the internal ticket. 

**Additional context**
Used memset for PipeNameBuf to be consistent with CDSNameBuf and other instances of PipeNameBuf 

**Contributor Info - All information REQUIRED for consideration of pull request**
Ariel Walker, MCSG TECH. 
