### PR TITLE
fix: guard against NULL return from CFE_ES_LocateTaskRecordByID in StartAppTask

### DIFF
--- a/modules/es/fsw/src/cfe_es_apps.c
+++ b/modules/es/fsw/src/cfe_es_apps.c
@@ -680,34 +680,47 @@ int32 CFE_ES_StartAppTask(CFE_ES_TaskId_t                *TaskIdPtr,
          */
         LocalTaskId = CFE_ES_TaskId_FromOSAL(OsalTaskId);
         TaskRecPtr  = CFE_ES_LocateTaskRecordByID(LocalTaskId);
-        if (CFE_ES_TaskRecordIsUsed(TaskRecPtr))
+
+        if (TaskRecPtr == NULL)
         {
-            CFE_ES_SysLogWrite_Unsync("%s: Error: ES_TaskTable slot for ID %lx in use at task creation!\n",
+            CFE_ES_SysLogWrite_Unsync("%s: Error: No task record slot available for ID %lx\n",
                                       __func__,
                                       OS_ObjectIdToInteger(OsalTaskId));
+            OS_TaskDelete(OsalTaskId);
+            ReturnCode = CFE_ES_NO_RESOURCE_IDS_AVAILABLE;
+            *TaskIdPtr = CFE_ES_TASKID_UNDEFINED;
         }
+        else
+        {
+            if (CFE_ES_TaskRecordIsUsed(TaskRecPtr))
+            {
+                CFE_ES_SysLogWrite_Unsync("%s: Error: ES_TaskTable slot for ID %lx in use at task creation!\n",
+                                          __func__,
+                                          OS_ObjectIdToInteger(OsalTaskId));
+            }
 
-        /*
-         * Clear any other/stale data that might be in the entry,
-         * and reset all fields to the correct value.
-         */
-        memset(TaskRecPtr, 0, sizeof(*TaskRecPtr));
+            /*
+             * Clear any other/stale data that might be in the entry,
+             * and reset all fields to the correct value.
+             */
+            memset(TaskRecPtr, 0, sizeof(*TaskRecPtr));
 
-        TaskRecPtr->AppId       = ParentAppId;
-        TaskRecPtr->EntryFunc   = EntryFunc;
-        TaskRecPtr->StartParams = *Params;
+            TaskRecPtr->AppId       = ParentAppId;
+            TaskRecPtr->EntryFunc   = EntryFunc;
+            TaskRecPtr->StartParams = *Params;
 
-        strncpy(TaskRecPtr->TaskName, TaskName, sizeof(TaskRecPtr->TaskName) - 1);
-        TaskRecPtr->TaskName[sizeof(TaskRecPtr->TaskName) - 1] = 0;
+            strncpy(TaskRecPtr->TaskName, TaskName, sizeof(TaskRecPtr->TaskName) - 1);
+            TaskRecPtr->TaskName[sizeof(TaskRecPtr->TaskName) - 1] = 0;
 
-        CFE_ES_TaskRecordSetUsed(TaskRecPtr, CFE_RESOURCEID_UNWRAP(LocalTaskId));
+            CFE_ES_TaskRecordSetUsed(TaskRecPtr, CFE_RESOURCEID_UNWRAP(LocalTaskId));
 
-        /*
-         * Increment the registered Task count.
-         */
-        CFE_ES_Global.RegisteredTasks++;
-        ReturnCode = CFE_SUCCESS;
-        *TaskIdPtr = CFE_ES_TaskRecordGetID(TaskRecPtr);
+            /*
+             * Increment the registered Task count.
+             */
+            CFE_ES_Global.RegisteredTasks++;
+            ReturnCode = CFE_SUCCESS;
+            *TaskIdPtr = CFE_ES_TaskRecordGetID(TaskRecPtr);
+        }
     }
     else
     {


### PR DESCRIPTION
## Summary

Fixes #2491

### Problem

In `CFE_ES_StartAppTask`, the return value of `CFE_ES_LocateTaskRecordByID` was used without a null check. The function can return NULL when the resource ID is out of range, leading to a null pointer dereference at the subsequent `CFE_ES_TaskRecordIsUsed()` call and `memset()`. This was flagged by Klocwork static analysis.

### Fix

Add a null check immediately after `CFE_ES_LocateTaskRecordByID`, following the same pattern used in `CFE_ES_AppCreate` (where `LocateAppRecordByID` is already guarded):

- If `TaskRecPtr == NULL`: log the error, call `OS_TaskDelete` on the newly created OSAL task to avoid leaking the OS resource, set `CFE_ES_NO_RESOURCE_IDS_AVAILABLE`, and return.
- Otherwise: continue with existing logic (in-use check, memset, field initialization).

## Test plan

- [ ] Existing ES unit tests pass
- [ ] Static analysis (Klocwork) no longer flags this path