### PR TITLE
fix: replace unsafe strcpy with memcpy in CFE_Assert and CFE_TBL

### DIFF
--- a/modules/cfe_assert/src/cfe_assert_init.c
+++ b/modules/cfe_assert/src/cfe_assert_init.c
@@ -70,7 +70,7 @@ int32 CFE_Assert_OpenLogFile(const char *Filename)
     {
         NameLen = sizeof(CFE_Assert_Global.LogFileTemp) - 5;
     }
-    strcpy(&CFE_Assert_Global.LogFileTemp[NameLen], ".tmp");
+    memcpy(&CFE_Assert_Global.LogFileTemp[NameLen], ".tmp", 5); /* 4 chars + null terminator */
 
     OsStatus = OS_OpenCreate(&CFE_Assert_Global.LogFileDesc,
                              CFE_Assert_Global.LogFileTemp,

--- a/modules/tbl/fsw/src/cfe_tbl_internal.c
+++ b/modules/tbl/fsw/src/cfe_tbl_internal.c
@@ -902,7 +902,7 @@ void CFE_TBL_MarkNameAsModified(char *NameBufPtr, size_t NameBufSize)
         EndPtr = &NameBufPtr[NameBufSize - 4];
     }
 
-    strcpy(EndPtr, "(*)");
+    memcpy(EndPtr, "(*)", 4); /* 3 chars + null terminator; caller ensures >= 4 bytes remain */
 }
 
 /*----------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #2737

Static analyzer flagged two unbounded `strcpy` calls that should use a bounded alternative.

### CFE_Assert_OpenLogFile (cfe_assert_init.c)

`strcpy` was used to append `.tmp` to the log filename. The preceding bounds check already ensures at least 5 bytes of space remain in the buffer, so replace with `memcpy(dst, ".tmp", 5)` to copy the 4-character suffix plus null terminator explicitly.

### CFE_TBL_MarkNameAsModified (cfe_tbl_internal.c)

`strcpy` was used to append `(*)` to the table name. The preceding calculation already ensures at least 4 bytes remain at `EndPtr`, so replace with `memcpy(dst, "(*)", 4)` to copy the 3-character suffix plus null terminator explicitly.

Both replacements are semantically identical to the original code — the bounds are already enforced by the surrounding logic — but eliminate the unsafe unbounded copy pattern.

## Test plan

- [ ] Existing unit tests pass
- [ ] Static analysis no longer flags these locations