### PR TITLE
fix: initialize variables flagged as uninitialized by static analysis

### DIFF
--- a/modules/cfe_testcase/src/es_cds_test.c
+++ b/modules/cfe_testcase/src/es_cds_test.c
@@ -88,7 +88,7 @@ void TestCDSName(void)
     const char        *CDSName      = "CFE_TEST.CDS_Test";
     const char        *INVALID_NAME = "INVALID_NAME";
 
-    CFE_ES_CDSHandle_t IdByName;
+    CFE_ES_CDSHandle_t IdByName = CFE_ES_CDS_BAD_HANDLE;
     char               CDSNameBuf[CFE_MISSION_ES_CDS_MAX_FULL_NAME_LEN];
 
     memset(CDSNameBuf, 0, sizeof(CDSNameBuf));

--- a/modules/cfe_testcase/src/es_resource_id_test.c
+++ b/modules/cfe_testcase/src/es_resource_id_test.c
@@ -33,7 +33,7 @@ void TestAppIDToIndex(void)
 {
     UtPrintf("Testing: CFE_ES_AppID_ToIndex");
     CFE_ES_AppId_t TestAppId;
-    uint32         TestAppIdx;
+    uint32         TestAppIdx = 0;
     uint32         idx;
     UtAssert_INT32_EQ(CFE_ES_GetAppID(&TestAppId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_AppID_ToIndex(TestAppId, &TestAppIdx), CFE_SUCCESS);
@@ -86,7 +86,7 @@ void TestCounterIDToIndex(void)
     UtPrintf("Testing: CFE_ES_CounterID_ToIndex");
     const char        *CounterName = "TEST_COUNTER";
     CFE_ES_CounterId_t CounterId;
-    uint32             CounterIdx;
+    uint32             CounterIdx = 0;
     uint32             idx;
     UtAssert_UINT32_EQ(CFE_ES_RegisterGenCounter(&CounterId, CounterName), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_CounterID_ToIndex(CounterId, &CounterIdx), CFE_SUCCESS);

--- a/modules/cfe_testcase/src/sb_pipe_mang_test.c
+++ b/modules/cfe_testcase/src/sb_pipe_mang_test.c
@@ -147,7 +147,7 @@ void TestPipeName(void)
     CFE_SB_PipeId_t PipeId     = CFE_SB_INVALID_PIPE;
     uint16          PipeDepth  = 10;
     const char      PipeName[] = "Test Pipe";
-    char            PipeNameBuf[OS_MAX_API_NAME];
+    char            PipeNameBuf[OS_MAX_API_NAME] = {0};
     CFE_SB_PipeId_t PipeIdBuff        = CFE_SB_INVALID_PIPE;
     const char      InvalidPipeName[] = "Invalid Pipe";
 

--- a/modules/sb/fsw/src/cfe_sb_priv.c
+++ b/modules/sb/fsw/src/cfe_sb_priv.c
@@ -1465,7 +1465,7 @@ void CFE_SB_ReceiveTxn_ExportReference(CFE_SB_MessageTxn_State_t *TxnPtr,
  *-----------------------------------------------------------------*/
 bool CFE_SB_ReceiveTxn_PipeHandler(CFE_SB_MessageTxn_State_t *TxnPtr, CFE_SB_PipeSetEntry_t *ContextPtr, void *Arg)
 {
-    CFE_SB_BufferD_t  *BufDscPtr;
+    CFE_SB_BufferD_t  *BufDscPtr = NULL;
     CFE_SB_BufferD_t **ParentBufDscPtrP;
     size_t             BufDscSize;
 

--- a/modules/tbl/fsw/src/cfe_tbl_dump.c
+++ b/modules/tbl/fsw/src/cfe_tbl_dump.c
@@ -88,7 +88,7 @@ CFE_Status_t CFE_TBL_TxnOpenTableDumpFile(CFE_TBL_TxnState_t              *Txn,
 {
     CFE_Status_t ReturnCode;
     int32        OsStatus;
-    osal_id_t    FileDescriptor;
+    osal_id_t    FileDescriptor = OS_OBJECT_ID_UNDEFINED;
 
     /* Create a new dump file, overwriting anything that may have existed previously */
     OsStatus = OS_OpenCreate(&FileDescriptor, Filename, OS_FILE_FLAG_CREATE | OS_FILE_FLAG_TRUNCATE, OS_WRITE_ONLY);
@@ -126,7 +126,7 @@ CFE_Status_t CFE_TBL_WriteSnapshotToFile(const CFE_TBL_DumpControl_t *DumpCtlPtr
     int32                     OsStatus;
     bool                      FileExistedPrev;
     CFE_TBL_CombinedFileHdr_t FileHeader;
-    osal_id_t                 FileDescriptor;
+    osal_id_t                 FileDescriptor = OS_OBJECT_ID_UNDEFINED;
     const char               *DumpFilename;
     const void               *DumpDataAddr;
     size_t                    DumpDataSize;


### PR DESCRIPTION
## Summary

Fixes #2736

Static analyzer reported several variables passed to functions as output parameters without being explicitly initialized at the point of declaration.

These are not runtime bugs — the called functions properly initialize the outputs via pointer — but the SA tool cannot prove this, generating false-positive warnings. Adding explicit initialization at declaration eliminates the warnings and follows defensive programming practice.

### Changes

| File | Variable | Initializer |
|------|----------|-------------|
| `cfe_tbl_dump.c` (TxnOpenTableDumpFile) | `FileDescriptor` | `OS_OBJECT_ID_UNDEFINED` |
| `cfe_tbl_dump.c` (WriteSnapshotToFile) | `FileDescriptor` | `OS_OBJECT_ID_UNDEFINED` |
| `cfe_sb_priv.c` (ReceiveTxn_PipeHandler) | `BufDscPtr` | `NULL` |
| `es_cds_test.c` (TestCDSName) | `IdByName` | `CFE_ES_CDS_BAD_HANDLE` |
| `es_resource_id_test.c` (TestAppIDToIndex) | `TestAppIdx` | `0` |
| `es_resource_id_test.c` (TestCounterIDToIndex) | `CounterIdx` | `0` |
| `sb_pipe_mang_test.c` (TestPipeName) | `PipeNameBuf` | `{0}` |

## Test plan

- [ ] Existing unit and functional tests pass unchanged
- [ ] Static analysis no longer flags these locations