### PR TITLE
Fix #2752, cFE use UtAssert_StrCmp replaced with UtAssert_STRINGBUF_EQ.

### DIFF
--- a/modules/cfe_testcase/src/es_cds_test.c
+++ b/modules/cfe_testcase/src/es_cds_test.c
@@ -98,7 +98,7 @@ void TestCDSName(void)
     UtAssert_INT32_EQ(CFE_ES_RegisterCDS(&CDSHandlePtr, BlockSize, Name), CFE_ES_CDS_ALREADY_EXISTS);
 
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockName(CDSNameBuf, CDSHandlePtr, sizeof(CDSNameBuf)), CFE_SUCCESS);
-    UtAssert_StrCmp(CDSNameBuf, CDSName, "CFE_ES_GetCDSBlockName() = %s", CDSNameBuf);
+    UtAssert_STRINGBUF_EQ(CDSNameBuf, sizeof(CDSNameBuf), CDSName, sizeof(CDSName));
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockIDByName(&IdByName, CDSNameBuf), CFE_SUCCESS);
     CFE_Assert_RESOURCEID_EQ(CDSHandlePtr, IdByName);
 
@@ -134,7 +134,7 @@ void TestCopyRestoreCDS(void)
 
     UtAssert_INT32_EQ(CFE_ES_CopyToCDS(CDSHandlePtr, Data), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_RestoreFromCDS(DataBuff, CDSHandlePtr), CFE_SUCCESS);
-    UtAssert_StrCmp(Data, DataBuff, "RestoreFromCDS = %s", DataBuff);
+    UtAssert_STRINGBUF_EQ(Data, sizeof(Data), DataBuff, sizeof(DataBuff));
 
     UtAssert_INT32_EQ(CFE_ES_CopyToCDS(CFE_ES_CDS_BAD_HANDLE, Data), CFE_ES_ERR_RESOURCEID_NOT_VALID);
     UtAssert_INT32_EQ(CFE_ES_CopyToCDS(CDSHandlePtr, NULL), CFE_ES_BAD_ARGUMENT);

--- a/modules/cfe_testcase/src/es_cds_test.c
+++ b/modules/cfe_testcase/src/es_cds_test.c
@@ -98,7 +98,7 @@ void TestCDSName(void)
     UtAssert_INT32_EQ(CFE_ES_RegisterCDS(&CDSHandlePtr, BlockSize, Name), CFE_ES_CDS_ALREADY_EXISTS);
 
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockName(CDSNameBuf, CDSHandlePtr, sizeof(CDSNameBuf)), CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(CDSNameBuf, sizeof(CDSNameBuf), CDSName, sizeof(CDSName));
+    UtAssert_STRINGBUF_EQ(CDSNameBuf, strlen(CDSNameBuf), CDSName, strlen(CDSName));
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockIDByName(&IdByName, CDSNameBuf), CFE_SUCCESS);
     CFE_Assert_RESOURCEID_EQ(CDSHandlePtr, IdByName);
 
@@ -134,7 +134,7 @@ void TestCopyRestoreCDS(void)
 
     UtAssert_INT32_EQ(CFE_ES_CopyToCDS(CDSHandlePtr, Data), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_RestoreFromCDS(DataBuff, CDSHandlePtr), CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(Data, sizeof(Data), DataBuff, sizeof(DataBuff));
+    UtAssert_STRINGBUF_EQ(Data, strlen(Data), DataBuff, strlen(DataBuff));
 
     UtAssert_INT32_EQ(CFE_ES_CopyToCDS(CFE_ES_CDS_BAD_HANDLE, Data), CFE_ES_ERR_RESOURCEID_NOT_VALID);
     UtAssert_INT32_EQ(CFE_ES_CopyToCDS(CDSHandlePtr, NULL), CFE_ES_BAD_ARGUMENT);

--- a/modules/cfe_testcase/src/es_cds_test.c
+++ b/modules/cfe_testcase/src/es_cds_test.c
@@ -98,7 +98,7 @@ void TestCDSName(void)
     UtAssert_INT32_EQ(CFE_ES_RegisterCDS(&CDSHandlePtr, BlockSize, Name), CFE_ES_CDS_ALREADY_EXISTS);
 
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockName(CDSNameBuf, CDSHandlePtr, sizeof(CDSNameBuf)), CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(CDSNameBuf, strlen(CDSNameBuf), CDSName, strlen(CDSName));
+    UtAssert_STRINGBUF_EQ(CDSNameBuf, UTASSERT_STRINGBUF_NULL_TERM, CDSName, UTASSERT_STRINGBUF_NULL_TERM);
     UtAssert_INT32_EQ(CFE_ES_GetCDSBlockIDByName(&IdByName, CDSNameBuf), CFE_SUCCESS);
     CFE_Assert_RESOURCEID_EQ(CDSHandlePtr, IdByName);
 
@@ -134,7 +134,7 @@ void TestCopyRestoreCDS(void)
 
     UtAssert_INT32_EQ(CFE_ES_CopyToCDS(CDSHandlePtr, Data), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_RestoreFromCDS(DataBuff, CDSHandlePtr), CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(Data, strlen(Data), DataBuff, strlen(DataBuff));
+    UtAssert_STRINGBUF_EQ(Data, UTASSERT_STRINGBUF_NULL_TERM, DataBuff, UTASSERT_STRINGBUF_NULL_TERM);
 
     UtAssert_INT32_EQ(CFE_ES_CopyToCDS(CFE_ES_CDS_BAD_HANDLE, Data), CFE_ES_ERR_RESOURCEID_NOT_VALID);
     UtAssert_INT32_EQ(CFE_ES_CopyToCDS(CDSHandlePtr, NULL), CFE_ES_BAD_ARGUMENT);

--- a/modules/cfe_testcase/src/es_info_test.c
+++ b/modules/cfe_testcase/src/es_info_test.c
@@ -50,7 +50,7 @@ void TestGetAppInfo(void)
     UtAssert_INT32_EQ(CFE_ES_GetAppID(&TestAppId), CFE_SUCCESS);
     CFE_Assert_RESOURCEID_EQ(TestAppId, AppIdByName);
     UtAssert_INT32_EQ(CFE_ES_GetAppName(AppNameBuf, TestAppId, sizeof(AppNameBuf)), CFE_SUCCESS);
-    UtAssert_StrCmp(AppNameBuf, TEST_EXPECTED_APP_NAME, "CFE_ES_GetAppName() = %s", AppNameBuf);
+    UtAssert_STRINGBUF_EQ(AppNameBuf, sizeof(AppNameBuf), TEST_EXPECTED_APP_NAME, sizeof(TEST_EXPECTED_APP_NAME));
 
     UtAssert_INT32_EQ(CFE_ES_GetAppInfo(&TestAppInfo, TestAppId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetAppIDByName(&ESAppId, ES_APP_EXPECTED_NAME), CFE_SUCCESS);
@@ -59,13 +59,16 @@ void TestGetAppInfo(void)
     UtAssert_True(TestAppInfo.Type == CFE_ES_AppType_EXTERNAL, "Test App Info -> Type = %d", (int)TestAppInfo.Type);
     UtAssert_True(ESAppInfo.Type == CFE_ES_AppType_CORE, "ES App Info -> Type = %d", (int)ESAppInfo.Type);
 
-    UtAssert_StrCmp(TestAppInfo.Name, TEST_EXPECTED_APP_NAME, "Test App Info -> Name = %s", TestAppInfo.Name);
-    UtAssert_StrCmp(ESAppInfo.Name, ES_APP_EXPECTED_NAME, "ES App Info -> Name = %s", ESAppInfo.Name);
+    UtAssert_STRINGBUF_EQ(TestAppInfo.Name,
+                          sizeof(TestAppInfo.Name),
+                          TEST_EXPECTED_APP_NAME,
+                          sizeof(TEST_EXPECTED_APP_NAME));
+    UtAssert_STRINGBUF_EQ(ESAppInfo.Name, sizeof(ESAppInfo.Name), ES_APP_EXPECTED_NAME, sizeof(ES_APP_EXPECTED_NAME));
 
-    UtAssert_StrCmp(TestAppInfo.EntryPoint,
-                    TEST_EXPECTED_ENTRYPOINT,
-                    "Test App Info -> EntryPt  = %s",
-                    TestAppInfo.EntryPoint);
+    UtAssert_STRINGBUF_EQ(TestAppInfo.EntryPoint,
+                          sizeof(TestAppInfo.EntryPoint),
+                          TEST_EXPECTED_ENTRYPOINT,
+                          sizeof(TEST_EXPECTED_ENTRYPOINT));
     UtAssert_True(strlen(ESAppInfo.EntryPoint) == 0, "ES App Info -> EntryPt  = %s", ESAppInfo.EntryPoint);
 
     UtAssert_True(strstr(TestAppInfo.FileName, TEST_EXPECTED_FILE_NAME) != NULL,
@@ -141,16 +144,11 @@ void TestGetTaskInfo(void)
     UtAssert_INT32_EQ(CFE_ES_GetTaskID(&TaskId), CFE_SUCCESS);
     CFE_Assert_RESOURCEID_EQ(TaskId, AppInfo.MainTaskId);
 
-    UtAssert_StrCmp(TaskInfo.AppName,
-                    AppInfo.Name,
-                    "TaskInfo.AppName (%s) = AppInfo.name (%s)",
-                    TaskInfo.AppName,
-                    AppInfo.Name);
-    UtAssert_StrCmp(TaskInfo.TaskName,
-                    AppInfo.MainTaskName,
-                    "TaskInfo.TaskName (%s) = AppInfo.MainTaskName (%s)",
-                    TaskInfo.TaskName,
-                    AppInfo.MainTaskName);
+    UtAssert_STRINGBUF_EQ(TaskInfo.AppName, sizeof(TaskInfo.AppName), AppInfo.Name, sizeof(AppInfo.Name));
+    UtAssert_STRINGBUF_EQ(TaskInfo.TaskName,
+                          sizeof(TaskInfo.TaskName),
+                          AppInfo.MainTaskName,
+                          sizeof(AppInfo.MainTaskName));
 
     CFE_Assert_RESOURCEID_EQ(TaskInfo.TaskId, AppInfo.MainTaskId);
     CFE_Assert_RESOURCEID_EQ(TaskInfo.AppId, AppId);
@@ -176,10 +174,10 @@ void TestGetLibInfo(void)
     UtAssert_INT32_EQ(CFE_ES_GetLibIDByName(&LibId, LibName), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetLibInfo(&LibInfo, LibId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetLibName(LibNameBuf, LibId, sizeof(LibNameBuf)), CFE_SUCCESS);
-    UtAssert_StrCmp(LibNameBuf, LibName, "CFE_ES_GetLibName() = %s", LibNameBuf);
+    UtAssert_STRINGBUF_EQ(LibNameBuf, sizeof(LibNameBuf), LibName, sizeof(LibName));
     UtAssert_True(LibInfo.Type == CFE_ES_AppType_LIBRARY, "Lib Info -> Type = %d", (int)LibInfo.Type);
-    UtAssert_StrCmp(LibInfo.Name, LibName, "Lib Info -> Name = %s", LibInfo.Name);
-    UtAssert_StrCmp(LibInfo.EntryPoint, "CFE_Assert_LibInit", "Lib Info -> EntryPt  = %s", LibInfo.EntryPoint);
+    UtAssert_STRINGBUF_EQ(LibInfo.Name, sizeof(LibInfo.Name), LibName, sizeof(LibName));
+    UtAssert_STRINGBUF_EQ(LibInfo.EntryPoint, sizeof(LibInfo.EntryPoint), "CFE_Assert_LibInit", -1);
     UtAssert_True(strstr(LibInfo.FileName, FileName) != NULL,
                   "Lib Info -> FileName = %s contains %s",
                   LibInfo.FileName,
@@ -260,20 +258,12 @@ void TestGetModuleInfo(void)
     UtAssert_INT32_EQ(CFE_ES_GetAppID(&TestAppId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetAppInfo(&TestAppInfo, TestAppId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetModuleInfo(&ModuleInfo, CFE_RESOURCEID_UNWRAP(TestAppId)), CFE_SUCCESS);
-    UtAssert_StrCmp(TestAppInfo.Name,
-                    ModuleInfo.Name,
-                    "App Info Name (%s) = Module Info Name (%s) ",
-                    TestAppInfo.Name,
-                    ModuleInfo.Name);
+    UtAssert_STRINGBUF_EQ(TestAppInfo.Name, sizeof(TestAppInfo.Name), ModuleInfo.Name, sizeof(ModuleInfo.Name));
 
     UtAssert_INT32_EQ(CFE_ES_GetLibIDByName(&LibIdByName, LibName), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetLibInfo(&LibInfo, LibIdByName), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetModuleInfo(&ModuleInfo, CFE_RESOURCEID_UNWRAP(LibIdByName)), CFE_SUCCESS);
-    UtAssert_StrCmp(LibInfo.Name,
-                    ModuleInfo.Name,
-                    "Lib Info Name (%s) = Module Info Name (%s) ",
-                    LibInfo.Name,
-                    ModuleInfo.Name);
+    UtAssert_STRINGBUF_EQ(LibInfo.Name, sizeof(LibInfo.Name), ModuleInfo.Name, sizeof(ModuleInfo.Name));
 
     UtAssert_INT32_EQ(CFE_ES_GetModuleInfo(&ModuleInfo, CFE_RESOURCEID_UNDEFINED), CFE_ES_ERR_RESOURCEID_NOT_VALID);
     UtAssert_INT32_EQ(CFE_ES_GetModuleInfo(NULL, CFE_RESOURCEID_UNWRAP(TestAppId)), CFE_ES_BAD_ARGUMENT);

--- a/modules/cfe_testcase/src/es_info_test.c
+++ b/modules/cfe_testcase/src/es_info_test.c
@@ -50,7 +50,7 @@ void TestGetAppInfo(void)
     UtAssert_INT32_EQ(CFE_ES_GetAppID(&TestAppId), CFE_SUCCESS);
     CFE_Assert_RESOURCEID_EQ(TestAppId, AppIdByName);
     UtAssert_INT32_EQ(CFE_ES_GetAppName(AppNameBuf, TestAppId, sizeof(AppNameBuf)), CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(AppNameBuf, sizeof(AppNameBuf), TEST_EXPECTED_APP_NAME, sizeof(TEST_EXPECTED_APP_NAME));
+    UtAssert_STRINGBUF_EQ(AppNameBuf, strlen(AppNameBuf), TEST_EXPECTED_APP_NAME, strlen(TEST_EXPECTED_APP_NAME));
 
     UtAssert_INT32_EQ(CFE_ES_GetAppInfo(&TestAppInfo, TestAppId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetAppIDByName(&ESAppId, ES_APP_EXPECTED_NAME), CFE_SUCCESS);
@@ -60,15 +60,15 @@ void TestGetAppInfo(void)
     UtAssert_True(ESAppInfo.Type == CFE_ES_AppType_CORE, "ES App Info -> Type = %d", (int)ESAppInfo.Type);
 
     UtAssert_STRINGBUF_EQ(TestAppInfo.Name,
-                          sizeof(TestAppInfo.Name),
+                          strlen(TestAppInfo.Name),
                           TEST_EXPECTED_APP_NAME,
-                          sizeof(TEST_EXPECTED_APP_NAME));
-    UtAssert_STRINGBUF_EQ(ESAppInfo.Name, sizeof(ESAppInfo.Name), ES_APP_EXPECTED_NAME, sizeof(ES_APP_EXPECTED_NAME));
+                          strlen(TEST_EXPECTED_APP_NAME));
+    UtAssert_STRINGBUF_EQ(ESAppInfo.Name, strlen(ESAppInfo.Name), ES_APP_EXPECTED_NAME, strlen(ES_APP_EXPECTED_NAME));
 
     UtAssert_STRINGBUF_EQ(TestAppInfo.EntryPoint,
-                          sizeof(TestAppInfo.EntryPoint),
+                          strlen(TestAppInfo.EntryPoint),
                           TEST_EXPECTED_ENTRYPOINT,
-                          sizeof(TEST_EXPECTED_ENTRYPOINT));
+                          strlen(TEST_EXPECTED_ENTRYPOINT));
     UtAssert_True(strlen(ESAppInfo.EntryPoint) == 0, "ES App Info -> EntryPt  = %s", ESAppInfo.EntryPoint);
 
     UtAssert_True(strstr(TestAppInfo.FileName, TEST_EXPECTED_FILE_NAME) != NULL,
@@ -144,11 +144,11 @@ void TestGetTaskInfo(void)
     UtAssert_INT32_EQ(CFE_ES_GetTaskID(&TaskId), CFE_SUCCESS);
     CFE_Assert_RESOURCEID_EQ(TaskId, AppInfo.MainTaskId);
 
-    UtAssert_STRINGBUF_EQ(TaskInfo.AppName, sizeof(TaskInfo.AppName), AppInfo.Name, sizeof(AppInfo.Name));
+    UtAssert_STRINGBUF_EQ(TaskInfo.AppName, strlen(TaskInfo.AppName), AppInfo.Name, strlen(AppInfo.Name));
     UtAssert_STRINGBUF_EQ(TaskInfo.TaskName,
-                          sizeof(TaskInfo.TaskName),
+                          strlen(TaskInfo.TaskName),
                           AppInfo.MainTaskName,
-                          sizeof(AppInfo.MainTaskName));
+                          strlen(AppInfo.MainTaskName));
 
     CFE_Assert_RESOURCEID_EQ(TaskInfo.TaskId, AppInfo.MainTaskId);
     CFE_Assert_RESOURCEID_EQ(TaskInfo.AppId, AppId);
@@ -174,10 +174,10 @@ void TestGetLibInfo(void)
     UtAssert_INT32_EQ(CFE_ES_GetLibIDByName(&LibId, LibName), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetLibInfo(&LibInfo, LibId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetLibName(LibNameBuf, LibId, sizeof(LibNameBuf)), CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(LibNameBuf, sizeof(LibNameBuf), LibName, sizeof(LibName));
+    UtAssert_STRINGBUF_EQ(LibNameBuf, strlen(LibNameBuf), LibName, strlen(LibName));
     UtAssert_True(LibInfo.Type == CFE_ES_AppType_LIBRARY, "Lib Info -> Type = %d", (int)LibInfo.Type);
-    UtAssert_STRINGBUF_EQ(LibInfo.Name, sizeof(LibInfo.Name), LibName, sizeof(LibName));
-    UtAssert_STRINGBUF_EQ(LibInfo.EntryPoint, sizeof(LibInfo.EntryPoint), "CFE_Assert_LibInit", -1);
+    UtAssert_STRINGBUF_EQ(LibInfo.Name, strlen(LibInfo.Name), LibName, strlen(LibName));
+    UtAssert_STRINGBUF_EQ(LibInfo.EntryPoint, strlen(LibInfo.EntryPoint), "CFE_Assert_LibInit", -1);
     UtAssert_True(strstr(LibInfo.FileName, FileName) != NULL,
                   "Lib Info -> FileName = %s contains %s",
                   LibInfo.FileName,
@@ -258,12 +258,12 @@ void TestGetModuleInfo(void)
     UtAssert_INT32_EQ(CFE_ES_GetAppID(&TestAppId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetAppInfo(&TestAppInfo, TestAppId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetModuleInfo(&ModuleInfo, CFE_RESOURCEID_UNWRAP(TestAppId)), CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(TestAppInfo.Name, sizeof(TestAppInfo.Name), ModuleInfo.Name, sizeof(ModuleInfo.Name));
+    UtAssert_STRINGBUF_EQ(TestAppInfo.Name, strlen(TestAppInfo.Name), ModuleInfo.Name, strlen(ModuleInfo.Name));
 
     UtAssert_INT32_EQ(CFE_ES_GetLibIDByName(&LibIdByName, LibName), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetLibInfo(&LibInfo, LibIdByName), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetModuleInfo(&ModuleInfo, CFE_RESOURCEID_UNWRAP(LibIdByName)), CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(LibInfo.Name, sizeof(LibInfo.Name), ModuleInfo.Name, sizeof(ModuleInfo.Name));
+    UtAssert_STRINGBUF_EQ(LibInfo.Name, strlen(LibInfo.Name), ModuleInfo.Name, strlen(ModuleInfo.Name));
 
     UtAssert_INT32_EQ(CFE_ES_GetModuleInfo(&ModuleInfo, CFE_RESOURCEID_UNDEFINED), CFE_ES_ERR_RESOURCEID_NOT_VALID);
     UtAssert_INT32_EQ(CFE_ES_GetModuleInfo(NULL, CFE_RESOURCEID_UNWRAP(TestAppId)), CFE_ES_BAD_ARGUMENT);

--- a/modules/cfe_testcase/src/es_info_test.c
+++ b/modules/cfe_testcase/src/es_info_test.c
@@ -50,7 +50,10 @@ void TestGetAppInfo(void)
     UtAssert_INT32_EQ(CFE_ES_GetAppID(&TestAppId), CFE_SUCCESS);
     CFE_Assert_RESOURCEID_EQ(TestAppId, AppIdByName);
     UtAssert_INT32_EQ(CFE_ES_GetAppName(AppNameBuf, TestAppId, sizeof(AppNameBuf)), CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(AppNameBuf, strlen(AppNameBuf), TEST_EXPECTED_APP_NAME, strlen(TEST_EXPECTED_APP_NAME));
+    UtAssert_STRINGBUF_EQ(AppNameBuf,
+                          UTASSERT_STRINGBUF_NULL_TERM,
+                          TEST_EXPECTED_APP_NAME,
+                          UTASSERT_STRINGBUF_NULL_TERM);
 
     UtAssert_INT32_EQ(CFE_ES_GetAppInfo(&TestAppInfo, TestAppId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetAppIDByName(&ESAppId, ES_APP_EXPECTED_NAME), CFE_SUCCESS);
@@ -60,15 +63,18 @@ void TestGetAppInfo(void)
     UtAssert_True(ESAppInfo.Type == CFE_ES_AppType_CORE, "ES App Info -> Type = %d", (int)ESAppInfo.Type);
 
     UtAssert_STRINGBUF_EQ(TestAppInfo.Name,
-                          strlen(TestAppInfo.Name),
+                          UTASSERT_STRINGBUF_NULL_TERM,
                           TEST_EXPECTED_APP_NAME,
-                          strlen(TEST_EXPECTED_APP_NAME));
-    UtAssert_STRINGBUF_EQ(ESAppInfo.Name, strlen(ESAppInfo.Name), ES_APP_EXPECTED_NAME, strlen(ES_APP_EXPECTED_NAME));
+                          UTASSERT_STRINGBUF_NULL_TERM);
+    UtAssert_STRINGBUF_EQ(ESAppInfo.Name,
+                          UTASSERT_STRINGBUF_NULL_TERM,
+                          ES_APP_EXPECTED_NAME,
+                          UTASSERT_STRINGBUF_NULL_TERM);
 
     UtAssert_STRINGBUF_EQ(TestAppInfo.EntryPoint,
-                          strlen(TestAppInfo.EntryPoint),
+                          UTASSERT_STRINGBUF_NULL_TERM,
                           TEST_EXPECTED_ENTRYPOINT,
-                          strlen(TEST_EXPECTED_ENTRYPOINT));
+                          UTASSERT_STRINGBUF_NULL_TERM);
     UtAssert_True(strlen(ESAppInfo.EntryPoint) == 0, "ES App Info -> EntryPt  = %s", ESAppInfo.EntryPoint);
 
     UtAssert_True(strstr(TestAppInfo.FileName, TEST_EXPECTED_FILE_NAME) != NULL,
@@ -144,11 +150,11 @@ void TestGetTaskInfo(void)
     UtAssert_INT32_EQ(CFE_ES_GetTaskID(&TaskId), CFE_SUCCESS);
     CFE_Assert_RESOURCEID_EQ(TaskId, AppInfo.MainTaskId);
 
-    UtAssert_STRINGBUF_EQ(TaskInfo.AppName, strlen(TaskInfo.AppName), AppInfo.Name, strlen(AppInfo.Name));
+    UtAssert_STRINGBUF_EQ(TaskInfo.AppName, UTASSERT_STRINGBUF_NULL_TERM, AppInfo.Name, UTASSERT_STRINGBUF_NULL_TERM);
     UtAssert_STRINGBUF_EQ(TaskInfo.TaskName,
-                          strlen(TaskInfo.TaskName),
+                          UTASSERT_STRINGBUF_NULL_TERM,
                           AppInfo.MainTaskName,
-                          strlen(AppInfo.MainTaskName));
+                          UTASSERT_STRINGBUF_NULL_TERM);
 
     CFE_Assert_RESOURCEID_EQ(TaskInfo.TaskId, AppInfo.MainTaskId);
     CFE_Assert_RESOURCEID_EQ(TaskInfo.AppId, AppId);
@@ -174,10 +180,13 @@ void TestGetLibInfo(void)
     UtAssert_INT32_EQ(CFE_ES_GetLibIDByName(&LibId, LibName), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetLibInfo(&LibInfo, LibId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetLibName(LibNameBuf, LibId, sizeof(LibNameBuf)), CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(LibNameBuf, strlen(LibNameBuf), LibName, strlen(LibName));
+    UtAssert_STRINGBUF_EQ(LibNameBuf, UTASSERT_STRINGBUF_NULL_TERM, LibName, UTASSERT_STRINGBUF_NULL_TERM);
     UtAssert_True(LibInfo.Type == CFE_ES_AppType_LIBRARY, "Lib Info -> Type = %d", (int)LibInfo.Type);
-    UtAssert_STRINGBUF_EQ(LibInfo.Name, strlen(LibInfo.Name), LibName, strlen(LibName));
-    UtAssert_STRINGBUF_EQ(LibInfo.EntryPoint, strlen(LibInfo.EntryPoint), "CFE_Assert_LibInit", -1);
+    UtAssert_STRINGBUF_EQ(LibInfo.Name, UTASSERT_STRINGBUF_NULL_TERM, LibName, UTASSERT_STRINGBUF_NULL_TERM);
+    UtAssert_STRINGBUF_EQ(LibInfo.EntryPoint,
+                          UTASSERT_STRINGBUF_NULL_TERM,
+                          "CFE_Assert_LibInit",
+                          UTASSERT_STRINGBUF_NULL_TERM);
     UtAssert_True(strstr(LibInfo.FileName, FileName) != NULL,
                   "Lib Info -> FileName = %s contains %s",
                   LibInfo.FileName,
@@ -258,12 +267,15 @@ void TestGetModuleInfo(void)
     UtAssert_INT32_EQ(CFE_ES_GetAppID(&TestAppId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetAppInfo(&TestAppInfo, TestAppId), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetModuleInfo(&ModuleInfo, CFE_RESOURCEID_UNWRAP(TestAppId)), CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(TestAppInfo.Name, strlen(TestAppInfo.Name), ModuleInfo.Name, strlen(ModuleInfo.Name));
+    UtAssert_STRINGBUF_EQ(TestAppInfo.Name,
+                          UTASSERT_STRINGBUF_NULL_TERM,
+                          ModuleInfo.Name,
+                          UTASSERT_STRINGBUF_NULL_TERM);
 
     UtAssert_INT32_EQ(CFE_ES_GetLibIDByName(&LibIdByName, LibName), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetLibInfo(&LibInfo, LibIdByName), CFE_SUCCESS);
     UtAssert_INT32_EQ(CFE_ES_GetModuleInfo(&ModuleInfo, CFE_RESOURCEID_UNWRAP(LibIdByName)), CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(LibInfo.Name, strlen(LibInfo.Name), ModuleInfo.Name, strlen(ModuleInfo.Name));
+    UtAssert_STRINGBUF_EQ(LibInfo.Name, UTASSERT_STRINGBUF_NULL_TERM, ModuleInfo.Name, UTASSERT_STRINGBUF_NULL_TERM);
 
     UtAssert_INT32_EQ(CFE_ES_GetModuleInfo(&ModuleInfo, CFE_RESOURCEID_UNDEFINED), CFE_ES_ERR_RESOURCEID_NOT_VALID);
     UtAssert_INT32_EQ(CFE_ES_GetModuleInfo(NULL, CFE_RESOURCEID_UNWRAP(TestAppId)), CFE_ES_BAD_ARGUMENT);

--- a/modules/cfe_testcase/src/es_task_test.c
+++ b/modules/cfe_testcase/src/es_task_test.c
@@ -278,7 +278,7 @@ void TestChildTaskName(void)
     CFE_Assert_RESOURCEID_EQ(TaskIdByName, TaskId);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(TaskNameBuf, TaskId, sizeof(TaskNameBuf)), CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(TaskNameBuf, strlen(TaskNameBuf), TaskName, strlen(TaskName));
+    UtAssert_STRINGBUF_EQ(TaskNameBuf, UTASSERT_STRINGBUF_NULL_TERM, TaskName, UTASSERT_STRINGBUF_NULL_TERM);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(NULL, TaskName), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(&TaskIdByName, NULL), CFE_ES_BAD_ARGUMENT);

--- a/modules/cfe_testcase/src/es_task_test.c
+++ b/modules/cfe_testcase/src/es_task_test.c
@@ -278,7 +278,7 @@ void TestChildTaskName(void)
     CFE_Assert_RESOURCEID_EQ(TaskIdByName, TaskId);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(TaskNameBuf, TaskId, sizeof(TaskNameBuf)), CFE_SUCCESS);
-    UtAssert_StrCmp(TaskNameBuf, TaskName, "CFE_ES_GetTaskName() = %s", TaskNameBuf);
+    UtAssert_STRINGBUF_EQ(TaskNameBuf, sizeof(TaskNameBuf), TaskName, sizeof(TaskName));
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(NULL, TaskName), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(&TaskIdByName, NULL), CFE_ES_BAD_ARGUMENT);

--- a/modules/cfe_testcase/src/es_task_test.c
+++ b/modules/cfe_testcase/src/es_task_test.c
@@ -278,7 +278,7 @@ void TestChildTaskName(void)
     CFE_Assert_RESOURCEID_EQ(TaskIdByName, TaskId);
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskName(TaskNameBuf, TaskId, sizeof(TaskNameBuf)), CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(TaskNameBuf, sizeof(TaskNameBuf), TaskName, sizeof(TaskName));
+    UtAssert_STRINGBUF_EQ(TaskNameBuf, strlen(TaskNameBuf), TaskName, strlen(TaskName));
 
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(NULL, TaskName), CFE_ES_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_ES_GetTaskIDByName(&TaskIdByName, NULL), CFE_ES_BAD_ARGUMENT);

--- a/modules/cfe_testcase/src/fs_header_test.c
+++ b/modules/cfe_testcase/src/fs_header_test.c
@@ -83,7 +83,10 @@ void TestReadHeader(void)
 
     UtAssert_INT32_EQ(Header.ContentType, ReadHeader.ContentType);
     UtAssert_INT32_EQ(Header.SubType, ReadHeader.SubType);
-    UtAssert_StrCmp(TestDescription, ReadHeader.Description, "ReadHeader.Description = %s", ReadHeader.Description);
+    UtAssert_STRINGBUF_EQ(TestDescription,
+                          sizeof(TestDescription),
+                          ReadHeader.Description,
+                          sizeof(ReadHeader.Description));
 
     UtAssert_INT32_EQ(CFE_FS_ReadHeader(NULL, fd), CFE_FS_BAD_ARGUMENT);
     CFE_Assert_STATUS_ERROR(CFE_FS_ReadHeader(&ReadHeader, OS_OBJECT_ID_UNDEFINED));

--- a/modules/cfe_testcase/src/fs_header_test.c
+++ b/modules/cfe_testcase/src/fs_header_test.c
@@ -84,9 +84,9 @@ void TestReadHeader(void)
     UtAssert_INT32_EQ(Header.ContentType, ReadHeader.ContentType);
     UtAssert_INT32_EQ(Header.SubType, ReadHeader.SubType);
     UtAssert_STRINGBUF_EQ(TestDescription,
-                          sizeof(TestDescription),
+                          strlen(TestDescription),
                           ReadHeader.Description,
-                          sizeof(ReadHeader.Description));
+                          strlen(ReadHeader.Description));
 
     UtAssert_INT32_EQ(CFE_FS_ReadHeader(NULL, fd), CFE_FS_BAD_ARGUMENT);
     CFE_Assert_STATUS_ERROR(CFE_FS_ReadHeader(&ReadHeader, OS_OBJECT_ID_UNDEFINED));

--- a/modules/cfe_testcase/src/fs_header_test.c
+++ b/modules/cfe_testcase/src/fs_header_test.c
@@ -84,9 +84,9 @@ void TestReadHeader(void)
     UtAssert_INT32_EQ(Header.ContentType, ReadHeader.ContentType);
     UtAssert_INT32_EQ(Header.SubType, ReadHeader.SubType);
     UtAssert_STRINGBUF_EQ(TestDescription,
-                          strlen(TestDescription),
+                          UTASSERT_STRINGBUF_NULL_TERM,
                           ReadHeader.Description,
-                          strlen(ReadHeader.Description));
+                          UTASSERT_STRINGBUF_NULL_TERM);
 
     UtAssert_INT32_EQ(CFE_FS_ReadHeader(NULL, fd), CFE_FS_BAD_ARGUMENT);
     CFE_Assert_STATUS_ERROR(CFE_FS_ReadHeader(&ReadHeader, OS_OBJECT_ID_UNDEFINED));

--- a/modules/cfe_testcase/src/fs_util_test.c
+++ b/modules/cfe_testcase/src/fs_util_test.c
@@ -81,18 +81,18 @@ void TestInputFile(void)
     UtAssert_INT32_EQ(
         CFE_FS_ParseInputFileNameEx(OutNameBuf, InNameBuf, sizeof(OutNameBuf), sizeof(InNameBuf), Name, Path, Ext),
         CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(ExpectedBuf, sizeof(ExpectedBuf), OutNameBuf, sizeof(OutNameBuf));
+    UtAssert_STRINGBUF_EQ(ExpectedBuf, strlen(ExpectedBuf), OutNameBuf, strlen(OutNameBuf));
     UtAssert_INT32_EQ(
         CFE_FS_ParseInputFileNameEx(OutNameBuf, NULL, sizeof(OutNameBuf), sizeof(InNameBuf), Name, Path, Ext),
         CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(ExpectedName, sizeof(ExpectedName), OutNameBuf, sizeof(OutNameBuf));
+    UtAssert_STRINGBUF_EQ(ExpectedName, strlen(ExpectedName), OutNameBuf, strlen(OutNameBuf));
     UtAssert_INT32_EQ(CFE_FS_ParseInputFileNameEx(OutNameBuf, InNameBuf, sizeof(OutNameBuf), 0, Name, Path, Ext),
                       CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(ExpectedName, sizeof(ExpectedName), OutNameBuf, sizeof(OutNameBuf));
+    UtAssert_STRINGBUF_EQ(ExpectedName, strlen(ExpectedName), OutNameBuf, strlen(OutNameBuf));
     UtAssert_INT32_EQ(
         CFE_FS_ParseInputFileNameEx(OutNameBuf, InNameBuf, sizeof(OutNameBuf), sizeof(InNameBuf), NULL, Path, Ext),
         CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(ExpectedBuf, sizeof(ExpectedBuf), OutNameBuf, sizeof(OutNameBuf));
+    UtAssert_STRINGBUF_EQ(ExpectedBuf, strlen(ExpectedBuf), OutNameBuf, strlen(OutNameBuf));
 
     UtAssert_INT32_EQ(
         CFE_FS_ParseInputFileNameEx(NULL, InNameBuf, sizeof(OutNameBuf), sizeof(InNameBuf), Name, Path, Ext),
@@ -122,7 +122,7 @@ void TestFileName(void)
 
     snprintf(Path, sizeof(Path), "/func/FileName.test");
     UtAssert_INT32_EQ(CFE_FS_ExtractFilenameFromPath(Path, Name), CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(Name, sizeof(Name), ExpectedName, sizeof(ExpectedName));
+    UtAssert_STRINGBUF_EQ(Name, strlen(Name), ExpectedName, strlen(ExpectedName));
 
     UtAssert_INT32_EQ(CFE_FS_ExtractFilenameFromPath(NULL, Name), CFE_FS_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_FS_ExtractFilenameFromPath(Path, NULL), CFE_FS_BAD_ARGUMENT);

--- a/modules/cfe_testcase/src/fs_util_test.c
+++ b/modules/cfe_testcase/src/fs_util_test.c
@@ -81,18 +81,18 @@ void TestInputFile(void)
     UtAssert_INT32_EQ(
         CFE_FS_ParseInputFileNameEx(OutNameBuf, InNameBuf, sizeof(OutNameBuf), sizeof(InNameBuf), Name, Path, Ext),
         CFE_SUCCESS);
-    UtAssert_StrCmp(ExpectedBuf, OutNameBuf, "Parse Input EX: %s", OutNameBuf);
+    UtAssert_STRINGBUF_EQ(ExpectedBuf, sizeof(ExpectedBuf), OutNameBuf, sizeof(OutNameBuf));
     UtAssert_INT32_EQ(
         CFE_FS_ParseInputFileNameEx(OutNameBuf, NULL, sizeof(OutNameBuf), sizeof(InNameBuf), Name, Path, Ext),
         CFE_SUCCESS);
-    UtAssert_StrCmp(ExpectedName, OutNameBuf, "Parse Input EX: %s", OutNameBuf);
+    UtAssert_STRINGBUF_EQ(ExpectedName, sizeof(ExpectedName), OutNameBuf, sizeof(OutNameBuf));
     UtAssert_INT32_EQ(CFE_FS_ParseInputFileNameEx(OutNameBuf, InNameBuf, sizeof(OutNameBuf), 0, Name, Path, Ext),
                       CFE_SUCCESS);
-    UtAssert_StrCmp(ExpectedName, OutNameBuf, "Parse Input EX: %s", OutNameBuf);
+    UtAssert_STRINGBUF_EQ(ExpectedName, sizeof(ExpectedName), OutNameBuf, sizeof(OutNameBuf));
     UtAssert_INT32_EQ(
         CFE_FS_ParseInputFileNameEx(OutNameBuf, InNameBuf, sizeof(OutNameBuf), sizeof(InNameBuf), NULL, Path, Ext),
         CFE_SUCCESS);
-    UtAssert_StrCmp(ExpectedBuf, OutNameBuf, "Parse Input EX: %s", OutNameBuf);
+    UtAssert_STRINGBUF_EQ(ExpectedBuf, sizeof(ExpectedBuf), OutNameBuf, sizeof(OutNameBuf));
 
     UtAssert_INT32_EQ(
         CFE_FS_ParseInputFileNameEx(NULL, InNameBuf, sizeof(OutNameBuf), sizeof(InNameBuf), Name, Path, Ext),
@@ -122,7 +122,7 @@ void TestFileName(void)
 
     snprintf(Path, sizeof(Path), "/func/FileName.test");
     UtAssert_INT32_EQ(CFE_FS_ExtractFilenameFromPath(Path, Name), CFE_SUCCESS);
-    UtAssert_StrCmp(Name, ExpectedName, "Extract Filename: %s", Name);
+    UtAssert_STRINGBUF_EQ(Name, sizeof(Name), ExpectedName, sizeof(ExpectedName));
 
     UtAssert_INT32_EQ(CFE_FS_ExtractFilenameFromPath(NULL, Name), CFE_FS_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_FS_ExtractFilenameFromPath(Path, NULL), CFE_FS_BAD_ARGUMENT);

--- a/modules/cfe_testcase/src/fs_util_test.c
+++ b/modules/cfe_testcase/src/fs_util_test.c
@@ -81,18 +81,18 @@ void TestInputFile(void)
     UtAssert_INT32_EQ(
         CFE_FS_ParseInputFileNameEx(OutNameBuf, InNameBuf, sizeof(OutNameBuf), sizeof(InNameBuf), Name, Path, Ext),
         CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(ExpectedBuf, strlen(ExpectedBuf), OutNameBuf, strlen(OutNameBuf));
+    UtAssert_STRINGBUF_EQ(ExpectedBuf, UTASSERT_STRINGBUF_NULL_TERM, OutNameBuf, UTASSERT_STRINGBUF_NULL_TERM);
     UtAssert_INT32_EQ(
         CFE_FS_ParseInputFileNameEx(OutNameBuf, NULL, sizeof(OutNameBuf), sizeof(InNameBuf), Name, Path, Ext),
         CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(ExpectedName, strlen(ExpectedName), OutNameBuf, strlen(OutNameBuf));
+    UtAssert_STRINGBUF_EQ(ExpectedName, UTASSERT_STRINGBUF_NULL_TERM, OutNameBuf, UTASSERT_STRINGBUF_NULL_TERM);
     UtAssert_INT32_EQ(CFE_FS_ParseInputFileNameEx(OutNameBuf, InNameBuf, sizeof(OutNameBuf), 0, Name, Path, Ext),
                       CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(ExpectedName, strlen(ExpectedName), OutNameBuf, strlen(OutNameBuf));
+    UtAssert_STRINGBUF_EQ(ExpectedName, UTASSERT_STRINGBUF_NULL_TERM, OutNameBuf, UTASSERT_STRINGBUF_NULL_TERM);
     UtAssert_INT32_EQ(
         CFE_FS_ParseInputFileNameEx(OutNameBuf, InNameBuf, sizeof(OutNameBuf), sizeof(InNameBuf), NULL, Path, Ext),
         CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(ExpectedBuf, strlen(ExpectedBuf), OutNameBuf, strlen(OutNameBuf));
+    UtAssert_STRINGBUF_EQ(ExpectedBuf, UTASSERT_STRINGBUF_NULL_TERM, OutNameBuf, UTASSERT_STRINGBUF_NULL_TERM);
 
     UtAssert_INT32_EQ(
         CFE_FS_ParseInputFileNameEx(NULL, InNameBuf, sizeof(OutNameBuf), sizeof(InNameBuf), Name, Path, Ext),
@@ -122,7 +122,7 @@ void TestFileName(void)
 
     snprintf(Path, sizeof(Path), "/func/FileName.test");
     UtAssert_INT32_EQ(CFE_FS_ExtractFilenameFromPath(Path, Name), CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(Name, strlen(Name), ExpectedName, strlen(ExpectedName));
+    UtAssert_STRINGBUF_EQ(Name, UTASSERT_STRINGBUF_NULL_TERM, ExpectedName, UTASSERT_STRINGBUF_NULL_TERM);
 
     UtAssert_INT32_EQ(CFE_FS_ExtractFilenameFromPath(NULL, Name), CFE_FS_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_FS_ExtractFilenameFromPath(Path, NULL), CFE_FS_BAD_ARGUMENT);

--- a/modules/cfe_testcase/src/sb_pipe_mang_test.c
+++ b/modules/cfe_testcase/src/sb_pipe_mang_test.c
@@ -156,7 +156,7 @@ void TestPipeName(void)
     UtAssert_INT32_EQ(CFE_SB_CreatePipe(&PipeId, PipeDepth, PipeName), CFE_SUCCESS);
 
     UtAssert_INT32_EQ(CFE_SB_GetPipeName(PipeNameBuf, sizeof(PipeNameBuf), PipeId), CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(PipeNameBuf, sizeof(PipeNameBuf), PipeName, sizeof(PipeName));
+    UtAssert_STRINGBUF_EQ(PipeNameBuf, strlen(PipeNameBuf), PipeName, strlen(PipeName));
 
     UtAssert_INT32_EQ(CFE_SB_GetPipeIdByName(&PipeIdBuff, PipeName), CFE_SUCCESS);
     CFE_Assert_RESOURCEID_EQ(PipeId, PipeIdBuff);

--- a/modules/cfe_testcase/src/sb_pipe_mang_test.c
+++ b/modules/cfe_testcase/src/sb_pipe_mang_test.c
@@ -156,7 +156,7 @@ void TestPipeName(void)
     UtAssert_INT32_EQ(CFE_SB_CreatePipe(&PipeId, PipeDepth, PipeName), CFE_SUCCESS);
 
     UtAssert_INT32_EQ(CFE_SB_GetPipeName(PipeNameBuf, sizeof(PipeNameBuf), PipeId), CFE_SUCCESS);
-    UtAssert_STRINGBUF_EQ(PipeNameBuf, strlen(PipeNameBuf), PipeName, strlen(PipeName));
+    UtAssert_STRINGBUF_EQ(PipeNameBuf, UTASSERT_STRINGBUF_NULL_TERM, PipeName, UTASSERT_STRINGBUF_NULL_TERM);
 
     UtAssert_INT32_EQ(CFE_SB_GetPipeIdByName(&PipeIdBuff, PipeName), CFE_SUCCESS);
     CFE_Assert_RESOURCEID_EQ(PipeId, PipeIdBuff);

--- a/modules/cfe_testcase/src/sb_pipe_mang_test.c
+++ b/modules/cfe_testcase/src/sb_pipe_mang_test.c
@@ -156,7 +156,7 @@ void TestPipeName(void)
     UtAssert_INT32_EQ(CFE_SB_CreatePipe(&PipeId, PipeDepth, PipeName), CFE_SUCCESS);
 
     UtAssert_INT32_EQ(CFE_SB_GetPipeName(PipeNameBuf, sizeof(PipeNameBuf), PipeId), CFE_SUCCESS);
-    UtAssert_StrCmp(PipeNameBuf, PipeName, "CFE_SB_GetPipeName() = %s", PipeNameBuf);
+    UtAssert_STRINGBUF_EQ(PipeNameBuf, sizeof(PipeNameBuf), PipeName, sizeof(PipeName));
 
     UtAssert_INT32_EQ(CFE_SB_GetPipeIdByName(&PipeIdBuff, PipeName), CFE_SUCCESS);
     CFE_Assert_RESOURCEID_EQ(PipeId, PipeIdBuff);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Replaced UtAssert_StrCmp calls with UtAssert_STRINGBUF_EQ.  
- Fixes #2752 

**Testing performed**
Steps taken to test the contribution:
1. make native_std.install
1. make native_std.runtest

**Expected behavior changes**
No impact to behavior

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu 
 - Versions: cFE v7.0.1

**Contributor Info - All information REQUIRED for consideration of pull request**
José Lombay, NASA GRC
