### PR TITLE
Fix 2764, Added null check to CFE_Config_GetIdByName and updated unit…

### DIFF
--- a/modules/config/fsw/src/cfe_config_get.c
+++ b/modules/config/fsw/src/cfe_config_get.c
@@ -147,6 +147,11 @@ CFE_ConfigId_t CFE_Config_GetIdByName(const char *Name)
     const CFE_Config_IdNameEntry_t *NamePtr;
     uint32                          OffsetVal;
 
+    if (Name == NULL)
+    {
+        return CFE_CONFIGID_UNDEFINED;
+    }
+
     NamePtr = CFE_CONFIGID_NAMETABLE;
     for (OffsetVal = 0; OffsetVal < CFE_ConfigIdOffset_MAX; ++OffsetVal)
     {

--- a/modules/config/ut-coverage/test_cfe_config.c
+++ b/modules/config/ut-coverage/test_cfe_config.c
@@ -234,6 +234,7 @@ void Test_CFE_Config_GetIdByName(void)
      */
     CFE_UtAssert_RESOURCEID_EQ(CFE_Config_GetIdByName("UT_CHECK_2"), CFE_CONFIGID_UT_CHECK_2);
     CFE_UtAssert_RESOURCEID_EQ(CFE_Config_GetIdByName("INVALID"), CFE_CONFIGID_UNDEFINED);
+    CFE_UtAssert_RESOURCEID_EQ(CFE_Config_GetIdByName(NULL), CFE_CONFIGID_UNDEFINED);
 }
 
 void UT_Callback(void *Arg, CFE_ConfigId_t Id, const char *Name)


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Added null check to argument in function `CFE_Config_GetIdByName` and updated unit test to include this case.
-Fixes #2764 

**Testing performed**
Steps taken to test the contribution:
1. make native_std.install
1. make native_std.runtest

**Expected behavior changes**
 No impact to behavior. 

**System(s) tested on**
 - Hardware: PC
 - OS: Ubuntu
 - Versions: cFE v7.0.1 

**Contributor Info - All information REQUIRED for consideration of pull request**
José Lombay, NASA GRC
