### PR TITLE
Fix #2766, add osconfig max cpus for multicore platforms

### DIFF
--- a/cmake/sample_defs/leon3-gaisler-rtems5_osconfig.cmake
+++ b/cmake/sample_defs/leon3-gaisler-rtems5_osconfig.cmake
@@ -1,0 +1,43 @@
+##########################################################################
+#
+# CFE-specific configuration options for OSAL
+#
+# This file specifies the CFE-specific values for various compile options
+# supported by OSAL.
+#
+# OSAL has many configuration options, which may vary depending on the
+# specific version of OSAL in use.  The complete list of OSAL options,
+# along with a description of each, can be found OSAL source in the file:
+#
+#    osal/default_config.cmake
+#
+# A CFE framework build utilizes mostly the OSAL default configuration.
+# This file only contains a few specific overrides that tune for a debug
+# environment, rather than a deployment environment.
+#
+# ALSO NOTE: There is also an arch-specific addendum to this file
+# to allow further tuning on a per-arch basis, in the form of:
+#
+#    ${TOOLCHAIN_NAME}_osconfig.cmake
+#
+# See "native_osconfig.cmake" for options which apply only to "native" builds.
+#
+##########################################################################
+
+#
+# OSAL_CONFIG_MAX_CPUS
+# --------------------------------
+#
+#  Defines the maximum number of CPU cores that the OSAL can manage and interact with.
+#  This parameter dictates the sizing of internal OSAL data structures, sets the bounds 
+#  for CPU-specific API checks, and determines the required bit width for operations 
+#  like setting and getting Task Affinity masks.
+#
+#  This should be set to the highest number of logical CPU cores available on your 
+#  target platform (or the maximum expected across all platforms in a multi-target 
+#  mission) to ensure masks and arrays are sized correctly without wasting memory.
+#
+# Limits:
+#   Must be an integer greater than 0. 
+#
+set(OSAL_CONFIG_MAX_CPUS 2)

--- a/cmake/sample_defs/native_osconfig.cmake
+++ b/cmake/sample_defs/native_osconfig.cmake
@@ -56,3 +56,29 @@ set(OSAL_CONFIG_DEBUG_PERMISSIVE_MODE TRUE)
 # However for a flight deployment this may cause undesired delays.
 #
 set(OSAL_CONFIG_UTILITYTASK_PRIORITY 10)
+
+#
+# OSAL_CONFIG_INCLUDE_DNS
+# --------------------------------
+#
+# Includes DNS support in the name to address conversion
+#
+set(OSAL_CONFIG_INCLUDE_DNS TRUE)
+
+#
+# OSAL_CONFIG_MAX_CPUS
+# --------------------------------
+#
+#  Defines the maximum number of CPU cores that the OSAL can manage and interact with.
+#  This parameter dictates the sizing of internal OSAL data structures, sets the bounds 
+#  for CPU-specific API checks, and determines the required bit width for operations 
+#  like setting and getting Task Affinity masks.
+#
+#  This should be set to the highest number of logical CPU cores available on your 
+#  target platform (or the maximum expected across all platforms in a multi-target 
+#  mission) to ensure masks and arrays are sized correctly without wasting memory.
+#
+# Limits:
+#   Must be an integer greater than 0. 
+#
+set(OSAL_CONFIG_MAX_CPUS 64)

--- a/cmake/sample_defs/riscv64-poky-linux_osconfig.cmake
+++ b/cmake/sample_defs/riscv64-poky-linux_osconfig.cmake
@@ -1,0 +1,43 @@
+##########################################################################
+#
+# CFE-specific configuration options for OSAL
+#
+# This file specifies the CFE-specific values for various compile options
+# supported by OSAL.
+#
+# OSAL has many configuration options, which may vary depending on the
+# specific version of OSAL in use.  The complete list of OSAL options,
+# along with a description of each, can be found OSAL source in the file:
+#
+#    osal/default_config.cmake
+#
+# A CFE framework build utilizes mostly the OSAL default configuration.
+# This file only contains a few specific overrides that tune for a debug
+# environment, rather than a deployment environment.
+#
+# ALSO NOTE: There is also an arch-specific addendum to this file
+# to allow further tuning on a per-arch basis, in the form of:
+#
+#    ${TOOLCHAIN_NAME}_osconfig.cmake
+#
+# See "native_osconfig.cmake" for options which apply only to "native" builds.
+#
+##########################################################################
+
+#
+# OSAL_CONFIG_MAX_CPUS
+# --------------------------------
+#
+#  Defines the maximum number of CPU cores that the OSAL can manage and interact with.
+#  This parameter dictates the sizing of internal OSAL data structures, sets the bounds 
+#  for CPU-specific API checks, and determines the required bit width for operations 
+#  like setting and getting Task Affinity masks.
+#
+#  This should be set to the highest number of logical CPU cores available on your 
+#  target platform (or the maximum expected across all platforms in a multi-target 
+#  mission) to ensure masks and arrays are sized correctly without wasting memory.
+#
+# Limits:
+#   Must be an integer greater than 0. 
+#
+set(OSAL_CONFIG_MAX_CPUS 8)

--- a/cmake/sample_defs/vxsim_lnx-vx7dkm_osconfig.cmake
+++ b/cmake/sample_defs/vxsim_lnx-vx7dkm_osconfig.cmake
@@ -1,0 +1,35 @@
+##########################################################################
+#
+# CFE-specific configuration options for OSAL
+#
+# This file specifies the CFE-specific values for various compile options
+# supported by OSAL.
+#
+# OSAL has many configuration options, which may vary depending on the
+# specific version of OSAL in use.  The complete list of OSAL options,
+# along with a description of each, can be found OSAL source in the file:
+#
+#    osal/default_config.cmake
+#
+# A CFE framework build utilizes mostly the OSAL default configuration.
+# This file only contains a few specific overrides that tune for a debug
+# environment, rather than a deployment environment.
+#
+# ALSO NOTE: There is also an arch-specific addendum to this file
+# to allow further tuning on a per-arch basis, in the form of:
+#
+#    ${TOOLCHAIN_NAME}_osconfig.cmake
+#
+# See "native_osconfig.cmake" for options which apply only to "native" builds.
+#
+##########################################################################
+
+#
+# OSAL_CONFIG_DEBUG_PRINTF
+# ------------------------
+#
+# For CFE builds this can be helpful during debugging as it will display more
+# specific error messages for various OSAL error/warning events, such as if a
+# module cannot be loaded or a file cannot be opened for some reason.
+#
+set(OSAL_CONFIG_MAX_CPUS 16)


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Adding osconfig for max cpus for multicore platforms

**Testing performed**
Run on native and vxsim and use the TA cFE module to verify that the cores utilized matches the cpu config set for the platform

Hardware: PC, VxSIM(on a linux VM), GR740
OS: Debian, VxWorks, RTEMS

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

Contributor Info - All information REQUIRED for consideration of pull request
Adrian Rodriguez NASA GSFC
