### PR TITLE
Fix #2695, Updates in-range external MET state path TIME UT

### DIFF
--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -1020,13 +1020,16 @@ void Test_External(void)
     CFE_TIME_ExternalMET(settime);
     UtAssert_UINT32_EQ(CFE_TIME_Global.InternalCount, 1);
 
-    /* Test setting time data from MET (external source, state set) */
+    /* Test setting time data from MET using an external source with the clock
+     * state set and time in range
+     */
     UT_InitData();
     CFE_TIME_Global.ClockSource                              = CFE_TIME_SourceSelect_EXTERNAL;
-    CFE_TIME_Global.ReferenceState[0].ClockSetState          = CFE_TIME_SetState_NOT_SET;
+    CFE_TIME_Global.ReferenceState[0].ClockSetState          = CFE_TIME_SetState_WAS_SET;
     settime.Seconds                                          = 10;
     settime.Subseconds                                       = 0;
     CFE_TIME_Global.ExternalCount                            = 0;
+    CFE_TIME_Global.InternalCount                            = 0;
     CFE_TIME_Global.ReferenceState[0].AtToneMET.Seconds      = 10;
     CFE_TIME_Global.ReferenceState[0].AtToneMET.Subseconds   = 0;
     CFE_TIME_Global.ReferenceState[0].AtToneDelay.Seconds    = 0;
@@ -1040,6 +1043,7 @@ void Test_External(void)
     UT_SetBSP_Time(0, 0);
     CFE_TIME_ExternalMET(settime);
     UtAssert_UINT32_EQ(CFE_TIME_Global.ExternalCount, 1);
+    UtAssert_UINT32_EQ(CFE_TIME_Global.InternalCount, 0);
 
     /* Test setting time data from MET (internal source) */
     UT_InitData();


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
- Fixes #2695, This updates the existing in-range MET case in Test_External() to exercise the `ClockSetState == WAS_SET` and in-range path in CFE_TIME_ToneSendMET(). It also adds an `InternalCount == 0` assertion to confirm the test stays on the external-data path

**Testing performed**
cfe time lcov with and without the config changes below:
`DEFAULT_CFE_MISSION_TIME_CFG_FAKE_TONE` = false
`DEFAULT_CFE_PLATFORM_TIME_CFG_SOURCE` = true
`DEFAULT_CFE_PLATFORM_TIME_CFG_SRC_MET` = true

**Expected behavior changes**
provides coverage for 1 uncovered branch in CFE_TIME_ToneSendMET() when configured as specified above.

**System(s) tested on**
Ubuntu 24.04

**Additional context**
InternalCount and ExternalCount are incremented by mutually exclusive paths. The new assertion is there to make the test self-contained and explicitly confirm that the in-range, state case stayed on the external data path.

https://github.com/nasa/cFE/pull/2700 was merged to main unintentionally. This merges correctly to dev.

**Third party code**
N/A

**Contributor Info - All information REQUIRED for consideration of pull request**
Justin Figueroa, Vantage Systems Inc
