### PR TITLE
Fix nasa/cFS#1064, close table fd leak in CFE_TBL_LoadCmd

### DIFF
--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
@@ -449,6 +449,13 @@ CFE_Status_t CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
         CFE_TBL_SetMetaDataFromFileHeader(&Txn, LoadFilename, &Header.Std);
     }
 
+    /* Done with the file now -- must always close the file if it was opened,
+     * regardless of what happened, otherwise the file descriptor is leaked */
+    if (OS_ObjectIdDefined(FileDescriptor))
+    {
+        OS_close(FileDescriptor);
+    }
+
     CFE_TBL_TxnFinish(&Txn);
 
     if (Status == CFE_SUCCESS)


### PR DESCRIPTION
**Checklist**
- [x] I reviewed the Contributing Guide.
- [x] Signed and emailed the CLA to GSFC-SoftwareRelease@mail.nasa.gov, cc cfs-program@lists.nasa.gov (2026-07-08).

**Describe the contribution**
CFE_TBL_LoadCmd opens the table file via CFE_TBL_TxnOpenTableLoadFile but never
closes the descriptor, so every TBL_LOAD leaks one fd until OSAL is exhausted
and OS_OpenCreate returns OS_FS_ERR_NO_FREE_FDS (-14). Adds a guarded OS_close
before CFE_TBL_TxnFinish, matching the sibling CFE_TBL_TxnLoadFromFile.
Fixes nasa/cFS#1064.

**Testing performed**
Code-level only, not run on a target. Both branches of the new guard are already
covered by tbl_ut_load.c (Test_CFE_TBL_LoadCmd). Left as draft so CI runs the
full build and coverage.

**Expected behavior changes**
No API change. The load descriptor is released each load, so repeated TBL_LOAD no
longer exhausts OSAL. No change to return codes, counters, or events.

**System(s) tested on**
Not run on a target; verified against the dev branch. Leak is also present on the
v7.0.1 (Draco) tag cited in the report.

**Third party code**
None.

**Contributor Info**
Sammy Dabbas, Personal.
