### PR TITLE
Fix #2223, correct Doxygen parameter names

### DIFF
--- a/modules/core_private/ut-stubs/inc/ut_support.h
+++ b/modules/core_private/ut-stubs/inc/ut_support.h
@@ -304,12 +304,13 @@ void UT_SetupBasicMsgDispatch(const UT_TaskPipeDispatchId_t *DispatchReq,
 ** \par Assumptions, External Events, and Notes:
 **        None
 **
-** \param[in] msg_ptr  Pointer to the buffer that contains the software
-**                     bus message
+** \param[in] TaskPipeFunc  Task pipe function to invoke
 **
-** \param[in] id       Message ID to put into the message header
+** \param[in] MsgPtr        Pointer to the software bus message
 **
-** \param[in] code     Command code to include in the message
+** \param[in] MsgSize       Size of the software bus message
+**
+** \param[in] DispatchId    Dispatcher configuration for the message
 **
 ** \returns
 **        This function does not return a value.
@@ -595,7 +596,7 @@ uint16 UT_GetNumEventsSent(void);
 ** \par Assumptions, External Events, and Notes:
 **        None
 **
-** \param[in] ptr   Pointer to packet to display
+** \param[in] MsgPtr  Pointer to packet to display
 **
 ** \param[in] size  Size of packet in bytes
 **


### PR DESCRIPTION
## Description of Change

Correct the Doxygen parameter documentation for `UT_CallTaskPipe()` and `UT_DisplayPkt()` so every documented name matches the corresponding function declaration. This removes stale names left behind by earlier signature changes and documents the four current `UT_CallTaskPipe()` parameters.

## Linked Issue

Closes #2223

## Areas of Expertise Touched

- [ ] ASTRO
- [ ] CI/CD
- [ ] COSMOS
- [ ] Cybersecurity
- [ ] Docker
- [ ] EDS
- [ ] Git
- [ ] PSPs
- [ ] SBN
- [ ] SMP
- [ ] Tables
- [ ] TSN
- [x] Unit Tests
- [ ] Other

---

## Author Checklist

- [x] Linked GitHub issue is referenced above/linked to this PR
- [ ] Documentation generation workflow ran successfully on this branch
- [x] Changes are limited to documentation/comments (no code behavior changes)

## Testing

- `git diff upstream/dev...HEAD --check`
- Confirmed each Doxygen `param` name exactly matches its function declaration

---

## Reviewer Checklist

- [ ] Documentation is clear, accurate, and complete
- [ ] Spelling and grammar reviewed
- [ ] Any links in the documentation have been verified to work
- [ ] Documentation generation workflow output looks correct
- [ ] Appropriate Expert areas have been reviewed