### PR TITLE
Fix #2778, Adds perfID bounds reporting and populate full hk mask

### DIFF
--- a/modules/core_private/fsw/inc/cfe_es_perfdata_typedef.h
+++ b/modules/core_private/fsw/inc/cfe_es_perfdata_typedef.h
@@ -29,7 +29,7 @@
 #include "cfe_mission_cfg.h"  /* Required for CFE_MISSION_ES_PERF_MAX_IDS */
 #include "cfe_platform_cfg.h" /* Required for CFE_PLATFORM_ES_PERF_DATA_BUFFER_SIZE */
 
-#define CFE_ES_PERF_32BIT_WORDS_IN_MASK ((CFE_MISSION_ES_PERF_MAX_IDS) / 32)
+#define CFE_ES_PERF_8BIT_WORDS_IN_MASK ((CFE_MISSION_ES_PERF_MAX_IDS) / 8)
 
 typedef struct
 {
@@ -60,8 +60,8 @@ typedef struct
     uint32          DataCount;
     uint32          InvalidMarkerReported;
     uint32          FilterTriggerMaskSize;
-    uint32          FilterMask[CFE_ES_PERF_32BIT_WORDS_IN_MASK];
-    uint32          TriggerMask[CFE_ES_PERF_32BIT_WORDS_IN_MASK];
+    uint8           FilterMask[CFE_ES_PERF_8BIT_WORDS_IN_MASK];
+    uint8           TriggerMask[CFE_ES_PERF_8BIT_WORDS_IN_MASK];
 } CFE_ES_PerfMetaData_t;
 
 typedef struct

--- a/modules/es/config/default_cfe_es_msgdefs.h
+++ b/modules/es/config/default_cfe_es_msgdefs.h
@@ -330,23 +330,23 @@ typedef struct CFE_ES_HousekeepingTlm_Payload
     uint32 BootSource;         /**< \cfetlmmnemonic \ES_BOOTSOURCE
                                     \brief Boot source ( as provided from BSP ) */
 
-    uint32 PerfState;                                        /**< \cfetlmmnemonic \ES_PERFSTATE
-                                                                  \brief Current state of Performance Analyzer */
+    uint32 PerfState;                                       /**< \cfetlmmnemonic \ES_PERFSTATE
+                                                                 \brief Current state of Performance Analyzer */
     uint32 PerfMode;                                        /**< \cfetlmmnemonic \ES_PERFMODE
                                                                   \brief Current mode of Performance Analyzer */
-    uint32 PerfTriggerCount;                                 /**< \cfetlmmnemonic \ES_PERFTRIGCNT
-                                                                  \brief Number of Times Performance Analyzer has Triggered */
-    uint8 PerfFilterMask[CFE_MISSION_ES_PERF_MAX_IDS / 8]; /**< \cfetlmmnemonic \ES_PERFFLTRMASK
-                                                          \brief Current Setting of Performance Analyzer Filter Masks */
+    uint32 PerfTriggerCount;                                /**< \cfetlmmnemonic \ES_PERFTRIGCNT
+                                                                 \brief Number of Times Performance Analyzer has Triggered */
+    uint8  PerfFilterMask[CFE_MISSION_ES_PERF_MAX_IDS / 8]; /**< \cfetlmmnemonic \ES_PERFFLTRMASK
+                                                           \brief Current Setting of Performance Analyzer Filter Masks */
     uint8
            PerfTriggerMask[CFE_MISSION_ES_PERF_MAX_IDS / 8]; /**< \cfetlmmnemonic \ES_PERFTRIGMASK
                                                            \brief Current Setting of Performance Analyzer Trigger Masks */
-    uint32 PerfDataStart;                                     /**< \cfetlmmnemonic \ES_PERFDATASTART
-                                                                   \brief Identifies First Stored Entry in Performance Analyzer Log */
-    uint32 PerfDataEnd;                                       /**< \cfetlmmnemonic \ES_PERFDATAEND
-                                                                   \brief Identifies Last Stored Entry in Performance Analyzer Log */
-    uint32 PerfDataCount;                                     /**< \cfetlmmnemonic \ES_PERFDATACNT
-                                                                   \brief Number of Entries Put Into the Performance Analyzer Log */
+    uint32 PerfDataStart;                                    /**< \cfetlmmnemonic \ES_PERFDATASTART
+                                                                  \brief Identifies First Stored Entry in Performance Analyzer Log */
+    uint32 PerfDataEnd;                                      /**< \cfetlmmnemonic \ES_PERFDATAEND
+                                                                  \brief Identifies Last Stored Entry in Performance Analyzer Log */
+    uint32 PerfDataCount;                                    /**< \cfetlmmnemonic \ES_PERFDATACNT
+                                                                  \brief Number of Entries Put Into the Performance Analyzer Log */
     uint32
                        PerfDataToWrite;  /**< \cfetlmmnemonic \ES_PERFDATA2WRITE
                                               \brief Number of Performance Analyzer Log Entries Left to be Written to Log Dump File */

--- a/modules/es/config/default_cfe_es_msgdefs.h
+++ b/modules/es/config/default_cfe_es_msgdefs.h
@@ -191,8 +191,8 @@ typedef struct CFE_ES_StopPerfCmd_Payload
 **/
 typedef struct CFE_ES_SetPerfFilterMaskCmd_Payload
 {
-    uint32 FilterMaskNum; /**< \brief Index into array of Filter Masks */
-    uint32 FilterMask;    /**< \brief New Mask for specified entry in array of Filter Masks */
+    uint8 FilterMaskNum; /**< \brief Index into array of Filter Masks */
+    uint8 FilterMask;    /**< \brief New Mask for specified entry in array of Filter Masks */
 } CFE_ES_SetPerfFilterMaskCmd_Payload_t;
 
 /**
@@ -203,8 +203,8 @@ typedef struct CFE_ES_SetPerfFilterMaskCmd_Payload
 **/
 typedef struct CFE_ES_SetPerfTrigMaskCmd_Payload
 {
-    uint32 TriggerMaskNum; /**< \brief Index into array of Trigger Masks */
-    uint32 TriggerMask;    /**< \brief New Mask for specified entry in array of Trigger Masks */
+    uint8 TriggerMaskNum; /**< \brief Index into array of Trigger Masks */
+    uint8 TriggerMask;    /**< \brief New Mask for specified entry in array of Trigger Masks */
 } CFE_ES_SetPerfTrigMaskCmd_Payload_t;
 
 /**
@@ -332,14 +332,14 @@ typedef struct CFE_ES_HousekeepingTlm_Payload
 
     uint32 PerfState;                                        /**< \cfetlmmnemonic \ES_PERFSTATE
                                                                   \brief Current state of Performance Analyzer */
-    uint32 PerfMode;                                         /**< \cfetlmmnemonic \ES_PERFMODE
+    uint32 PerfMode;                                        /**< \cfetlmmnemonic \ES_PERFMODE
                                                                   \brief Current mode of Performance Analyzer */
     uint32 PerfTriggerCount;                                 /**< \cfetlmmnemonic \ES_PERFTRIGCNT
                                                                   \brief Number of Times Performance Analyzer has Triggered */
-    uint32 PerfFilterMask[CFE_MISSION_ES_PERF_MAX_IDS / 32]; /**< \cfetlmmnemonic \ES_PERFFLTRMASK
+    uint8 PerfFilterMask[CFE_MISSION_ES_PERF_MAX_IDS / 8]; /**< \cfetlmmnemonic \ES_PERFFLTRMASK
                                                           \brief Current Setting of Performance Analyzer Filter Masks */
-    uint32
-           PerfTriggerMask[CFE_MISSION_ES_PERF_MAX_IDS / 32]; /**< \cfetlmmnemonic \ES_PERFTRIGMASK
+    uint8
+           PerfTriggerMask[CFE_MISSION_ES_PERF_MAX_IDS / 8]; /**< \cfetlmmnemonic \ES_PERFTRIGMASK
                                                            \brief Current Setting of Performance Analyzer Trigger Masks */
     uint32 PerfDataStart;                                     /**< \cfetlmmnemonic \ES_PERFDATASTART
                                                                    \brief Identifies First Stored Entry in Performance Analyzer Log */

--- a/modules/es/eds/cfe_es.xml
+++ b/modules/es/eds/cfe_es.xml
@@ -499,8 +499,8 @@
           For command details, see #CFE_ES_PERF_SETFILTERMASK_CC
         </LongDescription>
         <EntryList>
-          <Entry name="FilterMaskNum" type="BASE_TYPES/uint32" shortDescription="Index into array of Filter Masks" />
-          <Entry name="FilterMask" type="BASE_TYPES/uint32" shortDescription="New Mask for specified entry in array of Filter Masks" />
+          <Entry name="FilterMaskNum" type="BASE_TYPES/uint8" shortDescription="Index into array of Filter Masks" />
+          <Entry name="FilterMask" type="BASE_TYPES/uint8" shortDescription="New Mask for specified entry in array of Filter Masks" />
         </EntryList>
       </ContainerDataType>
 
@@ -509,8 +509,8 @@
           For command details, see #CFE_ES_PERF_SETTRIGMASK_CC
         </LongDescription>
         <EntryList>
-          <Entry name="TriggerMaskNum" type="BASE_TYPES/uint32" shortDescription="Index into array of Trigger Masks" />
-          <Entry name="TriggerMask" type="BASE_TYPES/uint32" shortDescription="New Mask for specified entry in array of Trigger Masks" />
+          <Entry name="TriggerMaskNum" type="BASE_TYPES/uint8" shortDescription="Index into array of Trigger Masks" />
+          <Entry name="TriggerMask" type="BASE_TYPES/uint8" shortDescription="New Mask for specified entry in array of Trigger Masks" />
         </EntryList>
       </ContainerDataType>
 

--- a/modules/es/fsw/src/cfe_es_perf.c
+++ b/modules/es/fsw/src/cfe_es_perf.c
@@ -80,9 +80,9 @@ void CFE_ES_SetupPerfVariables(uint32 ResetType)
         Perf->MetaData.DataEnd               = 0;
         Perf->MetaData.DataCount             = 0;
         Perf->MetaData.InvalidMarkerReported = false;
-        Perf->MetaData.FilterTriggerMaskSize = CFE_ES_PERF_32BIT_WORDS_IN_MASK;
+        Perf->MetaData.FilterTriggerMaskSize = CFE_ES_PERF_8BIT_WORDS_IN_MASK;
 
-        for (i = 0; i < CFE_ES_PERF_32BIT_WORDS_IN_MASK; i++)
+        for (i = 0; i < CFE_ES_PERF_8BIT_WORDS_IN_MASK; i++)
         {
             Perf->MetaData.FilterMask[i]  = CFE_PLATFORM_ES_PERF_FILTMASK_INIT;
             Perf->MetaData.TriggerMask[i] = CFE_PLATFORM_ES_PERF_TRIGMASK_INIT;
@@ -515,7 +515,7 @@ int32 CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMaskCmd_t *data)
     */
     Perf = &CFE_ES_Global.ResetDataPtr->Perf;
 
-    if (cmd->FilterMaskNum < CFE_ES_PERF_32BIT_WORDS_IN_MASK)
+    if (cmd->FilterMaskNum < CFE_ES_PERF_8BIT_WORDS_IN_MASK)
     {
         Perf->MetaData.FilterMask[cmd->FilterMaskNum] = cmd->FilterMask;
 
@@ -533,7 +533,7 @@ int32 CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMaskCmd_t *data)
                           CFE_EVS_EventType_ERROR,
                           "Performance Filter Mask Cmd Error, Index(%u) out of range, valid range is 0 to %u",
                           (unsigned int)cmd->FilterMaskNum,
-                          (unsigned int)(CFE_ES_PERF_32BIT_WORDS_IN_MASK - 1));
+                          (unsigned int)(CFE_ES_PERF_8BIT_WORDS_IN_MASK - 1));
 
         CFE_ES_Global.TaskData.CommandErrorCounter++;
     }
@@ -557,7 +557,7 @@ int32 CFE_ES_SetPerfTriggerMaskCmd(const CFE_ES_SetPerfTriggerMaskCmd_t *data)
     */
     Perf = &CFE_ES_Global.ResetDataPtr->Perf;
 
-    if (cmd->TriggerMaskNum < CFE_ES_PERF_32BIT_WORDS_IN_MASK)
+    if (cmd->TriggerMaskNum < CFE_ES_PERF_8BIT_WORDS_IN_MASK)
     {
         Perf->MetaData.TriggerMask[cmd->TriggerMaskNum] = cmd->TriggerMask;
 
@@ -575,7 +575,7 @@ int32 CFE_ES_SetPerfTriggerMaskCmd(const CFE_ES_SetPerfTriggerMaskCmd_t *data)
                           CFE_EVS_EventType_ERROR,
                           "Performance Trigger Mask Cmd Error, Index(%u) out of range, valid range is 0 to %u",
                           (unsigned int)cmd->TriggerMaskNum,
-                          (unsigned int)(CFE_ES_PERF_32BIT_WORDS_IN_MASK - 1));
+                          (unsigned int)(CFE_ES_PERF_8BIT_WORDS_IN_MASK - 1));
 
         CFE_ES_Global.TaskData.CommandErrorCounter++;
     }
@@ -632,7 +632,7 @@ void CFE_ES_PerfLogAdd(uint32 Marker, uint32 EntryExit)
      * locking (and potential task switch) if the data is ultimately not going to
      * be written to the log.
      */
-    if (!CFE_ES_TEST_U32_MASK(Perf->MetaData.FilterMask, Marker))
+    if (!CFE_ES_TEST_U8_MASK(Perf->MetaData.FilterMask, Marker))
     {
         return;
     }
@@ -684,7 +684,7 @@ void CFE_ES_PerfLogAdd(uint32 Marker, uint32 EntryExit)
         /* waiting for trigger */
         if (Perf->MetaData.State == CFE_ES_PERF_WAITING_FOR_TRIGGER)
         {
-            if (CFE_ES_TEST_U32_MASK(Perf->MetaData.TriggerMask, Marker))
+            if (CFE_ES_TEST_U8_MASK(Perf->MetaData.TriggerMask, Marker))
             {
                 Perf->MetaData.State = CFE_ES_PERF_TRIGGERED;
             }

--- a/modules/es/fsw/src/cfe_es_perf.c
+++ b/modules/es/fsw/src/cfe_es_perf.c
@@ -521,7 +521,7 @@ int32 CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMaskCmd_t *data)
 
         CFE_EVS_SendEvent(CFE_ES_PERF_FILTMSKCMD_EID,
                           CFE_EVS_EventType_DEBUG,
-                          "Set Performance Filter Mask Cmd rcvd, num %u, val 0x%08X",
+                          "Set Performance Filter Mask Cmd rcvd, num %u, val 0x%02X",
                           (unsigned int)cmd->FilterMaskNum,
                           (unsigned int)cmd->FilterMask);
 
@@ -563,7 +563,7 @@ int32 CFE_ES_SetPerfTriggerMaskCmd(const CFE_ES_SetPerfTriggerMaskCmd_t *data)
 
         CFE_EVS_SendEvent(CFE_ES_PERF_TRIGMSKCMD_EID,
                           CFE_EVS_EventType_DEBUG,
-                          "Set Performance Trigger Mask Cmd rcvd,num %u, val 0x%08X",
+                          "Set Performance Trigger Mask Cmd rcvd, num %u, val 0x%02X",
                           (unsigned int)cmd->TriggerMaskNum,
                           (unsigned int)cmd->TriggerMask);
 

--- a/modules/es/fsw/src/cfe_es_perf.c
+++ b/modules/es/fsw/src/cfe_es_perf.c
@@ -531,9 +531,9 @@ int32 CFE_ES_SetPerfFilterMaskCmd(const CFE_ES_SetPerfFilterMaskCmd_t *data)
     {
         CFE_EVS_SendEvent(CFE_ES_PERF_FILTMSKERR_EID,
                           CFE_EVS_EventType_ERROR,
-                          "Performance Filter Mask Cmd Error,Index(%u)out of range(%u)",
+                          "Performance Filter Mask Cmd Error, Index(%u) out of range, valid range is 0 to %u",
                           (unsigned int)cmd->FilterMaskNum,
-                          (unsigned int)CFE_ES_PERF_32BIT_WORDS_IN_MASK);
+                          (unsigned int)(CFE_ES_PERF_32BIT_WORDS_IN_MASK - 1));
 
         CFE_ES_Global.TaskData.CommandErrorCounter++;
     }
@@ -573,9 +573,9 @@ int32 CFE_ES_SetPerfTriggerMaskCmd(const CFE_ES_SetPerfTriggerMaskCmd_t *data)
     {
         CFE_EVS_SendEvent(CFE_ES_PERF_TRIGMSKERR_EID,
                           CFE_EVS_EventType_ERROR,
-                          "Performance Trigger Mask Cmd Error,Index(%u)out of range(%u)",
+                          "Performance Trigger Mask Cmd Error, Index(%u) out of range, valid range is 0 to %u",
                           (unsigned int)cmd->TriggerMaskNum,
-                          (unsigned int)CFE_ES_PERF_32BIT_WORDS_IN_MASK);
+                          (unsigned int)(CFE_ES_PERF_32BIT_WORDS_IN_MASK - 1));
 
         CFE_ES_Global.TaskData.CommandErrorCounter++;
     }

--- a/modules/es/fsw/src/cfe_es_perf.h
+++ b/modules/es/fsw/src/cfe_es_perf.h
@@ -41,21 +41,21 @@
 ** Macro Definitions
 */
 
-#define CFE_ES_DBIT(x)     ((uint32)1 << (x))            /* Places a one at bit positions 0 thru 31 */
+#define CFE_ES_DBIT(x)     ((uint8)1 << (x))            /* Places a one at bit positions 0 thru 7 */
 #define CFE_ES_DTEST(i, x) (((i) & CFE_ES_DBIT(x)) != 0) /* true iff bit x of i is set */
 
-/* Test a bit within an array of 32-bit integers. */
-static inline bool CFE_ES_TEST_U32_MASK(const uint32 *m, uint32 s)
+/* Test a bit within an array of 8-bit integers. */
+static inline bool CFE_ES_TEST_U8_MASK(const uint8 *m, uint32 s)
 {
-    return (CFE_ES_DTEST(m[s / 32], s % 32));
+    return (CFE_ES_DTEST(m[s / 8], s % 8));
 }
 
-/* Set a bit within an array of 32-bit integers. */
-static inline void CFE_ES_SET_U32_MASK(uint32 *m, uint32 s, bool v)
+/* Set a bit within an array of 8-bit integers. */
+static inline void CFE_ES_SET_U8_MASK(uint8 *m, uint32 s, bool v)
 {
-    uint32 b = CFE_ES_DBIT(s % 32);
+    uint8 b = CFE_ES_DBIT(s % 8);
 
-    m += s / 32;
+    m += s / 8;
     if (v)
     {
         *m |= b;

--- a/modules/es/fsw/src/cfe_es_perf.h
+++ b/modules/es/fsw/src/cfe_es_perf.h
@@ -41,7 +41,7 @@
 ** Macro Definitions
 */
 
-#define CFE_ES_DBIT(x)     ((uint8)1 << (x))            /* Places a one at bit positions 0 thru 7 */
+#define CFE_ES_DBIT(x)     ((uint8)1 << (x))             /* Places a one at bit positions 0 thru 7 */
 #define CFE_ES_DTEST(i, x) (((i) & CFE_ES_DBIT(x)) != 0) /* true iff bit x of i is set */
 
 /* Test a bit within an array of 8-bit integers. */

--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -539,10 +539,9 @@ int32 CFE_ES_SendHkCmd(const CFE_ES_SendHkCmd_t *data)
      */
     for (PerfIdx = 0; PerfIdx < CFE_MISSION_ES_PERF_MAX_IDS; ++PerfIdx)
     {
-        CFE_ES_SET_HKTLM_PERF_MASK(
-            PerfTriggerMask,
-            PerfIdx,
-            CFE_ES_TEST_U8_MASK(CFE_ES_Global.ResetDataPtr->Perf.MetaData.TriggerMask, PerfIdx));
+        CFE_ES_SET_HKTLM_PERF_MASK(PerfTriggerMask,
+                                   PerfIdx,
+                                   CFE_ES_TEST_U8_MASK(CFE_ES_Global.ResetDataPtr->Perf.MetaData.TriggerMask, PerfIdx));
     }
 
     /* Filter mask, populated the same way as the trigger mask above */

--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -534,7 +534,7 @@ int32 CFE_ES_SendHkCmd(const CFE_ES_SendHkCmd_t *data)
      * Copy the performance trigger and filter masks into the HK telemetry packet
      * one performance ID (bit) at a time. The internal reset-data masks and the HK
      * packet masks are both sized from CFE_MISSION_ES_PERF_MAX_IDS, which is a
-     * multiple of 32 (enforced in cfe_es_verify.h), so every ID maps onto a valid
+     * multiple of 8 (enforced in cfe_es_verify.h), so every ID maps onto a valid
      * bit in both arrays and is copied directly with no need to pad or truncate.
      */
     for (PerfIdx = 0; PerfIdx < CFE_MISSION_ES_PERF_MAX_IDS; ++PerfIdx)
@@ -542,7 +542,7 @@ int32 CFE_ES_SendHkCmd(const CFE_ES_SendHkCmd_t *data)
         CFE_ES_SET_HKTLM_PERF_MASK(
             PerfTriggerMask,
             PerfIdx,
-            CFE_ES_TEST_U32_MASK(CFE_ES_Global.ResetDataPtr->Perf.MetaData.TriggerMask, PerfIdx));
+            CFE_ES_TEST_U8_MASK(CFE_ES_Global.ResetDataPtr->Perf.MetaData.TriggerMask, PerfIdx));
     }
 
     /* Filter mask, populated the same way as the trigger mask above */
@@ -550,7 +550,7 @@ int32 CFE_ES_SendHkCmd(const CFE_ES_SendHkCmd_t *data)
     {
         CFE_ES_SET_HKTLM_PERF_MASK(PerfFilterMask,
                                    PerfIdx,
-                                   CFE_ES_TEST_U32_MASK(CFE_ES_Global.ResetDataPtr->Perf.MetaData.FilterMask, PerfIdx));
+                                   CFE_ES_TEST_U8_MASK(CFE_ES_Global.ResetDataPtr->Perf.MetaData.FilterMask, PerfIdx));
     }
 
     /* Fill in heap info if get successful/supported */

--- a/modules/es/fsw/src/cfe_es_task.c
+++ b/modules/es/fsw/src/cfe_es_task.c
@@ -531,21 +531,13 @@ int32 CFE_ES_SendHkCmd(const CFE_ES_SendHkCmd_t *data)
     CFE_ES_Global.TaskData.HkPacket.Payload.PerfDataToWrite  = CFE_ES_GetPerfLogDumpRemaining();
 
     /*
-     * Fill out the perf trigger/filter mask objects
-     * The entire array in the HK payload object (external size) must be filled,
-     * to avoid sending garbage data.
-     *
-     * If it is larger than what the platform supports (internal size), it will
-     * be padded with 0's
-     *
-     * If it is smaller than what the platform supports, then truncate.
+     * Copy the performance trigger and filter masks into the HK telemetry packet
+     * one performance ID (bit) at a time. The internal reset-data masks and the HK
+     * packet masks are both sized from CFE_MISSION_ES_PERF_MAX_IDS, which is a
+     * multiple of 32 (enforced in cfe_es_verify.h), so every ID maps onto a valid
+     * bit in both arrays and is copied directly with no need to pad or truncate.
      */
-
-    /* COVERAGE NOTICE: If the following static_assert fails, that means the
-     * macros below were redifined such that they are no longer equal. Be sure
-     * to adjust the code below in the for loop according to the comment
-     * directly above. */
-    for (PerfIdx = 0; PerfIdx < CFE_ES_PERF_TRIGGERMASK_EXT_SIZE; ++PerfIdx)
+    for (PerfIdx = 0; PerfIdx < CFE_MISSION_ES_PERF_MAX_IDS; ++PerfIdx)
     {
         CFE_ES_SET_HKTLM_PERF_MASK(
             PerfTriggerMask,
@@ -553,8 +545,8 @@ int32 CFE_ES_SendHkCmd(const CFE_ES_SendHkCmd_t *data)
             CFE_ES_TEST_U32_MASK(CFE_ES_Global.ResetDataPtr->Perf.MetaData.TriggerMask, PerfIdx));
     }
 
-    /* See comment "COVERAGE NOTICE" */
-    for (PerfIdx = 0; PerfIdx < CFE_ES_PERF_FILTERMASK_EXT_SIZE; ++PerfIdx)
+    /* Filter mask, populated the same way as the trigger mask above */
+    for (PerfIdx = 0; PerfIdx < CFE_MISSION_ES_PERF_MAX_IDS; ++PerfIdx)
     {
         CFE_ES_SET_HKTLM_PERF_MASK(PerfFilterMask,
                                    PerfIdx,

--- a/modules/es/fsw/src/cfe_es_verify.h
+++ b/modules/es/fsw/src/cfe_es_verify.h
@@ -131,15 +131,15 @@
 /*
 ** Maximum number of performance IDs
 */
-#if CFE_MISSION_ES_PERF_MAX_IDS < 32
-#error CFE_MISSION_ES_PERF_MAX_IDS cannot be less than 32!
+#if CFE_MISSION_ES_PERF_MAX_IDS < 8
+#error CFE_MISSION_ES_PERF_MAX_IDS cannot be less than 8!
 #endif
 
 /*
-** Performance IDs must span whole 32-bit mask words
+** Performance IDs must span whole 8-bit mask words
 */
-#if (CFE_MISSION_ES_PERF_MAX_IDS % 32) != 0
-#error CFE_MISSION_ES_PERF_MAX_IDS must be a multiple of 32!
+#if (CFE_MISSION_ES_PERF_MAX_IDS % 8) != 0
+#error CFE_MISSION_ES_PERF_MAX_IDS must be a multiple of 8!
 #endif
 
 /*

--- a/modules/es/fsw/src/cfe_es_verify.h
+++ b/modules/es/fsw/src/cfe_es_verify.h
@@ -136,6 +136,13 @@
 #endif
 
 /*
+** Performance IDs must span whole 32-bit mask words
+*/
+#if (CFE_MISSION_ES_PERF_MAX_IDS % 32) != 0
+#error CFE_MISSION_ES_PERF_MAX_IDS must be a multiple of 32!
+#endif
+
+/*
 ** Performance data buffer size
 */
 #if CFE_PLATFORM_ES_PERF_DATA_BUFFER_SIZE < 1025

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -3365,7 +3365,7 @@ void TestPerf(void)
          mask value */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CmdBuf.PerfSetFilterMaskCmd.Payload.FilterMaskNum = CFE_ES_PERF_32BIT_WORDS_IN_MASK;
+    CmdBuf.PerfSetFilterMaskCmd.Payload.FilterMaskNum = CFE_ES_PERF_8BIT_WORDS_IN_MASK;
     UT_CallTaskPipe(CFE_ES_TaskPipe,
                     CFE_MSG_PTR(CmdBuf),
                     sizeof(CmdBuf.PerfSetFilterMaskCmd),
@@ -3375,7 +3375,7 @@ void TestPerf(void)
     /* Test successful performance filter mask command */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CmdBuf.PerfSetFilterMaskCmd.Payload.FilterMaskNum = CFE_ES_PERF_32BIT_WORDS_IN_MASK / 2;
+    CmdBuf.PerfSetFilterMaskCmd.Payload.FilterMaskNum = CFE_ES_PERF_8BIT_WORDS_IN_MASK / 2;
     UT_CallTaskPipe(CFE_ES_TaskPipe,
                     CFE_MSG_PTR(CmdBuf),
                     sizeof(CmdBuf.PerfSetFilterMaskCmd),
@@ -3398,7 +3398,7 @@ void TestPerf(void)
      */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CmdBuf.PerfSetTrigMaskCmd.Payload.TriggerMaskNum = CFE_ES_PERF_32BIT_WORDS_IN_MASK - 1;
+    CmdBuf.PerfSetTrigMaskCmd.Payload.TriggerMaskNum = CFE_ES_PERF_8BIT_WORDS_IN_MASK - 1;
     UT_CallTaskPipe(CFE_ES_TaskPipe,
                     CFE_MSG_PTR(CmdBuf),
                     sizeof(CmdBuf.PerfSetTrigMaskCmd),
@@ -3410,7 +3410,7 @@ void TestPerf(void)
      */
     ES_ResetUnitTest();
     memset(&CmdBuf, 0, sizeof(CmdBuf));
-    CmdBuf.PerfSetTrigMaskCmd.Payload.TriggerMaskNum = CFE_ES_PERF_32BIT_WORDS_IN_MASK + 1;
+    CmdBuf.PerfSetTrigMaskCmd.Payload.TriggerMaskNum = CFE_ES_PERF_8BIT_WORDS_IN_MASK + 1;
     UT_CallTaskPipe(CFE_ES_TaskPipe,
                     CFE_MSG_PTR(CmdBuf),
                     sizeof(CmdBuf.PerfSetTrigMaskCmd),
@@ -3433,7 +3433,7 @@ void TestPerf(void)
     Perf->MetaData.InvalidMarkerReported = true;
     Perf->MetaData.Mode                  = CFE_ES_PerfTrigger_START;
     Perf->MetaData.DataCount             = CFE_PLATFORM_ES_PERF_DATA_BUFFER_SIZE + 1;
-    Perf->MetaData.TriggerMask[0]        = 0xFFFF;
+    Perf->MetaData.TriggerMask[0]        = 0xFF;
     CFE_ES_PerfLogAdd(1, 0);
     UtAssert_UINT32_EQ(Perf->MetaData.Mode, CFE_ES_PerfTrigger_START);
     UtAssert_UINT32_EQ(Perf->MetaData.State, CFE_ES_PERF_IDLE);
@@ -3490,7 +3490,7 @@ void TestPerf(void)
     ES_ResetUnitTest();
     Perf->MetaData.State         = CFE_ES_PERF_WAITING_FOR_TRIGGER;
     Perf->MetaData.DataCount     = 0;
-    Perf->MetaData.FilterMask[0] = 0xffff;
+    Perf->MetaData.FilterMask[0] = 0xFF;
     CFE_ES_PerfLogAdd(0x1, 0);
     UtAssert_UINT32_EQ(Perf->MetaData.DataCount, 1);
 
@@ -3510,7 +3510,7 @@ void TestPerf(void)
     Perf->MetaData.TriggerCount   = 0;
     Perf->MetaData.State          = CFE_ES_PERF_TRIGGERED;
     Perf->MetaData.Mode           = CFE_ES_PerfTrigger_START;
-    Perf->MetaData.TriggerMask[0] = 0xffff;
+    Perf->MetaData.TriggerMask[0] = 0xFF;
     CFE_ES_PerfLogAdd(0x1, 0);
     UtAssert_UINT32_EQ(Perf->MetaData.TriggerCount, 1);
 


### PR DESCRIPTION
---
name: Adds perfID bounds reporting and populate full hk mask
about: Adds a clear out of bounds event reporting message and fully populates the fsw housekeeping packet with both filter and trigger mask. Before, only 0-(CFE_MISSION_ES_PERF_MAX_IDS[128]/32) bits of either mask in the housekeeping packet were getting populated.
labels: fsw
---

## Description of Change

The change updates the trigger/filter mask invalid command input event message to more accurately represent the valid input. No functional behavior change there. The second part of this change bounds the copying of the internal trigger/filter mask packet to the external housekeeping packet by number of perfids which is what the underlying handling logic expects. Before, it was iterating by number of 32 bit mask words. 

The result is that the loops now iterate through all `CFE_MISSION_ES_PERF_MAX_IDS`, ensuring every supported mask bit is reflected in the corresponding housekeeping fields. With the default configuration of 128 performance IDs, all four 32-bit trigger and filter mask words are now reported correctly.


<!-- Describe what was changed, why, and how. Include any design notes that will help reviewers. -->

## Linked Issue

Closes #2778

## Requirements Impact

<!-- List any requirements impacted by this change. Indicate whether each was updated, or confirm the change continues to satisfy existing requirements. -->
- Requirement ID(s):
- [x] Requirements updated as necessary
- [x] Existing requirements are still satisfied by this change

## Testing Evidence
After sending a CFE_ES_SET_PERF_FILTER_MASK_CC command with FilterMaskNum=2 and FilterMask=4294901760 (0xFFFF0000), observed the fsw hk packet was populated accordingly. Intent was to verify that the last 16 bits of the FilterMask at the 3rd word (i.e. 

<img width="940" height="854" alt="Screenshot 2026-07-23 at 10 08 13 AM" src="https://github.com/user-attachments/assets/2afa57fc-6aeb-4dfc-8bb5-5811a0b6ca11" />

After sending a CFE_ES_SET_PERF_FILTER_MASK_CC command with FilterMaskNum=4 (invalid index) and FilterMask=0, observed a cleaner event report message.
<img width="966" height="46" alt="Screenshot 2026-07-23 at 8 00 00 AM" src="https://github.com/user-attachments/assets/e2f2c55f-b080-461d-b2f7-a14aedcf95f0" />


### Unit Tests (UT Assert)
https://github.com/nasa/cFE/actions/runs/30007564547/job/89207184330?pr=2784

### COSMOS Test Suite
No relevant changes.

## Areas of Expertise Touched

- [ ] ASTRO
- [ ] CI/CD
- [ ] COSMOS
- [ ] Cybersecurity
- [ ] Docker
- [ ] EDS
- [ ] Git
- [ ] PSPs
- [ ] SBN
- [ ] SMP
- [ ] Tables
- [ ] TSN
- [ ] Unit Tests
- [ ] Other

---

## Author Checklist

- [x] Linked GitHub issue is referenced above
- [x] Code has been formatted with `.clang-format`
- [x] Static analysis workflows ran and passed
- [x] Unit tests (UT Assert) updated/added to cover code changes
- [x] Unit test workflows ran and passed
- [x] COSMOS test suite was run; tests updated/added if relevant changes were made
- [x] Requirements have been reviewed; updated or confirmed still satisfied (see above)
- [x] Testing evidence is included above
- [x] Self-review of the diff completed

---

## Reviewer Checklist

- [x] Code logic is correct and matches the stated intent
- [x] Code is readable, maintainable, and follows project conventions
- [x] `.clang-format` has been applied
- [x] Static analysis results reviewed and acceptable
- [x] Unit tests are meaningful and adequately cover the changes
- [x] **The change has been exercised by the unit tests** (not just that tests pass — the new/changed code paths are actually covered)
- [x] **COSMOS test suite was executed against this change** and results reviewed (or confirmed N/A with justification)
- [x] **Reviewer has independently verified the change behaves as described** (e.g., by running the tests locally, reviewing CI output in detail, or performing additional ad-hoc testing as warranted)
- [x] **Memory safety** reviewed (allocation, bounds, lifetime, stack usage)
- [x] Requirements impact reviewed and appropriate
- [x] Error handling is appropriate
- [x] Appropriate Expert areas have been reviewed

### Reviewer Testing Notes

<!--
Describe how you independently verified this change. For example:
  - "Pulled the branch locally, ran `make test`, all UT Assert tests passed including the new ones for X."
  - "Ran the COSMOS test suite against the branch; observed expected telemetry behavior for Y."
  - "Reviewed CI run #1234; verified the new code paths are covered by inspecting the coverage report."
  - "Performed ad-hoc test by [describe scenario]; observed [result]."
-->