### PR TITLE
Fix #2786, include fragment in syslog dump

### DIFF
--- a/modules/es/fsw/inc/cfe_es_internal_cfg.h
+++ b/modules/es/fsw/inc/cfe_es_internal_cfg.h
@@ -164,7 +164,7 @@
 **       verified.
 */
 #define CFE_PLATFORM_ES_SYSTEM_LOG_SIZE         CFE_PLATFORM_ES_CFGVAL(SYSTEM_LOG_SIZE)
-#define DEFAULT_CFE_PLATFORM_ES_SYSTEM_LOG_SIZE 3072
+#define DEFAULT_CFE_PLATFORM_ES_SYSTEM_LOG_SIZE 8192
 
 /**
 **  \cfeescfg Define Max Number of Generic Counters

--- a/modules/es/fsw/src/cfe_es_log.h
+++ b/modules/es/fsw/src/cfe_es_log.h
@@ -110,6 +110,7 @@ typedef struct
     size_t BlockSize;  /**< Size of content currently in the "Data" member */
     size_t EndIdx;     /**< End of the syslog buffer at the time reading started */
     size_t LastOffset; /**< Current Read Position */
+    bool   IsFragment; /**< Flag indicating that the data is NOT a complete message */
 
     char Data[CFE_ES_SYSLOG_READ_BUFFER_SIZE]; /**< Actual syslog content */
 } CFE_ES_SysLogReadBuffer_t;

--- a/modules/es/fsw/src/cfe_es_syslog.c
+++ b/modules/es/fsw/src/cfe_es_syslog.c
@@ -97,27 +97,13 @@ void CFE_ES_SysLogReadStart_Unsync(CFE_ES_SysLogReadBuffer_t *Buffer)
 {
     size_t ReadIdx;
     size_t EndIdx;
-    size_t TotalSize;
 
-    ReadIdx   = CFE_ES_Global.ResetDataPtr->SystemLogWriteIdx;
-    EndIdx    = CFE_ES_Global.ResetDataPtr->SystemLogEndIdx;
-    TotalSize = EndIdx;
+    ReadIdx = CFE_ES_Global.ResetDataPtr->SystemLogWriteIdx;
+    EndIdx  = CFE_ES_Global.ResetDataPtr->SystemLogEndIdx;
 
-    /*
-     * Ensure that we start reading at the start of a message
-     * Likely pointing to an old fragment right now -- find the end of it
-     */
-    while (TotalSize > 0 && ReadIdx < EndIdx)
-    {
-        ++ReadIdx;
-        --TotalSize;
-        if (CFE_ES_Global.ResetDataPtr->SystemLog[ReadIdx - 1] == '\n')
-        {
-            break;
-        }
-    }
-
-    Buffer->SizeLeft   = TotalSize;
+    /* If the write position is NOT at the tail of the buffer, then its a fragement */
+    Buffer->IsFragment = (ReadIdx != EndIdx);
+    Buffer->SizeLeft   = EndIdx;
     Buffer->LastOffset = ReadIdx;
     Buffer->EndIdx     = EndIdx;
     Buffer->BlockSize  = 0;
@@ -286,9 +272,21 @@ int32 CFE_ES_SysLogWrite_Unsync(const char *SpecStringPtr, ...)
  *-----------------------------------------------------------------*/
 void CFE_ES_SysLogReadData(CFE_ES_SysLogReadBuffer_t *Buffer)
 {
-    size_t BlockSize;
+    size_t            BlockSize;
+    static const char FRAGMENT_TAG[] = "<<FRAGMENT>> ";
 
-    Buffer->BlockSize = 0;
+    if (Buffer->IsFragment)
+    {
+        /* Add a tag indicating that this block of data does not begin w/a complete message */
+        memcpy(Buffer->Data, FRAGMENT_TAG, sizeof(FRAGMENT_TAG) - 1);
+        Buffer->BlockSize  = sizeof(FRAGMENT_TAG) - 1;
+        Buffer->IsFragment = false;
+    }
+    else
+    {
+        Buffer->BlockSize = 0;
+    }
+
     while (Buffer->SizeLeft > 0 && Buffer->BlockSize < sizeof(Buffer->Data))
     {
         /*

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -5276,9 +5276,9 @@ void TestSysLog(void)
 
     UtPrintf("Begin Test Sys Log");
 
-    /* Test loop in CFE_ES_SysLogReadStart_Unsync that ensures
-     * reading at the start of a message */
+    /* Test conditional in CFE_ES_SysLogReadStart_Unsync that checks for a fragment */
     ES_ResetUnitTest();
+    memset(&SysLogBuffer, 0, sizeof(SysLogBuffer));
     CFE_ES_Global.ResetDataPtr->SystemLogWriteIdx = 0;
     CFE_ES_Global.ResetDataPtr->SystemLogEndIdx   = sizeof(CFE_ES_Global.ResetDataPtr->SystemLog) - 1;
 
@@ -5288,9 +5288,15 @@ void TestSysLog(void)
     CFE_ES_SysLogReadStart_Unsync(&SysLogBuffer);
 
     UtAssert_EQ(size_t, SysLogBuffer.EndIdx, sizeof(CFE_ES_Global.ResetDataPtr->SystemLog) - 1);
-    UtAssert_EQ(size_t, SysLogBuffer.LastOffset, sizeof(CFE_ES_Global.ResetDataPtr->SystemLog) - 1);
+    UtAssert_ZERO(SysLogBuffer.LastOffset);
+    UtAssert_BOOL_TRUE(SysLogBuffer.IsFragment);
     UtAssert_ZERO(SysLogBuffer.BlockSize);
-    UtAssert_ZERO(SysLogBuffer.SizeLeft);
+    UtAssert_EQ(size_t, SysLogBuffer.SizeLeft, sizeof(CFE_ES_Global.ResetDataPtr->SystemLog) - 1);
+
+    CFE_ES_SysLogReadData(&SysLogBuffer);
+    UtAssert_BOOL_FALSE(SysLogBuffer.IsFragment);
+    UtAssert_EQ(size_t, SysLogBuffer.EndIdx, SysLogBuffer.LastOffset + SysLogBuffer.SizeLeft);
+    UtAssert_LT(size_t, SysLogBuffer.LastOffset, SysLogBuffer.BlockSize);
 
     /* Test truncation of a sys log message that is over half
      * the size of the total log */
@@ -5307,6 +5313,7 @@ void TestSysLog(void)
 
     /* Test Reading space between the current read offset and end of the log buffer */
     ES_ResetUnitTest();
+    memset(&SysLogBuffer, 0, sizeof(SysLogBuffer));
     SysLogBuffer.EndIdx     = 3;
     SysLogBuffer.LastOffset = 0;
     SysLogBuffer.BlockSize  = 3;


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Do not skip the initial fragment when dumping syslog.  Write it to the log with a tag indicating it is a fragment.

Also increases the default log size to 8k, so that all messages in a normal boot can be stored.

Fixes #2786

**Testing performed**
Issue sys log write command, confirm behavior

**Expected behavior changes**
Initial fragment (after wrap) is written to the file, along with a fixed-length tag indicating that it is a fragment.

**System(s) tested on**
Linux

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
