### PR TITLE
Fix #2785, reset CDS between test cases

### DIFF
--- a/modules/core_private/ut-stubs/src/ut_support.c
+++ b/modules/core_private/ut-stubs/src/ut_support.c
@@ -129,6 +129,7 @@ void UT_Init(const char *subsys)
     }
 
     UT_NumCountersTracked = 0;
+    UT_ResetCDS();
 }
 
 /*

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -4406,6 +4406,7 @@ void TestCDS(void)
     uint8                BlockData[ES_UT_CDS_BLOCK_SIZE];
 
     UtPrintf("Begin Test CDS");
+    UT_ResetCDS();
 
     memset(BlockData, 0, sizeof(BlockData));
 
@@ -4594,7 +4595,6 @@ void TestCDS(void)
 
     /* Test CDS initialization with rebuilding not possible */
     ES_ResetUnitTest();
-    UT_SetDeferredRetcode(UT_KEY(CFE_PSP_ReadFromCDS), 3, OS_ERROR);
     CFE_UtAssert_SUCCESS(CFE_ES_CDS_EarlyInit());
 
     /* Test CDS validation with first CDS read call failure */
@@ -4753,6 +4753,7 @@ void TestCDSMempool(void)
     void                *CdsPtr;
 
     UtPrintf("Begin Test CDS memory pool");
+    UT_ResetCDS();
 
     ES_UT_SetupCDSGlobal(0);
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Invoke UT_ResetCDS() during test init and for test cases that use the CDS to ensure its in a consistent state.

Fixes #2785

**Testing performed**
Run unit tests

**Expected behavior changes**
More stable behavior by ensuring CDS has predictable data.

**Additional context**
We cannot reset between _every_ test case because some of these test cases do require that the CDS data persists between them.  Calling the UT_ResetCDS selectively in those tests as well as during the global init should cover it and do not break any tests.

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
