### PR TITLE
Fix #2781, guard server-only TIME message ID

### DIFF
--- a/modules/time/fsw/src/cfe_time_dispatch.c
+++ b/modules/time/fsw/src/cfe_time_dispatch.c
@@ -220,7 +220,9 @@ void CFE_TIME_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
     static CFE_SB_MsgId_t ONEHZ_CMD_MID = CFE_SB_MSGID_RESERVED;
     static CFE_SB_MsgId_t TONE_CMD_MID  = CFE_SB_MSGID_RESERVED;
     static CFE_SB_MsgId_t DATA_CMD_MID  = CFE_SB_MSGID_RESERVED;
-    static CFE_SB_MsgId_t SEND_CMD_MID  = CFE_SB_MSGID_RESERVED;
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+    static CFE_SB_MsgId_t SEND_CMD_MID = CFE_SB_MSGID_RESERVED;
+#endif
 
     CFE_SB_MsgId_t MessageID = CFE_SB_INVALID_MSG_ID;
 
@@ -232,7 +234,9 @@ void CFE_TIME_TaskPipe(const CFE_SB_Buffer_t *SBBufPtr)
         ONEHZ_CMD_MID = CFE_SB_ValueToMsgId(CFE_TIME_ONEHZ_CMD_MID);
         TONE_CMD_MID  = CFE_SB_ValueToMsgId(CFE_TIME_TONE_CMD_MID);
         DATA_CMD_MID  = CFE_SB_ValueToMsgId(CFE_TIME_DATA_CMD_MID);
-        SEND_CMD_MID  = CFE_SB_ValueToMsgId(CFE_TIME_SEND_CMD_MID);
+#if (CFE_PLATFORM_TIME_CFG_SERVER == true)
+        SEND_CMD_MID = CFE_SB_ValueToMsgId(CFE_TIME_SEND_CMD_MID);
+#endif
     }
 
     CFE_MSG_GetMsgId(&SBBufPtr->Msg, &MessageID);


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**

Fix #2781.

Guard the `SEND_CMD_MID` declaration and initialization in `CFE_TIME_TaskPipe()` with `CFE_PLATFORM_TIME_CFG_SERVER`.

`SEND_CMD_MID` is only used by the server-only `CFE_TIME_ToneSendCmd()` dispatch path. In a TIME client configuration, the previous unconditional declaration and initialization left a server-only static variable unused, which causes strict client builds to fail.

**Testing performed**

1. Verified the change is limited to the server-only message ID declaration and initialization in `modules/time/fsw/src/cfe_time_dispatch.c`.
2. Verified the existing server-only use remains under the same `CFE_PLATFORM_TIME_CFG_SERVER == true` condition.
3. Upstream GitHub Actions are currently awaiting authorization for this fork PR, so no CI result is being claimed yet.

**Expected behavior changes**

- API Change: none.
- Behavior Change: TIME client builds no longer compile the unused server-only `SEND_CMD_MID` variable.
- TIME server dispatch behavior is unchanged.

**System(s) tested on**

- The issue was reported on RHEL 9.x, x86_64, using the native_std build.
- This PR is awaiting NASA GitHub Actions authorization for repository CI validation.

**Additional context**

The patch intentionally keeps the declaration, initialization, and use of `SEND_CMD_MID` under the same server-only compile-time condition.

**Third party code**

None.

**Contributor Info - All information REQUIRED for consideration of pull request**

Sylvester Kaczmarek, Personal
