### PR TITLE
Fix #2738, use bounded string comparisons

### DIFF
--- a/modules/config/cmake/cfe_configid_nametable.c.in
+++ b/modules/config/cmake/cfe_configid_nametable.c.in
@@ -2,7 +2,7 @@
 #include "cfe_configid_offset.h"
 #include "cfe_config_nametable.h"
 
-#define CFE_CONFIGID_DEFINE(x) [CFE_CONFIGID_OFFSETNAME(x)] = { #x },
+#define CFE_CONFIGID_DEFINE(x) [CFE_CONFIGID_OFFSETNAME(x)] = {#x, sizeof(#x)},
 
 /* Map of configuration key IDs to printable names */
 const CFE_Config_IdNameEntry_t CFE_CONFIGID_NAMETABLE[CFE_ConfigIdOffset_MAX] =

--- a/modules/config/fsw/inc/cfe_config_nametable.h
+++ b/modules/config/fsw/inc/cfe_config_nametable.h
@@ -28,11 +28,14 @@
 /*
 ** Includes
 */
+#include <stddef.h>
+
 #include "cfe_configid_offset.h"
 
 typedef struct CFE_Config_IdNameEntry
 {
     const char *Name;
+    size_t      NameSize;
 } CFE_Config_IdNameEntry_t;
 
 extern const CFE_Config_IdNameEntry_t CFE_CONFIGID_NAMETABLE[];

--- a/modules/config/fsw/src/cfe_config_get.c
+++ b/modules/config/fsw/src/cfe_config_get.c
@@ -155,7 +155,7 @@ CFE_ConfigId_t CFE_Config_GetIdByName(const char *Name)
     NamePtr = CFE_CONFIGID_NAMETABLE;
     for (OffsetVal = 0; OffsetVal < CFE_ConfigIdOffset_MAX; ++OffsetVal)
     {
-        if (NamePtr->Name != NULL && strcmp(NamePtr->Name, Name) == 0)
+        if (NamePtr->Name != NULL && strncmp(NamePtr->Name, Name, NamePtr->NameSize) == 0)
         {
             break;
         }

--- a/modules/config/ut-coverage/test_cfe_config.c
+++ b/modules/config/ut-coverage/test_cfe_config.c
@@ -33,12 +33,12 @@
 /* clang-format off */
 const CFE_Config_IdNameEntry_t CFE_CONFIGID_NAMETABLE[CFE_ConfigIdOffset_MAX] =
 {
-    {"UT_CHECK_1"},
-    {"UT_CHECK_2"},
-    {"UT_CHECK_3"},
-    {"UT_CHECK_4"},
-    {"MOD_SRCVER_COREMODULE1"},
-    {"MOD_SRCVER_COREMODULE2"}
+    {"UT_CHECK_1", sizeof("UT_CHECK_1")},
+    {"UT_CHECK_2", sizeof("UT_CHECK_2")},
+    {"UT_CHECK_3", sizeof("UT_CHECK_3")},
+    {"UT_CHECK_4", sizeof("UT_CHECK_4")},
+    {"MOD_SRCVER_COREMODULE1", sizeof("MOD_SRCVER_COREMODULE1")},
+    {"MOD_SRCVER_COREMODULE2", sizeof("MOD_SRCVER_COREMODULE2")}
 };
 /* clang-format on */
 
@@ -234,6 +234,7 @@ void Test_CFE_Config_GetIdByName(void)
      */
     CFE_UtAssert_RESOURCEID_EQ(CFE_Config_GetIdByName("UT_CHECK_2"), CFE_CONFIGID_UT_CHECK_2);
     CFE_UtAssert_RESOURCEID_EQ(CFE_Config_GetIdByName("INVALID"), CFE_CONFIGID_UNDEFINED);
+    CFE_UtAssert_RESOURCEID_EQ(CFE_Config_GetIdByName("UT_CHECK_2_EXTRA"), CFE_CONFIGID_UNDEFINED);
     CFE_UtAssert_RESOURCEID_EQ(CFE_Config_GetIdByName(NULL), CFE_CONFIGID_UNDEFINED);
 }
 

--- a/modules/es/fsw/src/cfe_es_apps.c
+++ b/modules/es/fsw/src/cfe_es_apps.c
@@ -185,7 +185,7 @@ int32 CFE_ES_LoadModule(CFE_ResourceId_t                 ParentResourceId,
      * If the Load was OK, then lookup the address of the entry point
      */
     if (ReturnCode == CFE_SUCCESS && LoadParams->InitSymbolName[0] != 0
-        && strcmp(LoadParams->InitSymbolName, "NULL") != 0)
+        && strncmp(LoadParams->InitSymbolName, "NULL", sizeof("NULL")) != 0)
     {
         OsStatus = OS_ModuleSymbolLookup(ModuleId, &InitSymbolAddress, LoadParams->InitSymbolName);
         if (OsStatus != OS_SUCCESS)

--- a/modules/es/fsw/src/cfe_es_cds.c
+++ b/modules/es/fsw/src/cfe_es_cds.c
@@ -903,7 +903,7 @@ CFE_ES_CDS_RegRec_t *CFE_ES_LocateCDSBlockRecordByName(const char *CDSName)
         if (CFE_ES_CDSBlockRecordIsUsed(CDSRegRecPtr))
         {
             /* Perform a case sensitive name comparison */
-            if (strcmp(CDSName, CDSRegRecPtr->Name) == 0)
+            if (strncmp(CDSName, CDSRegRecPtr->Name, sizeof(CDSRegRecPtr->Name)) == 0)
             {
                 /* If the names match, then stop */
                 break;

--- a/modules/es/fsw/src/cfe_es_resource.c
+++ b/modules/es/fsw/src/cfe_es_resource.c
@@ -94,7 +94,8 @@ CFE_ES_AppRecord_t *CFE_ES_LocateAppRecordByName(const char *Name)
             AppRecPtr = NULL;
             break;
         }
-        if (CFE_ES_AppRecordIsUsed(AppRecPtr) && strcmp(Name, CFE_ES_AppRecordGetName(AppRecPtr)) == 0)
+        if (CFE_ES_AppRecordIsUsed(AppRecPtr)
+            && strncmp(Name, CFE_ES_AppRecordGetName(AppRecPtr), OS_MAX_API_NAME) == 0)
         {
             break;
         }
@@ -129,7 +130,8 @@ CFE_ES_LibRecord_t *CFE_ES_LocateLibRecordByName(const char *Name)
             LibRecPtr = NULL;
             break;
         }
-        if (CFE_ES_LibRecordIsUsed(LibRecPtr) && strcmp(Name, CFE_ES_LibRecordGetName(LibRecPtr)) == 0)
+        if (CFE_ES_LibRecordIsUsed(LibRecPtr)
+            && strncmp(Name, CFE_ES_LibRecordGetName(LibRecPtr), OS_MAX_API_NAME) == 0)
         {
             break;
         }
@@ -164,7 +166,8 @@ CFE_ES_GenCounterRecord_t *CFE_ES_LocateCounterRecordByName(const char *Name)
             CounterRecPtr = NULL;
             break;
         }
-        if (CFE_ES_CounterRecordIsUsed(CounterRecPtr) && strcmp(Name, CFE_ES_CounterRecordGetName(CounterRecPtr)) == 0)
+        if (CFE_ES_CounterRecordIsUsed(CounterRecPtr)
+            && strncmp(Name, CFE_ES_CounterRecordGetName(CounterRecPtr), OS_MAX_API_NAME) == 0)
         {
             break;
         }

--- a/modules/es/fsw/src/cfe_es_startupscript.c
+++ b/modules/es/fsw/src/cfe_es_startupscript.c
@@ -359,7 +359,7 @@ int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens)
 
     strncpy(ParamBuf.BasicInfo.InitSymbolName, TokenList[2], sizeof(ParamBuf.BasicInfo.InitSymbolName) - 1);
 
-    if (strcmp(EntryType, "CFE_APP") == 0)
+    if (strncmp(EntryType, "CFE_APP", sizeof("CFE_APP")) == 0)
     {
         CFE_ES_WriteToSysLog("%s: Loading file: %s, APP: %s\n", __func__, ParamBuf.BasicInfo.FileName, ModuleName);
 
@@ -403,7 +403,7 @@ int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens)
         */
         Status = CFE_ES_AppCreate(&IdBuf.AppId, ModuleName, &ParamBuf);
     }
-    else if (strcmp(EntryType, "CFE_LIB") == 0)
+    else if (strncmp(EntryType, "CFE_LIB", sizeof("CFE_LIB")) == 0)
     {
         CFE_ES_WriteToSysLog("%s: Loading shared library: %s\n", __func__, ParamBuf.BasicInfo.FileName);
 

--- a/modules/ta/fsw/src/cfe_ta_task.c
+++ b/modules/ta/fsw/src/cfe_ta_task.c
@@ -465,7 +465,7 @@ int32 CFE_TA_SetTaskAffinityCmd(const CFE_TA_SetTaskAffinityCmd_t *data)
     for (uint32 i = 0; i < OS_MAX_TASKS; i++)
     {
         /* Reached the end of the entries, task not found */
-        if (strlen(CFE_TA_CpuTaskAffinity[i].TaskName) == 0)
+        if (CFE_TA_CpuTaskAffinity[i].TaskName[0] == '\0')
         {
             Status = CFE_TA_APP_TASK_NOT_FOUND;
 
@@ -477,7 +477,7 @@ int32 CFE_TA_SetTaskAffinityCmd(const CFE_TA_SetTaskAffinityCmd_t *data)
             CFE_TA_Global.CommandErrorCounter++;
             break;
         }
-        else if (strcmp(CmdPtr->TaskName, CFE_TA_CpuTaskAffinity[i].TaskName) == 0)
+        else if (strncmp(CmdPtr->TaskName, CFE_TA_CpuTaskAffinity[i].TaskName, sizeof(CmdPtr->TaskName)) == 0)
         {
             /* Task found in the list */
             CFE_TA_CpuTaskAffinity[i].Status = CFE_TA_Status_Ok;
@@ -582,7 +582,7 @@ int32 CFE_TA_GetTaskAffinityCmd(const CFE_TA_GetTaskAffinityCmd_t *data)
     /* Look for the task in the task affinity list */
     for (uint32 i = 0; i < OS_MAX_TASKS; i++)
     {
-        if (strlen(CFE_TA_CpuTaskAffinity[i].TaskName) == 0)
+        if (CFE_TA_CpuTaskAffinity[i].TaskName[0] == '\0')
         {
             Status = CFE_TA_APP_TASK_NOT_FOUND;
 
@@ -595,7 +595,7 @@ int32 CFE_TA_GetTaskAffinityCmd(const CFE_TA_GetTaskAffinityCmd_t *data)
             CFE_TA_Global.CommandErrorCounter++;
             break;
         }
-        else if (strcmp(CmdPtr->TaskName, CFE_TA_CpuTaskAffinity[i].TaskName) == 0)
+        else if (strncmp(CmdPtr->TaskName, CFE_TA_CpuTaskAffinity[i].TaskName, sizeof(CmdPtr->TaskName)) == 0)
         {
             /* Task found in the list */
             CFE_TA_CpuTaskAffinity[i].Status = CFE_TA_Status_Ok;
@@ -677,7 +677,7 @@ int32 CFE_TA_SetStartupAffinity(const char *taskname)
     {
         for (uint32 i = 0; i < OS_MAX_TASKS; i++)
         {
-            if (strlen(CFE_TA_CpuTaskAffinity[i].TaskName) == 0)
+            if (CFE_TA_CpuTaskAffinity[i].TaskName[0] == '\0')
             {
                 /* Couldn't find the task in the task affinity table */
                 CFE_ES_WriteToSysLog("%s: Set Startup Affinity - task (%s) not found "
@@ -715,7 +715,8 @@ int32 CFE_TA_SetStartupAffinity(const char *taskname)
                 }
                 break;
             }
-            else if (strcmp(taskname, CFE_TA_CpuTaskAffinity[i].TaskName) == 0)
+            else if (strncmp(taskname, CFE_TA_CpuTaskAffinity[i].TaskName, sizeof(CFE_TA_CpuTaskAffinity[i].TaskName))
+                     == 0)
             {
                 /* Task found in the list */
                 CFE_TA_CpuTaskAffinity[i].Status = CFE_TA_Status_Ok;

--- a/modules/ta/ut-coverage/ta_UT.c
+++ b/modules/ta/ut-coverage/ta_UT.c
@@ -131,7 +131,8 @@ void Test_TA_EarlyInit_WithTable(void)
     UT_SetDeferredRetcode(UT_KEY(OS_RegisterEventHandler), 1, OS_SUCCESS);
 
     UtAssert_INT32_EQ(CFE_TA_EarlyInit(), CFE_SUCCESS);
-    UtAssert_True(strcmp(CFE_TA_CpuTaskAffinity[0].TaskName, "MOCK_TASK") == 0, "TaskName matched");
+    UtAssert_True(strncmp(CFE_TA_CpuTaskAffinity[0].TaskName, "MOCK_TASK", sizeof("MOCK_TASK")) == 0,
+                  "TaskName matched");
     UtAssert_True(CFE_TA_CpuTaskAffinity[1].TaskName[0] == '\0', "Loop broke cleanly");
 }
 
@@ -151,7 +152,8 @@ void Test_TA_EarlyInit_MaxTasks(void)
     UT_SetDeferredRetcode(UT_KEY(OS_RegisterEventHandler), 1, OS_SUCCESS);
 
     UtAssert_INT32_EQ(CFE_TA_EarlyInit(), CFE_SUCCESS);
-    UtAssert_True(strcmp(CFE_TA_CpuTaskAffinity[OS_MAX_TASKS - 1].TaskName, "TASK") == 0, "Max tasks copied");
+    UtAssert_True(strncmp(CFE_TA_CpuTaskAffinity[OS_MAX_TASKS - 1].TaskName, "TASK", sizeof("TASK")) == 0,
+                  "Max tasks copied");
 }
 
 void Test_TA_EarlyInit_Error(void)

--- a/modules/ta/ut-coverage/ta_UT_task.c
+++ b/modules/ta/ut-coverage/ta_UT_task.c
@@ -132,7 +132,8 @@ void Test_TA_EarlyInit_WithTable(void)
     UT_SetDeferredRetcode(UT_KEY(OS_RegisterEventHandler), 1, OS_SUCCESS);
 
     UtAssert_INT32_EQ(CFE_TA_EarlyInit(), CFE_SUCCESS);
-    UtAssert_True(strcmp(CFE_TA_CpuTaskAffinity[0].TaskName, "MOCK_TASK") == 0, "TaskName matched");
+    UtAssert_True(strncmp(CFE_TA_CpuTaskAffinity[0].TaskName, "MOCK_TASK", sizeof("MOCK_TASK")) == 0,
+                  "TaskName matched");
     UtAssert_True(CFE_TA_CpuTaskAffinity[1].TaskName[0] == '\0', "Loop broke cleanly");
 }
 
@@ -152,7 +153,8 @@ void Test_TA_EarlyInit_MaxTasks(void)
     UT_SetDeferredRetcode(UT_KEY(OS_RegisterEventHandler), 1, OS_SUCCESS);
 
     UtAssert_INT32_EQ(CFE_TA_EarlyInit(), CFE_SUCCESS);
-    UtAssert_True(strcmp(CFE_TA_CpuTaskAffinity[OS_MAX_TASKS - 1].TaskName, "TASK") == 0, "Max tasks copied");
+    UtAssert_True(strncmp(CFE_TA_CpuTaskAffinity[OS_MAX_TASKS - 1].TaskName, "TASK", sizeof("TASK")) == 0,
+                  "Max tasks copied");
 }
 void Test_TA_EarlyInit_Error(void)
 {

--- a/modules/tbl/fsw/src/cfe_tbl_load.c
+++ b/modules/tbl/fsw/src/cfe_tbl_load.c
@@ -192,7 +192,7 @@ CFE_Status_t CFE_TBL_ValidateFileIsLoadable(CFE_TBL_TxnState_t *Txn, const CFE_T
         Status = CFE_TBL_ERR_INVALID_HANDLE;
         CFE_TBL_TxnAddEvent(Txn, CFE_TBL_NO_SUCH_TABLE_ERR_EID, Status, 0);
     }
-    else if (strcmp(CFE_TBL_RegRecGetName(RegRecPtr), TblFileHeader->TableName) != 0)
+    else if (strncmp(CFE_TBL_RegRecGetName(RegRecPtr), TblFileHeader->TableName, sizeof(TblFileHeader->TableName)) != 0)
     {
         Status = CFE_TBL_ERR_FILE_FOR_WRONG_TABLE;
         CFE_TBL_TxnAddEvent(Txn, CFE_TBL_LOAD_TBLNAME_MISMATCH_ERR_EID, Status, 0);

--- a/modules/tbl/fsw/src/cfe_tbl_regrec.c
+++ b/modules/tbl/fsw/src/cfe_tbl_regrec.c
@@ -142,7 +142,8 @@ CFE_TBL_RegistryRec_t *CFE_TBL_LocateRegRecByName(const char *Name)
     {
         RegRecPtr = &CFE_TBL_Global.Registry[i];
 
-        if (CFE_TBL_RegRecIsUsed(RegRecPtr) && strcmp(Name, CFE_TBL_RegRecGetName(RegRecPtr)) == 0)
+        if (CFE_TBL_RegRecIsUsed(RegRecPtr)
+            && strncmp(Name, CFE_TBL_RegRecGetName(RegRecPtr), CFE_TBL_MAX_FULL_NAME_LEN) == 0)
         {
             break;
         }


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**

Fix #2738.

Replace the remaining unbounded `strcmp()` uses under `modules/` with bounded comparisons while preserving exact-match behavior.

The change uses bounds derived from the relevant fixed-size field, API-name limit, string literal, or generated configuration-name entry. The configuration name table now records each generated name size so `CFE_Config_GetIdByName()` can distinguish an exact name from a longer string sharing the same prefix.

Regression coverage includes a prefix-plus-suffix configuration name to verify that bounded comparison does not introduce prefix matching.

**Testing performed**

1. Config build and unit tests passed.
2. ES build and unit tests passed.
3. TBL build and unit tests passed.
4. Task Affinity build and unit tests passed.
5. Fork GitHub Actions passed Format Check, documentation, Static Analysis, both Code Coverage workflows, MCDC Analysis, and both Functional Test workflows.
6. Fork CodeQL reported `startup_failure` before any CodeQL job executed.
7. NASA-side PR workflows currently report `action_required` with no jobs created. No upstream CI success is being claimed yet.

**Expected behavior changes**

- Public API change: none.
- Internal data change: `CFE_Config_IdNameEntry_t` records the generated configuration-name size.
- String comparisons in the affected module paths are bounded while retaining exact-match semantics.
- No intended functional change for valid null-terminated names.

**System(s) tested on**

- Repository baseline: cFE `dev`.
- Validation: targeted module builds and unit tests plus the fork GitHub Actions workflows listed above.

**Additional context**

On the current `dev` baseline, this patch addresses the remaining unbounded `strcmp()` uses under `modules/` covered by #2738.

**Third party code**

None.

**Contributor Info - All information REQUIRED for consideration of pull request**

Sylvester Kaczmarek, Personal

### Latest rebase validation

Rebased onto current `dev` at `39d765fa568943c50c6a8f7dbc957edc31607900`. Preserved the upstream startup-parser refactor and moved the relevant change to `cfe_es_startupscript.c`. Config, ES, TBL, and TA coverage targets all passed for ten repetitions in a Debian 12 arm64 native configuration with EDS disabled. The local TA fixture supplies its required performance ID. Clang-format 19 and `git diff --check` passed. New upstream CI results are pending.
