### PR TITLE
Fix #2446, clarify startup token count message

### DIFF
--- a/modules/es/fsw/src/cfe_es_startupscript.c
+++ b/modules/es/fsw/src/cfe_es_startupscript.c
@@ -334,7 +334,9 @@ int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens)
     */
     if (NumTokens < 8)
     {
-        CFE_ES_WriteToSysLog("%s: Invalid ES Startup file entry: %u\n", __func__, (unsigned int)NumTokens);
+        CFE_ES_WriteToSysLog("%s: Invalid ES Startup file entry: NumTokens = %u, expected at least 8\n",
+                             __func__,
+                             (unsigned int)NumTokens);
         return CFE_ES_BAD_ARGUMENT;
     }
 

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -659,6 +659,7 @@ void TestApps(void)
     /* Test parsing the startup script with an invalid argument passed in */
     ES_ResetUnitTest();
     UtAssert_INT32_EQ(CFE_ES_ParseFileEntry(NULL, 0), CFE_ES_BAD_ARGUMENT);
+    CFE_UtAssert_PRINTF("NumTokens = 0, expected at least 8");
 
     /* Test application loading and creation with a task creation failure */
     ES_ResetUnitTest();


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate Contributor License Agreement.

**Describe the contribution**

Fix #2446.

Clarify the malformed startup-script diagnostic so the reported value is explicitly identified as `NumTokens` and the required minimum is stated.

The parser rejects entries with fewer than eight tokens. The previous message printed only the raw count, which could be mistaken for a startup-file entry or line number.

**Testing performed**

1. Added regression coverage for the existing zero-token error path.
2. The test verifies that the diagnostic contains `NumTokens = 0, expected at least 8`.
3. NASA Format Check passed.
4. NASA Static Analysis passed.
5. NASA Code Coverage Analysis passed.
6. NASA Code Coverage Analysis with EDS enabled passed.
7. NASA MCDC Analysis passed.
8. NASA Functional Test passed.
9. NASA Functional Test with EDS enabled passed.
10. NASA cFS Documentation and Guides passed.
11. NASA CodeQL Analysis passed.

**Expected behavior changes**

- API Change: none.
- Behavior Change: malformed startup-script entries with fewer than eight tokens produce a clearer diagnostic.
- Startup parsing and error-return behavior are unchanged.

**System(s) tested on**

- Repository baseline: cFE `dev`.
- Validation: NASA GitHub Actions workflows listed above.

**Additional context**

The branch is one commit ahead of `dev`, zero commits behind, and changes only the ES diagnostic plus its regression assertion.

**Third party code**

None.

**Contributor Info - All information REQUIRED for consideration of pull request**

Sylvester Kaczmarek, Personal

### Latest rebase validation

Rebased onto current `dev` at `39d765fa568943c50c6a8f7dbc957edc31607900`. Preserved the upstream startup-parser refactor and moved the relevant change to `cfe_es_startupscript.c`. Config, ES, TBL, and TA coverage targets all passed for ten repetitions in a Debian 12 arm64 native configuration with EDS disabled. The local TA fixture supplies its required performance ID. Clang-format 19 and `git diff --check` passed. New upstream CI results are pending.
