### PR TITLE
Fix #2782, make TIME print independent of time_t width

### DIFF
--- a/modules/time/fsw/src/cfe_time_api.c
+++ b/modules/time/fsw/src/cfe_time_api.c
@@ -565,25 +565,63 @@ uint32 CFE_TIME_Micro2SubSecs(uint32 MicroSeconds)
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
+static void CFE_TIME_UnixSecondsToTm(struct tm *Time, uint64 UnixSeconds)
+{
+    uint64 Days;
+    uint32 SecondsOfDay;
+    uint32 Year;
+    uint32 DaysInYear;
+
+    Days         = UnixSeconds / 86400;
+    SecondsOfDay = UnixSeconds % 86400;
+    Year         = 1970;
+
+    while (true)
+    {
+        DaysInYear = 365;
+        if (((Year % 4) == 0) && (((Year % 100) != 0) || ((Year % 400) == 0)))
+        {
+            ++DaysInYear;
+        }
+
+        if (Days < DaysInYear)
+        {
+            break;
+        }
+
+        Days -= DaysInYear;
+        ++Year;
+    }
+
+    Time->tm_year  = (int)Year - 1900;
+    Time->tm_yday  = (int)Days;
+    Time->tm_hour  = (int)(SecondsOfDay / 3600);
+    SecondsOfDay  %= 3600;
+    Time->tm_min   = (int)(SecondsOfDay / 60);
+    Time->tm_sec   = (int)(SecondsOfDay % 60);
+}
+
 CFE_Status_t CFE_TIME_Print(char *PrintBuffer, CFE_TIME_SysTime_t TimeToPrint)
 {
     size_t    FmtLen = 0;
     uint32    Micros = (CFE_TIME_Sub2MicroSecs(TimeToPrint.Subseconds) + CFE_MISSION_TIME_EPOCH_MICROS) / 10;
-    struct tm tm     = { 0 };
+    uint64    UnixSeconds;
+    struct tm tm = { 0 };
 
     if (PrintBuffer == NULL)
     {
         return CFE_TIME_BAD_ARGUMENT;
     }
 
-    time_t sec = TimeToPrint.Seconds + CFE_MISSION_TIME_EPOCH_SECONDS; // epoch is Jan 1, 1980
+    UnixSeconds = (uint64)TimeToPrint.Seconds + (uint64)CFE_MISSION_TIME_EPOCH_SECONDS;
+    CFE_TIME_UnixSecondsToTm(&tm, UnixSeconds);
 
-    if (gmtime_r(&sec, &tm) == NULL)
+    FmtLen = strftime(PrintBuffer, CFE_TIME_PRINTED_STRING_SIZE - 6, "%Y-%j-%H:%M:%S", &tm);
+    if (FmtLen == 0)
     {
         return CFE_TIME_BAD_ARGUMENT;
     }
 
-    FmtLen            = strftime(PrintBuffer, CFE_TIME_PRINTED_STRING_SIZE - 6, "%Y-%j-%H:%M:%S", &tm);
     PrintBuffer      += FmtLen;
     *(PrintBuffer++)  = '.';
 

--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -863,6 +863,24 @@ void Test_Print(void)
                      (unsigned int)time.Subseconds,
                      timeBuf);
     }
+    /* Test the maximum seconds value, including the 2100 non-leap-century boundary */
+    time.Subseconds = 0;
+    time.Seconds    = 0xffffffff;
+
+    CFE_UtAssert_SUCCESS(CFE_TIME_Print(timeBuf, time));
+    if (usingDefaultEpoch)
+    {
+        strcpy(expectedBuf, "2116-038-06:28:15.00000");
+        UtAssert_STRINGBUF_EQ(timeBuf, sizeof(timeBuf), expectedBuf, sizeof(expectedBuf));
+    }
+    else
+    {
+        UtAssert_MIR("Confirm adding seconds = %u, subseconds = %u to configured EPOCH results in time %s",
+                     (unsigned int)time.Seconds,
+                     (unsigned int)time.Subseconds,
+                     timeBuf);
+    }
+
 }
 
 /*

--- a/modules/time/ut-coverage/time_UT.c
+++ b/modules/time/ut-coverage/time_UT.c
@@ -880,7 +880,6 @@ void Test_Print(void)
                      (unsigned int)time.Subseconds,
                      timeBuf);
     }
-
 }
 
 /*


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**

Fix #2782.

Make `CFE_TIME_Print()` independent of the host C library's `time_t` width.

The previous implementation converted cFE seconds to `time_t` and called `gmtime_r()`. On platforms with a 32-bit `time_t`, timestamps beyond the signed 32-bit Unix-time range could wrap and produce an incorrect calendar date.

This change converts the cFE timestamp directly into the `struct tm` fields required by the existing `%Y-%j-%H:%M:%S` output format using 64-bit arithmetic and Gregorian leap-year rules.

The public API and printed format remain unchanged.

Regression coverage also exercises the maximum 32-bit cFE seconds value and crosses the year-2100 non-leap-century boundary.

**Testing performed**

1. Added focused TIME unit coverage for the maximum cFE seconds value.
2. Verified the existing timestamps continue to produce their expected output.
3. Fork-side Code Coverage Analysis passed.
4. Upstream NASA GitHub Actions currently require repository authorization for this fork-originated PR, so no upstream CI success is being claimed yet.

**Expected behavior changes**

- API Change: none.
- Behavior Change: `CFE_TIME_Print()` no longer depends on the host `time_t` range for supported cFE timestamps.
- 32-bit and 64-bit builds produce the same calendar representation for timestamps beyond the 2038 Unix-time boundary.

**System(s) tested on**

- Repository baseline: cFE `dev`.
- Validation: focused TIME regression coverage and fork GitHub Actions.

**Additional context**

Issue #2782 reports the existing rollover in a 32-bit TIME build. This change fixes the underlying flight-software behavior rather than making the test accept the wrapped date.

**Third party code**

None.

**Contributor Info - All information REQUIRED for consideration of pull request**

Sylvester Kaczmarek, Personal