### PR TITLE
Fix #2574, document software bus timeout clock behavior

### DIFF
--- a/docs/src/cfe_sb.dox
+++ b/docs/src/cfe_sb.dox
@@ -391,6 +391,13 @@
 /**
   \page cfesbugknwnprob Known Problem
 
+  Finite timeouts passed to #CFE_SB_ReceiveBuffer and #CFE_SB_ReceiveBufferWithRoute
+  are implemented by the underlying OS queue. On POSIX systems that use an absolute
+  real-time clock for timed queue receives, changing the system wall clock while a
+  receive is pending may cause the call to time out early or wait longer than requested.
+  Applications requiring timeout behavior independent of wall-clock adjustments should
+  account for this platform-specific limitation.
+
   The software bus may perform unexpectedly under an unlikely corner-case scenario. This
   scenario was revealed in a stress test. The stress test was designed to deplete the Software
   Bus memory pool by having a high priority application continuously send 1000 byte packets


### PR DESCRIPTION
Fix #2574

Document the platform-specific behavior of finite `CFE_SB_ReceiveBuffer` and `CFE_SB_ReceiveBufferWithRoute` timeouts when the underlying POSIX queue uses an absolute real-time clock.

The Software Bus known-problem note now explains that wall-clock adjustments while a finite receive is pending can cause an early timeout or a longer wait, and advises applications that require elapsed-time semantics to account for this platform limitation.

Testing:
- documentation-only change
- verified the branch contains only the intended update to `docs/src/cfe_sb.dox`

Expected behavior changes:
- none; this documents existing platform behavior

Contributor: `sylvesterkaczmarek`