### PR TITLE
Part nasa/cFS#1079, adding further guidance to the pull request templates

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/comment_documentation_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/comment_documentation_change.md
@@ -16,6 +16,7 @@ Closes #
 ## Areas of Expertise Touched
 
 <!-- Check all that apply so the appropriate Experts can be tagged as reviewers. -->
+<!-- See the expertise tags in the "cFS Dev Team" Teams channel or ask your team lead to help identify experts. -->
 - [ ] ASTRO
 - [ ] CI/CD
 - [ ] COSMOS

--- a/.github/PULL_REQUEST_TEMPLATE/fsw_code_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/fsw_code_change.md
@@ -31,6 +31,8 @@ Closes #
 
 ## Areas of Expertise Touched
 
+<!-- Check all that apply so the appropriate Experts can be tagged as reviewers. -->
+<!-- See the expertise tags in the "cFS Dev Team" Teams channel or ask your team lead to help identify experts. -->
 - [ ] ASTRO
 - [ ] CI/CD
 - [ ] COSMOS
@@ -65,10 +67,9 @@ Closes #
 ## Reviewer Checklist
 
 - [ ] Code logic is correct and matches the stated intent
-- [ ] Code is readable, maintainable, and follows project conventions
+- [ ] Code is readable, maintainable, and follows project conventions (ask your lead if you are unsure of where to find these conventions)
 - [ ] `.clang-format` has been applied
 - [ ] Static analysis results reviewed and acceptable
-- [ ] Unit tests are meaningful and adequately cover the changes
 - [ ] **The change has been exercised by the unit tests** (not just that tests pass — the new/changed code paths are actually covered)
 - [ ] **COSMOS test suite was executed against this change** and results reviewed (or confirmed N/A with justification)
 - [ ] **Reviewer has independently verified the change behaves as described** (e.g., by running the tests locally, reviewing CI output in detail, or performing additional ad-hoc testing as warranted)

--- a/.github/PULL_REQUEST_TEMPLATE/workflows_change.md
+++ b/.github/PULL_REQUEST_TEMPLATE/workflows_change.md
@@ -14,6 +14,8 @@ Closes #
 
 ## Areas of Expertise Touched
 
+<!-- Check all that apply so the appropriate Experts can be tagged as reviewers. -->
+<!-- See the expertise tags in the "cFS Dev Team" Teams channel or ask your team lead to help identify experts. -->
 - [ ] ASTRO
 - [ ] CI/CD
 - [ ] COSMOS

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,9 @@
+**For members of the cFS Team**
+Click the `Preview` tab and select the pull request template corresponding to the type of change you are submitting:
+- [Comment/Documentation Change](?expand=1&template=comment_documentation_change.md)
+- [Flight Software Code Change](?expand=1&template=fsw_code_change.md)
+- [Workflows Change](?expand=1&template=workflows_change.md)
+
 **Checklist (Please check before submitting)**
 
 * [ ] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
@@ -32,9 +38,4 @@ If included, identify any third party code and provide text file of license
 **Contributor Info - All information REQUIRED for consideration of pull request**
 Full name and company/organization/center of all contributors ("Personal" if individual work)
  - Note CLAs apply to only software contributions.
-
-**For members of the cFS Team**
-Click the `Preview` tab and select the pull request template corresponding to the type of change you are submitting:
-- [Comment/Documentation Change](?expand=1&template=comment_documentation_change.md)
-- [Flight Software Code Change](?expand=1&template=fsw_code_change.md)
-- [Workflows Change](?expand=1&template=workflows_change.md)
+ 


### PR DESCRIPTION
## Description of Change

This addresses findings found during the review of pull request templates for other cFS modules:
- Provides guidance on where to find team expertise list and coding conventions
- Removes redundant check from reviewer checklist

## Linked Issue

<!-- Required. Reference the GitHub issue this PR addresses, e.g., Closes #123 -->
Partially Closes nasa/cFS#1079

## Areas of Expertise Touched

<!-- Check all that apply so the appropriate Experts can be tagged as reviewers. -->
- [ ] ASTRO
- [ ] CI/CD
- [ ] COSMOS
- [ ] Cybersecurity
- [ ] Docker
- [ ] EDS
- [ ] Git
- [ ] PSPs
- [ ] SBN
- [ ] SMP
- [ ] Tables
- [ ] TSN
- [ ] Unit Tests
- [ ] Other

---

## Author Checklist

- [x] Linked GitHub issue is referenced above/linked to this PR
- [x] Documentation generation workflow ran successfully on this branch
- [x] Changes are limited to documentation/comments (no code behavior changes)

---

## Reviewer Checklist

- [ ] Documentation is clear, accurate, and complete
- [x] Spelling and grammar reviewed
- [x] Any links in the documentation have been verified to work
- [x] Documentation generation workflow output looks correct
- [x] Appropriate Expert areas have been reviewed