### PR TITLE
Fix #2798, reduce complexity of ES functions

### DIFF
--- a/cmake/target/inc/target_objtab.h
+++ b/cmake/target/inc/target_objtab.h
@@ -40,18 +40,22 @@
  * objtab.c file.  ES iterates the table of pointers to these descriptors
  * at each lifecycle phase:
  *
- *  - EarlyInit  : called before any tasks are started
- *  - TaskMain   : entry point passed to OS_TaskCreate(); NULL for library modules
- *  - Cleanup    : called during shutdown; NULL if not required
+ *  - EarlyInit    : called before any tasks are started
+ *  - TaskMain     : entry point passed to OS_TaskCreate(); NULL for library modules
+ *  - AppCleanupCb : Notification function called when state from an external is cleaned up.
+ *           If this module has any resources associated with the given app, this routine
+ *           should free those resources.  If this module does not track any per-app state,
+ *           then this should be set NULL.  The parameter is the CFE ES AppId converted to
+ *           a plain unsigned integer value (the CFE_ES_AppId_t typedef does not exist here).
  */
 typedef struct
 {
-    const char *Name;            /**< Module name, e.g. "CFE_EVS" */
-    int32 (*EarlyInit)(void);    /**< Early initialization function; must not be NULL */
-    void (*TaskMain)(void);      /**< Task entry point; NULL for library-only modules */
-    int32 (*Cleanup)(uint32 Id); /**< Cleanup function; NULL if not required */
-    uint32 Priority;             /**< Task priority; ignored if TaskMain is NULL */
-    uint32 StackSize;            /**< Task stack size in bytes; ignored if TaskMain is NULL */
+    const char *Name;                 /**< Module name, e.g. "CFE_EVS" */
+    int32 (*EarlyInit)(void);         /**< Early initialization function; must not be NULL */
+    void (*TaskMain)(void);           /**< Task entry point; NULL for library-only modules */
+    int32 (*AppCleanupCb)(uint32 Id); /**< Callback function to invoke when external apps are stopped */
+    uint32 Priority;                  /**< Task priority; ignored if TaskMain is NULL */
+    uint32 StackSize;                 /**< Task stack size in bytes; ignored if TaskMain is NULL */
 } Target_ObjectTable_t;
 
 #endif /* CFE_ES_OBJTAB_H */

--- a/modules/config/fsw/src/cfe_config_objtab.c
+++ b/modules/config/fsw/src/cfe_config_objtab.c
@@ -30,9 +30,5 @@
 #include "target_objtab.h"
 #include "cfe_config_core_internal.h"
 
-const Target_ObjectTable_t CFE_CONFIG_ModuleEntry = { .Name      = "CFE_CONFIG",
-                                                      .EarlyInit = CFE_Config_Init,
-                                                      .TaskMain  = NULL, /* library module - no task */
-                                                      .Cleanup   = NULL,
-                                                      .Priority  = 0,
-                                                      .StackSize = 0 };
+/* this is a core library module with no task, but it does have global data to initialize */
+const Target_ObjectTable_t CFE_CONFIG_ModuleEntry = { .Name = "CFE_CONFIG", .EarlyInit = CFE_Config_Init };

--- a/modules/es/CMakeLists.txt
+++ b/modules/es/CMakeLists.txt
@@ -9,6 +9,7 @@ project(CFE_ES C)
 # Executive services source files
 set(es_SOURCES
     fsw/src/cfe_es_api.c
+    fsw/src/cfe_es_appctrl.c
     fsw/src/cfe_es_apps.c
     fsw/src/cfe_es_backgroundtask.c
     fsw/src/cfe_es_cds.c
@@ -21,6 +22,7 @@ set(es_SOURCES
     fsw/src/cfe_es_perf.c
     fsw/src/cfe_es_resource.c
     fsw/src/cfe_es_start.c
+    fsw/src/cfe_es_startupscript.c
     fsw/src/cfe_es_syslog.c
     fsw/src/cfe_es_task.c
 )

--- a/modules/es/fsw/src/cfe_es_appctrl.c
+++ b/modules/es/fsw/src/cfe_es_appctrl.c
@@ -1,0 +1,499 @@
+/************************************************************************
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
+ *
+ * Copyright (c) 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/*
+**  File:
+**    cfe_es_apps.c
+**
+**  Purpose:
+**    This file contains functions for starting cFE applications from a filesystem.
+**
+**  References:
+**     Flight Software Branch C Coding Standard Version 1.0a
+**     cFE Flight Software Application Developers Guide
+**
+**  Notes:
+**
+*/
+
+/*
+** Includes
+*/
+#include "cfe_es_module_all.h"
+#include "cfe_es_appctrl.h"
+
+#include <stdio.h>
+#include <string.h> /* memset() */
+#include <fcntl.h>
+#include <ctype.h>
+
+#include "target_config.h"
+
+/*
+ * Mapping for control requests
+ * Provides event details to send when the control request is processed
+ */
+typedef struct
+{
+    const char *ReqName; /* printable name */
+
+    uint16 CleanupErrEventID; /* Event to send if cleanup failed (always an error) */
+    uint16 StartupErrEventID; /* Event to send if startup failed (always an error)  */
+    uint16 ErrorEventID;      /* Generic Error Event to send (valid for abnormal requests) */
+    uint16 NominalEventID;    /* Generic Info Event to send (valid for normal requests) */
+} CFE_ES_ControlReqMapEntry_t;
+
+/*
+****************************************************************************
+** Functions
+***************************************************************************
+*/
+
+/*----------------------------------------------------------------
+ *
+ * Local helper function
+ * Sends the event after a control request error / invalid condition
+ *
+ *-----------------------------------------------------------------*/
+static void CFE_ES_ProcessControlRequest_ErrorEvent(const CFE_ES_ControlReqMapEntry_t *ControlReqInfo,
+                                                    const char                        *AppName,
+                                                    uint32                             ControlReq)
+{
+    char        ControlReqBuff[16];
+    const char *PrintableReqName;
+
+    if (ControlReqInfo->ReqName == NULL)
+    {
+        /* This is for invalid request IDs - should never happen in operation. */
+        snprintf(ControlReqBuff, sizeof(ControlReqBuff), "[Req%u]", (unsigned int)ControlReq);
+        PrintableReqName = ControlReqBuff;
+    }
+    else
+    {
+        /* The request has a valid name, so use it directly */
+        PrintableReqName = ControlReqInfo->ReqName;
+    }
+
+    CFE_EVS_SendEvent(ControlReqInfo->ErrorEventID,
+                      CFE_EVS_EventType_ERROR,
+                      "%s Application %s",
+                      PrintableReqName,
+                      AppName);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local helper function
+ * Sends the event after successful processing of a control request
+ *
+ *-----------------------------------------------------------------*/
+static void CFE_ES_ProcessControlRequest_SuccessEvent(const CFE_ES_ControlReqMapEntry_t *ControlReqInfo,
+                                                      const char                        *AppName,
+                                                      CFE_ES_AppId_t                     NewAppId)
+{
+    char AppIdStr[32];
+
+    if (CFE_RESOURCEID_TEST_DEFINED(NewAppId))
+    {
+        /* Additional string showing the new appid */
+        snprintf(AppIdStr, sizeof(AppIdStr), ", AppID=0x%lx", CFE_RESOURCEID_TO_ULONG(NewAppId));
+    }
+    else
+    {
+        /* No additional string */
+        AppIdStr[0] = 0;
+    }
+
+    CFE_EVS_SendEvent(ControlReqInfo->NominalEventID,
+                      CFE_EVS_EventType_INFORMATION,
+                      "%s Application %s Success%s.",
+                      ControlReqInfo->ReqName,
+                      AppName,
+                      AppIdStr);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+uint32 CFE_ES_ProcessControlRequest_Start(CFE_ES_AppId_t           AppId,
+                                          char                    *OrigAppNameBuf,
+                                          size_t                   OrigAppNameSz,
+                                          CFE_ES_AppStartParams_t *RestartParamPtr)
+{
+    CFE_ES_AppRecord_t *AppRecPtr;
+    uint32              PendingControlReq;
+
+    /* Init/clear all local state variables */
+    PendingControlReq = 0;
+
+    AppRecPtr = CFE_ES_LocateAppRecordByID(AppId);
+
+    /*
+     * Take a local snapshot of the important app record data
+     * This way it becomes private and can be accessed without
+     * concerns about other threads/tasks, even after the global
+     * data records are eventually cleared.
+     */
+    CFE_ES_LockSharedData(__func__, __LINE__);
+
+    if (CFE_ES_AppRecordIsMatch(AppRecPtr, AppId))
+    {
+        PendingControlReq = AppRecPtr->ControlReq.AppControlRequest;
+        strncpy(OrigAppNameBuf, AppRecPtr->AppName, OrigAppNameSz - 1);
+        OrigAppNameBuf[OrigAppNameSz - 1] = 0;
+
+        /* If a restart was requested, copy the parameters to re-use in new app */
+        if (PendingControlReq == CFE_ES_RunStatus_SYS_RESTART || PendingControlReq == CFE_ES_RunStatus_SYS_RELOAD)
+        {
+            *RestartParamPtr = AppRecPtr->StartParams;
+        }
+    }
+
+    CFE_ES_UnlockSharedData(__func__, __LINE__);
+
+    return PendingControlReq;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void CFE_ES_ProcessControlRequest_Finish(uint32         ControlReq,
+                                         const char    *AppName,
+                                         CFE_Status_t   StartupStatus,
+                                         CFE_Status_t   CleanupStatus,
+                                         CFE_ES_AppId_t NewAppId)
+{
+    const CFE_ES_ControlReqMapEntry_t *ControlReqInfo;
+
+    /*
+     * NOTE: The ControlReqInfo entry should set the ErrorEventID (only) for
+     * abnormal conditions.  Normal Request conditions should set NominalEventID
+     * and should NOT set ErrorEventID.
+     */
+
+    static const CFE_ES_ControlReqMapEntry_t CONTROL_REQ_MAP[CFE_ES_RunStatus_MAX] =
+    {
+    [CFE_ES_RunStatus_UNDEFINED] =
+    {
+        /* catches all abnormal cases */
+        .ErrorEventID = CFE_ES_PCR_ERR2_EID,
+    },
+    [CFE_ES_RunStatus_APP_RUN] =
+    {
+        /* while "APP_RUN" is normal, it should not show up in a control request */
+        .ReqName = "Run",
+        //jphfix .ErrorEventID = CFE_ES_PCR_ERR2_EID,
+    },
+    [CFE_ES_RunStatus_APP_EXIT] =
+    {
+        .ReqName = "Exit",
+        .CleanupErrEventID = CFE_ES_EXIT_APP_ERR_EID,
+        .NominalEventID = CFE_ES_EXIT_APP_INF_EID,
+    },
+    [CFE_ES_RunStatus_APP_ERROR] =
+    {
+        .ReqName = "ErrExit",
+        .CleanupErrEventID = CFE_ES_ERREXIT_APP_ERR_EID,
+        .NominalEventID = CFE_ES_ERREXIT_APP_INF_EID,
+    },
+    [CFE_ES_RunStatus_SYS_EXCEPTION] =
+    {
+        .ReqName = "Exception",
+        .NominalEventID = CFE_ES_PCR_ERR1_EID,
+    },
+    [CFE_ES_RunStatus_SYS_RESTART] =
+    {
+        .ReqName = "Restart",
+        .CleanupErrEventID = CFE_ES_RESTART_APP_ERR4_EID,
+        .StartupErrEventID = CFE_ES_RESTART_APP_ERR3_EID,
+        .NominalEventID = CFE_ES_RESTART_APP_INF_EID,
+    },
+    [CFE_ES_RunStatus_SYS_RELOAD] =
+    {
+        .ReqName = "Reload",
+        .CleanupErrEventID = CFE_ES_RELOAD_APP_ERR4_EID,
+        .StartupErrEventID = CFE_ES_RELOAD_APP_ERR3_EID,
+        .NominalEventID = CFE_ES_RELOAD_APP_INF_EID,
+    },
+    [CFE_ES_RunStatus_SYS_DELETE] =
+    {
+        .ReqName = "Stop",
+        .CleanupErrEventID = CFE_ES_STOP_ERR3_EID,
+        .NominalEventID = CFE_ES_STOP_INF_EID,
+    },
+    [CFE_ES_RunStatus_CORE_APP_INIT_ERROR] =
+    {
+        .ReqName = "Core Init Err",
+        .ErrorEventID = CFE_ES_PCR_ERR2_EID,
+    },
+    [CFE_ES_RunStatus_CORE_APP_RUNTIME_ERROR] =
+    {
+        .ReqName = "Core Runtime Err",
+        .ErrorEventID = CFE_ES_PCR_ERR2_EID,
+    },
+
+    };
+
+    if (ControlReq < CFE_ES_RunStatus_MAX)
+    {
+        ControlReqInfo = &CONTROL_REQ_MAP[ControlReq];
+    }
+    else
+    {
+        ControlReqInfo = &CONTROL_REQ_MAP[CFE_ES_RunStatus_UNDEFINED];
+    }
+
+    /* If the ErrorEventID is set, it will ALWAYS be sent */
+    /* This also catches all invalid request IDs where ReqName == NULL.  */
+    if (ControlReqInfo->ReqName == NULL || ControlReqInfo->ErrorEventID != 0)
+    {
+        /* This event sender can tolerate ReqName being NULL (unknown) */
+        CFE_ES_ProcessControlRequest_ErrorEvent(ControlReqInfo, AppName, ControlReq);
+    }
+    else
+    {
+        /*
+         * NOTE: all these event senders require that ReqName is valid/non-NULL
+         * The CleanupStatus is a dont-care when CleanupErrEventID is not set
+         * The StartupStatus is a dont-care when StartupErrEventID is not set
+         */
+
+        /* If there is a specific event for cleanup error, send it */
+        if (CleanupStatus != CFE_SUCCESS && ControlReqInfo->CleanupErrEventID != 0)
+        {
+            /* Make detail message for event containing cleanup error code */
+            CFE_EVS_SendEvent(ControlReqInfo->CleanupErrEventID,
+                              CFE_EVS_EventType_ERROR,
+                              "%s Application %s Failed: CleanUpApp Error 0x%08X.",
+                              ControlReqInfo->ReqName,
+                              AppName,
+                              (unsigned int)CleanupStatus);
+        }
+        else if (StartupStatus != CFE_SUCCESS && ControlReqInfo->StartupErrEventID != 0)
+        {
+            /* Make detail message for event containing startup error code */
+            /* The StartupStatus is a dont-care if StartupErrEventID is not set */
+            CFE_EVS_SendEvent(ControlReqInfo->StartupErrEventID,
+                              CFE_EVS_EventType_ERROR,
+                              "%s Application %s Failed: AppCreate Error 0x%08X.",
+                              ControlReqInfo->ReqName,
+                              AppName,
+                              (unsigned int)StartupStatus);
+        }
+        else if (ControlReqInfo->NominalEventID != 0)
+        {
+            /* Make detail message including new AppID, if valid */
+            CFE_ES_ProcessControlRequest_SuccessEvent(ControlReqInfo, AppName, NewAppId);
+        }
+    }
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void CFE_ES_ProcessControlRequest(CFE_ES_AppId_t AppId)
+{
+    uint32                  PendingControlReq;
+    CFE_ES_AppStartParams_t RestartParams;
+    char                    OrigAppName[OS_MAX_API_NAME];
+    CFE_Status_t            CleanupStatus;
+    CFE_Status_t            StartupStatus;
+    CFE_ES_AppId_t          NewAppId;
+
+    /* Init/clear all local state variables */
+    NewAppId = CFE_ES_APPID_UNDEFINED;
+    memset(&RestartParams, 0, sizeof(RestartParams));
+    memset(&OrigAppName, 0, sizeof(OrigAppName));
+
+    /*
+     * This subroutine looks up the app, gets the name, checks for the pending request
+     */
+    PendingControlReq = CFE_ES_ProcessControlRequest_Start(AppId, OrigAppName, sizeof(OrigAppName), &RestartParams);
+
+    /*
+     * All control requests start by deleting the app/task and
+     * all associated resources.
+     *
+     * The reload/restart requests will start it again, and it gets
+     * a new appID.  For other requests it just leaves it deleted.
+     *
+     * Note that Cleanup can fail for a variety of reasons, including
+     * situations where e.g. a task ID had become stale because the task
+     * already exited itself.  In most cases these are minor errors and
+     * reflect problems with the consistency of the old app record.
+     *
+     * Even when this happens the cleanup should still do its best effort
+     * to release all relevant global data entries.  So it should not
+     * prevent starting the new app, if a restart/reload is indicated.
+     */
+    CleanupStatus = CFE_ES_CleanUpApp(AppId);
+
+    /*
+     * Attempt to restart the app if the request indicated to do so,
+     * regardless of the CleanupStatus.
+     */
+    if (PendingControlReq == CFE_ES_RunStatus_SYS_RESTART || PendingControlReq == CFE_ES_RunStatus_SYS_RELOAD)
+    {
+        StartupStatus = CFE_ES_AppCreate(&NewAppId, OrigAppName, &RestartParams);
+    }
+    else
+    {
+        StartupStatus = CFE_STATUS_NOT_IMPLEMENTED;
+    }
+
+    /*
+     * Send the event(s)
+     *
+     * Determine the event ID associated with the control request,
+     * which indicates the success/failure of the operation and
+     * any other relevant detail.
+     *
+     * Note that the specific event ID that gets generated is the only
+     * other difference between all these control request types.
+     */
+    CFE_ES_ProcessControlRequest_Finish(PendingControlReq, OrigAppName, StartupStatus, CleanupStatus, NewAppId);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+bool CFE_ES_RunAppTableScan(uint32 ElapsedTime, void *Arg)
+{
+    CFE_ES_AppTableScanState_t *State = (CFE_ES_AppTableScanState_t *)Arg;
+    uint32                      i;
+    CFE_ES_AppRecord_t         *AppPtr;
+    CFE_ES_AppId_t              AppTimeoutList[CFE_PLATFORM_ES_MAX_APPLICATIONS];
+    uint32                      NumAppTimeouts;
+
+    if (State->PendingAppStateChanges == 0)
+    {
+        /*
+         * If the command count changes, then a scan becomes due immediately.
+         */
+        if (State->LastScanCommandCount == CFE_ES_Global.TaskData.CommandCounter
+            && State->BackgroundScanTimer > ElapsedTime)
+        {
+            /* no action at this time, background scan is not due yet */
+            State->BackgroundScanTimer -= ElapsedTime;
+            return false;
+        }
+    }
+
+    /*
+     * Every time a scan is initiated (for any reason)
+     * reset the background scan timer to the full value,
+     * and take a snapshot of the command counter.
+     */
+    NumAppTimeouts                = 0;
+    State->BackgroundScanTimer    = CFE_PLATFORM_ES_APP_SCAN_RATE;
+    State->LastScanCommandCount   = CFE_ES_Global.TaskData.CommandCounter;
+    State->PendingAppStateChanges = 0;
+
+    /*
+     * Scan needs to be done with the table locked,
+     * as these state changes need to be done atomically
+     * with respect to other tasks that also access/update
+     * the state.
+     */
+    CFE_ES_LockSharedData(__func__, __LINE__);
+
+    /*
+    ** Scan the ES Application table. Skip entries that are:
+    **  - Not in use, or
+    **  - cFE Core apps, or
+    **  - Currently running
+    */
+    AppPtr = CFE_ES_Global.AppTable;
+    for (i = 0; i < CFE_PLATFORM_ES_MAX_APPLICATIONS; i++)
+    {
+        if (CFE_ES_AppRecordIsUsed(AppPtr) && AppPtr->Type == CFE_ES_AppType_EXTERNAL)
+        {
+            if (AppPtr->AppState > CFE_ES_AppState_RUNNING)
+            {
+                /*
+                 * Increment the "pending" counter which reflects
+                 * the number of apps that are in some phase of clean up.
+                 */
+                ++State->PendingAppStateChanges;
+
+                /*
+                 * Decrement the wait timer, if active.
+                 * When the timeout value becomes zero, take the action to delete/restart/reload the app
+                 */
+                if (AppPtr->ControlReq.AppTimerMsec > ElapsedTime)
+                {
+                    AppPtr->ControlReq.AppTimerMsec -= ElapsedTime;
+                }
+                else
+                {
+                    AppPtr->ControlReq.AppTimerMsec = 0;
+
+                    /* Add it to the list to be processed later */
+                    AppTimeoutList[NumAppTimeouts] = CFE_ES_AppRecordGetID(AppPtr);
+                    ++NumAppTimeouts;
+                }
+            }
+            else if (AppPtr->AppState == CFE_ES_AppState_RUNNING
+                     && AppPtr->ControlReq.AppControlRequest > CFE_ES_RunStatus_APP_RUN)
+            {
+                /* this happens after a command arrives to restart/reload/delete an app */
+                /* switch to WAITING state, and set the timer for transition */
+                AppPtr->AppState                = CFE_ES_AppState_WAITING;
+                AppPtr->ControlReq.AppTimerMsec = CFE_PLATFORM_ES_APP_KILL_TIMEOUT * CFE_PLATFORM_ES_APP_SCAN_RATE;
+            }
+        }
+
+        ++AppPtr;
+
+    } /* end for loop */
+
+    CFE_ES_UnlockSharedData(__func__, __LINE__);
+
+    /*
+     * Now invoke the CFE_ES_ProcessControlRequest() routine for any app
+     * which has reached that point.
+     */
+    for (i = 0; i < NumAppTimeouts; i++)
+    {
+        /*
+         * Call CFE_ES_ProcessControlRequest() with a reference to
+         * the _copies_ of the app record details.  (This avoids
+         * needing to access the global records outside of the lock).
+         */
+        CFE_ES_ProcessControlRequest(AppTimeoutList[i]);
+    }
+
+    /*
+     * This state machine is considered active if there are any
+     * pending app state changes.  Returning "true" will cause this job
+     * to be called from the background task at a faster interval.
+     */
+    return (State->PendingAppStateChanges != 0);
+}

--- a/modules/es/fsw/src/cfe_es_appctrl.h
+++ b/modules/es/fsw/src/cfe_es_appctrl.h
@@ -1,0 +1,78 @@
+/************************************************************************
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
+ *
+ * Copyright (c) 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *
+ *  Purpose:
+ *  This file contains the Internal interface for the cFE Application control functions of ES.
+ *  These functions and data structures manage the Applications and Child tasks in the cFE.
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *     cFE Flight Software Application Developers Guide
+ *
+ */
+
+#ifndef CFE_ES_APPCTRL_H
+#define CFE_ES_APPCTRL_H
+
+/*
+** Include Files
+*/
+#include "common_types.h"
+
+#include "cfe_es_api_typedefs.h"
+
+/*
+** Type Definitions
+*/
+
+/*
+** CFE_ES_AppTableScanState_t is an internal structure used to keep state of
+** the background app table scan/cleanup process
+*/
+typedef struct
+{
+    uint32 PendingAppStateChanges;
+    uint32 BackgroundScanTimer;
+    uint8  LastScanCommandCount;
+} CFE_ES_AppTableScanState_t;
+
+/*****************************************************************************/
+/*
+** Function prototypes
+*/
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * Scan the Application Table for actions to take
+ *
+ * This function scans the ES Application table and acts on the changes
+ * in application states. This is where the external cFE Applications are
+ * restarted, reloaded, or deleted.
+ */
+bool CFE_ES_RunAppTableScan(uint32 ElapsedTime, void *Arg);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * Perform the requested control action for an application
+ */
+void CFE_ES_ProcessControlRequest(CFE_ES_AppId_t AppId);
+
+#endif /* CFE_ES_APPS_H */

--- a/modules/es/fsw/src/cfe_es_apps.c
+++ b/modules/es/fsw/src/cfe_es_apps.c
@@ -39,17 +39,23 @@
 #include <stdio.h>
 #include <string.h> /* memset() */
 #include <fcntl.h>
+#include <ctype.h>
+
 #include "target_config.h"
-/*
-** Defines
-*/
-#define ES_START_BUFF_SIZE 128
 
 /*
-**
-**  Global Variables
-**
-*/
+ * Simple state structure used when cleaning up objects associated with tasks
+ *
+ * This is used locally by CFE_ES_CleanupTaskResources
+ */
+typedef struct
+{
+    uint32 ErrorFlag;
+    uint32 FoundObjects;
+    uint32 PrevFoundObjects;
+    uint32 DeletedObjects;
+    int32  OverallStatus;
+} CFE_ES_CleanupState_t;
 
 /*
 ****************************************************************************
@@ -104,344 +110,6 @@ CFE_ES_AppRecord_t *CFE_ES_LockUserAppRecord(CFE_ES_AppId_t AppID, const char *L
     }
 
     return AppRecPtr;
-}
-
-/*----------------------------------------------------------------
- *
- * Application-scope internal function
- * See description in header file for argument/return detail
- *
- *-----------------------------------------------------------------*/
-void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath)
-{
-    char        ES_AppLoadBuffer[ES_START_BUFF_SIZE]; /* A buffer of for a line in a file */
-    char        ScriptFileName[OS_MAX_PATH_LEN];
-    const char *TokenList[CFE_ES_STARTSCRIPT_MAX_TOKENS_PER_LINE];
-    uint32      NumTokens;
-    uint32      NumLines;
-    size_t      BuffLen; /* Length of the current buffer */
-    osal_id_t   AppFile = OS_OBJECT_ID_UNDEFINED;
-    int32       Status;
-    int32       OsStatus;
-    char        c           = 0;
-    bool        LineTooLong = false;
-    bool        FileOpened  = false;
-
-    /*
-    ** Get the ES startup script filename.
-    ** If this is a Processor Reset, try to open the file in the volatile disk first.
-    */
-    if (ResetType == CFE_PSP_RST_TYPE_PROCESSOR)
-    {
-        /*
-        ** First Attempt to parse as file in the volatile disk (temp area).
-        */
-        Status = CFE_FS_ParseInputFileName(ScriptFileName,
-                                           CFE_PLATFORM_ES_VOLATILE_STARTUP_FILE,
-                                           sizeof(ScriptFileName),
-                                           CFE_FS_FileCategory_TEMP);
-
-        if (Status == CFE_SUCCESS)
-        {
-            OsStatus = OS_OpenCreate(&AppFile, ScriptFileName, OS_FILE_FLAG_NONE, OS_READ_ONLY);
-            if (OsStatus == OS_SUCCESS)
-            {
-                FileOpened = true;
-            }
-            else
-            {
-                CFE_ES_WriteToSysLog("%s: Cannot Open Volatile Startup file: %s, Trying Nonvolatile.\n",
-                                     __func__,
-                                     ScriptFileName);
-            }
-        }
-        else
-        {
-            /* not expected -- likely a misconfiguration in CFE_PLATFORM_ES_VOLATILE_STARTUP_FILE setting */
-            CFE_ES_WriteToSysLog("%s: CFE_FS_ParseInputFileName() RC=%08x parsing volatile script file name.\n",
-                                 __func__,
-                                 (unsigned int)Status);
-        }
-    }
-
-    /*
-    ** This if block covers two cases: A Power on reset, and a Processor reset when
-    ** the startup file on the volatile file system could not be opened.
-    */
-    if (FileOpened == false)
-    {
-        /*
-        ** Try to Open the file passed in to the cFE start.
-        */
-        Status = CFE_FS_ParseInputFileName(ScriptFileName,
-                                           StartFilePath,
-                                           sizeof(ScriptFileName),
-                                           CFE_FS_FileCategory_SCRIPT);
-
-        if (Status == CFE_SUCCESS)
-        {
-            OsStatus = OS_OpenCreate(&AppFile, ScriptFileName, OS_FILE_FLAG_NONE, OS_READ_ONLY);
-            if (OsStatus == OS_SUCCESS)
-            {
-                FileOpened = true;
-            }
-            else
-            {
-                CFE_ES_WriteToSysLog("%s: Error, Can't Open ES App Startup file: %s, EC = %ld\n",
-                                     __func__,
-                                     ScriptFileName,
-                                     (long)OsStatus);
-            }
-        }
-        else
-        {
-            /* not expected -- likely a misconfiguration in the user-supplied StartFilePath */
-            CFE_ES_WriteToSysLog("%s: CFE_FS_ParseInputFileName() RC=%08x parsing StartFilePath.\n",
-                                 __func__,
-                                 (unsigned int)Status);
-        }
-    }
-
-    /*
-    ** If the file is opened in either the Nonvolatile or the Volatile disk, process it.
-    */
-    if (FileOpened == true)
-    {
-        CFE_ES_WriteToSysLog("%s: Opened ES App Startup file: %s\n", __func__, ScriptFileName);
-
-        memset(ES_AppLoadBuffer, 0x0, ES_START_BUFF_SIZE);
-        BuffLen      = 0;
-        NumTokens    = 0;
-        NumLines     = 0;
-        TokenList[0] = ES_AppLoadBuffer;
-
-        /*
-        ** Parse the lines from the file. If it has an error
-        ** or reaches EOF, then abort the loop.
-        */
-        while (1)
-        {
-            OsStatus = OS_read(AppFile, &c, 1);
-            if (OsStatus < OS_SUCCESS)
-            {
-                CFE_ES_WriteToSysLog("%s: Error Reading Startup file. EC = %ld\n", __func__, (long)OsStatus);
-                break;
-            }
-            else if (OsStatus == 0)
-            {
-                /*
-                ** EOF Reached
-                */
-                break;
-            }
-            else if (c != '!')
-            {
-                if (c <= ' ')
-                {
-                    /*
-                    ** Skip all white space in the file
-                    */
-                    ;
-                }
-                else if (c == ',')
-                {
-                    /*
-                    ** replace the field delimiter with a null
-                    ** This is used to separate the tokens
-                    */
-                    if (BuffLen < ES_START_BUFF_SIZE)
-                    {
-                        ES_AppLoadBuffer[BuffLen] = 0;
-                    }
-                    else
-                    {
-                        LineTooLong = true;
-                    }
-                    BuffLen++;
-
-                    ++NumTokens;
-                    if (NumTokens < CFE_ES_STARTSCRIPT_MAX_TOKENS_PER_LINE && !LineTooLong)
-                    {
-                        /*
-                         * NOTE: pointer never dereferenced unless "LineTooLong" is false.
-                         */
-                        TokenList[NumTokens] = &ES_AppLoadBuffer[BuffLen];
-                    }
-                    else
-                    {
-                        LineTooLong = true;
-                    }
-                }
-                else if (c != ';')
-                {
-                    /*
-                    ** Regular data gets copied in
-                    */
-                    if (BuffLen < ES_START_BUFF_SIZE)
-                    {
-                        ES_AppLoadBuffer[BuffLen] = c;
-                    }
-                    else
-                    {
-                        LineTooLong = true;
-                    }
-                    BuffLen++;
-                }
-                else
-                {
-                    ++NumLines;
-
-                    if (LineTooLong == true || BuffLen >= ES_START_BUFF_SIZE)
-                    {
-                        /*
-                        ** The line was not formed correctly
-                        */
-                        CFE_ES_WriteToSysLog("%s: **WARNING** File Line %u is malformed: %u bytes, %u tokens.\n",
-                                             __func__,
-                                             (unsigned int)NumLines,
-                                             (unsigned int)BuffLen,
-                                             (unsigned int)NumTokens);
-                        LineTooLong = false;
-                    }
-                    else
-                    {
-                        /*
-                        ** Send the line to the file parser
-                        ** Ensure termination of the last token and send it along
-                        */
-                        ES_AppLoadBuffer[BuffLen] = 0;
-                        CFE_ES_ParseFileEntry(TokenList, 1 + NumTokens);
-                    }
-                    BuffLen   = 0;
-                    NumTokens = 0;
-                }
-            }
-            else
-            {
-                /*
-                ** break when EOF character '!' is reached
-                */
-                break;
-            }
-        }
-        /*
-        ** close the file
-        */
-        OS_close(AppFile);
-    }
-}
-
-/*----------------------------------------------------------------
- *
- * Application-scope internal function
- * See description in header file for argument/return detail
- *
- *-----------------------------------------------------------------*/
-int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens)
-{
-    const char   *ModuleName;
-    const char   *EntryType;
-    unsigned long ParsedValue;
-    union
-    {
-        CFE_ES_AppId_t AppId;
-        CFE_ES_LibId_t LibId;
-    } IdBuf;
-    int32                   Status;
-    CFE_ES_AppStartParams_t ParamBuf;
-
-    memset(&ParamBuf, 0, sizeof(ParamBuf));
-
-    /*
-    ** Check to see if the correct number of items were parsed
-    */
-    if (NumTokens < 8)
-    {
-        CFE_ES_WriteToSysLog("%s: Invalid ES Startup file entry: %u\n", __func__, (unsigned int)NumTokens);
-        return CFE_ES_BAD_ARGUMENT;
-    }
-
-    /* Get pointers to specific tokens that are simple strings used as-is */
-    EntryType  = TokenList[0];
-    ModuleName = TokenList[3];
-
-    /*
-     * Other tokens will need to be scrubbed/converted.
-     * Both Libraries and Apps use File Name (1) and Symbol Name (2) fields so copy those now
-     */
-    memset(&ParamBuf, 0, sizeof(ParamBuf));
-    Status = CFE_FS_ParseInputFileName(ParamBuf.BasicInfo.FileName,
-                                       TokenList[1],
-                                       sizeof(ParamBuf.BasicInfo.FileName),
-                                       CFE_FS_FileCategory_DYNAMIC_MODULE);
-    if (Status != CFE_SUCCESS)
-    {
-        CFE_ES_WriteToSysLog("%s: Invalid ES Startup script file name: %s\n", __func__, TokenList[1]);
-        return Status;
-    }
-
-    strncpy(ParamBuf.BasicInfo.InitSymbolName, TokenList[2], sizeof(ParamBuf.BasicInfo.InitSymbolName) - 1);
-
-    if (strcmp(EntryType, "CFE_APP") == 0)
-    {
-        CFE_ES_WriteToSysLog("%s: Loading file: %s, APP: %s\n", __func__, ParamBuf.BasicInfo.FileName, ModuleName);
-
-        /*
-         * Priority and Exception action have limited ranges, which is checked here
-         * Task priority cannot be bigger than OS_MAX_TASK_PRIORITY
-         */
-        ParsedValue = strtoul(TokenList[4], NULL, 0);
-        if (ParsedValue > OS_MAX_TASK_PRIORITY)
-        {
-            ParamBuf.MainTaskInfo.Priority = OS_MAX_TASK_PRIORITY;
-        }
-        else
-        {
-            /* convert parsed value to correct type */
-            ParamBuf.MainTaskInfo.Priority = (CFE_ES_TaskPriority_Atom_t)ParsedValue;
-        }
-
-        /* No specific upper/lower limit for stack size - will pass value through */
-        ParamBuf.MainTaskInfo.StackSize = strtoul(TokenList[5], NULL, 0);
-
-        /*
-        ** Validate Some parameters
-        ** Exception action should be 0 ( Restart App ) or
-        ** 1 ( Processor reset ). If it's non-zero, assume it means
-        ** reset CPU.
-        */
-        ParsedValue = strtoul(TokenList[7], NULL, 0);
-        if (ParsedValue > CFE_ES_ExceptionAction_RESTART_APP)
-        {
-            ParamBuf.ExceptionAction = CFE_ES_ExceptionAction_PROC_RESTART;
-        }
-        else
-        {
-            /* convert parsed value to correct type */
-            ParamBuf.ExceptionAction = (CFE_ES_ExceptionAction_Enum_t)ParsedValue;
-        }
-
-        /*
-        ** Now create the application
-        */
-        Status = CFE_ES_AppCreate(&IdBuf.AppId, ModuleName, &ParamBuf);
-    }
-    else if (strcmp(EntryType, "CFE_LIB") == 0)
-    {
-        CFE_ES_WriteToSysLog("%s: Loading shared library: %s\n", __func__, ParamBuf.BasicInfo.FileName);
-
-        /*
-        ** Now load the library
-        */
-        Status = CFE_ES_LoadLibrary(&IdBuf.LibId, ModuleName, &ParamBuf.BasicInfo);
-    }
-    else
-    {
-        CFE_ES_WriteToSysLog("%s: Unexpected EntryType %s in startup file.\n", __func__, EntryType);
-        Status = CFE_ES_ERR_APP_CREATE;
-    }
-
-    return Status;
 }
 
 /*----------------------------------------------------------------
@@ -1056,372 +724,26 @@ int32 CFE_ES_LoadLibrary(CFE_ES_LibId_t *LibraryIdPtr, const char *LibName, cons
 
 /*----------------------------------------------------------------
  *
- * Application-scope internal function
- * See description in header file for argument/return detail
+ * Local helper function
+ * Collects the set of resources that are associated with the app being cleaned up
+ * This only marks them for removal, it does not fully remove yet.
  *
  *-----------------------------------------------------------------*/
-bool CFE_ES_RunAppTableScan(uint32 ElapsedTime, void *Arg)
+static CFE_Status_t CFE_ES_CleanUpApp_GetResources(CFE_ES_AppId_t      AppId,
+                                                   osal_id_t          *ModuleIdPtr,
+                                                   CFE_ES_TaskId_t    *TaskList,
+                                                   CFE_ES_MemHandle_t *PoolList)
 {
-    CFE_ES_AppTableScanState_t *State = (CFE_ES_AppTableScanState_t *)Arg;
-    uint32                      i;
-    CFE_ES_AppRecord_t         *AppPtr;
-    CFE_ES_AppId_t              AppTimeoutList[CFE_PLATFORM_ES_MAX_APPLICATIONS];
-    uint32                      NumAppTimeouts;
-
-    if (State->PendingAppStateChanges == 0)
-    {
-        /*
-         * If the command count changes, then a scan becomes due immediately.
-         */
-        if (State->LastScanCommandCount == CFE_ES_Global.TaskData.CommandCounter
-            && State->BackgroundScanTimer > ElapsedTime)
-        {
-            /* no action at this time, background scan is not due yet */
-            State->BackgroundScanTimer -= ElapsedTime;
-            return false;
-        }
-    }
-
-    /*
-     * Every time a scan is initiated (for any reason)
-     * reset the background scan timer to the full value,
-     * and take a snapshot of the command counter.
-     */
-    NumAppTimeouts                = 0;
-    State->BackgroundScanTimer    = CFE_PLATFORM_ES_APP_SCAN_RATE;
-    State->LastScanCommandCount   = CFE_ES_Global.TaskData.CommandCounter;
-    State->PendingAppStateChanges = 0;
-
-    /*
-     * Scan needs to be done with the table locked,
-     * as these state changes need to be done atomically
-     * with respect to other tasks that also access/update
-     * the state.
-     */
-    CFE_ES_LockSharedData(__func__, __LINE__);
-
-    /*
-    ** Scan the ES Application table. Skip entries that are:
-    **  - Not in use, or
-    **  - cFE Core apps, or
-    **  - Currently running
-    */
-    AppPtr = CFE_ES_Global.AppTable;
-    for (i = 0; i < CFE_PLATFORM_ES_MAX_APPLICATIONS; i++)
-    {
-        if (CFE_ES_AppRecordIsUsed(AppPtr) && AppPtr->Type == CFE_ES_AppType_EXTERNAL)
-        {
-            if (AppPtr->AppState > CFE_ES_AppState_RUNNING)
-            {
-                /*
-                 * Increment the "pending" counter which reflects
-                 * the number of apps that are in some phase of clean up.
-                 */
-                ++State->PendingAppStateChanges;
-
-                /*
-                 * Decrement the wait timer, if active.
-                 * When the timeout value becomes zero, take the action to delete/restart/reload the app
-                 */
-                if (AppPtr->ControlReq.AppTimerMsec > ElapsedTime)
-                {
-                    AppPtr->ControlReq.AppTimerMsec -= ElapsedTime;
-                }
-                else
-                {
-                    AppPtr->ControlReq.AppTimerMsec = 0;
-
-                    /* Add it to the list to be processed later */
-                    AppTimeoutList[NumAppTimeouts] = CFE_ES_AppRecordGetID(AppPtr);
-                    ++NumAppTimeouts;
-                }
-            }
-            else if (AppPtr->AppState == CFE_ES_AppState_RUNNING
-                     && AppPtr->ControlReq.AppControlRequest > CFE_ES_RunStatus_APP_RUN)
-            {
-                /* this happens after a command arrives to restart/reload/delete an app */
-                /* switch to WAITING state, and set the timer for transition */
-                AppPtr->AppState                = CFE_ES_AppState_WAITING;
-                AppPtr->ControlReq.AppTimerMsec = CFE_PLATFORM_ES_APP_KILL_TIMEOUT * CFE_PLATFORM_ES_APP_SCAN_RATE;
-            }
-        }
-
-        ++AppPtr;
-
-    } /* end for loop */
-
-    CFE_ES_UnlockSharedData(__func__, __LINE__);
-
-    /*
-     * Now invoke the CFE_ES_ProcessControlRequest() routine for any app
-     * which has reached that point.
-     */
-    for (i = 0; i < NumAppTimeouts; i++)
-    {
-        /*
-         * Call CFE_ES_ProcessControlRequest() with a reference to
-         * the _copies_ of the app record details.  (This avoids
-         * needing to access the global records outside of the lock).
-         */
-        CFE_ES_ProcessControlRequest(AppTimeoutList[i]);
-    }
-
-    /*
-     * This state machine is considered active if there are any
-     * pending app state changes.  Returning "true" will cause this job
-     * to be called from the background task at a faster interval.
-     */
-    return (State->PendingAppStateChanges != 0);
-}
-
-/*----------------------------------------------------------------
- *
- * Application-scope internal function
- * See description in header file for argument/return detail
- *
- *-----------------------------------------------------------------*/
-void CFE_ES_ProcessControlRequest(CFE_ES_AppId_t AppId)
-{
-    CFE_ES_AppRecord_t      *AppRecPtr;
-    uint32                   PendingControlReq;
-    CFE_ES_AppStartParams_t  RestartParams;
-    char                     OrigAppName[OS_MAX_API_NAME];
-    CFE_Status_t             CleanupStatus;
-    CFE_Status_t             StartupStatus;
-    CFE_ES_AppId_t           NewAppId;
-    const char              *ReqName;
-    char                     MessageDetail[48];
-    uint16                   EventID;
-    CFE_EVS_EventType_Enum_t EventType;
-
-    /* Init/clear all local state variables */
-    ReqName           = NULL;
-    MessageDetail[0]  = 0;
-    EventID           = 0;
-    EventType         = 0;
-    StartupStatus     = CFE_SUCCESS;
-    PendingControlReq = 0;
-    NewAppId          = CFE_ES_APPID_UNDEFINED;
-    OrigAppName[0]    = 0;
-    memset(&RestartParams, 0, sizeof(RestartParams));
-
-    AppRecPtr = CFE_ES_LocateAppRecordByID(AppId);
-
-    /*
-     * Take a local snapshot of the important app record data
-     * This way it becomes private and can be accessed without
-     * concerns about other threads/tasks, even after the global
-     * data records are eventually cleared.
-     */
-    CFE_ES_LockSharedData(__func__, __LINE__);
-
-    if (CFE_ES_AppRecordIsMatch(AppRecPtr, AppId))
-    {
-        PendingControlReq = AppRecPtr->ControlReq.AppControlRequest;
-        strncpy(OrigAppName, AppRecPtr->AppName, sizeof(OrigAppName) - 1);
-        OrigAppName[sizeof(OrigAppName) - 1] = 0;
-
-        /* If a restart was requested, copy the parameters to re-use in new app */
-        if (PendingControlReq == CFE_ES_RunStatus_SYS_RESTART || PendingControlReq == CFE_ES_RunStatus_SYS_RELOAD)
-        {
-            RestartParams = AppRecPtr->StartParams;
-        }
-    }
-
-    CFE_ES_UnlockSharedData(__func__, __LINE__);
-
-    /*
-     * All control requests start by deleting the app/task and
-     * all associated resources.
-     *
-     * The reload/restart requests will start it again, and it gets
-     * a new appID.  For other requests it just leaves it deleted.
-     *
-     * Note that Cleanup can fail for a variety of reasons, including
-     * situations where e.g. a task ID had become stale because the task
-     * already exited itself.  In most cases these are minor errors and
-     * reflect problems with the consistency of the old app record.
-     *
-     * Even when this happens the cleanup should still do its best effort
-     * to release all relevant global data entries.  So it should not
-     * prevent starting the new app, if a restart/reload is indicated.
-     */
-    CleanupStatus = CFE_ES_CleanUpApp(AppId);
-
-    /*
-     * Attempt to restart the app if the request indicated to do so,
-     * regardless of the CleanupStatus.
-     */
-    if (PendingControlReq == CFE_ES_RunStatus_SYS_RESTART || PendingControlReq == CFE_ES_RunStatus_SYS_RELOAD)
-    {
-        StartupStatus = CFE_ES_AppCreate(&NewAppId, OrigAppName, &RestartParams);
-    }
-
-    /*
-     * Determine the event ID associated with the control request,
-     * which indicates the success/failure of the operation and
-     * any other relevant detail.
-     *
-     * Note that the specific event ID that gets generated is the only
-     * other difference between all these control request types.
-     */
-    switch (PendingControlReq)
-    {
-        case CFE_ES_RunStatus_APP_EXIT:
-            ReqName = "Exit";
-            if (CleanupStatus != CFE_SUCCESS)
-            {
-                /* error event for this request */
-                EventID = CFE_ES_EXIT_APP_ERR_EID;
-            }
-            else
-            {
-                /* success event for this request */
-                EventID = CFE_ES_EXIT_APP_INF_EID;
-            }
-            break;
-
-        case CFE_ES_RunStatus_APP_ERROR:
-            ReqName = "Exit";
-            if (CleanupStatus != CFE_SUCCESS)
-            {
-                /* error event for this request */
-                EventID = CFE_ES_ERREXIT_APP_ERR_EID;
-            }
-            else
-            {
-                /* success event for this request */
-                EventID = CFE_ES_ERREXIT_APP_INF_EID;
-            }
-            break;
-
-        case CFE_ES_RunStatus_SYS_DELETE:
-            ReqName = "Stop";
-            if (CleanupStatus != CFE_SUCCESS)
-            {
-                /* error event for this request */
-                EventID = CFE_ES_STOP_ERR3_EID;
-            }
-            else
-            {
-                /* success event for this request */
-                EventID = CFE_ES_STOP_INF_EID;
-            }
-            break;
-
-        case CFE_ES_RunStatus_SYS_RESTART:
-            ReqName = "Restart";
-            if (CleanupStatus != CFE_SUCCESS)
-            {
-                /* error event for this request */
-                EventID = CFE_ES_RESTART_APP_ERR4_EID;
-            }
-            else if (StartupStatus != CFE_SUCCESS)
-            {
-                /* error event for this request */
-                EventID = CFE_ES_RESTART_APP_ERR3_EID;
-            }
-            else
-            {
-                /* success event for this request */
-                EventID = CFE_ES_RESTART_APP_INF_EID;
-            }
-            break;
-
-        case CFE_ES_RunStatus_SYS_RELOAD:
-            ReqName = "Reload";
-            if (CleanupStatus != CFE_SUCCESS)
-            {
-                /* error event for this request */
-                EventID = CFE_ES_RELOAD_APP_ERR4_EID;
-            }
-            else if (StartupStatus != CFE_SUCCESS)
-            {
-                /* error event for this request */
-                EventID = CFE_ES_RELOAD_APP_ERR3_EID;
-            }
-            else
-            {
-                /* success event for this request */
-                EventID = CFE_ES_RELOAD_APP_INF_EID;
-            }
-            break;
-
-            /*
-             * These two cases below should never occur so they are always
-             * reported as errors, but the  CFE_ES_CleanUpApp() should hopefully
-             * have fixed it either way.
-             */
-        case CFE_ES_RunStatus_SYS_EXCEPTION:
-            ReqName = "ES_ProcControlReq: Invalid State";
-            EventID = CFE_ES_PCR_ERR1_EID;
-            snprintf(MessageDetail, sizeof(MessageDetail), "EXCEPTION");
-            break;
-
-        default:
-            ReqName = "ES_ProcControlReq: Unknown State";
-            EventID = CFE_ES_PCR_ERR2_EID;
-            snprintf(MessageDetail, sizeof(MessageDetail), "( %lu )", (unsigned long)PendingControlReq);
-            break;
-    }
-
-    if (MessageDetail[0] != 0)
-    {
-        /* Detail message already set, assume it is an error event */
-        EventType = CFE_EVS_EventType_ERROR;
-    }
-    else if (StartupStatus != CFE_SUCCESS)
-    {
-        /* Make detail message for event containing startup error code */
-        EventType = CFE_EVS_EventType_ERROR;
-        snprintf(MessageDetail, sizeof(MessageDetail), "Failed: AppCreate Error 0x%08X.", (unsigned int)StartupStatus);
-    }
-    else if (CleanupStatus != CFE_SUCCESS)
-    {
-        /* Make detail message for event containing cleanup error code */
-        EventType = CFE_EVS_EventType_ERROR;
-        snprintf(MessageDetail, sizeof(MessageDetail), "Failed: CleanUpApp Error 0x%08X.", (unsigned int)CleanupStatus);
-    }
-    else if (CFE_RESOURCEID_TEST_DEFINED(NewAppId))
-    {
-        /* Record success message for event where app is restarted */
-        EventType = CFE_EVS_EventType_INFORMATION;
-        snprintf(MessageDetail, sizeof(MessageDetail), "Completed, AppID=%lu", CFE_RESOURCEID_TO_ULONG(NewAppId));
-    }
-    else
-    {
-        /* Record success message for event */
-        EventType = CFE_EVS_EventType_INFORMATION;
-        snprintf(MessageDetail, sizeof(MessageDetail), "Completed.");
-    }
-
-    CFE_EVS_SendEvent(EventID, EventType, "%s Application %s %s", ReqName, OrigAppName, MessageDetail);
-}
-
-/*----------------------------------------------------------------
- *
- * Application-scope internal function
- * See description in header file for argument/return detail
- *
- *-----------------------------------------------------------------*/
-int32 CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId)
-{
-    uint32                  i;
-    int32                   OsStatus;
-    int32                   Status;
     int32                   ReturnCode;
-    CFE_ES_TaskId_t         TaskList[OS_MAX_TASKS];
-    CFE_ES_MemHandle_t      PoolList[CFE_PLATFORM_ES_MAX_MEMORY_POOLS];
-    osal_id_t               ModuleId;
-    uint32                  NumTasks;
-    uint32                  NumPools;
     CFE_ES_AppRecord_t     *AppRecPtr;
     CFE_ES_TaskRecord_t    *TaskRecPtr;
     CFE_ES_MemPoolRecord_t *MemPoolRecPtr;
+    size_t                  i;
+    size_t                  NumTasks;
+    size_t                  NumPools;
 
     NumTasks   = 0;
     NumPools   = 0;
-    ModuleId   = OS_OBJECT_ID_UNDEFINED;
     ReturnCode = CFE_SUCCESS;
 
     AppRecPtr = CFE_ES_LocateAppRecordByID(AppId);
@@ -1443,7 +765,7 @@ int32 CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId)
              *
              * (this will be OS_OBJECT_ID_UNDEFINED if it was not loaded dynamically)
              */
-            ModuleId = AppRecPtr->LoadStatus.ModuleId;
+            *ModuleIdPtr = AppRecPtr->LoadStatus.ModuleId;
         }
 
         /*
@@ -1507,11 +829,31 @@ int32 CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId)
 
     CFE_ES_UnlockSharedData(__func__, __LINE__);
 
-    if (ReturnCode != CFE_SUCCESS)
+    /* clear out any remaining entries in the lists */
+    for (i = NumTasks; i < OS_MAX_TASKS; ++i)
     {
-        return ReturnCode;
+        TaskList[i] = CFE_ES_TASKID_UNDEFINED;
     }
 
+    for (i = NumPools; i < CFE_PLATFORM_ES_MAX_MEMORY_POOLS; ++i)
+    {
+        PoolList[i] = CFE_ES_MEMHANDLE_UNDEFINED;
+    }
+
+    return ReturnCode;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local helper function
+ * Frees resources associated with this app in _other_ core modules
+ * This is done by invoking the notification callback for that module
+ *
+ * Returns the number of callbacks that returned non-success.  Should be 0.
+ *
+ *-----------------------------------------------------------------*/
+static uint32 CFE_ES_CleanUpApp_FreeCoreResources(CFE_ES_AppId_t AppId)
+{
     /*
      * Now actually delete all the resources associated with the task.
      *
@@ -1520,35 +862,61 @@ int32 CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId)
      * than one lock at a time.
      */
 
-    int32 CleanupStatus = CFE_SUCCESS;
-
+    CFE_Status_t                Status;
+    uint32                      i;
+    uint32                      FailCount;
     const Target_ObjectTable_t *Entry;
-    for (i = 0;; i++)
+
+    /* Cleaning up resource is "best effort" -- the app is gone, so
+     * we reclaim everything assocated with that app if possible.  If
+     * failures occur, that should not stop the rest of cleanup. */
+    FailCount = 0;
+
+    i = 0;
+    while (true)
     {
         Entry = GLOBAL_CONFIGDATA.CoreObjectTable[i];
         if (Entry == NULL)
         {
+            /* this list is always terminated with a NULL entry */
             break;
         }
-        if (Entry->Cleanup != NULL)
+
+        if (Entry->AppCleanupCb != NULL)
         {
-            ReturnCode = Entry->Cleanup(CFE_RESOURCEID_TO_ULONG(AppId));
-            if (ReturnCode != CFE_SUCCESS)
+            /* Notify the core module that the app is going away.  This is so those
+             * modules can also reclaim any resources associated with this app */
+            Status = Entry->AppCleanupCb(CFE_RESOURCEID_TO_ULONG(AppId));
+            if (Status != CFE_SUCCESS)
             {
                 CFE_ES_WriteToSysLog("%s: Error returned from app Cleanup for %s: EC = 0x%08X\n",
                                      __func__,
                                      Entry->Name,
-                                     (unsigned int)ReturnCode);
-                CleanupStatus = CFE_ES_APP_CLEANUP_ERR; /* remember failure but keep going */
+                                     (unsigned int)Status);
+                ++FailCount;
             }
         }
+
+        ++i;
     }
 
-    /* Use CleanupStatus as the final result */
-    if (CleanupStatus != CFE_SUCCESS)
-    {
-        ReturnCode = CleanupStatus;
-    }
+    return FailCount;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local helper function
+ * Frees task resources associated with this app, for every task
+ * that was identified for removal
+ *
+ * Returns the number of task cleanups that returned non-success.  Should be 0.
+ *
+ *-----------------------------------------------------------------*/
+static uint32 CFE_ES_CleanUpApp_FreeTasks(CFE_ES_AppId_t AppId, const CFE_ES_TaskId_t *TaskList)
+{
+    size_t       i;
+    uint32       FailCount;
+    CFE_Status_t Status;
 
     /*
      * Delete all tasks.
@@ -1558,55 +926,86 @@ int32 CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId)
      * This iterates the list in reverse order, such that the child
      * tasks are deleted first (in any order) and main task is deleted last.
      */
-    i = NumTasks;
+    FailCount = 0;
+    i         = OS_MAX_TASKS;
     while (i > 0)
     {
         --i;
-        Status = CFE_ES_CleanupTaskResources(TaskList[i]);
+        if (CFE_RESOURCEID_TEST_DEFINED(TaskList[i]))
+        {
+            Status = CFE_ES_CleanupTaskResources(TaskList[i]);
+        }
+        else
+        {
+            Status = CFE_SUCCESS;
+        }
         if (Status != CFE_SUCCESS)
         {
             CFE_ES_WriteToSysLog("%s: CleanUpTaskResources for Task ID:%lu returned Error: 0x%08X\n",
                                  __func__,
                                  CFE_RESOURCEID_TO_ULONG(TaskList[i]),
                                  (unsigned int)Status);
-            ReturnCode = CFE_ES_APP_CLEANUP_ERR;
+            ++FailCount;
         }
     }
+    return FailCount;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local helper function
+ * Frees memory pool resources associated with this app, for every mempool
+ * that was identified for removal
+ *
+ * Returns the number of cleanups that returned non-success.  Should be 0.
+ *
+ *-----------------------------------------------------------------*/
+static uint32 CFE_ES_CleanUpApp_FreePools(CFE_ES_AppId_t AppId, const CFE_ES_MemHandle_t *PoolList)
+{
+    size_t       i;
+    uint32       FailCount;
+    CFE_Status_t Status;
 
     /*
      * Delete all mem pools.
      */
-    for (i = 0; i < NumPools; ++i)
+    FailCount = 0;
+    for (i = 0; i < CFE_PLATFORM_ES_MAX_MEMORY_POOLS; ++i)
     {
-        Status = CFE_ES_PoolDelete(PoolList[i]);
+        if (CFE_RESOURCEID_TEST_DEFINED(PoolList[i]))
+        {
+            Status = CFE_ES_PoolDelete(PoolList[i]);
+        }
+        else
+        {
+            Status = CFE_SUCCESS;
+        }
+
         if (Status != CFE_SUCCESS)
         {
             CFE_ES_WriteToSysLog("%s: delete pool %lu returned Error: 0x%08X\n",
                                  __func__,
                                  CFE_RESOURCEID_TO_ULONG(PoolList[i]),
                                  (unsigned int)Status);
-            ReturnCode = CFE_ES_APP_CLEANUP_ERR;
+            ++FailCount;
         }
     }
 
-    /*
-     ** Unload the module, if applicable
-     */
-    if (OS_ObjectIdDefined(ModuleId))
-    {
-        /*
-         ** Unload the module only if it is an external app
-         */
-        OsStatus = OS_ModuleUnload(ModuleId);
-        if (OsStatus != OS_SUCCESS)
-        {
-            CFE_ES_WriteToSysLog("%s: Module (ID:0x%08lX) Unload failed. RC=%ld\n",
-                                 __func__,
-                                 OS_ObjectIdToInteger(ModuleId),
-                                 (long)OsStatus);
-            ReturnCode = CFE_ES_APP_CLEANUP_ERR;
-        }
-    }
+    return FailCount;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local helper function
+ * All task/app resources that were previously marked for removal are
+ * fully removed here.  This cannot fail.
+ *
+ *-----------------------------------------------------------------*/
+static void CFE_ES_CleanUpApp_Finish(CFE_ES_AppId_t AppId, const CFE_ES_TaskId_t *TaskList)
+{
+    CFE_ES_AppRecord_t  *AppRecPtr;
+    CFE_ES_TaskRecord_t *TaskRecPtr;
+    size_t               i;
 
     /*
      * Finally, re-acquire the ES lock and set all
@@ -1617,8 +1016,9 @@ int32 CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId)
     /*
      * Free all task records.
      */
-    for (i = 0; i < NumTasks; ++i)
+    for (i = 0; i < OS_MAX_TASKS; ++i)
     {
+        /* note - if this returns NULL then CFE_ES_TaskRecordIsMatch will be false */
         TaskRecPtr = CFE_ES_LocateTaskRecordByID(TaskList[i]);
         if (CFE_ES_TaskRecordIsMatch(TaskRecPtr, CFE_ES_TASKID_C(CFE_RESOURCEID_RESERVED)))
         {
@@ -1629,29 +1029,94 @@ int32 CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId)
     /*
      * Now finally delete the record and allow re-use of the slot.
      */
+    AppRecPtr = CFE_ES_LocateAppRecordByID(AppId);
     if (CFE_ES_AppRecordIsMatch(AppRecPtr, CFE_ES_APPID_C(CFE_RESOURCEID_RESERVED)))
     {
         CFE_ES_AppRecordSetFree(AppRecPtr);
     }
 
     CFE_ES_UnlockSharedData(__func__, __LINE__);
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 CFE_ES_CleanUpApp(CFE_ES_AppId_t AppId)
+{
+    int32              ReturnCode;
+    CFE_ES_TaskId_t    TaskList[OS_MAX_TASKS];
+    CFE_ES_MemHandle_t PoolList[CFE_PLATFORM_ES_MAX_MEMORY_POOLS];
+    osal_id_t          ModuleId;
+    int32              OsStatus;
+    uint32             FailCount;
+
+    ModuleId  = OS_OBJECT_ID_UNDEFINED;
+    FailCount = 0;
+    memset(TaskList, 0, sizeof(TaskList));
+    memset(PoolList, 0, sizeof(PoolList));
+
+    /*
+     * Collect a list of resources previously owned by this app, which
+     * must be done while the global data is locked.
+     */
+    ReturnCode = CFE_ES_CleanUpApp_GetResources(AppId, &ModuleId, TaskList, PoolList);
+
+    /* if that failed, do not do anything else */
+    if (ReturnCode == CFE_SUCCESS)
+    {
+        /*
+         * Now actually delete all the resources associated with the task.
+         *
+         * Most of this involves calling into other subsystems, so it is
+         * done while the ES global data is UNLOCKED to avoid holding more
+         * than one lock at a time.
+         */
+        FailCount += CFE_ES_CleanUpApp_FreeCoreResources(AppId);
+        FailCount += CFE_ES_CleanUpApp_FreeTasks(AppId, TaskList);
+        FailCount += CFE_ES_CleanUpApp_FreePools(AppId, PoolList);
+
+        /*
+        ** Unload the module, if applicable
+        */
+        if (OS_ObjectIdDefined(ModuleId))
+        {
+            /*
+            ** Unload the module only if it is an external app
+            */
+            OsStatus = OS_ModuleUnload(ModuleId);
+            if (OsStatus != OS_SUCCESS)
+            {
+                CFE_ES_WriteToSysLog("%s: Module (ID:0x%08lX) Unload failed. RC=%ld\n",
+                                     __func__,
+                                     OS_ObjectIdToInteger(ModuleId),
+                                     (long)OsStatus);
+                ++FailCount;
+            }
+        }
+
+        /*
+         * Finally, re-acquire the ES lock and set all
+         * table entries free for re-use.
+         */
+        CFE_ES_CleanUpApp_Finish(AppId, TaskList);
+
+        /*
+         * The FailCount is the number of resources that were _not_ successfully reclaimed.
+         * It should normally be 0.  This return value is for informational purposes only,
+         * the caller should not really do anything differently - the app is gone as much
+         * as it can be, even if this is nonzero.
+         */
+        if (FailCount != 0)
+        {
+            ReturnCode = CFE_ES_APP_CLEANUP_ERR;
+        }
+    }
 
     return ReturnCode;
 }
-
-/*
- * Simple state structure used when cleaning up objects associated with tasks
- *
- * This is used locally by CFE_ES_CleanupTaskResources
- */
-typedef struct
-{
-    uint32 ErrorFlag;
-    uint32 FoundObjects;
-    uint32 PrevFoundObjects;
-    uint32 DeletedObjects;
-    int32  OverallStatus;
-} CFE_ES_CleanupState_t;
 
 /*----------------------------------------------------------------
  *

--- a/modules/es/fsw/src/cfe_es_apps.h
+++ b/modules/es/fsw/src/cfe_es_apps.h
@@ -41,11 +41,6 @@
 #include "cfe_fs_api_typedefs.h"
 
 /*
-** Macro Definitions
-*/
-#define CFE_ES_STARTSCRIPT_MAX_TOKENS_PER_LINE 8
-
-/*
 ** Type Definitions
 */
 
@@ -163,33 +158,10 @@ typedef struct
     CFE_ES_ModuleLoadStatus_t LoadStatus;               /* Runtime information about the module */
 } CFE_ES_LibRecord_t;
 
-/*
-** CFE_ES_AppTableScanState_t is an internal structure used to keep state of
-** the background app table scan/cleanup process
-*/
-typedef struct
-{
-    uint32 PendingAppStateChanges;
-    uint32 BackgroundScanTimer;
-    uint8  LastScanCommandCount;
-} CFE_ES_AppTableScanState_t;
-
 /*****************************************************************************/
 /*
 ** Function prototypes
 */
-
-/*---------------------------------------------------------------------------------------*/
-/**
- * This routine loads/starts cFE applications.
- */
-void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath);
-
-/*---------------------------------------------------------------------------------------*/
-/**
- * This function parses the startup file line for an individual cFE application.
- */
-int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens);
 
 /*---------------------------------------------------------------------------------------*/
 /**
@@ -278,16 +250,6 @@ int32 CFE_ES_LoadLibrary(CFE_ES_LibId_t *LibraryIdPtr, const char *LibName, cons
 
 /*---------------------------------------------------------------------------------------*/
 /**
- * Scan the Application Table for actions to take
- *
- * This function scans the ES Application table and acts on the changes
- * in application states. This is where the external cFE Applications are
- * restarted, reloaded, or deleted.
- */
-bool CFE_ES_RunAppTableScan(uint32 ElapsedTime, void *Arg);
-
-/*---------------------------------------------------------------------------------------*/
-/**
  * Scan for new exceptions stored in the PSP
  *
  * This function pools the PSP to check if any exceptions have been logged
@@ -316,12 +278,6 @@ void CFE_ES_BackgroundERLogFileEventHandler(void                   *Meta,
                                             uint32                  RecordNum,
                                             size_t                  BlockSize,
                                             size_t                  Position);
-
-/*---------------------------------------------------------------------------------------*/
-/**
- * Perform the requested control action for an application
- */
-void CFE_ES_ProcessControlRequest(CFE_ES_AppId_t AppId);
 
 /*---------------------------------------------------------------------------------------*/
 /**

--- a/modules/es/fsw/src/cfe_es_global.h
+++ b/modules/es/fsw/src/cfe_es_global.h
@@ -41,6 +41,7 @@
 #include "cfe_es_erlog_typedef.h"
 #include "cfe_es_resetdata_typedef.h"
 #include "cfe_es_cds.h"
+#include "cfe_es_appctrl.h"
 
 #include <signal.h> /* for sig_atomic_t */
 

--- a/modules/es/fsw/src/cfe_es_objtab.c
+++ b/modules/es/fsw/src/cfe_es_objtab.c
@@ -36,7 +36,6 @@ const Target_ObjectTable_t CFE_ES_ModuleEntry = {
     .Name      = "CFE_ES",
     .EarlyInit = CFE_ES_CDS_EarlyInit, /* ES drives its own startup, this is for CDS*/
     .TaskMain  = CFE_ES_TaskMain,
-    .Cleanup   = NULL, /* ES does not clean up - it owns shutdown */
     .Priority  = CFE_PLATFORM_ES_START_TASK_PRIORITY,
     .StackSize = CFE_PLATFORM_ES_START_TASK_STACK_SIZE
 };

--- a/modules/es/fsw/src/cfe_es_start.c
+++ b/modules/es/fsw/src/cfe_es_start.c
@@ -36,6 +36,7 @@
 */
 
 #include "cfe_es_module_all.h"
+#include "cfe_es_startupscript.h"
 #include "target_config.h"
 
 #include <stdio.h>

--- a/modules/es/fsw/src/cfe_es_startupscript.c
+++ b/modules/es/fsw/src/cfe_es_startupscript.c
@@ -1,0 +1,422 @@
+/************************************************************************
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
+ *
+ * Copyright (c) 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/*
+**  File:
+**    cfe_es_startupscript.c
+**
+**  Purpose:
+**    This file contains functions for parsing the CFE ES startup script.
+**
+**  References:
+**     Flight Software Branch C Coding Standard Version 1.0a
+**     cFE Flight Software Application Developers Guide
+**
+**  Notes:
+**
+*/
+
+/*
+** Includes
+*/
+#include "cfe_es_module_all.h"
+#include "cfe_es_startupscript.h"
+
+#include <stdio.h>
+#include <string.h> /* memset() */
+#include <fcntl.h>
+#include <ctype.h>
+
+#include "target_config.h"
+
+/*----------------------------------------------------------------
+ *
+ * Local helper function
+ * Opens the startup script file
+ *
+ *-----------------------------------------------------------------*/
+static osal_id_t CFE_ES_OpenStartupScript(uint32 ResetType, const char *StartFilePath)
+{
+    char      ScriptFileName[OS_MAX_PATH_LEN];
+    osal_id_t AppFile;
+    int32     Status;
+    int32     OsStatus;
+    bool      FileOpened;
+
+    FileOpened = false;
+
+    /*
+    ** Get the ES startup script filename.
+    ** If this is a Processor Reset, try to open the file in the volatile disk first.
+    */
+    if (ResetType == CFE_PSP_RST_TYPE_PROCESSOR)
+    {
+        /*
+        ** First Attempt to parse as file in the volatile disk (temp area).
+        */
+        Status = CFE_FS_ParseInputFileName(ScriptFileName,
+                                           CFE_PLATFORM_ES_VOLATILE_STARTUP_FILE,
+                                           sizeof(ScriptFileName),
+                                           CFE_FS_FileCategory_TEMP);
+
+        if (Status == CFE_SUCCESS)
+        {
+            OsStatus = OS_OpenCreate(&AppFile, ScriptFileName, OS_FILE_FLAG_NONE, OS_READ_ONLY);
+            if (OsStatus == OS_SUCCESS)
+            {
+                FileOpened = true;
+            }
+            else
+            {
+                CFE_ES_WriteToSysLog("%s: Cannot Open Volatile Startup file: %s, Trying Nonvolatile.\n",
+                                     __func__,
+                                     ScriptFileName);
+            }
+        }
+        else
+        {
+            /* not expected -- likely a misconfiguration in CFE_PLATFORM_ES_VOLATILE_STARTUP_FILE setting */
+            CFE_ES_WriteToSysLog("%s: CFE_FS_ParseInputFileName() RC=%08x parsing volatile script file name.\n",
+                                 __func__,
+                                 (unsigned int)Status);
+        }
+    }
+
+    /*
+    ** This if block covers two cases: A Power on reset, and a Processor reset when
+    ** the startup file on the volatile file system could not be opened.
+    */
+    if (!FileOpened)
+    {
+        /*
+        ** Try to Open the file passed in to the cFE start.
+        */
+        Status = CFE_FS_ParseInputFileName(ScriptFileName,
+                                           StartFilePath,
+                                           sizeof(ScriptFileName),
+                                           CFE_FS_FileCategory_SCRIPT);
+
+        if (Status == CFE_SUCCESS)
+        {
+            OsStatus = OS_OpenCreate(&AppFile, ScriptFileName, OS_FILE_FLAG_NONE, OS_READ_ONLY);
+            if (OsStatus == OS_SUCCESS)
+            {
+                FileOpened = true;
+            }
+            else
+            {
+                CFE_ES_WriteToSysLog("%s: Error, Can't Open ES App Startup file: %s, EC = %ld\n",
+                                     __func__,
+                                     ScriptFileName,
+                                     (long)OsStatus);
+            }
+        }
+        else
+        {
+            /* not expected -- likely a misconfiguration in the user-supplied StartFilePath */
+            CFE_ES_WriteToSysLog("%s: CFE_FS_ParseInputFileName() RC=%08x parsing StartFilePath.\n",
+                                 __func__,
+                                 (unsigned int)Status);
+        }
+    }
+
+    if (FileOpened)
+    {
+        CFE_ES_WriteToSysLog("%s: Opened ES App Startup file: %s\n", __func__, ScriptFileName);
+    }
+    else
+    {
+        /* be sure to return undefined if this did not work */
+        AppFile = OS_OBJECT_ID_UNDEFINED;
+    }
+
+    return AppFile;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local helper function
+ * Reads a single line from the startup script
+ *
+ *-----------------------------------------------------------------*/
+static int32 CFE_ES_ReadStartupLine(osal_id_t   AppFile,
+                                    const char *TokenList[],
+                                    size_t     *NumTokensPtr,
+                                    char       *BuffPtr,
+                                    size_t     *BuffSizePtr)
+{
+    int32        OsStatus;
+    char         c;
+    char        *CurrPtr;
+    char        *EndPtr;
+    const char **CurrTokenPtr;
+    const char **LastTokenPtr;
+
+    /* placeholder values - overwritten later */
+    OsStatus = OS_ERROR;
+
+    CurrPtr = BuffPtr;
+    EndPtr  = CurrPtr + *BuffSizePtr;
+
+    CurrTokenPtr = TokenList;
+    LastTokenPtr = CurrTokenPtr + *NumTokensPtr;
+
+    --EndPtr; /* Save 1 char for the terminating NULL, always required */
+
+    while (1)
+    {
+        c        = 0;
+        OsStatus = OS_read(AppFile, &c, 1);
+        if (OsStatus < OS_SUCCESS)
+        {
+            /* Leave OsStatus with error code - will be returned */
+            break;
+        }
+
+        if (OsStatus == 0 || c == '!')
+        {
+            /* End of file marker */
+            /* EOF reported from OSAL is treated the same as the EOF from a ! char */
+            OsStatus = 0;
+            break;
+        }
+
+        if (c == ';')
+        {
+            /* End of Line Reached, OsStatus will be left >0 */
+            break;
+        }
+
+        /* process all other chars, if buffer space permits */
+        if (CurrPtr < EndPtr)
+        {
+            if (c == ',')
+            {
+                /*
+                ** replace the field delimiter with a null
+                ** This is used to separate the tokens
+                */
+                *CurrPtr = 0;
+                ++CurrPtr;
+
+                if (CurrTokenPtr < LastTokenPtr)
+                {
+                    *CurrTokenPtr = CurrPtr;
+                    ++CurrTokenPtr;
+                }
+            }
+            else if (isgraph((int)c))
+            {
+                /* store normal (non-space) chars */
+                *CurrPtr = c;
+                ++CurrPtr;
+            }
+        }
+    }
+
+    /* space for this terminating NUL was reserved at the beginning */
+    *CurrPtr      = 0;
+    *NumTokensPtr = CurrTokenPtr - TokenList;
+    *BuffSizePtr  = CurrPtr - BuffPtr;
+
+    return OsStatus;
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath)
+{
+    char        ES_AppLoadBuffer[CFE_ES_START_BUFF_SIZE + 1]; /* A buffer of for a line in a file */
+    const char *TokenList[CFE_ES_STARTSCRIPT_MAX_TOKENS_PER_LINE + 1];
+    size_t      NumTokens;
+    size_t      NumLines;
+    size_t      BuffLen; /* Length of the current buffer */
+    osal_id_t   AppFile = OS_OBJECT_ID_UNDEFINED;
+    int32       OsStatus;
+
+    /* There may be more than one startup script - this finds and opens the correct one */
+    AppFile = CFE_ES_OpenStartupScript(ResetType, StartFilePath);
+
+    /*
+    ** If the file is opened in either the Nonvolatile or the Volatile disk, process it.
+    */
+    if (OS_ObjectIdDefined(AppFile))
+    {
+        memset(ES_AppLoadBuffer, 0x0, sizeof(ES_AppLoadBuffer));
+        NumLines = 0;
+
+        /*
+        ** Parse the lines from the file. If it has an error
+        ** or reaches EOF, then abort the loop.
+        */
+        do
+        {
+            /* The first token is always assumed to be at the beginning of the line */
+            TokenList[0] = ES_AppLoadBuffer;
+            NumTokens    = CFE_ES_STARTSCRIPT_MAX_TOKENS_PER_LINE;
+            BuffLen      = sizeof(ES_AppLoadBuffer);
+
+            OsStatus = CFE_ES_ReadStartupLine(AppFile, &TokenList[1], &NumTokens, ES_AppLoadBuffer, &BuffLen);
+            if (OsStatus < OS_SUCCESS)
+            {
+                CFE_ES_WriteToSysLog("%s: Error Reading Startup file. EC = %ld\n", __func__, (long)OsStatus);
+                break;
+            }
+
+            /* Note: because both of these buffers are sized +1 from the allowed amount,
+             * it means if we filled it, then the input was too long */
+            if (BuffLen >= CFE_ES_START_BUFF_SIZE || NumTokens >= CFE_ES_STARTSCRIPT_MAX_TOKENS_PER_LINE)
+            {
+                /* The line was not formed correctly */
+                CFE_ES_WriteToSysLog("%s: **WARNING** File Line %u is malformed: %u bytes, %u tokens.\n",
+                                     __func__,
+                                     (unsigned int)NumLines + 1,
+                                     (unsigned int)BuffLen,
+                                     (unsigned int)NumTokens);
+            }
+            else if (NumTokens > 0)
+            {
+                /* Send the line to the file parser */
+                CFE_ES_ParseFileEntry(TokenList, 1 + NumTokens);
+                ++NumLines;
+            }
+        } while (OsStatus > 0);
+
+        /*
+        ** close the file
+        */
+        OS_close(AppFile);
+    }
+}
+
+/*----------------------------------------------------------------
+ *
+ * Application-scope internal function
+ * See description in header file for argument/return detail
+ *
+ *-----------------------------------------------------------------*/
+int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens)
+{
+    const char   *ModuleName;
+    const char   *EntryType;
+    unsigned long ParsedValue;
+    union
+    {
+        CFE_ES_AppId_t AppId;
+        CFE_ES_LibId_t LibId;
+    } IdBuf;
+    int32                   Status;
+    CFE_ES_AppStartParams_t ParamBuf;
+
+    memset(&ParamBuf, 0, sizeof(ParamBuf));
+
+    /*
+    ** Check to see if the correct number of items were parsed
+    */
+    if (NumTokens < 8)
+    {
+        CFE_ES_WriteToSysLog("%s: Invalid ES Startup file entry: %u\n", __func__, (unsigned int)NumTokens);
+        return CFE_ES_BAD_ARGUMENT;
+    }
+
+    /* Get pointers to specific tokens that are simple strings used as-is */
+    EntryType  = TokenList[0];
+    ModuleName = TokenList[3];
+
+    /*
+     * Other tokens will need to be scrubbed/converted.
+     * Both Libraries and Apps use File Name (1) and Symbol Name (2) fields so copy those now
+     */
+    memset(&ParamBuf, 0, sizeof(ParamBuf));
+    Status = CFE_FS_ParseInputFileName(ParamBuf.BasicInfo.FileName,
+                                       TokenList[1],
+                                       sizeof(ParamBuf.BasicInfo.FileName),
+                                       CFE_FS_FileCategory_DYNAMIC_MODULE);
+    if (Status != CFE_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("%s: Invalid ES Startup script file name: %s\n", __func__, TokenList[1]);
+        return Status;
+    }
+
+    strncpy(ParamBuf.BasicInfo.InitSymbolName, TokenList[2], sizeof(ParamBuf.BasicInfo.InitSymbolName) - 1);
+
+    if (strcmp(EntryType, "CFE_APP") == 0)
+    {
+        CFE_ES_WriteToSysLog("%s: Loading file: %s, APP: %s\n", __func__, ParamBuf.BasicInfo.FileName, ModuleName);
+
+        /*
+         * Priority and Exception action have limited ranges, which is checked here
+         * Task priority cannot be bigger than OS_MAX_TASK_PRIORITY
+         */
+        ParsedValue = strtoul(TokenList[4], NULL, 0);
+        if (ParsedValue > OS_MAX_TASK_PRIORITY)
+        {
+            ParamBuf.MainTaskInfo.Priority = OS_MAX_TASK_PRIORITY;
+        }
+        else
+        {
+            /* convert parsed value to correct type */
+            ParamBuf.MainTaskInfo.Priority = (CFE_ES_TaskPriority_Atom_t)ParsedValue;
+        }
+
+        /* No specific upper/lower limit for stack size - will pass value through */
+        ParamBuf.MainTaskInfo.StackSize = strtoul(TokenList[5], NULL, 0);
+
+        /*
+        ** Validate Some parameters
+        ** Exception action should be 0 ( Restart App ) or
+        ** 1 ( Processor reset ). If it's non-zero, assume it means
+        ** reset CPU.
+        */
+        ParsedValue = strtoul(TokenList[7], NULL, 0);
+        if (ParsedValue > CFE_ES_ExceptionAction_RESTART_APP)
+        {
+            ParamBuf.ExceptionAction = CFE_ES_ExceptionAction_PROC_RESTART;
+        }
+        else
+        {
+            /* convert parsed value to correct type */
+            ParamBuf.ExceptionAction = (CFE_ES_ExceptionAction_Enum_t)ParsedValue;
+        }
+
+        /*
+        ** Now create the application
+        */
+        Status = CFE_ES_AppCreate(&IdBuf.AppId, ModuleName, &ParamBuf);
+    }
+    else if (strcmp(EntryType, "CFE_LIB") == 0)
+    {
+        CFE_ES_WriteToSysLog("%s: Loading shared library: %s\n", __func__, ParamBuf.BasicInfo.FileName);
+
+        /*
+        ** Now load the library
+        */
+        Status = CFE_ES_LoadLibrary(&IdBuf.LibId, ModuleName, &ParamBuf.BasicInfo);
+    }
+    else
+    {
+        CFE_ES_WriteToSysLog("%s: Unexpected EntryType %s in startup file.\n", __func__, EntryType);
+        Status = CFE_ES_ERR_APP_CREATE;
+    }
+
+    return Status;
+}

--- a/modules/es/fsw/src/cfe_es_startupscript.h
+++ b/modules/es/fsw/src/cfe_es_startupscript.h
@@ -1,0 +1,66 @@
+/************************************************************************
+ * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
+ *
+ * Copyright (c) 2023 United States Government as represented by the
+ * Administrator of the National Aeronautics and Space Administration.
+ * All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License. You may obtain
+ * a copy of the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ************************************************************************/
+
+/**
+ * @file
+ *
+ *  Purpose:
+ *  This file contains the Internal interface for the cFE Application control functions of ES.
+ *  These functions and data structures manage the Applications and Child tasks in the cFE.
+ *
+ *  References:
+ *     Flight Software Branch C Coding Standard Version 1.0a
+ *     cFE Flight Software Application Developers Guide
+ *
+ */
+
+#ifndef CFE_ES_STARTUPSCRIPT_H
+#define CFE_ES_STARTUPSCRIPT_H
+
+/*
+** Include Files
+*/
+#include "common_types.h"
+
+#include "cfe_es_api_typedefs.h"
+#include "cfe_fs_api_typedefs.h"
+
+/*
+** Macro Definitions
+*/
+#define CFE_ES_STARTSCRIPT_MAX_TOKENS_PER_LINE 8
+#define CFE_ES_START_BUFF_SIZE                 128
+
+/*****************************************************************************/
+/*
+** Function prototypes
+*/
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * This routine loads/starts cFE applications.
+ */
+void CFE_ES_StartApplications(uint32 ResetType, const char *StartFilePath);
+
+/*---------------------------------------------------------------------------------------*/
+/**
+ * This function parses the startup file line for an individual cFE application.
+ */
+int32 CFE_ES_ParseFileEntry(const char **TokenList, uint32 NumTokens);
+
+#endif /* CFE_ES_STARTUPSCRIPT_H */

--- a/modules/es/ut-coverage/es_UT.c
+++ b/modules/es/ut-coverage/es_UT.c
@@ -756,12 +756,12 @@ void TestApps(void)
      */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_WAITING, NULL, &UtAppRecPtr, NULL);
-    UtAppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_APP_RUN;
+    UtAppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_APP_ERROR;
     UtAppRecPtr->ControlReq.AppTimerMsec      = 0;
     memset(&CFE_ES_Global.BackgroundAppScanState, 0, sizeof(CFE_ES_Global.BackgroundAppScanState));
     UtAssert_BOOL_TRUE(CFE_ES_RunAppTableScan(0, &CFE_ES_Global.BackgroundAppScanState));
     UtAssert_INT32_EQ(UtAppRecPtr->ControlReq.AppTimerMsec, 0);
-    CFE_UtAssert_EVENTSENT(CFE_ES_PCR_ERR2_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_ERREXIT_APP_INF_EID);
 
     /* Test scanning and acting on the application table where the timer
      * has not expired for a waiting application
@@ -773,17 +773,18 @@ void TestApps(void)
     UtAssert_BOOL_TRUE(CFE_ES_RunAppTableScan(1000, &CFE_ES_Global.BackgroundAppScanState));
     UtAssert_INT32_EQ(UtAppRecPtr->ControlReq.AppTimerMsec, 4000);
     UtAssert_UINT32_EQ(UtAppRecPtr->ControlReq.AppControlRequest, CFE_ES_RunStatus_APP_EXIT);
+    // jphfix not thrown CFE_UtAssert_EVENTSENT(CFE_ES_EXIT_APP_INF_EID);
 
     /* Test scanning and acting on the application table where the application
      * has stopped and is ready to be acted on
      */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_STOPPED, NULL, &UtAppRecPtr, NULL);
-    UtAppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_APP_RUN;
+    UtAppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_APP_EXIT;
     UtAppRecPtr->ControlReq.AppTimerMsec      = 0;
     UtAssert_BOOL_TRUE(CFE_ES_RunAppTableScan(0, &CFE_ES_Global.BackgroundAppScanState));
     UtAssert_INT32_EQ(UtAppRecPtr->ControlReq.AppTimerMsec, 0);
-    CFE_UtAssert_EVENTSENT(CFE_ES_PCR_ERR2_EID);
+    CFE_UtAssert_EVENTSENT(CFE_ES_EXIT_APP_INF_EID);
 
     /* Test scanning and acting on the application table where the application
      * is running and is ready to exit
@@ -848,8 +849,55 @@ void TestApps(void)
     UtAssert_VOIDCALL(CFE_ES_ProcessControlRequest(AppId));
     CFE_UtAssert_EVENTSENT(CFE_ES_STOP_ERR3_EID);
 
+    /* Test a control action request to stop an application where the
+     * request fails and the subject is a core app
+     */
+    ES_ResetUnitTest();
+    ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
+    UtAppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_CORE_APP_RUNTIME_ERROR;
+    UT_SetDeferredRetcode(UT_KEY(CFE_EVS_CleanUpApp), 1, -1);
+    AppId = CFE_ES_AppRecordGetID(UtAppRecPtr);
+    UtAssert_VOIDCALL(CFE_ES_ProcessControlRequest(AppId));
+    CFE_UtAssert_EVENTSENT(CFE_ES_PCR_ERR2_EID);
+
+    /* Test a control action request to run an application
+     * Not really valid - this exists to cover the corresponding entry in the table
+     * this should NOT send any events
+     */
+    ES_ResetUnitTest();
+    ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
+    UtAppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_APP_RUN;
+    AppId                                     = CFE_ES_AppRecordGetID(UtAppRecPtr);
+    UtAssert_VOIDCALL(CFE_ES_ProcessControlRequest(AppId));
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0); /*  */
+
+    /* Test a control action request to run an application and CleanUpApp fails
+     * Not really valid - this exists to cover the event sending logic
+     * this should NOT send any events
+     */
+    ES_ResetUnitTest();
+    ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
+    UtAppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_APP_RUN;
+    UT_SetDeferredRetcode(UT_KEY(CFE_EVS_CleanUpApp), 1, -1);
+    AppId = CFE_ES_AppRecordGetID(UtAppRecPtr);
+    UtAssert_VOIDCALL(CFE_ES_ProcessControlRequest(AppId));
+    UtAssert_STUB_COUNT(CFE_EVS_SendEvent, 0); /*  */
+
     /* Test a control action request to restart an application where the
-     * request fails due to a CleanUpApp error
+     * request fails due to a CleanUpApp error, where there should be a
+     * Cleanup only
+     */
+    ES_ResetUnitTest();
+    ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);
+    UtAppRecPtr->ControlReq.AppControlRequest = CFE_ES_RunStatus_APP_ERROR;
+    UT_SetDeferredRetcode(UT_KEY(CFE_EVS_CleanUpApp), 1, -1);
+    AppId = CFE_ES_AppRecordGetID(UtAppRecPtr);
+    UtAssert_VOIDCALL(CFE_ES_ProcessControlRequest(AppId));
+    CFE_UtAssert_EVENTSENT(CFE_ES_ERREXIT_APP_ERR_EID);
+
+    /* Test a control action request to restart an application where the
+     * request fails due to a CleanUpApp error, where there should be a
+     * Cleanup + Restart
      */
     ES_ResetUnitTest();
     ES_UT_SetupSingleAppId(CFE_ES_AppType_EXTERNAL, CFE_ES_AppState_RUNNING, NULL, &UtAppRecPtr, NULL);

--- a/modules/es/ut-coverage/es_UT.h
+++ b/modules/es/ut-coverage/es_UT.h
@@ -46,6 +46,7 @@
 */
 #include <string.h>
 #include "cfe_es_module_all.h"
+#include "cfe_es_startupscript.h"
 #include "cfe_time_core_internal.h"
 #include "cfe_tbl_core_internal.h"
 #include "cfe_evs_core_internal.h"

--- a/modules/es/ut-coverage/es_UT_objtab.c
+++ b/modules/es/ut-coverage/es_UT_objtab.c
@@ -47,65 +47,58 @@ extern int32 CFE_FS_EarlyInit(void);
 
 extern int32 CFE_Config_Init(void);
 
-const Target_ObjectTable_t CFE_EVS_ModuleEntry = { .Name      = "CFE_EVS",
-                                                   .EarlyInit = CFE_EVS_EarlyInit,
-                                                   .TaskMain  = CFE_EVS_TaskMain,
-                                                   .Cleanup   = CFE_EVS_CleanUpApp,
-                                                   .Priority  = 64,
-                                                   .StackSize = 8192 };
+const Target_ObjectTable_t CFE_EVS_ModuleEntry = { .Name         = "CFE_EVS",
+                                                   .EarlyInit    = CFE_EVS_EarlyInit,
+                                                   .TaskMain     = CFE_EVS_TaskMain,
+                                                   .AppCleanupCb = CFE_EVS_CleanUpApp,
+                                                   .Priority     = 64,
+                                                   .StackSize    = 8192 };
 
-const Target_ObjectTable_t CFE_SB_ModuleEntry = { .Name      = "CFE_SB",
-                                                  .EarlyInit = CFE_SB_EarlyInit,
-                                                  .TaskMain  = CFE_SB_TaskMain,
-                                                  .Cleanup   = CFE_SB_CleanUpApp,
-                                                  .Priority  = 64,
-                                                  .StackSize = 8192 };
+const Target_ObjectTable_t CFE_SB_ModuleEntry = { .Name         = "CFE_SB",
+                                                  .EarlyInit    = CFE_SB_EarlyInit,
+                                                  .TaskMain     = CFE_SB_TaskMain,
+                                                  .AppCleanupCb = CFE_SB_CleanUpApp,
+                                                  .Priority     = 64,
+                                                  .StackSize    = 8192 };
 
 const Target_ObjectTable_t CFE_TIME_ModuleEntry = { .Name      = "CFE_TIME",
                                                     .EarlyInit = CFE_TIME_EarlyInit,
                                                     .TaskMain  = CFE_TIME_TaskMain,
-                                                    .Cleanup   = NULL,
                                                     .Priority  = 64,
                                                     .StackSize = 8192 };
 
 const Target_ObjectTable_t CFE_TBL_ModuleEntry = { .Name      = "CFE_TBL",
                                                    .EarlyInit = CFE_TBL_EarlyInit,
                                                    .TaskMain  = CFE_TBL_TaskMain,
-                                                   .Cleanup   = NULL,
                                                    .Priority  = 64,
                                                    .StackSize = 8192 };
 
 const Target_ObjectTable_t CFE_FS_ModuleEntry = { .Name      = "CFE_FS",
                                                   .EarlyInit = CFE_FS_EarlyInit,
                                                   .TaskMain  = NULL,
-                                                  .Cleanup   = NULL,
                                                   .Priority  = 0,
                                                   .StackSize = 0 };
 
 const Target_ObjectTable_t CFE_CONFIG_ModuleEntry = { .Name      = "CFE_CONFIG",
                                                       .EarlyInit = CFE_Config_Init,
                                                       .TaskMain  = NULL,
-                                                      .Cleanup   = NULL,
                                                       .Priority  = 0,
                                                       .StackSize = 0 };
 
 const Target_ObjectTable_t CFE_MSG_ModuleEntry = { .Name      = "CFE_MSG",
                                                    .EarlyInit = NULL,
                                                    .TaskMain  = NULL,
-                                                   .Cleanup   = NULL,
                                                    .Priority  = 0,
                                                    .StackSize = 0 };
 
 const Target_ObjectTable_t CFE_SBR_ModuleEntry = { .Name      = "CFE_SBR",
                                                    .EarlyInit = NULL,
                                                    .TaskMain  = NULL,
-                                                   .Cleanup   = NULL,
                                                    .Priority  = 0,
                                                    .StackSize = 0 };
 
 const Target_ObjectTable_t CFE_RESOURCEID_ModuleEntry = { .Name      = "CFE_RESOURCEID",
                                                           .EarlyInit = NULL,
                                                           .TaskMain  = NULL,
-                                                          .Cleanup   = NULL,
                                                           .Priority  = 0,
                                                           .StackSize = 0 };

--- a/modules/evs/fsw/src/cfe_evs_objtab.c
+++ b/modules/evs/fsw/src/cfe_evs_objtab.c
@@ -31,9 +31,9 @@
 #include "cfe_es_internal_cfg.h"
 #include "cfe_evs_platform_cfg.h"
 
-const Target_ObjectTable_t CFE_EVS_ModuleEntry = { .Name      = "CFE_EVS",
-                                                   .EarlyInit = CFE_EVS_EarlyInit,
-                                                   .TaskMain  = CFE_EVS_TaskMain,
-                                                   .Cleanup   = CFE_EVS_CleanUpApp,
-                                                   .Priority  = CFE_PLATFORM_EVS_START_TASK_PRIORITY,
-                                                   .StackSize = CFE_PLATFORM_EVS_START_TASK_STACK_SIZE };
+const Target_ObjectTable_t CFE_EVS_ModuleEntry = { .Name         = "CFE_EVS",
+                                                   .EarlyInit    = CFE_EVS_EarlyInit,
+                                                   .TaskMain     = CFE_EVS_TaskMain,
+                                                   .AppCleanupCb = CFE_EVS_CleanUpApp,
+                                                   .Priority     = CFE_PLATFORM_EVS_START_TASK_PRIORITY,
+                                                   .StackSize    = CFE_PLATFORM_EVS_START_TASK_STACK_SIZE };

--- a/modules/fs/fsw/src/cfe_fs_objtab.c
+++ b/modules/fs/fsw/src/cfe_fs_objtab.c
@@ -29,9 +29,5 @@
 #include "target_objtab.h"
 #include "cfe_fs_core_internal.h"
 
-const Target_ObjectTable_t CFE_FS_ModuleEntry = { .Name      = "CFE_FS",
-                                                  .EarlyInit = CFE_FS_EarlyInit,
-                                                  .TaskMain  = NULL, /* library module - no task */
-                                                  .Cleanup   = NULL,
-                                                  .Priority  = 0,
-                                                  .StackSize = 0 };
+/* this is a core library module with no task, but it does have a global data struct */
+const Target_ObjectTable_t CFE_FS_ModuleEntry = { .Name = "CFE_FS", .EarlyInit = CFE_FS_EarlyInit };

--- a/modules/msg/fsw/src/cfe_msg_objtab.c
+++ b/modules/msg/fsw/src/cfe_msg_objtab.c
@@ -29,9 +29,5 @@
 
 #include "target_objtab.h"
 
-const Target_ObjectTable_t CFE_MSG_ModuleEntry = { .Name      = "CFE_MSG",
-                                                   .EarlyInit = NULL,
-                                                   .TaskMain  = NULL,
-                                                   .Cleanup   = NULL,
-                                                   .Priority  = 0,
-                                                   .StackSize = 0 };
+/* this is a core library module with no task */
+const Target_ObjectTable_t CFE_MSG_ModuleEntry = { .Name = "CFE_MSG" };

--- a/modules/resourceid/fsw/src/cfe_resourceid_objtab.c
+++ b/modules/resourceid/fsw/src/cfe_resourceid_objtab.c
@@ -29,9 +29,5 @@
 
 #include "target_objtab.h"
 
-const Target_ObjectTable_t CFE_RESOURCEID_ModuleEntry = { .Name      = "CFE_RESOURCEID",
-                                                          .EarlyInit = NULL,
-                                                          .TaskMain  = NULL,
-                                                          .Cleanup   = NULL,
-                                                          .Priority  = 0,
-                                                          .StackSize = 0 };
+/* this is a core library module with no task */
+const Target_ObjectTable_t CFE_RESOURCEID_ModuleEntry = { .Name = "CFE_RESOURCEID" };

--- a/modules/sb/fsw/src/cfe_sb_objtab.c
+++ b/modules/sb/fsw/src/cfe_sb_objtab.c
@@ -30,9 +30,9 @@
 #include "cfe_es_internal_cfg.h"
 #include "cfe_sb_platform_cfg.h"
 
-const Target_ObjectTable_t CFE_SB_ModuleEntry = { .Name      = "CFE_SB",
-                                                  .EarlyInit = CFE_SB_EarlyInit,
-                                                  .TaskMain  = CFE_SB_TaskMain,
-                                                  .Cleanup   = CFE_SB_CleanUpApp,
-                                                  .Priority  = CFE_PLATFORM_SB_START_TASK_PRIORITY,
-                                                  .StackSize = CFE_PLATFORM_SB_START_TASK_STACK_SIZE };
+const Target_ObjectTable_t CFE_SB_ModuleEntry = { .Name         = "CFE_SB",
+                                                  .EarlyInit    = CFE_SB_EarlyInit,
+                                                  .TaskMain     = CFE_SB_TaskMain,
+                                                  .AppCleanupCb = CFE_SB_CleanUpApp,
+                                                  .Priority     = CFE_PLATFORM_SB_START_TASK_PRIORITY,
+                                                  .StackSize    = CFE_PLATFORM_SB_START_TASK_STACK_SIZE };

--- a/modules/sbr/fsw/src/cfe_sbr_objtab.c
+++ b/modules/sbr/fsw/src/cfe_sbr_objtab.c
@@ -29,9 +29,5 @@
 
 #include "target_objtab.h"
 
-const Target_ObjectTable_t CFE_SBR_ModuleEntry = { .Name      = "CFE_SBR",
-                                                   .EarlyInit = NULL,
-                                                   .TaskMain  = NULL,
-                                                   .Cleanup   = NULL,
-                                                   .Priority  = 0,
-                                                   .StackSize = 0 };
+/* this is a core library module with no task */
+const Target_ObjectTable_t CFE_SBR_ModuleEntry = { .Name = "CFE_SBR" };

--- a/modules/ta/fsw/src/cfe_ta_objtab.c
+++ b/modules/ta/fsw/src/cfe_ta_objtab.c
@@ -30,9 +30,9 @@
 #include "cfe_ta_platform_cfg.h"
 #include "cfe_ta_task.h"
 
-const Target_ObjectTable_t CFE_TA_ModuleEntry = { .Name      = "CFE_TA",
-                                                  .EarlyInit = CFE_TA_EarlyInit,
-                                                  .TaskMain  = CFE_TA_TaskMain,
-                                                  .Cleanup   = CFE_TA_CleanUpApp,
-                                                  .Priority  = CFE_PLATFORM_TA_START_TASK_PRIORITY,
-                                                  .StackSize = CFE_PLATFORM_TA_START_TASK_STACK_SIZE };
+const Target_ObjectTable_t CFE_TA_ModuleEntry = { .Name         = "CFE_TA",
+                                                  .EarlyInit    = CFE_TA_EarlyInit,
+                                                  .TaskMain     = CFE_TA_TaskMain,
+                                                  .AppCleanupCb = CFE_TA_CleanUpApp,
+                                                  .Priority     = CFE_PLATFORM_TA_START_TASK_PRIORITY,
+                                                  .StackSize    = CFE_PLATFORM_TA_START_TASK_STACK_SIZE };

--- a/modules/tbl/fsw/src/cfe_tbl_objtab.c
+++ b/modules/tbl/fsw/src/cfe_tbl_objtab.c
@@ -30,9 +30,9 @@
 #include "cfe_es_internal_cfg.h"
 #include "cfe_tbl_platform_cfg.h"
 
-const Target_ObjectTable_t CFE_TBL_ModuleEntry = { .Name      = "CFE_TBL",
-                                                   .EarlyInit = CFE_TBL_EarlyInit,
-                                                   .TaskMain  = CFE_TBL_TaskMain,
-                                                   .Cleanup   = CFE_TBL_CleanUpApp,
-                                                   .Priority  = CFE_PLATFORM_TBL_START_TASK_PRIORITY,
-                                                   .StackSize = CFE_PLATFORM_TBL_START_TASK_STACK_SIZE };
+const Target_ObjectTable_t CFE_TBL_ModuleEntry = { .Name         = "CFE_TBL",
+                                                   .EarlyInit    = CFE_TBL_EarlyInit,
+                                                   .TaskMain     = CFE_TBL_TaskMain,
+                                                   .AppCleanupCb = CFE_TBL_CleanUpApp,
+                                                   .Priority     = CFE_PLATFORM_TBL_START_TASK_PRIORITY,
+                                                   .StackSize    = CFE_PLATFORM_TBL_START_TASK_STACK_SIZE };

--- a/modules/time/fsw/src/cfe_time_objtab.c
+++ b/modules/time/fsw/src/cfe_time_objtab.c
@@ -30,9 +30,9 @@
 #include "cfe_es_internal_cfg.h"
 #include "cfe_time_platform_cfg.h"
 
-const Target_ObjectTable_t CFE_TIME_ModuleEntry = { .Name      = "CFE_TIME",
-                                                    .EarlyInit = CFE_TIME_EarlyInit,
-                                                    .TaskMain  = CFE_TIME_TaskMain,
-                                                    .Cleanup   = CFE_TIME_CleanUpApp,
-                                                    .Priority  = CFE_PLATFORM_TIME_START_TASK_PRIORITY,
-                                                    .StackSize = CFE_PLATFORM_TIME_START_TASK_STACK_SIZE };
+const Target_ObjectTable_t CFE_TIME_ModuleEntry = { .Name         = "CFE_TIME",
+                                                    .EarlyInit    = CFE_TIME_EarlyInit,
+                                                    .TaskMain     = CFE_TIME_TaskMain,
+                                                    .AppCleanupCb = CFE_TIME_CleanUpApp,
+                                                    .Priority     = CFE_PLATFORM_TIME_START_TASK_PRIORITY,
+                                                    .StackSize    = CFE_PLATFORM_TIME_START_TASK_STACK_SIZE };


### PR DESCRIPTION
**Checklist (Please check before submitting)**

* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md).
* [x] I signed and emailed the appropriate [Contributor License Agreement](https://github.com/nasa/cFS/blob/main/CONTRIBUTING.md#contributor-license-agreement-cla) to GSFC-SoftwareRelease@mail.nasa.gov and copied cfs-program@lists.nasa.gov.

**Describe the contribution**
Splits the startup script handling and control request handling into their own separate .c files.  This reduces the size of cfe_es_apps.c considerably, making it more manageable.

The three cited routines CFE_ES_ProcessControlRequest, CFE_ES_CleanupApps, CFE_ES_StartApplications are split into multiple smaller functions.  The cyclic complexity now ranks at 2, 5, and 7, respectively.  The highest complexity helper function is 13, with most under 10.

Fixes #2798

**Testing performed**
Run all tests

**Expected behavior changes**
Lower cyclic complexity

**Contributor Info - All information REQUIRED for consideration of pull request**
Joseph Hickey, Vantage Systems, Inc.
