### PR TITLE
fix(tbl): overflow-safe bounds check in cfe_tbl_load.c LoadContentFromFile (#2707)

### DIFF
--- a/modules/tbl/fsw/src/cfe_tbl_load.c
+++ b/modules/tbl/fsw/src/cfe_tbl_load.c
@@ -245,15 +245,20 @@ CFE_TBL_LoadContentFromFile(CFE_TBL_TxnState_t *Txn, osal_id_t FileDescriptor, s
         return Status;
     }
 
-    /* Confirm that the data about to be loaded will fit */
-    LoadTailSize = Offset + NumBytes;
-    if (LoadTailSize > CFE_TBL_LoadBuffGetAllocSize(WorkingBufferPtr))
+    /* Confirm that the data about to be loaded will fit.
+     * Use an overflow-safe check: on 32-bit targets (ARM/SPARC/PPC RTEMS)
+     * `Offset + NumBytes` can wrap around and bypass the bounds check
+     * (CVE-2026-5476, Site 2). Test each operand against the buffer size
+     * instead of summing them first, so the comparison can never wrap. */
+    size_t BufSize = CFE_TBL_LoadBuffGetAllocSize(WorkingBufferPtr);
+    LoadTailSize   = Offset + NumBytes; /* retained only for the event log */
+    if (NumBytes > BufSize || Offset > BufSize - NumBytes)
     {
         Status = CFE_TBL_ERR_FILE_TOO_LARGE;
         CFE_TBL_TxnAddEvent(Txn,
                             CFE_TBL_FILE_TOO_BIG_ERR_EID,
                             LoadTailSize,
-                            CFE_TBL_LoadBuffGetAllocSize(WorkingBufferPtr));
+                            BufSize);
     }
     else
     {


### PR DESCRIPTION
## Summary
- Resolves #2707 (bug + security). In cfe_tbl_load.c::LoadContentFromFile, LoadTailSize = Offset + NumBytes is compared against the buffer allocation size. On 32-bit targets (ARM/SPARC/PPC RTEMS) size_t is 32-bit, so the sum can wrap (e.g. to 0), bypassing the bounds check. The load then proceeds and DestPtr += Offset wraps the pointer backward, producing an out-of-bounds write (CVE-2026-5476, Site 2). This is defense-in-depth even though the codec layer (#2691) now gates the path.
- Replace the summing comparison with an overflow-safe one:
  \\\c
  size_t BufSize = CFE_TBL_LoadBuffGetAllocSize(WorkingBufferPtr);
  if (NumBytes > BufSize || Offset > BufSize - NumBytes)
  \\\
  The \BufSize - NumBytes\ term is only evaluated when \NumBytes <= BufSize\ (the first clause short-circuits otherwise), so it can never underflow.

## Verification
Verified with a clang (C99) standalone test modeling 32-bit \uint32_t\ arithmetic (the failure only manifests on 32-bit \size_t\):
- Malicious payload where \Offset + NumBytes\ wraps to 0: **old check ACCEPTS it (bug reproduced)**, **new check REJECTS it (fixed)**.
- In-bounds load (Offset=100, NumBytes=200, Buf=1000): accepted by both.
- Genuinely-too-large (no wrap): rejected by both.
- \NumBytes\ alone exceeds \BufSize\: rejected by both.

## Test plan
- [ ] CI (build + unit tests) green on \dev\
- [ ] maintainer confirms the overflow-safe form matches project style

Fixes #2707