### PR TITLE
fix(msg): balance parentheses/braces in CFE_MSG_CMD_HDR_INIT priext variant (#2317)

### DIFF
--- a/modules/msg/option_inc/default_cfe_msg_hdr_priext.h
+++ b/modules/msg/option_inc/default_cfe_msg_hdr_priext.h
@@ -60,14 +60,14 @@
     { \
         .Pri = \
         { \
-            .StreamId = {(((mid)&0x80)<<5, (mid)&0x7F}, \
+            .StreamId = {(((mid)&0x80)<<5), (mid)&0x7F}, \
             .Sequence = {0xC0, 0}, \
             .Length = {((size)-7)>>8, ((size)-7)&0xFF} \
         }, \
         .Ext = \
         { \
             .Subsystem = {0, ((mid)>>8)&0xFF}, \
-            .SystemId = {0, 0) \
+            .SystemId = {0, 0} \
         } \
     }, \
     CFE_MSG_CMD_HDR_SEC_INIT(fc, cksum) \


### PR DESCRIPTION
## Summary
- Resolves #2317 (bug). The extended-header definition of CFE_MSG_CMD_HDR_INIT in modules/msg/option_inc/default_cfe_msg_hdr_priext.h had two unbalanced delimiters, so any TU including this header variant fails to compile:
  1. **Line 63**: .StreamId = {(((mid)&0x80)<<5, ...} — the shift expression has three ( but only two ); add the missing ).
  2. **Line 70**: .SystemId = {0, 0) — opens with { but closes with ); change ) to }.
- The primary-header variant (default_cfe_msg_hdr_pri.h) is already balanced and is left unchanged (confirmed by compiling it standalone).

## Why
#2318 attempted this same fix but was closed unmerged, so the bug persisted. The unbalanced )/} makes the macro a hard compile error whenever the priext header configuration is selected.

## Verification
Verified with a clang (C99) standalone reproduction of the macro:
- original (buggy) text → error: expected ')' (compile failure)
- corrected text → compiles cleanly
- the pri.h variant also compiles cleanly (no change needed)

## Test plan
- [ ] CI (build with the priext header configuration) green on dev
- [ ] maintainer confirms the corrected StreamId shift expression matches intent

Fixes #2317