### PR TITLE
Fix #2803, reduce complexity in cfe_sb_api.c

### DIFF
--- a/modules/core_api/fsw/inc/cfe_error.h
+++ b/modules/core_api/fsw/inc/cfe_error.h
@@ -859,6 +859,17 @@ char *CFE_ES_StatusToString(CFE_Status_t status, CFE_StatusString_t *status_stri
 #define CFE_SB_BUFFER_INVALID ((CFE_Status_t)0xca00000e)
 
 /**
+ * @brief Destination Pipe Already Exists on this Path
+ *
+ * This error code will be returned when a destination from the routing
+ * table has the same pipe ID as the provided pipe ID. It's set to
+ * CFE_SUCCESS because it's not an error per se, it's a status that
+ * needs to noted for accounting and event reasons
+ *
+ */
+#define CFE_SB_DUP_SUBSCRIP_ERR (CFE_SUCCESS)
+
+/**
  * @brief Not Implemented
  *
  *  Current version of cFE does not have the function or the feature

--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -1021,10 +1021,11 @@ int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t  MsgId,
         {
             ++DestCount;
 
-            /* Check if duplicate (status stays as CFE_SUCCESS) */
+            /* Check if duplicate, see documentation on CFE_SB_DUP_SUBSCRIP_ERR */
             if (CFE_RESOURCEID_TEST_EQUAL(DestPtr->PipeId, PipeId))
             {
                 PendingEventID = CFE_SB_DUP_SUBSCRIP_EID;
+                Status         = CFE_SB_DUP_SUBSCRIP_ERR;
                 break;
             }
 
@@ -1073,24 +1074,14 @@ int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t  MsgId,
     }
 
     /* Increment counter before unlock */
-    switch (PendingEventID)
+    if (PendingEventID != 0)
     {
-        case CFE_SB_SUB_INV_PIPE_EID:
-        case CFE_SB_SUB_INV_CALLER_EID:
-        case CFE_SB_SUB_ARG_ERR_EID:
-        case CFE_SB_MAX_MSGS_MET_EID:
-        case CFE_SB_DEST_BLK_ERR_EID:
-        case CFE_SB_MAX_DESTS_MET_EID:
-            CFE_SB_Global.HKTlmMsg.Payload.SubscribeErrorCounter++;
-            break;
-        case CFE_SB_DUP_SUBSCRIP_EID:
-            CFE_SB_Global.HKTlmMsg.Payload.DuplicateSubscriptionsCounter++;
-            break;
+        CFE_SB_IncrementSubscribeCounters(Status);
     }
 
     CFE_SB_UnlockSharedData(__func__, __LINE__);
 
-    /* Send events now - get the pipe name only if something is pending */
+    /* Send events now that the SB resources are unlocked */
     if (PendingEventID != 0)
     {
         CFE_SB_GetPipeName(PipeName, sizeof(PipeName), PipeId);
@@ -1098,83 +1089,6 @@ int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t  MsgId,
     else
     {
         PipeName[0] = 0; /* make empty string */
-    }
-
-    switch (PendingEventID)
-    {
-        case CFE_SB_DUP_SUBSCRIP_EID:
-            CFE_EVS_SendEventWithAppID(CFE_SB_DUP_SUBSCRIP_EID,
-                                       CFE_EVS_EventType_INFORMATION,
-                                       CFE_SB_Global.AppId,
-                                       "Duplicate Subscription,MsgId 0x%x on %s pipe,app %s",
-                                       (unsigned int)CFE_SB_MsgIdToValue(MsgId),
-                                       PipeName,
-                                       CFE_SB_GetAppTskName(TskId, FullName));
-            break;
-
-        case CFE_SB_SUB_INV_CALLER_EID:
-            CFE_EVS_SendEventWithAppID(CFE_SB_SUB_INV_CALLER_EID,
-                                       CFE_EVS_EventType_ERROR,
-                                       CFE_SB_Global.AppId,
-                                       "Subscribe Err:Caller(%s) is not the owner of pipe %lu,Msg=0x%x",
-                                       CFE_SB_GetAppTskName(TskId, FullName),
-                                       CFE_RESOURCEID_TO_ULONG(PipeId),
-                                       (unsigned int)CFE_SB_MsgIdToValue(MsgId));
-            break;
-
-        case CFE_SB_SUB_INV_PIPE_EID:
-            CFE_EVS_SendEventWithAppID(CFE_SB_SUB_INV_PIPE_EID,
-                                       CFE_EVS_EventType_ERROR,
-                                       CFE_SB_Global.AppId,
-                                       "Subscribe Err:Invalid Pipe Id,Msg=0x%x,PipeId=%lu,App %s",
-                                       (unsigned int)CFE_SB_MsgIdToValue(MsgId),
-                                       CFE_RESOURCEID_TO_ULONG(PipeId),
-                                       CFE_SB_GetAppTskName(TskId, FullName));
-            break;
-
-        case CFE_SB_DEST_BLK_ERR_EID:
-            CFE_EVS_SendEventWithAppID(CFE_SB_DEST_BLK_ERR_EID,
-                                       CFE_EVS_EventType_ERROR,
-                                       CFE_SB_Global.AppId,
-                                       "Subscribe Err:Request for Destination Blk failed for Msg 0x%x",
-                                       (unsigned int)CFE_SB_MsgIdToValue(MsgId));
-            break;
-
-        case CFE_SB_MAX_DESTS_MET_EID:
-            CFE_EVS_SendEventWithAppID(CFE_SB_MAX_DESTS_MET_EID,
-                                       CFE_EVS_EventType_ERROR,
-                                       CFE_SB_Global.AppId,
-                                       "Subscribe Err:Max Dests(%d)In Use For Msg 0x%x,pipe %s,app %s",
-                                       CFE_PLATFORM_SB_MAX_DEST_PER_PKT,
-                                       (unsigned int)CFE_SB_MsgIdToValue(MsgId),
-                                       PipeName,
-                                       CFE_SB_GetAppTskName(TskId, FullName));
-            break;
-
-        case CFE_SB_MAX_MSGS_MET_EID:
-            CFE_EVS_SendEventWithAppID(CFE_SB_MAX_MSGS_MET_EID,
-                                       CFE_EVS_EventType_ERROR,
-                                       CFE_SB_Global.AppId,
-                                       "Subscribe Err:Max Msgs(%d)In Use,MsgId 0x%x,pipe %s,app %s",
-                                       CFE_PLATFORM_SB_MAX_MSG_IDS,
-                                       (unsigned int)CFE_SB_MsgIdToValue(MsgId),
-                                       PipeName,
-                                       CFE_SB_GetAppTskName(TskId, FullName));
-            break;
-
-        case CFE_SB_SUB_ARG_ERR_EID:
-            CFE_EVS_SendEventWithAppID(CFE_SB_SUB_ARG_ERR_EID,
-                                       CFE_EVS_EventType_ERROR,
-                                       CFE_SB_Global.AppId,
-                                       "Subscribe Err:Bad Arg,MsgId 0x%x,PipeId %lu,app %s,scope %d",
-                                       (unsigned int)CFE_SB_MsgIdToValue(MsgId),
-                                       CFE_RESOURCEID_TO_ULONG(PipeId),
-                                       CFE_SB_GetAppTskName(TskId, FullName),
-                                       Scope);
-            break;
-
-        default:
-            break;
     }
 
     /* If no other event pending, send a debug event indicating success */

--- a/modules/sb/fsw/src/cfe_sb_api.c
+++ b/modules/sb/fsw/src/cfe_sb_api.c
@@ -948,7 +948,6 @@ int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t  MsgId,
     CFE_SB_DestinationD_t *DestPtr;
     uint32                 DestCount;
     char                   FullName[(OS_MAX_API_NAME * 2)];
-    char                   PipeName[OS_MAX_API_NAME];
     uint32                 Collisions;
     uint16                 PendingEventID;
 
@@ -1084,11 +1083,7 @@ int32 CFE_SB_SubscribeFull(CFE_SB_MsgId_t  MsgId,
     /* Send events now that the SB resources are unlocked */
     if (PendingEventID != 0)
     {
-        CFE_SB_GetPipeName(PipeName, sizeof(PipeName), PipeId);
-    }
-    else
-    {
-        PipeName[0] = 0; /* make empty string */
+        CFE_SB_IssueSubscribeEvents(PendingEventID, PipeId, MsgId, Scope);
     }
 
     /* If no other event pending, send a debug event indicating success */

--- a/modules/sb/fsw/src/cfe_sb_priv.c
+++ b/modules/sb/fsw/src/cfe_sb_priv.c
@@ -1643,3 +1643,19 @@ CFE_Status_t CFE_SB_GetPipeNamePriv(CFE_SB_PipeId_t PipeId, char *PipeNameBuf, s
 
     return Status;
 }
+
+void CFE_SB_IncrementSubscribeCounters(CFE_Status_t ErrorStatus)
+{
+    switch (ErrorStatus)
+    {
+        case CFE_SB_BAD_ARGUMENT:
+        case CFE_SB_MAX_MSGS_MET:
+        case CFE_SB_BUF_ALOC_ERR:
+        case CFE_SB_MAX_DESTS_MET:
+            CFE_SB_Global.HKTlmMsg.Payload.SubscribeErrorCounter++;
+            break;
+        case CFE_SB_DUP_SUBSCRIP_ERR:
+            CFE_SB_Global.HKTlmMsg.Payload.DuplicateSubscriptionsCounter++;
+            break;
+    }
+}

--- a/modules/sb/fsw/src/cfe_sb_priv.c
+++ b/modules/sb/fsw/src/cfe_sb_priv.c
@@ -1659,3 +1659,87 @@ void CFE_SB_IncrementSubscribeCounters(CFE_Status_t ErrorStatus)
             break;
     }
 }
+
+void CFE_SB_IssueSubscribeEvents(uint16 PendingEventID, CFE_SB_PipeId_t PipeId, CFE_SB_MsgId_t MsgId, uint16 Scope)
+{
+    CFE_ES_TaskId_t TskId;
+    char            FullName[(OS_MAX_API_NAME * 2)];
+    char            PipeName[OS_MAX_API_NAME];
+
+    CFE_ES_GetTaskID(&TskId);
+    CFE_SB_GetPipeName(PipeName, sizeof(PipeName), PipeId);
+
+    switch (PendingEventID)
+    {
+        case CFE_SB_DUP_SUBSCRIP_EID:
+            CFE_EVS_SendEventWithAppID(CFE_SB_DUP_SUBSCRIP_EID,
+                                       CFE_EVS_EventType_INFORMATION,
+                                       CFE_SB_Global.AppId,
+                                       "Duplicate Subscription,MsgId 0x%x on %s pipe,app %s",
+                                       (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+                                       PipeName,
+                                       CFE_SB_GetAppTskName(TskId, FullName));
+            break;
+
+        case CFE_SB_SUB_INV_CALLER_EID:
+            CFE_EVS_SendEventWithAppID(CFE_SB_SUB_INV_CALLER_EID,
+                                       CFE_EVS_EventType_ERROR,
+                                       CFE_SB_Global.AppId,
+                                       "Subscribe Err:Caller(%s) is not the owner of pipe %lu,Msg=0x%x",
+                                       CFE_SB_GetAppTskName(TskId, FullName),
+                                       CFE_RESOURCEID_TO_ULONG(PipeId),
+                                       (unsigned int)CFE_SB_MsgIdToValue(MsgId));
+            break;
+
+        case CFE_SB_SUB_INV_PIPE_EID:
+            CFE_EVS_SendEventWithAppID(CFE_SB_SUB_INV_PIPE_EID,
+                                       CFE_EVS_EventType_ERROR,
+                                       CFE_SB_Global.AppId,
+                                       "Subscribe Err:Invalid Pipe Id,Msg=0x%x,PipeId=%lu,App %s",
+                                       (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+                                       CFE_RESOURCEID_TO_ULONG(PipeId),
+                                       CFE_SB_GetAppTskName(TskId, FullName));
+            break;
+
+        case CFE_SB_DEST_BLK_ERR_EID:
+            CFE_EVS_SendEventWithAppID(CFE_SB_DEST_BLK_ERR_EID,
+                                       CFE_EVS_EventType_ERROR,
+                                       CFE_SB_Global.AppId,
+                                       "Subscribe Err:Request for Destination Blk failed for Msg 0x%x",
+                                       (unsigned int)CFE_SB_MsgIdToValue(MsgId));
+            break;
+
+        case CFE_SB_MAX_DESTS_MET_EID:
+            CFE_EVS_SendEventWithAppID(CFE_SB_MAX_DESTS_MET_EID,
+                                       CFE_EVS_EventType_ERROR,
+                                       CFE_SB_Global.AppId,
+                                       "Subscribe Err:Max Dests(%d)In Use For Msg 0x%x,pipe %s,app %s",
+                                       CFE_PLATFORM_SB_MAX_DEST_PER_PKT,
+                                       (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+                                       PipeName,
+                                       CFE_SB_GetAppTskName(TskId, FullName));
+            break;
+
+        case CFE_SB_MAX_MSGS_MET_EID:
+            CFE_EVS_SendEventWithAppID(CFE_SB_MAX_MSGS_MET_EID,
+                                       CFE_EVS_EventType_ERROR,
+                                       CFE_SB_Global.AppId,
+                                       "Subscribe Err:Max Msgs(%d)In Use,MsgId 0x%x,pipe %s,app %s",
+                                       CFE_PLATFORM_SB_MAX_MSG_IDS,
+                                       (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+                                       PipeName,
+                                       CFE_SB_GetAppTskName(TskId, FullName));
+            break;
+
+        case CFE_SB_SUB_ARG_ERR_EID:
+            CFE_EVS_SendEventWithAppID(CFE_SB_SUB_ARG_ERR_EID,
+                                       CFE_EVS_EventType_ERROR,
+                                       CFE_SB_Global.AppId,
+                                       "Subscribe Err:Bad Arg,MsgId 0x%x,PipeId %lu,app %s,scope %d",
+                                       (unsigned int)CFE_SB_MsgIdToValue(MsgId),
+                                       CFE_RESOURCEID_TO_ULONG(PipeId),
+                                       CFE_SB_GetAppTskName(TskId, FullName),
+                                       Scope);
+            break;
+    }
+}

--- a/modules/sb/fsw/src/cfe_sb_priv.h
+++ b/modules/sb/fsw/src/cfe_sb_priv.h
@@ -1519,6 +1519,13 @@ void CFE_SB_BackgroundFileEventHandler(void                   *Meta,
                                        size_t                  BlockSize,
                                        size_t                  Position);
 
+/*---------------------------------------------------------------------------------------
+**
+** \brief Local function that increments the subscription counters based on the Status
+**        of the subscribe function to that point
+*/
+void CFE_SB_IncrementSubscribeCounters(CFE_Status_t ErrorStatus);
+
 /*
  * External variables private to the software bus module
  */

--- a/modules/sb/fsw/src/cfe_sb_priv.h
+++ b/modules/sb/fsw/src/cfe_sb_priv.h
@@ -1526,6 +1526,14 @@ void CFE_SB_BackgroundFileEventHandler(void                   *Meta,
 */
 void CFE_SB_IncrementSubscribeCounters(CFE_Status_t ErrorStatus);
 
+/*---------------------------------------------------------------------------------------
+**
+** \brief Local function that issues event for the subscribe function. The delay is to
+**        allow the lock on SB resource to be released, a lock that CFE_EVS_SendEvent-type
+**        functions need
+*/
+void CFE_SB_IssueSubscribeEvents(uint16 PendingEventID, CFE_SB_PipeId_t PipeId, CFE_SB_MsgId_t MsgId, uint16 Scope);
+
 /*
  * External variables private to the software bus module
  */


### PR DESCRIPTION
---
name: FSW Code Change
about: Flight Software code changes
labels: fsw
---

## Description of Change

Functions `CFE_SB_CreatePipe()` and `CFE_SB_SubscribeFull()` have high complexity. The complexity was lowered by ...

## Linked Issue

Closes #2803 

## Requirements Impact

- Requirement ID(s): None
- [ ] Requirements updated as necessary
- [x] Existing requirements are still satisfied by this change

## Testing Evidence

- [ ] Link to complexity analysis CI run

### Unit Tests (UT Assert)

- [ ] Link to CI run

### COSMOS Test Suite

- [ ] Link to CI run

## Areas of Expertise Touched

- [ ] ASTRO
- [ ] CI/CD
- [ ] COSMOS
- [ ] Cybersecurity
- [ ] Docker
- [ ] EDS
- [ ] Git
- [ ] PSPs
- [ ] SBN
- [ ] SMP
- [ ] Tables
- [ ] TSN
- [ ] Unit Tests
- [ ] Other

---

## Author Checklist

- [x] Linked GitHub issue is referenced above
- [x] Code has been formatted with `.clang-format`
- [ ] Static analysis workflows ran and passed
- [ ] Unit tests (UT Assert) updated/added to cover code changes
- [x] Unit test workflows ran and passed
- [ ] COSMOS test suite was run; tests updated/added if relevant changes were made
- [x] Requirements have been reviewed; updated or confirmed still satisfied (see above)
- [ ] Testing evidence is included above
- [ ] Self-review of the diff completed

---

## Reviewer Checklist

- [ ] Code logic is correct and matches the stated intent
- [ ] Code is readable, maintainable, and follows project conventions
- [ ] `.clang-format` has been applied
- [ ] Static analysis results reviewed and acceptable
- [ ] Unit tests are meaningful and adequately cover the changes
- [ ] **The change has been exercised by the unit tests** (not just that tests pass — the new/changed code paths are actually covered)
- [ ] **COSMOS test suite was executed against this change** and results reviewed (or confirmed N/A with justification)
- [ ] **Reviewer has independently verified the change behaves as described** (e.g., by running the tests locally, reviewing CI output in detail, or performing additional ad-hoc testing as warranted)
- [ ] **Memory safety** reviewed (allocation, bounds, lifetime, stack usage)
- [ ] Requirements impact reviewed and appropriate
- [ ] Error handling is appropriate
- [ ] Appropriate Expert areas have been reviewed

### Reviewer Testing Notes

<!--
Describe how you independently verified this change. For example:
  - "Pulled the branch locally, ran `make test`, all UT Assert tests passed including the new ones for X."
  - "Ran the COSMOS test suite against the branch; observed expected telemetry behavior for Y."
  - "Reviewed CI run #1234; verified the new code paths are covered by inspecting the coverage report."
  - "Performed ad-hoc test by [describe scenario]; observed [result]."
-->