### PR TITLE
Fix #2818, CFE_SB_MessageStringSet leaves destination unterminated

### DIFF
--- a/modules/sb/fsw/src/cfe_sb_util.c
+++ b/modules/sb/fsw/src/cfe_sb_util.c
@@ -193,7 +193,12 @@ int32 CFE_SB_MessageStringSet(char       *DestStringPtr,
 {
     int32 Result;
 
-    if (SourceStringPtr == NULL || DestStringPtr == NULL)
+    /*
+     * Error in caller if DestMaxSize == 0.
+     * Cannot terminate the string, since there is no place for the NUL
+     * In this case, do nothing
+     */
+    if (DestMaxSize == 0 || SourceStringPtr == NULL || DestStringPtr == NULL)
     {
         Result = CFE_SB_BAD_ARGUMENT;
     }
@@ -201,7 +206,17 @@ int32 CFE_SB_MessageStringSet(char       *DestStringPtr,
     {
         Result = 0;
 
-        while (SourceMaxSize > 0 && *SourceStringPtr != 0 && DestMaxSize > 0)
+        /*
+         * Stop copying with at least 1 character of space left in the
+         * destination, so the NUL terminator below always has room.
+         * Without this, a source buffer with no NUL character within
+         * the first DestMaxSize bytes (permitted per this function's
+         * documented contract, which does not require the source to
+         * be NUL terminated) would leave DestStringPtr completely
+         * filled with non-NUL data and not NUL terminated anywhere
+         * within its bounds.
+         */
+        while (SourceMaxSize > 0 && *SourceStringPtr != 0 && DestMaxSize > 1)
         {
             *DestStringPtr = *SourceStringPtr;
             ++DestStringPtr;
@@ -213,7 +228,11 @@ int32 CFE_SB_MessageStringSet(char       *DestStringPtr,
 
         /*
          * Pad the remaining space with NUL chars,
-         * but this should NOT be included in the final size
+         * but this should NOT be included in the final size.
+         * Because the loop above always leaves at least 1 byte
+         * of destination space remaining, this unconditionally
+         * NUL terminates the destination, even when the source
+         * data had to be truncated to fit.
          */
         while (DestMaxSize > 0)
         {

--- a/modules/sb/ut-coverage/sb_UT.c
+++ b/modules/sb/ut-coverage/sb_UT.c
@@ -5267,6 +5267,7 @@ void Test_MessageString(void)
                       CFE_SB_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_SB_MessageStringSet(DestString, NULL, sizeof(DestString), sizeof(SrcString)),
                       CFE_SB_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_SB_MessageStringSet(DestString, SrcString, 0, sizeof(SrcString)), CFE_SB_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_SB_MessageStringGet(NULL, SrcString, DefString, sizeof(DestString), sizeof(SrcString)),
                       CFE_SB_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_SB_MessageStringGet(DestString, SrcString, DefString, 0, sizeof(SrcString)),
@@ -5289,7 +5290,17 @@ void Test_MessageString(void)
     strcpy(SrcString, "abcdefg");
     memset(DestString, 'q', sizeof(DestString));
     CFE_SB_MessageStringSet(DestString, SrcString, 4, sizeof(SrcString));
-    UtAssert_STRINGBUF_EQ(DestString, 4, SrcString, 4);
+    UtAssert_STRINGBUF_EQ(DestString, sizeof(DestString), "abc", UTASSERT_STRINGBUF_NULL_TERM);
+    /* Confirm the destination is left NUL terminated within its 4 byte
+     * allotment, even though the source string had to be truncated to fit */
+    UtAssert_UINT8_EQ(DestString[3], 0);
+
+    /* Test setting string where the source has no NUL character within
+     * the destination size (source is not required to be NUL terminated) */
+    memset(SrcString, 'z', sizeof(SrcString));
+    memset(DestString, 'q', sizeof(DestString));
+    CFE_SB_MessageStringSet(DestString, SrcString, sizeof(DestString), sizeof(SrcString));
+    UtAssert_UINT8_EQ(DestString[sizeof(DestString) - 1], 0);
 
     /* Test getting string where the destination size > source string size */
     strcpy(SrcString, "abcdefg");


### PR DESCRIPTION
## Description of Change

`CFE_SB_MessageStringSet()` did not always leave its destination buffer NUL terminated, contrary to its own documented contract. When `DestMaxSize <= SourceMaxSize` and the source has no NUL byte within the first `DestMaxSize` bytes, the copy loop consumed the entire destination and the padding loop that follows never ran, so no terminator was ever written. See issue #2818 for the full writeup, a concrete real call site (`fm_cmds.c`), and an AddressSanitizer reproduction against the unmodified function.

The fix mirrors the existing pattern already used in the sibling function `CFE_SB_MessageStringGet()`: reserve one byte for the terminator before the copy loop runs, by changing the loop guard from `DestMaxSize > 0` to `DestMaxSize > 1`. This guarantees the padding loop that follows always writes at least one NUL byte, regardless of whether the source had one. Also added a `DestMaxSize == 0` check that returns `CFE_SB_BAD_ARGUMENT`, matching the existing behavior of `CFE_SB_MessageStringGet()` (previously `Set()` would silently no-op on a zero-size destination instead of reporting an error).

No behavior change for any source string that is already NUL terminated within `DestMaxSize` bytes, which is the common case. The only observable difference is in the truncation case: the destination is now correctly truncated to `DestMaxSize - 1` copied characters plus a terminator, instead of `DestMaxSize` copied characters with no terminator.

## Linked Issue

Closes #2818

## Requirements Impact

- Requirement ID(s): none identified, this is an internal utility function with no direct requirement mapping
- [x] Requirements updated as necessary
- [x] Existing requirements are still satisfied by this change

## Testing Evidence

### Unit Tests (UT Assert)

Built and ran the full SB and TBL coverage test binaries locally (native_std config, `ENABLE_UNIT_TESTS=TRUE`), both modules exercise this function:

```
SB: 1025/1025 tests pass
TBL: 1358/1358 tests pass
```

Updated `modules/sb/ut-coverage/sb_UT.c`:
- Added a `DestMaxSize == 0` bad-argument case for `CFE_SB_MessageStringSet()`, mirroring the existing case already present for `CFE_SB_MessageStringGet()`.
- Fixed the existing truncation test (`DestMaxSize=4`, longer source) to assert the correct truncated-and-terminated result instead of 4 raw unterminated bytes, plus an explicit check that the last byte in that 4-byte allotment is NUL.
- Added a new case for a source with no NUL at all within `DestMaxSize` bytes, asserting the destination's last byte is NUL.

### AddressSanitizer

Not part of CI here, but since this is a memory-safety fix I built a standalone harness that `#include`s the unmodified upstream function verbatim and calls it the same way `fm_cmds.c` does (matching heap-allocated source/dest sizes), then calls `strlen()` on the result the way any normal caller would. Before the fix this reliably reproduces a heap-buffer-overflow read under ASan; after the fix it exits clean with the correct truncated length. Full harness and both outputs are attached to issue #2818.

### COSMOS Test Suite

N/A, no telemetry/command definitions or interfaces changed, this is an internal string-copy utility fix with no message format impact.

## Areas of Expertise Touched

- [ ] ASTRO
- [ ] CI/CD
- [ ] COSMOS
- [x] Cybersecurity
- [ ] Docker
- [ ] EDS
- [ ] Git
- [ ] PSPs
- [ ] SBN
- [ ] SMP
- [x] Tables
- [ ] TSN
- [x] Unit Tests
- [ ] Other

---

## Author Checklist

- [x] Linked GitHub issue is referenced above
- [x] Code has been formatted with `.clang-format`
- [ ] Static analysis workflows ran and passed <!-- ran cppcheck locally with no findings on the changed file, but haven't seen the actual CI static-analysis workflow run yet, that only happens once the PR is opened -->
- [x] Unit tests (UT Assert) updated/added to cover code changes
- [x] Unit test workflows ran and passed <!-- ran locally, not yet through CI -->
- [ ] COSMOS test suite was run; tests updated/added if relevant changes were made <!-- N/A, see above -->
- [x] Requirements have been reviewed; updated or confirmed still satisfied (see above)
- [x] Testing evidence is included above
- [x] Self-review of the diff completed