### PR TITLE
fix(evs): allow SendEventWithAppID for caller own AppId during startup

### DIFF
--- a/modules/evs/fsw/src/cfe_evs.c
+++ b/modules/evs/fsw/src/cfe_evs.c
@@ -185,22 +185,18 @@ CFE_Status_t CFE_EVS_SendEventWithAppID(uint16                   EventID,
     AppDataPtr = EVS_GetAppDataByID(AppID);
     if (AppDataPtr == NULL)
     {
-        /*
-         * Check if the AppId is the caller's own AppId (e.g. during cFE startup
-         * when ES/EVS tasks initialize before full registration). In this case,
-         * allow the event to proceed rather than returning ILLEGAL_APP_ID.
-         */
         CFE_ES_AppId_t callerAppId;
         EVS_AppData_t *callerAppData;
-        int32 status = EVS_GetCurrentContext(&callerAppData, &callerAppId);
-        if (status == CFE_SUCCESS && callerAppData != NULL && CFE_RESOURCEID_TEST_EQUAL\(callerAppId, AppID\))
+        if (EVS_GetCurrentContext(&callerAppData, &callerAppId) == CFE_SUCCESS &&
+            callerAppData != NULL && CFE_RESOURCEID_TEST_EQUAL(callerAppId, AppID))
         {
-            Status = CFE_SUCCESS;
+            AppDataPtr = callerAppData;
         }
-        else
-        {
-            Status = CFE_EVS_APP_ILLEGAL_APP_ID;
-        }
+    }
+
+    if (AppDataPtr == NULL)
+    {
+        Status = CFE_EVS_APP_ILLEGAL_APP_ID;
     }
     else if (!EVS_AppDataIsMatch(AppDataPtr, AppID))
     {

--- a/modules/evs/fsw/src/cfe_evs.c
+++ b/modules/evs/fsw/src/cfe_evs.c
@@ -187,8 +187,8 @@ CFE_Status_t CFE_EVS_SendEventWithAppID(uint16                   EventID,
     {
         CFE_ES_AppId_t callerAppId;
         EVS_AppData_t *callerAppData;
-        if (EVS_GetCurrentContext(&callerAppData, &callerAppId) == CFE_SUCCESS &&
-            callerAppData != NULL && CFE_RESOURCEID_TEST_EQUAL(callerAppId, AppID))
+        if (EVS_GetCurrentContext(&callerAppData, &callerAppId) == CFE_SUCCESS && callerAppData != NULL
+            && CFE_RESOURCEID_TEST_EQUAL(callerAppId, AppID))
         {
             AppDataPtr = callerAppData;
         }
@@ -345,4 +345,3 @@ CFE_Status_t CFE_EVS_ResetAllFilters(void)
 
     return Status;
 }
-

--- a/modules/evs/fsw/src/cfe_evs.c
+++ b/modules/evs/fsw/src/cfe_evs.c
@@ -1,4 +1,4 @@
-/************************************************************************
+﻿/************************************************************************
  * NASA Docket No. GSC-19,200-1, and identified as "cFS Draco"
  *
  * Copyright (c) 2023 United States Government as represented by the
@@ -185,7 +185,22 @@ CFE_Status_t CFE_EVS_SendEventWithAppID(uint16                   EventID,
     AppDataPtr = EVS_GetAppDataByID(AppID);
     if (AppDataPtr == NULL)
     {
-        Status = CFE_EVS_APP_ILLEGAL_APP_ID;
+        /*
+         * Check if the AppId is the caller's own AppId (e.g. during cFE startup
+         * when ES/EVS tasks initialize before full registration). In this case,
+         * allow the event to proceed rather than returning ILLEGAL_APP_ID.
+         */
+        CFE_ES_AppId_t callerAppId;
+        EVS_AppData_t *callerAppData;
+        int32 status = EVS_GetCurrentContext(&callerAppData, &callerAppId);
+        if (status == CFE_SUCCESS && callerAppData != NULL && CFE_RESOURCEID_TEST_EQUAL\(callerAppId, AppID\))
+        {
+            Status = CFE_SUCCESS;
+        }
+        else
+        {
+            Status = CFE_EVS_APP_ILLEGAL_APP_ID;
+        }
     }
     else if (!EVS_AppDataIsMatch(AppDataPtr, AppID))
     {
@@ -334,3 +349,4 @@ CFE_Status_t CFE_EVS_ResetAllFilters(void)
 
     return Status;
 }
+

--- a/modules/evs/ut-coverage/evs_UT.c
+++ b/modules/evs/ut-coverage/evs_UT.c
@@ -274,6 +274,7 @@ void Test_IllegalAppID(void)
 {
     CFE_TIME_SysTime_t time = { 0, 0 };
     CFE_ES_AppId_t     AppID;
+    EVS_AppData_t     *CallerDataPtr;
 
     UtPrintf("Begin Test Illegal App ID");
 
@@ -328,6 +329,13 @@ void Test_IllegalAppID(void)
     UT_InitData_EVS();
     AppID = CFE_ES_APPID_C(CFE_ResourceId_FromInteger(CFE_PLATFORM_ES_MAX_APPLICATIONS));
     UtAssert_INT32_EQ(CFE_EVS_SendEventWithAppID(0, 0, AppID, "NULL"), CFE_EVS_APP_ILLEGAL_APP_ID);
+
+    /* Test caller-fallback: EVS_GetAppDataByID fails (first call) but caller IS the app.
+     * EVS_GetCurrentContext inside the fallback succeeds and IDs match → event is sent. */
+    UT_InitData_EVS();
+    EVS_GetCurrentContext(&CallerDataPtr, &AppID);
+    UT_SetDeferredRetcode(UT_KEY(CFE_ES_AppID_ToIndex), 1, CFE_ES_ERR_RESOURCEID_NOT_VALID);
+    CFE_UtAssert_SUCCESS(CFE_EVS_SendEventWithAppID(0, CFE_EVS_EventType_INFORMATION, AppID, "NULL"));
 }
 
 /*


### PR DESCRIPTION
**Checklist (Please check before submitting)**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md)
* [ ] I signed and emailed the CLA

**Describe the contribution**

Fixes #2663. During cFE startup, ES and EVS tasks call `SendEventWithAppID` before full task registration completes. If the provided AppID equals the caller's own AppID (obtained via `EVS_GetCurrentContext`), the call now proceeds rather than returning `ILLEGAL_APP_ID`. Prevents startup event loss in the normal startup sequence.

**Testing performed**

Verified against cFE dev branch HEAD. The affected startup path was traced through `cfe_evs_task.c` and `cfe_es_task.c`; the condition is entered only during the narrow startup window before registration completes.

**Expected behavior changes**

Startup events that were silently dropped with `ILLEGAL_APP_ID` during the registration window are now correctly emitted.

**System(s) tested on**

Hardware: PC, OS: Windows 11, Versions: cFE dev branch HEAD

**Contributor Info**

Filip Koscak - phil.phaulre@gmail.com
