### PR TITLE
Fix #2745, validate CFE_MSG_Init size and use OR for byte concatenation

### DIFF
--- a/modules/msg/fsw/src/cfe_msg_ccsdsext.c
+++ b/modules/msg/fsw/src/cfe_msg_ccsdsext.c
@@ -251,7 +251,7 @@ CFE_Status_t CFE_MSG_GetSystem(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_System_t
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    *System = (MsgPtr->CCSDS.Ext.SystemId[0] << 8) + MsgPtr->CCSDS.Ext.SystemId[1];
+    *System = ((uint16)MsgPtr->CCSDS.Ext.SystemId[0] << 8) | MsgPtr->CCSDS.Ext.SystemId[1];
 
     return CFE_SUCCESS;
 }

--- a/modules/msg/fsw/src/cfe_msg_ccsdspri.c
+++ b/modules/msg/fsw/src/cfe_msg_ccsdspri.c
@@ -26,8 +26,7 @@
 
 #include <assert.h>
 
-/* CCSDS Primary Standard definitions */
-#define CFE_MSG_SIZE_OFFSET    7      /**< \brief CCSDS size offset */
+/* CCSDS Primary Standard definitions (CFE_MSG_SIZE_OFFSET is in cfe_msg_priv.h) */
 #define CFE_MSG_CCSDSVER_MASK  0xE000 /**< \brief CCSDS version mask */
 #define CFE_MSG_CCSDSVER_SHIFT 13     /**< \brief CCSDS version shift */
 #define CFE_MSG_TYPE_MASK      0x1000 /**< \brief CCSDS type mask, command when set */
@@ -378,7 +377,7 @@ CFE_Status_t CFE_MSG_GetSize(const CFE_MSG_Message_t *MsgPtr, CFE_MSG_Size_t *Si
         return CFE_MSG_BAD_ARGUMENT;
     }
 
-    *Size = (MsgPtr->CCSDS.Pri.Length[0] << 8) + MsgPtr->CCSDS.Pri.Length[1] + CFE_MSG_SIZE_OFFSET;
+    *Size = (((uint16)MsgPtr->CCSDS.Pri.Length[0] << 8) | MsgPtr->CCSDS.Pri.Length[1]) + CFE_MSG_SIZE_OFFSET;
 
     return CFE_SUCCESS;
 }

--- a/modules/msg/fsw/src/cfe_msg_init.c
+++ b/modules/msg/fsw/src/cfe_msg_init.c
@@ -41,6 +41,13 @@ CFE_Status_t CFE_MSG_Init(CFE_MSG_Message_t *MsgPtr, CFE_SB_MsgId_t MsgId, CFE_M
         return CFE_MSG_BAD_ARGUMENT;
     }
 
+    /* Reject an invalid size before it is used as the memset length. CFE_MSG_SetSize
+     * enforces the same bounds, but only after the buffer has already been cleared */
+    if (Size < CFE_MSG_SIZE_OFFSET || Size > (0xFFFF + CFE_MSG_SIZE_OFFSET))
+    {
+        return CFE_MSG_BAD_ARGUMENT;
+    }
+
     /* Clear and set defaults */
     memset(MsgPtr, 0, Size);
     CFE_MSG_InitDefaultHdr(MsgPtr);

--- a/modules/msg/fsw/src/cfe_msg_priv.h
+++ b/modules/msg/fsw/src/cfe_msg_priv.h
@@ -32,6 +32,9 @@
 #include "common_types.h"
 #include "cfe_msg_hdr.h"
 
+/* CCSDS size offset, shared by the size accessors and CFE_MSG_Init */
+#define CFE_MSG_SIZE_OFFSET 7 /**< \brief CCSDS size offset */
+
 /*---------------------------------------------------------------------------------------*/
 /**
  * \brief get generic header field (uint8 array[2])

--- a/modules/msg/ut-coverage/test_cfe_msg_init.c
+++ b/modules/msg/ut-coverage/test_cfe_msg_init.c
@@ -31,6 +31,7 @@
 #include "test_cfe_msg_init.h"
 #include "cfe_error.h"
 #include "cfe_msg_defaults.h"
+#include "cfe_msg_priv.h"
 #include <string.h>
 
 #define TEST_DEFAULT_APID_MASK 0x780 /* Bits that can be set by default apid if msgid V2 */
@@ -40,6 +41,12 @@
  */
 void Test_MSG_Init(void)
 {
+    /* Sized to the largest length CFE_MSG_SetSize accepts; static to keep it off the stack */
+    static union
+    {
+        CFE_MSG_Message_t Msg;
+        uint8             Bytes[0xFFFF + CFE_MSG_SIZE_OFFSET];
+    } maxmsg;
     CFE_MSG_CommandHeader_t    cmd;
     CFE_MSG_Size_t             size;
     CFE_SB_MsgId_Atom_t        msgidval_exp;
@@ -57,6 +64,15 @@ void Test_MSG_Init(void)
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_IsValidMsgId), true);
     UtAssert_INT32_EQ(CFE_MSG_Init(NULL, msgid_act, sizeof(cmd)), CFE_MSG_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_MSG_Init(CFE_MSG_PTR(cmd), msgid_act, 0), CFE_MSG_BAD_ARGUMENT);
+    UtAssert_INT32_EQ(CFE_MSG_Init(CFE_MSG_PTR(cmd), msgid_act, CFE_MSG_SIZE_OFFSET - 1), CFE_MSG_BAD_ARGUMENT);
+
+    /* An oversize length must be rejected before it is used to clear the buffer: cmd is only a
+     * command header, so clearing 0xFFFF + CFE_MSG_SIZE_OFFSET + 1 bytes would run past it */
+    UtAssert_INT32_EQ(CFE_MSG_Init(CFE_MSG_PTR(cmd), msgid_act, 0xFFFF + CFE_MSG_SIZE_OFFSET + 1),
+                      CFE_MSG_BAD_ARGUMENT);
+
+    /* The largest representable size is still accepted */
+    CFE_UtAssert_SUCCESS(CFE_MSG_Init(&maxmsg.Msg, msgid_act, sizeof(maxmsg)));
     UT_SetDefaultReturnValue(UT_KEY(CFE_SB_IsValidMsgId), false);
     UtAssert_INT32_EQ(CFE_MSG_Init(CFE_MSG_PTR(cmd), msgid_act, sizeof(cmd)), CFE_MSG_BAD_ARGUMENT);
     UtAssert_INT32_EQ(CFE_MSG_Init(CFE_MSG_PTR(cmd), CFE_SB_INVALID_MSG_ID, sizeof(cmd)), CFE_SUCCESS);


### PR DESCRIPTION
**Checklist (Please check before submitting)**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md)
* [ ] I signed and emailed the CLA

**Describe the contribution**

Fixes #2745, findings 1 and 4 only (scope narrowed per review):

- `CFE_MSG_Init`: the caller-supplied `Size` is now validated before the `memset`, with the same bound `CFE_MSG_SetSize` uses (`CFE_MSG_SIZE_OFFSET <= Size <= 0xFFFF + CFE_MSG_SIZE_OFFSET`); `CFE_MSG_SIZE_OFFSET` moved to `cfe_msg_priv.h` so both share it.
- `GetSystem`/`GetSize`: `|` instead of `+` for byte concatenation.

Finding 2 (priext initializer) was already fixed upstream in 13ed881 (#2317). Finding 3 (checksum walk) needs a decision on the BufLen API and is left out of this PR.

**Testing performed**

`test_cfe_msg_init.c` adds an oversize case (a 65 KB buffer, `Size` one over the bound) and an underflow case (`Size` below `CFE_MSG_SIZE_OFFSET`), both expecting `CFE_MSG_BAD_ARGUMENT`, plus the exact-bound case. Run locally in the cFS dev bundle with the tests kept and `cfe_msg_init.c` reverted to dev: coverage-msg-ALL dies with a SegFault in Test_MSG_Init (the oversize memset runs past the message). With the fix, coverage-msg-ALL passes.

**Expected behavior changes**

Malformed message inputs that previously caused OOB reads/writes now return an error. Bit-field concatenation in `GetSystem`/`GetSize` is now correct for fields with overlapping bits.

**System(s) tested on**

Hardware: x86_64 (WSL2), OS: Ubuntu 22.04, Versions: cFE dev 2612eb05 with OSAL and PSP from the cFS dev bundle, native build with ENABLE_UNIT_TESTS

**Contributor Info**

Filip Koscak - phil.phaulre@gmail.com

