### PR TITLE
Fix #2801, reduce file systems init complexity

### DIFF
--- a/modules/es/fsw/src/cfe_es_start.c
+++ b/modules/es/fsw/src/cfe_es_start.c
@@ -478,20 +478,230 @@ void CFE_ES_SetupResetVariables(uint32 StartType, uint32 StartSubtype, uint32 Bo
 
 /*----------------------------------------------------------------
  *
+ * Local helper function
+ * Creates or initializes the volatile file system based on the reset type
+ *
+ *-----------------------------------------------------------------*/
+static void
+CFE_ES_InitializeFileSystems_SetupVolume(uint32 StartType, cpuaddr RamDiskMemoryAddress, const char *LogFunction)
+{
+    int32 OsStatus;
+
+    /*
+    ** Either format or just initialize the RAM disk depending on the reset type
+    */
+    if (StartType == CFE_PSP_RST_TYPE_POWERON)
+    {
+        OsStatus = OS_mkfs((void *)RamDiskMemoryAddress,
+                           "/ramdev0",
+                           "RAM",
+                           CFE_PLATFORM_ES_RAM_DISK_SECTOR_SIZE,
+                           CFE_PLATFORM_ES_RAM_DISK_NUM_SECTORS);
+        if (OsStatus != OS_SUCCESS)
+        {
+            CFE_ES_WriteToSysLog("%s: Error Creating Volatile(RAM) Volume. EC = %ld\n", LogFunction, (long)OsStatus);
+
+            /*
+            ** Delay to allow the message to be read
+            */
+            OS_TaskDelay(CFE_ES_PANIC_DELAY);
+
+            /*
+            ** cFE Cannot continue to start up.
+            */
+            CFE_PSP_Panic(CFE_PSP_PANIC_VOLATILE_DISK);
+        }
+    }
+    else
+    {
+        OsStatus = OS_initfs((void *)RamDiskMemoryAddress,
+                             "/ramdev0",
+                             "RAM",
+                             CFE_PLATFORM_ES_RAM_DISK_SECTOR_SIZE,
+                             CFE_PLATFORM_ES_RAM_DISK_NUM_SECTORS);
+        if (OsStatus != OS_SUCCESS)
+        {
+            CFE_ES_WriteToSysLog("%s: Error Initializing Volatile(RAM) Volume. EC = %ld\n",
+                                 LogFunction,
+                                 (long)OsStatus);
+            CFE_ES_WriteToSysLog("%s: Formatting Volatile(RAM) Volume.\n", LogFunction);
+
+            OsStatus = OS_mkfs((void *)RamDiskMemoryAddress,
+                               "/ramdev0",
+                               "RAM",
+                               CFE_PLATFORM_ES_RAM_DISK_SECTOR_SIZE,
+                               CFE_PLATFORM_ES_RAM_DISK_NUM_SECTORS);
+            if (OsStatus != OS_SUCCESS)
+            {
+                CFE_ES_WriteToSysLog("%s: Error Creating Volatile(RAM) Volume. EC = %ld\n",
+                                     LogFunction,
+                                     (long)OsStatus);
+
+                /*
+                ** Delay to allow the message to be read
+                */
+                OS_TaskDelay(CFE_ES_PANIC_DELAY);
+
+                /*
+                ** cFE Cannot continue to start up.
+                */
+                CFE_PSP_Panic(CFE_PSP_PANIC_VOLATILE_DISK);
+            }
+        }
+    }
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local helper function
+ * Re-formats and re-mounts a volatile file system that is too full
+ *
+ *-----------------------------------------------------------------*/
+static void CFE_ES_InitializeFileSystems_ReformatVolume(cpuaddr RamDiskMemoryAddress, const char *LogFunction)
+{
+    int32 OsStatus;
+
+    /*
+    ** First, unmount the disk
+    */
+    OsStatus = OS_unmount(CFE_PLATFORM_ES_RAM_DISK_MOUNT_STRING);
+    if (OsStatus != OS_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("%s: Error Un-Mounting Volatile(RAM) Volume. EC = %ld\n", LogFunction, (long)OsStatus);
+        /*
+        ** Delay to allow the message to be read
+        */
+        OS_TaskDelay(CFE_ES_PANIC_DELAY);
+
+        /*
+        ** cFE Cannot continue to start up.
+        */
+        CFE_PSP_Panic(CFE_PSP_PANIC_VOLATILE_DISK);
+        return;
+    }
+
+    /*
+    ** Remove the file system from the OSAL
+    */
+    OsStatus = OS_rmfs("/ramdev0");
+    if (OsStatus != OS_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("%s: Error Removing Volatile(RAM) Volume. EC = %ld\n", LogFunction, (long)OsStatus);
+        /*
+        ** Delay to allow the message to be read
+        */
+        OS_TaskDelay(CFE_ES_PANIC_DELAY);
+
+        /*
+        ** cFE Cannot continue to start up.
+        */
+        CFE_PSP_Panic(CFE_PSP_PANIC_VOLATILE_DISK);
+        return;
+    }
+
+    /*
+    ** Next, make a new file system on the disk
+    */
+    OsStatus = OS_mkfs((void *)RamDiskMemoryAddress,
+                       "/ramdev0",
+                       "RAM",
+                       CFE_PLATFORM_ES_RAM_DISK_SECTOR_SIZE,
+                       CFE_PLATFORM_ES_RAM_DISK_NUM_SECTORS);
+    if (OsStatus != OS_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("%s: Error Re-Formatting Volatile(RAM) Volume. EC = %ld\n", LogFunction, (long)OsStatus);
+        /*
+        ** Delay to allow the message to be read
+        */
+        OS_TaskDelay(CFE_ES_PANIC_DELAY);
+
+        /*
+        ** cFE Cannot continue to start up.
+        */
+        CFE_PSP_Panic(CFE_PSP_PANIC_VOLATILE_DISK);
+        return;
+    }
+
+    /*
+    ** Last, remount the disk
+    */
+    OsStatus = OS_mount("/ramdev0", CFE_PLATFORM_ES_RAM_DISK_MOUNT_STRING);
+    if (OsStatus != OS_SUCCESS)
+    {
+        CFE_ES_WriteToSysLog("%s: Error Re-Mounting Volatile(RAM) Volume. EC = %ld\n", LogFunction, (long)OsStatus);
+        /*
+        ** Delay to allow the message to be read
+        */
+        OS_TaskDelay(CFE_ES_PANIC_DELAY);
+
+        /*
+        ** cFE Cannot continue to start up.
+        */
+        CFE_PSP_Panic(CFE_PSP_PANIC_VOLATILE_DISK);
+    }
+}
+
+/*----------------------------------------------------------------
+ *
+ * Local helper function
+ * Checks the free space on the volatile file system and re-formats if necessary
+ *
+ *-----------------------------------------------------------------*/
+static void CFE_ES_InitializeFileSystems_CheckFreeSpace(cpuaddr RamDiskMemoryAddress, const char *LogFunction)
+{
+    int32        OsStatus;
+    int32        PercentFree;
+    OS_statvfs_t StatBuf;
+
+    memset(&StatBuf, 0, sizeof(StatBuf));
+
+    /*
+    ** See how many blocks are free in the RAM disk
+    */
+    OsStatus = OS_FileSysStatVolume(CFE_PLATFORM_ES_RAM_DISK_MOUNT_STRING, &StatBuf);
+    if (OsStatus == OS_SUCCESS && StatBuf.total_blocks > 0)
+    {
+        /*
+        ** Determine if the disk is too full
+        */
+        PercentFree = (StatBuf.blocks_free * 100) / StatBuf.total_blocks;
+        CFE_ES_WriteToSysLog("%s: Volatile Disk has %d Percent free space.\n", LogFunction, (int)PercentFree);
+
+        if (PercentFree < CFE_PLATFORM_ES_RAM_DISK_PERCENT_RESERVED)
+        {
+            CFE_ES_WriteToSysLog("%s: Insufficient Free Space on Volatile Disk, Reformatting.\n", LogFunction);
+            CFE_ES_InitializeFileSystems_ReformatVolume(RamDiskMemoryAddress, LogFunction);
+        }
+    }
+    else
+    {
+        /* Log error message -- note that BlocksFree returns the error code in this case */
+        CFE_ES_WriteToSysLog("%s: Error Determining Blocks Free on Volume. EC = %ld\n", LogFunction, (long)OsStatus);
+
+        /*
+        ** Delay to allow the message to be read
+        */
+        OS_TaskDelay(CFE_ES_PANIC_DELAY);
+
+        /*
+        ** cFE Cannot continue to start up.
+        */
+        CFE_PSP_Panic(CFE_PSP_PANIC_VOLATILE_DISK);
+    }
+}
+
+/*----------------------------------------------------------------
+ *
  * Application-scope internal function
  * See description in header file for argument/return detail
  *
  *-----------------------------------------------------------------*/
 void CFE_ES_InitializeFileSystems(uint32 StartType)
 {
-    int32        OsStatus;
-    int32        PspStatus;
-    cpuaddr      RamDiskMemoryAddress = 0;
-    uint32       RamDiskMemorySize;
-    int32        PercentFree;
-    OS_statvfs_t StatBuf;
-
-    memset(&StatBuf, 0, sizeof(StatBuf));
+    int32   OsStatus;
+    int32   PspStatus;
+    cpuaddr RamDiskMemoryAddress = 0;
+    uint32  RamDiskMemorySize;
 
     /*
     ** Get the memory area for the RAM disk
@@ -515,65 +725,7 @@ void CFE_ES_InitializeFileSystems(uint32 StartType)
         CFE_PSP_Panic(CFE_PSP_PANIC_VOLATILE_DISK);
     }
 
-    /*
-    ** Next, either format, or just initialize the RAM disk depending on
-    ** the reset type
-    */
-    if (StartType == CFE_PSP_RST_TYPE_POWERON)
-    {
-        OsStatus = OS_mkfs((void *)RamDiskMemoryAddress,
-                           "/ramdev0",
-                           "RAM",
-                           CFE_PLATFORM_ES_RAM_DISK_SECTOR_SIZE,
-                           CFE_PLATFORM_ES_RAM_DISK_NUM_SECTORS);
-        if (OsStatus != OS_SUCCESS)
-        {
-            CFE_ES_WriteToSysLog("%s: Error Creating Volatile(RAM) Volume. EC = %ld\n", __func__, (long)OsStatus);
-
-            /*
-            ** Delay to allow the message to be read
-            */
-            OS_TaskDelay(CFE_ES_PANIC_DELAY);
-
-            /*
-            ** cFE Cannot continue to start up.
-            */
-            CFE_PSP_Panic(CFE_PSP_PANIC_VOLATILE_DISK);
-        }
-    }
-    else
-    {
-        OsStatus = OS_initfs((void *)RamDiskMemoryAddress,
-                             "/ramdev0",
-                             "RAM",
-                             CFE_PLATFORM_ES_RAM_DISK_SECTOR_SIZE,
-                             CFE_PLATFORM_ES_RAM_DISK_NUM_SECTORS);
-        if (OsStatus != OS_SUCCESS)
-        {
-            CFE_ES_WriteToSysLog("%s: Error Initializing Volatile(RAM) Volume. EC = %ld\n", __func__, (long)OsStatus);
-            CFE_ES_WriteToSysLog("%s: Formatting Volatile(RAM) Volume.\n", __func__);
-
-            OsStatus = OS_mkfs((void *)RamDiskMemoryAddress,
-                               "/ramdev0",
-                               "RAM",
-                               CFE_PLATFORM_ES_RAM_DISK_SECTOR_SIZE,
-                               CFE_PLATFORM_ES_RAM_DISK_NUM_SECTORS);
-            if (OsStatus != OS_SUCCESS)
-            {
-                CFE_ES_WriteToSysLog("%s: Error Creating Volatile(RAM) Volume. EC = %ld\n", __func__, (long)OsStatus);
-
-                /*
-                ** Delay to allow the message to be read
-                */
-                OS_TaskDelay(CFE_ES_PANIC_DELAY);
-
-                /*
-                ** cFE Cannot continue to start up.
-                */
-                CFE_PSP_Panic(CFE_PSP_PANIC_VOLATILE_DISK);
-            }
-        }
-    }
+    CFE_ES_InitializeFileSystems_SetupVolume(StartType, RamDiskMemoryAddress, __func__);
 
     /*
     ** Now, mount the RAM disk
@@ -602,134 +754,7 @@ void CFE_ES_InitializeFileSystems(uint32 StartType)
     */
     if ((StartType == CFE_PSP_RST_TYPE_PROCESSOR) && (CFE_PLATFORM_ES_RAM_DISK_PERCENT_RESERVED > 0))
     {
-        /*
-        ** See how many blocks are free in the RAM disk
-        */
-        OsStatus = OS_FileSysStatVolume(CFE_PLATFORM_ES_RAM_DISK_MOUNT_STRING, &StatBuf);
-        if (OsStatus == OS_SUCCESS && StatBuf.total_blocks > 0)
-        {
-            /*
-            ** Determine if the disk is too full
-            */
-            PercentFree = (StatBuf.blocks_free * 100) / StatBuf.total_blocks;
-            CFE_ES_WriteToSysLog("%s: Volatile Disk has %d Percent free space.\n", __func__, (int)PercentFree);
-
-            if (PercentFree < CFE_PLATFORM_ES_RAM_DISK_PERCENT_RESERVED)
-            {
-                CFE_ES_WriteToSysLog("%s: Insufficient Free Space on Volatile Disk, Reformatting.\n", __func__);
-
-                /*
-                ** First, unmount the disk
-                */
-                OsStatus = OS_unmount(CFE_PLATFORM_ES_RAM_DISK_MOUNT_STRING);
-                if (OsStatus == OS_SUCCESS)
-                {
-                    /*
-                    ** Remove the file system from the OSAL
-                    */
-                    OsStatus = OS_rmfs("/ramdev0");
-                    if (OsStatus == OS_SUCCESS)
-                    {
-                        /*
-                        ** Next, make a new file system on the disk
-                        */
-                        OsStatus = OS_mkfs((void *)RamDiskMemoryAddress,
-                                           "/ramdev0",
-                                           "RAM",
-                                           CFE_PLATFORM_ES_RAM_DISK_SECTOR_SIZE,
-                                           CFE_PLATFORM_ES_RAM_DISK_NUM_SECTORS);
-                        if (OsStatus == OS_SUCCESS)
-                        {
-                            /*
-                            ** Last, remount the disk
-                            */
-                            OsStatus = OS_mount("/ramdev0", CFE_PLATFORM_ES_RAM_DISK_MOUNT_STRING);
-                            if (OsStatus != OS_SUCCESS)
-                            {
-                                CFE_ES_WriteToSysLog("%s: Error Re-Mounting Volatile(RAM) Volume. EC = %ld\n",
-                                                     __func__,
-                                                     (long)OsStatus);
-                                /*
-                                ** Delay to allow the message to be read
-                                */
-                                OS_TaskDelay(CFE_ES_PANIC_DELAY);
-
-                                /*
-                                ** cFE Cannot continue to start up.
-                                */
-                                CFE_PSP_Panic(CFE_PSP_PANIC_VOLATILE_DISK);
-
-                            } /* end if mount */
-                        }
-                        else
-                        {
-                            CFE_ES_WriteToSysLog("%s: Error Re-Formatting Volatile(RAM) Volume. EC = %ld\n",
-                                                 __func__,
-                                                 (long)OsStatus);
-                            /*
-                            ** Delay to allow the message to be read
-                            */
-                            OS_TaskDelay(CFE_ES_PANIC_DELAY);
-
-                            /*
-                            ** cFE Cannot continue to start up.
-                            */
-                            CFE_PSP_Panic(CFE_PSP_PANIC_VOLATILE_DISK);
-
-                        } /* end if mkfs */
-                    }
-                    else /* could not Remove File system */
-                    {
-                        CFE_ES_WriteToSysLog("%s: Error Removing Volatile(RAM) Volume. EC = %ld\n",
-                                             __func__,
-                                             (long)OsStatus);
-                        /*
-                        ** Delay to allow the message to be read
-                        */
-                        OS_TaskDelay(CFE_ES_PANIC_DELAY);
-
-                        /*
-                        ** cFE Cannot continue to start up.
-                        */
-                        CFE_PSP_Panic(CFE_PSP_PANIC_VOLATILE_DISK);
-
-                    } /* end if OS_rmfs */
-                }
-                else /* could not un-mount disk */
-                {
-                    CFE_ES_WriteToSysLog("%s: Error Un-Mounting Volatile(RAM) Volume. EC = %ld\n",
-                                         __func__,
-                                         (long)OsStatus);
-                    /*
-                    ** Delay to allow the message to be read
-                    */
-                    OS_TaskDelay(CFE_ES_PANIC_DELAY);
-
-                    /*
-                    ** cFE Cannot continue to start up.
-                    */
-                    CFE_PSP_Panic(CFE_PSP_PANIC_VOLATILE_DISK);
-                }
-
-            } /* end if enough free space */
-        }
-        else /* could not determine free blocks */
-        {
-            /* Log error message -- note that BlocksFree returns the error code in this case */
-            CFE_ES_WriteToSysLog("%s: Error Determining Blocks Free on Volume. EC = %ld\n", __func__, (long)OsStatus);
-
-            /*
-            ** Delay to allow the message to be read
-            */
-            OS_TaskDelay(CFE_ES_PANIC_DELAY);
-
-            /*
-            ** cFE Cannot continue to start up.
-            */
-            CFE_PSP_Panic(CFE_PSP_PANIC_VOLATILE_DISK);
-
-        } /* end if BlocksFree */
-
+        CFE_ES_InitializeFileSystems_CheckFreeSpace(RamDiskMemoryAddress, __func__);
     } /* end if processor reset */
 }
 


### PR DESCRIPTION
---
name: FSW Code Change
about: Flight Software code changes
labels: fsw
---

## Description of Change

Creates three static helpers: _SetupVolume , _CheckFreeSpace , and _ReformatVolume . drops the cyclomatic complexity of CFE_ES_InitializeFileSystems from 16 to 5, with no helper exceeding 5, and existing ES unit tests reach 100% line and branch coverage on all four functions unchanged

explicit return is added in the _ReformatVolume helper to stop the code from attempting to reformat a disk it just failed to unmount.

Note that we pass the original function string as LogFunction so the log avoids using helper function naming.

## Linked Issue

Closes #2801

## Requirements Impact

<!-- List any requirements impacted by this change. Indicate whether each was updated, or confirm the change continues to satisfy existing requirements. -->
- Requirement ID(s):
- [x] Requirements updated as necessary
- [x] Existing requirements are still satisfied by this change

## Testing Evidence

build, unit and functional tests. No functional change

### Unit Tests (UT Assert)
<!-- Link to CI run or paste summary -->

### COSMOS Test Suite
N/A

## Areas of Expertise Touched

<!-- Check all that apply so the appropriate Experts can be tagged as reviewers. -->
<!-- See the expertise tags in the "cFS Dev Team" Teams channel or ask your team lead to help identify experts. -->
- [ ] ASTRO
- [ ] CI/CD
- [ ] COSMOS
- [ ] Cybersecurity
- [ ] Docker
- [ ] EDS
- [ ] Git
- [ ] PSPs
- [ ] SBN
- [ ] SMP
- [ ] Tables
- [ ] TSN
- [ ] Unit Tests
- [ ] Other

---

## Author Checklist

- [x] Linked GitHub issue is referenced above
- [x] Code has been formatted with `.clang-format`
- [x] Static analysis workflows ran and passed
- [x] Unit tests (UT Assert) updated/added to cover code changes
- [x] Unit test workflows ran and passed
- [x] COSMOS test suite was run; tests updated/added if relevant changes were made
- [x] Requirements have been reviewed; updated or confirmed still satisfied (see above)
- [x] Testing evidence is included above
- [x] Self-review of the diff completed

---

## Reviewer Checklist

- [ ] Code logic is correct and matches the stated intent
- [ ] Code is readable, maintainable, and follows project conventions (ask your lead if you are unsure of where to find these conventions)
- [ ] `.clang-format` has been applied
- [ ] Static analysis results reviewed and acceptable
- [ ] **The change has been exercised by the unit tests** (not just that tests pass — the new/changed code paths are actually covered)
- [ ] **COSMOS test suite was executed against this change** and results reviewed (or confirmed N/A with justification)
- [ ] **Reviewer has independently verified the change behaves as described** (e.g., by running the tests locally, reviewing CI output in detail, or performing additional ad-hoc testing as warranted)
- [ ] **Memory safety** reviewed (allocation, bounds, lifetime, stack usage)
- [ ] Requirements impact reviewed and appropriate
- [ ] Error handling is appropriate
- [ ] Appropriate Expert areas have been reviewed

### Reviewer Testing Notes

<!--
Describe how you independently verified this change. For example:
  - "Pulled the branch locally, ran `make test`, all UT Assert tests passed including the new ones for X."
  - "Ran the COSMOS test suite against the branch; observed expected telemetry behavior for Y."
  - "Reviewed CI run #1234; verified the new code paths are covered by inspecting the coverage report."
  - "Performed ad-hoc test by [describe scenario]; observed [result]."
-->