### PR TITLE
fix(es): use PLATFORM bound for pool bucket array size check

### DIFF
--- a/modules/es/fsw/src/cfe_es_mempool.c
+++ b/modules/es/fsw/src/cfe_es_mempool.c
@@ -227,12 +227,12 @@ CFE_Status_t CFE_ES_PoolCreateEx_WithAlignment(CFE_ES_MemHandle_t *PoolID,
     }
 
     /* If too many sizes are specified, return an error */
-    if (NumBlockSizes > CFE_MISSION_ES_POOL_MAX_BUCKETS)
+    if (NumBlockSizes > CFE_PLATFORM_ES_POOL_MAX_BUCKETS)
     {
         CFE_ES_WriteToSysLog("%s: Num Block Sizes (%d) greater than max (%d)\n",
                              __func__,
                              (int)NumBlockSizes,
-                             CFE_MISSION_ES_POOL_MAX_BUCKETS);
+                             CFE_PLATFORM_ES_POOL_MAX_BUCKETS);
         return CFE_ES_BAD_ARGUMENT;
     }
 


### PR DESCRIPTION
**Checklist (Please check before submitting)**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md)
* [ ] I signed and emailed the CLA

**Describe the contribution**

Fixes #2828. In `CFE_ES_PoolCreateEx_WithAlignment()`, `NumBlockSizes` is checked against `CFE_MISSION_ES_POOL_MAX_BUCKETS`, but the `Buckets[]` array is sized to `CFE_PLATFORM_ES_POOL_MAX_BUCKETS`. When `MISSION > PLATFORM` (valid per `cfe_missionlib_verify.h`), the bounds check passes but subsequent writes exceed the array, causing OOB writes.

One-line fix: replace `CFE_MISSION_ES_POOL_MAX_BUCKETS` with `CFE_PLATFORM_ES_POOL_MAX_BUCKETS` in `cfe_es_mempool.c` so the check matches the actual array size.

**Testing performed**

The bucket-count check in `cfe_es_mempool.c` now uses the PLATFORM bound the array is allocated with, and the syslog prints that same bound. Run locally in the cFS dev bundle: coverage-es passes. With sample_defs (MISSION == PLATFORM == 17) behavior is unchanged; the check only differs when a mission raises the MISSION bound above the PLATFORM allocation.

**Expected behavior changes**

Configurations where `CFE_MISSION_ES_POOL_MAX_BUCKETS > CFE_PLATFORM_ES_POOL_MAX_BUCKETS` now correctly reject excess bucket counts instead of writing out of bounds.

**System(s) tested on**

Hardware: x86_64 (WSL2), OS: Ubuntu 22.04, Versions: cFE dev 2612eb05 with OSAL and PSP from the cFS dev bundle, native build with ENABLE_UNIT_TESTS

**Contributor Info**

Filip Koscak - phil.phaulre@gmail.com

