### PR TITLE
fix(tbl): close file descriptor after table load command

### DIFF
--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
@@ -418,6 +418,8 @@ CFE_Status_t CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
     Status = CFE_TBL_TxnOpenTableLoadFile(&Txn, LoadFilename, &FileDescriptor, &Header);
     if (Status == CFE_SUCCESS)
     {
+        /* NOTE: the FileDescriptor is valid and must be closed before leaving this block */
+
         /* Locate specified table in registry (wrapped in a lock) */
         /* NOTE: The header reading code ensures null term on the table name string, so its OK to pass direct */
         CFE_TBL_TxnLockRegistry(&Txn);
@@ -430,17 +432,20 @@ CFE_Status_t CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
         }
 
         CFE_TBL_TxnUnlockRegistry(&Txn);
-    }
 
-    if (Status == CFE_SUCCESS)
-    {
-        Status = CFE_TBL_ValidateFileIsLoadable(&Txn, &Header.Tbl);
-    }
+        if (Status == CFE_SUCCESS)
+        {
+            Status = CFE_TBL_ValidateFileIsLoadable(&Txn, &Header.Tbl);
+        }
 
-    if (Status == CFE_SUCCESS)
-    {
-        /* Read the file content into the working buffer */
-        Status = CFE_TBL_LoadContentFromFile(&Txn, FileDescriptor, Header.Tbl.Offset, Header.Tbl.NumBytes);
+        if (Status == CFE_SUCCESS)
+        {
+            /* Read the file content into the working buffer */
+            Status = CFE_TBL_LoadContentFromFile(&Txn, FileDescriptor, Header.Tbl.Offset, Header.Tbl.NumBytes);
+        }
+
+        /* Done with the file now -- must always close the file regardless of what happened */
+        OS_close(FileDescriptor);
     }
 
     /* If all the above worked out, then set the meta info in the load buffer */

--- a/modules/tbl/ut-coverage/tbl_ut_load.c
+++ b/modules/tbl/ut-coverage/tbl_ut_load.c
@@ -308,6 +308,8 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
     UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_SUCCESS);
     CFE_UtAssert_COUNTER_INCR(CFE_TBL_Global.CommandErrorCounter);
+    /* Nothing was opened, so nothing is closed */
+    UtAssert_STUB_COUNT(OS_close, 0);
 
     /* Test response to inability to find the table in the registry */
     UT_InitData_TBL();
@@ -317,6 +319,8 @@ void Test_CFE_TBL_LoadCmd(void)
     UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_SUCCESS);
     CFE_UtAssert_COUNTER_INCR(CFE_TBL_Global.CommandErrorCounter);
     CFE_UtAssert_EVENTSENT(CFE_TBL_NO_SUCH_TABLE_ERR_EID);
+    /* The file was opened before the lookup failed and must not leak */
+    UtAssert_STUB_COUNT(OS_close, 1);
 
     /* The rest of the tests will use registry 0, note empty name matches */
     RegRec0Ptr->OwnerAppId = AppID;
@@ -362,6 +366,8 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_SUCCESS);
     CFE_UtAssert_COUNTER_INCR(CFE_TBL_Global.CommandCounter);
+    /* A successful load closes its file exactly once */
+    UtAssert_STUB_COUNT(OS_close, 1);
 
     /* Test with differing amount of data from header's claim */
     UT_InitData_TBL();


### PR DESCRIPTION
**Checklist (Please check before submitting)**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md)
* [ ] I signed and emailed the CLA

**Describe the contribution**

Fixes #2811. In `CFE_TBL_LoadCmd()` the file descriptor from `CFE_FS_OpenFileForReading()` was never closed on any path. The descriptor is now closed inside the open-success block once `CFE_TBL_SetMetaDataFromFileHeader()` has consumed the header, the same shape `CFE_TBL_LoadFromFile` uses.

**Testing performed**

`tbl_ut_load.c` adds `UtAssert_STUB_COUNT(OS_close, n)` on each path that opens the file (per the note on #2811). The close sits inside the open-success block, like `CFE_TBL_LoadFromFile`, because the OSAL stub hands back a fake object id on a forced open failure (this is what the first CI run tripped on). Run locally in the cFS dev bundle with the tests kept and `cfe_tbl_task_cmds.c` reverted to dev: the two success-path asserts fail with `CallCount: OS_close() (0) == 1` (tbl_ut_load.c:323 and :370) and the failed-open path stays at 0 as it should. With the fix, coverage-tbl-ALL passes 1361/1361.

**Expected behavior changes**

Table load commands no longer leak the opened file descriptor. Repeated table loads no longer accumulate leaked descriptors.

**System(s) tested on**

Hardware: x86_64 (WSL2), OS: Ubuntu 22.04, Versions: cFE dev 2612eb05 with OSAL and PSP from the cFS dev bundle, native build with ENABLE_UNIT_TESTS

**Contributor Info**

Filip Koscak - phil.phaulre@gmail.com

