### PR TITLE
Fix #2811, close tbl file descriptors

### DIFF
--- a/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
+++ b/modules/tbl/fsw/src/cfe_tbl_task_cmds.c
@@ -430,17 +430,20 @@ CFE_Status_t CFE_TBL_LoadCmd(const CFE_TBL_LoadCmd_t *data)
         }
 
         CFE_TBL_TxnUnlockRegistry(&Txn);
-    }
 
-    if (Status == CFE_SUCCESS)
-    {
-        Status = CFE_TBL_ValidateFileIsLoadable(&Txn, &Header.Tbl);
-    }
+        if (Status == CFE_SUCCESS)
+        {
+            Status = CFE_TBL_ValidateFileIsLoadable(&Txn, &Header.Tbl);
+        }
 
-    if (Status == CFE_SUCCESS)
-    {
-        /* Read the file content into the working buffer */
-        Status = CFE_TBL_LoadContentFromFile(&Txn, FileDescriptor, Header.Tbl.Offset, Header.Tbl.NumBytes);
+        if (Status == CFE_SUCCESS)
+        {
+            /* Read the file content into the working buffer */
+            Status = CFE_TBL_LoadContentFromFile(&Txn, FileDescriptor, Header.Tbl.Offset, Header.Tbl.NumBytes);
+        }
+
+        /* Done with the file now -- must always close the file regardless of what happened */
+        OS_close(FileDescriptor);
     }
 
     /* If all the above worked out, then set the meta info in the load buffer */

--- a/modules/tbl/ut-coverage/tbl_ut_load.c
+++ b/modules/tbl/ut-coverage/tbl_ut_load.c
@@ -308,6 +308,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_SetDefaultReturnValue(UT_KEY(OS_OpenCreate), OS_ERROR);
     UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_SUCCESS);
     CFE_UtAssert_COUNTER_INCR(CFE_TBL_Global.CommandErrorCounter);
+    UtAssert_STUB_COUNT(OS_close, 0);
 
     /* Test response to inability to find the table in the registry */
     UT_InitData_TBL();
@@ -317,6 +318,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_SUCCESS);
     CFE_UtAssert_COUNTER_INCR(CFE_TBL_Global.CommandErrorCounter);
     CFE_UtAssert_EVENTSENT(CFE_TBL_NO_SUCH_TABLE_ERR_EID);
+    UtAssert_STUB_COUNT(OS_close, 1);
 
     /* The rest of the tests will use registry 0, note empty name matches */
     RegRec0Ptr->OwnerAppId = AppID;
@@ -330,6 +332,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_SUCCESS);
     CFE_UtAssert_COUNTER_INCR(CFE_TBL_Global.CommandErrorCounter);
     UT_TBL_Config(RegRec0Ptr)->DumpOnly = false;
+    UtAssert_STUB_COUNT(OS_close, 1);
 
     /* Test attempt to load a table with a load already pending */
     UT_InitData_TBL();
@@ -338,6 +341,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_TBL_SetupLoadBuff(RegRec0Ptr, false, 0);
     UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_SUCCESS);
     CFE_UtAssert_COUNTER_INCR(CFE_TBL_Global.CommandErrorCounter);
+    UtAssert_STUB_COUNT(OS_close, 1);
 
     /* Test where the file isn't dump only and passes table checks, get a
      * working buffer, and there is an extra byte (more data than header
@@ -362,6 +366,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_SUCCESS);
     CFE_UtAssert_COUNTER_INCR(CFE_TBL_Global.CommandCounter);
+    UtAssert_STUB_COUNT(OS_close, 1);
 
     /* Test with differing amount of data from header's claim */
     UT_InitData_TBL();
@@ -370,6 +375,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_SUCCESS);
     CFE_UtAssert_COUNTER_INCR(CFE_TBL_Global.CommandErrorCounter);
+    UtAssert_STUB_COUNT(OS_close, 1);
 
     /* Test with no working buffers available */
     UT_InitData_TBL();
@@ -382,6 +388,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_SUCCESS);
     CFE_UtAssert_COUNTER_INCR(CFE_TBL_Global.CommandErrorCounter);
     CFE_UtAssert_EVENTSENT(CFE_TBL_NO_WORK_BUFFERS_ERR_EID);
+    UtAssert_STUB_COUNT(OS_close, 1);
 
     /* Test with interal CFE_TBL_GetWorkingBuffer error (memcpy with matching address */
     UT_InitData_TBL();
@@ -393,6 +400,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_SUCCESS);
     CFE_UtAssert_COUNTER_INCR(CFE_TBL_Global.CommandErrorCounter);
+    UtAssert_STUB_COUNT(OS_close, 1);
 
     /* Test with table header indicating data beyond size of the table */
     UT_InitData_TBL();
@@ -401,6 +409,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_SUCCESS);
     CFE_UtAssert_COUNTER_INCR(CFE_TBL_Global.CommandErrorCounter);
+    UtAssert_STUB_COUNT(OS_close, 1);
 
     /* Test with table header indicating no data in the file */
     UT_InitData_TBL();
@@ -408,6 +417,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_SUCCESS);
     CFE_UtAssert_COUNTER_INCR(CFE_TBL_Global.CommandErrorCounter);
+    UtAssert_STUB_COUNT(OS_close, 1);
 
     /* Test where file has partial load for uninitialized table and offset
      * is non-zero
@@ -423,6 +433,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_SUCCESS);
     CFE_UtAssert_COUNTER_INCR(CFE_TBL_Global.CommandErrorCounter);
     CFE_UtAssert_EVENTSENT(CFE_TBL_PARTIAL_LOAD_ERR_EID);
+    UtAssert_STUB_COUNT(OS_close, 1);
 
     /* Test where file has the wrong name in the header */
     UT_InitData_TBL();
@@ -433,6 +444,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_SUCCESS);
     CFE_UtAssert_COUNTER_INCR(CFE_TBL_Global.CommandErrorCounter);
     CFE_UtAssert_EVENTSENT(CFE_TBL_NO_SUCH_TABLE_ERR_EID);
+    UtAssert_STUB_COUNT(OS_close, 1);
 
     /* Test where file has partial load for uninitialized table and offset
      * is zero
@@ -444,6 +456,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_SUCCESS);
     CFE_UtAssert_COUNTER_INCR(CFE_TBL_Global.CommandErrorCounter);
+    UtAssert_STUB_COUNT(OS_close, 1);
 
     /* Test response to inability to read the file header */
     UT_InitData_TBL();
@@ -451,6 +464,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_SetDeferredRetcode(UT_KEY(CFE_FS_ReadHeader), 1, sizeof(CFE_FS_Header_t) - 1);
     UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_SUCCESS);
     CFE_UtAssert_COUNTER_INCR(CFE_TBL_Global.CommandErrorCounter);
+    UtAssert_STUB_COUNT(OS_close, 1);
 
     /* Test where file has partial load for initialized table and offset
      * is non-zero
@@ -463,6 +477,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_SUCCESS);
     CFE_UtAssert_EVENTSENT(CFE_TBL_ZERO_LENGTH_LOAD_ERR_EID);
     CFE_UtAssert_COUNTER_INCR(CFE_TBL_Global.CommandErrorCounter);
+    UtAssert_STUB_COUNT(OS_close, 1);
 
     /* Test where file has partial load for initialized table and offset
      * is non-zero
@@ -473,6 +488,7 @@ void Test_CFE_TBL_LoadCmd(void)
     UT_SetReadHeader(&StdFileHeader, sizeof(StdFileHeader));
     UtAssert_INT32_EQ(CFE_TBL_LoadCmd(&LoadCmd), CFE_SUCCESS);
     CFE_UtAssert_COUNTER_INCR(CFE_TBL_Global.CommandErrorCounter);
+    UtAssert_STUB_COUNT(OS_close, 1);
 }
 
 /*


### PR DESCRIPTION
---
name: FSW Code Change
about: Flight Software code changes
labels: fsw
---

## Description of Change

Ensure that if CFE_TBL_TxnOpenTableLoadFile() returns success, that the path always calls OS_close() before returning.

## Linked Issue

Closes #2811

## Requirements Impact

- Requirement ID(s):
- [ ] Requirements updated as necessary
- [x] Existing requirements are still satisfied by this change

## Testing Evidence

Confirmed OS_close is called during table load

### Unit Tests (UT Assert)

All tests pass.  Includes additional test cases to confirm that OS_close is correctly called for all of the CFE_TBL_LoadCmd tests.

### COSMOS Test Suite
N/A

## Areas of Expertise Touched

- [ ] ASTRO
- [ ] CI/CD
- [ ] COSMOS
- [ ] Cybersecurity
- [ ] Docker
- [ ] EDS
- [ ] Git
- [ ] PSPs
- [ ] SBN
- [ ] SMP
- [ ] Tables
- [ ] TSN
- [ ] Unit Tests
- [ ] Other

---

## Author Checklist

- [x] Linked GitHub issue is referenced above
- [x] Code has been formatted with `.clang-format`
- [x] Static analysis workflows ran and passed
- [x] Unit tests (UT Assert) updated/added to cover code changes
- [x] Unit test workflows ran and passed
- [ ] COSMOS test suite was run; tests updated/added if relevant changes were made
- [x] Requirements have been reviewed; updated or confirmed still satisfied (see above)
- [x] Testing evidence is included above
- [x] Self-review of the diff completed

---

## Reviewer Checklist

- [ ] Code logic is correct and matches the stated intent
- [ ] Code is readable, maintainable, and follows project conventions (ask your lead if you are unsure of where to find these conventions)
- [ ] `.clang-format` has been applied
- [ ] Static analysis results reviewed and acceptable
- [ ] **The change has been exercised by the unit tests** (not just that tests pass — the new/changed code paths are actually covered)
- [ ] **COSMOS test suite was executed against this change** and results reviewed (or confirmed N/A with justification)
- [ ] **Reviewer has independently verified the change behaves as described** (e.g., by running the tests locally, reviewing CI output in detail, or performing additional ad-hoc testing as warranted)
- [ ] **Memory safety** reviewed (allocation, bounds, lifetime, stack usage)
- [ ] Requirements impact reviewed and appropriate
- [ ] Error handling is appropriate
- [ ] Appropriate Expert areas have been reviewed

### Reviewer Testing Notes

<!--
Describe how you independently verified this change. For example:
  - "Pulled the branch locally, ran `make test`, all UT Assert tests passed including the new ones for X."
  - "Ran the COSMOS test suite against the branch; observed expected telemetry behavior for Y."
  - "Reviewed CI run #1234; verified the new code paths are covered by inspecting the coverage report."
  - "Performed ad-hoc test by [describe scenario]; observed [result]."
-->