### PR TITLE
Fix #2836, clear the whole unused tail of the EVS housekeeping app table

### DIFF
--- a/modules/evs/fsw/src/cfe_evs_task.c
+++ b/modules/evs/fsw/src/cfe_evs_task.c
@@ -394,6 +394,8 @@ int32 CFE_EVS_SendHkCmd(const CFE_EVS_SendHkCmd_t *data)
         AppTlmDataPtr->AppEnableStatus            = false;
         AppTlmDataPtr->AppMessageSentCounter      = 0;
         AppTlmDataPtr->AppMessageSquelchedCounter = 0;
+
+        ++AppTlmDataPtr;
     }
 
     CFE_SB_TimeStampMsg(CFE_MSG_PTR(CFE_EVS_Global.EVS_TlmPkt.TelemetryHeader));

--- a/modules/evs/ut-coverage/evs_UT.c
+++ b/modules/evs/ut-coverage/evs_UT.c
@@ -2137,6 +2137,28 @@ void Test_Misc(void)
         EVS_AppDataSetUsed(&CFE_EVS_Global.AppData[i], AppID);
     }
     UtAssert_UINT32_EQ(CFE_EVS_SendHkCmd(NULL), CFE_STATUS_NO_COUNTER_INCREMENT);
+
+    /* Free AppData entries between housekeeping reports and confirm the
+     * unused tail of the telemetry packet is cleared, not just the first slot */
+    UT_InitData_EVS();
+    for (i = 0; i < sizeof(CFE_EVS_Global.AppData) / sizeof(CFE_EVS_Global.AppData[0]); i++)
+    {
+        EVS_AppDataSetFree(&CFE_EVS_Global.AppData[i]);
+    }
+    for (i = 0; i < 3; i++)
+    {
+        EVS_AppDataSetUsed(&CFE_EVS_Global.AppData[i], AppID);
+        CFE_EVS_Global.AppData[i].EventCount = 100 + i;
+    }
+    UtAssert_UINT32_EQ(CFE_EVS_SendHkCmd(NULL), CFE_STATUS_NO_COUNTER_INCREMENT);
+    UtAssert_UINT32_EQ(CFE_EVS_Global.EVS_TlmPkt.Payload.AppData[2].AppMessageSentCounter, 102);
+    EVS_AppDataSetFree(&CFE_EVS_Global.AppData[1]);
+    EVS_AppDataSetFree(&CFE_EVS_Global.AppData[2]);
+    UtAssert_UINT32_EQ(CFE_EVS_SendHkCmd(NULL), CFE_STATUS_NO_COUNTER_INCREMENT);
+    CFE_UtAssert_RESOURCEID_EQ(CFE_EVS_Global.EVS_TlmPkt.Payload.AppData[1].AppID, CFE_ES_APPID_UNDEFINED);
+    CFE_UtAssert_RESOURCEID_EQ(CFE_EVS_Global.EVS_TlmPkt.Payload.AppData[2].AppID, CFE_ES_APPID_UNDEFINED);
+    UtAssert_UINT32_EQ(CFE_EVS_Global.EVS_TlmPkt.Payload.AppData[1].AppMessageSentCounter, 0);
+    UtAssert_UINT32_EQ(CFE_EVS_Global.EVS_TlmPkt.Payload.AppData[2].AppMessageSentCounter, 0);
 }
 
 void Test_SetEvent(void)


### PR DESCRIPTION
**Checklist (Please check before submitting)**
* [x] I reviewed the [Contributing Guide](https://github.com/nasa/cFE/blob/main/CONTRIBUTING.md)
* [ ] I signed and emailed the CLA

**Describe the contribution**

Hi! Fixes #2836. `CFE_EVS_SendHkCmd` never advanced `AppTlmDataPtr` in the loop that clears the unused tail of the housekeeping app table, so only the first free slot was cleared. This advances the pointer the same way the fill loop above it does.

**Testing performed**

New Test_Misc case in evs_UT.c: mark 3 AppData entries used, send HK, free entries 1 and 2, send HK again, assert slots 1 and 2 read AppID UNDEFINED and counter 0.

With `cfe_evs_task.c` reverted to dev and the test kept, the new assertions fail: `AppData[2].AppID (0x110001) == CFE_ES_APPID_UNDEFINED (0x0)` and `AppMessageSentCounter (102) == 0` (Test_Misc 21 pass / 2 fail). With it, coverage-evs-ALL passes 1409/1409.

cFS dev bundle: `make SIMULATION=native ENABLE_UNIT_TESTS=true prep && make`, `ctest -R coverage-evs`.

**Expected behavior changes**

The housekeeping packet no longer reports AppID/counters of apps unregistered since the previous cycle. No API change.

**System(s) tested on**

- Hardware: x86_64 (WSL2)
- OS: Ubuntu 22.04
- Versions: cFE dev 2612eb05, OSAL and PSP from the cFS dev bundle

**Contributor Info**

Filip Koscak, phil.phaulre@gmail.com

Thanks for looking, and have a nice day!