### PR TITLE
Fix #2840, Preserve log files for functional test

### DIFF
--- a/.github/workflows/functional-test-eds.yml
+++ b/.github/workflows/functional-test-eds.yml
@@ -77,8 +77,6 @@ jobs:
       actions: read
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GH_HOST: developer.nasa.gov
-      GH_REPO: cFS/cFE
     runs-on: ubuntu-22.04
     needs: Local-Test-Build
     timeout-minutes: 15
@@ -114,38 +112,58 @@ jobs:
           container-id: ${{ steps.start-cpu1.outputs.container-id }}
           healthcheck-regex: 'CFE_ES_Main entering OPERATIONAL state$'
 
-      - name: Execute No-Op Check
+      - name: Send No-Op Check
         working-directory: ./host
+        env:
+          CFE_HOST: ${{ steps.check-cpu1.outputs.ip-addr }}
         run: |
-          ./cmd_send -v --host=${{ steps.check-cpu1.outputs.ip-addr }} --endian=EDS --pktid=CFE_ES/Application/CMD --cmdcode=NoopCmd
+          ./cmd_send -v --host="${CFE_HOST}" --endian=EDS --pktid=CFE_ES/Application/CMD --cmdcode=NoopCmd
           sleep 2
-          docker logs "${{ steps.start-cpu1.outputs.container-id }}" | grep -A 2 'CFE_ES 3: No-op command'
+
+      - name: Get container logs
+        env:
+          CONTAINER_ID: ${{ steps.start-cpu1.outputs.container-id }}
+        run: |
+          docker logs "${CONTAINER_ID}" | tee "${RUNNER_TEMP}/cfe_${CONTAINER_ID}.log"
+
+      - name: Verify No-Op Receipt
+        env:
+          CONTAINER_ID: ${{ steps.start-cpu1.outputs.container-id }}
+        run: |
+          grep -A 2 'CFE_ES 3: No-op command' "${RUNNER_TEMP}/cfe_${CONTAINER_ID}.log"
+
       - name: Launch Functional Test
         working-directory: ./host
+        env:
+          CFE_HOST: ${{ steps.check-cpu1.outputs.ip-addr }}
+          CONTAINER_ID: ${{ steps.start-cpu1.outputs.container-id }}
         run: |
-          ./cmd_send -v --host=${{ steps.check-cpu1.outputs.ip-addr }} --endian=EDS --pktid=CFE_ES/Application/CMD --cmdcode=StartAppCmd Application="CFE_TEST" AppEntryPoint="CFE_TestMain" AppFileName="cfe_testcase" StackSize=16384 Priority=100
+          ./cmd_send -v --host="${CFE_HOST}" --endian=EDS --pktid=CFE_ES/Application/CMD --cmdcode=StartAppCmd Application="CFE_TEST" AppEntryPoint="CFE_TestMain" AppFileName="cfe_testcase" StackSize=16384 Priority=100
           sleep 10
-          docker logs "${{ steps.start-cpu1.outputs.container-id }}"
+
       - name: Wait for Functional Test
         working-directory: ./cpu1
+        env:
+          LIMIT: 3
         run: |
           counter=0
           stuck=0
           while [ ! -f cf/cfe_test.log ]
           do
-            temp=$(grep -c "BEGIN" cf/cfe_test.tmp)
+            temp=$(grep -c "BEGIN" cf/cfe_test.tmp || echo 0)
             if [ $temp -eq $counter ]
             then
-              stuck=$(($stuck + 1))
+              let stuck=$stuck + 1
             else
               stuck=0
+              counter=$temp
             fi
-            if [ $stuck -ge 3 ]
+
+            if [ $stuck -ge "${LIMIT}" ]
             then
               echo "Test is frozen. Quitting"
-              break
+              exit 1
             fi
-            counter=$(grep -c "BEGIN" cf/cfe_test.tmp)
             echo "Waiting for CFE Tests"
             sleep 30
           done
@@ -153,9 +171,20 @@ jobs:
       - name: Shut down CFE
         if: ${{ always() && steps.check-cpu1.outputs.ip-addr != '' }}
         working-directory: ./host
+        env:
+          CFE_HOST: ${{ steps.check-cpu1.outputs.ip-addr }}
         run: |
-          ./cmd_send -v --host=${{ steps.check-cpu1.outputs.ip-addr }} --endian=EDS --pktid=CFE_ES/Application/CMD --cmdcode=RestartCmd RestartType=2
+          ./cmd_send -v --host="${CFE_HOST}" --endian=EDS --pktid=CFE_ES/Application/CMD --cmdcode=RestartCmd RestartType=2
           sleep 1
+
+      - name: Get final container logs
+        if: always()
+        env:
+          CONTAINER_ID: ${{ steps.start-cpu1.outputs.container-id }}
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/logs"
+          cp -t "${GITHUB_WORKSPACE}/logs" cpu1/cf/*.log ||:
+          docker logs "${CONTAINER_ID}" | tee "${GITHUB_WORKSPACE}/logs/cfe_full_output.log"
 
       - name: Stop CPU1 Container
         if: ${{ always() && steps.start-cpu1.outputs.container-id != '' }}
@@ -163,12 +192,12 @@ jobs:
         with:
           container-id: ${{ steps.start-cpu1.outputs.container-id }}
 
-      - name: Archive cFS Startup Artifacts
+      - name: Archive cFS Artifacts
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: cFS-startup-log-deprecate-true-release
-          path: cpu1/cf/cfe_test.log
+          path: logs/*
 
       - name: Check for cFS Warnings
         run: |

--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -76,8 +76,6 @@ jobs:
       actions: read
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      GH_HOST: github.com
-      GH_REPO: cFS/cFE
     runs-on: ubuntu-22.04
     needs: Local-Test-Build
     timeout-minutes: 15
@@ -114,40 +112,58 @@ jobs:
           container-id: ${{ steps.start-cpu1.outputs.container-id }}
           healthcheck-regex: 'CFE_ES_Main entering OPERATIONAL state$'
 
-      - name: Execute No-Op Check
+      - name: Send No-Op Check
         working-directory: ./host
+        env:
+          CFE_HOST: ${{ steps.check-cpu1.outputs.ip-addr }}
         run: |
-          ./cmd_send -v --host=${{ steps.check-cpu1.outputs.ip-addr }} --endian=LE --pktid=0x1806 --cmdcode=0
+          ./cmd_send -v --host="${CFE_HOST}" --endian=LE --pktid=0x1806 --cmdcode=0
           sleep 2
-          docker logs "${{ steps.start-cpu1.outputs.container-id }}" | grep -A 2 'CFE_ES 3: No-op command'
+
+      - name: Get container logs
+        env:
+          CONTAINER_ID: ${{ steps.start-cpu1.outputs.container-id }}
+        run: |
+          docker logs "${CONTAINER_ID}" | tee "${RUNNER_TEMP}/cfe_${CONTAINER_ID}.log"
+
+      - name: Verify No-Op Receipt
+        env:
+          CONTAINER_ID: ${{ steps.start-cpu1.outputs.container-id }}
+        run: |
+          grep -A 2 'CFE_ES 3: No-op command' "${RUNNER_TEMP}/cfe_${CONTAINER_ID}.log"
 
       - name: Launch Functional Test
         working-directory: ./host
+        env:
+          CFE_HOST: ${{ steps.check-cpu1.outputs.ip-addr }}
+          CONTAINER_ID: ${{ steps.start-cpu1.outputs.container-id }}
         run: |
-          ./cmd_send -v --host=${{ steps.check-cpu1.outputs.ip-addr }} --pktid=0x1806 --cmdcode=4 --endian=LE --string="20:CFE_TEST" --string="20:CFE_TestMain" --string="64:cfe_testcase" --uint64=16384 --uint8=0 --uint8=0 --uint16=100 --uint32=0
+          ./cmd_send -v --host="${CFE_HOST}" --pktid=0x1806 --cmdcode=4 --endian=LE --string="20:CFE_TEST" --string="20:CFE_TestMain" --string="64:cfe_testcase" --uint64=16384 --uint8=0 --uint8=0 --uint16=100 --uint32=0
           sleep 10
-          docker logs "${{ steps.start-cpu1.outputs.container-id }}"
 
       - name: Wait for Functional Test
         working-directory: ./cpu1
+        env:
+          LIMIT: 3
         run: |
           counter=0
           stuck=0
 
           while [ ! -f cf/cfe_test.log ]
           do
-            temp=$(grep -c "BEGIN" cf/cfe_test.tmp)
+            temp=$(grep -c "BEGIN" cf/cfe_test.tmp || echo 0)
             if [ $temp -eq $counter ]
             then
-              stuck=$(($stuck + 1))
+              let stuck=$stuck + 1
             else
               stuck=0
+              counter=$temp
             fi
 
-            if [ $stuck -ge 3 ]
+            if [ $stuck -ge "${LIMIT}" ]
             then
               echo "Test is frozen. Quitting"
-              break
+              exit 1
             fi
 
             counter=$(grep -c "BEGIN" cf/cfe_test.tmp)
@@ -158,8 +174,10 @@ jobs:
       - name: Shut down CFE
         if: ${{ always() && steps.check-cpu1.outputs.ip-addr != '' }}
         working-directory: ./host
+        env:
+          CFE_HOST: ${{ steps.check-cpu1.outputs.ip-addr }}
         run: |
-          ./cmd_send -v --host=${{ steps.check-cpu1.outputs.ip-addr }} --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002
+          ./cmd_send -v --host="$CFE_HOST" --endian=LE --pktid=0x1806 --cmdcode=2 --half=0x0002
           sleep 1
 
       - name: Stop CPU1 Container
@@ -168,12 +186,21 @@ jobs:
         with:
           container-id: ${{ steps.start-cpu1.outputs.container-id }}
 
-      - name: Archive cFS Startup Artifacts
+      - name: Get final container logs
+        if: always()
+        env:
+          CONTAINER_ID: ${{ steps.start-cpu1.outputs.container-id }}
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/logs"
+          cp -t "${GITHUB_WORKSPACE}/logs" cpu1/cf/*.log ||:
+          docker logs "${CONTAINER_ID}" | tee "${GITHUB_WORKSPACE}/logs/cfe_full_output.log"
+
+      - name: Archive cFS Artifacts
         if: always()
         uses: actions/upload-artifact@v7
         with:
           name: cFS-startup-log-deprecate-true-release
-          path: cpu1/cf/cfe_test.log
+          path: logs/*
 
       - name: Check for cFS Warnings
         run: |


### PR DESCRIPTION
---
name: Workflows Change
about: Changes to files under .github/workflows/
labels: ci/workflows
---

## Description of Change

* Shell references to environment variables are used rather than GitHub variables
* Functional test log files are preserved

## Linked Issue

Closes #2840 

## Areas of Expertise Touched

<!-- Check all that apply so the appropriate Experts can be tagged as reviewers. -->
<!-- See the expertise tags in the "cFS Dev Team" Teams channel or ask your team lead to help identify experts. -->
- [ ] ASTRO
- [x] CI/CD
- [ ] COSMOS
- [ ] Cybersecurity
- [ ] Docker
- [ ] EDS
- [ ] Git
- [ ] PSPs
- [ ] SBN
- [ ] SMP
- [ ] Tables
- [ ] TSN
- [ ] Unit Tests
- [ ] Other

---

## Author Checklist

- [x] Linked GitHub issue is referenced above
- [x] Workflow changes were tested on a branch/fork before submitting this PR
- [x] All workflows ran successfully on this branch

---

## Reviewer Checklist

- [ ] Workflow logic is correct and achieves the stated goal
- [ ] Third-party actions are from trusted sources and pinned to a specific SHA/tag
- [ ] Secrets are handled appropriately (no secrets exposed in logs, least-privilege usage)
- [ ] Workflow permissions follow the principle of least privilege
- [ ] Changes do not break or bypass existing branch protection rules
- [ ] All workflow runs on this PR completed successfully
- [ ] Appropriate Expert areas have been reviewed