### PR TITLE
Fix #2842, Use Standard Header Include Format in cfe_msg_init.c

### DIFF
--- a/modules/msg/fsw/src/cfe_msg_init.c
+++ b/modules/msg/fsw/src/cfe_msg_init.c
@@ -24,7 +24,7 @@
 #include "cfe_msg_defaults.h"
 #include "cfe_time.h"
 #include "cfe_sb.h"
-#include "string.h"
+#include <string.h>
 
 /*----------------------------------------------------------------
  *


### PR DESCRIPTION
---
name: FSW Code Change
about: Flight Software code changes
labels: fsw
---

## Description of Change

An internal static code analysis tool caught an instance of where #include "string.h" is used instead of #include <string.h>.

## Linked Issue

Closes #2842

## Requirements Impact

N/A

## Testing Evidence

Ran the internal static code analysis tool to ensure warning was resolved. Running the tool included make prep and install. 

## Areas of Expertise Touched

<!-- Check all that apply so the appropriate Experts can be tagged as reviewers. -->
<!-- See the expertise tags in the "cFS Dev Team" Teams channel or ask your team lead to help identify experts. -->
- [ ] ASTRO
- [ ] CI/CD
- [ ] COSMOS
- [ ] Cybersecurity
- [ ] Docker
- [ ] EDS
- [ ] Git
- [ ] PSPs
- [ ] SBN
- [ ] SMP
- [ ] Tables
- [ ] TSN
- [ ] Unit Tests
- [ ] Other

---

## Author Checklist

- [x] Linked GitHub issue is referenced above
- [x] Code has been formatted with `.clang-format`
- [x] Static analysis workflows ran and passed
- [x] Unit tests (UT Assert) updated/added to cover code changes - N/A
- [x] Unit test workflows ran and passed
- [x] COSMOS test suite was run; tests updated/added if relevant changes were made - N/A
- [x] Requirements have been reviewed; updated or confirmed still satisfied (see above) - N/A
- [x] Testing evidence is included above
- [x] Self-review of the diff completed

---

## Reviewer Checklist

- [ ] Code logic is correct and matches the stated intent
- [ ] Code is readable, maintainable, and follows project conventions (ask your lead if you are unsure of where to find these conventions)
- [ ] `.clang-format` has been applied
- [ ] Static analysis results reviewed and acceptable
- [ ] **The change has been exercised by the unit tests** (not just that tests pass — the new/changed code paths are actually covered)
- [ ] **COSMOS test suite was executed against this change** and results reviewed (or confirmed N/A with justification)
- [ ] **Reviewer has independently verified the change behaves as described** (e.g., by running the tests locally, reviewing CI output in detail, or performing additional ad-hoc testing as warranted)
- [ ] **Memory safety** reviewed (allocation, bounds, lifetime, stack usage)
- [ ] Requirements impact reviewed and appropriate
- [ ] Error handling is appropriate
- [ ] Appropriate Expert areas have been reviewed

### Reviewer Testing Notes

Code coverage workflows are failing unrelated to my changes in this PR. I created an [issue ](https://github.com/nasa/cFE/issues/2844)for the failing workflows that was caused from another PR that was merged into dev despite having failing workflows. 